### PR TITLE
Gitlab event source for new commits

### DIFF
--- a/components/gitlab/gitlab.app.js
+++ b/components/gitlab/gitlab.app.js
@@ -40,7 +40,6 @@ module.exports = {
         const url = this._projectBranchesEndpoint(projectId);
         const params = {
           order_by: "name",
-          // sort: "asc",
         };
 
         const { data, next } = await this._propDefinitionsOptions(url, params, context);

--- a/components/gitlab/gitlab.app.js
+++ b/components/gitlab/gitlab.app.js
@@ -31,6 +31,29 @@ module.exports = {
         };
       },
     },
+    branchName: {
+      type: "string",
+      label: "Branch Name",
+      description: "The name of the branch",
+      async options(context) {
+        const { projectId } = context;
+        const url = this._projectBranchesEndpoint(projectId);
+        const params = {
+          order_by: "name",
+          // sort: "asc",
+        };
+
+        const { data, next } = await this._propDefinitionsOptions(url, params, context);
+
+        const options = data.map(branch => branch.name);
+        return {
+          options,
+          context: {
+            nextPage: next,
+          },
+        };
+      },
+    },
   },
   methods: {
     _apiUrl() {
@@ -40,6 +63,10 @@ module.exports = {
       const baseUrl = this._apiUrl();
       const userId = this._gitlabUserId();
       return `${baseUrl}/users/${userId}/projects`;
+    },
+    _projectBranchesEndpoint(projectId) {
+      const baseUrl = this._apiUrl();
+      return `${baseUrl}/projects/${projectId}/repository/branches`;
     },
     _hooksEndpointUrl(projectId) {
       const baseUrl = this._apiUrl();

--- a/components/gitlab/new-commit.js
+++ b/components/gitlab/new-commit.js
@@ -83,6 +83,7 @@ module.exports = {
     // in a separate variable called `total_commits_count`, which
     // we'll use to keep track of the commits that we need to emit
     // downstream.
+    // See https://gitlab.com/help/user/project/integrations/webhooks#push-events
     const { total_commits_count } = body;
     const allCommits = this.gitlab.getCommits({
       projectId: this.projectId,

--- a/components/gitlab/new-commit.js
+++ b/components/gitlab/new-commit.js
@@ -1,0 +1,106 @@
+const gitlab = require("https://github.com/PipedreamHQ/pipedream/components/gitlab/gitlab.app.js");
+
+module.exports = {
+  name: "New Branch (Instant)",
+  description: "Emits an event when a new branch is created",
+  version: "0.0.1",
+  dedupe: "unique",
+  props: {
+    gitlab,
+    projectId: { propDefinition: [gitlab, "projectId"] },
+    branchName: {
+      propDefinition: [gitlab, "branchName", c => ({ projectId: c.projectId })],
+    },
+    http: "$.interface.http",
+    db: "$.service.db",
+  },
+  hooks: {
+    async activate() {
+      const hookParams = {
+        push_events: true,
+        url: this.http.endpoint,
+      };
+      const opts = {
+        hookParams,
+        projectId: this.projectId,
+      };
+      const { hookId, token } = await this.gitlab.createHook(opts);
+      console.log(
+        `Created "push events" webhook for project ID ${this.projectId}.
+        (Hook ID: ${hookId}, endpoint: ${hookParams.url})`
+      );
+      this.db.set("hookId", hookId);
+      this.db.set("token", token);
+    },
+    async deactivate() {
+      const hookId = this.db.get("hookId");
+      const opts = {
+        hookId,
+        projectId: this.projectId,
+      };
+      await this.gitlab.deleteHook(opts);
+      console.log(
+        `Deleted webhook for project ID ${this.projectId}.
+        (Hook ID: ${hookId})`
+      );
+    },
+  },
+  methods: {
+    generateMeta(commit) {
+      const {
+        id,
+        message,
+        committed_date,
+        short_id,
+      } = commit;
+      const summary = `New commit: ${message} (${short_id})`;
+      return {
+        id,
+        summary,
+        ts: committed_date,
+      };
+    },
+  },
+  async run(event) {
+    const { headers, body } = event;
+
+    // Reject any calls not made by the proper Gitlab webhook.
+    if (!this.gitlab.isValidSource(headers, this.db)) {
+      this.http.respond({
+        status: 404,
+      });
+      return;
+    }
+
+    // Acknowledge the event back to Gitlab.
+    this.http.respond({
+      status: 200,
+    });
+
+    // Gitlab "push events" are only provisioned with at most
+    // 20 commit objects (which also lack information when compared
+    // to the Commits API). The amount of new commits is specified
+    // in a separate variable called `total_commits_count`, which
+    // we'll use to keep track of the commits that we need to emit
+    // downstream.
+    const { total_commits_count } = body;
+    const allCommits = this.gitlab.getCommits({
+      projectId: this.projectId,
+      branchName: this.branchName,
+      totalCommitsCount: total_commits_count,
+    });
+
+    // We need to collect all the relevant commits, sort
+    // them in reverse order (since the Gitlab API sorts them
+    // from most to least recent) and emit an event for each
+    // one of them.
+    const allCommitsCollected = [];
+    for await (const commit of allCommits) {
+      allCommitsCollected.push(commit);
+    };
+    allCommitsCollected.reverse().forEach(commit => {
+      const meta = this.generateMeta(commit)
+      this.$emit(commit, meta);
+    });
+  },
+};


### PR DESCRIPTION
This PR is in support of issue #376 

* Extract Gitlab API pagination logic into separate method
* Add branch name prop definition to Gitlab app
* Add commit retrieval logic to Gitlab app file.
* Process retrieved commit list and emit events for each one of the
  commits.