### PR TITLE
Fix Super-Linter error in Lint Code Base check

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -58,7 +58,7 @@ jobs:
         run: npm ci
 
       - name: Lint Code Base
-        uses: github/super-linter@v3
+        uses: github/super-linter@v4
         env:
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Upgrades Lint Code Base action to `github/super-linter@v4` to avoid the broken version, v3.17.1.

**Context**

Recent runs of the [Lint Code Base](https://github.com/PipedreamHQ/pipedream/actions/runs/1612658366/workflow#L60) job have [failed with the error](https://github.com/PipedreamHQ/pipedream/runs/4610598550?check_suite_focus=true#step:6:11):
```
/action/lib/linter.sh: line 57: /action/lib/functions/tapLibrary.sh: No such file or directory
```
This error appears to be caused by a bug in the Super-Linter GitHub Action. See [this issue in the Super-Linter GitHub repo](https://togithub.com/github/super-linter/issues/2253). To fix this error, [this comment](https://togithub.com/github/super-linter/issues/2253#issuecomment-999776302) suggests to move to Super-Linter 4.x.
