### PR TITLE
Basic Dependabot configuration proposal

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Basic dependabot.yml file
+# REF: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-actions-up-to-date-with-dependabot
+
+version: 2
+updates:
+  # Enable version updates for Actions
+  - package-ecosystem: "github-actions"
+    # Look for `.github/workflows` in the `root` directory
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This is a propossal for a basic [Dependabot](https://github.com/dependabot) configuration.

It scans the `.github/workflows/` directory for actions and will create PRs proposing updates if any of the actions have newer releases. It is configured to weekly scheduled runs.

Dependabot can be extended to support more, this focus of this PR is on GitHub Actions, where I have found Dependabot very useful in keeping my supply chain up to date.

More information is also available in the [GitHub Documentation](https://docs.github.com/en/code-security/supply-chain-security/managing-vulnerabilities-in-your-projects-dependencies/about-alerts-for-vulnerable-dependencies)
