### PR TITLE
Fix JSDocs in Ghost Admin

### DIFF
--- a/components/ghost_admin/sources/common-webhook.mjs
+++ b/components/ghost_admin/sources/common-webhook.mjs
@@ -28,14 +28,14 @@ export default {
      * Gets the [Ghost event](https://ghost.org/docs/webhooks/) for which this webhook should
      * receieve events
      *
-     * To receieve webhook requests for the Ghost event `site.changed`, the function would look
-     * like this:
+     * To receieve webhook requests for the Ghost event `site.changed`, the function would look like
+     * this:
      * @example
      * function getEvent() {
      *   return "site.changed";
      * }
      *
-     * @returns {String} The full Ghost event string
+     * @returns {string} The full Ghost event string
      */
     getEvent() {
       throw new Error("getEvent is not implemented");
@@ -43,18 +43,18 @@ export default {
     /**
      * Generates the metadata object to append to the emitted event
      *
-     * @param {object} data the data being processed by the event
-     * source
-     * @returns {object} a metadata object containing a unique ID (`id`), a
-     * summary of the event (`summary`) and its timestamp (`ts`) as
-     * the number of milliseconds since the [Unix Epoch](https://en.wikipedia.org/wiki/Unix_time)
+     * @param {object} data - The data being processed by the event source
+     * @returns {object} A metadata object containing a unique ID (`id`), a summary of the event
+     * (`summary`) and its timestamp (`ts`) as the number of milliseconds since the [Unix
+     * Epoch](https://en.wikipedia.org/wiki/Unix_time)
      */
     generateMeta() {
       throw new Error("generateMeta is not implemented");
     },
     /**
-     * Default emitEvent. Components should overwrite this function if something more
+     * Emits an event. Components should overwrite this function if something more
      * needs to be emitted in the event.
+     *
      * @param {object} body - The event body to be emitted
      */
     emitEvent(body) {

--- a/components/ghost_admin/sources/member-created/member-created.mjs
+++ b/components/ghost_admin/sources/member-created/member-created.mjs
@@ -6,7 +6,7 @@ export default {
   key: "ghost_admin-member-created",
   name: "New Member Created (Instant)",
   description: "Emit new event for each new member added to a site.",
-  version: "0.0.4",
+  version: "0.0.5",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/ghost_admin/sources/member-deleted/member-deleted.mjs
+++ b/components/ghost_admin/sources/member-deleted/member-deleted.mjs
@@ -6,7 +6,7 @@ export default {
   key: "ghost_admin-member-deleted",
   name: "Member Deleted (Instant)",
   description: "Emit new event each time a member is deleted from a site.",
-  version: "0.0.4",
+  version: "0.0.5",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/ghost_admin/sources/member-updated/member-updated.mjs
+++ b/components/ghost_admin/sources/member-updated/member-updated.mjs
@@ -6,7 +6,7 @@ export default {
   key: "ghost_admin-member-updated",
   name: "Member Updated (Instant)",
   description: "Emit new event each time a member is updated.",
-  version: "0.0.4",
+  version: "0.0.5",
   methods: {
     ...common.methods,
     getEvent() {

--- a/components/ghost_admin/sources/new-tag/new-tag.mjs
+++ b/components/ghost_admin/sources/new-tag/new-tag.mjs
@@ -6,7 +6,7 @@ export default {
   key: "ghost_admin-new-tag",
   name: "Tag Added (Instant)",
   description: "Emit new event for each new tag created on a site.",
-  version: "0.0.4",
+  version: "0.0.5",
   methods: {
     ...common.methods,
     getEvent() {

--- a/components/ghost_admin/sources/page-published/page-published.mjs
+++ b/components/ghost_admin/sources/page-published/page-published.mjs
@@ -6,7 +6,7 @@ export default {
   key: "ghost-page-published",
   name: "Page Published (Instant)",
   description: "Emit new event for each new page published on a site.",
-  version: "0.0.4",
+  version: "0.0.5",
   methods: {
     ...common.methods,
     getEvent() {

--- a/components/ghost_admin/sources/post-published/post-published.mjs
+++ b/components/ghost_admin/sources/post-published/post-published.mjs
@@ -6,7 +6,7 @@ export default {
   key: "ghost-post-published",
   name: "Post Published (Instant)",
   description: "Emit new event for each new post published on a site.",
-  version: "0.0.4",
+  version: "0.0.5",
   methods: {
     ...common.methods,
     getEvent() {


### PR DESCRIPTION
#### Changes
- Updates the JSDoc comments in Ghost Admin app's `common-webhook.mjs` file for consistency
- Bumps source versions for Ghost Admin

#### Note

This PR is intended to test changes in #1819. The [**Publish Components to Pipedream Registry**](https://github.com/PipedreamHQ/pipedream/blob/master/.github/workflows/publish-components.yaml) workflow should run after squash or rebase and merges of PRs from a forked repository.

**Edit**:
After squashing and merging this PR into the master branch, the [**Publish Components to Pipedream Registry**](https://github.com/PipedreamHQ/pipedream/blob/master/.github/workflows/publish-components.yaml) workflow run [completed successfully](https://github.com/PipedreamHQ/pipedream/actions/runs/1370105803).