### PR TITLE
Fix bug related to initial empty records being captured

### DIFF
--- a/components/airtable/sources/common.js
+++ b/components/airtable/sources/common.js
@@ -10,6 +10,7 @@ module.exports = {
         intervalSeconds: 60 * 5,
       },
     },
+    baseId: { type: "$.airtable.baseId", appProp: "airtable" },
   },
   hooks: {
     activate() {

--- a/components/airtable/sources/common.js
+++ b/components/airtable/sources/common.js
@@ -1,0 +1,23 @@
+const airtable = require("../airtable.app");
+
+module.exports = {
+  props: {
+    airtable,
+    db: "$.service.db",
+    timer: {
+      type: "$.interface.timer",
+      default: {
+        intervalSeconds: 60 * 5,
+      },
+    },
+  },
+  hooks: {
+    activate() {
+      const startTimestamp = new Date().toISOString();
+      this.db.set("lastTimestamp", startTimestamp);
+    },
+    deactivate() {
+      this.db.set("lastTimestamp", null);
+    },
+  },
+};

--- a/components/airtable/sources/new-modified-or-deleted-records/new-modified-or-deleted-records.js
+++ b/components/airtable/sources/new-modified-or-deleted-records/new-modified-or-deleted-records.js
@@ -18,7 +18,6 @@ module.exports = {
     "Emits an event each time a record is added, updated, or deleted in an Airtable table. Supports tables up to 10,000 records",
   props: {
     ...common.props,
-    baseId: { type: '$.airtable.baseId', appProp: 'airtable' },
     tableId: { type: '$.airtable.tableId', baseIdProp: 'baseId' },
   },
   async run(event) {

--- a/components/airtable/sources/new-modified-or-deleted-records/new-modified-or-deleted-records.js
+++ b/components/airtable/sources/new-modified-or-deleted-records/new-modified-or-deleted-records.js
@@ -1,7 +1,8 @@
-const airtable = require('../../airtable.app.js');
 const moment = require('moment');
 const axios = require('axios');
 const Bottleneck = require('bottleneck');
+
+const common = require('../common');
 
 const limiter = new Bottleneck({
   minTime: 200, // 5 requets per second
@@ -9,22 +10,16 @@ const limiter = new Bottleneck({
 const axiosRateLimiter = limiter.wrap(axios);
 
 module.exports = {
+  ...common,
   name: 'New, Modified or Deleted Records',
   key: 'airtable-new-modified-or-deleted-records',
-  version: '0.0.1',
+  version: '0.0.2',
   description:
     "Emits an event each time a record is added, updated, or deleted in an Airtable table. Supports tables up to 10,000 records",
   props: {
-    db: '$.service.db',
-    airtable,
+    ...common.props,
     baseId: { type: '$.airtable.baseId', appProp: 'airtable' },
     tableId: { type: '$.airtable.tableId', baseIdProp: 'baseId' },
-    timer: {
-      type: '$.interface.timer',
-      default: {
-        intervalSeconds: 60 * 5,
-      },
-    },
   },
   async run(event) {
     const { baseId, tableId, viewId } = this;
@@ -42,13 +37,11 @@ module.exports = {
       },
     };
 
-    const lastTimestamp = this.db.get('lastTimestamp');
     const prevAllRecordIds = this.db.get('prevAllRecordIds');
 
-    if (lastTimestamp) {
-      config.params.filterByFormula = `LAST_MODIFIED_TIME() > "${lastTimestamp}"`;
-    }
-    const timestamp = new Date().toISOString();
+    const lastTimestamp = this.db.get('lastTimestamp');
+    config.params.filterByFormula = `LAST_MODIFIED_TIME() > "${lastTimestamp}"`;
+
     const { data } = await axios(config);
 
     let allRecordIds = [],
@@ -113,6 +106,10 @@ module.exports = {
       `Emitted ${newRecordsCount} new records(s) and ${modifiedRecordsCount} modified record(s) and ${deletedRecordsCount} deleted records.`
     );
     this.db.set('prevAllRecordIds', allRecordIds);
-    this.db.set('lastTimestamp', timestamp);
+
+    // We keep track of the timestamp of the current invocation
+    const { timestamp } = event;
+    const formattedTimestamp = new Date(timestamp).toISOString();
+    this.db.set("lastTimestamp", formattedTimestamp);
   },
 };

--- a/components/airtable/sources/new-or-modified-records-in-view/new-or-modified-records-in-view.js
+++ b/components/airtable/sources/new-or-modified-records-in-view/new-or-modified-records-in-view.js
@@ -11,7 +11,6 @@ module.exports = {
   version: "0.0.3",
   props: {
     ...common.props,
-    baseId: { type: "$.airtable.baseId", appProp: "airtable" },
     tableId: { type: "$.airtable.tableId", baseIdProp: "baseId" },
     viewId: { type: "$.airtable.viewId", tableIdProp: "tableId" },
   },

--- a/components/airtable/sources/new-or-modified-records-in-view/new-or-modified-records-in-view.js
+++ b/components/airtable/sources/new-or-modified-records-in-view/new-or-modified-records-in-view.js
@@ -1,24 +1,19 @@
-const airtable = require('../../airtable.app.js')
 const moment = require('moment')
 const axios = require('axios')
 
+const common = require('../common')
+
 module.exports = {
+  ...common,
   name: "New or Modified Records in View",
   description: "Emit an event for each new or modified record in a view",
   key: 'airtable-new-or-modified-records-in-view',
-  version: "0.0.2",
+  version: "0.0.3",
   props: {
-    db: "$.service.db",
-    airtable,
+    ...common.props,
     baseId: { type: "$.airtable.baseId", appProp: "airtable" },
     tableId: { type: "$.airtable.tableId", baseIdProp: "baseId" },
     viewId: { type: "$.airtable.viewId", tableIdProp: "tableId" },
-    timer: {
-      type: "$.interface.timer",
-      default: {
-        intervalSeconds: 60 * 5,
-      },
-    },
   },
   async run(event) {
     const config = {
@@ -31,12 +26,10 @@ module.exports = {
       },
     }
 
-    
+
     const lastTimestamp = this.db.get("lastTimestamp")
-    if (lastTimestamp) {
-      config.params.filterByFormula = `LAST_MODIFIED_TIME() > "${lastTimestamp}"`
-    }
-    const timestamp = new Date().toISOString()
+    config.params.filterByFormula = `LAST_MODIFIED_TIME() > "${lastTimestamp}"`
+
     const { data } = await axios(config)
 
     if (!data.records.length) {
@@ -69,6 +62,10 @@ module.exports = {
       })
     }
     console.log(`Emitted ${newRecords} new records(s) and ${modifiedRecords} modified record(s).`)
-    this.db.set("lastTimestamp", timestamp)
+
+    // We keep track of the timestamp of the current invocation
+    const { timestamp } = event
+    const formattedTimestamp = new Date(timestamp).toISOString()
+    this.db.set("lastTimestamp", formattedTimestamp)
   },
 }

--- a/components/airtable/sources/new-or-modified-records/new-or-modified-records.js
+++ b/components/airtable/sources/new-or-modified-records/new-or-modified-records.js
@@ -11,7 +11,6 @@ module.exports = {
   version: "0.0.3",
   props: {
     ...common.props,
-    baseId: { type: "$.airtable.baseId", appProp: "airtable" },
     tableId: { type: "$.airtable.tableId", baseIdProp: "baseId" },
   },
   async run(event) {

--- a/components/airtable/sources/new-or-modified-records/new-or-modified-records.js
+++ b/components/airtable/sources/new-or-modified-records/new-or-modified-records.js
@@ -1,23 +1,18 @@
-const airtable = require('../../airtable.app.js')
 const moment = require('moment')
 const axios = require('axios')
 
+const common = require('../common')
+
 module.exports = {
+  ...common,
   name: "New or Modified Records",
   key: 'airtable-new-or-modified-records',
   description: "Emit an event for each new or modified record in a table",
-  version: "0.0.2",
+  version: "0.0.3",
   props: {
-    db: "$.service.db",
-    airtable,
+    ...common.props,
     baseId: { type: "$.airtable.baseId", appProp: "airtable" },
     tableId: { type: "$.airtable.tableId", baseIdProp: "baseId" },
-    timer: {
-      type: "$.interface.timer",
-      default: {
-        intervalSeconds: 60 * 5,
-      },
-    },
   },
   async run(event) {
     const config = {
@@ -29,10 +24,8 @@ module.exports = {
     }
 
     const lastTimestamp = this.db.get("lastTimestamp")
-    if (lastTimestamp) {
-      config.params.filterByFormula = `LAST_MODIFIED_TIME() > "${lastTimestamp}"`
-    }
-    const timestamp = new Date().toISOString()
+    config.params.filterByFormula = `LAST_MODIFIED_TIME() > "${lastTimestamp}"`
+
     const { data } = await axios(config)
 
     if (!data.records.length) {
@@ -66,6 +59,10 @@ module.exports = {
       })
     }
     console.log(`Emitted ${newRecords} new records(s) and ${modifiedRecords} modified record(s).`)
-    this.db.set("lastTimestamp", timestamp)
+
+    // We keep track of the timestamp of the current invocation
+    const { timestamp } = event
+    const formattedTimestamp = new Date(timestamp).toISOString()
+    this.db.set("lastTimestamp", formattedTimestamp)
   },
 }

--- a/components/airtable/sources/new-records-in-view/new-records-in-view.js
+++ b/components/airtable/sources/new-records-in-view/new-records-in-view.js
@@ -1,24 +1,19 @@
-const airtable = require('../../airtable.app.js')
 const moment = require('moment')
 const axios = require('axios')
 
+const common = require('../common')
+
 module.exports = {
+  ...common,
   name: "New Records in View",
   description: "Emit an event for each new record in a view",
   key: "airtable-new-records-in-view",
-  version: "0.0.2",
+  version: "0.0.3",
   props: {
-    db: "$.service.db",
-    airtable,
+    ...common.props,
     baseId: { type: "$.airtable.baseId", appProp: "airtable" },
     tableId: { type: "$.airtable.tableId", baseIdProp: "baseId" },
     viewId: { type: "$.airtable.viewId", tableIdProp: "tableId" },
-    timer: {
-      type: "$.interface.timer",
-      default: {
-        intervalSeconds: 60 * 5,
-      },
-    },
   },
   async run(event) {
     const config = {
@@ -31,12 +26,8 @@ module.exports = {
       },
     }
 
-    let maxTimestamp
-    const lastMaxTimestamp = this.db.get("lastMaxTimestamp")
-    if (lastMaxTimestamp) {
-      config.params.filterByFormula = `CREATED_TIME() > "${lastMaxTimestamp}"`
-      maxTimestamp = lastMaxTimestamp
-    }
+    const lastTimestamp = this.db.get("lastTimestamp")
+    config.params.filterByFormula = `CREATED_TIME() > "${lastTimestamp}"`
 
     const { data } = await axios(config)
 
@@ -53,6 +44,7 @@ module.exports = {
     }
 
 
+    let maxTimestamp
     let recordCount = 0
     for (let record of data.records) {
       record.metadata = metadata
@@ -68,6 +60,6 @@ module.exports = {
       recordCount++
     }
     console.log(`Emitted ${recordCount} new records(s).`)
-    this.db.set("lastMaxTimestamp", maxTimestamp)
+    this.db.set("lastTimestamp", maxTimestamp)
   },
 }

--- a/components/airtable/sources/new-records-in-view/new-records-in-view.js
+++ b/components/airtable/sources/new-records-in-view/new-records-in-view.js
@@ -11,7 +11,6 @@ module.exports = {
   version: "0.0.3",
   props: {
     ...common.props,
-    baseId: { type: "$.airtable.baseId", appProp: "airtable" },
     tableId: { type: "$.airtable.tableId", baseIdProp: "baseId" },
     viewId: { type: "$.airtable.viewId", tableIdProp: "tableId" },
   },

--- a/components/airtable/sources/new-records/new-records.js
+++ b/components/airtable/sources/new-records/new-records.js
@@ -11,7 +11,6 @@ module.exports = {
   version: "0.0.3",
   props: {
     ...common.props,
-    baseId: { type: "$.airtable.baseId", appProp: "airtable" },
     tableId: { type: "$.airtable.tableId", baseIdProp: "baseId" },
   },
   async run(event) {


### PR DESCRIPTION
Fixes #695

* Manage the "starting" timestamp through the components hooks in
  addition to doing it during `run()`, so that we only capture records
  created/updated/deleted after the activation of the event source.
* Refactored some common logic into a single common component for
  reusability