### PR TITLE
[ACTION] Google Calendar new actions

### DIFF
--- a/components/google_calendar/actions/clear-calendar/clear-calendar.js
+++ b/components/google_calendar/actions/clear-calendar/clear-calendar.js
@@ -13,8 +13,6 @@ module.exports = {
         googleCalendar,
         "calendarId",
       ],
-      optional: true,
-      default: "primary",
     },
   },
   async run() {

--- a/components/google_calendar/actions/clear-calendar/clear-calendar.js
+++ b/components/google_calendar/actions/clear-calendar/clear-calendar.js
@@ -1,0 +1,26 @@
+const googleCalendar = require("../../google_calendar.app");
+
+module.exports = {
+  key: "google_calendar_clear_calendar",
+  name: "Delete all events from a calendar",
+  description: "Delete all events from a calendar.",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    googleCalendar,
+    calendarId: {
+      propDefinition: [
+        googleCalendar,
+        "calendarId",
+      ],
+      optional: true,
+      default: "primary",
+    },
+  },
+  async run() {
+    const calendar = this.googleCalendar.calendar();
+    return (await calendar.calendars.clear({
+      calendarId: this.calendarId,
+    })).data;
+  },
+};

--- a/components/google_calendar/actions/create-acl/create-acl.js
+++ b/components/google_calendar/actions/create-acl/create-acl.js
@@ -1,9 +1,9 @@
 const googleCalendar = require("../../google_calendar.app");
 
 module.exports = {
-  key: "google_calendar_update_acl",
-  name: "Update Access Control Rule",
-  description: "Update Access Control Rule Metadata of a google calendar.",
+  key: "google_calendar_create_acl",
+  name: "Create an Access Control Rule for a calendar",
+  description: "Create an Access Control Rule for a calendar.",
   version: "0.0.1",
   type: "action",
   props: {
@@ -12,15 +12,6 @@ module.exports = {
       propDefinition: [
         googleCalendar,
         "calendarId",
-      ],
-    },
-    ruleId: {
-      propDefinition: [
-        googleCalendar,
-        "ruleId",
-        (c) => ({
-          calendarId: c.calendarId,
-        }),
       ],
     },
     role: {
@@ -44,7 +35,6 @@ module.exports = {
   },
   async run() {
     const calendar = this.googleCalendar.calendar();
-
     let scope = {
       type: this.scopeType,
     };
@@ -53,12 +43,11 @@ module.exports = {
       scope["value"] = this.scopeValue;
     }
 
-    return (await calendar.acl.update({
+    return (await calendar.acl.insert({
       calendarId: this.calendarId,
-      ruleId: this.ruleId,
       requestBody: {
-        scope,
         role: this.role,
+        scope: scope,
       },
     })).data;
   },

--- a/components/google_calendar/actions/create-calendar/create-calendar.js
+++ b/components/google_calendar/actions/create-calendar/create-calendar.js
@@ -1,0 +1,32 @@
+const googleCalendar = require("../../google_calendar.app");
+
+module.exports = {
+  key: "google_calendar_create_calendar",
+  name: "Create a Calendar in an user account",
+  description: "Create a Calendar in an user account.",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    googleCalendar,
+    summary: {
+      type: "string",
+      description: "Title of the calendar.",
+      label: "Title",
+    },
+    description: {
+      type: "string",
+      description: "Description of the calendar.",
+      label: "Description",
+      optional: true,
+    },
+  },
+  async run() {
+    const calendar = this.googleCalendar.calendar();
+    return (await calendar.calendars.insert({
+      requestBody: {
+        summary: this.summary,
+        description: this.description,
+      },
+    })).data;
+  },
+};

--- a/components/google_calendar/actions/create-event/create-event.js
+++ b/components/google_calendar/actions/create-event/create-event.js
@@ -1,0 +1,115 @@
+const googleCalendar = require("../../google_calendar.app");
+const timezones = require("moment-timezone");
+
+module.exports = {
+  key: "google_calendar_create_event",
+  name: "Create Event",
+  description: "Create an event to the Google Calendar.",
+  version: "0.0.6",
+  type: "action",
+  props: {
+    googleCalendar,
+    calendarId: {
+      propDefinition: [
+        googleCalendar,
+        "calendarId",
+      ],
+    },
+    summary: {
+      label: "Event Title",
+      type: "string",
+      description: "Enter static text (e.g., `hello world`) for the event name",
+    },
+    location: {
+      label: "Event Venue",
+      type: "string",
+      description: "Enter static text (e.g., `hello world`) for the event venue",
+    },
+    description: {
+      label: "Event Description",
+      type: "string",
+      description: "Enter detailed event description",
+    },
+    attendees: {
+      label: "Attendees",
+      type: "string[]",
+      description: "Enter the EmailId of the attendees",
+    },
+    eventStartDate: {
+      label: "Event Date",
+      type: "string",
+      description: "Enter the Event day in the format 'yyyy-mm-dd', if this is an all-day event.",
+    },
+    eventEndDate: {
+      label: "Event End Date",
+      type: "string",
+      description: "Enter the Event day in the format 'yyyy-mm-dd', if this is an all-day event.",
+    },
+    timeZone: {
+      propDefinition: [
+        googleCalendar,
+        "timeZone",
+      ],
+      options() {
+        const timeZonesList = timezones.tz.names().map((timezone) => {
+          return {
+            label: timezone,
+            value: timezone,
+          };
+        });
+
+        return timeZonesList;
+      },
+    },
+    // TODO: Should I add reminders
+  },
+  async run() {
+    const calendar = this.googleCalendar.calendar();
+    /**
+     * Format for the attendees
+     *
+     * [
+     *   { "email": "lpage@example.com",},
+     *   { "email": "sbrin@example.com",},
+     * ]
+     */
+    const attendees = [];
+
+    /**
+     * Based on the IINA Time Zone DB
+     * http://www.iana.org/time-zones
+     */
+    let timeZone = this.timeZone
+      ? this.timeZone
+      : await calendar.settings.get({
+        setting: "timezone",
+      }).value;
+
+    if (Array.isArray(this.attendees)) {
+      for (let attendee of this.attendees) {
+        attendees.push({
+          email: attendee,
+        });
+      }
+    }
+
+    const resource = {
+      summary: this.summary,
+      location: this.location,
+      description: this.description,
+      start: {
+        date: this.eventStartDate,
+        timeZone: timeZone,
+      },
+      end: {
+        date: this.eventEndDate,
+        timeZone: timeZone,
+      },
+      attendees,
+    };
+    return (await calendar.events.insert({
+      calendarId: this.calendarId,
+      resource,
+    })).data;
+  },
+};

--- a/components/google_calendar/actions/delete-acl/delete-acl.js
+++ b/components/google_calendar/actions/delete-acl/delete-acl.js
@@ -3,7 +3,7 @@ const googleCalendar = require("../../google_calendar.app");
 module.exports = {
   key: "google_calendar_delete_acl",
   name: "Delete Access Control Rule",
-  description: "Delete Access Control Rule Metadata from a google calendar.",
+  description: "Delete Access Control Rule Metadata of a google calendar.",
   version: "0.0.1",
   type: "action",
   props: {

--- a/components/google_calendar/actions/delete-acl/delete-acl.js
+++ b/components/google_calendar/actions/delete-acl/delete-acl.js
@@ -1,9 +1,9 @@
 const googleCalendar = require("../../google_calendar.app");
 
 module.exports = {
-  key: "google_calendar_get_acl",
-  name: "Retreive Access Control Rule",
-  description: "Retreive Access Control Rule Metadata from a google calendar.",
+  key: "google_calendar_delete_acl",
+  name: "Delete Access Control Rule",
+  description: "Delete Access Control Rule Metadata from a google calendar.",
   version: "0.0.1",
   type: "action",
   props: {
@@ -26,7 +26,7 @@ module.exports = {
   },
   async run() {
     const calendar = this.googleCalendar.calendar();
-    return (await calendar.acl.get({
+    return (await calendar.acl.delete({
       calendarId: this.calendarId,
       ruleId: this.ruleId,
     })).data;

--- a/components/google_calendar/actions/delete-calendar/delete-calendar.js
+++ b/components/google_calendar/actions/delete-calendar/delete-calendar.js
@@ -1,0 +1,24 @@
+const googleCalendar = require("../../google_calendar.app");
+
+module.exports = {
+  key: "google_calendar_delete_calendar",
+  name: "Delete an calendar",
+  description: "Delete an calendar from the user account.",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    googleCalendar,
+    calendarId: {
+      propDefinition: [
+        googleCalendar,
+        "calendarId",
+      ],
+    },
+  },
+  async run() {
+    const calendar = this.googleCalendar.calendar();
+    return (await calendar.calendars.delete({
+      calendarId: this.calendarId,
+    })).data;
+  },
+};

--- a/components/google_calendar/actions/delete-event/delete-event.js
+++ b/components/google_calendar/actions/delete-event/delete-event.js
@@ -1,0 +1,34 @@
+const googleCalendar = require("../../google_calendar.app");
+
+module.exports = {
+  key: "google_calendar_delete_event",
+  name: "Delete an Event",
+  description: "Delete an event to the Google Calendar.",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    googleCalendar,
+    calendarId: {
+      propDefinition: [
+        googleCalendar,
+        "calendarId",
+      ],
+    },
+    eventId: {
+      propDefinition: [
+        googleCalendar,
+        "eventId",
+        (c) => ({
+          calendarId: c.calendarId,
+        }),
+      ],
+    },
+  },
+  async run() {
+    const calendar = this.googleCalendar.calendar();
+    return (await calendar.events.delete({
+      calendarId: this.calendarId,
+      eventId: this.eventId,
+    })).data;
+  },
+};

--- a/components/google_calendar/actions/free-busy-calendars/free-busy-calendars.js
+++ b/components/google_calendar/actions/free-busy-calendars/free-busy-calendars.js
@@ -1,0 +1,16 @@
+const googleCalendar = require("../../google_calendar.app");
+
+module.exports = {
+  key: "google_calendar_free_busy_calendar_info",
+  name: "Retreive Free/Busy Calendar Details",
+  description: "Retreive Free/Busy Calendar Details from the user account.",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    googleCalendar,
+  },
+  async run() {
+    const calendar = this.googleCalendar.calendar();
+    return (await calendar.freebusy.freebusy()).data;
+  },
+};

--- a/components/google_calendar/actions/get-acl/get-acl.js
+++ b/components/google_calendar/actions/get-acl/get-acl.js
@@ -1,0 +1,34 @@
+const googleCalendar = require("../../google_calendar.app");
+
+module.exports = {
+  key: "google_calendar_get_calendar",
+  name: "Retreive Calendar Details",
+  description: "Retreive Calendar details of a Google Calendar.",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    googleCalendar,
+    calendarId: {
+      propDefinition: [
+        googleCalendar,
+        "calendarId",
+      ],
+    },
+    ruleId: {
+      propDefinition: [
+        googleCalendar,
+        "ruleId",
+        (c) => ({
+          calendarId: c.calendarId,
+        }),
+      ],
+    },
+  },
+  async run() {
+    const calendar = this.googleCalendar.calendar();
+    return (await calendar.acl.get({
+      calendarId: this.calendarId,
+      ruleId: this.ruleId,
+    })).data;
+  },
+};

--- a/components/google_calendar/actions/get-acl/get-acl.js
+++ b/components/google_calendar/actions/get-acl/get-acl.js
@@ -3,7 +3,7 @@ const googleCalendar = require("../../google_calendar.app");
 module.exports = {
   key: "google_calendar_get_acl",
   name: "Retreive Access Control Rule",
-  description: "Retreive Access Control Rule Metadata from a google calendar.",
+  description: "Retreive Access Control Rule Metadata of a google calendar.",
   version: "0.0.1",
   type: "action",
   props: {

--- a/components/google_calendar/actions/get-calendar/get-calendar.js
+++ b/components/google_calendar/actions/get-calendar/get-calendar.js
@@ -1,0 +1,24 @@
+const googleCalendar = require("../../google_calendar.app");
+
+module.exports = {
+  key: "google_calendar_get_calendar",
+  name: "Retreive Calendar Details",
+  description: "Retreive Calendar details of a Google Calendar.",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    googleCalendar,
+    calendarId: {
+      propDefinition: [
+        googleCalendar,
+        "calendarId",
+      ],
+    },
+  },
+  async run() {
+    const calendar = this.googleCalendar.calendar();
+    return (await calendar.calendars.get({
+      calendarId: this.calendarId,
+    })).data;
+  },
+};

--- a/components/google_calendar/actions/get-event/get-event.js
+++ b/components/google_calendar/actions/get-event/get-event.js
@@ -1,9 +1,9 @@
 const googleCalendar = require("../../google_calendar.app");
 
 module.exports = {
-  key: "google_calendar_delete_event",
-  name: "Delete an Event",
-  description: "Delete an event to the Google Calendar.",
+  key: "google_calendar_get_event",
+  name: "Retreive Event Details",
+  description: "Retreive event details from the Google Calendar.",
   version: "0.0.1",
   type: "action",
   props: {

--- a/components/google_calendar/actions/get-event/get-event.js
+++ b/components/google_calendar/actions/get-event/get-event.js
@@ -1,0 +1,34 @@
+const googleCalendar = require("../../google_calendar.app");
+
+module.exports = {
+  key: "google_calendar_delete_event",
+  name: "Delete an Event",
+  description: "Delete an event to the Google Calendar.",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    googleCalendar,
+    calendarId: {
+      propDefinition: [
+        googleCalendar,
+        "calendarId",
+      ],
+    },
+    eventId: {
+      propDefinition: [
+        googleCalendar,
+        "eventId",
+        (c) => ({
+          calendarId: c.calendarId,
+        }),
+      ],
+    },
+  },
+  async run() {
+    const calendar = this.googleCalendar.calendar();
+    return (await calendar.events.get({
+      calendarId: this.calendarId,
+      eventId: this.eventId,
+    })).data;
+  },
+};

--- a/components/google_calendar/actions/list-acl/list-acl.js
+++ b/components/google_calendar/actions/list-acl/list-acl.js
@@ -1,0 +1,24 @@
+const googleCalendar = require("../../google_calendar.app");
+
+module.exports = {
+  key: "google_calendar_list_acl_rules",
+  name: "Retreive all Access Control Rules",
+  description: "Retreive list of Access Control Rules of a google calendar.",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    googleCalendar,
+    calendarId: {
+      propDefinition: [
+        googleCalendar,
+        "calendarId",
+      ],
+    },
+  },
+  async run() {
+    const calendar = this.googleCalendar.calendar();
+    return (await calendar.acl.list({
+      calendarId: this.calendarId,
+    })).data;
+  },
+};

--- a/components/google_calendar/actions/list-calendars/list-calendars.js
+++ b/components/google_calendar/actions/list-calendars/list-calendars.js
@@ -1,0 +1,16 @@
+const googleCalendar = require("../../google_calendar.app");
+
+module.exports = {
+  key: "google_calendar_list_calendar",
+  name: "List calendars from user account",
+  description: "Retreive calendars from the user account.",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    googleCalendar,
+  },
+  async run() {
+    const calendar = this.googleCalendar.calendar();
+    return (await calendar.calendarList.list()).data;
+  },
+};

--- a/components/google_calendar/actions/quick-add-event/quick-add-event.js
+++ b/components/google_calendar/actions/quick-add-event/quick-add-event.js
@@ -1,0 +1,30 @@
+const googleCalendar = require("../../google_calendar.app");
+
+module.exports = {
+  key: "google_calendar_quick_add_event",
+  name: "Add Quick Event",
+  description: "Create an event to the Google Calendar.",
+  version: "0.0.8",
+  type: "action",
+  props: {
+    googleCalendar,
+    calendarId: {
+      propDefinition: [
+        googleCalendar,
+        "calendarId",
+      ],
+    },
+    text: {
+      label: "Event Title",
+      type: "string",
+      description: "Enter static text (e.g., `hello world`) for the event name",
+    },
+  },
+  async run() {
+    const calendar = this.googleCalendar.calendar();
+    return (await calendar.events.quickAdd({
+      calendarId: this.calendarId,
+      text: this.text,
+    })).data;
+  },
+};

--- a/components/google_calendar/actions/update-acl/update-acl.js
+++ b/components/google_calendar/actions/update-acl/update-acl.js
@@ -1,0 +1,97 @@
+const googleCalendar = require("../../google_calendar.app");
+
+module.exports = {
+  key: "google_calendar_update_acl",
+  name: "Update Access Control Rule",
+  description: "Update Access Control Rule Metadata of a google calendar.",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    googleCalendar,
+    calendarId: {
+      propDefinition: [
+        googleCalendar,
+        "calendarId",
+      ],
+    },
+    ruleId: {
+      propDefinition: [
+        googleCalendar,
+        "ruleId",
+        (c) => ({
+          calendarId: c.calendarId,
+        }),
+      ],
+    },
+    role: {
+      label: "Role",
+      type: "string",
+      description: "The role assigned to the scope.",
+      optional: true,
+      options() {
+        const roles = [
+          "none",
+          "freeBusyReader",
+          "reader",
+          "writer",
+          "owner",
+        ];
+        const options = roles.map((role) => {
+          return {
+            label: role,
+            value: role,
+          };
+        });
+        return options;
+      },
+    },
+    scopeType: {
+      label: "Type of the Scope",
+      type: "string",
+      description: "The extent to which calendar access is granted by this ACL rule.",
+      optional: true,
+      default: "default",
+      options() {
+        const types = [
+          "user",
+          "group",
+          "domain",
+        ];
+        const options = types.map((type) => {
+          return {
+            label: type,
+            value: type,
+          };
+        });
+        return options;
+      },
+    },
+    scopeValue: {
+      label: "Type of the Scope",
+      type: "string",
+      description: "The email address of a user or group, or the name of a domain, depending on the scope type. Omitted for type 'default'",
+      optional: true,
+      default: "",
+    },
+  },
+  async run() {
+    const calendar = this.googleCalendar.calendar();
+
+    let scope = {
+      type: this.scopeType,
+    };
+
+    if (this.scopeType !== "default") {
+      scope["value"] = this.scopeValue;
+    }
+
+    return (await calendar.acl.update({
+      calendarId: this.calendarId,
+      ruleId: this.ruleId,
+      requestBody: {
+        scope,
+        role: this.role,
+      },
+    })).data;
+  },
+};

--- a/components/google_calendar/actions/update-acl/update-acl.js
+++ b/components/google_calendar/actions/update-acl/update-acl.js
@@ -81,7 +81,7 @@ module.exports = {
       type: this.scopeType,
     };
 
-    if (this.scopeType !== "default") {
+    if (this.scopeType !== "default" && this.scopeValue.trim().length) {
       scope["value"] = this.scopeValue;
     }
 

--- a/components/google_calendar/actions/update-attendees/update-attendees.js
+++ b/components/google_calendar/actions/update-attendees/update-attendees.js
@@ -1,0 +1,74 @@
+const googleCalendar = require("../../google_calendar.app");
+
+module.exports = {
+  key: "google_calendar_update_event_attendees",
+  name: "Update attendees of an event",
+  description: "Update attendees of an existing event.",
+  version: "0.0.3",
+  type: "action",
+  props: {
+    googleCalendar,
+    calendarId: {
+      propDefinition: [
+        googleCalendar,
+        "calendarId",
+      ],
+    },
+    eventId: {
+      propDefinition: [
+        googleCalendar,
+        "eventId",
+        (c) => ({
+          calendarId: c.calendarId,
+        }),
+      ],
+    },
+    attendees: {
+      type: "string[]",
+      label: "Attendees",
+      description: "Add EmailId's of the attendees",
+      async options() {
+        const calendar = this.googleCalendar.calendar();
+        const { data } = await calendar.events.get({
+          eventId: this.eventId,
+          calendarId: this.calendarId,
+        });
+        const attendees = data.attendees
+          ? data.attendees
+          : [];
+
+        const options = attendees.map((attendee) => {
+          return {
+            label: attendee.email,
+            value: attendee.email,
+          };
+        });
+
+        return options;
+      },
+    },
+  },
+  async run() {
+    const calendar = this.googleCalendar.calendar();
+    const { data } = await calendar.events.get({
+      eventId: this.eventId,
+      calendarId: this.calendarId,
+    });
+    let attendees = this.attendees
+      ? this.attendees
+      : [];
+    attendees = attendees.map( (attendee) => {
+      return {
+        email: attendee,
+      };
+    });
+    return (await calendar.events.update({
+      calendarId: this.calendarId,
+      eventId: this.eventId,
+      requestBody: {
+        ...data,
+        attendees,
+      },
+    })).data;
+  },
+};

--- a/components/google_calendar/google_calendar.app.js
+++ b/components/google_calendar/google_calendar.app.js
@@ -132,6 +132,14 @@ module.exports = {
       optional: true,
       type: "string",
     },
+    ruleId: {
+      type: "string",
+      label: "ACL rule identifier",
+      description: "ACL rule identifier.",
+      async options({ calendarId }) {
+        return await this.listACLOptions(calendarId);
+      },
+    },
   },
   methods: {
     _tokens() {
@@ -219,6 +227,26 @@ module.exports = {
         return {
           label: event.summary,
           value: event.id,
+        };
+      });
+
+      return options;
+    },
+
+    /**
+     * @param {string} [calendarId] - User Calendar Id
+     * @returns
+     */
+
+    async listACLOptions(calendarId) {
+      const calendar = this.calendar();
+      const { data } = await calendar.acl.list({
+        calendarId: calendarId,
+      });
+      const options = data.items.map((item) => {
+        return {
+          label: item.role,
+          value: item.id,
         };
       });
 

--- a/components/google_calendar/google_calendar.app.js
+++ b/components/google_calendar/google_calendar.app.js
@@ -1,154 +1,198 @@
-const { google } = require("googleapis")
-const get = require("lodash.get")
+const { google } = require("googleapis");
+const get = require("lodash.get");
 
 module.exports = {
   type: "app",
   app: "google_calendar",
   propDefinitions: {
     calendarId: {
+      label: "Calender Name",
       description: "Calendar identifier. To retrieve calendar IDs call the calendarList.list method. If you want to access the primary calendar of the currently logged in user, use the \"primary\" keyword.",
-      type: "string"
+      type: "string",
+      async options({ prevContext }) {
+        const { nextPageToken } = prevContext;
+        const calendars = await this.listCalendarsInPage(nextPageToken);
+        const options = [];
+        for (const calendar of calendars.items) {
+          options.push({
+            label: calendar.summary,
+            value: calendar.id,
+          });
+        }
+        return {
+          options,
+          context: {
+            nextPageToken,
+          },
+        };
+      },
     },
-    iCalUID : {
+    iCalUID: {
       description: "Specifies event ID in the iCalendar format to be included in the response. Optional.",
       optional: true,
-      type: "string"
+      type: "string",
     },
     maxAttendees: {
       description: "The maximum number of attendees to include in the response. If there are more than the specified number of attendees, only the participant is returned. Optional.",
       optional: true,
-      type: "integer"
+      type: "integer",
     },
     maxResults: {
       description: "Maximum number of events returned on one result page. The number of events in the resulting page may be less than this value, or none at all, even if there are more events matching the query. Incomplete pages can be detected by a non-empty nextPageToken field in the response. By default the value is 250 events. The page size can never be larger than 2500 events. Optional.",
       optional: true,
-      type: "integer"
+      type: "integer",
     },
     orderBy: {
       description: "The order of the events returned in the result. Optional. The default is an unspecified, stable order.",
       optional: true,
       type: "string",
       options() {
-        return [{label: "startTime", value: "startTime"}, {label: "updated", value: "updated"}]
+        return [
+          {
+            label: "startTime",
+            value: "startTime",
+          },
+          {
+            label: "updated",
+            value: "updated",
+          },
+        ];
       },
-//      async options: ["startTime", "updated"],
-      default: "startTime"
+      //      async options: ["startTime", "updated"],
+      default: "startTime",
     },
     pageToken: {
       description: "Token specifying which result page to return. Optional.",
       optional: true,
-      type: "string"
+      type: "string",
     },
     privateExtendedProperty: {
       description: "Extended properties constraint specified as propertyName=value. Matches only private properties. This parameter might be repeated multiple times to return events that match all given constraints.",
       optional: true,
-      type: "string"
+      type: "string",
     },
     q: {
       description: "Free text search terms to find events that match these terms in any field, except for extended properties. Optional.",
       optional: true,
-      type: "string"
+      type: "string",
     },
     sharedExtendedProperty: {
       description: "Extended properties constraint specified as propertyName=value. Matches only shared properties. This parameter might be repeated multiple times to return events that match all given constraints.",
       optional: true,
-      type: "string"
+      type: "string",
     },
     showDeleted: {
       description: "Whether to include deleted events (with status equals \"cancelled\") in the result. Cancelled instances of recurring events (but not the underlying recurring event) will still be included if showDeleted and singleEvents are both False. If showDeleted and singleEvents are both True, only single instances of deleted events (but not the underlying recurring events) are returned. Optional. The default is False.",
       optional: true,
-      type: "boolean"
+      type: "boolean",
     },
     showHiddenInvitations: {
       description: "Whether to include hidden invitations in the result. Optional. The default is False.",
       optional: true,
-      type: "boolean"
+      type: "boolean",
     },
     singleEvents: {
       description: "Whether to expand recurring events into instances and only return single one-off events and instances of recurring events, but not the underlying recurring events themselves. Optional. The default is False.",
       optional: true,
-      type: "boolean"
+      type: "boolean",
     },
     syncToken: {
       description: "Token obtained from the nextSyncToken field returned on the last page of results from the previous list request. It makes the result of this list request contain only entries that have changed since then. All events deleted since the previous list request will always be in the result set and it is not allowed to set showDeleted to False.",
       optional: true,
-      type: "string"
+      type: "string",
     },
     timeMax: {
       description: "Upper bound (exclusive) for an event's start time to filter by. Optional. The default is not to filter by start time. Must be an RFC3339 timestamp with mandatory time zone offset, for example, 2011-06-03T10:00:00-07:00, 2011-06-03T10:00:00Z. Milliseconds may be provided but are ignored. If timeMin is set, timeMax must be greater than timeMin.",
       optional: true,
-      type: "string"
+      type: "string",
     },
     timeMin: {
       description: "Lower bound (exclusive) for an event's end time to filter by. Optional. The default is not to filter by end time. Must be an RFC3339 timestamp with mandatory time zone offset, for example, 2011-06-03T10:00:00-07:00, 2011-06-03T10:00:00Z. Milliseconds may be provided but are ignored. If timeMax is set, timeMin must be smaller than timeMax.",
       optional: true,
-      type: "string"
+      type: "string",
     },
     timeZone: {
       description: "Time zone used in the response. Optional. The default is the time zone of the calendar.",
       optional: true,
-      type: "string"
+      type: "string",
     },
-    updatedMin: { description: "Lower bound for an event's last modification time (as a RFC3339 timestamp) to filter by. When specified, entries deleted since this time will always be included regardless of showDeleted. Optional. The default is not to filter by last modification time.",
+    updatedMin: {
+      description: "Lower bound for an event's last modification time (as a RFC3339 timestamp) to filter by. When specified, entries deleted since this time will always be included regardless of showDeleted. Optional. The default is not to filter by last modification time.",
       optional: true,
-      type: "string"
-    }
+      type: "string",
+    },
   },
   methods: {
     _tokens() {
-      const access_token = get(this, "$auth.oauth_access_token")
-      const refresh_token = get(this, "$auth.oauth_refresh_token")
+      const access_token = get(this, "$auth.oauth_access_token");
+      const refresh_token = get(this, "$auth.oauth_refresh_token");
       return {
         access_token,
         refresh_token,
-      }
+      };
     },
     // returns a calendar object you can do whatever you want with
     calendar() {
-      const auth = new google.auth.OAuth2()
-      auth.setCredentials(this._tokens())
-      const calendar = google.calendar({version: "v3", auth})
-      return calendar
+      const auth = new google.auth.OAuth2();
+      auth.setCredentials(this._tokens());
+      const calendar = google.calendar({
+        version: "v3",
+        auth,
+      });
+      return calendar;
     },
     async calendarList() {
-      const calendar = this.calendar()
-      const resp = await calendar.calendarList.list()
-      return resp
+      const calendar = this.calendar();
+      const resp = await calendar.calendarList.list();
+      return resp;
     },
     async list(config) {
-      const calendar = this.calendar()
-      const resp = await calendar.events.list(config)
-      return resp
+      const calendar = this.calendar();
+      const resp = await calendar.events.list(config);
+      return resp;
     },
     // for config key value pairs - https://developers.google.com/calendar/v3/reference/events/list
     // deprecated
     async getEvents(config) {
-      return await this.list(config)
+      return await this.list(config);
     },
     async watch(config) {
-      const calendar = this.calendar()
-      const resp = await calendar.events.watch(config)
-      return resp
+      const calendar = this.calendar();
+      const resp = await calendar.events.watch(config);
+      return resp;
     },
     async stop(config) {
-      const calendar = this.calendar()
-      const resp = await calendar.channels.stop(config)
-      return resp
+      const calendar = this.calendar();
+      const resp = await calendar.channels.stop(config);
+      return resp;
     },
     async fullSync(calendarId) {
-      let nextSyncToken = null
-      let nextPageToken = null
-      while(!nextSyncToken) {
+      let nextSyncToken = null;
+      let nextPageToken = null;
+      while (!nextSyncToken) {
         const listConfig = {
           calendarId,
-          pageToken: nextPageToken
-        }
-        const syncResp = await this.list(listConfig)
-        nextPageToken = get(syncResp, "data.nextPageToken")
-        nextSyncToken = get(syncResp, "data.nextSyncToken")
+          pageToken: nextPageToken,
+        };
+        const syncResp = await this.list(listConfig);
+        nextPageToken = get(syncResp, "data.nextPageToken");
+        nextSyncToken = get(syncResp, "data.nextSyncToken");
       }
-      return nextSyncToken
-    }
-  }
-}
+      return nextSyncToken;
+    },
+    /**
+     * @param {string} [pageToken] - the page token for the next page of shared
+     * calendars
+     * @returns
+     */
+    async listCalendarsInPage(pageToken) {
+      const calendar = this.calendar();
+      const { data } = await calendar.calendarList.list({
+        pageToken,
+        showHidden: true,
+      });
+      return data;
+    },
+  },
+};
 

--- a/components/google_calendar/google_calendar.app.js
+++ b/components/google_calendar/google_calendar.app.js
@@ -27,6 +27,14 @@ module.exports = {
         };
       },
     },
+    eventId: {
+      label: "Event Name",
+      description: "Event identifier. To retreive event Ids from a calender.",
+      type: "string",
+      async options({ calendarId }) {
+        return await this.listEventOptions(calendarId);
+      },
+    },
     iCalUID: {
       description: "Specifies event ID in the iCalendar format to be included in the response. Optional.",
       optional: true,
@@ -193,6 +201,26 @@ module.exports = {
         showHidden: true,
       });
       return data;
+    },
+
+    /**
+     * @param {string} [calendarId] - user calender id
+     * @returns
+     */
+    async listEventOptions(calendarId) {
+      const calendar = this.calendar();
+      const { data } = await calendar.events.list({
+        calendarId,
+      });
+
+      const options = data.items.map((event) => {
+        return {
+          label: event.summary,
+          value: event.id,
+        };
+      });
+
+      return options;
     },
   },
 };

--- a/components/google_calendar/google_calendar.app.js
+++ b/components/google_calendar/google_calendar.app.js
@@ -140,6 +140,56 @@ module.exports = {
         return await this.listACLOptions(calendarId);
       },
     },
