### PR TITLE
Refactor generateMeta function into a component method

### DIFF
--- a/components/github/new-branch.js
+++ b/components/github/new-branch.js
@@ -1,13 +1,7 @@
 const github = require("https://github.com/PipedreamHQ/pipedream/components/github/github.app.js");
 //const github = require("./github.app.js");
-const events = ["create"]
-const eventTypes = ['branch']
-
-function generateMeta(data) {
-  return {
-    summary: `New Branch: ${data.ref} by ${data.sender.login}`,
-  }
-}
+const events = ["create"];
+const eventTypes = ['branch'];
 
 module.exports = {
   name: "New Branch (Instant)",
@@ -38,6 +32,13 @@ module.exports = {
       });
     },
   },
+  methods: {
+    generateMeta(data) {
+      return {
+        summary: `New Branch: ${data.ref} by ${data.sender.login}`,
+      };
+    },
+  },
   async run(event) {
     this.http.respond({
       status: 200,
@@ -60,7 +61,7 @@ module.exports = {
     }
 
     if (eventTypes.indexOf(body.ref_type) > -1) {
-      const meta = generateMeta(body)
+      const meta = this.generateMeta(body);
       this.$emit(body, meta);
     }
   },

--- a/components/github/new-commit-comment.js
+++ b/components/github/new-commit-comment.js
@@ -1,14 +1,7 @@
 const github = require("https://github.com/PipedreamHQ/pipedream/components/github/github.app.js");
 //const github = require("./github.app.js");
-const eventNames = ["commit_comment"]
-const eventTypes = ['created']
-
-function generateMeta(data) {
-  return {
-    summary: `${data.comment.user.login}: ${data.comment.body}`,
-    ts: data.comment.updated_at && +new Date(data.comment.updated_at),
-  }
-}
+const eventNames = ["commit_comment"];
+const eventTypes = ['created'];
 
 module.exports = {
   name: "New Commit Comment (Instant)",
@@ -39,6 +32,14 @@ module.exports = {
       });
     },
   },
