### PR TITLE
Bug fixes for tweet search

### DIFF
--- a/components/twitter/sources/language-codes.js
+++ b/components/twitter/sources/language-codes.js
@@ -1,5 +1,9 @@
 module.exports = [
   {
+    English: "Undefined",
+    alpha2: "und",
+  },
+  {
     English: "Abkhazian",
     alpha2: "ab",
   },

--- a/components/twitter/sources/language-codes.js
+++ b/components/twitter/sources/language-codes.js
@@ -1,6 +1,6 @@
 module.exports = [
   {
-    English: "Undefined",
+    English: "Undetected",
     alpha2: "und",
   },
   {

--- a/components/twitter/sources/my-liked-tweets/my-liked-tweets.js
+++ b/components/twitter/sources/my-liked-tweets/my-liked-tweets.js
@@ -1,10 +1,10 @@
 const twitter = require('../../twitter.app.js')
 
-module.exports = { 
+module.exports = {
   key: "twitter-my-liked-tweets",
-  name: "My Liked Tweets", 
-  description: "Emit new Tweets you like on Twitter", 
-  version: "0.0.1",
+  name: "My Liked Tweets",
+  description: "Emit new Tweets you like on Twitter",
+  version: "0.0.2",
   props: {
     twitter,
     timer: {
@@ -15,7 +15,7 @@ module.exports = {
     },
   },
   dedupe: "unique",
-  async run(event) {     
+  async run(event) {
     (await this.twitter.getLikedTweets()).reverse().forEach(tweet => {
       this.$emit(tweet, {
         id: tweet.id_str,

--- a/components/twitter/sources/my-tweets/my-tweets.js
+++ b/components/twitter/sources/my-tweets/my-tweets.js
@@ -1,11 +1,11 @@
 const twitter = require('../../twitter.app.js')
 const moment = require('moment')
- 
-module.exports = { 
+
+module.exports = {
   key: "twitter-my-tweets",
   name: "My Tweets",
-  description: "Emit new Tweets you post to Twitter", 
-  version: "0.0.1",
+  description: "Emit new Tweets you post to Twitter",
+  version: "0.0.2",
   props: {
     db: "$.service.db",
     twitter,
@@ -32,7 +32,7 @@ module.exports = {
     const since_id = this.db.get("since_id")
     const { lang, locale, geocode, result_type, enrichTweets, includeReplies, includeRetweets, maxRequests, count } = this
     let q = from, max_id, limitFirstPage
-    
+
     // join "from" filter and search keywords
     if (this.q) {
       q += ` ${this.q}`
@@ -45,16 +45,16 @@ module.exports = {
     }
 
     // run paginated search
-    const tweets = await this.twitter.paginatedSearch({ 
-      q, 
-      since_id, 
-      lang, 
-      locale, 
-      geocode, 
-      result_type, 
-      enrichTweets, 
-      includeReplies, 
-      includeRetweets, 
+    const tweets = await this.twitter.paginatedSearch({
+      q,
+      since_id,
+      lang,
+      locale,
+      geocode,
+      result_type,
+      enrichTweets,
+      includeReplies,
+      includeRetweets,
       maxRequests,
       count,
       limitFirstPage,
@@ -75,7 +75,7 @@ module.exports = {
           max_id = tweet.id_str
         }
       })
-    } 
+    }
     if (max_id) {
       this.db.set("since_id", max_id)
     }

--- a/components/twitter/sources/new-follower-of-me/new-follower-of-me.js
+++ b/components/twitter/sources/new-follower-of-me/new-follower-of-me.js
@@ -1,10 +1,10 @@
 const twitter = require('../../twitter.app.js')
 
-module.exports = { 
+module.exports = {
   key: "twitter-new-follower-of-me",
-  name: "New Follower of Me", 
-  description: "Emit an event when a user follows you on Twitter", 
-  version: "0.0.1",
+  name: "New Follower of Me",
+  description: "Emit an event when a user follows you on Twitter",
+  version: "0.0.2",
   props: {
     db: "$.service.db",
     twitter,
@@ -15,7 +15,7 @@ module.exports = {
       },
     },
   },
-  async run(event) {     
+  async run(event) {
     const cached = this.db.get("followers") || []
     const activation = this.db.get("activation") || true
     let newFollowers = []
@@ -62,7 +62,7 @@ module.exports = {
 
       // set the checkpoint to the full set of followers from the last step
       this.db.set("followers", followers)
-      this.db.set("activation", false) 
+      this.db.set("activation", false)
     }
   },
 }

--- a/components/twitter/sources/new-follower-of-user/new-follower-of-user.js
+++ b/components/twitter/sources/new-follower-of-user/new-follower-of-user.js
@@ -1,10 +1,10 @@
 const twitter = require('../../twitter.app.js')
 
-module.exports = { 
+module.exports = {
   key: "twitter-new-follower-of-user",
   name: "New Follower of User",
-  description: "Emit an event when a specific user gains a follower",  
-  version: "0.0.1",
+  description: "Emit an event when a specific user gains a follower",
+  version: "0.0.2",
   props: {
     db: "$.service.db",
     twitter,
@@ -16,7 +16,7 @@ module.exports = {
       },
     },
   },
-  async run(event) {     
+  async run(event) {
     const cached = this.db.get("followers") || []
     const activation = this.db.get("activation") || true
     let newFollowers = []

--- a/components/twitter/sources/new-trends-by-geo/new-trends-by-geo.js
+++ b/components/twitter/sources/new-trends-by-geo/new-trends-by-geo.js
@@ -1,10 +1,10 @@
 const twitter = require('../../twitter.app.js')
 
-module.exports = { 
+module.exports = {
   key: "twitter-new-trends-by-geo",
-  name: "New Trends by Geo", 
-  description: "Emit an event when a new topic is trending on Twitter in a specific geographic location", 
-  version: "0.0.1",
+  name: "New Trends by Geo",
+  description: "Emit an event when a new topic is trending on Twitter in a specific geographic location",
+  version: "0.0.2",
   props: {
     twitter,
     trendLocation: { propDefinition: [twitter, "trendLocation"] },
@@ -16,7 +16,7 @@ module.exports = {
     },
   },
   dedupe: "unique",
-  async run(event) {     
+  async run(event) {
     const response = (await this.twitter.getTrends()).forEach(geo => {
       geo.trends.reverse().forEach(trend => {
         this.$emit(trend, {

--- a/components/twitter/sources/new-unfollower-of-me/new-unfollower-of-me.js
+++ b/components/twitter/sources/new-unfollower-of-me/new-unfollower-of-me.js
@@ -5,7 +5,7 @@ module.exports = {
   key: "twitter-new-unfollower-of-me",
   name: "New Unfollower of Me",
   description: "Emit an event when a user unfollows you on Twitter",
-  version: "0.0.1",
+  version: "0.0.2",
   methods: {
     ...common.methods,
     getRelevantIds() {

--- a/components/twitter/sources/new-unfollower-of-user/new-unfollower-of-user.js
+++ b/components/twitter/sources/new-unfollower-of-user/new-unfollower-of-user.js
@@ -5,7 +5,7 @@ module.exports = {
   key: "twitter-new-unfollower-of-user",
   name: "New Unfollower of User",
   description: "Emit an event when a specific user loses a follower on Twitter",
-  version: "0.0.1",
+  version: "0.0.2",
   props: {
     ...common.props,
     screen_name: { propDefinition: [common.twitter, "screen_name"] },

--- a/components/twitter/sources/search-mentions/search-mentions.js
+++ b/components/twitter/sources/search-mentions/search-mentions.js
@@ -1,11 +1,11 @@
 const twitter = require('../../twitter.app.js')
 const moment = require('moment')
- 
+
 module.exports = {
   key: "twitter-search-mentions",
   name: "Search Mentions",
-  description: "Emit new Tweets that matches your search criteria", 
-  version: "0.0.1",
+  description: "Emit new Tweets that matches your search criteria",
+  version: "0.0.2",
   props: {
     db: "$.service.db",
     twitter,
@@ -24,8 +24,8 @@ module.exports = {
       default: {
         intervalSeconds: 60 * 15,
       },
-    }, 
-  }, 
+    },
+  },
   async run(event) {
     const since_id = this.db.get("since_id")
     const { lang, locale, geocode, result_type, enrichTweets, includeReplies, includeRetweets, maxRequests, count } = this
@@ -36,18 +36,18 @@ module.exports = {
     } else {
       limitFirstPage = false
     }
- 
+
     // run paginated search
-    const tweets = await this.twitter.paginatedSearch({ 
-      q, 
-      since_id, 
-      lang, 
-      locale, 
-      geocode, 
-      result_type, 
-      enrichTweets, 
-      includeReplies, 
-      includeRetweets, 
+    const tweets = await this.twitter.paginatedSearch({
+      q,
+      since_id,
+      lang,
+      locale,
+      geocode,
+      result_type,
+      enrichTweets,
+      includeReplies,
+      includeRetweets,
       maxRequests,
       count,
       limitFirstPage,

--- a/components/twitter/sources/tweets-liked-by-user/tweets-liked-by-user.js
+++ b/components/twitter/sources/tweets-liked-by-user/tweets-liked-by-user.js
@@ -1,10 +1,10 @@
 const twitter = require('../../twitter.app.js')
 
-module.exports = { 
+module.exports = {
   key: "twitter-tweet-liked-by-user",
   name: "Tweet Liked by User",
-  description: "Emit new Tweets liked by a specific user on Twitter", 
-  version: "0.0.1",
+  description: "Emit new Tweets liked by a specific user on Twitter",
+  version: "0.0.2",
   props: {
     twitter,
     screen_name: { propDefinition: [twitter, "screen_name"] },
@@ -16,7 +16,7 @@ module.exports = {
     },
   },
   dedupe: "unique",
-  async run(event) {     
+  async run(event) {
     (await this.twitter.getLikedTweets({ screen_name: this.screen_name })).reverse().forEach(tweet => {
       this.$emit(tweet, {
         id: tweet.id_str,

--- a/components/twitter/sources/user-tweets/user-tweets.js
+++ b/components/twitter/sources/user-tweets/user-tweets.js
@@ -4,13 +4,13 @@ const moment = require('moment')
 module.exports = {
   key: "twitter-user-tweets",
   name: "User Tweets",
-  description: "Emit new Tweets posted by a user", 
-  version: "0.0.1",
-  props: { 
+  description: "Emit new Tweets posted by a user",
+  version: "0.0.2",
+  props: {
     db: "$.service.db",
     twitter,
-    screen_name: { propDefinition: [twitter, "screen_name"] }, 
-    include_rts: { propDefinition: [twitter, "includeRetweets"] },
+    screen_name: { propDefinition: [twitter, "screen_name"] },
+    includeRetweets: { propDefinition: [twitter, "includeRetweets"] },
     includeReplies: { propDefinition: [twitter, "includeReplies"] },
     enrichTweets: { propDefinition: [twitter, "enrichTweets"] },
     count: { propDefinition: [twitter, "count"] },
@@ -20,28 +20,25 @@ module.exports = {
         intervalSeconds: 60 * 15,
       },
     },
-  }, 
+  },
   methods: {},
   async run(event) {
     const screen_name = this.screen_name //.replace('@','')
     const since_id = this.db.get("since_id")
-    const { enrichTweets, includeReplies, include_rts, count } = this
+    const { enrichTweets, count } = this
     let max_id
 
-    if(!includeReplies) {
-      exclude_replies = true
-    } else {
-      exclude_replies = false
-    }
+    const shouldExcludeReplies = this.includeReplies === "exclude"
+    const shouldIncludeRetweets = this.includeRetweets !== "exclude"
 
     const tweets = await this.twitter.getUserTimeline({
       screen_name,
-      enrichTweets, 
-      exclude_replies: !includeReplies,
-      include_rts, 
+      enrichTweets,
+      exclude_replies: shouldExcludeReplies,
+      include_rts: shouldIncludeRetweets,
       count,
       since_id,
-    }) 
+    })
 
     // emit array of tweet objects
     if(tweets.length > 0) {

--- a/components/twitter/twitter.app.js
+++ b/components/twitter/twitter.app.js
@@ -61,24 +61,24 @@ module.exports = {
     includeRetweets: {
       type: "string",
       label: "Retweets",
-      description: "Select whether to `include`, `exclude` or `only` include retweets in emitted events.",
+      description: "Select whether to **include**, **exclude** or **only include** retweets in emitted events.",
       optional: true,
       options: [
         { label: "Include", value: "include" },
         { label: "Exclude", value: "exclude" },
-        { label: "Only include retweets", value: "only" },
+        { label: "Only include retweets", value: "filter" },
       ],
       default: "include",
     },
     includeReplies: {
       type: "string",
       label: "Replies",
-      description: "Select whether to `include`, `exclude` or `only` include replies in emitted events.",
+      description: "Select whether to **include**, **exclude** or **only include** replies in emitted events.",
       optional: true,
       options: [
         { label: "Include", value: "include" },
         { label: "Exclude", value: "exclude" },
-        { label: "Only include replies", value: "only" },
+        { label: "Only include replies", value: "filter" },
       ],
       default: "include",
     },
@@ -96,9 +96,10 @@ module.exports = {
       optional: true,
     },
     lang: {
-      type: "string",
-      label: "Language",
-      description: "Restricts tweets to the given language. Language detection is best-effort.",
+      type: "string[]",
+      label: "Languages",
+      description: "Restricts tweets to the given languages. Language detection is best-effort. When unsure, leave blank.",
+      default: [],
       optional: true,
       async options(context) {
         const { page } = context;
@@ -119,7 +120,7 @@ module.exports = {
             value: code,
           };
         })
-      }
+      },
     },
     screen_name: {
       type: "string",
@@ -258,7 +259,7 @@ module.exports = {
       })).data
     },
     async search(opts = {}) {
-      const { q, since_id, tweet_mode, count, result_type, lang, locale, geocode, max_id } = opts
+      const { q, since_id, tweet_mode, count, result_type, locale, geocode, max_id } = opts
       return (await this._makeRequest({
         url: `https://api.twitter.com/1.1/search/tweets.json`,
         params: {
@@ -268,7 +269,6 @@ module.exports = {
           tweet_mode,
           count,
           result_type,
-          lang,
           locale,
           geocode,
         }
@@ -328,26 +328,21 @@ module.exports = {
         locale,
         geocode,
         enrichTweets = true,
-        includeReplies = true,
-        includeRetweets = true,
+        includeReplies = "include",
+        includeRetweets = "include",
       } = opts
 
       let { q, max_id, since_id } = opts
       let min_id
 
-      if(includeReplies === 'exclude') {
-        q = `${q} -filter:replies`
-      } else if(includeReplies === 'only') {
-        q = `${q} filter:replies`
-      }
+      const langs = lang
+        .map(l => `lang:${l}`)
+        .join(" OR ")
+      q = `${q} ${langs}`
+      q = `${q} ${includeReplies}:replies`
+      q = `${q} ${includeRetweets}:nativeretweets`
 
-      if(includeRetweets === 'exclude') {
-        q = `${q} -filter:nativeretweets`
-      } else if(includeRetweets === 'only') {
-        q = `${q} filter:nativeretweets`
-      }
-
-      const response = await this.search({ q, since_id, tweet_mode, count, result_type, lang, locale, geocode, max_id })
+      const response = await this.search({ q, since_id, tweet_mode, count, result_type, locale, geocode, max_id })
 
       if(!response) {
         console.log(`Last request was not successful.`)


### PR DESCRIPTION
**Note: the change contains a lot of removed trailing whitespaces, so I suggest hiding those when doing your review**

Fixes issue #528

* Properly handle `includeRetweets` and `includeReplies` as strings
  instead of booleans
* Add new language option (**Undefined**) to allow for tweet searches
  where the tweet language was not identified
* Manage the `lang` property as a string array to allow users to fetch
  tweets of multiple languages (including "undefined"). This required
  setting the `lang` parameter as part of the search query instead of
  a URL query param.