### PR TITLE
Twitch: Poll for live streams instead of using webhooks

### DIFF
--- a/components/twitch/sources/followed-streams/followed-streams.js
+++ b/components/twitch/sources/followed-streams/followed-streams.js
@@ -1,40 +1,49 @@
-const common = require("../common-webhook.js");
+const common = require("../common-polling.js");
 
 module.exports = {
   ...common,
-  name: "Followed Streams (Instant)",
+  name: "Followed Streams",
   key: "twitch-followed-streams",
   description: "Emits an event when a followed stream is live.",
-  version: "0.0.2",
+  version: "0.0.3",
   methods: {
     ...common.methods,
-    async getTopics() {
-      // get the authenticated user
-      const { data: authenticatedUserData } = await this.twitch.getUsers();
-      const params = {
-        from_id: authenticatedUserData[0].id,
-      };
-      const items = await this.paginate(
-        this.twitch.getUserFollows.bind(this),
-        params
-      );
-      const topics = [];
-      for await (const item of items) {
-        topics.push(this.getTopicString(item));
-      }
-      return topics;
-    },
-    getTopicString(followed) {
-      return `streams?user_id=${followed.to_id}`;
-    },
-    getMeta(item, headers) {
-      const { started_at: startedAt, title: summary } = item;
+    getMeta(item) {
+      const { id, started_at: startedAt, title: summary } = item;
       const ts = new Date(startedAt).getTime();
       return {
-        id: headers["twitch-notification-id"],
+        id,
         summary,
         ts,
       };
     },
+  },
+  hooks: {
+    async deploy() {
+      // get the authenticated user
+      const { data: authenticatedUserData } = await this.twitch.getUsers();
+      this.db.set("authenticatedUserId", authenticatedUserData[0].id);
+    },
+  },
+  async run() {
+    const params = {
+      from_id: this.db.get("authenticatedUserId"),
+    };
+    // get the user_ids of the streamers followed by the authenticated user
+    const follows = await this.paginate(
+      this.twitch.getUserFollows.bind(this),
+      params
+    );
+    const followedIds = [];
+    for await (const follow of follows) {
+      followedIds.push(follow.to_id);
+    }
+    // get and emit streams for the followed streamers
+    const streams = await this.paginate(this.twitch.getStreams.bind(this), {
+      user_id: followedIds,
+    });
+    for await (const stream of streams) {
+      this.$emit(stream, this.getMeta(stream));
+    }
   },
 };


### PR DESCRIPTION
Twitch limits webhook subscriptions by Client ID.

> Limits: By default, each client ID can have at most 10,000 subscriptions. Also, you can subscribe to the same topic at most 3 times. 

https://dev.twitch.tv/docs/api/webhooks-guide

To allow more than 3 subscriptions to a user's streams across the app, we will poll for live streams instead of using a webhook subscription.