### PR TITLE
Calendly: emit Pipedream events for each invitee on events that support multiple invitees

### DIFF
--- a/components/calendly/calendly.app.js
+++ b/components/calendly/calendly.app.js
@@ -10,13 +10,13 @@ module.exports = {
       };
     },
     _getBaseURL() {
-      return "https://calendly.com/api/v1"
+      return "https://calendly.com/api/v1";
     },
     monthAgo() {
       const now = new Date();
       const monthAgo = new Date(now.getTime());
       monthAgo.setMonth(monthAgo.getMonth() - 1);
-      return monthAgo;
+      return Date.parse(monthAgo);
     },
     async getEventTypes() {
       return (
@@ -39,7 +39,7 @@ module.exports = {
         headers: this._getAuthHeader(),
         data,
       };
-      return (await axios(config));
+      return await axios(config);
     },
     async deleteHook(hookId) {
       const config = {

--- a/components/calendly/sources/common-polling.js
+++ b/components/calendly/sources/common-polling.js
@@ -1,0 +1,36 @@
+const calendly = require("../calendly.app.js");
+
+module.exports = {
+  props: {
+    calendly,
+    db: "$.service.db",
+    timer: {
+      type: "$.interface.timer",
+      default: {
+        intervalSeconds: 60 * 15,
+      },
+    },
+  },
+  methods: {
+    _getLastEvent() {
+      const lastEvent = this.db.get("lastEvent") || this.calendly.monthAgo();
+      return lastEvent;
+    },
+    _setLastEvent(lastEvent) {
+      this.db.set("lastEvent", lastEvent);
+    },
+  },
+  async run(event) {
+    const lastEvent = this._getLastEvent();
+
+    const results = await this.getResults();
+    for (const result of results) {
+      if (this.isRelevant(result, lastEvent)) {
+        const meta = this.generateMeta(result);
+        this.$emit(result, meta);
+      }
+    }
+
+    this._setLastEvent(Date.now());
+  },
+};

--- a/components/calendly/sources/common-webhook.js
+++ b/components/calendly/sources/common-webhook.js
@@ -25,7 +25,10 @@ module.exports = {
     },
   },
   methods: {
-    generateMeta(body) {
+    generateMeta() {
+      throw new Error("generateMeta is not implemented");
+    },
+    generateInviteeMeta(body) {
       const eventId = get(body, "payload.event.uuid");
       const inviteeId = get(body, "payload.invitee.uuid");
       const summary = get(body, "payload.event_type.name");

--- a/components/calendly/sources/common-webhook.js
+++ b/components/calendly/sources/common-webhook.js
@@ -1,0 +1,52 @@
+const calendly = require("../calendly.app.js");
+const get = require("lodash/get");
+
+module.exports = {
+  props: {
+    calendly,
+    db: "$.service.db",
+    http: {
+      type: "$.interface.http",
+      customResponse: true,
+    },
+  },
+  hooks: {
+    async activate() {
+      const events = this.getEvents();
+      const body = {
+        url: this.http.endpoint,
+        events,
+      };
+      const resp = await this.calendly.createHook(body);
+      this.db.set("hookId", resp.data.id);
+    },
+    async deactivate() {
+      await this.calendly.deleteHook(this.db.get("hookId"));
+    },
+  },
+  methods: {
+    generateMeta(body) {
+      const eventId = get(body, "payload.event.uuid");
+      const inviteeId = get(body, "payload.invitee.uuid");
+      const summary = get(body, "payload.event_type.name");
+      const ts = Date.parse(get(body, "time"));
+      return {
+        id: `${eventId}${inviteeId}`,
+        summary,
+        ts,
+      };
+    },
+  },
+  async run(event) {
+    const { body, headers } = event;
+
+    if (headers["x-calendly-hook-id"] != this.db.get("hookId")) {
+      return this.http.respond({ status: 404 });
+    }
+
+    this.http.respond({ status: 200 });
+
+    const meta = this.generateMeta(body);
+    this.$emit(body, meta);
+  },
+};

--- a/components/calendly/sources/invitee-canceled/invitee-canceled.js
+++ b/components/calendly/sources/invitee-canceled/invitee-canceled.js
@@ -12,5 +12,8 @@ module.exports = {
     getEvents() {
       return ["invitee.canceled"];
     },
+    generateMeta(body) {
+      return this.generateInviteeMeta(body);
+    },
   },
 };

--- a/components/calendly/sources/invitee-canceled/invitee-canceled.js
+++ b/components/calendly/sources/invitee-canceled/invitee-canceled.js
@@ -1,45 +1,16 @@
-const calendly = require("../../calendly.app.js");
+const common = require("../common-webhook.js");
 
 module.exports = {
+  ...common,
   key: "calendly-invitee-cancelled",
   name: "Invitee Cancelled (Instant)",
   description: "Emits an event when an invitee cancels a scheduled event",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
-  props: {
-    calendly,
-    db: "$.service.db",
-    http: {
-      type: "$.interface.http",
-      customResponse: true,
-    }
-  },
-
-  hooks: {
-    async activate() {
-      const body = {
-        url: this.http.endpoint,
-        events: ['invitee.canceled']
-      };
-      const resp = await this.calendly.createHook(body);
-      this.db.set("hookId", resp.data.id);
-    },
-    async deactivate() {
-      await this.calendly.deleteHook(this.db.get("hookId"));
+  methods: {
+    ...common.methods,
+    getEvents() {
+      return ["invitee.canceled"];
     },
   },
-
-  async run(event) {
-    if (event.headers["x-calendly-hook-id"] != this.db.get("hookId")) {
-      return this.http.respond({status: 404});
-    }
-
-    this.http.respond({status: 200});
-    
-    this.$emit(event.body, {
-      id: event.body.payload.event.uuid,
-      summary: event.body.payload.event_type.name,
-      ts: Date.now(),
-    });
-  }
-}
+};

--- a/components/calendly/sources/invitee-created/invitee-created.js
+++ b/components/calendly/sources/invitee-created/invitee-created.js
@@ -1,45 +1,16 @@
-const calendly = require("../../calendly.app.js");
+const common = require("../common-webhook.js");
 
 module.exports = {
+  ...common,
   key: "calendly-invitee-created",
   name: "Invitee Created (Instant)",
   description: "Emits an event when an invitee schedules an event",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
-  props: {
-    calendly,
-    db: "$.service.db",
-        http: {
-      type: "$.interface.http",
-      customResponse: true,
-    }
-  },
-
-  hooks: {
-    async activate() {
-      const body = {
-        url: this.http.endpoint,
-        events: ['invitee.created']
-      };
-      const resp = await this.calendly.createHook(body);
-      this.db.set("hookId", resp.data.id);
-    },
-    async deactivate() {
-      await this.calendly.deleteHook(this.db.get("hookId"));
+  methods: {
+    ...common.methods,
+    getEvents() {
+      return ["invitee.created"];
     },
   },
-
-  async run(event) {
-    if (event.headers["x-calendly-hook-id"] != this.db.get("hookId")) {
-      return this.http.respond({status: 404});
-    }
-
-    this.http.respond({status: 200});
-
-    this.$emit(event.body, {
-      id: event.body.payload.event.uuid,
-      summary: event.body.payload.event_type.name,
-      ts: Date.now(),
-    });
-  }
-}
+};

--- a/components/calendly/sources/invitee-created/invitee-created.js
+++ b/components/calendly/sources/invitee-created/invitee-created.js
@@ -12,5 +12,8 @@ module.exports = {
     getEvents() {
       return ["invitee.created"];
     },
+    generateMeta(body) {
+      return this.generateInviteeMeta(body);
+    },
   },
 };

--- a/components/calendly/sources/new-event-type/new-event-type.js
+++ b/components/calendly/sources/new-event-type/new-event-type.js
@@ -1,38 +1,28 @@
-const calendly = require("../../calendly.app.js");
+const common = require("../common-polling.js");
+const get = require("lodash/get");
 
 module.exports = {
+  ...common,
   key: "calendly-new-event-type",
   name: "New Event Type",
   description: "Emits an event for each new event type",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
-  props: {
-    calendly,
-    db: "$.service.db",
-    timer: {
-      type: "$.interface.timer",
-      default: {
-        intervalSeconds: 60 * 15,
-      },
+  methods: {
+    ...common.methods,
+    async getResults() {
+      return await this.calendly.getEventTypes();
     },
-  },
-
-  async run(event) {
-    let lastEvent = this.db.get("lastEvent") || this.calendly.monthAgo();
-    lastEvent = new Date(lastEvent);
-
-    const eventTypes = await this.calendly.getEventTypes();
-    for (const eventType of eventTypes) {
-      let created_at = new Date(eventType.attributes.created_at);
-      if (created_at.getTime() > lastEvent) {
-        this.$emit(eventType, {
-          id: eventType.id,
-          summary: eventType.attributes.name,
-          ts: Date.now(),
-        });
-      }
-    }
-
-    this.db.set("lastEvent", Date.now());
+    isRelevant(eventType, lastEvent) {
+      const createdAt = Date.parse(get(eventType, "attributes.created_at"));
+      return createdAt > lastEvent;
+    },
+    generateMeta({ id, attributes }) {
+      return {
+        id,
+        summary: attributes.name,
+        ts: Date.now(),
+      };
+    },
   },
 };

--- a/components/calendly/sources/new-event/new-event.js
+++ b/components/calendly/sources/new-event/new-event.js
@@ -1,39 +1,34 @@
-const calendly = require("../../calendly.app.js");
+const common = require("../common-polling.js");
+const get = require("lodash/get");
 
 module.exports = {
+  ...common,
   key: "calendly-new-event",
   name: "New Event",
   description: "Emits an event for each new event created",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
-  props: {
-    calendly,
-    db: "$.service.db",
-    timer: {
-      type: "$.interface.timer",
-      default: {
-        intervalSeconds: 60 * 15,
-      },
+  methods: {
+    ...common.methods,
+    async getResults() {
+      return await this.calendly.getEvents();
+    },
+    isRelevant(event, lastEvent) {
+      const createdAt = this.getCreatedAt(event);
+      return createdAt > lastEvent;
+    },
+    generateMeta(event) {
+      const { id } = event;
+      const createdAt = this.getCreatedAt(event);
+      const startTime = new Date(get(event, "attributes.start_time"));
+      return {
+        id,
+        summary: `New Event at ${startTime.toLocaleString()}`,
+        ts: Date.parse(createdAt),
+      };
+    },
+    getCreatedAt(event) {
+      return Date.parse(get(event, "attributes.created_at"));
     },
   },
-
-  async run(event) {
-    let lastEvent = this.db.get("lastEvent") || this.calendly.monthAgo();
-    lastEvent = new Date(lastEvent);
-
-    const events = await this.calendly.getEvents();
-    for (const event of events) {
-      let created_at = new Date(event.attributes.created_at);
-      let start_time = new Date(event.attributes.start_time);
-      if (created_at.getTime() > lastEvent) {
-        this.$emit(event, {
-          id: event.id,
-          summary: `New Event at ${start_time.toLocaleString()}`,
-          ts: created_at.getTime(),
-        });
-      }
-    }
-
-    this.db.set("lastEvent", Date.now());
-  }
 };


### PR DESCRIPTION
Updated the deduped meta ID to concatenate both the event ID and invitee ID, and also cleaned up the code.