+    role: {
+      label: "Role",
+      type: "string",
+      description: "The role assigned to the scope.",
+      optional: true,
+      options() {
+        const roles = [
+          "none",
+          "freeBusyReader",
+          "reader",
+          "writer",
+          "owner",
+        ];
+        const options = roles.map((role) => {
+          return {
+            label: role,
+            value: role,
+          };
+        });
+        return options;
+      },
+    },
+    scopeType: {
+      label: "Type of the Scope",
+      type: "string",
+      description: "The extent to which calendar access is granted by this ACL rule.",
+      optional: true,
+      default: "default",
+      options() {
+        const types = [
+          "user",
+          "group",
+          "domain",
+        ];
+        const options = types.map((type) => {
+          return {
+            label: type,
+            value: type,
+          };
+        });
+        return options;
+      },
+    },
+    scopeValue: {
+      label: "Type of the Scope",
+      type: "string",
+      description: "The email address of a user or group, or the name of a domain, depending on the scope type. Omitted for type 'default'",
+      optional: true,
+      default: "",
+    },
   },
   methods: {
     _tokens() {

--- a/components/google_calendar/google_calendar.app.js
+++ b/components/google_calendar/google_calendar.app.js
@@ -9,6 +9,8 @@ module.exports = {
       label: "Calender Name",
       description: "Calendar identifier. To retrieve calendar IDs call the calendarList.list method. If you want to access the primary calendar of the currently logged in user, use the \"primary\" keyword.",
       type: "string",
+      optional: true,
+      default: "primary",
       async options({ prevContext }) {
         const { nextPageToken } = prevContext;
         const calendars = await this.listCalendarsInPage(nextPageToken);

--- a/components/google_calendar/google_calendar.app.js
+++ b/components/google_calendar/google_calendar.app.js
@@ -115,6 +115,7 @@ module.exports = {
       description: "Time zone used in the response. Optional. The default is the time zone of the calendar.",
       optional: true,
       type: "string",
+      label: "TimeZone",
     },
     updatedMin: {
       description: "Lower bound for an event's last modification time (as a RFC3339 timestamp) to filter by. When specified, entries deleted since this time will always be included regardless of showDeleted. Optional. The default is not to filter by last modification time.",

--- a/components/google_calendar/package-lock.json
+++ b/components/google_calendar/package-lock.json
@@ -208,6 +208,19 @@
             "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.7.tgz",
             "integrity": "sha512-dhNd1uA2u397uQk3Nv5LM4lm93WYDUXFn3Fu291FJerns4jyTudqhIWe4W04YLy7Uk1tm1Ore04NpjRvQp/NPA=="
         },
+        "moment": {
+            "version": "2.29.1",
+            "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+            "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+        },
+        "moment-timezone": {
+            "version": "0.5.33",
+            "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.33.tgz",
+            "integrity": "sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==",
+            "requires": {
+                "moment": ">= 2.9.0"
+            }
+        },
         "ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",

--- a/components/google_calendar/package.json
+++ b/components/google_calendar/package.json
@@ -12,7 +12,8 @@
     "license": "MIT",
     "dependencies": {
         "googleapis": "^67.0.0",
-        "lodash.get": "^4.4.2"
+        "lodash.get": "^4.4.2",
+        "moment-timezone": "^0.5.33"
     },
     "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
     "publishConfig": {


### PR DESCRIPTION
Fixes #1444 

- [x] **Quick Add Event** | Create an event from a piece of text. Google parses the text for date, time, and description info
- [x] **Create Detailed Event** | Create an event by defining each field
- [ ] **Update Event** | Update an event
- [x] **Add Attendees to Event** | Invite one or more persons to an existing event
- [x] **Delete Event** | Delete an event
- [x] **Create Calendar** | Create a new calendar
- [ ] **Find Event** | Find an event in your calendar. Optionally, create one if none are found
- [x] **Get Event** | Return metadata for an event
- [x] **List Calendars** | Return the calendars on the user's calendar list
- [x] **Get Calendar** | Return metadata for a calendar
- [ ] **Update Calendar** | Update an existing calendar
- [x] **Delete Calendar** | Delete a calendar
- [x] **Clear Calendar** | Clear a primary calendar. Deletes all events associated with the primary calendar of an account
- [x] **List Access Control Rules** | Return the rules in the access control list for a calendar
- [x] **Get Access Control Rule** | Return metadata of an access control rule
- [x] **Create Access Control Rule** | Create a new access control rule
- [x] **Update Access Control Rule** | Update an existing access control rule
- [x] **Delete Access Control Rule** | Delete an access control rule
- [x] **Get Free/Busy Information** | Return free/busy information for a set of calendars

Signed-off-by: Moulik Aggarwal <qwertymoulik@gmail.com>
