### PR TITLE
Fix: Google Calendar to honor 'New Events Only' flag

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -36,6 +36,8 @@
   ],
   "root": true,
   "rules": {
+    "arrow-parens": "error",
+    "arrow-spacing": "error",
     "array-bracket-newline": [
       "error",
       {

--- a/interfaces/timer/examples/create-component/deploy-cron-job.js
+++ b/interfaces/timer/examples/create-component/deploy-cron-job.js
@@ -10,5 +10,5 @@ axios({
   },
   data,
 })
-  .then(res => console.log(res))
-  .catch(err => console.log(`Error: ${err}`));
+  .then((res) => console.log(res))
+  .catch((err) => console.log(`Error: ${err}`));


### PR DESCRIPTION
* Fix the logic around the detection of new vs updated calendar events
* Apply some reformatting to make the linter happy
* Enforce parenthesis around arrow function args
* Enforce spaces around arrow function's arrows

Fixes #1267 