### PR TITLE
Add missing / in the link

### DIFF
--- a/docs/docs/api/rest/README.md
+++ b/docs/docs/api/rest/README.md
@@ -176,7 +176,7 @@ POST /components
 
 `component_code` **string** (_optional_)
 
-The full code for a [Pipedream component](components/api/).
+The full code for a [Pipedream component](/components/api/).
 
 ---
 


### PR DESCRIPTION
Due to missing /, the url was coming relative to current URL, because of which instead of pointing to [expected link](https://pipedream.com/docs/components/api/), it pointed to [this link](https://pipedream.com/docs/api/rest/components/api/) under [this section](https://pipedream.com/docs/api/rest/#parameters)