### PR TITLE
Airtable refactor / improvements

### DIFF
--- a/components/airtable/actions/common-list.js
+++ b/components/airtable/actions/common-list.js
@@ -1,0 +1,65 @@
+// Shared code for list-* actions
+const airtable = require("../airtable.app.js");
+
+module.exports = {
+  props: {
+    sortFieldId: {
+      propDefinition: [
+        airtable,
+        "sortFieldId",
+      ],
+    },
+    sortDirection: {
+      propDefinition: [
+        airtable,
+        "sortDirection",
+      ],
+    },
+    maxRecords: {
+      propDefinition: [
+        airtable,
+        "maxRecords",
+      ],
+    },
+    filterByFormula: {
+      propDefinition: [
+        airtable,
+        "filterByFormula",
+      ],
+    },
+  },
+  async run() {
+    const base = this.airtable.base(this.baseId);
+    const data = [];
+    const config = {};
+
+    if (this.viewId) { config.view = this.viewId; }
+    if (this.filterByFormula) { config.filterByFormula = this.filterByFormula; }
+    if (this.maxRecords) { config.maxRecords = this.maxRecords; }
+    if (this.sortFieldId && this.sortDirection) {
+      config.sort = [
+        {
+          field: this.sortFieldId,
+          direction: this.sortDirection,
+        },
+      ];
+    }
+
+    await base(this.tableId).select({
+      ...config,
+    })
+      .eachPage(function page(records, fetchNextPage) {
+      // This function (`page`) will get called for each page of records.
+        records.forEach(function(record) {
+          data.push(record._rawJson);
+        });
+
+        // To fetch the next page of records, call `fetchNextPage`.
+        // If there are more records, `page` will get called again.
+        // If there are no more records, `done` will get called.
+        fetchNextPage();
+      });
+
+    return data;
+  },
+};

--- a/components/airtable/actions/common.js
+++ b/components/airtable/actions/common.js
@@ -1,0 +1,15 @@
+const airtable = require("../airtable.app.js");
+
+module.exports = {
+  props: {
+    airtable,
+    baseId: {
+      type: "$.airtable.baseId",
+      appProp: "airtable",
+    },
+    tableId: {
+      type: "$.airtable.tableId",
+      baseIdProp: "baseId",
+    },
+  },
+};

