### PR TITLE
Fixing a bug reported by a Teams customer on Google Sheets actions

### DIFF
--- a/components/google_sheets/actions/add-multiple-rows/add-multiple-rows.js
+++ b/components/google_sheets/actions/add-multiple-rows/add-multiple-rows.js
@@ -3,8 +3,8 @@ const googleSheets = require("../../google_sheets.app");
 module.exports = {
   key: "google_sheets-add-multiple-rows",
   name: "Add Multiple Rows",
-  description: "Add multiple rows of data to Google Sheets.",
-  version: "0.0.29",
+  description: "Add multiple rows of data to a Google Sheet",
+  version: "0.1.0",
   type: "action",
   props: {
     googleSheets,
@@ -41,7 +41,6 @@ module.exports = {
     },
   },
   async run() {
-    const sheets = this.googleSheets.sheets();
     let rows = this.rows;
 
     let inputValidated = true;
@@ -63,14 +62,10 @@ module.exports = {
       throw new Error("Rows data is not an array of arrays. Please enter an array of arrays in the `Rows` parameter above. If you're trying to send a single rows to Google Sheets, search for the action to add a single row to Sheets or try modifying the code for this step.");
     }
 
-    return (await sheets.spreadsheets.values.append({
+    return await this.googleSheets.addRowsToSheet({
       spreadsheetId: this.sheetId,
       range: this.sheetName,
-      valueInputOption: "USER_ENTERED",
-      insertDataOption: "INSERT_ROWS",
-      resource: {
-        values: rows,
-      },
-    })).data.updates;
+      rows,
+    });
   },
 };

--- a/components/google_sheets/actions/add-single-row/add-single-row.js
+++ b/components/google_sheets/actions/add-single-row/add-single-row.js
@@ -4,7 +4,7 @@ module.exports = {
   key: "google_sheets-add-single-row",
   name: "Add Single Row",
   description: "Add a single row of data to Google Sheets",
-  version: "0.0.31",
+  version: "0.1.0",
   type: "action",
   props: {
     googleSheets,
@@ -41,7 +41,6 @@ module.exports = {
     },
   },
   async run() {
-    const sheets = this.googleSheets.sheets();
     const cells = this.cells;
 
     // validate input
@@ -53,16 +52,12 @@ module.exports = {
       throw new Error("Cell / Column data is a multi-dimensional array. A one-dimensional is expected. If you're trying to send multiple rows to Google Sheets, search for the action to add multiple rows to Sheets.");
     }
 
-    return (await sheets.spreadsheets.values.append({
+    return await this.googleSheets.addRowsToSheet({
       spreadsheetId: this.sheetId,
       range: this.sheetName,
-      valueInputOption: "USER_ENTERED",
-      insertDataOption: "INSERT_ROWS",
-      resource: {
-        values: [
-          cells,
-        ],
-      },
-    })).data.updates;
+      rows: [
+        cells,
+      ],
+    });
   },
 };

--- a/components/google_sheets/google_sheets.app.js
+++ b/components/google_sheets/google_sheets.app.js
@@ -1,3 +1,4 @@
+const { default: axios } = require("axios");
 const { google } = require("googleapis");
 const googleDrive = require("../google_drive/google_drive.app");
 
@@ -38,14 +39,17 @@ module.exports = {
     sheetName: {
       type: "string",
       label: "Sheet Name",
+      description: "The name of the worksheet within your Google spreadsheet, e.g. `Sheet1`",
       async options({ sheetId }) {
         const { sheets } = await this.getSpreadsheet(sheetId);
         return sheets.map((sheet) => sheet.properties.title);
       },
     },
+    // TODO: is this a duplicate of the prop above?
     worksheetIDs: {
       type: "string[]",
       label: "Worksheet(s)",
+      description: "The name of the worksheet within your Google spreadsheet, e.g. `Sheet1`",
       async options({ sheetId }) {
         const { sheets } = await this.getSpreadsheet(sheetId);
 
@@ -189,6 +193,29 @@ module.exports = {
             };
           }),
       );
+    },
+    async addRowsToSheet({
+      spreadsheetId, range, rows,
+    }) {
+      const resp = await axios({
+        method: "POST",
+        url: `https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}/values/${range}:append`,
+        headers: {
+          "Authorization": `Bearer ${this.$auth.oauth_access_token}`,
+        },
+        validateStatus: () => true,
+        params: {
+          valueInputOption: "USER_ENTERED",
+          insertDataOption: "INSERT_ROWS",
+        },
+        data: {
+          values: rows,
+        },
+      });
+      if (resp.status >= 400) {
+        throw new Error(resp.data);
+      }
+      return resp.data.updates;
     },
   },
 };

--- a/components/google_sheets/sources/new-row-added/new-row-added.js
+++ b/components/google_sheets/sources/new-row-added/new-row-added.js
@@ -5,9 +5,10 @@ module.exports = {
   key: "google_sheets-new-row-added",
   name: "New Row Added (Instant)",
   description:
-    "Emits an event each time a row or rows are added to the bottom of a spreadsheet.",
-  version: "0.0.18",
+    "Emit new events each time a row or rows are added to the bottom of a spreadsheet",
+  version: "0.0.19",
   dedupe: "unique",
+  type: "source",
   props: {
     ...common.props,
     sheetID: {


### PR DESCRIPTION
'valueInputOption' is required but not specified