### PR TITLE
GitHub: changes to event deduplication, ESLint fixes

### DIFF
--- a/components/github/github.app.js
+++ b/components/github/github.app.js
@@ -9,6 +9,7 @@ module.exports = {
     repoFullName: {
       type: "string",
       label: "Repo",
+      description: "The name of your repository (the `pipedream` in `PipedreamHQ/pipedream`",
       async options({ page }) {
         const repos = await this.getRepos({
           page: page + 1, // pipedream page 0-indexed, github is 1
@@ -19,6 +20,7 @@ module.exports = {
     org: {
       type: "string",
       label: "Organization",
+      description: "The name of your organization (the `PipedreamHQ` in `PipedreamHQ/pipedream`",
       async options({ page }) {
         const orgs = await this.getOrgs({
           page: page + 1, // pipedream page 0-indexed, github is 1
@@ -30,6 +32,7 @@ module.exports = {
     branch: {
       type: "string",
       label: "Branch",
+      description: "The name of your branch",
       async options({
         page, repoFullName,
       }) {
@@ -44,11 +47,13 @@ module.exports = {
     events: {
       type: "string[]",
       label: "Events",
+      description: "The types of events you'd like to listen for. [See the GitHub docs](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads) for details on each.",
       options: listOfEvents,
     },
     labels: {
       type: "string[]",
       label: "Labels",
+      description: "Labels attached to issues or PRs",
       async options({
         page, repoFullName,
       }) {
@@ -67,6 +72,7 @@ module.exports = {
     labelNames: {
       type: "string[]",
       label: "Labels",
+      description: "Labels attached to issues or PRs",
       async options({
         page, repoFullName,
       }) {
@@ -82,6 +88,7 @@ module.exports = {
     milestone: {
       type: "string",
       label: "Milestone",
+      description: "[See the GitHub docs](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones)",
       async options({
         page, repoFullName,
       }) {
@@ -98,8 +105,10 @@ module.exports = {
       },
     },
     order: {
+      label: "Result order",
       type: "string",
       optional: true,
+      description: "Order of returned results",
       options: [
         {
           label: "Descending",
@@ -113,14 +122,16 @@ module.exports = {
       default: "desc",
     },
     per_page: {
+      label: "Results per page",
       type: "integer",
-      description: "Results per page (max `100`)",
+      description: "The number of results to return per page (max `100`)",
       optional: true,
       default: 100,
     },
     page: {
+      label: "Page number",
       type: "integer",
-      description: "Page number of the results to fetch.",
+      description: "Page number of the results to fetch",
       optional: true,
     },
     paginate: {

--- a/components/github/sources/common-webhook.js
+++ b/components/github/sources/common-webhook.js
@@ -3,15 +3,20 @@ const github = require("../github.app.js");
 module.exports = {
   props: {
     github,
-    repoFullName: { propDefinition: [github, "repoFullName"] },
+    repoFullName: {
+      propDefinition: [
+        github,
+        "repoFullName",
+      ],
+    },
     http: "$.interface.http",
     db: "$.service.db",
   },
   methods: {
-    emitEvent(body) {
+    emitEvent(body, id) {
       const eventTypes = this.getEventTypes();
       if (eventTypes.includes(body.action)) {
-        const meta = this.generateMeta(body);
+        const meta = this.generateMeta(body, id);
         this.$emit(body, meta);
       }
     },
@@ -37,7 +42,10 @@ module.exports = {
     },
   },
   async run(event) {
-    const { body, headers } = event;
+    const {
+      body,
+      headers,
+    } = event;
 
     if (headers["X-Hub-Signature"]) {
       const crypto = require("crypto");
@@ -54,6 +62,6 @@ module.exports = {
       return;
     }
 
-    this.emitEvent(body);
+    this.emitEvent(body, headers["x-github-delivery"]);
   },
 };

--- a/components/github/sources/custom-webhook-events/custom-webhook-events.js
+++ b/components/github/sources/custom-webhook-events/custom-webhook-events.js
@@ -6,8 +6,9 @@ module.exports = {
   key: "github-custom-events",
   name: "Custom Webhook Events",
   description:
-    "Subscribe to one or more event types and emit an event on each webhook request",
-  version: "0.0.4",
+    "Emit new events of selected types",
+  type: "source",
+  version: "0.0.5",
   props: {
     ...common.props,
     events: {
@@ -22,16 +23,16 @@ module.exports = {
     getEventNames() {
       return this.events;
     },
-    generateMeta(data) {
+    generateMeta(data, id) {
       const ts = Date.now();
       return {
-        id: `${data.repository.id}${ts}`,
+        id,
         summary: `${data.action} event by ${data.sender.login}`,
         ts,
       };
     },
-    emitEvent(body) {
-      const meta = this.generateMeta(body);
+    emitEvent(body, id) {
+      const meta = this.generateMeta(body, id);
       this.$emit(body, meta);
     },
   },

--- a/components/github/sources/new-branch/new-branch.js
+++ b/components/github/sources/new-branch/new-branch.js
@@ -1,16 +1,21 @@
 const common = require("../common-webhook.js");
-const eventTypes = ["branch"];
+const eventTypes = [
+  "branch",
+];
 
 module.exports = {
   ...common,
   key: "github-new-branch",
   name: "New Branch (Instant)",
-  description: "Emit an event when a new branch is created",
-  version: "0.0.3",
+  description: "Emit new events when a new branch is created",
+  version: "0.0.4",
   dedupe: "unique",
+  type: "source",
   methods: {
     getEventNames() {
-      return ["create"];
+      return [
+        "create",
+      ];
     },
     generateMeta(data) {
       const ts = Date.now();

--- a/components/github/sources/new-collaborator/new-collaborator.js
+++ b/components/github/sources/new-collaborator/new-collaborator.js
@@ -4,16 +4,21 @@ module.exports = {
   ...common,
   key: "github-new-collaborator",
   name: "New Collaborator (Instant)",
-  description: "Emit an event when a new collaborator is added to a repo",
-  version: "0.0.1",
+  description: "Emit new events when collaborators are added to a repo",
+  version: "0.0.2",
   dedupe: "unique",
+  type: "source",
   methods: {
     ...common.methods,
     getEventNames() {
-      return ["member"];
+      return [
+        "member",
+      ];
     },
     getEventTypes() {
-      return ["added"];
+      return [
+        "added",
+      ];
     },
     generateMeta(data) {
       const ts = Date.now();

--- a/components/github/sources/new-commit-comment/new-commit-comment.js
+++ b/components/github/sources/new-commit-comment/new-commit-comment.js
@@ -4,23 +4,28 @@ module.exports = {
   ...common,
   key: "github-new-commit-comment",
   name: "New Commit Comment (Instant)",
-  description: "Emit an event when a new commit comment is created",
-  version: "0.0.3",
+  description: "Emit new events on new commit comments",
+  version: "0.0.5",
+  type: "source",
   dedupe: "unique",
   methods: {
     ...common.methods,
     getEventNames() {
-      return ["commit_comment"];
+      return [
+        "commit_comment",
+      ];
     },
     getEventTypes() {
-      return ["created"];
+      return [
+        "created",
+      ];
     },
-    generateMeta(data) {
+    generateMeta(data, id) {
       const ts = data.comment.updated_at
         ? Date.parse(data.comment.updated_at)
         : Date.parse(data.comment.created_at);
       return {
-        id: `${data.comment.id}${ts}`,
+        id,
         summary: `${data.comment.user.login}: ${data.comment.body}`,
         ts,
       };

--- a/components/github/sources/new-commit/new-commit.js
+++ b/components/github/sources/new-commit/new-commit.js
@@ -5,16 +5,24 @@ module.exports = {
   ...common,
   key: "github-new-commit",
   name: "New Commit",
-  description: "Emit an event on new commit to a repo or branch",
-  version: "0.0.2",
+  description: "Emit new events on new commits to a repo or branch",
+  version: "0.0.3",
+  type: "source",
   props: {
     ...common.props,
-    repoFullName: { propDefinition: [github, "repoFullName"] },
+    repoFullName: {
+      propDefinition: [
+        github,
+        "repoFullName",
+      ],
+    },
     branch: {
       propDefinition: [
         github,
         "branch",
-        (c) => ({ repoFullName: c.repoFullName }),
+        (c) => ({
+          repoFullName: c.repoFullName,
+        }),
       ],
       description:
         "Branch to monitor for new commits. If no branch is selected, the repository’s default branch will be used (usually master).",
@@ -31,7 +39,7 @@ module.exports = {
       };
     },
   },
-  async run(event) {
+  async run() {
     const since = this.db.get("since");
 
     const config = {

--- a/components/github/sources/new-fork/new-fork.js
+++ b/components/github/sources/new-fork/new-fork.js
@@ -4,12 +4,15 @@ module.exports = {
   ...common,
   key: "github-new-fork",
   name: "New Fork (Instant)",
-  description: "Emit an event when a new fork is created",
-  version: "0.0.1",
+  description: "Emit new events on new forks",
+  version: "0.0.2",
+  type: "source",
   dedupe: "unique",
   methods: {
     getEventNames() {
-      return ["fork"];
+      return [
+        "fork",
+      ];
     },
     generateMeta(data) {
       const ts = new Date(data.forkee.created_at).getTime();

--- a/components/github/sources/new-gist/new-gist.js
+++ b/components/github/sources/new-gist/new-gist.js
@@ -5,7 +5,7 @@ module.exports = {
   key: "github-new-gist",
   name: "New Gist",
   description: "Emit new events when new gists are created by the authenticated user",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   dedupe: "last",
   methods: {

--- a/components/github/sources/new-gist/new-gist.js
+++ b/components/github/sources/new-gist/new-gist.js
@@ -4,8 +4,9 @@ module.exports = {
   ...common,
   key: "github-new-gist",
   name: "New Gist",
-  description: "Emit an event when a new gist is created by the user.",
+  description: "Emit new events when new gists are created by the authenticated user",
   version: "0.0.1",
+  type: "source",
   dedupe: "last",
   methods: {
     generateMeta(data) {
@@ -17,7 +18,7 @@ module.exports = {
       };
     },
   },
-  async run(event) {
+  async run() {
     const since = this.db.get("since");
 
     const gists = await this.github.getGists({

--- a/components/github/sources/new-issue/new-issue.js
+++ b/components/github/sources/new-issue/new-issue.js
@@ -4,16 +4,21 @@ module.exports = {
   ...common,
   key: "github-new-issue",
   name: "New Issue (Instant)",
-  description: "Emit an event when a new issue is created in a repo",
-  version: "0.0.3",
+  description: "Emit new events when new issues are created in a repo",
+  version: "0.0.4",
+  type: "source",
   dedupe: "unique",
   methods: {
     ...common.methods,
     getEventNames() {
-      return ["issues"];
+      return [
+        "issues",
+      ];
     },
     getEventTypes() {
-      return ["opened"];
+      return [
+        "opened",
+      ];
     },
     generateMeta(data) {
       const ts = new Date(data.issue.created_at).getTime();

--- a/components/github/sources/new-label/new-label.js
+++ b/components/github/sources/new-label/new-label.js
@@ -4,16 +4,21 @@ module.exports = {
   ...common,
   key: "github-new-label",
   name: "New Label (Instant)",
-  description: "Emit an event when a new label is created in a repo",
-  version: "0.0.3",
+  description: "Emit new events when new labels are created in a repo",
+  version: "0.0.4",
+  type: "source",
   dedupe: "unique",
   methods: {
     ...common.methods,
     getEventNames() {
-      return ["label"];
+      return [
+        "label",
+      ];
     },
     getEventTypes() {
-      return ["created"];
+      return [
+        "created",
+      ];
     },
     generateMeta(data) {
       const ts = Date.now();

--- a/components/github/sources/new-mention/new-mention.js
+++ b/components/github/sources/new-mention/new-mention.js
@@ -5,8 +5,9 @@ module.exports = {
   key: "github-new-mention",
   name: "New Mention",
   description:
-    "Emit an event when you are @mentioned in a new commit, comment, issue or pull request",
-  version: "0.0.2",
+    "Emit new events when you are @mentioned in a new commit, comment, issue or pull request",
+  version: "0.0.3",
+  type: "source",
   hooks: {
     async activate() {
       const user = await this.github.getUser();
@@ -25,13 +26,16 @@ module.exports = {
       };
     },
   },
-  async run(event) {
+  async run() {
     const since = this.db.get("since");
     const login = this.db.get("login");
 
     const mentions = await this.getFilteredNotifications(
-      { participating: true, since },
-      "mention"
+      {
+        participating: true,
+        since,
+      },
+      "mention",
     );
 
     let maxDate = since;

--- a/components/github/sources/new-milestone/new-milestone.js
+++ b/components/github/sources/new-milestone/new-milestone.js
@@ -4,16 +4,21 @@ module.exports = {
   ...common,
   key: "github-new-milestone",
   name: "New Milestone (Instant)",
-  description: "Emit an event when a new milestone is created in a repo",
-  version: "0.0.3",
+  description: "Emit new events when new milestones are created in a repo",
+  version: "0.0.4",
+  type: "source",
   dedupe: "unique",
   methods: {
     ...common.methods,
     getEventNames() {
-      return ["milestone"];
+      return [
+        "milestone",
+      ];
     },
     getEventTypes() {
-      return ["created"];
+      return [
+        "created",
+      ];
     },
     generateMeta(data) {
       const ts = new Date(data.milestone.created_at).getTime();

--- a/components/github/sources/new-notification/new-notification.js
+++ b/components/github/sources/new-notification/new-notification.js
@@ -4,8 +4,9 @@ module.exports = {
   ...common,
   key: "github-new-notification",
   name: "New Notification",
-  description: "Emit an event when you receive a notification.",
-  version: "0.0.1",
+  description: "Emit new events when you receive new notifications",
+  version: "0.0.2",
+  type: "source",
   dedupe: "unique",
   methods: {
     generateMeta(data) {
@@ -17,7 +18,7 @@ module.exports = {
       };
     },
   },
-  async run(event) {
+  async run() {
     const since = this.db.get("since");
 
     const notifications = await this.github.getNotifications({

--- a/components/github/sources/new-or-updated-issue/new-or-updated-issue.js
+++ b/components/github/sources/new-or-updated-issue/new-or-updated-issue.js
@@ -4,13 +4,16 @@ module.exports = {
   ...common,
   key: "github-new-or-updated-issue",
   name: "New or Updated Issue (Instant)",
-  description: "Emit an event when an issue is opened or updated.",
-  version: "0.0.1",
+  description: "Emit new events when an issue is opened or updated",
+  version: "0.0.2",
+  type: "source",
   dedupe: "unique",
   methods: {
     ...common.methods,
     getEventNames() {
-      return ["issues"];
+      return [
+        "issues",
+      ];
     },
     getEventTypes() {
       return [
@@ -32,12 +35,12 @@ module.exports = {
         "demilestoned",
       ];
     },
-    generateMeta(data) {
+    generateMeta(data, id) {
       const ts = data.issue.updated_at
         ? Date.parse(data.issue.updated_at)
         : Date.parse(data.issue.created_at);
       return {
-        id: `${data.issue.id}${ts}`,
+        id,
         summary: `#${data.issue.number} ${data.issue.title} ${data.action} by ${data.sender.login}`,
         ts,
       };

--- a/components/github/sources/new-or-updated-milestone/new-or-updated-milestone.js
+++ b/components/github/sources/new-or-updated-milestone/new-or-updated-milestone.js
@@ -5,23 +5,32 @@ module.exports = {
   key: "github-new-or-updated-milestone",
   name: "New or Updated Milestone (Instant)",
   description:
-    "Emit an event when a milestone is created or updated in a repo.",
-  version: "0.0.1",
+    "Emit new events when a milestone is created or updated in a repo",
+  version: "0.0.2",
+  type: "source",
   dedupe: "unique",
   methods: {
     ...common.methods,
     getEventNames() {
-      return ["milestone"];
+      return [
+        "milestone",
+      ];
     },
     getEventTypes() {
-      return ["created", "edited", "opened", "closed", "deleted"];
+      return [
+        "created",
+        "edited",
+        "opened",
+        "closed",
+        "deleted",
+      ];
     },
-    generateMeta(data) {
+    generateMeta(data, id) {
       const ts = data.milestone.updated_at
         ? Date.parse(data.milestone.updated_at)
         : Date.parse(data.milestone.created_at);
       return {
-        id: `${data.milestone.id}${ts}`,
+        id,
         summary: `${data.milestone.title} ${data.action} by ${data.sender.login}`,
         ts,
       };

--- a/components/github/sources/new-organization/new-organization.js
+++ b/components/github/sources/new-organization/new-organization.js
@@ -5,8 +5,9 @@ module.exports = {
   key: "github-new-organization",
   name: "New Organization",
   description:
-    "Emit an event when the authenticated user is added to a new organization.",
-  version: "0.0.1",
+    "Emit new events when the authenticated user is added to a new organization",
+  version: "0.0.2",
+  type: "source",
   dedupe: "last",
   methods: {
     generateMeta(data) {
@@ -18,7 +19,7 @@ module.exports = {
       };
     },
   },
-  async run(event) {
+  async run() {
     const orgs = await this.github.getOrgs();
 
     orgs.forEach((org) => {

--- a/components/github/sources/new-project-card/new-project-card.js
+++ b/components/github/sources/new-project-card/new-project-card.js
@@ -4,16 +4,21 @@ module.exports = {
   ...common,
   key: "github-new-project-card",
   name: "New Project Card (Instant)",
-  description: "Emit an event when a new project card is created",
-  version: "0.0.3",
+  description: "Emit new events when new project cards are created",
+  version: "0.0.4",
+  type: "source",
   dedupe: "unique",
   methods: {
     ...common.methods,
     getEventNames() {
-      return ["project_card"];
+      return [
+        "project_card",
+      ];
     },
     getEventTypes() {
-      return ["created"];
+      return [
+        "created",
+      ];
     },
     generateMeta(data) {
       const ts = new Date(data.project_card.created_at).getTime();

--- a/components/github/sources/new-pull-request/new-pull-request.js
+++ b/components/github/sources/new-pull-request/new-pull-request.js
@@ -4,16 +4,21 @@ module.exports = {
   ...common,
   key: "github-new-pull-request",
   name: "New Pull Request (Instant)",
-  description: "Emit an event when a new pull request is opened",
-  version: "0.0.3",
+  description: "Emit new event on new pull requests",
+  version: "0.0.4",
+  type: "source",
   dedupe: "unique",
   methods: {
     ...common.methods,
     getEventNames() {
-      return ["pull_request"];
+      return [
+        "pull_request",
+      ];
     },
     getEventTypes() {
-      return ["opened"];
+      return [
+        "opened",
+      ];
     },
     generateMeta(data) {
       const ts = new Date(data.pull_request.updated_at).getTime();

--- a/components/github/sources/new-push/new-push.js
+++ b/components/github/sources/new-push/new-push.js
@@ -4,13 +4,16 @@ module.exports = {
   ...common,
   key: "github-new-push",
   name: "New Push",
-  description: "Emit an event on each new push to a repo",
-  version: "0.0.3",
+  description: "Emit new events on each new push to a repo",
+  version: "0.0.4",
+  type: "source",
   dedupe: "unique",
   methods: {
     ...common.methods,
     getEventNames() {
-      return ["push"];
+      return [
+        "push",
+      ];
     },
     generateMeta(data) {
       const ts = Date.now();

--- a/components/github/sources/new-release/new-release.js
+++ b/components/github/sources/new-release/new-release.js
@@ -4,16 +4,21 @@ module.exports = {
   ...common,
   key: "github-new-release",
   name: "New Release (Instant)",
-  description: "Emit an event when a new release is published.",
-  version: "0.0.1",
+  description: "Emit new event when a new release is published",
+  version: "0.0.2",
+  type: "source",
   dedupe: "unique",
   methods: {
     ...common.methods,
     getEventNames() {
-      return ["release"];
+      return [
+        "release",
+      ];
     },
     getEventTypes() {
-      return ["published"];
+      return [
+        "published",
+      ];
     },
     generateMeta(data) {
       const ts = new Date(data.release.published_at).getTime();

--- a/components/github/sources/new-repository/new-repository.js
+++ b/components/github/sources/new-repository/new-repository.js
@@ -4,8 +4,9 @@ module.exports = {
   ...common,
   key: "github-new-repository",
   name: "New Repository",
-  description: "Emit an event when a new repository is created",
-  version: "0.0.2",
+  description: "Emit new events when new repositories are created",
+  version: "0.0.3",
+  type: "source",
   dedupe: "last",
   methods: {
     generateMeta(data) {
@@ -17,7 +18,7 @@ module.exports = {
       };
     },
   },
-  async run(event) {
+  async run() {
     let since = this.db.get("since");
 
     const repos = await this.github.getRepos({

--- a/components/github/sources/new-review-request/new-review-request.js
+++ b/components/github/sources/new-review-request/new-review-request.js
@@ -5,8 +5,9 @@ module.exports = {
   key: "github-new-review-request",
   name: "New Review Request",
   description:
-    "Emit an event when you or a team you're a member of are requested to review a pull request",
-  version: "0.0.2",
+    "Emit new events when you or a team you're a member of are requested to review a pull request",
+  version: "0.0.3",
+  type: "source",
   dedupe: "greatest",
   methods: {
     ...common.methods,
@@ -19,12 +20,15 @@ module.exports = {
       };
     },
   },
-  async run(event) {
+  async run() {
     const since = this.db.get("since");
 
     const notifications = await this.getFilteredNotifications(
-      { participating: false, since },
-      "review_requested"
+      {
+        participating: false,
+        since,
+      },
+      "review_requested",
     );
 
     let maxDate = since;

--- a/components/github/sources/new-security-alert/new-security-alert.js
+++ b/components/github/sources/new-security-alert/new-security-alert.js
@@ -5,8 +5,9 @@ module.exports = {
   key: "github-new-security-alert",
   name: "New Security Alert",
   description:
-    "Emit an event when GitHub discovers a security vulnerability in one of your repositories",
-  version: "0.0.2",
+    "Emit new events when GitHub discovers a security vulnerability in one of your repositories",
+  version: "0.0.3",
+  type: "source",
   dedupe: "greatest",
   methods: {
     ...common.methods,
@@ -19,12 +20,15 @@ module.exports = {
       };
     },
   },
-  async run(event) {
+  async run() {
     const since = this.db.get("since");
 
     const notifications = await this.getFilteredNotifications(
-      { participating: false, since },
-      "security_alert"
+      {
+        participating: false,
+        since,
+      },
+      "security_alert",
     );
 
     let maxDate = since;

--- a/components/github/sources/new-star/new-star.js
+++ b/components/github/sources/new-star/new-star.js
@@ -4,16 +4,21 @@ module.exports = {
   ...common,
   key: "github-new-star",
   name: "New Stars (Instant)",
-  version: "0.0.3",
-  description: "Emit an event when a repo is starred",
+  version: "0.0.4",
+  description: "Emit new events when a repo is starred",
+  type: "source",
   dedupe: "unique",
   methods: {
     ...common.methods,
     getEventNames() {
-      return ["star"];
+      return [
+        "star",
+      ];
     },
     getEventTypes() {
-      return ["created"];
+      return [
+        "created",
+      ];
     },
     generateMeta(data) {
       const ts = new Date(data.starred_at).getTime();

--- a/components/github/sources/new-team/new-team.js
+++ b/components/github/sources/new-team/new-team.js
@@ -4,8 +4,9 @@ module.exports = {
   ...common,
   key: "github-new-team",
   name: "New Team",
-  description: "Emit an event when the user is added to a new team.",
-  version: "0.0.1",
+  description: "Emit new events when the user is added to a new team",
+  version: "0.0.2",
+  type: "source",
   dedupe: "last",
   methods: {
     generateMeta(data) {
@@ -17,7 +18,7 @@ module.exports = {
       };
     },
   },
-  async run(event) {
+  async run() {
     const teams = await this.github.getTeams();
 
     for (const team of teams) {

--- a/components/github/sources/new-watcher/new-watcher.js
+++ b/components/github/sources/new-watcher/new-watcher.js
@@ -5,12 +5,18 @@ module.exports = {
   ...common,
   key: "github-new-watcher",
   name: "New Watcher",
-  description: "Emit an event when a new watcher is added to a repository.",
-  version: "0.0.1",
+  description: "Emit new events when new watchers are added to a repository",
+  version: "0.0.2",
+  type: "source",
   dedupe: "last",
   props: {
     ...common.props,
-    repoFullName: { propDefinition: [github, "repoFullName"] },
+    repoFullName: {
+      propDefinition: [
+        github,
+        "repoFullName",
+      ],
+    },
   },
   methods: {
     generateMeta(data) {
@@ -22,7 +28,7 @@ module.exports = {
       };
     },
   },
-  async run(event) {
+  async run() {
     const watchers = await this.github.getWatchers({
       repoFullName: this.repoFullName,
     });

--- a/components/github/sources/updated-repository/updated-repository.js
+++ b/components/github/sources/updated-repository/updated-repository.js
@@ -15,19 +15,22 @@ module.exports = {
   ...common,
   key: "github-updated-repository",
   name: "Updated Repository (Instant)",
-  description: "Emit an event when an existing repository is updated.",
-  version: "0.0.1",
+  description: "Emit new events when an existing repository is updated",
+  version: "0.0.2",
+  type: "source",
   dedupe: "unique",
   methods: {
     getEventNames() {
-      return ["repository"];
+      return [
+        "repository",
+      ];
     },
-    generateMeta(data) {
+    generateMeta(data, id) {
       const ts = data.repository.updated_at
         ? Date.parse(data.repository.updated_at)
         : Date.parse(data.repository.created_at);
       return {
-        id: `${data.repository.id}${ts}`,
+        id,
         summary: `${data.repository.full_name} ${data.action} by ${data.sender.login}`,
         ts,
       };


### PR DESCRIPTION
Updating certain sources to use the GitHub webhook event ID, instead of the properties of the event, because we failed to catch certain events as a result.

Revving versions.

Adding type: "source".

Adding missing prop descriptions / labels, other ESLint fixes.