### PR TITLE
Fix attempting to publish common files in publish-components GitHub action

### DIFF
--- a/.github/workflows/publish-components.yaml
+++ b/.github/workflows/publish-components.yaml
@@ -36,8 +36,10 @@ jobs:
           SKIPPED=""
           mapfile -d ',' -t added_modified_files < <(printf '%s,' '${{ steps.files.outputs.added_modified }}')
           for added_modified_file in "${added_modified_files[@]}"; do
-            # starts with components, ends with .*js (e.g. .js and .mjs) and not app.js
-            if [[ $added_modified_file == components/* ]] && [[ $added_modified_file == *.*js ]] && [[ $added_modified_file != *.app.*js ]]
+          # starts with components, ends with .*js (e.g. .js and .mjs) and not app.js,
+          # doesn't end with /common*.*js, and doesn't follow */common/
+          if [[ $added_modified_file == components/* ]] && [[ $added_modified_file == *.*js ]] && [[ $added_modified_file != *.app.*js ]] \
+              && [[ $added_modified_file != */common*.*js ]] && [[ $added_modified_file != */common/* ]]
             then
               echo "attempting to publish ${added_modified_file}"
               PD_OUTPUT=`./pd publish ${added_modified_file} --json`


### PR DESCRIPTION
Modifies the publish-components GitHub action to skip common files so publishing them isn't attempted. 

Previously, attempting to publish non-component files resulted in in an error like:
> Validation failed: Key component code must have a key attribute, Version component code must have a version attribute in semver form...

Used the [ESLint configuration](https://github.com/PipedreamHQ/pipedream/blob/e2c6f40ddb9fc12fe9f80d0130b784f8b9dd9713/.eslintrc#L37) for as a reference for which files are determined "common".

Note:
- This PR should prevent the GitHub action from attempting to publish "common" files, but I think some files that are not components will still be included. For example:
> Validation failed: Key component code must have a key attribute, Version component code must have a version attribute in semver form with components/google_drive/actions/google-mime-types.js
Validation failed: Key component code must have a key attribute, Version component code must have a version attribute in semver form with components/google_drive/actions/language-codes.js
- If all component files are in their own subfolders, we could skip files publishing fiels that are immediate children of `actions/` and `sources/`.
- Alternatively, we could move non-component files into `/common` folders.