### PR TITLE
Fix typo in Github source

### DIFF
--- a/components/github/sources/new-or-updated-pull-request/new-or-updated-pull-request.js
+++ b/components/github/sources/new-or-updated-pull-request/new-or-updated-pull-request.js
@@ -28,7 +28,7 @@ module.exports = {
         "converted_to_draft",
         "labeled",
         "unlabeled",
-        "syncronize",
+        "synchronize",
         "auto_merge_enabled",
         "auto_merge_disabled",
         "locked",


### PR DESCRIPTION
This PR fixes a typo that prevents `synchronize` pull request actions from emitting events.