### PR TITLE
Jotform Update: Support for EU region

### DIFF
--- a/components/jotform/jotform.app.js
+++ b/components/jotform/jotform.app.js
@@ -1,91 +1,99 @@
-const axios = require('axios')
-const querystring = require('querystring')
- 
+const axios = require("axios");
+const querystring = require("querystring");
+
 function ensureTrailingSlash(str) {
-  if (str.endsWith('/')) return str
-  return `${str}/`
+  if (str.endsWith("/")) return str;
+  return `${str}/`;
 }
 
-module.exports = { 
-  type: "app", 
-  app: "jotform", 
-  propDefinitions: {  
+module.exports = {
+  type: "app",
+  app: "jotform",
+  propDefinitions: {
     formId: {
-      type: "string", 
-      label: "Form", 
-      async options(opts) { 
-        const forms = await this.getForms(this.$auth.api_key)  
-        return forms.content.map(form => { 
-          return { label: form.title, value: form.id } 
-        }) 
+      type: "string",
+      label: "Form",
+      description: "The form to watch for new submissions",
+      async options() {
+        const forms = await this.getForms(this.$auth.api_key);
+        return forms.content.map((form) => {
+          return {
+            label: form.title,
+            value: form.id,
+          };
+        });
       },
-    }, 
-  }, 
-  methods: {
-    async _makeRequest(config) {
-      if (config.params) { 
-        const query = querystring.stringify(config.params)
-        delete config.params
-        const sep = config.url.indexOf('?') === -1 ? '?' : '&'
-        config.url += `${sep}${query}`
-        config.url = config.url.replace('?&','?')
-      }
-      return await axios(config)
     },
-    async getForms() {   
+  },
+  methods: {
+    _getBaseUrl() {
+      return `https://${this.$auth.region}.jotform.com/`;
+    },
+    async _makeRequest(config) {
+      config.headers = {
+        "APIKEY": this.$auth.api_key,
+      };
+      if (config.params) {
+        const query = querystring.stringify(config.params);
+        delete config.params;
+        const sep = config.url.indexOf("?") === -1
+          ? "?"
+          : "&";
+        config.url += `${sep}${query}`;
+        config.url = config.url.replace("?&", "?");
+      }
+      return await axios(config);
+    },
+    async getForms() {
       return (await this._makeRequest({
-        url: `https://api.jotform.com/user/forms`,
-        method: `GET`,
-        headers: {
-          "APIKEY": this.$auth.api_key,
-        },
-      })).data
-    }, 
+        url: `${this._getBaseUrl()}user/forms`,
+        method: "GET",
+      })).data;
+    },
     async getWebhooks(opts = {}) {
-      const { formId } = opts
+      const { formId } = opts;
       return (await this._makeRequest({
-        url: `https://api.jotform.com/form/${encodeURIComponent(formId)}/webhooks`,
-        method: `GET`,
-        headers: {
-          "APIKEY": this.$auth.api_key,
-        },
-      })).data
+        url: `${this._getBaseUrl()}form/${encodeURIComponent(formId)}/webhooks`,
+        method: "GET",
+      })).data;
     },
     async createHook(opts = {}) {
-      const { formId, endpoint } = opts
-      return (await this._makeRequest({ 
-        url: `https://api.jotform.com/form/${encodeURIComponent(formId)}/webhooks`,
-        method: `POST`, 
-        headers: {
-          "APIKEY": this.$auth.api_key,
-        },
+      const {
+        formId,
+        endpoint,
+      } = opts;
+      return (await this._makeRequest({
+        url: `${this._getBaseUrl()}form/${encodeURIComponent(formId)}/webhooks`,
+        method: "POST",
         params: {
           webhookURL: ensureTrailingSlash(endpoint),
         },
-      }))
+      }));
     },
-    async deleteHook(opts = {}) { 
-      const { formId, endpoint } = opts
-      const result = await this.getWebhooks({ formId }) 
-      let webhooks = Object.values(result && result.content || {})
-      let webhookIdx = -1 
+    async deleteHook(opts = {}) {
+      const {
+        formId,
+        endpoint,
+      } = opts;
+      const result = await this.getWebhooks({
+        formId,
+      });
+      let webhooks = Object.values(result && result.content || {});
+      let webhookIdx = -1;
       for (let idx in webhooks) {
         if (webhooks[idx] === ensureTrailingSlash(endpoint)) {
-          webhookIdx = idx
+          webhookIdx = idx;
         }
       }
-      if(webhookIdx === -1) {
-        console.log(`Did not detect ${endpoint} as a webhook registered for form ID ${formId}.`)
-        return
+      if (webhookIdx === -1) {
+        console.log(`Did not detect ${endpoint} as a webhook registered for form ID ${formId}.`);
+        return;
       }
-      console.log(`Deleting webhook at index ${webhookIdx}...`)
-      return (await this._makeRequest({ 
-        url: `https://api.jotform.com/form/${encodeURIComponent(formId)}/webhooks/${encodeURIComponent(webhookIdx)}`,
-        method: `DELETE`, 
-        headers: {
-          "APIKEY": this.$auth.api_key,
-        },
-      }))
+      console.log(`Deleting webhook at index ${webhookIdx}...`);
+      return (await this._makeRequest({
+        url: `${this._getBaseUrl()}form/${encodeURIComponent(formId)}/webhooks/${encodeURIComponent(webhookIdx)}`,
+        method: "DELETE",
+      }));
     },
   },
-}
+};

--- a/components/jotform/sources/new-submission/new-submission.js
+++ b/components/jotform/sources/new-submission/new-submission.js
@@ -1,13 +1,19 @@
-const jotform = require('../../jotform.app.js')
+const jotform = require("../../jotform.app.js");
 
 module.exports = {
   key: "jotform-new-submission",
   name: "New Submission (Instant)",
-  description: "Emit an event when a new form is submitted",
-  version: "0.0.2",
+  description: "Emit new event when a form is submitted",
+  version: "0.0.3",
+  type: "source",
   props: {
     jotform,
-    formId: { propDefinition: [jotform, "formId"] },
+    formId: {
+      propDefinition: [
+        jotform,
+        "formId",
+      ],
+    },
     http: "$.interface.http",
   },
   hooks: {
@@ -15,21 +21,21 @@ module.exports = {
       return (await this.jotform.createHook({
         endpoint: this.http.endpoint,
         formId: this.formId,
-      }))
+      }));
     },
     async deactivate() {
       return (await this.jotform.deleteHook({
         endpoint: this.http.endpoint,
         formId: this.formId,
-      }))
+      }));
     },
   },
   async run(event) {
-    event.body.formData = JSON.parse(event.body.rawRequest)
+    event.body.formData = JSON.parse(event.body.rawRequest);
 
     this.$emit(event.body, {
       summary: event.body.rawRequest || JSON.stringify(event.body),
       id: event.body.submissionID,
-    })
+    });
   },
-}
+};


### PR DESCRIPTION
Support for EU vs. US regions.

`https://{this.$auth.region}.jotform.com` (`eu-api` for EU region, `api` for US, exposed via `this.$auth.region`)

Related issue for new Jotform actions: https://github.com/PipedreamHQ/pipedream/issues/1456