### PR TITLE
Airtable Timestamp Filter Bug

### DIFF
--- a/components/airtable/sources/common.js
+++ b/components/airtable/sources/common.js
@@ -21,4 +21,12 @@ module.exports = {
       this.db.set("lastTimestamp", null);
     },
   },
+  methods: {
+    updateLastTimestamp(event) {
+      const { timestamp } = event;
+      const timestampMillis = timestamp ? timestamp * 1000 : Date.now();
+      const formattedTimestamp = new Date(timestampMillis).toISOString();
+      this.db.set("lastTimestamp", formattedTimestamp);
+    },
+  },
 };

--- a/components/airtable/sources/new-modified-or-deleted-records/new-modified-or-deleted-records.js
+++ b/components/airtable/sources/new-modified-or-deleted-records/new-modified-or-deleted-records.js
@@ -13,7 +13,7 @@ module.exports = {
   ...common,
   name: 'New, Modified or Deleted Records',
   key: 'airtable-new-modified-or-deleted-records',
-  version: '0.0.2',
+  version: '0.0.3',
   description:
     "Emits an event each time a record is added, updated, or deleted in an Airtable table. Supports tables up to 10,000 records",
   props: {
@@ -49,7 +49,7 @@ module.exports = {
       deletedRecordsCount = 0;
 
     if (data.records) {
-      for (let record of data.records) {
+      for (const record of data.records) {
         if (!lastTimestamp || moment(record.createdTime) > moment(lastTimestamp)) {
           record.type = 'new_record';
           newRecordsCount++;
@@ -84,12 +84,12 @@ module.exports = {
     }
 
     if (prevAllRecordIds) {
-      let deletedRecordIds = prevAllRecordIds.filter(
+      const deletedRecordIds = prevAllRecordIds.filter(
         prevRecord => !allRecordIds.includes(prevRecord)
       );
-      for (let recordID of deletedRecordIds) {
+      for (const recordID of deletedRecordIds) {
         deletedRecordsCount++;
-        deletedRecordObj = {
+        const deletedRecordObj = {
           metadata,
           type: "record_deleted",
           id: recordID
@@ -107,8 +107,6 @@ module.exports = {
     this.db.set('prevAllRecordIds', allRecordIds);
 
     // We keep track of the timestamp of the current invocation
-    const { timestamp } = event;
-    const formattedTimestamp = new Date(timestamp).toISOString();
-    this.db.set("lastTimestamp", formattedTimestamp);
+    this.updateLastTimestamp(event);
   },
 };

--- a/components/airtable/sources/new-or-modified-records-in-view/new-or-modified-records-in-view.js
+++ b/components/airtable/sources/new-or-modified-records-in-view/new-or-modified-records-in-view.js
@@ -8,7 +8,7 @@ module.exports = {
   name: "New or Modified Records in View",
   description: "Emit an event for each new or modified record in a view",
   key: 'airtable-new-or-modified-records-in-view',
-  version: "0.0.3",
+  version: "0.0.4",
   props: {
     ...common.props,
     tableId: { type: "$.airtable.tableId", baseIdProp: "baseId" },
@@ -44,7 +44,7 @@ module.exports = {
     }
 
     let newRecords = 0, modifiedRecords = 0
-    for (let record of data.records) {
+    for (const record of data.records) {
       if(!lastTimestamp || moment(record.createdTime) > moment(lastTimestamp)) {
         record.type = "new_record"
         newRecords++
@@ -63,8 +63,6 @@ module.exports = {
     console.log(`Emitted ${newRecords} new records(s) and ${modifiedRecords} modified record(s).`)
 
     // We keep track of the timestamp of the current invocation
-    const { timestamp } = event
-    const formattedTimestamp = new Date(timestamp).toISOString()
-    this.db.set("lastTimestamp", formattedTimestamp)
+    this.updateLastTimestamp(event);
   },
 }

--- a/components/airtable/sources/new-or-modified-records/new-or-modified-records.js
+++ b/components/airtable/sources/new-or-modified-records/new-or-modified-records.js
@@ -8,7 +8,7 @@ module.exports = {
   name: "New or Modified Records",
   key: 'airtable-new-or-modified-records',
   description: "Emit an event for each new or modified record in a table",
-  version: "0.0.3",
+  version: "0.0.4",
   props: {
     ...common.props,
     tableId: { type: "$.airtable.tableId", baseIdProp: "baseId" },
@@ -41,7 +41,7 @@ module.exports = {
 
 
     let newRecords = 0, modifiedRecords = 0
-    for (let record of data.records) {
+    for (const record of data.records) {
       if(!lastTimestamp || moment(record.createdTime) > moment(lastTimestamp)) {
         record.type = "new_record"
         newRecords++
@@ -60,8 +60,6 @@ module.exports = {
     console.log(`Emitted ${newRecords} new records(s) and ${modifiedRecords} modified record(s).`)
 
     // We keep track of the timestamp of the current invocation
-    const { timestamp } = event
-    const formattedTimestamp = new Date(timestamp).toISOString()
-    this.db.set("lastTimestamp", formattedTimestamp)
+    this.updateLastTimestamp(event);
   },
 }

--- a/components/airtable/sources/new-records-in-view/new-records-in-view.js
+++ b/components/airtable/sources/new-records-in-view/new-records-in-view.js
@@ -8,7 +8,7 @@ module.exports = {
   name: "New Records in View",
   description: "Emit an event for each new record in a view",
   key: "airtable-new-records-in-view",
-  version: "0.0.3",
+  version: "0.0.4",
   props: {
     ...common.props,
     tableId: { type: "$.airtable.tableId", baseIdProp: "baseId" },
@@ -45,7 +45,7 @@ module.exports = {
 
     let maxTimestamp
     let recordCount = 0
-    for (let record of data.records) {
+    for (const record of data.records) {
       record.metadata = metadata
 
       this.$emit(record, {

--- a/components/airtable/sources/new-records/new-records.js
+++ b/components/airtable/sources/new-records/new-records.js
@@ -8,7 +8,7 @@ module.exports = {
   name: "New Records",
   description: "Emit an event for each new record in a table",
   key: "airtable-new-records",
-  version: "0.0.3",
+  version: "0.0.4",
   props: {
     ...common.props,
     tableId: { type: "$.airtable.tableId", baseIdProp: "baseId" },
@@ -41,7 +41,7 @@ module.exports = {
 
     let maxTimestamp
     let recordCount = 0
-    for (let record of data.records) {
+    for (const record of data.records) {
       record.metadata = metadata
 
       this.$emit(record, {


### PR DESCRIPTION
Fixes #1081

* Fix the computation of the last timestamp being used by adapting the
  timestamp provided in the input event object into the Javascript
  millisecond-based timestamp
* Extract the logic of setting the last timestamp into the `common`
  module
* Bump versions of all Airtable components