### PR TITLE
Upgrade Mailgun Verify action to v4 API

### DIFF
--- a/components/mailgun/actions/send-email/send-email.js
+++ b/components/mailgun/actions/send-email/send-email.js
@@ -4,7 +4,7 @@ module.exports = {
   key: "mailgun-send-email",
   name: "Mailgun Send Email",
   description: "Send email with Mailgun.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     mailgun,

--- a/components/mailgun/actions/suppress-email/suppress-email.js
+++ b/components/mailgun/actions/suppress-email/suppress-email.js
@@ -4,7 +4,7 @@ module.exports = {
   key: "mailgun-suppress-email",
   name: "Mailgun Suppress Email",
   description: "Add email to the Mailgun suppression list.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     mailgun,

--- a/components/mailgun/actions/verify-email/verify-email.js
+++ b/components/mailgun/actions/verify-email/verify-email.js
@@ -4,7 +4,7 @@ module.exports = {
   key: "mailgun-verify-email",
   name: "Mailgun Verify Email",
   description: "Verify email address deliverability with Mailgun.",
-  version: "0.0.1",
+  version: "0.0.3",
   type: "action",
   props: {
     mailgun,
@@ -23,7 +23,9 @@ module.exports = {
   },
   async run () {
     try {
-      return await this.mailgun.api("validate").get(this.email);
+      return await this.mailgun.api("request").get("/v4/address/validate", {
+        address: this.email,
+      });
     } catch (err) {
       if (this.haltOnError) {
         throw err;

--- a/components/mailgun/mailgun.app.js
+++ b/components/mailgun/mailgun.app.js
@@ -11,7 +11,6 @@ module.exports = {
       const mg = mailgun.client({
         username: "api",
         key: this.$auth.api_key,
-        public_key: this.$auth.api_key,
       });
       return mg[api];
     },
@@ -42,7 +41,7 @@ module.exports = {
           skip: 50 * page,
         };
         const domains = await this.api("domains").list(query);
-        return domains.map(domain => domain.name);
+        return domains.map((domain) => domain.name);
       },
     },
     email: {

--- a/components/mailgun/mailgun.app.js
+++ b/components/mailgun/mailgun.app.js
@@ -48,6 +48,24 @@ module.exports = {
       type: "string",
       label: "Email Address",
     },
+    acceptableRiskLevels: {
+      type: "string[]",
+      label: "Acceptable Risk Levels",
+      description: "If set, workflow execution will stop at this step if the email risk is not " +
+        "in this list",
+      options: [
+        "high",
+        "medium",
+        "low",
+        "unknown",
+      ],
+      default: [
+        "medium",
+        "low",
+        "unknown",
+      ],
+      optional: true,
+    },
     haltOnError: {
       type: "boolean",
       label: "Halt on error?",


### PR DESCRIPTION
The `mailgun.js` API client currently uses the old v3 validation API.

Current API documentation: https://documentation.mailgun.com/en/latest/api-email-validation.html#single-validation

Also adds an option to stop execution if the email is invalid.