### PR TITLE
Fix publish-components workflow to publish renamed components

### DIFF
--- a/.github/workflows/publish-components.yaml
+++ b/.github/workflows/publish-components.yaml
@@ -34,8 +34,8 @@ jobs:
           PUBLISHED=""
           ERRORS=""
           SKIPPED=""
-          mapfile -d ',' -t added_modified_files < <(printf '%s,' '${{ steps.files.outputs.added_modified }}')
-          for added_modified_file in "${added_modified_files[@]}"; do
+          mapfile -d ',' -t added_modified_renamed_files < <(printf '%s,%s' '${{ steps.files.outputs.added_modified }}' '${{ steps.files.outputs.renamed }}')
+          for added_modified_file in "${added_modified_renamed_files[@]}"; do
           # starts with components, ends with .*js (e.g. .js and .mjs) and not app.js,
           # doesn't end with /common*.*js, and doesn't follow */common/
           if [[ $added_modified_file == components/* ]] && [[ $added_modified_file == *.*js ]] && [[ $added_modified_file != *.app.*js ]] \


### PR DESCRIPTION
Adds renamed files to the array of files that the Publish Components step attempts to publish.

**Context**
The publish-components workflow currently doesn't attempt to publish component files that have been "renamed" (e.g. `foo.js` -> `foo.mjs`), even if they have also been modified.

Example of a run with skipped "renamed" components:
https://github.com/PipedreamHQ/pipedream/runs/4696049387?check_suite_focus=true#step:4:11

Renamed components are skipped because the [Publish](https://github.com/PipedreamHQ/pipedream/blob/9bc908e86aed1423d94b16d0a2bd213bea170bde/.github/workflows/publish-components.yaml#L26) step attempts to publish only files in the [`added_modified`](https://github.com/PipedreamHQ/pipedream/blob/9bc908e86aed1423d94b16d0a2bd213bea170bde/.github/workflows/publish-components.yaml#L37) output from the [Get Changed Files](https://github.com/PipedreamHQ/pipedream/blob/9bc908e86aed1423d94b16d0a2bd213bea170bde/.github/workflows/publish-components.yaml#L21) step. And the [`jitterbit/get-changed-files`](https://github.com/PipedreamHQ/pipedream/blob/9bc908e86aed1423d94b16d0a2bd213bea170bde/.github/workflows/publish-components.yaml#L23) GitHub action places "modified and renamed" files in its `renamed` output, but not its `added_modified` output. (See [this issue](https://togithub.com/jitterbit/get-changed-files/issues/37) in the [`jitterbit/get-changed-files`](https://github.com/jitterbit/get-changed-files) repo)

**Notes**
The changes in this PR were tested in a fork of this repo.