### PR TITLE
Fix github header verification

### DIFF
--- a/components/github/sources/common-webhook.js
+++ b/components/github/sources/common-webhook.js
@@ -46,13 +46,12 @@ module.exports = {
       body,
       headers,
     } = event;
-
-    if (headers["X-Hub-Signature"]) {
+    if (headers["x-hub-signature"]) {
       const crypto = require("crypto");
       const algo = "sha1";
       const hmac = crypto.createHmac(algo, this.db.get("secret"));
-      hmac.update(body, "utf-8");
-      if (headers["X-Hub-Signature"] !== `${algo}=${hmac.digest("hex")}`) {
+      hmac.update(JSON.stringify(body), "utf-8");
+      if (headers["x-hub-signature"] !== `${algo}=${hmac.digest("hex")}`) {
         throw new Error("signature mismatch");
       }
     }

--- a/components/github/sources/common-webhook.js
+++ b/components/github/sources/common-webhook.js
@@ -54,6 +54,8 @@ module.exports = {
       if (headers["x-hub-signature"] !== `${algo}=${hmac.digest("hex")}`) {
         throw new Error("signature mismatch");
       }
+    } else {
+      throw new Error("signature missing");
     }
 
     if ("zen" in body) {

--- a/components/github/sources/common-webhook.js
+++ b/components/github/sources/common-webhook.js
@@ -46,16 +46,16 @@ module.exports = {
       body,
       headers,
     } = event;
-    if (headers["x-hub-signature"]) {
-      const crypto = require("crypto");
-      const algo = "sha1";
-      const hmac = crypto.createHmac(algo, this.db.get("secret"));
-      hmac.update(JSON.stringify(body), "utf-8");
-      if (headers["x-hub-signature"] !== `${algo}=${hmac.digest("hex")}`) {
-        throw new Error("signature mismatch");
-      }
-    } else {
+    if (!headers["x-hub-signature"]) {
       throw new Error("signature missing");
+    }
+
+    const crypto = require("crypto");
+    const algo = "sha1";
+    const hmac = crypto.createHmac(algo, this.db.get("secret"));
+    hmac.update(JSON.stringify(body), "utf-8");
+    if (headers["x-hub-signature"] !== `${algo}=${hmac.digest("hex")}`) {
+      throw new Error("signature mismatch");
     }
 
     if ("zen" in body) {

--- a/components/github/sources/custom-webhook-events/custom-webhook-events.js
+++ b/components/github/sources/custom-webhook-events/custom-webhook-events.js
@@ -8,7 +8,7 @@ module.exports = {
   description:
     "Emit new events of selected types",
   type: "source",
-  version: "0.0.6",
+  version: "0.0.7",
   props: {
     ...common.props,
     events: {

--- a/components/github/sources/new-branch/new-branch.js
+++ b/components/github/sources/new-branch/new-branch.js
@@ -8,7 +8,7 @@ module.exports = {
   key: "github-new-branch",
   name: "New Branch (Instant)",
   description: "Emit new events when a new branch is created",
-  version: "0.0.5",
+  version: "0.0.6",
   dedupe: "unique",
   type: "source",
   methods: {

--- a/components/github/sources/new-collaborator/new-collaborator.js
+++ b/components/github/sources/new-collaborator/new-collaborator.js
@@ -5,7 +5,7 @@ module.exports = {
   key: "github-new-collaborator",
   name: "New Collaborator (Instant)",
   description: "Emit new events when collaborators are added to a repo",
-  version: "0.0.3",
+  version: "0.0.4",
   dedupe: "unique",
   type: "source",
   methods: {

--- a/components/github/sources/new-commit-comment/new-commit-comment.js
+++ b/components/github/sources/new-commit-comment/new-commit-comment.js
@@ -5,7 +5,7 @@ module.exports = {
   key: "github-new-commit-comment",
   name: "New Commit Comment (Instant)",
   description: "Emit new events on new commit comments",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-fork/new-fork.js
+++ b/components/github/sources/new-fork/new-fork.js
@@ -5,7 +5,7 @@ module.exports = {
   key: "github-new-fork",
   name: "New Fork (Instant)",
   description: "Emit new events on new forks",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-issue/new-issue.js
+++ b/components/github/sources/new-issue/new-issue.js
@@ -5,7 +5,7 @@ module.exports = {
   key: "github-new-issue",
   name: "New Issue (Instant)",
   description: "Emit new events when new issues are created in a repo",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-label/new-label.js
+++ b/components/github/sources/new-label/new-label.js
@@ -5,7 +5,7 @@ module.exports = {
   key: "github-new-label",
   name: "New Label (Instant)",
   description: "Emit new events when new labels are created in a repo",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-milestone/new-milestone.js
+++ b/components/github/sources/new-milestone/new-milestone.js
@@ -5,7 +5,7 @@ module.exports = {
   key: "github-new-milestone",
   name: "New Milestone (Instant)",
   description: "Emit new events when new milestones are created in a repo",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-or-updated-issue/new-or-updated-issue.js
+++ b/components/github/sources/new-or-updated-issue/new-or-updated-issue.js
@@ -5,7 +5,7 @@ module.exports = {
   key: "github-new-or-updated-issue",
   name: "New or Updated Issue (Instant)",
   description: "Emit new events when an issue is opened or updated",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-or-updated-milestone/new-or-updated-milestone.js
+++ b/components/github/sources/new-or-updated-milestone/new-or-updated-milestone.js
@@ -6,7 +6,7 @@ module.exports = {
   name: "New or Updated Milestone (Instant)",
   description:
     "Emit new events when a milestone is created or updated in a repo",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-or-updated-pull-request/new-or-updated-pull-request.mjs
+++ b/components/github/sources/new-or-updated-pull-request/new-or-updated-pull-request.mjs
@@ -5,7 +5,7 @@ export default {
   key: "github-new-or-updated-pull-request",
   name: "New or Updated Pull Request (Instant)",
   description: "Emit new events when a pull request is opened or updated",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-project-card/new-project-card.js
+++ b/components/github/sources/new-project-card/new-project-card.js
@@ -5,7 +5,7 @@ module.exports = {
   key: "github-new-project-card",
   name: "New Project Card (Instant)",
   description: "Emit new events when new project cards are created",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-pull-request/new-pull-request.js
+++ b/components/github/sources/new-pull-request/new-pull-request.js
@@ -5,7 +5,7 @@ module.exports = {
   key: "github-new-pull-request",
   name: "New Pull Request (Instant)",
   description: "Emit new event on new pull requests",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-push/new-push.js
+++ b/components/github/sources/new-push/new-push.js
@@ -5,7 +5,7 @@ module.exports = {
   key: "github-new-push",
   name: "New Push",
   description: "Emit new events on each new push to a repo",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-release/new-release.js
+++ b/components/github/sources/new-release/new-release.js
@@ -5,7 +5,7 @@ module.exports = {
   key: "github-new-release",
   name: "New Release (Instant)",
   description: "Emit new event when a new release is published",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-star/new-star.js
+++ b/components/github/sources/new-star/new-star.js
@@ -4,7 +4,7 @@ module.exports = {
   ...common,
   key: "github-new-star",
   name: "New Stars (Instant)",
-  version: "0.0.5",
+  version: "0.0.6",
   description: "Emit new events when a repo is starred",
   type: "source",
   dedupe: "unique",

--- a/components/github/sources/updated-repository/updated-repository.js
+++ b/components/github/sources/updated-repository/updated-repository.js
@@ -16,7 +16,7 @@ module.exports = {
   key: "github-updated-repository",
   name: "Updated Repository (Instant)",
   description: "Emit new events when an existing repository is updated",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "source",
   dedupe: "unique",
   methods: {


### PR DESCRIPTION
The webhook based GitHub components verify the header `X-Hub-Signature`. However, since NodeJS converts header field names to lowercase, we must be verifying the header `x-hub-signature`. More details in #1951.
Closes #1951