### PR TITLE
Rev components that failed to publish

### DIFF
--- a/components/aws/sources/new-emails-sent-to-ses-catch-all-domain/new-emails-sent-to-ses-catch-all-domain.mjs
+++ b/components/aws/sources/new-emails-sent-to-ses-catch-all-domain/new-emails-sent-to-ses-catch-all-domain.mjs
@@ -14,7 +14,7 @@ export default {
     These events can trigger a Pipedream workflow and can be consumed via SSE or REST API.
   `),
   type: "source",
-  version: "0.4.0",
+  version: "0.4.1",
   props: {
     ...base.props,
     domain: {

--- a/components/aws/sources/new-records-returned-by-cloudwatch-logs-insights-query/new-records-returned-by-cloudwatch-logs-insights-query.mjs
+++ b/components/aws/sources/new-records-returned-by-cloudwatch-logs-insights-query/new-records-returned-by-cloudwatch-logs-insights-query.mjs
@@ -6,7 +6,7 @@ export default {
   // eslint-disable-next-line pipedream/source-description
   description:
     "Executes a CloudWatch Logs Insights query on a schedule, and emits the records as invidual events (default) or in batch",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "source",
   props: {
     aws,

--- a/components/aws/sources/new-scheduled-tasks/new-scheduled-tasks.mjs
+++ b/components/aws/sources/new-scheduled-tasks/new-scheduled-tasks.mjs
@@ -10,7 +10,7 @@ export default {
     to an SNS topic at a specific timestamp. The SNS topic delivers
     the message to this Pipedream source, and the source emits it as a new event.
   `),
