### PR TITLE
Zoho CRM Bug Fix: New Event source fails with this._generateToken is not a function error

### DIFF
--- a/components/zoho_crm/sources/common/http-based/base.js
+++ b/components/zoho_crm/sources/common/http-based/base.js
@@ -2,7 +2,7 @@ const {
   randomBytes,
   randomInt,
 } = require("crypto");
-const zoho_crm = require("../../../zoho_crm.app");
+const zohoCrm = require("../../../zoho_crm.app");
 
 // Zoho CRM webhooks subscriptions have an expiration date of up to 1 day. This
 // event source renews the subscription every 12 hours by default. More info can
@@ -13,11 +13,13 @@ const hookRenewalPeriod = 60 * 60 * 12;
 module.exports = {
   dedupe: "unique",
   props: {
-    zoho_crm,
+    zohoCrm,
     db: "$.service.db",
     http: "$.interface.http",
     timer: {
       type: "$.interface.timer",
+      label: "Subscription Renewal Timer",
+      description: "Zoho CRM webhooks subscriptions have an expiration date of up to 1 day. This event source renews the subscription every 12 hours by default.",
       default: {
         intervalSeconds: hookRenewalPeriod,
       },
@@ -37,7 +39,7 @@ module.exports = {
         events,
       };
 
-      await this.zoho_crm.createHook(hookOpts);
+      await this.zohoCrm.createHook(hookOpts);
 
       console.log(`
         Created webhook notification for channel ID: ${channelId}
@@ -48,7 +50,7 @@ module.exports = {
     },
     async deactivate() {
       const channelId = this.db.get("channelId");
-      await this.zoho_crm.deleteHook(channelId);
+      await this.zohoCrm.deleteHook(channelId);
 
       console.log(`
         Deleted webhook notification for channel ID: ${channelId}
@@ -104,7 +106,7 @@ module.exports = {
         events,
         token,
       };
-      return this.zoho_crm.renewHookSubscription(renewOpts);
+      return this.zohoCrm.renewHookSubscription(renewOpts);
     },
     /**
      * Utility function that determines whether a module supports all the event
@@ -154,7 +156,7 @@ module.exports = {
 
       const apiCalls = ids
         .map((id) => `${uri}/${id}`)
-        .map(this.zoho_crm.genericApiGetCall);
+        .map(this.zohoCrm.genericApiGetCall);
       const responses = await Promise.all(apiCalls);
       return responses.map(({ data }) => data);
     },

--- a/components/zoho_crm/sources/new-event/new-event.js
+++ b/components/zoho_crm/sources/new-event/new-event.js
@@ -7,7 +7,8 @@ module.exports = {
   key: "zoho_crm-new-event",
   name: "New Event (Instant)",
   description: "Emits an event each time a specified event occurs in Zoho CRM",
-  version: "0.0.1",
+  version: "0.0.2",
+  type: "action",
   props: {
     ...common.props,
     events: {
@@ -25,6 +26,7 @@ module.exports = {
     },
   },
   methods: {
+    ...common.methods,
     _moduleSupportedEvents(module) {
       // See the docs for more information about these attributes:
       // https://www.zoho.com/crm/developer/docs/api/v2/modules-api.html


### PR DESCRIPTION
Bug was due to `...common.methods` being left out. Added it in and added a label and description for `timer` in `base.js`.