### PR TITLE
Code step exports `return` example clarification

### DIFF
--- a/docs/docs/workflows/steps/README.md
+++ b/docs/docs/workflows/steps/README.md
@@ -109,7 +109,7 @@ return {
 };
 ```
 
-When you use `return`, the exported data will appear at `steps.[STEP NAME].$return_value`. For example, if you ran the code above in a step named `nodejs`, you'd reference the returned data using `steps.nodejs.$return_value`.
+When you use `return`, the exported data will appear at `steps.[STEP NAME].$return_value`. For example, if you ran the code above in a step named `nodejs`, you'd reference the returned data using `steps.nodejs.$return_value.data`.
 
 Like with named exports, the returned data will appear below the step.
 


### PR DESCRIPTION
This clarifies how to use $return_value in the example given