### PR TITLE
StackExchange new question for keywords

### DIFF
--- a/components/stack-exchange/new-question-for-keywords.js
+++ b/components/stack-exchange/new-question-for-keywords.js
@@ -52,7 +52,6 @@ module.exports = {
       toDate,
       order: 'asc',
       sort: 'creation',
-      accepted: true,
       closed: false,
       site: this.siteId,
       q: keywordsQuery,

--- a/components/stack-exchange/new-question-for-keywords.js
+++ b/components/stack-exchange/new-question-for-keywords.js
@@ -1,0 +1,69 @@
+const stack_exchange = require('./stack-exchange.app');
+
+module.exports = {
+  name: "New Question for Specific Keywords",
+  description: "Emits an event when a new question is posted and related to a set of specific keywords",
+  version: "0.0.1",
+  dedupe: "unique",
+  props: {
+    stack_exchange,
+    db: "$.service.db",
+    siteId: { propDefinition: [stack_exchange, "siteId"] },
+    keywords: { propDefinition: [stack_exchange, "keywords"] },
+    timer: {
+      type: '$.interface.timer',
+      default: {
+        intervalSeconds: 60 * 15, // 15 minutes
+      },
+    },
+  },
+  hooks: {
+    async activate() {
+      const fromDate = this._getCurrentEpoch();
+      this.db.set("fromDate", fromDate);
+    },
+  },
+  methods: {
+    _getCurrentEpoch() {
+      // The StackExchange API works with Unix epochs in seconds.
+      const epochInMs = +new Date();
+      return Math.floor(epochInMs / 1000);
+    },
+    generateMeta(data) {
+      const {
+        question_id: id,
+        creation_date: ts,
+        title,
+      } = data;
+      const summary = `New question: ${title}`;
+      return {
+        id,
+        summary,
+        ts,
+      };
+    },
+  },
+  async run() {
+    const fromDate = this.db.get("fromDate");
+    const toDate = this._getCurrentEpoch();
+    const keywordsQuery = this.keywords.join(',');
+    const searchParams = {
+      fromDate,
+      toDate,
+      order: 'asc',
+      sort: 'creation',
+      accepted: true,
+      closed: false,
+      site: this.siteId,
+      q: keywordsQuery,
+    };
+
+    const items = this.stack_exchange.advancedSearch(searchParams);
+    for await (const item of items) {
+      const meta = this.generateMeta(item);
+      this.$emit(item, meta);
+    }
+
+    this.db.set("fromDate", toDate);
+  },
+};

--- a/components/stack-exchange/stack-exchange.app.js
+++ b/components/stack-exchange/stack-exchange.app.js
@@ -1,4 +1,4 @@
-const _ = require("underscore");
+const _ = require("lodash");
 const axios = require("axios");
 
 module.exports = {
@@ -24,7 +24,7 @@ module.exports = {
           label: site.name,
           value: site.api_site_parameter,
         }));
-        const options = _.sortBy(rawOptions, 'label');
+        const options = _.sortBy(rawOptions, ['label']);
         return {
           options,
         };

--- a/components/stack-exchange/stack-exchange.app.js
+++ b/components/stack-exchange/stack-exchange.app.js
@@ -1,0 +1,87 @@
+const _ = require("underscore");
+const axios = require("axios");
+
+module.exports = {
+  type: "app",
+  app: "stack_exchange",
+  propDefinitions: {
+    siteId: {
+      type: "string",
+      label: "Site",
+      description: "The StackExchange site for which questions are of interest",
+      async options(context) {
+        if (context.page !== 0) {
+          // The `sites` API is not paginated:
+          // https://api.stackexchange.com/docs/sites
+          return {
+            options: []
+          };
+        }
+
+        const url = this._sitesUrl();
+        const { data } = await axios.get(url);
+        const rawOptions = data.items.map(site => ({
+          label: site.name,
+          value: site.api_site_parameter,
+        }));
+        const options = _.sortBy(rawOptions, 'label');
+        return {
+          options,
+        };
+      },
+    },
+    keywords: {
+      type: "string[]",
+      label: "Keywords",
+      description: "Keywords to search for in questions",
+    },
+  },
+  methods: {
+    _apiUrl() {
+      return "https://api.stackexchange.com/2.2";
+    },
+    _sitesUrl() {
+      const baseUrl = this._apiUrl();
+      return `${baseUrl}/sites`;
+    },
+    _advancedSearchUrl() {
+      const baseUrl = this._apiUrl();
+      return `${baseUrl}/search/advanced`;
+    },
+    _authToken() {
+      return this.$auth.oauth_access_token
+    },
+    _makeRequestConfig() {
+      const authToken = this._authToken();
+      const headers = {
+        "Authorization": `Bearer ${authToken}`,
+        "User-Agent": "@PipedreamHQ/pipedream v0.1",
+      };
+      return {
+        headers,
+      };
+    },
+    async *advancedSearch(baseParams) {
+      const url = this._advancedSearchUrl();
+      const baseRequestConfig = this._makeRequestConfig();
+      let page = 1;
+      let hasMore = false;
+      do {
+        const params = {
+          ...baseParams,
+          page,
+        };
+        const requestConfig = {
+          ...baseRequestConfig,
+          params,
+        };
+        const { data } = await axios.get(url, requestConfig);
+        for (const item of data.items) {
+          yield item;
+        }
+        hasMore = data.has_more;
+        ++page;
+      } while (hasMore);
+    },
+  },
+};

--- a/components/stack-exchange/stack-exchange.app.js
+++ b/components/stack-exchange/stack-exchange.app.js
@@ -76,6 +76,14 @@ module.exports = {
           params,
         };
         const { data } = await axios.get(url, requestConfig);
+        if (data.items.length === 0) {
+          console.log(`
+            No new questions found for the following parameters:
+            ${JSON.stringify(baseParams, null, 2)}
+          `);
+        } else {
+          console.log(`Found ${data.items.length} new question(s)`);
+        }
         for (const item of data.items) {
           yield item;
         }


### PR DESCRIPTION
This PR is in support of issue #470 
* StackExchange New Question with keywords

The approach for this solution is the following:
1. Trigger the event source with a timer.
2. Perform an [advanced search](https://api.stackexchange.com/docs/advanced-search) against the StackExchange API for a specific time frame, from the last time the search was performed until now (for a [sample click here](https://api.stackexchange.com/docs/advanced-search#pagesize=10&fromdate=1602262702&todate=1602296890&order=asc&sort=creation&q=python&accepted=True&closed=False&filter=!9_bDE.BDp&site=stackoverflow&run=true))
3. Emit an event for each of the questions in the search result
4. Record the time of the search in the DB, to be used in the next execution