### PR TITLE
Removing acceptable use section of $send.http() docs to reduce

### DIFF
--- a/docs/docs/destinations/http/README.md
+++ b/docs/docs/destinations/http/README.md
@@ -86,8 +86,4 @@ When you make an HTTP request using `$send.http()`, the traffic will come from o
 
 This list may change over time. If you've previously whitelisted these IP addresses and are having trouble sending HTTP requests to your target service, please check to ensure this list matches your firewall rules.
 
-## Acceptable Use
-
-Do not use Pipedream to send HTTP requests to a service you do not own or operate. We take abuse of the service seriously and will terminate workflows or accounts found to be in violation of our [Acceptable Use policy](https://pipedream.com/terms#b-acceptable-use). If you have any questions about this policy or anything else, please [reach out](/support/).
-
 <Footer />

--- a/docs/docs/limits/README.md
+++ b/docs/docs/limits/README.md
@@ -86,7 +86,7 @@ Generally the rate of HTTP requests sent to an endpoint is quantified by QPS, or
 
 We'll also accept short bursts of traffic, as long as you remain close to an average of 10 QPS (e.g. sending a batch of 50 requests every 30 seconds should not trigger rate limiting).
 
-**This limit can be raised**. [Reach out to our team](/support/) to request an increase.
+**This limit can be raised for Professional, Teams, and Enterprise customers**. To request an increase, [reach out to our Support team](/support/) with the HTTP endpoint whose QPS you'd like to increase, with the new, desired limit.
 
 ## Email Triggers
 


### PR DESCRIPTION
confusion.

Noting that increasing the QPS of an endpoint is a Pro+ feature.