--- a/components/airtable/actions/create-multiple-records/create-multiple-records.js
+++ b/components/airtable/actions/create-multiple-records/create-multiple-records.js
@@ -1,43 +1,55 @@
-const airtable=require('../../airtable.app.js')
-const chunk = require('lodash.chunk')
-const Airtable = require('airtable')
+const airtable = require("../../airtable.app.js");
+const chunk = require("lodash.chunk");
+const common = require("../common.js");
 
 module.exports = {
   key: "airtable-create-multiple-records",
   name: "Create Multiple Records",
   description: "Create one or more records in a table by passing an array of objects containing field names and values as key/value pairs.",
-  version: "0.0.29",
+  version: "0.1.0",
   type: "action",
   props: {
-    airtable,
-    baseId: {type: "$.airtable.baseId", appProp: 'airtable'},
-    tableId: { type: '$.airtable.tableId', baseIdProp: 'baseId' },
-    records: { propDefinition: [airtable, "records"] },
+    ...common.props,
+    records: {
+      propDefinition: [
+        airtable,
+        "records",
+      ],
+    },
   },
   methods: {
     async addRecords(records) {
-      const base = new Airtable({apiKey: this.airtable.$auth.api_key}).base(this.baseId);
-      return await base(this.tableId).create(records)
+      const base = this.airtable.base(this.baseId);
+      return await base(this.tableId).create(records);
     },
   },
   async run() {
-    const records = []
-    let response_records = []
-    const BATCH_SIZE = 10; // Airtable API allows to update up to 10 rows per request.
+    let responseRecords = [];
+    const BATCH_SIZE = 10; // The Airtable API allows us to update up to 10 rows per request.
 
-    let inputRecords = this.records
+    let inputRecords = this.records;
 
-    if(!Array.isArray(inputRecords)) {
-      inputRecords = JSON.parse(inputRecords)
+    if (!Array.isArray(inputRecords)) {
+      inputRecords = JSON.parse(inputRecords);
     }
 
-    inputRecords.forEach(record => { records.push({ fields: record }) })
-    
-    const records_sets = chunk(records, BATCH_SIZE)
-    for (const records_set of records_sets) {        
-      response_records = response_records.concat((await this.addRecords(records_set)))
+    if (!inputRecords.length) {
+      throw new Error("No Airtable record data passed to step. Please pass at least one record");
     }
 
-    return response_records;
+    const records = inputRecords.map((record) => ({
+      fields: record,
+    }));
+
+    const chunkedRecords = chunk(records, BATCH_SIZE);
+    for (const chunk of chunkedRecords) {
+      try {
+        responseRecords = responseRecords.concat((await this.addRecords(chunk)));
+      } catch (err) {
+        this.airtable.throwFormattedError(err);
+      }
+    }
+
+    return responseRecords;
   },
-}
+};

--- a/components/airtable/actions/create-single-record/create-single-record.js
+++ b/components/airtable/actions/create-single-record/create-single-record.js
@@ -1,22 +1,32 @@
-const airtable=require('../../airtable.app.js')
+const airtable = require("../../airtable.app.js");
+const common = require("../common.js");
 
 module.exports = {
   key: "airtable-create-single-record",
   name: "Create single record",
-  description: "Create a record in a table.",
-  version: "0.0.11",
+  description: "Adds a record to a table.",
+  version: "0.1.0",
   type: "action",
   props: {
-    airtable,
-    baseId: {type: "$.airtable.baseId", appProp: 'airtable'},
-    tableId: { type: '$.airtable.tableId', baseIdProp: 'baseId' },
-    record: { propDefinition: [airtable, "record"] },
+    ...common.props,
+    record: {
+      propDefinition: [
+        airtable,
+        "record",
+      ],
+    },
   },
   async run() {
-    const Airtable = require('airtable');
-    const base = new Airtable({apiKey: this.airtable.$auth.api_key}).base(this.baseId);
-    return (await base(this.tableId).create([{
-      fields: this.record
-    }]))[0]
+    this.airtable.validateRecord(this.record);
+    const base = this.airtable.base(this.baseId);
+    try {
+      return (await base(this.tableId).create([
+        {
+          fields: this.record,
+        },
+      ]))[0];
+    } catch (err) {
+      this.airtable.throwFormattedError(err);
+    }
   },
-}
+};

--- a/components/airtable/actions/delete-record/delete-record.js
+++ b/components/airtable/actions/delete-record/delete-record.js
@@ -1,20 +1,28 @@
-const airtable=require('../../airtable.app.js')
+const airtable = require("../../airtable.app.js");
+const common = require("../common.js");
 
 module.exports = {
   key: "airtable-delete-record",
   name: "Delete Record",
-  description: "Delete a record from a table by `record_id`.",
-  version: "0.0.5",
+  description: "Delete a record from a table by record ID.",
+  version: "0.1.0",
   type: "action",
   props: {
-    airtable,
-    baseId: {type: "$.airtable.baseId", appProp: 'airtable'},
-    tableId: { type: '$.airtable.tableId', baseIdProp: 'baseId' },
-    recordId: { propDefinition: [airtable, "recordId"] },
+    ...common.props,
+    recordId: {
+      propDefinition: [
+        airtable,
+        "recordId",
+      ],
+    },
   },
-  async run() { 
-    const Airtable = require('airtable');
-    const base = new Airtable({apiKey: this.airtable.$auth.api_key}).base(this.baseId);
-    return await base(this.tableId).destroy(this.recordId)
+  async run() {
+    this.airtable.validateRecordID(this.recordId);
+    const base = this.airtable.base(this.baseId);
+    try {
+      return await base(this.tableId).destroy(this.recordId);
+    } catch (err) {
+      this.airtable.throwFormattedError(err);
+    }
   },
-}
+};