-  version: "0.2.0",
+  version: "0.2.1",
   type: "source",
   dedupe: "unique", // Dedupe on SNS message ID
   methods: {

--- a/components/aws/sources/new-sns-messages/new-sns-messages.mjs
+++ b/components/aws/sources/new-sns-messages/new-sns-messages.mjs
@@ -9,7 +9,7 @@ export default {
     Creates an SNS topic in your AWS account.
     Messages published to this topic are emitted from the Pipedream source.
   `),
-  version: "0.2.0",
+  version: "0.2.1",
   type: "source",
   dedupe: "unique", // Dedupe on SNS message ID
   props: {

--- a/components/ghost_org_admin_api/sources/member-created/member-created.mjs
+++ b/components/ghost_org_admin_api/sources/member-created/member-created.mjs
@@ -6,7 +6,7 @@ export default {
   key: "ghost_org_admin_api-member-created",
   name: "New Member Created (Instant)",
   description: "Emit new event for each new member added to a site.",
-  version: "0.0.5",
+  version: "0.0.6",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/ghost_org_admin_api/sources/member-deleted/member-deleted.mjs
+++ b/components/ghost_org_admin_api/sources/member-deleted/member-deleted.mjs
@@ -6,7 +6,7 @@ export default {
   key: "ghost_org_admin_api-member-deleted",
   name: "Member Deleted (Instant)",
   description: "Emit new event each time a member is deleted from a site.",
-  version: "0.0.5",
+  version: "0.0.6",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/ghost_org_admin_api/sources/member-updated/member-updated.mjs
+++ b/components/ghost_org_admin_api/sources/member-updated/member-updated.mjs
@@ -6,7 +6,7 @@ export default {
   key: "ghost_org_admin_api-member-updated",
   name: "Member Updated (Instant)",
   description: "Emit new event each time a member is updated.",
-  version: "0.0.5",
+  version: "0.0.6",
   methods: {
     ...common.methods,
     getEvent() {

--- a/components/ghost_org_admin_api/sources/new-tag/new-tag.mjs
+++ b/components/ghost_org_admin_api/sources/new-tag/new-tag.mjs
@@ -6,7 +6,7 @@ export default {
   key: "ghost_org_admin_api-new-tag",
   name: "Tag Added (Instant)",
   description: "Emit new event for each new tag created on a site.",
-  version: "0.0.5",
+  version: "0.0.6",
   methods: {
     ...common.methods,
     getEvent() {

--- a/components/ghost_org_admin_api/sources/page-published/page-published.mjs
+++ b/components/ghost_org_admin_api/sources/page-published/page-published.mjs
@@ -6,7 +6,7 @@ export default {
   key: "ghost_org_admin_api-page-published",
   name: "Page Published (Instant)",
   description: "Emit new event for each new page published on a site.",
-  version: "0.0.5",
+  version: "0.0.6",
   methods: {
     ...common.methods,
     getEvent() {

--- a/components/ghost_org_admin_api/sources/post-published/post-published.mjs
+++ b/components/ghost_org_admin_api/sources/post-published/post-published.mjs
@@ -6,7 +6,7 @@ export default {
   key: "ghost_org_admin_api-post-published",
   name: "Post Published (Instant)",
   description: "Emit new event for each new post published on a site.",
-  version: "0.0.5",
+  version: "0.0.6",
   methods: {
     ...common.methods,
     getEvent() {

--- a/components/ghost_org_content_api/sources/new-author/new-author.js
+++ b/components/ghost_org_content_api/sources/new-author/new-author.js
@@ -6,7 +6,7 @@ module.exports = {
   key: "ghost_org_content_api-new-author",
   name: "New Author",
   description: "Emit new event for each new author added on a site.",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
   props: {
     ghost_org_content_api,

--- a/components/google_cloud/sources/bigquery-new-row/bigquery-new-row.mjs
+++ b/components/google_cloud/sources/bigquery-new-row/bigquery-new-row.mjs
@@ -8,7 +8,7 @@ export default {
   // eslint-disable-next-line pipedream/source-name
   name: "BigQuery - New Row",
   description: "Emit new events when a new row is added to a table",
-  version: "0.1.0",
+  version: "0.1.1",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/google_cloud/sources/bigquery-query-results/bigquery-query-results.mjs
+++ b/components/google_cloud/sources/bigquery-query-results/bigquery-query-results.mjs
@@ -8,7 +8,7 @@ export default {
   // eslint-disable-next-line pipedream/source-name
   name: "BigQuery - Query Results",
   description: "Emit new events with the results of an arbitrary query",
-  version: "0.1.0",
+  version: "0.1.1",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/google_cloud/sources/new-pubsub-messages/new-pubsub-messages.mjs
+++ b/components/google_cloud/sources/new-pubsub-messages/new-pubsub-messages.mjs
@@ -8,7 +8,7 @@ export default {
   description:
     `Creates a Pub/Sub topic in your GCP account.
     Messages published to this topic are emitted from the Pipedream source.`,
-  version: "0.1.0",
+  version: "0.1.1",
   type: "source",
   dedupe: "unique", // Dedupe on Pub/Sub message ID
   props: {

--- a/components/google_docs/actions/append-text/append-text.mjs
+++ b/components/google_docs/actions/append-text/append-text.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-append-text",
   name: "Append Text",
   description: "Append text to an existing document",
-  version: "0.0.13",
+  version: "0.0.14",
   type: "action",
   props: {
     googleDocs,

--- a/components/google_docs/actions/create-document/create-document.mjs
+++ b/components/google_docs/actions/create-document/create-document.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-create-document",
   name: "Create a New Document",
   description: "Create a new, empty document. To add content after creating the document, pass the document ID exported by this step to the Append Text action.",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   props: {
     googleDocs,

--- a/components/google_docs/actions/get-document/get-document.mjs
+++ b/components/google_docs/actions/get-document/get-document.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-get-document",
   name: "Get Document",
   description: "Get the contents of the latest version of a document.",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   props: {
     googleDocs,

--- a/components/google_drive/sources/changes-to-specific-files/changes-to-specific-files.mjs
+++ b/components/google_drive/sources/changes-to-specific-files/changes-to-specific-files.mjs
@@ -20,7 +20,7 @@ export default {
   name: "Changes to Specific Files",
   description:
     "Watches for changes to specific files, emitting an event any time a change is made to one of those files",
-  version: "0.0.13",
+  version: "0.0.14",
   type: "source",
   // Dedupe events based on the "x-goog-message-number" header for the target channel:
   // https://developers.google.com/drive/api/v3/push#making-watch-requests

--- a/components/google_drive/sources/new-files-instant/new-files-instant.mjs
+++ b/components/google_drive/sources/new-files-instant/new-files-instant.mjs
@@ -10,7 +10,7 @@ export default {
   name: "New Files (Instant)",
   description:
     "Emits a new event any time a new file is added in your linked Google Drive",
-  version: "0.0.9",
+  version: "0.0.10",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_drive/sources/new-or-modified-comments/new-or-modified-comments.mjs
+++ b/components/google_drive/sources/new-or-modified-comments/new-or-modified-comments.mjs
@@ -17,7 +17,7 @@ export default {
   name: "New or Modified Comments",
   description:
     "Emits a new event any time a file comment is added, modified, or deleted in your linked Google Drive",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "source",
   // Dedupe events based on the "x-goog-message-number" header for the target channel:
   // https://developers.google.com/drive/api/v3/push#making-watch-requests

--- a/components/google_drive/sources/new-or-modified-files/new-or-modified-files.mjs
+++ b/components/google_drive/sources/new-or-modified-files/new-or-modified-files.mjs
@@ -21,7 +21,7 @@ export default {
   name: "New or Modified Files",
   description:
     "Emits a new event any time any file in your linked Google Drive is added, modified, or deleted",
-  version: "0.0.15",
+  version: "0.0.16",
   type: "source",
   // Dedupe events based on the "x-goog-message-number" header for the target channel:
   // https://developers.google.com/drive/api/v3/push#making-watch-requests

--- a/components/google_drive/sources/new-or-modified-folders/new-or-modified-folders.mjs
+++ b/components/google_drive/sources/new-or-modified-folders/new-or-modified-folders.mjs
@@ -21,7 +21,7 @@ export default {
   name: "New or Modified Folders",
   description:
     "Emits a new event any time any folder in your linked Google Drive is added, modified, or deleted",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "source",
   // Dedupe events based on the "x-goog-message-number" header for the target channel:
   // https://developers.google.com/drive/api/v3/push#making-watch-requests

--- a/components/google_drive/sources/new-shared-drive/new-shared-drive.mjs
+++ b/components/google_drive/sources/new-shared-drive/new-shared-drive.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-new-shared-drive",
   name: "New Shared Drive",
   description: "Emits a new event any time a shared drive is created.",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_sheets/actions/find-row/find-row.mjs
+++ b/components/google_sheets/actions/find-row/find-row.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_sheets-find-row",
   name: "Find Row",
   description: "Find one or more rows by a column and value",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "action",
   props: {
     googleSheets,

--- a/components/google_sheets/actions/upsert-row/upsert-row.mjs
+++ b/components/google_sheets/actions/upsert-row/upsert-row.mjs
@@ -21,7 +21,7 @@ export default {
   key: "google_sheets-upsert-row",
   name: "Upsert Row",
   description: "Upsert a row of data in a Google Sheet",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     googleSheets,

--- a/components/google_sheets/sources/new-row-added/new-row-added.mjs
+++ b/components/google_sheets/sources/new-row-added/new-row-added.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Row Added (Instant)",
   description:
     "Emit new events each time a row or rows are added to the bottom of a spreadsheet",
-  version: "0.0.20",
+  version: "0.0.21",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/google_sheets/sources/new-spreadsheet/new-spreadsheet.mjs
+++ b/components/google_sheets/sources/new-spreadsheet/new-spreadsheet.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Spreadsheet (Instant)",
   description:
     "Emit new event each time a new spreadsheet is created in a drive.",
-  version: "0.0.7",
+  version: "0.0.8",
   methods: {
     ...newFilesInstant.methods,
     shouldProcess(file) {

--- a/components/google_sheets/sources/new-updates/new-updates.mjs
+++ b/components/google_sheets/sources/new-updates/new-updates.mjs
@@ -8,7 +8,7 @@ export default {
   name: "New Updates (Instant)",
   description:
     "Emit new event each time a row or cell is updated in a spreadsheet.",
-  version: "0.0.21",
+  version: "0.0.22",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/google_sheets/sources/new-worksheet/new-worksheet.mjs
+++ b/components/google_sheets/sources/new-worksheet/new-worksheet.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Worksheet (Instant)",
   description:
     "Emit new event each time a new worksheet is created in a spreadsheet.",
-  version: "0.0.8",
+  version: "0.0.9",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/spotify/actions/add-items-to-playlist/add-items-to-playlist.mjs
+++ b/components/spotify/actions/add-items-to-playlist/add-items-to-playlist.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Add Items to a Playlist",
   description: "Add one or more items to a user’s playlist. [See the docs here](https://developer.spotify.com/documentation/web-api/reference/#/operations/add-tracks-to-playlist).",
   key: "spotify-add-item-to-a-playlist",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     spotify,

--- a/components/spotify/actions/get-track/get-track.mjs
+++ b/components/spotify/actions/get-track/get-track.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Get a Track",
   description: "Get a track by its name or ID. [See the docs here](https://developer.spotify.com/documentation/web-api/reference/#/operations/search)",
   key: "spotify-get-a-track",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     spotify,

--- a/components/spotify/sources/new-playlist/new-playlist.mjs
+++ b/components/spotify/sources/new-playlist/new-playlist.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Playlist",
   description:
     "Emit new event when a new playlist is created or followed by the current Spotify user.",
-  version: "0.0.3",
+  version: "0.0.4",
   props: {
     ...common.props,
   },

--- a/components/spotify/sources/new-saved-track/new-saved-track.mjs
+++ b/components/spotify/sources/new-saved-track/new-saved-track.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Saved Track",
   description:
     "Emit new event for each new track saved to the current Spotify user's Music Library.",
-  version: "0.0.3",
+  version: "0.0.4",
   props: {
     ...common.props,
     db: "$.service.db",

--- a/components/spotify/sources/new-track-in-playlist/new-track-in-playlist.mjs
+++ b/components/spotify/sources/new-track-in-playlist/new-track-in-playlist.mjs
@@ -7,7 +7,7 @@ export default {
   key: "spotify-source-new-track-in-playlist",
   name: "New Track in Playlist",
   description: "Emit new event for each new Spotify track added to a playlist",
-  version: "0.0.3",
+  version: "0.0.4",
   props: {
     ...common.props,
     db: "$.service.db",

--- a/components/telegram_bot_api/sources/channel-updates/channel-updates.mjs
+++ b/components/telegram_bot_api/sources/channel-updates/channel-updates.mjs
@@ -6,7 +6,7 @@ export default {
   key: "telegram_bot_api-channel-updates",
   name: "Channel Updates (Instant)",
   description: "Emit new event each time a channel message is created or updated.",
-  version: "0.0.2",
+  version: "0.0.3",
   dedupe: "unique",
   props: {
     db: "$.service.db",

--- a/components/telegram_bot_api/sources/message-updates/message-updates.mjs
+++ b/components/telegram_bot_api/sources/message-updates/message-updates.mjs
@@ -6,7 +6,7 @@ export default {
   key: "telegram_bot_api-message-updates",
   name: "Message Updates (Instant)",
   description: "Emit new event each time a Telegram message is created or updated.",
-  version: "0.0.2",
+  version: "0.0.3",
   dedupe: "unique",
   props: {
     db: "$.service.db",

--- a/components/telegram_bot_api/sources/new-updates/new-updates.mjs
+++ b/components/telegram_bot_api/sources/new-updates/new-updates.mjs
@@ -5,7 +5,7 @@ export default {
   key: "telegram_bot_api-new-updates",
   name: "New Updates (Instant)",
   description: "Emit new event for each new Telegram event.",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/trello/sources/card-archived/card-archived.mjs
+++ b/components/trello/sources/card-archived/card-archived.mjs
@@ -6,7 +6,7 @@ export default {
   key: "trello-card-archived",
   name: "Card Archived (Instant)",
   description: "Emit new event for each card archived.",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "source",
   props: {
     ...common.props,

--- a/components/trello/sources/card-due-date-reminder/card-due-date-reminder.mjs
+++ b/components/trello/sources/card-due-date-reminder/card-due-date-reminder.mjs
@@ -5,7 +5,7 @@ export default {
   key: "trello-card-due-date-reminder",
   name: "Card Due Date Reminder",
   description: "Emit new event at a specified time before a card is due.",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/trello/sources/card-moved/card-moved.mjs
+++ b/components/trello/sources/card-moved/card-moved.mjs
@@ -6,7 +6,7 @@ export default {
   key: "trello-card-moved",
   name: "Card Moved (Instant)",
   description: "Emit new event each time a card is moved to a list.",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   props: {
     ...common.props,

--- a/components/trello/sources/card-updates/card-updates.mjs
+++ b/components/trello/sources/card-updates/card-updates.mjs
@@ -6,7 +6,7 @@ export default {
   key: "trello-card-updates",
   name: "Card Updates (Instant)",
   description: "Emit new event for each update to a Trello card.",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   props: {
     ...common.props,

--- a/components/trello/sources/new-activity/new-activity.mjs
+++ b/components/trello/sources/new-activity/new-activity.mjs
@@ -6,7 +6,7 @@ export default {
   key: "trello-new-activity",
   name: "New Activity (Instant)",
   description: "Emit new event for new activity on a board.",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "source",
   props: {
     ...common.props,

--- a/components/trello/sources/new-attachment/new-attachment.mjs
+++ b/components/trello/sources/new-attachment/new-attachment.mjs
@@ -6,7 +6,7 @@ export default {
   key: "trello-new-attachment",
   name: "New Attachment (Instant)",
   description: "Emit new event for new attachment on a board.",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "source",
   props: {
     ...common.props,

--- a/components/trello/sources/new-board/new-board.mjs
+++ b/components/trello/sources/new-board/new-board.mjs
@@ -6,7 +6,7 @@ export default {
   key: "trello-new-board",
   name: "New Board (Instant)",
   description: "Emit new event for each new board added.",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/trello/sources/new-card/new-card.mjs
+++ b/components/trello/sources/new-card/new-card.mjs
@@ -6,7 +6,7 @@ export default {
   key: "trello-new-card",
   name: "New Card (Instant)",
   description: "Emit new event for each new Trello card on a board.",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/trello/sources/new-checklist/new-checklist.mjs
+++ b/components/trello/sources/new-checklist/new-checklist.mjs
@@ -6,7 +6,7 @@ export default {
   key: "trello-new-checklist",
   name: "New Checklist (Instant)",
   description: "Emit new event for each new checklist added to a board.",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/trello/sources/new-comment-added-to-card/new-comment-added-to-card.mjs
+++ b/components/trello/sources/new-comment-added-to-card/new-comment-added-to-card.mjs
@@ -6,7 +6,7 @@ export default {
   key: "trello-new-comment-added-to-card",
   name: "New Comment Added to Card (Instant)",
   description: "Emit new event for each new comment added to a card.",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/trello/sources/new-label-added-to-card/new-label-added-to-card.mjs
+++ b/components/trello/sources/new-label-added-to-card/new-label-added-to-card.mjs
@@ -6,7 +6,7 @@ export default {
   key: "trello-new-label-added-to-card",
   name: "New Label Added To Card (Instant)",
   description: "Emit new event for each label added to a card.",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   props: {
     ...common.props,

--- a/components/trello/sources/new-label/new-label.mjs
+++ b/components/trello/sources/new-label/new-label.mjs
@@ -6,7 +6,7 @@ export default {
   key: "trello-new-label",
   name: "New Label (Instant)",
   description: "Emit new event for each new label added to a board.",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/trello/sources/new-list/new-list.mjs
+++ b/components/trello/sources/new-list/new-list.mjs
@@ -6,7 +6,7 @@ export default {
   key: "trello-new-list",
   name: "New List (Instant)",
   description: "Emit new event for each new list added to a board.",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/trello/sources/new-member-on-card/new-member-on-card.mjs
+++ b/components/trello/sources/new-member-on-card/new-member-on-card.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Member on Card (Instant)",
   description:
     "Emit new event for each card joined by the authenticated Trello user.",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/trello/sources/new-notification/new-notification.mjs
+++ b/components/trello/sources/new-notification/new-notification.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Notification",
   description:
     "Emit new event for each new Trello notification for the authenticated user.",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/twilio/actions/make-phone-call/make-phone-call.mjs
+++ b/components/twilio/actions/make-phone-call/make-phone-call.mjs
@@ -6,7 +6,7 @@ export default {
   key: "twilio-make-phone-call",
   name: "Make a Phone Call",
   description: "Make a phone call, passing text that Twilio will speak to the recipient of the call. [See the docs](https://www.twilio.com/docs/voice/api/call-resource#create-a-call-resource) for more information",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   props: {
     twilio,

--- a/components/twilio/actions/send-mms/send-mms.mjs
+++ b/components/twilio/actions/send-mms/send-mms.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Send MMS",
   description: "Send an SMS with text and media files. [See the docs](https://www.twilio.com/docs/sms/api/message-resource#create-a-message-resource) for more information",
   type: "action",
-  version: "0.0.5",
+  version: "0.0.6",
   props: {
     twilio,
     from: {

--- a/components/twilio/actions/send-sms/send-sms.mjs
+++ b/components/twilio/actions/send-sms/send-sms.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Send SMS",
   description: "Send a simple text-only SMS. [See the docs](https://www.twilio.com/docs/sms/api/message-resource#create-a-message-resource) for more information",
   type: "action",
-  version: "0.0.5",
+  version: "0.0.6",
   props: {
     twilio,
     from: {

--- a/components/twilio/sources/new-call/new-call.mjs
+++ b/components/twilio/sources/new-call/new-call.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Call (Instant)",
   description:
     "Configures a webhook in Twilio, tied to a phone number, and emits an event each time a call to that number is completed",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/twilio/sources/new-incoming-sms/new-incoming-sms.mjs
+++ b/components/twilio/sources/new-incoming-sms/new-incoming-sms.mjs
@@ -8,7 +8,7 @@ export default {
   name: "New Incoming SMS (Instant)",
   description:
     "Configures a webhook in Twilio, tied to an incoming phone number, and emits an event each time an SMS is sent to that number",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/twilio/sources/new-phone-number/new-phone-number.mjs
+++ b/components/twilio/sources/new-phone-number/new-phone-number.mjs
@@ -5,7 +5,7 @@ export default {
   key: "twilio-new-phone-number",
   name: "New Phone Number",
   description: "Emits an event when you add a new phone number to your account",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/twilio/sources/new-recording/new-recording.mjs
+++ b/components/twilio/sources/new-recording/new-recording.mjs
@@ -5,7 +5,7 @@ export default {
   key: "twilio-new-phone-recording",
   name: "New Recording",
   description: "Emits an event when a new call recording is created",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/twilio/sources/new-transcription/new-transcription.mjs
+++ b/components/twilio/sources/new-transcription/new-transcription.mjs
@@ -5,7 +5,7 @@ export default {
   key: "twilio-new-transcription",
   name: "New Transcription",
   description: "Emits an event when a new call transcription is created",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/typeform/actions/update-form-title/update-form-title.mjs
+++ b/components/typeform/actions/update-form-title/update-form-title.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Update Form Title",
   description: "Updates an existing form's title. [See the docs here](https://developer.typeform.com/create/reference/update-form-patch/)",
   type: "action",
-  version: "0.0.1",
+  version: "0.0.2",
   props: {
     typeform,
     formId: {

--- a/components/youtube_data_api/sources/new-videos-by-location/new-videos-by-location.mjs
+++ b/components/youtube_data_api/sources/new-videos-by-location/new-videos-by-location.mjs
@@ -6,7 +6,7 @@ export default {
   key: "youtube_data_api-new-videos-by-location",
   name: "New Videos by Location",
   description: "Emit new event for each new YouTube video tied to a location.",
-  version: "0.0.3",
+  version: "0.0.4",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/youtube_data_api/sources/new-videos-by-search/new-videos-by-search.mjs
+++ b/components/youtube_data_api/sources/new-videos-by-search/new-videos-by-search.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Videos by Search",
   description:
     "Emit new event for each new YouTube video matching a search query.",
-  version: "0.0.4",
+  version: "0.0.5",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/youtube_data_api/sources/new-videos-by-username/new-videos-by-username.mjs
+++ b/components/youtube_data_api/sources/new-videos-by-username/new-videos-by-username.mjs
@@ -6,7 +6,7 @@ export default {
   key: "youtube_data_api-new-videos-by-username",
   name: "New Videos by Username",
   description: "Emit new event for each new Youtube video tied to a username.",
-  version: "0.0.3",
+  version: "0.0.4",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/youtube_data_api/sources/new-videos-in-channel/new-videos-in-channel.mjs
+++ b/components/youtube_data_api/sources/new-videos-in-channel/new-videos-in-channel.mjs
@@ -6,7 +6,7 @@ export default {
   key: "youtube_data_api-new-videos-in-channel",
   name: "New Videos in Channel",
   description: "Emit new event for each new Youtube video posted to a Channel.",
-  version: "0.0.3",
+  version: "0.0.4",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/youtube_data_api/sources/new-videos-in-playlist/new-videos-in-playlist.mjs
+++ b/components/youtube_data_api/sources/new-videos-in-playlist/new-videos-in-playlist.mjs
@@ -6,7 +6,7 @@ export default {
   key: "youtube_data_api-new-videos-in-playlist",
   name: "New Videos in Playlist",
   description: "Emit new event for each new Youtube video added to a Playlist.",
-  version: "0.0.4",
+  version: "0.0.5",
   dedupe: "unique",
   hooks: {
     ...common.hooks,

--- a/components/youtube_data_api/sources/new-videos/new-videos.mjs
+++ b/components/youtube_data_api/sources/new-videos/new-videos.mjs
@@ -6,7 +6,7 @@ export default {
   key: "youtube_data_api-new-videos",
   name: "New Videos",
   description: "Emit new event for each new Youtube video the user posts.",
-  version: "0.0.3",
+  version: "0.0.4",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/zoho_crm/sources/new-contact/new-contact.mjs
+++ b/components/zoho_crm/sources/new-contact/new-contact.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoho_crm-new-contact",
   name: "New Contact (Instant)",
   description: "Emits an event each time a new contact is created in Zoho CRM",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "source",
   methods: {
     ...common.methods,

--- a/components/zoho_crm/sources/new-event/new-event.mjs
+++ b/components/zoho_crm/sources/new-event/new-event.mjs
@@ -7,7 +7,7 @@ export default {
   key: "zoho_crm-new-event",
   name: "New Event (Instant)",
   description: "Emit new custom events from Zoho CRM",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "source",
   props: {
     ...common.props,

--- a/components/zoho_crm/sources/new-lead/new-lead.mjs
+++ b/components/zoho_crm/sources/new-lead/new-lead.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoho_crm-new-lead",
   name: "New Lead (Instant)",
   description: "Emits an event each time a new lead is created in Zoho CRM",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "source",
   methods: {
     ...common.methods,

--- a/components/zoho_crm/sources/new-module-entry/new-module-entry.mjs
+++ b/components/zoho_crm/sources/new-module-entry/new-module-entry.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoho_crm-new-module-entry",
   name: "New Module Entry (Instant)",
   description: "Emits an event each time a new module/record is created in Zoho CRM",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "source",
   methods: {
     ...common.methods,

--- a/components/zoho_crm/sources/new-or-updated-contact/new-or-updated-contact.mjs
+++ b/components/zoho_crm/sources/new-or-updated-contact/new-or-updated-contact.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoho_crm-new-or-updated-contact",
   name: "New or Updated Contact (Instant)",
   description: "Emits an event each time a new contact is created or updated in Zoho CRM",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "source",
   methods: {
     ...common.methods,

--- a/components/zoho_crm/sources/new-or-updated-lead/new-or-updated-lead.mjs
+++ b/components/zoho_crm/sources/new-or-updated-lead/new-or-updated-lead.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoho_crm-new-or-updated-lead",
   name: "New or Updated Lead (Instant)",
   description: "Emits an event each time a new lead is created or updated in Zoho CRM",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "source",
   methods: {
     ...common.methods,

--- a/components/zoho_crm/sources/new-or-updated-module-entry/new-or-updated-module-entry.mjs
+++ b/components/zoho_crm/sources/new-or-updated-module-entry/new-or-updated-module-entry.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoho_crm-new-or-updated-module-entry",
   name: "New or Updated Module Entry (Instant)",
   description: "Emits an event each time a module/record is created or edited in Zoho CRM",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "source",
   methods: {
     ...common.methods,

--- a/components/zoho_crm/sources/new-user/new-user.mjs
+++ b/components/zoho_crm/sources/new-user/new-user.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoho_crm-new-user",
   name: "New User",
   description: "Emits an event each time a new user is created in Zoho CRM",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/zoho_crm/sources/updated-module-entry/updated-module-entry.mjs
+++ b/components/zoho_crm/sources/updated-module-entry/updated-module-entry.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoho_crm-updated-module-entry",
   name: "Updated Module Entry (Instant)",
   description: "Emits an event each time a new module/record is updated in Zoho CRM",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "source",
   methods: {
     ...common.methods,


### PR DESCRIPTION
To modify and publish unpublished components, bumps version of components that the [publish-components](https://github.com/PipedreamHQ/pipedream/blob/9bc908e86aed1423d94b16d0a2bd213bea170bde/.github/workflows/publish-components.yaml) Github workflow failed to publish.

Apps with affected components:
* aws
* ghost_org_admin_api
* ghost_org_content_api
* google_cloud
* google_docs
* google_drive
* google_sheets
* spotify
* telegram_bot_api
* trello
* twilio
* typeform
* youtube_data_api
* zoho_crm

**Context**:
1. The [`jitterbit/get-changed-files`](https://github.com/PipedreamHQ/pipedream/blob/9bc908e86aed1423d94b16d0a2bd213bea170bde/.github/workflows/publish-components.yaml#L23) GitHub action places "modified and renamed" files in its `renamed` list output, but not its `added_modified` list output. (See [this issue](https://togithub.com/jitterbit/get-changed-files/issues/37) in the [`jitterbit/get-changed-files`](https://github.com/jitterbit/get-changed-files) repo)
2. The "Publish" GitHub action skips publishing "renamed" files (e.g. `foo.js` -> `foo.mjs`), even if the files were also modified, because they are not in the [`added_modified`](https://github.com/PipedreamHQ/pipedream/blob/9bc908e86aed1423d94b16d0a2bd213bea170bde/.github/workflows/publish-components.yaml#L37) list of files.

Example workflow run with "renamed" component files which are skipped by the Publish step: https://github.com/PipedreamHQ/pipedream/runs/4696049387?check_suite_focus=true#step:4:11