### PR TITLE
Gitlab new milestone

### DIFF
--- a/components/gitlab/new-milestone.js
+++ b/components/gitlab/new-milestone.js
@@ -1,0 +1,91 @@
+const gitlab = require("https://github.com/PipedreamHQ/pipedream/components/gitlab/gitlab.app.js");
+
+module.exports = {
+  name: "New Milestone (Instant)",
+  description: "Triggers when a new milestone is created in a project",
+  version: "0.0.1",
+  dedupe: "unique",
+  props: {
+    gitlab,
+    projectId: { propDefinition: [gitlab, "projectId"] },
+    timer: {
+      type: "$.interface.timer",
+      default: {
+        intervalSeconds: 60,
+      },
+    },
+    http: "$.interface.http",
+    db: "$.service.db",
+  },
+  hooks: {
+    async activate() {
+      const opts = {
+        projectId: this.projectId,
+        pageSize: 1,
+      };
+      const milestones = await this.collectMilestones(opts);
+      if (milestones.length > 0) {
+        const lastProcessedMilestoneId = milestones[0].id
+        this.db.set("lastProcessedMilestoneId", lastProcessedMilestoneId);
+        console.log(
+          `Polling Gitlab milestones created after ID ${lastProcessedMilestoneId}`
+        );
+      }
+    },
+  },
+  methods: {
+    generateMeta(data) {
+      const {
+        id,
+        created_at,
+        title,
+      } = data;
+      const summary = `New milestone created: ${title}`;
+      const ts = +new Date(created_at);
+      return {
+        id,
+        summary,
+        ts,
+      };
+    },
+    async collectMilestones(opts) {
+      const milestones = this.gitlab.getMilestones(opts);
+      const milestonesCollected = [];
+      for await (const milestone of milestones) {
+        milestonesCollected.push(milestone);
+      }
+      return milestonesCollected;
+    },
+  },
+  async run() {
+    // We use the ID of the last processed milestone so that we
+    // don't emit events for them (i.e. we only want to emit events
+    // for new milestones).
+    let lastProcessedMilestoneId = this.db.get("lastProcessedMilestoneId");
+    const opts = {
+      projectId: this.projectId,
+      lastProcessedMilestoneId,
+    };
+    const unprocessedMilestones = await this.collectMilestones(opts);
+
+    if (unprocessedMilestones.length > 0) {
+      console.log(`Detected ${unprocessedMilestones.length} new milestones`);
+
+      // We store the most recent milestone ID in the DB so that
+      // we don't process it (and previous milestones) in future runs.
+      lastProcessedMilestoneId = unprocessedMilestones[0].id;
+      this.db.set("lastProcessedMilestoneId", lastProcessedMilestoneId);
+
+      // We need to sort the retrieved milestones
+      // in reverse order (since the Gitlab API sorts them
+      // from most to least recent) and emit an event for each
+      // one of them.
+      unprocessedMilestones.reverse().forEach(milestone => {
+        const meta = this.generateMeta(milestone);
+        this.$emit(milestone, meta);
+      });
+    } else {
+      console.log("No new Gitlab milestones detected");
+    }
+  },
+};


### PR DESCRIPTION
This PR is in support of issue #376

* Implement method to retrieve milestones from the Gitlab API.
* Implement polling logic and emit events for any unprocessed
  milestone.
* Fix typo in method name.
* Fix bug leading to infinite loops.