--- a/components/airtable/actions/get-record/get-record.js
+++ b/components/airtable/actions/get-record/get-record.js
@@ -1,20 +1,28 @@
-const airtable=require('../../airtable.app.js')
+const airtable = require("../../airtable.app.js");
+const common = require("../common.js");
 
 module.exports = {
   key: "airtable-get-record",
   name: "Get Record",
-  description: "Get a record from a table by `record_id`.",
-  version: "0.0.7",
+  description: "Get a record from a table by record ID.",
+  version: "0.0.8",
   type: "action",
   props: {
-    airtable,
-    baseId: {type: "$.airtable.baseId", appProp: 'airtable'},
-    tableId: { type: '$.airtable.tableId', baseIdProp: 'baseId' },
-    recordId: { propDefinition: [airtable, "recordId"] },
+    ...common.props,
+    recordId: {
+      propDefinition: [
+        airtable,
+        "recordId",
+      ],
+    },
   },
-  async run() { 
-    const Airtable = require('airtable');
-    const base = new Airtable({apiKey: this.airtable.$auth.api_key}).base(this.baseId);
-    return await base(this.tableId).find(this.recordId)
+  async run() {
+    this.airtable.validateRecordID(this.recordId);
+    const base = this.airtable.base(this.baseId);
+    try {
+      return await base(this.tableId).find(this.recordId);
+    } catch (err) {
+      this.airtable.raiseFormattedError(err);
+    }
   },
-}
+};

