### PR TITLE
Replaced broken link to contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ See a gap or mistake in our [docs](https://github.com/PipedreamHQ/pipedream/tree
 
 ## Develop Sources and Actions
 
-[Contribute](COMPONENT-GUIDELINES.md) to Pipedream's registry of open source components by:
+[Contribute](https://pipedream.com/docs/components/guidelines/) to Pipedream's registry of open source components by:
 
 - Creating new components (sources and actions)
 - Updating existing components (e.g., fixing bugs, enhancing functionality)


### PR DESCRIPTION
The existing link (COMPONENT-GUIDELINES.md) gave me a 404 error. I found this page on the pipedream website that looks like a good replacement: https://pipedream.com/docs/components/guidelines/