### PR TITLE
Scope the linter command in the guide to a specific path

### DIFF
--- a/docs/docs/components/guidelines/README.md
+++ b/docs/docs/components/guidelines/README.md
@@ -110,17 +110,18 @@ run the following commands at the root of the project:
    npm ci
    ```
 
-2. To run the linter checks:
+2. To run the linter checks against your code (assuming that your changes are
+   located at `components/foo` for example):
 
    ```shell
-   npm run lint
+   npx eslint components/foo
    ```
 
 3. Optionally, you can automatically fix any linter issues by running the
    following command:
 
    ```bash
-   npm run lint:format
+   npx eslint --fix components/foo
    ```
 
 ### Process

--- a/docs/docs/components/guidelines/README.md
+++ b/docs/docs/components/guidelines/README.md
@@ -120,9 +120,12 @@ run the following commands at the root of the project:
 3. Optionally, you can automatically fix any linter issues by running the
    following command:
 
-   ```bash
+   ```shell
    npx eslint --fix components/foo
    ```
+
+   Keep in mind that not all issues can be automatically fixed by the linter
+   since they could alter the behaviour of the code.
 
 ### Process
 


### PR DESCRIPTION
Rephrasing the guideline docs section related to the linter usage, to scope it to a specific path.