--- a/components/airtable/actions/get-record/get-record.js
+++ b/components/airtable/actions/get-record/get-record.js
@@ -5,7 +5,7 @@ module.exports = {
   key: "airtable-get-record",
   name: "Get Record",
   description: "Get a record from a table by record ID.",
-  version: "0.0.8",
+  version: "0.1.0",
   type: "action",
   props: {
     ...common.props,
@@ -22,7 +22,7 @@ module.exports = {
     try {
       return await base(this.tableId).find(this.recordId);
     } catch (err) {
-      this.airtable.raiseFormattedError(err);
+      this.airtable.throwFormattedError(err);
     }
   },
 };

--- a/components/airtable/actions/list-records-in-view/list-records-in-view.js
+++ b/components/airtable/actions/list-records-in-view/list-records-in-view.js
@@ -1,85 +1,19 @@
-const airtable = require("../../airtable.app.js");
+const common = require("../common.js");
+const commonList = require("../common-list.js");
 
 module.exports = {
   key: "airtable-list-records-in-view",
   name: "List Records in View",
   description: "Retrieve records in a view with automatic pagination. Optionally sort and filter results.",
   type: "action",
-  version: "0.0.9",
+  version: "0.1.0",
+  ...commonList,
   props: {
-    airtable,
-    baseId: {
-      type: "$.airtable.baseId",
-      appProp: "airtable",
-    },
-    tableId: {
-      type: "$.airtable.tableId",
-      baseIdProp: "baseId",
-    },
+    ...common.props,
     viewId: {
       type: "$.airtable.viewId",
       tableIdProp: "tableId",
     },
-    sortFieldId: {
-      propDefinition: [
-        airtable,
-        "sortFieldId",
-      ],
-    },
-    sortDirection: {
-      propDefinition: [
-        airtable,
-        "sortDirection",
-      ],
-    },
-    maxRecords: {
-      propDefinition: [
-        airtable,
-        "maxRecords",
-      ],
-    },
-    filterByFormula: {
-      propDefinition: [
-        airtable,
-        "filterByFormula",
-      ],
-    },
-  },
-  async run() {
-    var Airtable = require("airtable");
-    var base = new Airtable({
-      apiKey: this.airtable.$auth.api_key,
-    }).base(this.baseId);
-    const data = [];
-    const config = {};
-
-    config.view = this.viewId;
-    if (this.filterByFormula) { config.filterByFormula = this.filterByFormula; }
-    if (this.maxRecords) { config.maxRecords = this.maxRecords; }
-    if (this.sortFieldId && this.sortDirection) {
-      config.sort = [
-        {
-          field: this.sortFieldId,
-          direction: this.sortDirection,
-        },
-      ];
-    }
-
-    await base(this.tableId).select({
-      ...config,
-    })
-      .eachPage(function page(records, fetchNextPage) {
-      // This function (`page`) will get called for each page of records.
-        records.forEach(function(record) {
-          data.push(record._rawJson);
-        });
-
-        // To fetch the next page of records, call `fetchNextPage`.
-        // If there are more records, `page` will get called again.
-        // If there are no more records, `done` will get called.
-        fetchNextPage();
-      });
-
-    return data;
+    ...commonList.props,
   },
 };

--- a/components/airtable/actions/list-records-in-view/list-records-in-view.js
+++ b/components/airtable/actions/list-records-in-view/list-records-in-view.js
@@ -1,6 +1,6 @@
-const airtable = require('../../airtable.app.js')
+const airtable = require("../../airtable.app.js");
 
-module.exports = {  
+module.exports = {
   key: "airtable-list-records-in-view",
   name: "List Records in View",
   description: "Retrieve records in a view with automatic pagination. Optionally sort and filter results.",
@@ -8,41 +8,78 @@ module.exports = {
   version: "0.0.9",
   props: {
     airtable,
-    baseId: { type: "$.airtable.baseId", appProp: "airtable" },
-    tableId: { type: "$.airtable.tableId", baseIdProp: "baseId" },
-    viewId: { type: "$.airtable.viewId", tableIdProp: "tableId" },
-    sortFieldId: { propDefinition: [airtable, "sortFieldId"] },
-    sortDirection: { propDefinition: [airtable, "sortDirection"] },
-    maxRecords: { propDefinition: [airtable, "maxRecords"] },
-    filterByFormula: { propDefinition: [airtable, "filterByFormula"]},
+    baseId: {
+      type: "$.airtable.baseId",
+      appProp: "airtable",
+    },
+    tableId: {
+      type: "$.airtable.tableId",
+      baseIdProp: "baseId",
+    },
+    viewId: {
+      type: "$.airtable.viewId",
+      tableIdProp: "tableId",
+    },
+    sortFieldId: {
+      propDefinition: [
+        airtable,
+        "sortFieldId",
+      ],
+    },
+    sortDirection: {
+      propDefinition: [
+        airtable,
+        "sortDirection",
+      ],
+    },
+    maxRecords: {
+      propDefinition: [
+        airtable,
+        "maxRecords",
+      ],
+    },
+    filterByFormula: {
+      propDefinition: [
+        airtable,
+        "filterByFormula",
+      ],
+    },
   },
   async run() {
-    var Airtable = require('airtable');
-    var base = new Airtable({apiKey: this.airtable.$auth.api_key}).base(this.baseId);
-    const data = []
-    const config = {}
+    var Airtable = require("airtable");
+    var base = new Airtable({
+      apiKey: this.airtable.$auth.api_key,
+    }).base(this.baseId);
+    const data = [];
+    const config = {};
 
-    config.view = this.viewId
-    if (this.filterByFormula) { config.filterByFormula = this.filterByFormula }
-    if (this.maxRecords) { config.maxRecords = this.maxRecords }
+    config.view = this.viewId;
+    if (this.filterByFormula) { config.filterByFormula = this.filterByFormula; }
+    if (this.maxRecords) { config.maxRecords = this.maxRecords; }
     if (this.sortFieldId && this.sortDirection) {
-      config.sort = [{field: this.sortFieldId, direction: this.sortDirection}]
+      config.sort = [
+        {
+          field: this.sortFieldId,
+          direction: this.sortDirection,
+        },
+      ];
     }
 
     await base(this.tableId).select({
-        ...config,
-    }).eachPage(function page(records, fetchNextPage) {
-        // This function (`page`) will get called for each page of records.
-         records.forEach(function(record) {
-             data.push(record._rawJson)
-         });
+      ...config,
+    })
+      .eachPage(function page(records, fetchNextPage) {
+      // This function (`page`) will get called for each page of records.
+        records.forEach(function(record) {
+          data.push(record._rawJson);
+        });
 
         // To fetch the next page of records, call `fetchNextPage`.
         // If there are more records, `page` will get called again.
         // If there are no more records, `done` will get called.
         fetchNextPage();
-    })
+      });
 
-    return data
+    return data;
   },
-}
+};

