### PR TITLE
Fix new row detection in Google Sheets event sources

### DIFF
--- a/components/google_sheets/google_sheets.app.js
+++ b/components/google_sheets/google_sheets.app.js
@@ -79,7 +79,15 @@ module.exports = {
         ...data,
       };
     },
-    async getWorksheetRowCounts(spreadsheetId) {
+    async getWorksheetRowCounts(spreadsheetId, worksheetIds) {
+      const values = await this.getSheetValues(spreadsheetId, worksheetIds);
+      return values
+        .map(({ values, worksheetId }) => ({
+          rowCount: values.length,
+          worksheetId,
+        }));
+    },
+    async getWorksheetLength(spreadsheetId) {
       const fields = [
         "sheets.properties.sheetId",
         "sheets.properties.gridProperties.rowCount",
@@ -92,8 +100,8 @@ module.exports = {
           gridProperties: { rowCount },
         }) => ({
           spreadsheetId,
-          sheetId,
-          rowCount,
+          worksheetId: sheetId,
+          worksheetLength: rowCount,
         }));
     },
     // returns an array of the spreadsheet values for the spreadsheet selected
@@ -111,8 +119,8 @@ module.exports = {
             const { values } = await this.getSpreadsheetValues(spreadsheetId, title);
             return {
               spreadsheetId,
-              sheetId,
               values,
+              worksheetId: sheetId,
             };
           })
       );

--- a/components/google_sheets/sources/new-updates/new-updates.js
+++ b/components/google_sheets/sources/new-updates/new-updates.js
@@ -127,14 +127,15 @@ module.exports = {
       const worksheetIds = this.getWorksheetIds();
       const sheetValues = await this.google_sheets.getSheetValues(sheetId, worksheetIds);
       for (const sheetVal of sheetValues) {
-        if (!this.isWorksheetRelevant(sheetVal.sheetId)) {
+        const {
+          values,
+          worksheetId,
+        } = sheetVal;
+        if (!this.isWorksheetRelevant(worksheetId)) {
           continue;
         }
 
-        this.db.set(
-          `${sheetVal.spreadsheetId}${sheetVal.sheetId}`,
-          sheetVal.values,
-        );
+        this.db.set(`${sheetId}${worksheetId}`, values);
       }
     },
     async processSpreadsheet(spreadsheet) {


### PR DESCRIPTION
* Obtain the row count from the `values.get` API instead of the `get`
  API, since the latter outputs the actual length of the spreadsheet
  file regardless of its actual content.
* Rename some variables to be more consistent in terms of
  nomenclature (i.e. sheet vs. spreadsheet vs. worksheet).