### PR TITLE
Fix typo and attempt to fix broken link

### DIFF
--- a/docs/docs/components/guidelines/README.md
+++ b/docs/docs/components/guidelines/README.md
@@ -237,7 +237,7 @@ directory](https://github.com/pipedreamhq/pipedream/components).
 
 #### Using APIs vs Client Libraries
 
-Use If the app has a well-supported [Node.js client
+If the app has a well-supported [Node.js client
 library](../api/#using-npm-packages), that should be preferred to manually
 constructed API requests to reduce code and improve maintenance.
 

--- a/docs/docs/components/guidelines/README.md
+++ b/docs/docs/components/guidelines/README.md
@@ -233,7 +233,7 @@ Registry components are organized by app in the `components` directory of the
   `/components/twitter/sources/search-mentions/search-mentions.js`.
 
 You can explore examples in the [components
-directory](https://github.com/pipedreamhq/pipedream/components).
+directory](https://github.com/pipedreamhq/pipedream/tree/master/components).
 
 #### Using APIs vs Client Libraries
 

--- a/docs/docs/components/quickstart/nodejs/actions/README.md
+++ b/docs/docs/components/quickstart/nodejs/actions/README.md
@@ -442,7 +442,7 @@ Select an existing account or connect a new one, and then deploy your workflow a
 
 ## What's Next?
 
-You're ready to start authoring and publishing actions on Pipedream! You can also check out the [detailed component reference](components/api/#component-api) at any time!
+You're ready to start authoring and publishing actions on Pipedream! You can also check out the [detailed component reference](/components/api/#component-api) at any time!
 
 If you have any questions or feedback, please [reach out](https://pipedream.com/community)!
 

--- a/docs/docs/components/quickstart/nodejs/actions/README.md
+++ b/docs/docs/components/quickstart/nodejs/actions/README.md
@@ -442,7 +442,7 @@ Select an existing account or connect a new one, and then deploy your workflow a
 
 ## What's Next?
 
-You're ready to start authoring and publishing actions on Pipedream! You can also check out the [detailed component reference](api/#component-api) at any time!
+You're ready to start authoring and publishing actions on Pipedream! You can also check out the [detailed component reference](components/api/#component-api) at any time!
 
 If you have any questions or feedback, please [reach out](https://pipedream.com/community)!
 

--- a/docs/docs/components/quickstart/nodejs/actions/README.md
+++ b/docs/docs/components/quickstart/nodejs/actions/README.md
@@ -442,7 +442,7 @@ Select an existing account or connect a new one, and then deploy your workflow a
 
 ## What's Next?
 
-You're ready to start authoring and publishing actions on Pipedream! You can also check out the [detailed component reference](/components/#actions) at any time!
+You're ready to start authoring and publishing actions on Pipedream! You can also check out the [detailed component reference](/components/api/#component-api) at any time!
 
 If you have any questions or feedback, please [reach out](https://pipedream.com/community)!
 

--- a/docs/docs/components/quickstart/nodejs/actions/README.md
+++ b/docs/docs/components/quickstart/nodejs/actions/README.md
@@ -442,7 +442,7 @@ Select an existing account or connect a new one, and then deploy your workflow a
 
 ## What's Next?
 
-You're ready to start authoring and publishing actions on Pipedream! You can also check out the [detailed component reference](COMPONENT-API.md) at any time!
+You're ready to start authoring and publishing actions on Pipedream! You can also check out the [detailed component reference](api/#component-api) at any time!
 
 If you have any questions or feedback, please [reach out](https://pipedream.com/community)!
 

--- a/docs/docs/components/quickstart/nodejs/actions/README.md
+++ b/docs/docs/components/quickstart/nodejs/actions/README.md
@@ -442,7 +442,7 @@ Select an existing account or connect a new one, and then deploy your workflow a
 
 ## What's Next?
 
-You're ready to start authoring and publishing actions on Pipedream! You can also check out the [detailed component reference](/components/api/#component-api) at any time!
+You're ready to start authoring and publishing actions on Pipedream! You can also check out the [detailed component reference](/components/#actions) at any time!
 
 If you have any questions or feedback, please [reach out](https://pipedream.com/community)!
 


### PR DESCRIPTION
I'm not sure if my updated link is correct — I couldn't figure out how to test it. But the old link was broken and I think it is supposed to point here: https://pipedream.com/docs/components/api/#component-api