--- a/components/airtable/actions/list-records/list-records.js
+++ b/components/airtable/actions/list-records/list-records.js
@@ -1,70 +1,15 @@
-const airtable = require("../../airtable.app.js");
 const common = require("../common.js");
+const commonList = require("../common-list.js");
 
 module.exports = {
   key: "airtable-list-records",
   name: "List Records",
   description: "Retrieve records from a table with automatic pagination. Optionally sort and filter results.",
   type: "action",
-  version: "0.0.1",
+  version: "0.1.0",
+  ...commonList,
   props: {
     ...common.props,
-    sortFieldId: {
-      propDefinition: [
-        airtable,
-        "sortFieldId",
-      ],
-    },
-    sortDirection: {
-      propDefinition: [
-        airtable,
-        "sortDirection",
-      ],
-    },
-    maxRecords: {
-      propDefinition: [
-        airtable,
-        "maxRecords",
-      ],
-    },
-    filterByFormula: {
-      propDefinition: [
-        airtable,
-        "filterByFormula",
-      ],
-    },
-  },
-  async run() {
-    const base = this.airtable.base(this.baseId);
-    const data = [];
-    const config = {};
-
-    if (this.filterByFormula) { config.filterByFormula = this.filterByFormula; }
-    if (this.maxRecords) { config.maxRecords = this.maxRecords; }
-    if (this.sortFieldId && this.sortDirection) {
-      config.sort = [
-        {
-          field: this.sortFieldId,
-          direction: this.sortDirection,
-        },
-      ];
-    }
-
-    await base(this.tableId).select({
-      ...config,
-    })
-      .eachPage(function page(records, fetchNextPage) {
-      // This function (`page`) will get called for each page of records.
-        records.forEach(function(record) {
-          data.push(record._rawJson);
-        });
-
-        // To fetch the next page of records, call `fetchNextPage`.
-        // If there are more records, `page` will get called again.
-        // If there are no more records, `done` will get called.
-        fetchNextPage();
-      });
-
-    return data;
+    ...commonList.props,
   },
 };

--- a/components/airtable/actions/list-records/list-records.js
+++ b/components/airtable/actions/list-records/list-records.js
@@ -1,46 +1,70 @@
-const airtable = require('../../airtable.app.js')
+const airtable = require("../../airtable.app.js");
+const common = require("../common.js");
 
