### PR TITLE
Fixed object destructuring syntax

### DIFF
--- a/docs/docs/workflows/steps/code/nodejs/http-requests/README.md
+++ b/docs/docs/workflows/steps/code/nodejs/http-requests/README.md
@@ -53,7 +53,7 @@ const data = resp.data;
 Alternatively, you can access the data using [object destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#Object_destructuring), which is equivalent to the above and preferred in modern JavaScript:
 
 ```javascript
-const { data } = resp.data;
+const { data } = resp;
 ```
 
 ## Send a `GET` request to fetch data


### PR DESCRIPTION
Syntax should be `const { data } = resp;` rather than `const { data } = resp.data`