### PR TITLE
Generalize Salesforce Event Sources

### DIFF
--- a/components/salesforce/common.js
+++ b/components/salesforce/common.js
@@ -12,6 +12,7 @@ module.exports = {
       customResponse: true,
     },
     salesforce,
+    objectType: { propDefinition: [salesforce, "objectType"] },
   },
   hooks: {
     async activate() {

--- a/components/salesforce/sources/new-object/new-object.js
+++ b/components/salesforce/sources/new-object/new-object.js
@@ -1,0 +1,60 @@
+const startCase = require("lodash/startCase");
+
+const common = require("../../common");
+
+const EVENT_SOURCE_NAME = "New Object (Instant)";
+
+module.exports = {
+  ...common,
+  name: EVENT_SOURCE_NAME,
+  key: "salesforce-new-object",
+  description: "Triggers when a new object is created",
+  version: "0.0.1",
+  methods: {
+    ...common.methods,
+    generateMeta(data) {
+      const {
+        New: newObject,
+      } = data.body;
+      const {
+        CreatedDate: createdDate,
+        Id: id,
+        Name: name,
+      } = newObject;
+      const entityType = startCase(this.getObjectType()).toLowerCase();
+      const summary = `New ${entityType} created: ${name}`;
+      const ts = Date.parse(createdDate);
+      return {
+        id,
+        summary,
+        ts,
+      };
+    },
+    getEventSourceName() {
+      return EVENT_SOURCE_NAME
+    },
+    getEventTypes() {
+      return [
+        "after insert",
+      ];
+    },
+    getObjectType() {
+      return this.objectType;
+    },
+    getTriggerBody(triggerName, webhookClass) {
+      const eventTypes = this.getEventTypes().join(", ");
+      const objectType = this.getObjectType();
+      const endpointUrl = this.http.endpoint;
+      return `
+        trigger ${triggerName} on ${objectType} (${eventTypes}) {
+            for (${objectType} item : Trigger.New) {
+                final Map<String, ${objectType}> eventData = new Map<String, ${objectType}>();
+                eventData.put('New', item);
+                String content = ${webhookClass}.jsonContent(eventData);
+                ${webhookClass}.callout('${endpointUrl}', content);
+            }
+        }
+      `;
+    },
+  },
+};

--- a/components/salesforce/sources/new-object/new-object.js
+++ b/components/salesforce/sources/new-object/new-object.js
@@ -8,7 +8,7 @@ module.exports = {
   ...common,
   name: EVENT_SOURCE_NAME,
   key: "salesforce-new-object",
-  description: "Triggers when a new object is created",
+  description: "Emit an event when an object is created",
   version: "0.0.1",
   methods: {
     ...common.methods,

--- a/components/salesforce/sources/object-deleted/object-deleted.js
+++ b/components/salesforce/sources/object-deleted/object-deleted.js
@@ -8,7 +8,7 @@ module.exports = {
   ...common,
   name: EVENT_SOURCE_NAME,
   key: "salesforce-object-deleted",
-  description: "Triggers when an object is deleted",
+  description: "Emit an event when an object is deleted",
   version: "0.0.1",
   methods: {
     ...common.methods,

--- a/components/salesforce/sources/object-updated/object-updated.js
+++ b/components/salesforce/sources/object-updated/object-updated.js
@@ -1,0 +1,66 @@
+const startCase = require("lodash/startCase");
+
+const common = require("../../common");
+
+const EVENT_SOURCE_NAME = "Object Updated (Instant)";
+
+module.exports = {
+  ...common,
+  name: EVENT_SOURCE_NAME,
+  key: "salesforce-object-updated",
+  description: "Triggers when an object is updated",
+  version: "0.0.1",
+  methods: {
+    ...common.methods,
+    generateMeta(data) {
+      const {
+        New: newObject,
+      } = data.body;
+      const {
+        LastModifiedDate: lastModifiedDate,
+        Id: id,
+        Name: name,
+      } = newObject;
+      const entityType = startCase(this.getObjectType());
+      const summary = `${entityType} updated: ${name}`;
+      const ts = Date.parse(lastModifiedDate);
+      const compositeId = `${id}-${ts}`;
+      return {
+        id: compositeId,
+        summary,
+        ts,
+      };
+    },
+    getEventSourceName() {
+      return EVENT_SOURCE_NAME
+    },
+    getEventTypes() {
+      return [
+        "after update",
+      ];
+    },
+    getObjectType() {
+      return this.objectType;
+    },
+    getTriggerBody(triggerName, webhookClass) {
+      const eventTypes = this.getEventTypes().join(", ");
+      const objectType = this.getObjectType();
+      const endpointUrl = this.http.endpoint;
+      return `
+        trigger ${triggerName} on ${objectType} (${eventTypes}) {
+            for (${objectType} item : Trigger.New) {
+                final Map<String, ${objectType}> eventData = new Map<String, ${objectType}>();
+                eventData.put('New', item);
+
+                if (Trigger.OldMap != null) {
+                    final ${objectType} oldItem = Trigger.OldMap.get(item.Id);
+                    eventData.put('Old', oldItem);
+                }
+                String content = ${webhookClass}.jsonContent(eventData);
+                ${webhookClass}.callout('${endpointUrl}', content);
+            }
+        }
+      `;
+    },
+  },
+};

--- a/components/salesforce/sources/object-updated/object-updated.js
+++ b/components/salesforce/sources/object-updated/object-updated.js
@@ -8,7 +8,7 @@ module.exports = {
   ...common,
   name: EVENT_SOURCE_NAME,
   key: "salesforce-object-updated",
-  description: "Triggers when an object is updated",
+  description: "Emit an event when an object is updated",
   version: "0.0.1",
   methods: {
     ...common.methods,


### PR DESCRIPTION
* Add event source logic for:
  * New objects
  * Updated objects
  * Deleted objects
* Add user input prop to allow users to select the type of sObject for
  which new events should be monitored

This PR is in support of issue #532 