-module.exports = {  
+module.exports = {
   key: "airtable-list-records",
   name: "List Records",
   description: "Retrieve records from a table with automatic pagination. Optionally sort and filter results.",
   type: "action",
-  version: "0.0.32",
+  version: "0.0.1",
   props: {
-    airtable,
-    baseId: { type: "$.airtable.baseId", appProp: "airtable" },
-    tableId: { type: "$.airtable.tableId", baseIdProp: "baseId" },
-    sortFieldId: { propDefinition: [airtable, "sortFieldId"] },
-    sortDirection: { propDefinition: [airtable, "sortDirection"] },
-    maxRecords: { propDefinition: [airtable, "maxRecords"] },
-    filterByFormula: { propDefinition: [airtable, "filterByFormula"]},
+    ...common.props,
+    sortFieldId: {
+      propDefinition: [
+        airtable,
+        "sortFieldId",
+      ],
+    },
+    sortDirection: {
+      propDefinition: [
+        airtable,
+        "sortDirection",
+      ],
+    },
+    maxRecords: {
+      propDefinition: [
+        airtable,
+        "maxRecords",
+      ],
+    },
+    filterByFormula: {
+      propDefinition: [
+        airtable,
+        "filterByFormula",
+      ],
+    },
   },
   async run() {
-    const Airtable = require('airtable');
-    const base = new Airtable({apiKey: this.airtable.$auth.api_key}).base(this.baseId);
-    const data = []
-    const config = {}
+    const base = this.airtable.base(this.baseId);
+    const data = [];
+    const config = {};
 
-    if (this.filterByFormula) { config.filterByFormula = this.filterByFormula }
-    if (this.maxRecords) { config.maxRecords = this.maxRecords }
+    if (this.filterByFormula) { config.filterByFormula = this.filterByFormula; }
+    if (this.maxRecords) { config.maxRecords = this.maxRecords; }
     if (this.sortFieldId && this.sortDirection) {
-      config.sort = [{field: this.sortFieldId, direction: this.sortDirection}]
+      config.sort = [
+        {
+          field: this.sortFieldId,
+          direction: this.sortDirection,
+        },
+      ];
     }
 
     await base(this.tableId).select({
-        ...config,
-    }).eachPage(function page(records, fetchNextPage) {
-        // This function (`page`) will get called for each page of records.
-         records.forEach(function(record) {
-             data.push(record._rawJson)
-         });
+      ...config,
+    })
+      .eachPage(function page(records, fetchNextPage) {
+      // This function (`page`) will get called for each page of records.
+        records.forEach(function(record) {
+          data.push(record._rawJson);
+        });
 
         // To fetch the next page of records, call `fetchNextPage`.
         // If there are more records, `page` will get called again.
         // If there are no more records, `done` will get called.
         fetchNextPage();
-    })
+      });
 
-    return data
+    return data;
   },
-}
+};

--- a/components/airtable/actions/update-record/update-record.js
+++ b/components/airtable/actions/update-record/update-record.js
@@ -1,24 +1,39 @@
-const airtable=require('../../airtable.app.js')
+const airtable = require("../../airtable.app.js");
+const common = require("../common.js");
 
 module.exports = {
   key: "airtable-update-record",
   name: "Update record",
-  description: "Update a record in a table by `record_id`.",
-  version: "0.0.5",
+  description: "Update a single record in a table by Record ID.",
+  version: "0.0.1",
   type: "action",
   props: {
-    airtable,
-    baseId: {type: "$.airtable.baseId", appProp: 'airtable'},
-    tableId: { type: '$.airtable.tableId', baseIdProp: 'baseId' },
-    recordId: { propDefinition: [airtable, "recordId"] },
-    record: { propDefinition: [airtable, "record"] },
+    ...common.props,
+    recordId: {
+      propDefinition: [
+        airtable,
+        "recordId",
+      ],
+    },
+    record: {
+      propDefinition: [
+        airtable,
+        "record",
+      ],
+    },
   },
   async run() {
-    const Airtable = require('airtable');
-    const base = new Airtable({apiKey: this.airtable.$auth.api_key}).base(this.baseId)
-    return (await base(this.tableId).update([{
-      id: this.recordId,
-      fields: this.record
-    }]))[0]
+    this.airtable.validateRecordID(this.recordId);
+    const base = this.airtable.base(this.baseId);
+    try {
+      return (await base(this.tableId).update([
+        {
+          id: this.recordId,
+          fields: this.record,
+        },
+      ]))[0];
+    } catch (err) {
+      this.airtable.raiseFormattedError(err);
+    }
   },
-}
+};

--- a/components/airtable/actions/update-record/update-record.js
+++ b/components/airtable/actions/update-record/update-record.js
@@ -5,7 +5,7 @@ module.exports = {
   key: "airtable-update-record",
   name: "Update record",
   description: "Update a single record in a table by Record ID.",
-  version: "0.0.1",
+  version: "0.1.0",
   type: "action",
   props: {
     ...common.props,
@@ -33,7 +33,7 @@ module.exports = {
         },
       ]))[0];
     } catch (err) {
-      this.airtable.raiseFormattedError(err);
+      this.airtable.throwFormattedError(err);
     }
   },
 };

