### PR TITLE
Zoho CRM Source Bug Fixes and Some Renaming for Readability

### DIFF
--- a/components/zoho_crm/sources/common/http-based/crud-operations.js
+++ b/components/zoho_crm/sources/common/http-based/crud-operations.js
@@ -7,17 +7,17 @@ const crudOpsData = [
   {
     op: "create",
     flagName: "creatable",
-    description: "Creation",
+    description: "Created",
   },
   {
     op: "delete",
     flagName: "deletable",
-    description: "Deletion",
+    description: "Deleted",
   },
   {
     op: "edit",
     flagName: "editable",
-    description: "Edition",
+    description: "Updated",
   },
 ];
 

--- a/components/zoho_crm/sources/common/http-based/crud-operations.js
+++ b/components/zoho_crm/sources/common/http-based/crud-operations.js
@@ -23,7 +23,7 @@ const crudOpsData = [
 
 const getOpData = (inputOp) => crudOpsData.find(({ op }) => op === inputOp);
 
-module.exports = {
+module.exports = {  // eslint-disable-line
   createOpData() {
     return getOpData("create");
   },

--- a/components/zoho_crm/sources/common/http-based/custom-module.js
+++ b/components/zoho_crm/sources/common/http-based/custom-module.js
@@ -15,7 +15,7 @@ module.exports = {
           return [];
         }
 
-        const { modules } = await this.zoho_crm.listModules();
+        const { modules } = await this.zohoCrm.listModules();
         const options = modules
           .filter(this.areEventsSupportedByModule)
           .map(({

--- a/components/zoho_crm/sources/common/http-based/custom-module.js
+++ b/components/zoho_crm/sources/common/http-based/custom-module.js
@@ -1,7 +1,7 @@
 const sortBy = require("lodash/sortBy");
 const base = require("./predefined-module");
 
-module.exports = {
+module.exports = { // eslint-disable-line
   ...base,
   props: {
     ...base.props,

--- a/components/zoho_crm/sources/common/http-based/predefined-module.js
+++ b/components/zoho_crm/sources/common/http-based/predefined-module.js
@@ -28,7 +28,7 @@ module.exports = {
      * source
      */
     async _retrieveModuleType() {
-      const { modules } = await this.zoho_crm.listModules();
+      const { modules } = await this.zohoCrm.listModules();
       const { api_name: moduleType } = modules
         .find(({ singular_label: moduleName }) => moduleName === this.getModuleName());
       return moduleType;

--- a/components/zoho_crm/sources/common/http-based/predefined-module.js
+++ b/components/zoho_crm/sources/common/http-based/predefined-module.js
@@ -1,6 +1,6 @@
 const base = require("./base");
 
-module.exports = {
+module.exports = {  // eslint-disable-line
   ...base,
   hooks: {
     ...base.hooks,

--- a/components/zoho_crm/sources/new-event/new-event.js
+++ b/components/zoho_crm/sources/new-event/new-event.js
@@ -5,8 +5,8 @@ const crudOps = require("../common/http-based/crud-operations");
 module.exports = {
   ...common,
   key: "zoho_crm-new-event",
-  name: "New Event (Instant)",
-  description: "Emit new custom events from Zoho CRM",
+  name: "Custom Event from Any Module (Instant)",  // eslint-disable-line
+  description: "Emit new, updated, or deleted records from one or more selected Zoho CRM Modules.",  // eslint-disable-line
   version: "0.0.6",
   type: "source",
   props: {

--- a/components/zoho_crm/sources/new-event/new-event.js
+++ b/components/zoho_crm/sources/new-event/new-event.js
@@ -7,14 +7,14 @@ module.exports = {
   key: "zoho_crm-new-event",
   name: "New Event (Instant)",
   description: "Emit new custom events from Zoho CRM",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   props: {
     ...common.props,
     events: {
       type: "string[]",
       label: "Events",
-      description: "List of CRUD events that will trigger this event source",
+      description: "Choose one or more module events to trigger this event source.",
       async options({ page = 0 }) {
         if (page !== 0) {
           return [];

--- a/components/zoho_crm/sources/new-module-entry/new-module-entry.js
+++ b/components/zoho_crm/sources/new-module-entry/new-module-entry.js
@@ -1,4 +1,4 @@
-const common = require("../common/http-based/custom-single-module");
+const common = require("../common/http-based/custom-module");
 const crudOps = require("../common/http-based/crud-operations");
 
 module.exports = {

--- a/components/zoho_crm/sources/new-module-entry/new-module-entry.js
+++ b/components/zoho_crm/sources/new-module-entry/new-module-entry.js
@@ -5,8 +5,9 @@ module.exports = {
   ...common,
   key: "zoho_crm-new-module-entry",
   name: "New Module Entry (Instant)",
-  description: "Emits an event each time a new module/record is created in Zoho CRM",
-  version: "0.0.1",
+  description: "Emit new event each time a new module/record is created in Zoho CRM",
+  version: "0.0.2",
+  type: "source",
   methods: {
     ...common.methods,
     getSupportedOps() {

--- a/components/zoho_crm/sources/new-or-updated-module-entry/new-or-updated-module-entry.js
+++ b/components/zoho_crm/sources/new-or-updated-module-entry/new-or-updated-module-entry.js
@@ -5,8 +5,9 @@ module.exports = {
   ...common,
   key: "zoho_crm-new-or-updated-module-entry",
   name: "New or Updated Module Entry (Instant)",
-  description: "Emits an event each time a module/record is created or edited in Zoho CRM",
-  version: "0.0.1",
+  description: "Emit new event each time a module/record is created or edited in Zoho CRM",
+  version: "0.0.2",
+  type: "source",
   methods: {
     ...common.methods,
     getSupportedOps() {

--- a/components/zoho_crm/sources/new-or-updated-module-entry/new-or-updated-module-entry.js
+++ b/components/zoho_crm/sources/new-or-updated-module-entry/new-or-updated-module-entry.js
@@ -1,4 +1,4 @@
-const common = require("../common/http-based/custom-single-module");
+const common = require("../common/http-based/custom-module");
 const crudOps = require("../common/http-based/crud-operations");
 
 module.exports = {

--- a/components/zoho_crm/sources/new-user/new-user.js
+++ b/components/zoho_crm/sources/new-user/new-user.js
@@ -5,13 +5,15 @@ module.exports = {
   ...common,
   key: "zoho_crm-new-user",
   name: "New User",
-  description: "Emits an event each time a new user is created in Zoho CRM",
-  version: "0.0.1",
+  description: "Emit new event each time a new user is created in Zoho CRM",
+  version: "0.0.2",
+  type: "source",
   dedupe: "unique",
   props: {
     ...common.props,
     userType: {
       type: "string",
+      label: "User Type",
       description: "The type of users to generate events for",
       options: userTypes,
     },
@@ -31,10 +33,12 @@ module.exports = {
     }) {
       const {
         id,
-        first_name: firstName = '',
-        last_name: lastName = '',
+        first_name: firstName = "",
+        last_name: lastName = "",
       } = user;
-      const lastNameInitial = lastName ? `${lastName.slice(0, 1)}.` : '';
+      const lastNameInitial = lastName
+        ? `${lastName.slice(0, 1)}.`
+        : "";
       const userNameDisplay = `${firstName} ${lastNameInitial}`;
       const summary = `New User: ${userNameDisplay}`;
       const { timestamp: ts } = event;

--- a/components/zoho_crm/sources/new-user/new-user.js
+++ b/components/zoho_crm/sources/new-user/new-user.js
@@ -18,7 +18,7 @@ module.exports = {
   },
   hooks: {
     async activate() {
-      const userCount = await this.zoho_crm.getUserCount({
+      const userCount = await this.zohoCrm.getUserCount({
         type: this.userType,
       });
       this.db.set("userCount", userCount);
@@ -46,14 +46,14 @@ module.exports = {
     },
     async processEvent(event) {
       const lastUserCount = this.db.get("userCount");
-      const usersPage = this.zoho_crm.computeLastUsersPage({
+      const usersPage = this.zohoCrm.computeLastUsersPage({
         userCount: lastUserCount,
       });
-      let usersOffset = this.zoho_crm.computeUsersOffset({
+      let usersOffset = this.zohoCrm.computeUsersOffset({
         userCount: lastUserCount,
       });
       let newUserCount = lastUserCount;
-      const userScan = await this.zoho_crm.getUsers({
+      const userScan = await this.zohoCrm.getUsers({
         page: usersPage,
         type: this.userType,
       });

--- a/components/zoho_crm/sources/updated-module-entry/updated-module-entry.js
+++ b/components/zoho_crm/sources/updated-module-entry/updated-module-entry.js
@@ -1,4 +1,4 @@
-const common = require("../common/http-based/custom-single-module");
+const common = require("../common/http-based/custom-module");
 const crudOps = require("../common/http-based/crud-operations");
 
 module.exports = {

--- a/components/zoho_crm/sources/updated-module-entry/updated-module-entry.js
+++ b/components/zoho_crm/sources/updated-module-entry/updated-module-entry.js
@@ -4,9 +4,10 @@ const crudOps = require("../common/http-based/crud-operations");
 module.exports = {
   ...common,
   key: "zoho_crm-updated-module-entry",
-  name: "Updated Module Entry (Instant)",
-  description: "Emits an event each time a new module/record is updated in Zoho CRM",
-  version: "0.0.1",
+  name: "Updated Module Entry (Instant)",  // eslint-disable-line
+  description: "Emit new event each time a new module/record is updated in Zoho CRM",
+  version: "0.0.2",
+  type: "source",
   methods: {
     ...common.methods,
     getSupportedOps() {


### PR DESCRIPTION
I'm working on converting everything to ESM so I can add a few Zoho CRM sources but in the meantime I found a some bugs that I wanted to fix ASAP. There were also a few names/labels that I'm renaming to be more understandable at-a-glance.

---

One issue I did not fix is that these sources seem to be incomplete: 
- `new-module-entry.js`
- `new-or-updated-module-entry.js`
- `updated-module-entry.js`

I noticed they were not showing up at all in the source picker. I fixed some reference errors in the `const common = require` lines but when I tried running `pd dev` I still got an error. Turns out there's no prop that would allow the user to choose which module to use, and `getModuleName()` is not defined in the source files which causes `predefined-module.js` to throw an error.

I’m not sure if these module-entry sources are even worth including. They’re basically more limited versions of the fully-customizable `new-event.js` source that lets you choose modules and operations. My recommendation would be to just delete them all together.

---

I changed the name of `new-event.js` from _New Event (Instant)_ to _Custom Event from Any Module (Instant)_. This puts it at the top of the list in the source picker and hopefully makes it more clear that it’s a configurable rather than hard-coded for a specific module. (I didn’t want to use the phrase "Custom Module" because Custom Modules are their own thing in Zoho CRM.)

I wasn’t sure if I should change the name of the file (and the name of the key) to match the new display name or not, so I left it as-is. I think it would be better if they matched but I wasn’t sure if renaming the file would cause any issues with existing sources.

---

My source description starts with "Emit new," but because there’s a comma after new it fails the `"Source descriptions should start with Emit new"` lint rule. I added `// eslint-disable-line` to suppress the warning per [this Slack discussion](https://pipedream-users.slack.com/archives/C01E5KCTR16/p1634149742149100).

I also added `// eslint-disable-line` to suppress `“components must export a key property”` errors in the common files. Ultimately I want to rename these files so they all start with `common` but I’m planning to do that as part of converting everything to ESM and wanted to get the bug fixes in first.