### PR TITLE
Fix spellcheck workflow to always check a file

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -11,7 +11,8 @@ on:
       - master
 
 jobs:
-  build:
+
+  spellcheck-markdown-files:
     name: Spellcheck
     runs-on: ubuntu-latest
     steps:
@@ -19,6 +20,9 @@ jobs:
     - uses: jitterbit/get-changed-files@v1
       id: changed_files
     - id: md_changed_files
+      outputs:
+        files:
+          description: The files to check for spelling mistakes
       run: |-
         files=''
         for f in ${{ steps.changed_files.outputs.all }}
@@ -30,14 +34,14 @@ jobs:
           fi
         done
 
-        # Exiting early if no markdown files are part of the PR
-        [ -z "$files" ] && exit 0
-        echo "files=${files}" >> $GITHUB_ENV
+        echo "::set-output name=files::${files}"
     - uses: rojopolis/spellcheck-github-actions@0.14.0
       name: Spellcheck
+      if: ${{ steps.md_changed_files.outputs.files }}
       with:
-        source_files: ${{ env.files }}
+        source_files: ${{ steps.md_changed_files.outputs.files }}
         task_name: Markdown
+
   lint:
     name: Lint Code Base
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -30,10 +30,9 @@ jobs:
           fi
         done
 
-        # Setting the list of files to include at least one entry, since
-        # otherwise the spellcheck action might not work properly if no markdown
-        # files are part of the changed files.
-        echo "files=${files:-README.md}" >> $GITHUB_ENV
+        # Exiting early if no markdown files are part of the PR
+        [ -z "$files" ] && exit 0
+        echo "files=${files}" >> $GITHUB_ENV
     - uses: rojopolis/spellcheck-github-actions@0.14.0
       name: Spellcheck
       with:

--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -11,8 +11,7 @@ on:
       - master
 
 jobs:
-
-  spellcheck-markdown-files:
+  build:
     name: Spellcheck
     runs-on: ubuntu-latest
     steps:
@@ -20,9 +19,6 @@ jobs:
     - uses: jitterbit/get-changed-files@v1
       id: changed_files
     - id: md_changed_files
-      outputs:
-        files:
-          description: The files to check for spelling mistakes
       run: |-
         files=''
         for f in ${{ steps.changed_files.outputs.all }}
@@ -34,14 +30,13 @@ jobs:
           fi
         done
 
-        echo "::set-output name=files::${files}"
+        echo "files=${files}" >> $GITHUB_ENV
     - uses: rojopolis/spellcheck-github-actions@0.14.0
       name: Spellcheck
-      if: ${{ steps.md_changed_files.outputs.files }}
+      if: ${{ env.files }}
       with:
-        source_files: ${{ steps.md_changed_files.outputs.files }}
+        source_files: ${{ env.files }}
         task_name: Markdown
-
   lint:
     name: Lint Code Base
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -19,14 +19,21 @@ jobs:
     - uses: jitterbit/get-changed-files@v1
       id: changed_files
     - id: md_changed_files
-      run: |
-        files=''; for f in ${{ steps.changed_files.outputs.all }}; do
+      run: |-
+        files=''
+        for f in ${{ steps.changed_files.outputs.all }}
+        do
           ext="${f##*.}"
-          if [ $ext = "md" ]; then
+          if [ $ext = "md" ]
+          then
             files="${f} ${files}"
-          fi;
+          fi
         done
-        echo "files=${files}" >> $GITHUB_ENV
+
+        # Setting the list of files to include at least one entry, since
+        # otherwise the spellcheck action might not work properly if no markdown
+        # files are part of the changed files.
+        echo "files=${files:-README.md}" >> $GITHUB_ENV
     - uses: rojopolis/spellcheck-github-actions@0.14.0
       name: Spellcheck
       with:

--- a/interfaces/timer/README.md
+++ b/interfaces/timer/README.md
@@ -118,7 +118,7 @@ You can also deploy components using the [Pipedream UI](https://pipedream.com/so
 
 ### Run local Node code
 
-Create a local file, `job.js`, that contains the following Node codde:
+Create a local file, `job.js`, that contains the following Node code:
 
 ```javascript
 console.log("Hello, world");

--- a/interfaces/timer/README.md
+++ b/interfaces/timer/README.md
@@ -118,7 +118,7 @@ You can also deploy components using the [Pipedream UI](https://pipedream.com/so
 
 ### Run local Node code
 
-Create a local file, `job.js`, that contains the following Node code:
+Create a local file, `job.js`, that contains the following Node codde:
 
 ```javascript
 console.log("Hello, world");


### PR DESCRIPTION
The spellcheck PR workflow currently scans the entire repository if the PR does not modify any markdown files, which at the moment makes them fail due to the fact that some markdown files in the repo have spelling mistakes.

Example of a failed check:
https://github.com/PipedreamHQ/pipedream/runs/2788759237

The cause seems to be that when the corresponding Github action receives an empty string as the "input source files" it doesn't skip the checks but actually assumes the default behaviour (which is to scan the entire repository).

This change makes sure that the action is fed with at least one file to scan (`README.md` by default if the PR does not modify any markdown files).