### PR TITLE
Adding a notice regarding @mentions twitter policy

### DIFF
--- a/components/twitter/actions/advanced-search/advanced-search.js
+++ b/components/twitter/actions/advanced-search/advanced-search.js
@@ -1,0 +1,51 @@
+const twitter = require('../../twitter.app.js')
+const moment = require('moment')
+ 
+module.exports = {
+  key: "twitter-advanced-search",
+  name: "Advanced Search",
+  description: "Return Tweets that matches your search criteria.", 
+  version: "0.0.2",
+  type: "action",
+  props: {
+    db: "$.service.db",
+    twitter,
+    q: { propDefinition: [twitter, "q"] },
+    result_type: { propDefinition: [twitter, "result_type"] },
+    includeRetweets: { propDefinition: [twitter, "includeRetweets"] },
+    includeReplies: { propDefinition: [twitter, "includeReplies"] },
+    lang: { propDefinition: [twitter, "lang"] },
+    locale: { propDefinition: [twitter, "locale"] },
+    geocode: { propDefinition: [twitter, "geocode"] },
+    since_id: { propDefinition: [twitter, "since_id"] },
+    enrichTweets: { propDefinition: [twitter, "enrichTweets"] },
+    count: { propDefinition: [twitter, "count"] },
+    maxRequests: { propDefinition: [twitter, "maxRequests"] },
+  }, 
+  async run(event) {
+    const { lang, locale, geocode, result_type, enrichTweets, includeReplies, includeRetweets, since_id, maxRequests, count } = this
+    let q = this.q, max_id, limitFirstPage
+
+    if (!since_id) {
+      limitFirstPage = true
+    } else {
+      limitFirstPage = false
+    }
+ 
+    // run paginated search
+    return await this.twitter.paginatedSearch({ 
+      q, 
+      since_id, 
+      lang, 
+      locale, 
+      geocode, 
+      result_type, 
+      enrichTweets, 
+      includeReplies, 
+      includeRetweets, 
+      maxRequests,
+      count,
+      limitFirstPage,
+    })
+  },
+}

--- a/components/twitter/twitter.app.mjs
+++ b/components/twitter/twitter.app.mjs
@@ -256,7 +256,9 @@ export default {
     status: {
       type: "string",
       label: "Status",
-      description: "The text of the status update",
+      description: `The text of the status update. Note: In order to comply with Twitter’s 
+        terms of service, this text will have all @mentions removed. 
+        Please refer to [our docs for more details](https://pipedream.com/docs/apps/twitter/#limitations-on-mentions).`,
     },
     inReplyToStatusId: {
       type: "string",


### PR DESCRIPTION
## Changes

* Updates `description` of the `status` prop for the Twitter app. There are restrictions on @'s in statuses to keep us from being banned