+  methods: {
+    generateMeta(data) {
+      return {
+        summary: `${data.comment.user.login}: ${data.comment.body}`,
+        ts: data.comment.updated_at && +new Date(data.comment.updated_at),
+      };
+    },
+  },
   async run(event) {
     this.http.respond({
       status: 200,
@@ -61,7 +62,7 @@ module.exports = {
     }
 
     if (eventTypes.indexOf(body.action) > -1) {
-      const meta = generateMeta(body)
+      const meta = this.generateMeta(body);
       this.$emit(body, meta);
     }
   },

--- a/components/github/new-issue.js
+++ b/components/github/new-issue.js
@@ -1,19 +1,13 @@
 const github = require("https://github.com/PipedreamHQ/pipedream/components/github/github.app.js");
 //const github = require("./github.app.js");
-const eventNames = ["issues"]
-const eventTypes = ['opened']
-
-function generateMeta(data) {
-  return {
-    summary: `#${data.issue.number} ${data.issue.title} opened by ${data.sender.login}`,
-  }
-}
+const eventNames = ["issues"];
+const eventTypes = ['opened'];
 
 module.exports = {
   name: "New Issue (Instant)",
   description: "Triggers when new issues are created in a repo",
   version: "0.0.1",
-  props: {   
+  props: {
     github,
     repoFullName: { propDefinition: [github, "repoFullName"] },
     http: "$.interface.http",
@@ -38,6 +32,13 @@ module.exports = {
       });
     },
   },
+  methods: {
+    generateMeta(data) {
+      return {
+        summary: `#${data.issue.number} ${data.issue.title} opened by ${data.sender.login}`,
+      };
+    },
+  },
   async run(event) {
     this.http.respond({
       status: 200,
@@ -60,7 +61,7 @@ module.exports = {
     }
 
     if (eventTypes.indexOf(body.action) > -1) {
-      const meta = generateMeta(body)
+      const meta = this.generateMeta(body);
       this.$emit(body, meta);
     }
   },

--- a/components/github/new-label.js
+++ b/components/github/new-label.js
@@ -1,13 +1,7 @@
 const github = require("https://github.com/PipedreamHQ/pipedream/components/github/github.app.js");
 //const github = require("./github.app.js");
-const eventNames = ["label"]
-const eventTypes = ['created']
-
-function generateMeta(data) {
-  return {
-    summary: `${data.repository.name} created by ${data.sender.login}`
-  }
-}
+const eventNames = ["label"];
+const eventTypes = ['created'];
 
 module.exports = {
   name: "New Label (Instant)",
@@ -38,6 +32,13 @@ module.exports = {
       });
     },
   },
+  methods: {
+    generateMeta(data) {
+      return {
+        summary: `${data.repository.name} created by ${data.sender.login}`,
+      };
+    },
+  },
   async run(event) {
     this.http.respond({
       status: 200,
@@ -60,7 +61,7 @@ module.exports = {
     }
 
     if (eventTypes.indexOf(body.action) > -1) {
-      const meta = generateMeta(body)
+      const meta = this.generateMeta(body);
       this.$emit(body, meta);
     }
   },

--- a/components/github/new-milestone.js
+++ b/components/github/new-milestone.js
@@ -1,13 +1,7 @@
 const github = require("https://github.com/PipedreamHQ/pipedream/components/github/github.app.js");
 //const github = require("./github.app.js");
-const eventNames = ["milestone"]
-const eventTypes = ['created']
-
-function generateMeta(data) {
-  return {
-    summary: `${data.milestone.title} created by ${data.sender.login}`
-  }
-}
+const eventNames = ["milestone"];
+const eventTypes = ['created'];
 
 module.exports = {
   name: "New Milestone (Instant)",
@@ -38,6 +32,13 @@ module.exports = {
       });
     },
   },
+  methods: {
+    generateMeta(data) {
+      return {
+        summary: `${data.milestone.title} created by ${data.sender.login}`,
+      };
+    },
+  },
   async run(event) {
     this.http.respond({
       status: 200,
@@ -60,7 +61,7 @@ module.exports = {
     }
 
     if (eventTypes.indexOf(body.action) > -1) {
-      const meta = generateMeta(body)
+      const meta = this.generateMeta(body);
       this.$emit(body, meta);
     }
   },

--- a/components/github/new-project-card.js
+++ b/components/github/new-project-card.js
@@ -1,19 +1,13 @@
 const github = require("https://github.com/PipedreamHQ/pipedream/components/github/github.app.js");
 //const github = require("./github.app.js");
-const eventNames = ["project_card"]
-const eventTypes = ['created']
-
-function generateMeta(data) {
-  return {
-    summary: JSON.stringify(data)
-  }
-}
+const eventNames = ["project_card"];
+const eventTypes = ['created'];
 
 module.exports = {
   name: "New Project Card (Instant)",
   description: "Triggers when a new project card is created",
   version: "0.0.1",
-  props: {    
+  props: {
     github,
     repoFullName: { propDefinition: [github, "repoFullName"] },
     http: "$.interface.http",
@@ -38,6 +32,13 @@ module.exports = {
       });
     },
   },
+  methods: {
+    generateMeta(data) {
+      return {
+        summary: JSON.stringify(data),
+      };
+    },
+  },
   async run(event) {
     this.http.respond({
       status: 200,
@@ -60,7 +61,7 @@ module.exports = {
     }
 
     if (eventTypes.indexOf(body.action) > -1) {
-      const meta = generateMeta(body)
+      const meta = this.generateMeta(body);
       this.$emit(body, meta);
     }
   },

--- a/components/github/new-pull-request.js
+++ b/components/github/new-pull-request.js
@@ -1,13 +1,7 @@
 const github = require("https://github.com/PipedreamHQ/pipedream/components/github/github.app.js");
 //const github = require("./github.app.js");
-const eventNames = ["pull_request"]
-const eventTypes = ['opened']
-
-function generateMeta(data) {
-  return {
-    summary: `#${data.number} ${data.pull_request.title} by ${data.sender.login}`
-  }
-}
+const eventNames = ["pull_request"];
+const eventTypes = ['opened'];
 
 module.exports = {
   name: "New Pull Request (Instant)",
@@ -38,6 +32,13 @@ module.exports = {
       });
     },
   },
+  methods: {
+    generateMeta(data) {
+      return {
+        summary: JSON.stringify(data),
+      };
+    },
+  },
   async run(event) {
     this.http.respond({
       status: 200,
@@ -60,7 +61,7 @@ module.exports = {
     }
 
     if (eventTypes.indexOf(body.action) > -1) {
-      const meta = generateMeta(body)
+      const meta = this.generateMeta(body);
       this.$emit(body, meta);
     }
   },

--- a/components/gitlab/new-branch.js
+++ b/components/gitlab/new-branch.js
@@ -1,22 +1,5 @@
 const gitlab = require("https://github.com/PipedreamHQ/pipedream/components/gitlab/gitlab.app.js");
 
-function generateMeta(data) {
-  const id = data.checkout_sha;
-
-  const newBranchName = data.ref;
-  const userFullName = data.user_name;
-  const userLogin = data.user_username;
-  const summary = `New Branch: ${newBranchName} by ${userFullName} (${userLogin})`;
-
-  const ts = +new Date();
-
-  return {
-    id,
-    summary,
-    ts,
-  };
-}
-
 module.exports = {
   name: "New Branch (Instant)",
   description: "Emits an event when a new branch is created",
@@ -66,6 +49,22 @@ module.exports = {
       const expectedBeforeValue = "0000000000000000000000000000000000000000";
       return before === expectedBeforeValue;
     },
+    generateMeta(data) {
+      const id = data.checkout_sha;
+
+      const newBranchName = data.ref;
+      const userFullName = data.user_name;
+      const userLogin = data.user_username;
+      const summary = `New Branch: ${newBranchName} by ${userFullName} (${userLogin})`;
+
+      const ts = +new Date();
+
+      return {
+        id,
+        summary,
+        ts,
+      };
+    },
   },
   async run(event) {
     const { headers, body } = event;
@@ -86,7 +85,7 @@ module.exports = {
     // Gitlab doesn't offer a specific hook for "new branch" events,
     // but such event can be deduced from the payload of "push" events.
     if (this.isNewBranch(body)) {
-      const meta = generateMeta(body);
+      const meta = this.generateMeta(body);
       this.$emit(body, meta);
     }
   },


### PR DESCRIPTION
### Description
This PR refactors the usage of a standalone function (`generateMeta`) into a method within each of the corresponding components, as discussed offline with @dylburger as part of PR #426.