### PR TITLE
Fix missing parenthesis in code example

### DIFF
--- a/docs/docs/destinations/sql/README.md
+++ b/docs/docs/destinations/sql/README.md
@@ -283,7 +283,7 @@ const response = await axios({
   data: {
     query: "SELECT COUNT(*) FROM your_table",
   }
-}
+})
 ```
 
 Some HTTP clients like `axios` automatically set a `Content-Type` header of `application/json` when you pass a JavaScript object in the `data` field, but you'll also need to ensure you set that header manually if necessary. For example, you'd make the same query above using `cURL` like so:


### PR DESCRIPTION
Copying this code block will lead to a syntax error because of the missing parenthesis.