### PR TITLE
Twist: Group Event Types & Sources

### DIFF
--- a/components/twist/event-types.js
+++ b/components/twist/event-types.js
@@ -3,30 +3,99 @@
 // but not yet available. Coming Soon!
 
 module.exports = [
-  { label: "Workspace Added", value: `workspace_added` },
-  { label: "Workspace Updated", value: `workspace_updated` },
+  {
+    label: "Workspace Added",
+    value: "workspace_added",
+  },
+  {
+    label: "Workspace Updated",
+    value: "workspace_updated",
+  },
   //  { label: "Workspace Deleted", value: `workspace_deleted` },
-  { label: "Workspace User Added", value: `workspace_user_added` },
-  { label: "Workspace User Updated", value: `workspace_user_updated` },
-  { label: "Workspace User Removed", value: `workspace_user_removed` },
-  { label: "Channel Added", value: `channel_added` },
-  { label: "Channel Updated", value: `channel_updated` },
-  { label: "Channel Deleted", value: `channel_deleted` },
-  { label: "Channel User Added", value: `channel_user_added` },
+  {
+    label: "Workspace User Added",
+    value: "workspace_user_added",
+  },
+  {
+    label: "Workspace User Updated",
+    value: "workspace_user_updated",
+  },
+  {
+    label: "Workspace User Removed",
+    value: "workspace_user_removed",
+  },
+  {
+    label: "Channel Added",
+    value: "channel_added",
+  },
+  {
+    label: "Channel Updated",
+    value: "channel_updated",
+  },
+  {
+    label: "Channel Deleted",
+    value: "channel_deleted",
+  },
+  {
+    label: "Channel User Added",
+    value: "channel_user_added",
+  },
   //  { label: "Channel User Updated", value: `channel_user_updated` },
-  { label: "Channel User Removed", value: `channel_user_removed` },
-  { label: "Thread Added", value: `thread_added` },
-  { label: "Thread Updated", value: `thread_updated` },
-  { label: "Thread Deleted", value: `thread_deleted` },
-  { label: "Comment Added", value: `comment_added` },
-  { label: "Comment Updated", value: `comment_updated` },
-  { label: "Comment Deleted", value: `comment_deleted` },
-  { label: "Message Added", value: `message_added` },
-  { label: "Message Updated", value: `message_updated` },
+  {
+    label: "Channel User Removed",
+    value: "channel_user_removed",
+  },
+  {
+    label: "Thread Added",
+    value: "thread_added",
+  },
+  {
+    label: "Thread Updated",
+    value: "thread_updated",
+  },
+  {
+    label: "Thread Deleted",
+    value: "thread_deleted",
+  },
+  {
+    label: "Comment Added",
+    value: "comment_added",
+  },
+  {
+    label: "Comment Updated",
+    value: "comment_updated",
+  },
+  {
+    label: "Comment Deleted",
+    value: "comment_deleted",
+  },
+  {
+    label: "Message Added",
+    value: "message_added",
+  },
+  {
+    label: "Message Updated",
+    value: "message_updated",
+  },
   //  { label: "Message Deleted", value: `message_deleted` },
-  //  { label: "Group Added", value: `group_added` },
-  //  { label: "Group Updated", value: `group_updated` },
-  //  { label: "Group Deleted", value: `group_deleted` },
-  //  { label: "Group User Added", value: `group_user_added` },
-  //  { label: "Group User Removed", value: `group_user_removed` },
+  {
+    label: "Group Added",
+    value: "group_added",
+  },
+  {
+    label: "Group Updated",
+    value: "group_updated",
+  },
+  {
+    label: "Group Deleted",
+    value: "group_deleted",
+  },
+  {
+    label: "Group User Added",
+    value: "group_user_added",
+  },
+  {
+    label: "Group User Removed",
+    value: "group_user_removed",
+  },
 ];

--- a/components/twist/sources/new-event/new-event.js
+++ b/components/twist/sources/new-event/new-event.js
@@ -4,19 +4,34 @@ const common = require("../common.js");
 module.exports = {
   ...common,
   name: "New Event (Instant)",
-  version: "0.0.1",
+  version: "0.0.2",
   key: "twist-new-event",
   description: "Emits an event for any new updates in a workspace",
   props: {
     ...common.props,
     channel: {
-      propDefinition: [twist, "channel", (c) => ({ workspace: c.workspace })],
+      propDefinition: [
+        twist,
+        "channel",
+        (c) => ({
+          workspace: c.workspace,
+        }),
+      ],
     },
     thread: {
-      propDefinition: [twist, "thread", (c) => ({ channel: c.channel })],
+      propDefinition: [
+        twist,
+        "thread",
+        (c) => ({
+          channel: c.channel,
+        }),
+      ],
     },
     eventType: {
-      propDefinition: [twist, "eventType"],
+      propDefinition: [
+        twist,
+        "eventType",
+      ],
     },
   },
   methods: {
@@ -30,9 +45,13 @@ module.exports = {
       };
     },
     getMeta(body) {
-      const { name, id, created } = body;
-      return {
+      const {
+        name,
         id,
+        created = Date.now(),
+      } = body;
+      return {
+        id: `${id}${created}`,
         summary: name || "New Event",
         ts: Date.parse(created),
       };

--- a/components/twist/sources/new-group-user/new-group-user.js
+++ b/components/twist/sources/new-group-user/new-group-user.js
@@ -1,0 +1,30 @@
+const common = require("../common.js");
+
+module.exports = {
+  ...common,
+  name: "New Group User(Instant)",
+  version: "0.0.1",
+  key: "twist-new-group-user",
+  description: "Emits an event for any new user added to a workspace group.",
+  methods: {
+    getHookActivationData() {
+      return {
+        target_url: this.http.endpoint,
+        event: "group_user_added",
+        workspace_id: this.workspace,
+      };
+    },
+    getMeta(body) {
+      const {
+        id,
+        name,
+        user_ids: userIds,
+      } = body;
+      return {
+        id: `${id}${userIds}`,
+        summary: name,
+        ts: Date.now(),
+      };
+    },
+  },
+};

--- a/components/twist/sources/new-group/new-group.js
+++ b/components/twist/sources/new-group/new-group.js
@@ -1,0 +1,29 @@
+const common = require("../common.js");
+
+module.exports = {
+  ...common,
+  name: "New Group (Instant)",
+  version: "0.0.1",
+  key: "twist-new-group",
+  description: "Emits an event for any new group added in a workspace",
+  methods: {
+    getHookActivationData() {
+      return {
+        target_url: this.http.endpoint,
+        event: "group_added",
+        workspace_id: this.workspace,
+      };
+    },
+    getMeta(body) {
+      const {
+        id,
+        name,
+      } = body;
+      return {
+        id,
+        summary: name,
+        ts: Date.now(),
+      };
+    },
+  },
+};


### PR DESCRIPTION
Group related event types (group_added, group_updated, group_deleted, group_user_added, and group_user_removed) are now available through via webhook. This PR adds those event types to event-types.js and adds two new event sources: new-group.js & new-group-user.js