### PR TITLE
Have atleast one space in place of multi-spaces

### DIFF
--- a/components/aws/sources/common/utils.js
+++ b/components/aws/sources/common/utils.js
@@ -36,6 +36,6 @@ module.exports = {
     return multiLineString
       .trim()
       .replace(/\n/g, " ")
-      .replace(/\s{2,}/g, "");
+      .replace(/\s{2,}/g, " ");
   },
 };


### PR DESCRIPTION
So, we were replacing multiple spaces combination to an empty string which is probably not expected.

For example, in `aws` source `new-emails-sent-to-ses-catch-all-domain`,

```js
toSingleLineString(`
    The source subscribes to all emails delivered to a
    specific domain configured in AWS SES.
    When an email is sent to any address at the domain,
    this event source emits that email as a formatted event.
    These events can trigger a Pipedream workflow and can be consumed via SSE or REST API.
  `)
```

results in the string

'The source subscribes to all emails delivered to aspecific domain configured in AWS SES.When an email is sent to any address at the domain,this event source emits that email as a formatted event.These events can trigger a Pipedream workflow and can be consumed via SSE or REST API.'

So after first line between words `a` and `specific` there should have been ideally a space.