### PR TITLE
Snowflake query results

### DIFF
--- a/components/snowflake/sources/common-table-scan.js
+++ b/components/snowflake/sources/common-table-scan.js
@@ -38,6 +38,8 @@ module.exports = {
   hooks: {
     ...common.hooks,
     async activate() {
+      await this.validateColumn(this.uniqueKey);
+
       let lastResultId = this.db.get("lastResultId");
       if (lastResultId === undefined) {
         lastResultId = await this._getLastId();
@@ -98,7 +100,6 @@ module.exports = {
       };
     },
     async _getLastId() {
-      await this.validateColumn(this.uniqueKey);
       const sqlText = `
         SELECT ${this.uniqueKey}
         FROM IDENTIFIER(:1)

--- a/components/snowflake/sources/common.js
+++ b/components/snowflake/sources/common.js
@@ -1,0 +1,87 @@
+const snowflake = require("../snowflake.app");
+
+module.exports = {
+  dedupe: "unique",
+  props: {
+    snowflake,
+    db: "$.service.db",
+    timer: {
+      type: "$.interface.timer",
+      default: {
+        intervalSeconds: 60 * 15, // 15 minutes
+      },
+    },
+    eventSize: {
+      type: "integer",
+      label: "Event Size",
+      description: "The number of rows to include in a single event (by default, emits 1 event per row)",
+      default: 1,
+      min: 1,
+    },
+  },
+  methods: {
+    async processCollection(statement, timestamp) {
+      let lastResultId;
+      let totalRowCount = 0;
+      const rowCollectionStream = this.snowflake.collectRowsPaginated(statement, this.eventSize);
+      for await (const rows of rowCollectionStream) {
+        const rowCount = rows.length;
+        if (rowCount <= 0) {
+          break;
+        }
+
+        lastResultId = rows[rowCount-1][this.uniqueKey];
+        totalRowCount += rowCount;
+        const meta = this.generateMetaForCollection({
+          lastResultId,
+          rowCount,
+          timestamp,
+        });
+        this.$emit({ rows }, meta);
+      }
+      return {
+        lastResultId,
+        rowCount: totalRowCount,
+      }
+    },
+    async processSingle(statement, timestamp) {
+      let lastResultId;
+      let rowCount = 0;
+      const rowStream = await this.snowflake.getRows(statement);
+      for await (const row of rowStream) {
+        const meta = this.generateMeta({
+          row,
+          timestamp,
+        });
+        this.$emit(row, meta);
+
+        lastResultId = row[this.uniqueKey];
+        ++rowCount;
+      }
+
+      return {
+        lastResultId,
+        rowCount,
+      };
+    },
+    getStatement() {
+      throw new Error('getStatement is not implemented');
+    },
+    generateMeta() {
+      throw new Error('generateMeta is not implemented');
+    },
+    generateMetaForCollection() {
+      throw new Error('generateMetaForCollection is not implemented');
+    },
+    processEvent() {
+      throw new Error('processEvent is not implemented');
+    },
+  },
+  async run(event) {
+    const { timestamp } = event;
+    const statement = this.getStatement(event);
+    return (this.eventSize === 1) ?
+      this.processSingle(statement, timestamp) :
+      this.processCollection(statement, timestamp);
+  },
+};

--- a/components/snowflake/sources/new-row/new-row.js
+++ b/components/snowflake/sources/new-row/new-row.js
@@ -5,58 +5,25 @@ module.exports = {
   key: "snowflake-new-row",
   name: "New Row",
   description: "Emit an event when a new row is added to a table",
+  version: "0.0.1",
   methods: {
     ...common.methods,
-    generateMeta(data) {
-      const {
-        row: {
-          [this.uniqueKey]: id,
-        },
-        timestamp: ts,
-      } = data;
-      const summary = `New row: ${id}`;
-      return {
-        id,
-        summary,
-        ts,
-      };
-    },
-    generateMetaForCollection(data) {
-      const {
-        lastResultId: id,
-        rowCount,
-        timestamp: ts,
-      } = data;
-      const entity = rowCount === 1 ? "row" : "rows";
-      const summary = `${rowCount} new ${entity}`;
-      return {
-        id,
-        summary,
-        ts,
-      };
-    },
-    async processEvent(lastResultId, event) {
-      this.validateColumn(this.uniqueKey);
+    async getStatement(lastResultId) {
+      await this.validateColumn(this.uniqueKey);
       const sqlText = `
         SELECT *
         FROM IDENTIFIER(:1)
         WHERE ${this.uniqueKey} > :2
-        ORDER BY :3 ASC
+        ORDER BY ${this.uniqueKey} ASC
       `;
       const binds = [
         this.tableName,
         lastResultId,
-        this.uniqueKey,
       ];
-      const statement = {
+      return {
         sqlText,
         binds,
       };
-
-      const { timestamp } = event;
-      return (this.eventSize === 1) ?
-        this.processSingle(statement, timestamp) :
-        this.processCollection(statement, timestamp);
     },
   },
 };

--- a/components/snowflake/sources/new-row/new-row.js
+++ b/components/snowflake/sources/new-row/new-row.js
@@ -9,7 +9,6 @@ module.exports = {
   methods: {
     ...common.methods,
     async getStatement(lastResultId) {
-      await this.validateColumn(this.uniqueKey);
       const sqlText = `
         SELECT *
         FROM IDENTIFIER(:1)

--- a/components/snowflake/sources/query-results/README.md
+++ b/components/snowflake/sources/query-results/README.md
@@ -1,0 +1,61 @@
+# Snowflake Query Results Source
+
+## Introduction
+
+This source emits new events with the results of an arbitrary SQL query provided
+by the user. It achieves so by periodically executing such query.
+
+Please note that the event source will **blindly** execute the query in an
+agnostic manner. This means that if the result of the query contains
+previously-seen records, those records will be re-sent in the event payload. It
+is the user's responsibility to customize the SQL query so that the amount of
+emitted events is bounded.
+
+Users can also provide a field/column name to use for de-duplication purposes.
+**This is only applicable when the _Event Size_ prop is set to 1**. See the
+[De-duplication Details](#de-duplication-details) section for more information.
+
+## Prerequisites
+
+To set up your Snowflake credentials, go to the [Pipedream
+Apps](https://pipedream.com/apps) page, and click on the **CONNECT AN APP**
+button. Look for the **Snowflake** app, and click on it. Fill in every field
+required in the form, and click on **SAVE**.
+
+## Usage
+
+1. Visit the [source
+   page](https://pipedream.com/sources/new?key=snowflake-query-results)
+2. Select the Snowflake account to use (see [the previous
+   section](#prerequisites) for information on how to set it up)
+3. You'll be prompted to enter the time interval for the executions. The default
+   value is 15 minutes.
+4. Select the _event size_ (i.e. the amount of records to be sent in a single
+   event). Select 1 (which is also the default value) if you prefer to send one
+   event per new row
+5. Enter the _SQL query_ to be executed at each iteration/execution of this
+   event source
+6. Optionally, select the _de-duplication key_ to use for the de-duplication
+   logic (see [the following section](#de-duplication-details) section for more
+   information)
+
+## De-duplication Details
+
+As an example, let's assume the user provides `ID` as a de-duplication field,
+and it also provided the following query:
+```sql
+SELECT * FROM MyTable
+```
+
+The results for such query could be:
+```
+ID	FIRSTNAME	LASTNAME
+101	TestUser	One
+102	TestUser	Two
+103	TestUser	Three
+```
+
+The event source would issue 3 events with ID's set to `101`, `102` and `103`,
+respectively. Even though results for subsequent executions of the query will
+include the records above, the de-duplication logic of the event source will not
+emit events for such records again.

--- a/components/snowflake/sources/query-results/query-results.js
+++ b/components/snowflake/sources/query-results/query-results.js
@@ -1,0 +1,58 @@
+const { v4: uuidv4 } = require("uuid");
+const common = require("../common");
+
+module.exports = {
+  ...common,
+  key: "snowflake-query-results",
+  name: "Query Results",
+  description: "Emit an event with the results of an arbitrary query",
+  version: "0.0.1",
+  props: {
+    ...common.props,
+    sqlQuery: {
+      type: "string",
+      label: "SQL Query",
+      description: "Your SQL query",
+    },
+    dedupeKey: {
+      type: "string",
+      label: "De-duplication Key",
+      description: "The name of a column in the table to use for de-duplication",
+      optional: true,
+    },
+  },
+  methods: {
+    ...common.methods,
+    generateMeta(data) {
+      const {
+        row: {
+          [this.dedupeKey]: id = uuidv4(),
+        },
+        timestamp: ts,
+      } = data;
+      const summary = `New event (ID: ${id})`;
+      return {
+        id,
+        summary,
+        ts,
+      };
+    },
+    generateMetaForCollection(data) {
+      const {
+        timestamp: ts,
+      } = data;
+      const id = uuidv4();
+      const summary = `New event (ID: ${id})`;
+      return {
+        id,
+        summary,
+        ts,
+      };
+    },
+    getStatement() {
+      return {
+        sqlText: this.sqlQuery,
+      };
+    },
+  },
+};


### PR DESCRIPTION
- Add event source logic for Snowflake Query Results
- Refactor common code
  - Move "table scan" common code to `common-table-scan`
  - Move event emitting logic and grouping (i.e. event size) to new
    `common` object
  - Fix bugs with "new row" query

This closes #636 