### PR TITLE
Fix Salesforce webhook event sources request verification

### DIFF
--- a/components/salesforce_rest_api/common-instant.js
+++ b/components/salesforce_rest_api/common-instant.js
@@ -62,7 +62,7 @@ module.exports = {
   },
   methods: {
     _isValidSource(event) {
-      const { undefined: webhookToken } = event.headers;
+      const webhookToken = event.headers["x-webhook-token"];
       const secretToken = this.db.get("secretToken");
       return webhookToken === secretToken;
     },

--- a/components/salesforce_rest_api/sources/new-object-instant/new-object-instant.js
+++ b/components/salesforce_rest_api/sources/new-object-instant/new-object-instant.js
@@ -11,7 +11,7 @@ module.exports = {
     Emit new event immediately after an object of arbitrary type
     (selected as an input parameter by the user) is created
   `,
-  version: "0.0.3",
+  version: "0.0.4",
   methods: {
     ...common.methods,
     generateMeta(data) {

--- a/components/salesforce_rest_api/sources/object-deleted-instant/object-deleted-instant.js
+++ b/components/salesforce_rest_api/sources/object-deleted-instant/object-deleted-instant.js
@@ -11,7 +11,7 @@ module.exports = {
     Emit new event immediately after an object of arbitrary type
     (selected as an input parameter by the user) is deleted
   `,
-  version: "0.0.3",
+  version: "0.0.4",
   methods: {
     ...common.methods,
     generateMeta(data) {

--- a/components/salesforce_rest_api/sources/object-updated-instant/object-updated-instant.js
+++ b/components/salesforce_rest_api/sources/object-updated-instant/object-updated-instant.js
@@ -11,7 +11,7 @@ module.exports = {
     Emit new event immediately after an object of arbitrary type
     (selected as an input parameter by the user) is updated
   `,
-  version: "0.0.3",
+  version: "0.0.4",
   methods: {
     ...common.methods,
     generateMeta(data) {


### PR DESCRIPTION
In [salesforce_rest_api/common-instant.js](https://github.com/PipedreamHQ/pipedream/blob/2f968db8f34977d4117721ff9fded090704451b3/components/salesforce_rest_api/common-instant.js#L65), the webhook token "x-webhook-token" was incorrectly destructured as `undefined` from `event.headers` following the codebase lint in commit e152f73.

This PR:
- Reverts [this change](https://github.com/PipedreamHQ/pipedream/commit/e152f7303d423624439c9beada19a264621d58b8#diff-dc14ce60113f1fc9b4611d0c8a6cb0ad57749394c4c7dfedbf901e8ce72bb962L65-R65) and sets `webhookToken` to `event.headers["x-webhook-token"]`
- Bumps versions of Salesforce (Instant) sources