### PR TITLE
Fix bug with Gitlab new branches dedupes

### DIFF
--- a/components/gitlab/new-branch.js
+++ b/components/gitlab/new-branch.js
@@ -50,17 +50,11 @@ module.exports = {
       return before === expectedBeforeValue;
     },
     generateMeta(data) {
-      const id = data.checkout_sha;
-
       const newBranchName = data.ref;
-      const userFullName = data.user_name;
-      const userLogin = data.user_username;
-      const summary = `New Branch: ${newBranchName} by ${userFullName} (${userLogin})`;
-
+      const summary = `New Branch: ${newBranchName}`;
       const ts = +new Date();
-
       return {
-        id,
+        id: newBranchName,
         summary,
         ts,
       };


### PR DESCRIPTION
This PR fixes a bug with the events metadata that prevents emitting events, for new branches without new commits.
It also compacts the event summary so that it fits in the UI.