--- a/components/airtable/airtable.app.js
+++ b/components/airtable/airtable.app.js
@@ -1,4 +1,5 @@
 const Airtable = require("airtable");
+const isEmpty = require("lodash/isEmpty");
 
 module.exports = {
   type: "app",
@@ -67,6 +68,17 @@ module.exports = {
     },
     throwFormattedError(err) {
       throw Error(`${err.error} - ${err.statusCode} - ${err.message}`);
+    },
+    validateRecord(record) {
+      if (typeof record !== "object") {
+        throw new Error("Airtable record isn't an object");
+      }
+      if (Array.isArray(record)) {
+        throw new Error("Airtable record is an array. Please pass an object, instead.");
+      }
+      if (isEmpty(record)) {
+        throw new Error("Airtable record data is empty");
+      }
     },
     validateRecordID(recordID) {
       if (!recordID) {

--- a/components/airtable/airtable.app.js
+++ b/components/airtable/airtable.app.js
@@ -65,12 +65,12 @@ module.exports = {
         apiKey: this.apiKey(),
       }).base(baseId);
     },
-    raiseFormattedError(err) {
+    throwFormattedError(err) {
       throw Error(`${err.error} - ${err.statusCode} - ${err.message}`);
     },
     validateRecordID(recordID) {
       if (!recordID) {
-        throw new Error("Record ID blank. Please pass a valid record ID");
+        throw new Error("Airtable record ID blank. Please pass a valid record ID");
       }
     },
   },

--- a/components/airtable/airtable.app.js
+++ b/components/airtable/airtable.app.js
@@ -66,7 +66,7 @@ module.exports = {
       }).base(baseId);
     },
     raiseFormattedError(err) {
-      throw Error(`${err.error} - ${err.statusCode} - ${err.message}`);
+      throw Error(`${err.error} - ${err.statusCode} - ${err.message}`);
     },
     validateRecordID(recordID) {
       if (!recordID) {

--- a/components/airtable/airtable.app.js
+++ b/components/airtable/airtable.app.js
@@ -1,3 +1,5 @@
+const Airtable = require("airtable");
+
 module.exports = {
   type: "app",
   app: "airtable",
@@ -6,7 +8,7 @@ module.exports = {
       type: "string",
       label: "Filter by Formula",
       description: "Optionally provide a [formula](https://support.airtable.com/hc/en-us/articles/203255215-Formula-Field-Reference) used to filter records. The formula will be evaluated for each record, and if the result is not `0`, `false`, `\"\"`, `NaN`, `[]`, or `#Error!` the record will be included in the response. For example, to only include records where `Name` isn't empty, pass `NOT({Name} = '')`.",
-      optional: true,      
+      optional: true,
     },
     maxRecords: {
       type: "integer",
@@ -17,35 +19,59 @@ module.exports = {
     record: {
       type: "object",
       label: "Record",
-      description: "Enter the column name for the key and the corresponding column value. You can include all, some, or none of the field values. You may also disable structured mode to pass a JSON object with key/value pairs representing columns and values."
+      description: "Enter the column name for the key and the corresponding column value. You can include all, some, or none of the field values. You may also disable structured mode to pass a JSON object with key/value pairs representing columns and values.",
     },
     recordId: {
       type: "string",
       label: "Record ID",
-      description: "Enter a [record ID](https://support.airtable.com/hc/en-us/articles/360051564873-Record-ID) (eg. `recxxxxxxx`).",   
+      description: "Enter a [record ID](https://support.airtable.com/hc/en-us/articles/360051564873-Record-ID) (eg. `recxxxxxxx`).",
     },
     records: {
       type: "string",
       label: "Records",
-      description: 'Provide an array of objects. Each object should represent a new record with the column name as the key and the data to insert as the corresponding value (e.g., passing `[{"foo":"bar","id":123},{"foo":"baz","id":456}]` will create two records and with values added to the fields `foo` and `id`). The most common pattern is to reference an array of objects exported by a previous step (e.g., `{{steps.foo.$return_value}}`). You may also enter or construct a string that will `JSON.parse()` to an array of objects.'
+      description: "Provide an array of objects. Each object should represent a new record with the column name as the key and the data to insert as the corresponding value (e.g., passing `[{\"foo\":\"bar\",\"id\":123},{\"foo\":\"baz\",\"id\":456}]` will create two records and with values added to the fields `foo` and `id`). The most common pattern is to reference an array of objects exported by a previous step (e.g., `{{steps.foo.$return_value}}`). You may also enter or construct a string that will `JSON.parse()` to an array of objects.",
     },
-    sortDirection: { 
-      type: "string", 
+    sortDirection: {
+      type: "string",
       label: "Sort: Direction",
       description: "This field will be ignored if you don't select a field to sort by.",
       options: [
-        { label: "Descending", value: "desc", },
-        { label: "Ascending", value: "asc" }
-      ], 
+        {
+          label: "Descending",
+          value: "desc",
+        },
+        {
+          label: "Ascending",
+          value: "asc",
+        },
+      ],
       default: "desc",
-      optional: true
+      optional: true,
     },
-    sortFieldId: { 
+    sortFieldId: {
       type: "$.airtable.fieldId",
-      tableIdProp: "tableId", 
+      tableIdProp: "tableId",
       label: "Sort: Field",
       description: "Optionally select a field to sort results. To sort by multiple fields, use the `Filter by Forumla` field.",
       optional: true,
     },
-  }
-}
+  },
+  methods: {
+    apiKey() {
+      return this.$auth.api_key;
+    },
+    base(baseId) {
+      return new Airtable({
+        apiKey: this.apiKey(),
+      }).base(baseId);
+    },
+    raiseFormattedError(err) {
+      throw Error(`${err.error} - ${err.statusCode} - ${err.message}`);
+    },
+    validateRecordID(recordID) {
+      if (!recordID) {
+        throw new Error("Record ID blank. Please pass a valid record ID");
+      }
+    },
+  },
+};

--- a/components/airtable/sources/common.js
+++ b/components/airtable/sources/common.js
@@ -10,7 +10,10 @@ module.exports = {
         intervalSeconds: 60 * 5,
       },
     },
-    baseId: { type: "$.airtable.baseId", appProp: "airtable" },
+    baseId: {
+      type: "$.airtable.baseId",
+      appProp: "airtable",
+    },
   },
   hooks: {
     activate() {
@@ -24,7 +27,9 @@ module.exports = {
   methods: {
     updateLastTimestamp(event) {
       const { timestamp } = event;
-      const timestampMillis = timestamp ? timestamp * 1000 : Date.now();
+      const timestampMillis = timestamp
+        ? timestamp * 1000
+        : Date.now();
       const formattedTimestamp = new Date(timestampMillis).toISOString();
       this.db.set("lastTimestamp", formattedTimestamp);
     },


### PR DESCRIPTION
A user in Slack encountered a generic error with the Airtable Update Record action:

![image (30)](https://user-images.githubusercontent.com/242668/120083282-78cb5000-c07c-11eb-9016-d16e24f5f3d2.png)

In this case, the issue was actually that `{{steps.get_record.id}}` returned `undefined`, so the update record object didn't contain a record ID, but that's hard to tell from this error message.

I added error handling to detect this case and raised an error telling the user the record ID they provided was blank. Then I refactored the rest of the action components:

* Linted components with the new ESLint rules
* Added the same error handling / validation for each component, providing specific error messages in other circumstances (failed to pass an object as a record, etc.)
* Adding `try` / `catch` logic in the components to catch and format errors returned from Airtable in a better way. The default error raised by the Airtable JS lib is hard to interpret, so I'm formatting the code / error message in a more readable way (see `throwFormattedError` method in the app file)
* Extracting common props / logic into `common.js` and `common-list.js` files.
* Revving `version` to `0.1.0` to communicate the added functionality.