### PR TITLE
Fix app folder of converted pushshift_reddit_search actions

### DIFF
--- a/components/pushshift_reddit_search/actions/search-reddit-comments/search-reddit-comments.mjs
+++ b/components/pushshift_reddit_search/actions/search-reddit-comments/search-reddit-comments.mjs
@@ -2,7 +2,7 @@
 import { axios } from "@pipedream/platform";
 
 export default {
-  key: "reddit-search-reddit-comments",
+  key: "pushshift_reddit_search-search-reddit-comments",
   name: "Search Reddit Comments",
   description: "Search Reddit comments using the Pushshift.io API. Learn more at https://github.com/pushshift/api",
   version: "0.1.1",

--- a/components/pushshift_reddit_search/actions/search-reddit-comments/search-reddit-comments.mjs
+++ b/components/pushshift_reddit_search/actions/search-reddit-comments/search-reddit-comments.mjs
@@ -8,6 +8,10 @@ export default {
   version: "0.1.1",
   type: "action",
   props: {
+    pushshift_reddit_search: {
+      type: "app",
+      app: "pushshift_reddit_search",
+    },
     q: {
       type: "string",
       description: "Search term. Will search ALL possible fields",

--- a/components/pushshift_reddit_search/actions/search-reddit-posts/search-reddit-posts.mjs
+++ b/components/pushshift_reddit_search/actions/search-reddit-posts/search-reddit-posts.mjs
@@ -2,7 +2,7 @@
 import { axios } from "@pipedream/platform";
 
 export default {
-  key: "reddit-search-reddit-posts",
+  key: "pushshift_reddit_search-search-reddit-posts",
   name: "Search Reddit Posts",
   description: "Search Reddit posts using the Pushshift.io API. Learn more at https://github.com/pushshift/api",
   version: "0.1.1",

--- a/components/pushshift_reddit_search/actions/search-reddit-posts/search-reddit-posts.mjs
+++ b/components/pushshift_reddit_search/actions/search-reddit-posts/search-reddit-posts.mjs
@@ -8,6 +8,10 @@ export default {
   version: "0.1.1",
   type: "action",
   props: {
+    "pushshift_reddit_search": {
+      type: "app",
+      app: "pushshift_reddit_search",
+    },
     "ids": {
       type: "string",
       description: "Get specific submissions via their ids",


### PR DESCRIPTION
* Moves actions from `reddit` app folder to `pushshift_reddit_search` folder
* Changes app slug in component key from `reddit` to `pushshift_reddit_search`
* Adds `pushshift_reddit_search` [app prop](https://pipedream.com/docs/components/api/#app-props) to converted pushshift actions

**Context**
https://github.com/PipedreamHQ/pipedream/pull/2243 incorrectly added two Pushshift Reddit Search actions to the Reddit app folder.
Without an app prop, the actions were not published to the component registry for the appropriate app.