### PR TITLE
Fix **Publish Components** GitHub action context

### DIFF
--- a/.github/workflows/publish-components.yaml
+++ b/.github/workflows/publish-components.yaml
@@ -1,11 +1,11 @@
 on: 
-  pull_request:
-    types: [ closed ]
+  push:
+    branches:
+      - master
 
 jobs:
   publish-components:
     name: Publish Components to Pipedream Registry
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
Reverts changes to **Publish Components** workflow in #1810, which had changed the workflow trigger from "on push to master" to "on closed pull request".

The change in #1810 was made to enable the workflow to run on "squash/rebase and merge". But when triggered by the `pull_request` event, the workflow would run from the context of the forked repo and lose access to secrets used in the workflow.

Triggering the workflow on `push` events to the `master` branch should allow it to run in the context of the base repo on squash/rebase and merges to `master`.