### PR TITLE
Fix Readme broken Llink to components API

### DIFF
--- a/docs/docs/components/quickstart/nodejs/sources/README.md
+++ b/docs/docs/components/quickstart/nodejs/sources/README.md
@@ -670,6 +670,6 @@ Save and reload your source in the Pipedream UI. You should now see a countdown 
 
 # What's Next?
 
-You're ready to start authoring and deploying components on Pipedream! You can also check out the [detailed component reference](../api/) at any time!
+You're ready to start authoring and deploying components on Pipedream! You can also check out the [detailed component reference](../../../api/) at any time!
 
 If you have any questions or feedback, please join our [public Slack](https://pipedream.com/support).


### PR DESCRIPTION
You might  also use /docs/components/api - unsure of your house style.