### PR TITLE
Add converted legacy actions: Gitlab-Zoom

### DIFF
--- a/components/algolia/actions/add-objects-to-index/add-objects-to-index.mjs
+++ b/components/algolia/actions/add-objects-to-index/add-objects-to-index.mjs
@@ -1,0 +1,38 @@
+// legacy_hash_id: a_B0ipOm
+import algoliasearch from "algoliasearch";
+
+export default {
+  key: "algolia-add-objects-to-index",
+  name: "Add Objects to Index",
+  description: "Adds an array of JavaScript objects to the given index",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    algolia: {
+      type: "app",
+      app: "algolia",
+    },
+    index: {
+      type: "string",
+      description: "The name of your Algolia index",
+    },
+    objects: {
+      type: "any",
+      description: "An array of JavaScript objects, each corresponding to a new object in your search index. It's recommended you create this array of objects in a prior code step, then select expression mode and enter a variable reference to that array here.",
+    },
+    autoGenerateObjectIDIfNotExist: {
+      type: "boolean",
+      label: "Auto Generate Object ID If Not Present",
+      description: "If an objectID property is not present on objects, automatically assign on. Defaults to true.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const client = algoliasearch(this.algolia.$auth.application_id, this.algolia.$auth.api_key);
+    const index = client.initIndex(this.index);
+
+    $.export("objectIds", await index.saveObjects(this.objects, {
+      autoGenerateObjectIDIfNotExist: this.autoGenerateObjectIDIfNotExist || true,
+    }));
+  },
+};

--- a/components/asana/actions/add-task-to-section/add-task-to-section.mjs
+++ b/components/asana/actions/add-task-to-section/add-task-to-section.mjs
@@ -1,0 +1,50 @@
+// legacy_hash_id: a_njiaY8
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "asana-add-task-to-section",
+  name: "Add Task To Section",
+  description: "Add task to section",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    asana: {
+      type: "app",
+      app: "asana",
+    },
+    section_gid: {
+      type: "string",
+    },
+    task: {
+      type: "string",
+    },
+    insert_before: {
+      type: "string",
+      optional: true,
+    },
+    insert_after: {
+      type: "string",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+
+    return await axios($, {
+      method: "post",
+      url: `https://app.asana.com/api/1.0/sections/${this.section_gid}/addTask`,
+
+      headers: {
+        "Authorization": `Bearer ${this.asana.$auth.oauth_access_token}`,
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+      },
+      data: {
+        data: {
+          task: this.task,
+          insert_before: this.insert_before,
+          insert_after: this.insert_after,
+        },
+      },
+    });
+  },
+};

--- a/components/asana/actions/create-project/create-project.mjs
+++ b/components/asana/actions/create-project/create-project.mjs
@@ -1,0 +1,59 @@
+// legacy_hash_id: a_zNiwKE
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "asana-create-project",
+  name: "Create Project",
+  description: "Create a project",
+  version: "0.8.1",
+  type: "action",
+  props: {
+    asana: {
+      type: "app",
+      app: "asana",
+    },
+    name: {
+      type: "string",
+    },
+    notes: {
+      type: "string",
+    },
+    workspace: {
+      type: "string",
+    },
+    team: {
+      type: "string",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    let dataPayload = new Object();
+    if (this.team) {
+      dataPayload =  {
+        name: this.name,
+        notes: this.notes,
+        workspace: this.workspace,
+        team: this.team,
+      };
+    } else {
+      dataPayload =  {
+        name: this.name,
+        notes: this.notes,
+        workspace: this.workspace,
+      };
+    }
+
+    return await axios($, {
+      method: "post",
+      url: "https://app.asana.com/api/1.0/projects",
+      headers: {
+        "Authorization": `Bearer ${this.asana.$auth.oauth_access_token}`,
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+      },
+      data: {
+        data: dataPayload,
+      },
+    });
+  },
+};

--- a/components/asana/actions/create-subtask/create-subtask.mjs
+++ b/components/asana/actions/create-subtask/create-subtask.mjs
@@ -1,0 +1,97 @@
+// legacy_hash_id: a_vgi87A
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "asana-create-subtask",
+  name: "Create Subtask",
+  description: "Create a subtask",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    asana: {
+      type: "app",
+      app: "asana",
+    },
+    task_gid: {
+      type: "string",
+    },
+    name: {
+      type: "string",
+    },
+    assignee: {
+      type: "string",
+      optional: true,
+    },
+    assignee_status: {
+      type: "string",
+      optional: true,
+    },
+    completed: {
+      type: "string",
+    },
+    due_at: {
+      type: "string",
+      optional: true,
+    },
+    due_on: {
+      type: "string",
+      optional: true,
+    },
+    followers: {
+      type: "string",
+      optional: true,
+    },
+    html_notes: {
+      type: "string",
+      optional: true,
+    },
+    notes: {
+      type: "string",
+      optional: true,
+    },
+    projects: {
+      type: "string",
+      optional: true,
+    },
+    start_on: {
+      type: "string",
+      optional: true,
+    },
+    tags: {
+      type: "string",
+      optional: true,
+    },
+    workspace: {
+      type: "string",
+    },
+  },
+  async run({ $ }) {
+
+    return await axios($, {
+      method: "post",
+      url: `https://app.asana.com/api/1.0/tasks/${this.task_gid}/subtasks`,
+      headers: {
+        "Authorization": `Bearer ${this.asana.$auth.oauth_access_token}`,
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+      },
+      data: {
+        data: {
+          name: this.name,
+          assignee: this.assignee,
+          assignee_status: this.assignee_status,
+          completed: this.completed,
+          due_at: this.due_at,
+          due_on: this.due_on,
+          followers: this.followers,
+          html_notes: this.html_notes,
+          notes: this.notes,
+          projects: this.projects,
+          start_on: this.start_on,
+          tags: this.tags,
+          workspace: this.workspace,
+        },
+      },
+    });
+  },
+};

--- a/components/asana/actions/create-task-comment/create-task-comment.mjs
+++ b/components/asana/actions/create-task-comment/create-task-comment.mjs
@@ -1,0 +1,40 @@
+// legacy_hash_id: a_l0iLdL
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "asana-create-task-comment",
+  name: "Create Task Comment",
+  description: "Create a comment on a task",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    asana: {
+      type: "app",
+      app: "asana",
+    },
+    task_gid: {
+      type: "string",
+    },
+    text: {
+      type: "string",
+    },
+  },
+  async run({ $ }) {
+
+    return await axios($, {
+      method: "post",
+      url: `https://app.asana.com/api/1.0/tasks/${this.task_gid}/stories`,
+      headers: {
+        "Authorization": `Bearer ${this.asana.$auth.oauth_access_token}`,
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+      },
+      data: {
+        data: {
+          task: this.task_gid,
+          text: this.text,
+        },
+      },
+    });
+  },
+};

--- a/components/asana/actions/create-task/create-task.mjs
+++ b/components/asana/actions/create-task/create-task.mjs
@@ -1,0 +1,99 @@
+// legacy_hash_id: a_Mdi8Vw
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "asana-create-task",
+  name: "Create Task",
+  description: "Create a task",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    asana: {
+      type: "app",
+      app: "asana",
+    },
+    name: {
+      type: "string",
+    },
+    assignee: {
+      type: "string",
+      optional: true,
+    },
+    assignee_status: {
+      type: "string",
+      optional: true,
+    },
+    completed: {
+      type: "string",
+    },
+    due_at: {
+      type: "string",
+      optional: true,
+    },
+    due_on: {
+      type: "string",
+      optional: true,
+    },
+    followers: {
+      type: "any",
+      optional: true,
+    },
+    html_notes: {
+      type: "string",
+      optional: true,
+    },
+    notes: {
+      type: "string",
+      optional: true,
+    },
+    parent: {
+      type: "string",
+      optional: true,
+    },
+    projects: {
+      type: "any",
+      optional: true,
+    },
+    start_on: {
+      type: "string",
+      optional: true,
+    },
+    tags: {
+      type: "any",
+      optional: true,
+    },
+    workspace: {
+      type: "string",
+    },
+  },
+  async run({ $ }) {
+
+    return await axios($, {
+      method: "post",
+      url: "https://app.asana.com/api/1.0/tasks",
+      headers: {
+        "Authorization": `Bearer ${this.asana.$auth.oauth_access_token}`,
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+      },
+      data: {
+        data: {
+          name: this.name,
+          assignee: this.assignee,
+          assignee_status: this.assignee_status,
+          completed: this.completed,
+          due_at: this.due_at,
+          due_on: this.due_on,
+          followers: this.followers,
+          html_notes: this.html_notes,
+          notes: this.notes,
+          parent: this.parent,
+          projects: this.projects,
+          start_on: this.start_on,
+          tags: this.tags,
+          workspace: this.workspace,
+        },
+      },
+    });
+  },
+};

--- a/components/asana/actions/find-task-by-id/find-task-by-id.mjs
+++ b/components/asana/actions/find-task-by-id/find-task-by-id.mjs
@@ -1,0 +1,48 @@
+// legacy_hash_id: a_K5i2Gr
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "asana-find-task-by-id",
+  name: "Find Task by ID",
+  description: "Searches for a task by id. Returns the complete task record for a single task.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    asana: {
+      type: "app",
+      app: "asana",
+    },
+    task_gid: {
+      type: "string",
+      description: "The ID of the task to find.",
+    },
+    opt_pretty: {
+      type: "boolean",
+      description: "Provides pretty output.",
+      optional: true,
+    },
+    opt_fields: {
+      type: "any",
+      description: "Defines fields to return.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    let taskGid = this.task_gid;
+    const asanaParams = [
+      "opt_pretty",
+      "opt_fields",
+    ];
+    let p = this;
+
+    const queryString = asanaParams.filter((param) => p[param]).map((param) => `${param}=${p[param]}`)
+      .join("&");
+
+    return await axios($, {
+      url: `https://app.asana.com/api/1.0/tasks/${taskGid}?${queryString}`,
+      headers: {
+        Authorization: `Bearer ${this.asana.$auth.oauth_access_token}`,
+      },
+    });
+  },
+};

--- a/components/asana/actions/search-projects/search-projects.mjs
+++ b/components/asana/actions/search-projects/search-projects.mjs
@@ -1,0 +1,40 @@
+// legacy_hash_id: a_2wimKj
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "asana-search-projects",
+  name: "Search Projects",
+  description: "Finds an existing project by name.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    asana: {
+      type: "app",
+      app: "asana",
+    },
+    name: {
+      type: "string",
+    },
+  },
+  async run({ $ }) {
+    let projects = null;
+    let matches = [];
+    let query = this.name;
+
+    projects = await axios($, {
+      url: "https://app.asana.com/api/1.0/projects",
+      headers: {
+        Authorization: `Bearer ${this.asana.$auth.oauth_access_token}`,
+      },
+    });
+
+    if (projects.data) {
+      projects.data.forEach(function(project) {
+        if (project.name.includes(query))
+          matches.push(project);
+      });
+    }
+
+    return matches;
+  },
+};

--- a/components/asana/actions/search-sections/search-sections.mjs
+++ b/components/asana/actions/search-sections/search-sections.mjs
@@ -1,0 +1,65 @@
+// legacy_hash_id: a_k6iYPz
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "asana-search-sections",
+  name: "Find Section in Project",
+  description: "Searches for a section by name within a particular project.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    asana: {
+      type: "app",
+      app: "asana",
+    },
+    project_gid: {
+      type: "string",
+      description: "Globally unique identifier for the project.",
+    },
+    name: {
+      type: "string",
+      description: "The name of the section to search for.",
+    },
+    opt_pretty: {
+      type: "boolean",
+      description: "Provides pretty output.",
+      optional: true,
+    },
+    opt_fields: {
+      type: "any",
+      description: "Defines fields to return.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    let sections = null;
+    let matches = [];
+    let projectGid = this.project_gid;
+    let query = this.name;
+
+    const asanaParams = [
+      "opt_pretty",
+      "opt_fields",
+    ];
+    let p = this;
+
+    const queryString = asanaParams.filter((param) => p[param]).map((param) => `${param}=${p[param]}`)
+      .join("&");
+
+    sections = await axios($, {
+      url: `https://app.asana.com/api/1.0/projects/${projectGid}/sections?${queryString}`,
+      headers: {
+        Authorization: `Bearer ${this.asana.$auth.oauth_access_token}`,
+      },
+    });
+    console.log(sections);
+    if (sections) {
+      sections.data.forEach(function(section) {
+        if (section.name.includes(query))
+          matches.push(section);
+      });
+    }
+
+    return matches;
+  },
+};

--- a/components/asana/actions/search-tasks/search-tasks.mjs
+++ b/components/asana/actions/search-tasks/search-tasks.mjs
@@ -1,0 +1,82 @@
+// legacy_hash_id: a_74iEBo
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "asana-search-tasks",
+  name: "Search Tasks",
+  description: "Searches for a Task by name within a Project.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    asana: {
+      type: "app",
+      app: "asana",
+    },
+    name: {
+      type: "string",
+      description: "The task name to search for.",
+    },
+    assignee: {
+      type: "string",
+      description: "The assignee to filter tasks on. Note: If you specify assignee, you must also specify the workspace to filter on.",
+      optional: true,
+    },
+    project: {
+      type: "string",
+      description: "The project to filter tasks on.",
+    },
+    section: {
+      type: "string",
+      description: "The section to filter tasks on.",
+      optional: true,
+    },
+    workspace: {
+      type: "string",
+      description: "The workspace to filter tasks on. Note: If you specify workspace, you must also specify the assignee to filter on.",
+      optional: true,
+    },
+    completed_since: {
+      type: "string",
+      description: "Only return tasks that are either incomplete or that have been completed since this time.",
+      optional: true,
+    },
+    modified_since: {
+      type: "string",
+      description: "Only return tasks that have been modified since the given time.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    let tasks = null;
+    let matches = [];
+    let query = this.name;
+    const asanaParams = [
+      "assignee",
+      "project",
+      "section",
+      "workspace",
+      "completed_since",
+      "modified_since",
+    ];
+    let p = this;
+
+    const queryString = asanaParams.filter((param) => p[param]).map((param) => `${param}=${p[param]}`)
+      .join("&");
+
+    tasks = await axios($, {
+      url: `https://app.asana.com/api/1.0/tasks?${queryString}`,
+      headers: {
+        Authorization: `Bearer ${this.asana.$auth.oauth_access_token}`,
+      },
+    });
+
+    if (tasks) {
+      tasks.data.forEach(function(task) {
+        if (task.name.includes(query))
+          matches.push(task);
+      });
+    }
+
+    return matches;
+  },
+};

--- a/components/aws/actions/invoke-lambda/invoke-lambda.mjs
+++ b/components/aws/actions/invoke-lambda/invoke-lambda.mjs
@@ -1,0 +1,62 @@
+// legacy_hash_id: a_8Ki7Xv
+import AWS from "aws-sdk";
+
+export default {
+  key: "aws-invoke-lambda",
+  name: "AWS - Lambda - Invoke Function",
+  description: "Invoke a Lambda function using the AWS API",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    aws: {
+      type: "app",
+      app: "aws",
+    },
+    region: {
+      type: "string",
+      label: "AWS Region",
+      description: "The AWS region tied to your Lambda, e.g us-east-1 or us-west-2",
+    },
+    FunctionName: {
+      type: "string",
+      label: "Lambda Function Name",
+      description: "The name of your Lambda function. Also accepts a function ARN",
+    },
+    eventData: {
+      type: "string",
+      label: "Event data",
+      description: "A variable reference to the event data you want to send to the event bus (e.g. event.body)",
+    },
+  },
+  async run({ $ }) {
+    const {
+      accessKeyId,
+      secretAccessKey,
+    } = this.aws.$auth;
+    const {
+      region,
+      FunctionName,
+      eventData,
+    } = this;
+
+    const lambda = new AWS.Lambda({
+      accessKeyId,
+      secretAccessKey,
+      region,
+    });
+
+    // This invokes the Lambda synchronously so you can view the response
+    // details associated with each invocation. This can be changed. See
+    // https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Lambda.html#invoke-property
+    // This also assumes the eventData passed to the step is JSON.
+    // Please modify the code accordingly if your data is in a different format.
+    const lambdaParams = {
+      Payload: JSON.stringify(eventData),
+      FunctionName,
+      InvocationType: "RequestResponse",
+      LogType: "Tail",
+    };
+
+    $.export("res", await lambda.invoke(lambdaParams).promise());
+  },
+};

--- a/components/aws/actions/send-event-to-eventbridge-bus/send-event-to-eventbridge-bus.mjs
+++ b/components/aws/actions/send-event-to-eventbridge-bus/send-event-to-eventbridge-bus.mjs
@@ -1,0 +1,62 @@
+// legacy_hash_id: a_Q3i5WQ
+import AWS from "aws-sdk";
+
+export default {
+  key: "aws-send-event-to-eventbridge-bus",
+  name: "AWS - EventBridge - Send event to Event Bus",
+  description: "Sends an event to an EventBridge event bus",
+  version: "0.3.1",
+  type: "action",
+  props: {
+    aws: {
+      type: "app",
+      app: "aws",
+    },
+    region: {
+      type: "string",
+      label: "AWS Region",
+      description: "Region tied to your EventBridge event bus, e.g. us-east-1 or us-west-2",
+    },
+    EventBusName: {
+      type: "string",
+      label: "Event Bus Name",
+      description: "The name of the EventBridge event bus",
+    },
+    eventData: {
+      type: "string",
+      label: "Event data",
+      description: "A variable reference to the event data you want to send to the event bus (e.g. event.body)",
+    },
+  },
+  async run({ $ }) {
+    const {
+      accessKeyId,
+      secretAccessKey,
+    } = this.aws.$auth;
+    const {
+      region,
+      EventBusName,
+      eventData,
+    } = this;
+
+    const eventbridge = new AWS.EventBridge({
+      accessKeyId,
+      secretAccessKey,
+      region,
+    });
+
+    // See https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/EventBridge.html#putEvents-property
+    const putEventsParams = {
+      Entries: [
+        {
+          Detail: JSON.stringify(eventData),
+          DetailType: Object.keys(eventData).join(" "),
+          EventBusName,
+          Source: "pipedream",
+        },
+      ],
+    };
+
+    $.export("res", await eventbridge.putEvents(putEventsParams).promise());
+  },
+};

--- a/components/aws/actions/send-message-to-sqs/send-message-to-sqs.mjs
+++ b/components/aws/actions/send-message-to-sqs/send-message-to-sqs.mjs
@@ -1,0 +1,56 @@
+// legacy_hash_id: a_67il7K
+import AWS from "aws-sdk";
+
+export default {
+  key: "aws-send-message-to-sqs",
+  name: "AWS - SQS - Send Message",
+  description: "Sends a message to an SQS queue",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    aws: {
+      type: "app",
+      app: "aws",
+    },
+    region: {
+      type: "string",
+      label: "AWS Region",
+      description: "The AWS region tied to your SQS queue, e.g us-east-1 or us-west-2",
+    },
+    QueueUrl: {
+      type: "string",
+      label: "SQS Queue URL",
+    },
+    eventData: {
+      type: "string",
+      label: "Event data",
+      description: "A variable reference to the event data you want to send to the event bus (e.g. event.body)",
+    },
+  },
+  async run({ $ }) {
+    const {
+      accessKeyId,
+      secretAccessKey,
+    } = this.aws.$auth;
+    const {
+      region,
+      QueueUrl,
+      eventData,
+    } = this;
+
+    const sqs = new AWS.SQS({
+      accessKeyId,
+      secretAccessKey,
+      region,
+    });
+
+    // This sends the payload to the SQS queue, and assumes the payload is JSON.
+    // Please modify the code accordingly if your data is in a different format
+    const sqsParams = {
+      MessageBody: JSON.stringify(eventData),
+      QueueUrl,
+    };
+
+    $.export("res", await sqs.sendMessage(sqsParams).promise());
+  },
+};

--- a/components/aws/actions/stream-file-to-s3/stream-file-to-s3.mjs
+++ b/components/aws/actions/stream-file-to-s3/stream-file-to-s3.mjs
@@ -1,0 +1,58 @@
+// legacy_hash_id: a_a4i84m
+import AWS from "aws-sdk";
+import { get } from "axios";
+
+export default {
+  key: "aws-stream-file-to-s3",
+  name: "S3 - Stream file to S3 from URL",
+  description: "Accepts a file URL, and streams the file to the provided S3 bucket/key",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    aws: {
+      type: "app",
+      app: "aws",
+    },
+    fileUrl: {
+      type: "string",
+      label: "File URL",
+      description: "The absolute URL of the file you'd like to upload",
+    },
+    s3Bucket: {
+      type: "string",
+      label: "S3 Bucket",
+      description: "The name of the S3 bucket you'd like to upload the file to",
+    },
+    s3Key: {
+      type: "string",
+      label: "S3 Key",
+      description: "The name of the S3 key you'd like to upload this file to",
+    },
+  },
+  async run() {
+    const {
+      fileUrl,
+      s3Bucket,
+      s3Key,
+    } = this;
+    const {
+      accessKeyId,
+      secretAccessKey,
+    } = this.aws.$auth;
+    const s3 = new AWS.S3({
+      accessKeyId,
+      secretAccessKey,
+    });
+    const urlResponse = await get(fileUrl, {
+      responseType: "stream",
+    });
+    const s3Response = await s3.upload({
+      Bucket: s3Bucket,
+      Key: s3Key.replace(/^\/+/, ""),
+      ContentType: urlResponse.headers["content-type"],
+      ContentLength: urlResponse.headers["content-length"],
+      Body: urlResponse.data,
+    }).promise();
+    return (await s3Response).Location;
+  },
+};

--- a/components/aws/actions/upload-file-to-s3/upload-file-to-s3.mjs
+++ b/components/aws/actions/upload-file-to-s3/upload-file-to-s3.mjs
@@ -1,0 +1,61 @@
+// legacy_hash_id: a_k6iKxV
+import AWS from "aws-sdk";
+
+export default {
+  key: "aws-upload-file-to-s3",
+  name: "S3 - Upload File",
+  description: "Accepts a base64-encoded string, a filename, and a content type, then uploads as a file to S3",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    aws: {
+      type: "app",
+      app: "aws",
+    },
+    bucket: {
+      type: "string",
+      label: "S3 Bucket Name",
+    },
+    ContentType: {
+      type: "string",
+      label: "Content Type",
+      description: "MIME type of the content to upload, for S3 metadata",
+    },
+    filename: {
+      type: "string",
+      label: "Filename",
+      description: "Filename with extension",
+    },
+    data: {
+      type: "string",
+      label: "Base64-encoded Data",
+      description: "A string of base64-encoded data, or a variable reference to that string",
+    },
+  },
+  async run({ $ }) {
+    const {
+      bucket,
+      ContentType,
+      filename,
+      data,
+    } = this;
+    const {
+      accessKeyId,
+      secretAccessKey,
+    } = this.aws.$auth;
+
+    const s3 = new AWS.S3({
+      accessKeyId,
+      secretAccessKey,
+    });
+
+    const uploadParams = {
+      Bucket: bucket,
+      Key: filename,
+      Body: Buffer.from(data, "base64"),
+      ContentType,
+    };
+    $.export("S3Response", await s3.upload(uploadParams).promise());
+    console.log("Uploaded file to S3!");
+  },
+};

--- a/components/bitbucket/actions/create-issue/create-issue.mjs
+++ b/components/bitbucket/actions/create-issue/create-issue.mjs
@@ -1,0 +1,126 @@
+// legacy_hash_id: a_OOiaQ0
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "bitbucket-create-issue",
+  name: "Creates a new issue",
+  description: "Creates a new issue",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    bitbucket: {
+      type: "app",
+      app: "bitbucket",
+    },
+    username: {
+      type: "string",
+      label: "username",
+    },
+    repo_slug: {
+      type: "string",
+      label: "repo_slug",
+    },
+    priority: {
+      type: "string",
+      optional: true,
+    },
+    kind: {
+      type: "string",
+      optional: true,
+    },
+    repository: {
+      type: "object",
+      optional: true,
+    },
+    links: {
+      type: "object",
+      optional: true,
+    },
+    reporter: {
+      type: "object",
+      optional: true,
+    },
+    title: {
+      type: "string",
+      label: "title",
+    },
+    component: {
+      type: "string",
+      optional: true,
+    },
+    votes: {
+      type: "string",
+      optional: true,
+    },
+    watches: {
+      type: "string",
+      optional: true,
+    },
+    content: {
+      type: "object",
+    },
+    assignee: {
+      type: "string",
+      optional: true,
+    },
+    state: {
+      type: "string",
+      optional: true,
+    },
+    version: {
+      type: "string",
+      optional: true,
+    },
+    edited_on: {
+      type: "string",
+      optional: true,
+    },
+    created_on: {
+      type: "string",
+      optional: true,
+    },
+    milestone: {
+      type: "string",
+      optional: true,
+    },
+    updated_on: {
+      type: "string",
+      optional: true,
+    },
+    type: {
+      type: "string",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    return await axios($, {
+      method: "post",
+      url: `https://api.bitbucket.org/2.0/repositories/${this.username}/${this.repo_slug}/issues`,
+      headers: {
+        Authorization: `Bearer ${this.bitbucket.$auth.oauth_access_token}`,
+      },
+      data: {
+        username: this.username,
+        repo_slug: this.repo_slug,
+        priority: this.priority,
+        kind: this.kind,
+        repository: this.repository,
+        links: this.links,
+        reporter: this.reporter,
+        title: this.title,
+        component: this.component,
+        votes: this.votes,
+        watches: this.watches,
+        content: this.content,
+        assignee: this.assignee,
+        state: this.state,
+        version: this.version,
+        edited_on: this.edited_on,
+        created_on: this.created_on,
+        milestone: this.milestone,
+        updated_on: this.updated_on,
+        type: this.type,
+      },
+    });
+  },
+};

--- a/components/browserless/actions/take-screenshot/take-screenshot.mjs
+++ b/components/browserless/actions/take-screenshot/take-screenshot.mjs
@@ -1,0 +1,41 @@
+// legacy_hash_id: a_oViVKv
+import puppeteer from "puppeteer-core";
+
+export default {
+  key: "browserless-take-screenshot",
+  name: "Take a Screenshot",
+  version: "0.5.1",
+  type: "action",
+  props: {
+    browserless: {
+      type: "app",
+      app: "browserless",
+    },
+    url: {
+      type: "string",
+      label: "URL",
+      description: "Enter the URL you'd like to take a screenshot of here",
+    },
+  },
+  async run({ $ }) {
+    const browser = await puppeteer.connect({
+      browserWSEndpoint: `wss://chrome.browserless.io?token=${this.browserless.$auth.api_key}`,
+    });
+    const page = await browser.newPage();
+
+    const { url } = this;
+    await page.goto(url);
+    const screenshot = await page.screenshot();
+
+    // export the base64-encoded screenshot for use in future steps,
+    // along with the image type and filename
+    $.export("screenshot", Buffer.from(screenshot, "binary").toString("base64"));
+    $.export("type", "png");
+    $.export(
+      "filename",
+      `${url.replace(/[&\/\\#, +()$~%.'":*?<>{}]/g, "_")}-${+new Date()}.${this.type}`,
+    );
+
+    await browser.close();
+  },
+};

--- a/components/buildkite/actions/get-user/get-user.mjs
+++ b/components/buildkite/actions/get-user/get-user.mjs
@@ -1,0 +1,24 @@
+// legacy_hash_id: a_1Wiqr1
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "buildkite-get-user",
+  name: "Get the current user",
+  description: "Returns basic details about the user account that sent the request",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    buildkite: {
+      type: "app",
+      app: "buildkite",
+    },
+  },
+  async run({ $ }) {
+    return await axios($, {
+      url: "https://api.buildkite.com/v2/user",
+      headers: {
+        Authorization: `Bearer ${this.buildkite.$auth.api_token}`,
+      },
+    });
+  },
+};

--- a/components/cloudflare_api_key/actions/cloudflare-create-dns-record/cloudflare-create-dns-record.mjs
+++ b/components/cloudflare_api_key/actions/cloudflare-create-dns-record/cloudflare-create-dns-record.mjs
@@ -1,0 +1,86 @@
+// legacy_hash_id: a_K5iLqd
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "cloudflare_api_key-cloudflare-create-dns-record",
+  name: "Create DNS Record",
+  description: "Creates a DNS Record given its zone id",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    cloudflare_api_key: {
+      type: "app",
+      app: "cloudflare_api_key",
+    },
+    zone_id: {
+      type: "string",
+      description: "The zone ID where the DNS record being created belongs to.",
+    },
+    type: {
+      type: "string",
+      description: "DNS record type.",
+      options: [
+        "A",
+        "AAAA",
+        "CNAME",
+        "TXT",
+        "SRV",
+        "LOC",
+        "MX",
+        "NS",
+        "SPF",
+        "CERT",
+        "DNSKEY",
+        "NAPTR",
+        "SMIMEA",
+        "SSHFP",
+        "TLSA",
+        "URI",
+        "NS",
+      ],
+    },
+    name: {
+      type: "string",
+      description: "DNS record name.",
+    },
+    content: {
+      type: "string",
+      description: "DNS record content.",
+    },
+    ttl: {
+      type: "integer",
+      description: "Time to live for DNS record. Value of 1 is 'automatic'.",
+    },
+    proxied: {
+      type: "boolean",
+      description: "Whether the record is receiving the performance and security benefits of Cloudflare",
+      optional: true,
+    },
+    priority: {
+      type: "string",
+      description: "Used with some records like MX and SRV to determine priority. If you do not supply a priority for an MX record, a default value of 0 will be set.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+
+    return await axios($, {
+      method: "post",
+      url: `https://api.cloudflare.com/client/v4/zones/${this.zone_id}/dns_records`,
+      headers: {
+        "X-Auth-Email": `${this.cloudflare_api_key.$auth.Email}`,
+        "X-Auth-Key": `${this.cloudflare_api_key.$auth.API_Key}`,
+        "Content-Type": "application/json",
+
+      },
+      data: {
+        type: this.type,
+        name: this.name,
+        content: this.content,
+        ttl: this.ttl,
+        proxied: this.proxied,
+        priority: this.priority,
+      },
+    });
+  },
+};

--- a/components/coinbase/actions/place-buy-order/place-buy-order.mjs
+++ b/components/coinbase/actions/place-buy-order/place-buy-order.mjs
@@ -1,0 +1,43 @@
+// legacy_hash_id: a_8KiVLP
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "coinbase-place-buy-order",
+  name: "Place Buy Order",
+  description: "Places a buy order",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    coinbase: {
+      type: "app",
+      app: "coinbase",
+    },
+    account_id: {
+      type: "string",
+    },
+    amount: {
+      type: "string",
+    },
+    currency: {
+      type: "string",
+    },
+    payment_method: {
+      type: "string",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+
+    return await axios($, {
+      url: `https://api.coinbase.com/v2/accounts/${this.account_id}/buys`,
+      headers: {
+        Authorization: `Bearer ${this.coinbase.$auth.oauth_access_token}`,
+      },
+      data: {
+        amount: this.amount,
+        currency: this.currency,
+        payment_method: this.payment_method,
+      },
+    });
+  },
+};

--- a/components/coinbase/actions/withdraw-funds/withdraw-funds.mjs
+++ b/components/coinbase/actions/withdraw-funds/withdraw-funds.mjs
@@ -1,0 +1,42 @@
+// legacy_hash_id: a_1WiqY1
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "coinbase-withdraw-funds",
+  name: "Withdraw Funds",
+  description: "Withdraw funds",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    coinbase: {
+      type: "app",
+      app: "coinbase",
+    },
+    account_id: {
+      type: "string",
+    },
+    amount: {
+      type: "string",
+    },
+    currency: {
+      type: "string",
+    },
+    payment_method: {
+      type: "string",
+    },
+  },
+  async run({ $ }) {
+
+    return await axios($, {
+      url: `https://api.coinbase.com/v2/accounts/${this.account_id}/withdrawals`,
+      headers: {
+        Authorization: `Bearer ${this.coinbase.$auth.oauth_access_token}`,
+      },
+      data: {
+        amount: this.amount,
+        currency: this.currency,
+        payment_method: this.payment_method,
+      },
+    });
+  },
+};

--- a/components/coinmarketcap/actions/id-map/id-map.mjs
+++ b/components/coinmarketcap/actions/id-map/id-map.mjs
@@ -1,0 +1,75 @@
+// legacy_hash_id: a_LgijYE
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "coinmarketcap-id-map",
+  name: "CoinMarketCap ID Map",
+  description: "Returns a mapping of all cryptocurrencies to unique CoinMarketCap ids. https://coinmarketcap.com/api/documentation/v1/#operation/getV1CryptocurrencyMap",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    coinmarketcap: {
+      type: "app",
+      app: "coinmarketcap",
+    },
+    listing_status: {
+      type: "string",
+      description: "Only active cryptocurrencies are returned by default. Pass inactive to get a list of cryptocurrencies that are no longer active. Pass untracked to get a list of cryptocurrencies that are listed but do not yet meet methodology requirements to have tracked markets available. You may pass one or more comma-separated values.",
+      optional: true,
+      options: [
+        "active",
+        "inactive",
+        "untracked",
+      ],
+    },
+    start: {
+      type: "integer",
+      description: "Optionally offset the start (1-based index) of the paginated list of items to return.",
+      optional: true,
+    },
+    limit: {
+      type: "string",
+      description: "Optionally specify the number of results to return. Use this parameter and the \"start\" parameter to determine your own pagination size.",
+      optional: true,
+    },
+    sort: {
+      type: "string",
+      description: "What field to sort the list of cryptocurrencies by.",
+      optional: true,
+      options: [
+        "cmc_rank",
+        "id",
+      ],
+    },
+    symbol: {
+      type: "string",
+      description: "Optionally pass a comma-separated list of cryptocurrency symbols to return CoinMarketCap IDs for. If this option is passed, other options will be ignored.",
+      optional: true,
+    },
+    aux: {
+      type: "string",
+      description: "Optionally specify a comma-separated list of supplemental data fields to return. Pass platform,first_historical_data,last_historical_data,is_active,status to include all auxiliary fields.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const limit = (typeof this.limit === "undefined")
+      ? 100
+      : this.limit;
+
+    return await axios($, {
+      url: `https://${this.coinmarketcap.$auth.environment}-api.coinmarketcap.com/v1/cryptocurrency/map`,
+      headers: {
+        "X-CMC_PRO_API_KEY": `${this.coinmarketcap.$auth.api_key}`,
+      },
+      params: {
+        listing_status: this.listing_status,
+        start: this.start,
+        limit,
+        sort: this.sort,
+        symbol: this.symbol,
+        aux: this.aux,
+      },
+    });
+  },
+};

--- a/components/coinmarketcap/actions/latest-listings/latest-listings.mjs
+++ b/components/coinmarketcap/actions/latest-listings/latest-listings.mjs
@@ -1,0 +1,108 @@
+// legacy_hash_id: a_rJiLNE
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "coinmarketcap-latest-listings",
+  name: "Latest Listings",
+  description: "Returns a paginated list of all active cryptocurrencies with latest market data. https://coinmarketcap.com/api/documentation/v1/#operation/getV1CryptocurrencyListingsLatest",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    coinmarketcap: {
+      type: "app",
+      app: "coinmarketcap",
+    },
+    start: {
+      type: "integer",
+      description: "Optionally offset the start (1-based index) of the paginated list of items to return.",
+      optional: true,
+    },
+    limit: {
+      type: "integer",
+      description: "Optionally specify the number of results to return. Use this parameter and the \"start\" parameter to determine your own pagination size.",
+      optional: true,
+    },
+    volume_24h_min: {
+      type: "integer",
+      description: "Optionally specify a threshold of minimum 24 hour USD volume to filter results by.",
+      optional: true,
+    },
+    convert: {
+      type: "string",
+      description: "Optionally calculate market quotes in up to 120 currencies at once by passing a comma-separated list of cryptocurrency or fiat currency symbols. Each additional convert option beyond the first requires an additional call credit. A list of supported fiat options can be found at https://coinmarketcap.com/api/documentation/v1/#section/Standards-and-Conventions. Each conversion is returned in its own \"quote\" object.",
+      optional: true,
+    },
+    convert_id: {
+      type: "string",
+      description: "Optionally calculate market quotes by CoinMarketCap ID instead of symbol. This option is identical to convert outside of ID format. Ex: convert_id=1,2781 would replace convert=BTC,USD in your query. This parameter cannot be used when convert is used.",
+      optional: true,
+    },
+    sort: {
+      type: "string",
+      description: "What field to sort the list of cryptocurrencies by.",
+      optional: true,
+      options: [
+        "market_cap",
+        "name",
+        "symbol",
+        "date_added",
+        "market_cap_strict",
+        "price",
+        "circulating_supply",
+        "total_supply",
+        "max_supply",
+        "num_market_pairs",
+        "volume_24h",
+        "percent_change_1h",
+        "percent_change_24h",
+        "percent_change_7d",
+        "market_cap_by_total_supply_strict",
+        "volume_7d",
+        "volume_30d",
+      ],
+    },
+    sort_dir: {
+      type: "string",
+      description: "The direction in which to order cryptocurrencies against the specified sort.",
+      optional: true,
+      options: [
+        "asc",
+        "desc",
+      ],
+    },
+    cryptocurrency_type: {
+      type: "string",
+      description: "The type of cryptocurrency to include.",
+      optional: true,
+      options: [
+        "all",
+        "coins",
+        "tokens",
+      ],
+    },
+    aux: {
+      type: "string",
+      description: "Optionally specify a comma-separated list of supplemental data fields to return. Pass num_market_pairs,cmc_rank,date_added,tags,platform,max_supply,circulating_supply,total_supply,market_cap_by_total_supply,volume_24h_reported,volume_7d,volume_7d_reported,volume_30d,volume_30d_reported to include all auxiliary fields.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    return await axios($, {
+      url: `https://${this.coinmarketcap.$auth.environment}-api.coinmarketcap.com/v1/cryptocurrency/listings/latest`,
+      headers: {
+        "X-CMC_PRO_API_KEY": `${this.coinmarketcap.$auth.api_key}`,
+      },
+      params: {
+        start: this.start,
+        limit: this.limit,
+        volume_24h_min: this.volume_24h_min,
+        convert: this.convert,
+        convert_id: this.convert_id,
+        sort: this.sort,
+        sort_dir: this.sort_dir,
+        cryptocurrency_type: this.cryptocurrency_type,
+        aux: this.aux,
+      },
+    });
+  },
+};

--- a/components/coinmarketcap/actions/latest-quotes/latest-quotes.mjs
+++ b/components/coinmarketcap/actions/latest-quotes/latest-quotes.mjs
@@ -1,0 +1,61 @@
+// legacy_hash_id: a_wdijbV
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "coinmarketcap-latest-quotes",
+  name: "Latest Quotes",
+  description: "Returns the latest market quote for 1 or more cryptocurrencies. Use the \"\"convert\"\" option to return market values in multiple fiat and cryptocurrency conversions in the same call. At least one \"\"id\"\" or \"\"slug\"\" or \"\"symbol\"\" is required for this request. https://coinmarketcap.com/api/documentation/v1/#operation/getV1CryptocurrencyQuotesLatest",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    coinmarketcap: {
+      type: "app",
+      app: "coinmarketcap",
+    },
+    id: {
+      type: "string",
+      description: "One or more comma-separated cryptocurrency CoinMarketCap IDs. Example: 1,2",
+      optional: true,
+      options: [
+        "active",
+        "inactive",
+        "untracked",
+      ],
+    },
+    slug: {
+      type: "string",
+      description: "Alternatively pass a comma-separated list of cryptocurrency slugs. Example: \"bitcoin,ethereum\"",
+      optional: true,
+    },
+    symbol: {
+      type: "string",
+      description: "Alternatively pass one or more comma-separated cryptocurrency symbols. Example: \"BTC,ETH\".",
+      optional: true,
+    },
+    convert: {
+      type: "string",
+      description: "Optionally calculate market quotes in up to 120 currencies at once by passing a comma-separated list of cryptocurrency or fiat currency symbols. Each additional convert option beyond the first requires an additional call credit. A list of supported fiat options can be found at https://coinmarketcap.com/api/documentation/v1/#section/Standards-and-Conventions. Each conversion is returned in its own \"quote\" object.",
+      optional: true,
+    },
+    convert_id: {
+      type: "string",
+      description: "Optionally calculate market quotes by CoinMarketCap ID instead of symbol. This option is identical to convert outside of ID format. Ex: convert_id=1,2781 would replace convert=BTC,USD in your query. This parameter cannot be used when convert is used.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    return await axios($, {
+      url: `https://${this.coinmarketcap.$auth.environment}-api.coinmarketcap.com/v1/cryptocurrency/quotes/latest`,
+      headers: {
+        "X-CMC_PRO_API_KEY": `${this.coinmarketcap.$auth.api_key}`,
+      },
+      params: {
+        id: this.id,
+        slug: this.slug,
+        symbol: this.symbol,
+        convert: this.convert,
+        convert_id: this.convert_id,
+      },
+    });
+  },
+};

--- a/components/digital_ocean/actions/add-ssh-key/add-ssh-key.mjs
+++ b/components/digital_ocean/actions/add-ssh-key/add-ssh-key.mjs
@@ -1,0 +1,45 @@
+// legacy_hash_id: a_8KiVPz
+import doWrapperModule from "do-wrapper";
+
+export default {
+  key: "digital_ocean-add-ssh-key",
+  name: "Add SSH Key",
+  description: "Adds a new SSH to your account.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    digital_ocean: {
+      type: "app",
+      app: "digital_ocean",
+    },
+    page_size: {
+      type: "integer",
+      description: "Desired pagination size when pulling results",
+      optional: true,
+    },
+    name: {
+      type: "string",
+      description: "The name to give the new SSH key in your account.",
+    },
+    public_key: {
+      type: "string",
+      description: "A string containing the entire public key.",
+    },
+  },
+  async run({ $ }) {
+    var DigitalOcean = doWrapperModule.default,
+      api = new DigitalOcean(this.digital_ocean.$auth.oauth_access_token, this.page_size);
+
+    try {
+      var configuration = {
+        "name": this.name,
+        "public_key": this.public_key,
+      };
+
+      $.export("resp", await api.accountAddKey(  configuration ));
+    } catch (err) {
+      $.export("err", err);
+
+    }
+  },
+};

--- a/components/digital_ocean/actions/create-droplet/create-droplet.mjs
+++ b/components/digital_ocean/actions/create-droplet/create-droplet.mjs
@@ -1,0 +1,102 @@
+// legacy_hash_id: a_Xzi2O8
+import doWrapperModule from "do-wrapper";
+
+export default {
+  key: "digital_ocean-create-droplet",
+  name: "Create Droplet",
+  description: "Creates a droplet",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    digital_ocean: {
+      type: "app",
+      app: "digital_ocean",
+    },
+    page_size: {
+      type: "integer",
+      description: "Desired pagination size when pulling results",
+      optional: true,
+    },
+    name: {
+      type: "string",
+      description: "Human-readable string to use when displaying the Droplet name.",
+    },
+    region: {
+      type: "string",
+      description: "Unique slug identifier for the region to deploy this Droplet in.",
+    },
+    size: {
+      type: "string",
+      description: "Unique slug identifier for the size to select for this Droplet.",
+    },
+    image: {
+      type: "string",
+      description: "The image ID of a public or private image, or the unique slug identifier for a public image. This image will be the base image for this Droplet.",
+    },
+    ssh_keys: {
+      type: "any",
+      description: "An array containing the IDs or fingerprints of the SSH keys that you wish to embed in the Droplet's root account upon creation.",
+      optional: true,
+    },
+    backups: {
+      type: "boolean",
+      description: "A boolean indicating whether automated backups should be enabled for the Droplet. Automated backups can only be enabled when the Droplet is created.",
+      optional: true,
+    },
+    ipv6: {
+      type: "boolean",
+      description: "A boolean indicating whether IPv6 is enabled on the Droplet.",
+      optional: true,
+    },
+    user_data: {
+      type: "string",
+      description: "A string containing 'user data' which may be used to configure the Droplet on first boot, often a 'cloud-config' file or Bash script. It must be plain text and may not exceed 64 KiB in size.",
+      optional: true,
+    },
+    private_networking: {
+      type: "boolean",
+      description: "A boolean indicating whether private networking is enabled for the Droplet. Private networking is currently only available in certain regions.",
+      optional: true,
+    },
+    volumes: {
+      type: "any",
+      description: "A flat array including the unique string identifier for each Block Storage volume to be attached to the Droplet. At the moment a volume can only be attached to a single Droplet.",
+      optional: true,
+    },
+    tags: {
+      type: "any",
+      description: "A flat array of tag names as strings to apply to the Droplet after it is created. Tag names can either be existing or new tags.",
+      optional: true,
+    },
+    monitoring: {
+      type: "boolean",
+      description: "A boolean indicating whether to install the DigitalOcean agent for monitoring.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    var DigitalOcean = doWrapperModule.default,
+      api = new DigitalOcean(this.digital_ocean.$auth.oauth_access_token, this.page_size);
+
+    try {
+      var data = {
+        name: this.name,
+        region: this.region,
+        size: this.size,
+        image: this.image,
+        ssh_keys: this.ssh_keys,
+        backups: this.backups,
+        ipv6: this.ipv6,
+        user_data: this.user_data,
+        private_networking: this.private_networking,
+        volumes: this.volumes,
+        tags: this.tags,
+        monitoring: this.monitoring,
+      };
+      $.export("resp", await api.dropletsCreate(data));
+    } catch (err) {
+      $.export("err", err);
+
+    }
+  },
+};

--- a/components/digital_ocean/actions/create-snapshot/create-snapshot.mjs
+++ b/components/digital_ocean/actions/create-snapshot/create-snapshot.mjs
@@ -1,0 +1,45 @@
+// legacy_hash_id: a_0Mi864
+import doWrapperModule from "do-wrapper";
+
+export default {
+  key: "digital_ocean-create-snapshot",
+  name: "Create Snapshot",
+  description: "Creates an snapshot from a droplet",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    digital_ocean: {
+      type: "app",
+      app: "digital_ocean",
+    },
+    page_size: {
+      type: "integer",
+      description: "Desired pagination size when pulling results",
+      optional: true,
+    },
+    snapshot_name: {
+      type: "string",
+      description: "The name to give the new snapshot",
+      optional: true,
+    },
+    droplet_id: {
+      type: "integer",
+      description: "The unique identifier of Droplet to snapshot.",
+    },
+  },
+  async run({ $ }) {
+    var DigitalOcean = doWrapperModule.default,
+      api = new DigitalOcean(this.digital_ocean.$auth.oauth_access_token, this.page_size);
+
+    try {
+      var action = {
+        "type": "snapshot",
+        "name": this.snapshot_name,
+      };
+      $.export("resp", await api.dropletsRequestAction(  this.droplet_id, action ));
+    } catch (err) {
+      $.export("err", err);
+
+    }
+  },
+};

--- a/components/digital_ocean/actions/turnonoff-droplet/turnonoff-droplet.mjs
+++ b/components/digital_ocean/actions/turnonoff-droplet/turnonoff-droplet.mjs
@@ -1,0 +1,46 @@
+// legacy_hash_id: a_67ij1A
+import doWrapperModule from "do-wrapper";
+
+export default {
+  key: "digital_ocean-turnonoff-droplet",
+  name: "Turn on/off Droplet",
+  description: "Turns a droplet on or off",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    digital_ocean: {
+      type: "app",
+      app: "digital_ocean",
+    },
+    page_size: {
+      type: "integer",
+      optional: true,
+    },
+    turn_onoff: {
+      type: "string",
+      description: "Must be \"power_on\" to turn on, or \"power_off\" to turn off.",
+      options: [
+        "power_off",
+        "power_on",
+      ],
+    },
+    droplet_id: {
+      type: "integer",
+      description: "The unique identifier of Droplet to turn on/off.",
+    },
+  },
+  async run({ $ }) {
+    var DigitalOcean = doWrapperModule.default,
+      api = new DigitalOcean(this.digital_ocean.$auth.oauth_access_token, this.page_size);
+
+    try {
+      var action = {
+        "type": this.turn_onoff,
+      };
+      $.export("resp", await api.dropletsRequestAction(  this.droplet_id, action ));
+    } catch (err) {
+      $.export("err", err);
+
+    }
+  },
+};

--- a/components/feedbin/actions/get-subscriptions/get-subscriptions.mjs
+++ b/components/feedbin/actions/get-subscriptions/get-subscriptions.mjs
@@ -1,0 +1,25 @@
+// legacy_hash_id: a_74ibwM
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "feedbin-get-subscriptions",
+  name: "Get subscriptions",
+  description: "GET /v2/subscriptions.json will return all subscriptions.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    feedbin: {
+      type: "app",
+      app: "feedbin",
+    },
+  },
+  async run({ $ }) {
+    return await axios($, {
+      url: "https://api.feedbin.com/v2/subscriptions.json",
+      auth: {
+        username: `${this.feedbin.$auth.email}`,
+        password: `${this.feedbin.$auth.password}`,
+      },
+    });
+  },
+};

--- a/components/frontapp/actions/import-message/import-message.mjs
+++ b/components/frontapp/actions/import-message/import-message.mjs
@@ -1,0 +1,169 @@
+// legacy_hash_id: a_a4iKLb
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "frontapp-import-message",
+  name: "Import Message",
+  description: "Appends a new message into an inbox.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    frontapp: {
+      type: "app",
+      app: "frontapp",
+    },
+    handle: {
+      type: "string",
+      description: "Handle used to reach the contact. Can be an email address, a twitter, handle, a phone number, custom handle ...",
+    },
+    name: {
+      type: "string",
+      description: "Name of the contact.",
+      optional: true,
+    },
+    author_id: {
+      type: "string",
+      description: "ID of the teammate who is the author of the message. Ignored if the message is inbound.",
+      optional: true,
+    },
+    to: {
+      type: "any",
+      description: "List of recipient handles who received the message.",
+    },
+    cc: {
+      type: "any",
+      description: "List of recipient handles who received a copy of the message.",
+      optional: true,
+    },
+    bcc: {
+      type: "any",
+      description: "List of the recipeient handles who received a blind copy of the message.",
+      optional: true,
+    },
+    subject: {
+      type: "string",
+      description: "Subject of the message.",
+      optional: true,
+    },
+    body: {
+      type: "string",
+      description: "Body of the message.",
+    },
+    body_format: {
+      type: "string",
+      description: "Format of the message body. Ignored if the message type is not email. Can be one of: 'html', 'markdown'. (Default: 'markdown')",
+      optional: true,
+      options: [
+        "html",
+        "markdown",
+      ],
+    },
+    external_id: {
+      type: "string",
+      description: "External identifier of the message. Front won't import two messages with the same external ID.",
+    },
+    created_at: {
+      type: "integer",
+      description: "Date at which the message as been sent or received. A timestamp is expected as in 1453770984.123",
+    },
+    type: {
+      type: "string",
+      description: "Type of the message to import. Can be one of: 'email', 'sms', 'intercom', 'custom'. (Default: 'email')",
+      optional: true,
+      options: [
+        "email",
+        "sms",
+        "intercom",
+        "custom",
+      ],
+    },
+    assignee_id: {
+      type: "string",
+      description: "ID of the teammate who will be assigned to the conversation.",
+      optional: true,
+    },
+    tags: {
+      type: "any",
+      description: "List of tag names to add to the conversation (unknown tags will automatically be created)",
+      optional: true,
+    },
+    thread_ref: {
+      type: "string",
+      description: "Custom reference which will be used to thread messages. If you omit this field, we'll thread by sender instead.",
+      optional: true,
+    },
+    is_inbound: {
+      type: "boolean",
+      description: "Whether or not the message is received (inbound) or sent (outbound) by you",
+    },
+    archive: {
+      type: "boolean",
+      description: "Whether or not the message should be directly archived once imported. (Default: true)",
+      optional: true,
+    },
+    should_skip_rules: {
+      type: "boolean",
+      description: "Whether or not the rules should apply to this message. (Default: true)",
+      optional: true,
+    },
+    inbox_id: {
+      type: "string",
+      description: "Id of the inbox into which the message should be append.",
+    },
+  },
+  async run({ $ }) {
+  //FrontApp api specifies body should be sent as a data binary.
+  //One way to comply with this is to populate an JS object normally
+  //and stringify it before requesting.
+
+    var messageToImportData = {
+      sender: {
+        handle: this.handle,
+        name: this.name,
+        author_id: this.author_id,
+      },
+      to: typeof this.to == "undefined"
+        ? this.to
+        : JSON.parse(this.to),
+      cc: typeof this.cc == "undefined"
+        ? this.cc
+        : JSON.parse(this.cc),
+      bcc: typeof this.bcc == "undefined"
+        ? this.bcc
+        : JSON.parse(this.bcc),
+      subject: this.subject,
+      body: this.body,
+      body_format: this.body_format,
+      external_id: this.external_id,
+      created_at: this.created_at,
+      type: this.type,
+      assignee_id: this.assignee_id,
+      tags: typeof this.tags == "undefined"
+        ? this.tags
+        : JSON.parse(this.tags),
+      metadata: {
+        thread_ref: this.thread_ref,
+        is_inbound: new Boolean(this.is_inbound),
+        is_archived: typeof this.archive == "undefined"
+          ? true
+          : new Boolean(this.archive),
+        should_skip_rules: typeof this.should_skip_rules == "undefined"
+          ? true
+          : new Boolean(this.should_skip_rules),
+      },
+    };
+
+    $.export("effective_request_body", JSON.stringify(messageToImportData));
+
+    return await axios($, {
+      method: "post",
+      url: `https://api2.frontapp.com/inboxes/${this.inbox_id}/messages`,
+      headers: {
+        "Authorization": `Bearer ${this.frontapp.$auth.oauth_access_token}`,
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+      },
+      data: this.effective_request_body,
+    });
+  },
+};

--- a/components/frontapp/actions/update-conversation/update-conversation.mjs
+++ b/components/frontapp/actions/update-conversation/update-conversation.mjs
@@ -1,0 +1,73 @@
+// legacy_hash_id: a_A6i7wv
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "frontapp-update-conversation",
+  name: "Update Conversation",
+  description: "Updates a conversation",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    frontapp: {
+      type: "app",
+      app: "frontapp",
+    },
+    assignee_id: {
+      type: "string",
+      description: "ID of the teammate to assign the conversation to. Set it to null to unassign.",
+      optional: true,
+    },
+    inbox_id: {
+      type: "string",
+      description: "ID of the inbox to move the conversation to.",
+      optional: true,
+    },
+    status: {
+      type: "string",
+      description: "New status of the conversation",
+      optional: true,
+      options: [
+        "archived",
+        "deleted",
+        "spam",
+        "open",
+      ],
+    },
+    tag_ids: {
+      type: "any",
+      description: "List of all the tag IDs replacing the old conversation tags",
+      optional: true,
+    },
+    conversation_id: {
+      type: "string",
+      description: "Conversation unique identifier",
+    },
+  },
+  async run({ $ }) {
+  //FrontApp api specifies body should be sent as a data binary.
+  //One way to comply with this is to populate an JS object normally
+  //and stringify it before requesting.
+
+    var conversationData = {
+      assignee_id: this.assignee_id,
+      inbox_id: this.inbox_id,
+      status: this.status,
+      tag_ids: typeof this.tag_ids == "undefined"
+        ? this.tag_ids
+        : JSON.parse(this.tag_ids),
+    };
+
+    $.export("effective_request_body", JSON.stringify(conversationData));
+
+    return await axios($, {
+      method: "patch",
+      url: `https://api2.frontapp.com/conversations/${this.conversation_id}`,
+      headers: {
+        "Authorization": `Bearer ${this.frontapp.$auth.oauth_access_token}`,
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+      },
+      data: this.effective_request_body,
+    });
+  },
+};

--- a/components/gitlab/actions/create-branch/create-branch.mjs
+++ b/components/gitlab/actions/create-branch/create-branch.mjs
@@ -1,0 +1,38 @@
+// legacy_hash_id: a_q1iol0
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "gitlab-create-branch",
+  name: "Create Branch",
+  description: "Create a new branch in the repository.",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    gitlab: {
+      type: "app",
+      app: "gitlab",
+    },
+    project_id: {
+      type: "string",
+      description: "ID or URL-encoded path of the project owned by the authenticated user.",
+    },
+    branch: {
+      type: "string",
+      description: "Name of the branch.",
+    },
+    ref: {
+      type: "string",
+      description: "Branch name or commit SHA to create branch from.",
+    },
+  },
+  async run({ $ }) {
+
+    return await axios($, {
+      url: `https://gitlab.com/api/v4/projects/${this.project_id}/repository/branches?branch=${this.branch}&ref=${this.ref}`,
+      method: "post",
+      headers: {
+        Authorization: `Bearer ${this.gitlab.$auth.oauth_access_token}`,
+      },
+    });
+  },
+};

--- a/components/gitlab/actions/create-issue/create-issue.mjs
+++ b/components/gitlab/actions/create-issue/create-issue.mjs
@@ -1,0 +1,114 @@
+// legacy_hash_id: a_eli54j
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "gitlab-create-issue",
+  name: "Create issue",
+  description: "Creates a new issue",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    gitlab: {
+      type: "app",
+      app: "gitlab",
+    },
+    id: {
+      type: "integer",
+      description: "The ID or [URL-encoded path of the project](https://docs.gitlab.com/ee/api/README.html#namespaced-path-encoding) owned by the authenticated user",
+    },
+    iid: {
+      type: "string",
+      description: "The internal ID of the project's issue (requires admin or project owner rights)",
+      optional: true,
+    },
+    title: {
+      type: "string",
+      description: "The title of an issue",
+    },
+    description: {
+      type: "string",
+      description: "The description of an issue. Limited to 1,048,576 characters.",
+      optional: true,
+    },
+    confidential: {
+      type: "boolean",
+      description: "Set an issue to be confidential. Default is`false`.",
+      optional: true,
+    },
+    assignee_ids: {
+      type: "any",
+      description: "The ID of a user to assign issue",
+      optional: true,
+    },
+    milestone_id: {
+      type: "string",
+      description: "The global ID of a milestone to assign issue",
+      optional: true,
+    },
+    labels: {
+      type: "string",
+      description: "Comma-separated label names for an issue",
+      optional: true,
+    },
+    created_at: {
+      type: "string",
+      description: "Date time string, ISO 8601 formatted, e.g. `2016-03-11T03:45:40Z` (requires admin or project/group owner rights)",
+      optional: true,
+    },
+    due_date: {
+      type: "string",
+      description: "Date time string in the format YEAR-MONTH-DAY, e.g. `2016-03-11`",
+      optional: true,
+    },
+    merge_request_to_resolve_discussions_of: {
+      type: "integer",
+      description: "The IID of a merge request in which to resolve all issues. This will fill the issue with a default description and mark all discussions as resolved. When passing a description or title, these values will take precedence over the default values.",
+      optional: true,
+    },
+    discussion_to_resolve: {
+      type: "string",
+      description: "The ID of a discussion to resolve. This will fill in the issue with a default description and mark the discussion as resolved. Use in combination with `merge_request_to_resolve_discussions_of`.",
+      optional: true,
+    },
+    weight: {
+      type: "integer",
+      description: "The weight of the issue. Valid values are greater than or equal to 0.",
+      optional: true,
+    },
+    epic_id: {
+      type: "integer",
+      description: "ID of the epic to add the issue to. Valid values are greater than or equal to 0.",
+      optional: true,
+    },
+    epic_iid: {
+      type: "string",
+      description: "IID of the epic to add the issue to. Valid values are greater than or equal to 0. (deprecated, [will be removed in 13.0](https://gitlab.com/gitlab-org/gitlab/issues/35157))",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    return await axios($, {
+      method: "post",
+      url: `https://gitlab.com/api/v4/projects/${this.id}/issues`,
+      headers: {
+        Authorization: `Bearer ${this.gitlab.$auth.oauth_access_token}`,
+      },
+      data: {
+        iid: this.iid,
+        title: this.title,
+        description: this.description,
+        confidential: this.confidential,
+        assignee_ids: this.assignee_ids,
+        milestone_id: this.milestone_id,
+        labels: this.labels,
+        created_at: this.created_at,
+        due_date: this.due_date,
+        merge_request_to_resolve_discussions_of: this.merge_request_to_resolve_discussions_of,
+        discussion_to_resolve: this.discussion_to_resolve,
+        weight: this.weight,
+        epic_id: this.epic_id,
+        epic_iid: this.epic_iid,
+      },
+    });
+  },
+};

--- a/components/gitlab/actions/edit-issue/edit-issue.mjs
+++ b/components/gitlab/actions/edit-issue/edit-issue.mjs
@@ -1,0 +1,115 @@
+// legacy_hash_id: a_eli56O
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "gitlab-edit-issue",
+  name: "Edit Issue",
+  description: "Updates an existing project issue.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    gitlab: {
+      type: "app",
+      app: "gitlab",
+    },
+    id: {
+      type: "string",
+      description: "The ID or [URL-encoded path of the project](https://docs.gitlab.com/ee/api/README.html#namespaced-path-encoding) owned by the authenticated user",
+    },
+    issue_iid: {
+      type: "integer",
+      description: "The internal ID of the project's issue (requires admin or project owner rights)",
+    },
+    title: {
+      type: "string",
+      description: "The title of an issue",
+      optional: true,
+    },
+    description: {
+      type: "string",
+      description: "The description of an issue. Limited to 1,048,576 characters.",
+      optional: true,
+    },
+    confidential: {
+      type: "boolean",
+      description: "Set an issue to be confidential. Default is`false`.",
+      optional: true,
+    },
+    assignee_ids: {
+      type: "any",
+      description: "The ID of the user(s) to assign the issue to. Set to 0 or provide an empty value to unassign all assignees.",
+      optional: true,
+    },
+    milestone_id: {
+      type: "integer",
+      description: "The global ID of a milestone to assign the issue to. Set to 0 or provide an empty value to unassign a milestone.",
+      optional: true,
+    },
+    labels: {
+      type: "string",
+      description: "Comma-separated label names for an issue. Set to an empty string to unassign all labels.",
+      optional: true,
+    },
+    state_event: {
+      type: "string",
+      description: "The state event of an issue. Set close to close the issue and reopen to reopen it.",
+      optional: true,
+    },
+    updated_at: {
+      type: "string",
+      description: "Date time string, ISO 8601 formatted, e.g. 2016-03-11T03:45:40Z (requires admin or project owner rights).",
+      optional: true,
+    },
+    due_date: {
+      type: "string",
+      description: "Date time string in the format YEAR-MONTH-DAY, e.g. 2016-03-11.",
+      optional: true,
+    },
+    weight: {
+      type: "integer",
+      description: "The weight of the issue. Valid values are greater than or equal to 0.",
+      optional: true,
+    },
+    discussion_locked: {
+      type: "boolean",
+      description: "Flag indicating if the issue's discussion is locked. If the discussion is locked only project members can add or edit comments.",
+      optional: true,
+    },
+    epic_id: {
+      type: "integer",
+      description: "ID of the epic to add the issue to. Valid values are greater than or equal to 0.",
+      optional: true,
+    },
+    epic_iid: {
+      type: "string",
+      description: "IID of the epic to add the issue to. Valid values are greater than or equal to 0. (deprecated, [will be removed in 13.0](https://gitlab.com/gitlab-org/gitlab/issues/35157))",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    return await axios($, {
+      method: "put",
+      url: `https://gitlab.com/api/v4/projects/${this.id}/issues/${this.issue_iid}`,
+      headers: {
+        Authorization: `Bearer ${this.gitlab.$auth.oauth_access_token}`,
+      },
+      data: {
+        title: this.title,
+        description: this.description,
+        confidential: this.confidential,
+        assignee_ids: typeof this.assignee_ids == "undefined"
+          ? this.assignee_ids
+          : JSON.parse(this.assignee_ids),
+        milestone_id: this.milestone_id,
+        labels: this.labels,
+        state_event: this.state_event,
+        updated_at: this.updated_at,
+        due_date: this.due_date,
+        weight: this.weight,
+        discussion_locked: this.discussion_locked,
+        epic_id: this.epic_id,
+        epic_iid: this.epic_iid,
+      },
+    });
+  },
+};

--- a/components/gitlab/actions/get-issue/get-issue.mjs
+++ b/components/gitlab/actions/get-issue/get-issue.mjs
@@ -1,0 +1,33 @@
+// legacy_hash_id: a_YEiPAO
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "gitlab-get-issue",
+  name: "Get Issue",
+  description: "Gets a single issue from repository.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    gitlab: {
+      type: "app",
+      app: "gitlab",
+    },
+    id: {
+      type: "string",
+      description: "The ID or [URL-encoded path of the project](https://docs.gitlab.com/ee/api/README.html#namespaced-path-encoding) owned by the authenticated user",
+    },
+    issue_iid: {
+      type: "integer",
+      description: "The internal ID of the project's issue (requires admin or project owner rights)",
+    },
+  },
+  async run({ $ }) {
+    return await axios($, {
+      method: "get",
+      url: `https://gitlab.com/api/v4/projects/${this.id}/issues/${this.issue_iid}`,
+      headers: {
+        Authorization: `Bearer ${this.gitlab.$auth.oauth_access_token}`,
+      },
+    });
+  },
+};

--- a/components/gitlab/actions/get-repo-branch/get-repo-branch.mjs
+++ b/components/gitlab/actions/get-repo-branch/get-repo-branch.mjs
@@ -1,0 +1,35 @@
+// legacy_hash_id: a_gniNj4
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "gitlab-get-repo-branch",
+  name: "Get Repo Branch",
+  description: "Get a single project repository branch.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    gitlab: {
+      type: "app",
+      app: "gitlab",
+    },
+    project_id: {
+      type: "string",
+      description: "ID or URL-encoded path of the project owned by the authenticated user.",
+    },
+    branch: {
+      type: "string",
+      description: "Return list of branches containing the search string. You can use ^term and term$ to find branches that begin and end with term respectively.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+
+    return await axios($, {
+      url: `https://gitlab.com/api/v4/projects/${this.project_id}/repository/branches/${this.branch}`,
+
+      headers: {
+        Authorization: `Bearer ${this.gitlab.$auth.oauth_access_token}`,
+      },
+    });
+  },
+};

--- a/components/gitlab/actions/list-project-issues/list-project-issues.mjs
+++ b/components/gitlab/actions/list-project-issues/list-project-issues.mjs
@@ -1,0 +1,289 @@
+// legacy_hash_id: a_EVioWG
+import requestPromise from "request-promise";
+
+export default {
+  key: "gitlab-list-project-issues",
+  name: "List Project Issues",
+  description: "Get a list of a project's issues.",
+  version: "0.3.1",
+  type: "action",
+  props: {
+    gitlab: {
+      type: "app",
+      app: "gitlab",
+    },
+    iids: {
+      type: "any",
+      description: "Return only the issues having the given iid",
+      optional: true,
+    },
+    state: {
+      type: "string",
+      description: "Return all issues or just those that are opened or closed",
+      optional: true,
+      options: [
+        "opened",
+        "closed",
+        "all",
+      ],
+    },
+    labels: {
+      type: "string",
+      description: "Comma-separated list of label names, issues must have all labels to be returned. None lists all issues with no labels. Any lists all issues with at least one label. No+Label (Deprecated) lists all issues with no labels. Predefined names are case-insensitive.",
+      optional: true,
+    },
+    with_labels_details: {
+      type: "boolean",
+      description: "If true, response will return more details for each label in labels field: :name, :color, :description, :description_html, :text_color. Default is false. description_html Introduced in GitLab 12.7",
+      optional: true,
+    },
+    milestone: {
+      type: "string",
+      description: "The milestone title. None lists all issues with no milestone. Any lists all issues that have an assigned milestone.",
+      optional: true,
+    },
+    scope: {
+      type: "string",
+      description: "Return issues for the given scope: created_by_me, assigned_to_me or all. Defaults to created_by_me\nFor versions before 11.0, use the now deprecated created-by-me or assigned-to-me scopes instead.",
+      optional: true,
+      options: [
+        "all",
+        "created_by_me",
+        "assigned_to_me",
+      ],
+    },
+    author_id: {
+      type: "integer",
+      description: "Return issues created by the given user id. Mutually exclusive with author_username. Combine with scope=all or scope=assigned_to_me.",
+      optional: true,
+    },
+    author_username: {
+      type: "string",
+      description: "Return issues created by the given username. Similar to author_id and mutually exclusive with author_id.",
+      optional: true,
+    },
+    assignee_id: {
+      type: "integer",
+      description: "Return issues assigned to the given user id. Mutually exclusive with assignee_username. None returns unassigned issues. Any returns issues with an assignee.",
+      optional: true,
+    },
+    assignee_username: {
+      type: "any",
+      description: "Return issues assigned to the given username. Similar to assignee_id and mutually exclusive with assignee_id. In CE version assignee_username array should only contain a single value or an invalid param error will be returned otherwise.",
+      optional: true,
+    },
+    my_reaction_emoji: {
+      type: "string",
+      description: "Return issues reacted by the authenticated user by the given emoji. None returns issues not given a reaction. Any returns issues given at least one reaction.",
+      optional: true,
+    },
+    weight: {
+      type: "string",
+      description: "Return issues with the specified weight. None returns issues with no weight assigned. Any returns issues with a weight assigned.",
+      optional: true,
+    },
+    order_by: {
+      type: "string",
+      description: "Return issues ordered by created_at, updated_at, priority, due_date, relative_position, label_priority, milestone_due, popularity, weight fields. Default is created_at",
+      optional: true,
+      options: [
+        "created_at",
+        "updated_at",
+        "priority",
+        "due_date",
+        "relative_position",
+        "label_priority",
+        "milestone_due",
+        "popularity",
+        "weight ",
+      ],
+    },
+    sort: {
+      type: "string",
+      description: "Return issues sorted in asc or desc order. Default is desc",
+      optional: true,
+      options: [
+        "asc",
+        "desc",
+      ],
+    },
+    search: {
+      type: "string",
+      description: "Search issues against their title and description.",
+      optional: true,
+    },
+    search_in: {
+      type: "string",
+      description: "Modify the scope of the search attribute. title, description, or a string joining them with comma. Default is title,description",
+      optional: true,
+    },
+    created_after: {
+      type: "string",
+      description: "Return issues created on or after the given time.",
+      optional: true,
+    },
+    created_before: {
+      type: "string",
+      description: "Return issues created on or before the given time",
+      optional: true,
+    },
+    updated_after: {
+      type: "string",
+      description: "Return issues updated on or after the given time",
+      optional: true,
+    },
+    updated_before: {
+      type: "string",
+      description: "Return issues updated on or before the given time",
+      optional: true,
+    },
+    confidential: {
+      type: "boolean",
+      description: "Filter confidential or public issues.",
+      optional: true,
+    },
+    not: {
+      type: "string",
+      description: "Return issues that do not match the parameters supplied. Accepts: labels, milestone, author_id, author_username, assignee_id, assignee_username, my_reaction_emoji, search, in",
+      optional: true,
+    },
+    id: {
+      type: "string",
+      description: "The ID or URL-encoded path of the project owned by the authenticated user",
+    },
+  },
+  async run({ $ }) {
+    var queryString = "";
+
+    var growQueryString = function(param_name, param_value, current_query_string) {
+      var newQueryString = "";
+
+      if (current_query_string.indexOf("?") > -1) {
+        newQueryString = current_query_string + "&" + param_name + "=" + param_value;
+      } else {
+        newQueryString = "?" + param_name + "=" + param_value;
+      }
+      return newQueryString;
+    };
+
+    var growQueryString2 = function(param_name, param_value, current_query_string) {
+      var newQueryString = "";
+
+      if (current_query_string.indexOf("?") > -1) {
+        newQueryString = current_query_string + "&&" + param_name + "=" + param_value;
+      } else {
+        newQueryString = "?" + param_name + "=" + param_value;
+      }
+      return newQueryString;
+    };
+
+    if (this.iids) {
+      var iids = JSON.parse(this.iids);
+      for (var i = 0; i < iids.length; i++) {
+        queryString = growQueryString2("iids[]", iids[i], queryString);
+      }
+    }
+
+    if (this.state) {
+      queryString = growQueryString("state", this.state, queryString);
+    }
+
+    if (this.labels) {
+      queryString = growQueryString("labels", this.labels, queryString);
+    }
+
+    if (this.with_labels_details) {
+      queryString = growQueryString("with_labels_details", this.with_labels_details, queryString);
+    }
+
+    if (this.milestone) {
+      queryString = growQueryString("milestone", this.milestone, queryString);
+    }
+
+    if (this.scope) {
+      queryString = growQueryString("scope", this.scope, queryString);
+    }
+
+    if (this.author_id) {
+      queryString = growQueryString("author_id", this.author_id, queryString);
+    }
+
+    if (this.author_username) {
+      queryString = growQueryString("author_username", this.author_username, queryString);
+    }
+
+    if (this.assignee_id) {
+      queryString = growQueryString("assignee_id", this.assignee_id, queryString);
+    }
+
+    if (this.assignee_username) {
+      try {
+        //Gitlab Community Edition uses a single element array
+        var assigneeUsernameArray =  JSON.parse(this.assignee_username);
+        queryString = growQueryString("assignee_username", assigneeUsernameArray[0], queryString);
+      } catch {
+        //Gitlab Enterprise uses plain string
+        queryString = growQueryString("assignee_username", this.assignee_username, queryString);
+      }
+    }
+
+    if (this.my_reaction_emoji) {
+      queryString = growQueryString("my_reaction_emoji", this.my_reaction_emoji, queryString);
+    }
+
+    if (this.weight ) {
+      queryString = growQueryString("weight", this.weight, queryString);
+    }
+
+    if (this.order_by) {
+      queryString = growQueryString("order_by", this.order_by, queryString);
+    }
+
+    if (this.sort) {
+      queryString = growQueryString("sort", this.sort, queryString);
+    }
+
+    if (this.search) {
+      queryString = growQueryString("search", this.search, queryString);
+    }
+
+    if (this.search_in) {
+      queryString = growQueryString("in", this.search_in, queryString);
+    }
+
+    if (this.created_after) {
+      queryString = growQueryString("created_after", this.created_after, queryString);
+    }
+
+    if (this.created_before) {
+      queryString = growQueryString("created_before", this.created_before, queryString);
+    }
+
+    if (this.updated_after) {
+      queryString = growQueryString("updated_after", this.updated_after, queryString);
+    }
+
+    if (this.updated_before) {
+      queryString = growQueryString("updated_before", this.updated_before, queryString);
+    }
+
+    if (this.confidential) {
+      queryString = growQueryString("confidential", this.confidential, queryString);
+    }
+
+    if (this.not) {
+      queryString = growQueryString("not", this.not, queryString);
+    }
+
+    try {
+      $.export("resp", await requestPromise({
+        uri: `https://gitlab.com/api/v4/projects/${this.id}/issues${queryString}`,
+        headers: {
+          Authorization: `Bearer ${this.gitlab.$auth.oauth_access_token}`,
+        },
+      }));
+    } catch (err) {
+      $.export("err", err);
+    }
+  },
+};

--- a/components/gitlab/actions/list-repo-branches/list-repo-branches.mjs
+++ b/components/gitlab/actions/list-repo-branches/list-repo-branches.mjs
@@ -1,0 +1,40 @@
+// legacy_hash_id: a_52iBGM
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "gitlab-list-repo-branches",
+  name: "List Repo Branches",
+  description: "Get a list of repository branches from a project",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    gitlab: {
+      type: "app",
+      app: "gitlab",
+    },
+    search_string: {
+      type: "string",
+      description: "Return list of branches containing the search string. You can use ^term and term$ to find branches that begin and end with term respectively.",
+      optional: true,
+    },
+    project_id: {
+      type: "string",
+      description: "ID or URL-encoded path of the project owned by the authenticated user.",
+    },
+  },
+  async run({ $ }) {
+
+    var searchString = "";
+    if (this.search_string) {
+      searchString = "?search=" + this.search_string;
+    }
+
+    return await axios($, {
+      url: `https://gitlab.com/api/v4/projects/${this.project_id}/repository/branches${searchString}`,
+
+      headers: {
+        Authorization: `Bearer ${this.gitlab.$auth.oauth_access_token}`,
+      },
+    });
+  },
+};

--- a/components/honeybadger/actions/get-projects/get-projects.mjs
+++ b/components/honeybadger/actions/get-projects/get-projects.mjs
@@ -1,0 +1,28 @@
+// legacy_hash_id: a_74ibvw
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "honeybadger-get-projects",
+  name: "Get projects",
+  description: "Get a project list",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    honeybadger: {
+      type: "app",
+      app: "honeybadger",
+    },
+  },
+  async run({ $ }) {
+    return await axios($, {
+      url: "https://app.honeybadger.io/v2/projects",
+      headers: {
+        "Accept": "application/json",
+      },
+      auth: {
+        username: `${this.honeybadger.$auth.api_token}`,
+        password: "",
+      },
+    });
+  },
+};

--- a/components/instapaper/actions/add-url/add-url.mjs
+++ b/components/instapaper/actions/add-url/add-url.mjs
@@ -1,0 +1,43 @@
+// legacy_hash_id: a_oVi3lO
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "instapaper-add-url",
+  name: "Add URL",
+  description: "Adding URLs to an Instapaper account",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    instapaper: {
+      type: "app",
+      app: "instapaper",
+    },
+    url: {
+      type: "string",
+    },
+    sitle: {
+      type: "string",
+      description: "Optional, plain text, no HTML, UTF-8. If omitted or empty, Instapaper will crawl the URL to detect a title.",
+      optional: true,
+    },
+    selection: {
+      type: "string",
+      description: "Optional, plain text, no HTML, UTF-8. Will show up as the description under an item in the interface. Some clients use this to describe where it came from, such as the text of the source Twitter post when sending a link from a Twitter client.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    return await axios($, {
+      url: "https://www.instapaper.com/api/authenticate",
+      auth: {
+        username: `${this.instapaper.$auth.username}`,
+        password: `${this.instapaper.$auth.password}`,
+        params: {
+          url: this.url,
+          title: this.sitle,
+          selection: this.selection,
+        },
+      },
+    });
+  },
+};

--- a/components/jira/actions/create-issue/create-issue.mjs
+++ b/components/jira/actions/create-issue/create-issue.mjs
@@ -1,0 +1,67 @@
+// legacy_hash_id: a_YEiwPB
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "jira-create-issue",
+  name: "JIRA - Create Issue",
+  description: "Creates a new issue. See https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-rest-api-3-issue-post",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    jira: {
+      type: "app",
+      app: "jira",
+    },
+    summary: {
+      type: "string",
+      label: "Issue Summary",
+      description: "The title of the issue",
+    },
+    issuetype: {
+      type: "string",
+      label: "Issue Type",
+      description: "An ID identifying the type of issue you'd like to create. See the API docs at https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-rest-api-3-issue-post to see available options",
+      optional: true,
+    },
+    projectID: {
+      type: "string",
+    },
+  },
+  async run({ $ }) {
+  // First we must make a request to get our the cloud instance ID tied
+  // to our connected account, which allows us to construct the correct REST API URL. See Section 3.2 of
+  // https://developer.atlassian.com/cloud/jira/platform/oauth-2-authorization-code-grants-3lo-for-apps/
+    const resp = await axios($, {
+      url: "https://api.atlassian.com/oauth/token/accessible-resources",
+      headers: {
+        Authorization: `Bearer ${this.jira.$auth.oauth_access_token}`,
+      },
+    });
+
+    // Assumes the access token has access to a single instance
+    const cloudId = resp[0].id;
+
+    // See https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-rest-api-3-issue-post
+    // for all options
+    return await axios($, {
+      method: "POST",
+      url: `https://api.atlassian.com/ex/jira/${cloudId}/rest/api/3/issue/`,
+      headers: {
+        "Authorization": `Bearer ${this.jira.$auth.oauth_access_token}`,
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+      },
+      data: {
+        fields: {
+          summary: this.summary,
+          issuetype: {
+            id: this.issuetype,
+          },
+          project: {
+            id: this.projectID,
+          },
+        },
+      },
+    });
+  },
+};

--- a/components/jira/actions/get-all-projects/get-all-projects.mjs
+++ b/components/jira/actions/get-all-projects/get-all-projects.mjs
@@ -1,0 +1,40 @@
+// legacy_hash_id: a_poimkX
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "jira-get-all-projects",
+  name: "JIRA - Get All Projects",
+  description: "Gets metadata on all projects. See https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-rest-api-3-project-get",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    jira: {
+      type: "app",
+      app: "jira",
+    },
+  },
+  async run({ $ }) {
+  // First we must make a request to get our the cloud instance ID tied
+  // to our connected account, which allows us to construct the correct REST API URL. See Section 3.2 of
+  // https://developer.atlassian.com/cloud/jira/platform/oauth-2-authorization-code-grants-3lo-for-apps/
+    const resp = await axios($, {
+      url: "https://api.atlassian.com/oauth/token/accessible-resources",
+      headers: {
+        Authorization: `Bearer ${this.jira.$auth.oauth_access_token}`,
+      },
+    });
+
+    // Assumes the access token has access to a single instance
+    const cloudID = resp[0].id;
+
+    return await axios($, {
+      method: "GET",
+      url: `https://api.atlassian.com/ex/jira/${cloudID}/rest/api/3/project`,
+      headers: {
+        "Authorization": `Bearer ${this.jira.$auth.oauth_access_token}`,
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+      },
+    });
+  },
+};

--- a/components/klaviyo/actions/get-lists/get-lists.mjs
+++ b/components/klaviyo/actions/get-lists/get-lists.mjs
@@ -1,0 +1,24 @@
+// legacy_hash_id: a_2wimkG
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "klaviyo-get-lists",
+  name: "Get Lists",
+  description: "Get a listing of all of the lists in an account.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    klaviyo: {
+      type: "app",
+      app: "klaviyo",
+    },
+  },
+  async run({ $ }) {
+    return await axios($, {
+      url: "https://a.klaviyo.com/api/v2/lists",
+      params: {
+        api_key: `${this.klaviyo.$auth.api_key}`,
+      },
+    });
+  },
+};

--- a/components/linear_app/actions/create-issue/create-issue.mjs
+++ b/components/linear_app/actions/create-issue/create-issue.mjs
@@ -1,0 +1,63 @@
+// legacy_hash_id: a_YEiPqm
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "linear_app-create-issue",
+  name: "Create issue",
+  description: "Create a new issue in Linear",
+  version: "0.3.1",
+  type: "action",
+  props: {
+    linear_app: {
+      type: "app",
+      app: "linear_app",
+    },
+    title: {
+      type: "string",
+    },
+    description: {
+      type: "string",
+      optional: true,
+    },
+    teamId: {
+      type: "string",
+    },
+  },
+  async run({ $ }) {
+    const data = {
+      query: `
+  mutation(
+    $title: String!
+    $description: String
+    $teamId: String!
+  ) {
+    issueCreate(
+      input: {
+        title: $title
+        description: $description
+        teamId: $teamId
+      }
+    ) {
+      success
+      issue {
+        id
+        title
+      }
+    }
+  }`,
+      variables: {
+        title: this.title,
+        description: this.description,
+        teamId: this.teamId,
+      },
+    };
+    return await axios($, {
+      method: "post",
+      url: "https://api.linear.app/graphql",
+      headers: {
+        "Authorization": `${this.linear_app.$auth.api_key}`,
+      },
+      data,
+    });
+  },
+};

--- a/components/linear_app/actions/get-teams/get-teams.mjs
+++ b/components/linear_app/actions/get-teams/get-teams.mjs
@@ -1,0 +1,37 @@
+// legacy_hash_id: a_wdijzb
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "linear_app-get-teams",
+  name: "Get teams",
+  description: "Get your team IDs",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    linear_app: {
+      type: "app",
+      app: "linear_app",
+    },
+  },
+  async run({ $ }) {
+    const data = {
+      "query": `{
+    teams {
+      nodes {
+        id
+        name
+      }
+    }
+  }`,
+    };
+
+    return await axios($, {
+      method: "post",
+      url: "https://api.linear.app/graphql",
+      headers: {
+        "Authorization": `${this.linear_app.$auth.api_key}`,
+      },
+      data,
+    });
+  },
+};

--- a/components/linear_app/actions/issue-create/issue-create.mjs
+++ b/components/linear_app/actions/issue-create/issue-create.mjs
@@ -1,0 +1,81 @@
+// legacy_hash_id: a_l0iLnj
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "linear_app-issue-create",
+  name: "issueCreate",
+  description: "Creates a new issue.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    linear_app: {
+      type: "app",
+      app: "linear_app",
+    },
+    input: {
+      type: "object",
+      description: "The issue object to create.",
+    },
+    defaultResolvedFields: {
+      type: "string",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const data = {
+      query: `query(
+    $input: IssueCreateInput!
+  ) {
+    issueCreate(
+      input: $input
+    ) {
+      ${this.defaultResolvedFields || `
+      lastSyncId
+      issue {
+        id
+        createdAt
+        updatedAt
+        archivedAt
+        number
+        title
+        description
+        descriptionData
+        priority
+        estimate
+        boardOrder
+        startedAt
+        completedAt
+        canceledAt
+        # team {}
+        # cycle {}
+        # state {}
+        # assignee {}
+        # parent {}
+        # project {}
+        # subscribers {}
+        # creator {}
+        # children {}
+        # comments {}
+        # history {}
+        # labels {}
+        # integrationResources {}
+        url
+      }
+      success
+      `}
+    }
+  }`,
+      variables: {
+        input: this.input,
+      },
+    };
+    return await axios($, {
+      method: "post",
+      url: "https://api.linear.app/graphql",
+      headers: {
+        "Authorization": `${this.linear_app.$auth.api_key}`,
+      },
+      data,
+    });
+  },
+};

--- a/components/medium/actions/create-post/create-post.mjs
+++ b/components/medium/actions/create-post/create-post.mjs
@@ -1,0 +1,90 @@
+// legacy_hash_id: a_Xzi2jX
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "medium-create-post",
+  name: "Create a post",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    medium: {
+      type: "app",
+      app: "medium",
+    },
+    title: {
+      type: "string",
+      description: "The title of the post. Note that this title is used for SEO and when rendering the post as a listing, but will not appear in the actual postfor that, the title must be specified in the content field as well. Titles longer than 100 characters will be ignored. In that case, a title will be synthesized from the first content in the post when it is published.",
+    },
+    contentFormat: {
+      type: "string",
+      description: "The format of the \"content\" field. There are two valid values, \"html\", and \"markdown\"",
+      options: [
+        "html",
+        "markdown",
+      ],
+    },
+    content: {
+      type: "string",
+      description: "The body of the post, in a valid, semantic, HTML fragment, or Markdown. Further markups may be supported in the future. For a full list of accepted HTML tags, see here. If you want your title to appear on the post page, you must also include it as part of the post content.",
+    },
+    tags: {
+      type: "any",
+      description: "Tags to classify the post. Only the first three will be used. Tags longer than 25 characters will be ignored.",
+      optional: true,
+    },
+    canonicalUrl: {
+      type: "string",
+      description: "The original home of this content, if it was originally published elsewhere.",
+      optional: true,
+    },
+    publishStatus: {
+      type: "string",
+      description: "The status of the post. Valid values are public, draft, or unlisted. The default is public.",
+      optional: true,
+      options: [
+        "public",
+        "draft",
+        "unlisted",
+      ],
+    },
+    license: {
+      type: "string",
+      description: "The license of the post. Valid values are all-rights-reserved, cc-40-by, cc-40-by-sa, cc-40-by-nd, cc-40-by-nc, cc-40-by-nc-nd, cc-40-by-nc-sa, cc-40-zero, public-domain. The default is all-rights-reserved.",
+      optional: true,
+      options: [
+        "all-rights-reserved",
+        "cc-40-by",
+        "cc-40-by-sa",
+        "cc-40-by-nd",
+        "cc-40-by-nc-nd",
+        "cc-40-by-nc-sa",
+        "cc-40-zero",
+        "public-domain",
+      ],
+    },
+    notifyFollowers: {
+      type: "boolean",
+      description: "Whether to notifyFollowers that the user has published.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    return await axios($, {
+      method: "post",
+      url: `https://api.medium.com/v1/users/${this.medium.$auth.oauth_uid}/posts`,
+      headers: {
+        Authorization: `Bearer ${this.medium.$auth.oauth_access_token}`,
+      },
+      data: {
+        title: this.title,
+        contentFormat: this.contentFormat,
+        content: this.content,
+        tags: this.tags,
+        canonicalUrl: this.canonicalUrl,
+        publishStatus: this.publishStatus,
+        license: this.license,
+        notifyFollowers: this.notifyFollowers,
+      },
+    });
+  },
+};

--- a/components/moosend/actions/add-subscriber/add-subscriber.mjs
+++ b/components/moosend/actions/add-subscriber/add-subscriber.mjs
@@ -1,0 +1,50 @@
+// legacy_hash_id: a_rJiLMv
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "moosend-add-subscriber",
+  name: "Add subscriber",
+  description: "Add a subscriber",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    moosend: {
+      type: "app",
+      app: "moosend",
+    },
+    MailingListID: {
+      type: "string",
+    },
+    name: {
+      type: "string",
+      optional: true,
+    },
+    email: {
+      type: "string",
+      optional: true,
+    },
+    hasExternalDoubleOptIn: {
+      type: "string",
+      optional: true,
+    },
+    customFields: {
+      type: "string",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    return await axios($, {
+      url: `https://api.moosend.com/v3/subscribers/${this.MailingListID}/subscribe.json`,
+      method: "post",
+      params: {
+        apikey: `${this.moosend.$auth.api_key}`,
+      },
+      data: {
+        name: this.name,
+        email: this.email,
+        hasExternalDoubleOptIn: this.hasExternalDoubleOptIn,
+        customFields: this.customFields,
+      },
+    });
+  },
+};

--- a/components/onesignal_rest_api/actions/create-notification/create-notification.mjs
+++ b/components/onesignal_rest_api/actions/create-notification/create-notification.mjs
@@ -1,0 +1,41 @@
+// legacy_hash_id: a_rJiLrx
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "onesignal_rest_api-create-notification",
+  name: "Create notification",
+  description: "Sends notifications to your users",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    onesignal_rest_api: {
+      type: "app",
+      app: "onesignal_rest_api",
+    },
+    included_segments: {
+      type: "any",
+      description: "[\"Active Users\", \"Inactive Users\"]",
+    },
+    contents: {
+      type: "object",
+      description: "Example: {\"en\": \"English Message\", \"es\": \"Spanish Message\"}",
+    },
+  },
+  async run({ $ }) {
+    const data = {
+      "app_id": `${this.onesignal_rest_api.$auth.app_id}`,
+      "included_segments": this.included_segments,
+      "contents": this.contents,
+    };
+
+    return await axios($, {
+      method: "post",
+      url: "https://onesignal.com/api/v1/notifications",
+      headers: {
+        "Authorization": `Basic ${this.onesignal_rest_api.$auth.rest_api_key}`,
+        "Content-Type": "application/json",
+      },
+      data,
+    });
+  },
+};

--- a/components/openweather_api/actions/get-current-weather-by-zip/get-current-weather-by-zip.mjs
+++ b/components/openweather_api/actions/get-current-weather-by-zip/get-current-weather-by-zip.mjs
@@ -1,0 +1,53 @@
+// legacy_hash_id: a_B0izKM
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "openweather_api-get-current-weather-by-zip",
+  name: "Get Current Weather by ZIP code",
+  description: "Retrieves the current weather for a given (ZIP, country)",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    openweather_api: {
+      type: "app",
+      app: "openweather_api",
+    },
+    country_code: {
+      type: "string",
+      label: "Country Code",
+      description: "The 2 or 3-letter country code, for example \"US\" for the United States. Defaults to US.",
+      optional: true,
+    },
+    zip: {
+      type: "string",
+      label: "ZIP code",
+      description: "ZIP code",
+    },
+    units: {
+      type: "string",
+      label: "Units",
+      description: "Units of measurement",
+      optional: true,
+      options: [
+        "kelvin",
+        "imperial",
+        "metric",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const { zip } = this;
+    const countryCode = this.country_code || "US";
+    // The OpenWeather API defaults to Kelvin
+    const units = this.units || "kelvin";
+
+    return await axios($, {
+      url: "https://api.openweathermap.org/data/2.5/weather",
+      params: {
+        zip: `${zip},${countryCode}`,
+        appid: `${this.openweather_api.$auth.api_key}`,
+        units,
+      },
+    });
+  },
+};

--- a/components/openweather_api/actions/get-weather-forecast-by-zip/get-weather-forecast-by-zip.mjs
+++ b/components/openweather_api/actions/get-weather-forecast-by-zip/get-weather-forecast-by-zip.mjs
@@ -1,0 +1,53 @@
+// legacy_hash_id: a_8KiVn0
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "openweather_api-get-weather-forecast-by-zip",
+  name: "Get Weather Forecast by ZIP code",
+  description: "Retrieves the 5-day weather forecast for a given (ZIP, country)",
+  version: "0.3.1",
+  type: "action",
+  props: {
+    openweather_api: {
+      type: "app",
+      app: "openweather_api",
+    },
+    country_code: {
+      type: "string",
+      label: "Country Code",
+      description: "The 2 or 3-letter country code, for example \"US\" for the United States. Defaults to US.",
+      optional: true,
+    },
+    zip: {
+      type: "string",
+      label: "ZIP code",
+      description: "ZIP code",
+    },
+    units: {
+      type: "string",
+      label: "Units",
+      description: "Units of measurement",
+      optional: true,
+      options: [
+        "kelvin",
+        "imperial",
+        "metric",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const { zip } = this;
+    const countryCode = this.country_code || "US";
+    // The OpenWeather API defaults to Kelvin
+    const units = this.units || "kelvin";
+
+    return await axios($, {
+      url: "https://api.openweathermap.org/data/2.5/forecast",
+      params: {
+        zip: `${zip},${countryCode}`,
+        appid: `${this.openweather_api.$auth.api_key}`,
+        units,
+      },
+    });
+  },
+};

--- a/components/paypal/actions/userinfo/userinfo.mjs
+++ b/components/paypal/actions/userinfo/userinfo.mjs
@@ -1,0 +1,27 @@
+// legacy_hash_id: a_Mdi8Y8
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "paypal-userinfo",
+  name: "Get user info",
+  description: "Shows user profile information. Filters the response by a schema.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    paypal: {
+      type: "app",
+      app: "paypal",
+    },
+  },
+  async run({ $ }) {
+    return await axios($, {
+      url: "https://api.paypal.com/v1/identity/oauth2/userinfo",
+      params: {
+        schema: "paypalv1.1",
+      },
+      headers: {
+        Authorization: `Bearer ${this.paypal.$auth.oauth_access_token}`,
+      },
+    });
+  },
+};

--- a/components/pipedrive/actions/add-activity/add-activity.mjs
+++ b/components/pipedrive/actions/add-activity/add-activity.mjs
@@ -1,0 +1,133 @@
+// legacy_hash_id: a_k6iKYA
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "pipedrive-add-activity",
+  name: "Add Activity",
+  description: "Adds a new activity. Includes more_activities_scheduled_in_context property in response's additional_data which indicates whether there are more undone activities scheduled with the same deal, person or organization (depending on the supplied data).",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    pipedrive: {
+      type: "app",
+      app: "pipedrive",
+    },
+    companydomain: {
+      type: "string",
+      description: "Your company name as registered in Pipedrive, which becomes part of Pipedrive API base url.",
+    },
+    subject: {
+      type: "string",
+      description: "Subject of the activity",
+    },
+    done: {
+      type: "integer",
+      description: "Whether the activity is done or not. 0 = Not done, 1 = Done",
+      optional: true,
+    },
+    type: {
+      type: "string",
+      description: "Type of the activity. This is in correlation with the key_string parameter of ActivityTypes.",
+    },
+    due_date: {
+      type: "string",
+      description: "Due date of the activity. Format: YYYY-MM-DD",
+      optional: true,
+    },
+    due_time: {
+      type: "string",
+      description: "Due time of the activity in UTC. Format: HH:MM",
+      optional: true,
+    },
+    duration: {
+      type: "string",
+      description: "Duration of the activity. Format: HH:MM",
+      optional: true,
+    },
+    user_id: {
+      type: "integer",
+      description: "ID of the user whom the activity will be assigned to. If omitted, the activity will be assigned to the authorized user.",
+      optional: true,
+    },
+    deal_id: {
+      type: "string",
+      description: "ID of the deal this activity will be associated with",
+      optional: true,
+    },
+    person_id: {
+      type: "integer",
+      description: "ID of the person this activity will be associated with",
+      optional: true,
+    },
+    participants: {
+      type: "any",
+      description: "List of multiple persons (participants) this activity will be associated with. If omitted, single participant from person_id field is used. It requires a structure as follows: [{\"person_id\":1,\"primary_flag\":true}]",
+      optional: true,
+    },
+    org_id: {
+      type: "integer",
+      description: "ID of the organization this activity will be associated with",
+      optional: true,
+    },
+    note: {
+      type: "string",
+      description: "Note of the activity (HTML format)",
+      optional: true,
+    },
+    location: {
+      type: "string",
+      description: "The address of the activity. Pipedrive will automatically check if the location matches a geo-location on Google maps.",
+      optional: true,
+    },
+    public_description: {
+      type: "string",
+      description: "Additional details about the activity that will be synced to your external calendar. Unlike the note added to the activity, the description will be publicly visible to any guests added to the activity.",
+      optional: true,
+    },
+    busy_flag: {
+      type: "boolean",
+      description: "Set the activity as 'Busy' or 'Free'. If the flag is set to true, your customers will not be able to book that time slot through any Scheduler links",
+      optional: true,
+    },
+    attendees: {
+      type: "any",
+      description: "Attendees of the activity. This can be either your existing Pipedrive contacts or an external email address. It requires a structure as follows: [{\"email_address\":\"mail@example.org\"}] or [{\"person_id\":1, \"email_address\":\"mail@example.org\"}",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  //See the Pipedrive API docs for Activities here: https://developers.pipedrive.com/docs/api/v1/#!/Activities
+  //For for info on adding an activity in Pipedrive: https://pipedrive.readme.io/docs/adding-an-activity
+    const config = {
+      method: "post",
+      url: `https://${this.companydomain}.pipedrive.com/v1/activities`,
+      data: {
+        subject: this.subject,
+        done: this.done,
+        type: this.type,
+        due_date: this.due_date,
+        due_time: this.due_time,
+        duration: this.duration,
+        user_id: this.user_id,
+        deal_id: this.deal_id,
+        person_id: this.person_id,
+        participants: typeof this.participants == "undefined"
+          ? this.participants
+          : JSON.parse(this.participants),
+        org_id: this.org_id,
+        note: this.note,
+        location: this.location,
+        public_description: this.public_description,
+        busy_flag: this.busy_flag,
+        attendees: typeof this.attendees == "undefined"
+          ? this.attendees
+          : JSON.parse(this.attendees),
+      },
+      headers: {
+        Authorization: `Bearer ${this.pipedrive.$auth.oauth_access_token}`,
+      },
+
+    };
+    return await axios($, config);
+  },
+};

--- a/components/pipedrive/actions/add-deal/add-deal.mjs
+++ b/components/pipedrive/actions/add-deal/add-deal.mjs
@@ -1,0 +1,115 @@
+// legacy_hash_id: a_EViLor
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "pipedrive-add-deal",
+  name: "Add Deal",
+  description: "Adds a new deal.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    pipedrive: {
+      type: "app",
+      app: "pipedrive",
+    },
+    companydomain: {
+      type: "string",
+      description: "Your company name as registered in Pipedrive, which becomes part of Pipedrive API base url.",
+    },
+    title: {
+      type: "string",
+      description: "Deal title",
+    },
+    value: {
+      type: "string",
+      description: "Value of the deal. If omitted, value will be set to 0.",
+      optional: true,
+    },
+    currency: {
+      type: "string",
+      description: "Currency of the deal. Accepts a 3-character currency code. If omitted, currency will be set to the default currency of the authorized user.",
+      optional: true,
+    },
+    user_id: {
+      type: "integer",
+      description: "ID of the user who will be marked as the owner of this deal. If omitted, the authorized user ID will be used.",
+      optional: true,
+    },
+    person_id: {
+      type: "integer",
+      description: "ID of the person this deal will be associated with",
+      optional: true,
+    },
+    org_id: {
+      type: "integer",
+      description: "ID of the organization this deal will be associated with",
+      optional: true,
+    },
+    stage_id: {
+      type: "integer",
+      description: "ID of the stage this deal will be placed in a pipeline (note that you can't supply the ID of the pipeline as this will be assigned automatically based on stage_id). If omitted, the deal will be placed in the first stage of the default pipeline.",
+      optional: true,
+    },
+    status: {
+      type: "string",
+      description: "open = Open, won = Won, lost = Lost, deleted = Deleted. If omitted, status will be set to open.",
+      optional: true,
+      options: [
+        "open",
+        "won",
+        "lost",
+        "deleted",
+      ],
+    },
+    probability: {
+      type: "integer",
+      description: "Deal success probability percentage. Used/shown only when deal_probability for the pipeline of the deal is enabled.",
+      optional: true,
+    },
+    lost_reason: {
+      type: "string",
+      description: "Optional message about why the deal was lost (to be used when status=lost)",
+      optional: true,
+    },
+    visible_to: {
+      type: "string",
+      description: "Visibility of the deal. If omitted, visibility will be set to the default visibility setting of this item type for the authorized user.\n1 - Owner & followers (private)\n3 - Entire company (shared)",
+      optional: true,
+      options: [
+        "1",
+        "3",
+      ],
+    },
+    add_time: {
+      type: "string",
+      description: "Optional creation date & time of the deal in UTC. Requires admin user API token. Format: YYYY-MM-DD HH:MM:SS",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  //See the Pipedrive API docs for Deals here: https://developers.pipedrive.com/docs/api/v1/#!/Deals
+    const config = {
+      method: "post",
+      url: `https://${this.companydomain}.pipedrive.com/v1/deals`,
+      data: {
+        title: this.title,
+        value: this.value,
+        currency: this.currency,
+        user_id: this.user_id,
+        person_id: this.person_id,
+        org_id: this.org_id,
+        stage_id: this.stage_id,
+        status: this.status,
+        probability: this.probability,
+        lost_reason: this.lost_reason,
+        visible_to: this.visible_to,
+        add_time: this.add_time,
+      },
+      headers: {
+        Authorization: `Bearer ${this.pipedrive.$auth.oauth_access_token}`,
+      },
+
+    };
+    return await axios($, config);
+  },
+};

--- a/components/pipedrive/actions/add-organization/add-organization.mjs
+++ b/components/pipedrive/actions/add-organization/add-organization.mjs
@@ -1,0 +1,61 @@
+// legacy_hash_id: a_WYiEeg
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "pipedrive-add-organization",
+  name: "Add Organization",
+  description: "Adds a new organization.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    pipedrive: {
+      type: "app",
+      app: "pipedrive",
+    },
+    companydomain: {
+      type: "string",
+      description: "Your company name as registered in Pipedrive, which becomes part of Pipedrive API base url.",
+    },
+    name: {
+      type: "string",
+      description: "Organization name",
+    },
+    owner_id: {
+      type: "integer",
+      description: "ID of the user who will be marked as the owner of this organization. When omitted, the authorized user ID will be used.",
+      optional: true,
+    },
+    visible_to: {
+      type: "string",
+      description: "Visibility of the organization. If omitted, visibility will be set to the default visibility setting of this item type for the authorized user.\n1 - Owner & followers (private)\n3 - Entire company (shared)",
+      optional: true,
+      options: [
+        "1",
+        "3",
+      ],
+    },
+    add_time: {
+      type: "string",
+      description: "Optional creation date & time of the organization in UTC. Requires admin user API token. Format: YYYY-MM-DD HH:MM:SS",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  //See the Pipedrive API docs for Organizations here: https://developers.pipedrive.com/docs/api/v1/#!/Organizations
+    const config = {
+      method: "post",
+      url: `https://${this.companydomain}.pipedrive.com/v1/organizations`,
+      data: {
+        name: this.name,
+        owner_id: this.owner_id,
+        visible_to: this.visible_to,
+        add_time: this.add_time,
+      },
+      headers: {
+        Authorization: `Bearer ${this.pipedrive.$auth.oauth_access_token}`,
+      },
+
+    };
+    return await axios($, config);
+  },
+};

--- a/components/pipedrive/actions/add-person/add-person.mjs
+++ b/components/pipedrive/actions/add-person/add-person.mjs
@@ -1,0 +1,79 @@
+// legacy_hash_id: a_K5iL2M
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "pipedrive-add-person",
+  name: "Add Person",
+  description: "Adds a new person.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    pipedrive: {
+      type: "app",
+      app: "pipedrive",
+    },
+    companydomain: {
+      type: "string",
+      description: "Your company name as registered in Pipedrive, which becomes part of Pipedrive API base url.",
+    },
+    name: {
+      type: "string",
+      description: "Person name",
+    },
+    owner_id: {
+      type: "integer",
+      description: "ID of the user who will be marked as the owner of this person. When omitted, the authorized user ID will be used.",
+      optional: true,
+    },
+    org_id: {
+      type: "integer",
+      description: "ID of the organization this person will belong to.",
+      optional: true,
+    },
+    email: {
+      type: "any",
+      description: "Email addresses (one or more) associated with the person, presented in the same manner as received by GET request of a person.",
+      optional: true,
+    },
+    phone: {
+      type: "any",
+      description: "Phone numbers (one or more) associated with the person, presented in the same manner as received by GET request of a person.",
+      optional: true,
+    },
+    visible_to: {
+      type: "string",
+      description: "Visibility of the person. If omitted, visibility will be set to the default visibility setting of this item type for the authorized user.\n1 - Owner & followers (private)\n3 - Entire company (shared)",
+      optional: true,
+      options: [
+        "1",
+        "3",
+      ],
+    },
+    add_time: {
+      type: "string",
+      description: "Optional creation date & time of the person in UTC. Requires admin user API token. Format: YYYY-MM-DD HH:MM:SS",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  //See the Pipedrive API docs for People here: https://developers.pipedrive.com/docs/api/v1/#!/Persons
+    const config = {
+      method: "post",
+      url: `https://${this.companydomain}.pipedrive.com/v1/persons`,
+      data: {
+        name: this.name,
+        owner_id: this.owner_id,
+        org_id: this.org_id,
+        email: this.email,
+        phone: this.phone,
+        visible_to: this.visible_to,
+        add_time: this.add_time,
+      },
+      headers: {
+        Authorization: `Bearer ${this.pipedrive.$auth.oauth_access_token}`,
+      },
+
+    };
+    return await axios($, config);
+  },
+};

--- a/components/pipedrive/actions/search-persons/search-persons.mjs
+++ b/components/pipedrive/actions/search-persons/search-persons.mjs
@@ -1,0 +1,93 @@
+// legacy_hash_id: a_4rixdN
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "pipedrive-search-persons",
+  name: "Search persons",
+  description: "Searches all Persons by name, email, phone, notes and/or custom fields. This endpoint is a wrapper of /v1/itemSearch with a narrower OAuth scope. Found Persons can be filtered by Organization ID.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    pipedrive: {
+      type: "app",
+      app: "pipedrive",
+    },
+    companydomain: {
+      type: "string",
+      label: "Company domain",
+      description: "Your company name as registered in Pipedrive, which becomes part of Pipedrive API base url.",
+    },
+    term: {
+      type: "string",
+      label: "Search term",
+      description: "The search term to look for. Minimum 2 characters (or 1 if using exact_match).",
+    },
+    fields: {
+      type: "string",
+      label: "Search fields",
+      description: "A comma-separated string array. The fields to perform the search from. Defaults to all of them.",
+      optional: true,
+      options: [
+        "custom_fields",
+        "email",
+        "notes",
+        "phone",
+        "name",
+      ],
+    },
+    exact_match: {
+      type: "boolean",
+      label: "Exact match",
+      description: "When enabled, only full exact matches against the given term are returned. It is not case sensitive.",
+      optional: true,
+    },
+    organization_id: {
+      type: "integer",
+      label: "Organization ID",
+      description: "Will filter Deals by the provided Organization ID. The upper limit of found Deals associated with the Organization is 2000.",
+      optional: true,
+    },
+    include_fields: {
+      type: "string",
+      label: "Optional fields",
+      description: "Supports including optional fields in the results which are not provided by default.",
+      optional: true,
+      options: [
+        "person.picture",
+      ],
+    },
+    start: {
+      type: "integer",
+      label: "Pagination start",
+      description: "Pagination start. Note that the pagination is based on main results and does not include related items when using search_for_related_items parameter.",
+      optional: true,
+    },
+    limit: {
+      type: "integer",
+      label: "Limit",
+      description: "Items shown per page.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  //See the Pipedrive API docs here: https://developers.pipedrive.com/docs/api/v1/#!/Persons/get_persons_search
+    const config = {
+      method: "get",
+      url: `https://${this.companydomain}.pipedrive.com/v1/persons/search`,
+      params: {
+        term: this.term,
+        fields: this.fields,
+        exact_match: this.exact_match,
+        organization_id: this.organization_id,
+        include_fields: this.include_fields,
+        start: this.start,
+        limit: this.limit,
+      },
+      headers: {
+        Authorization: `Bearer ${this.pipedrive.$auth.oauth_access_token}`,
+      },
+
+    };
+    return await axios($, config);
+  },
+};

--- a/components/pipedrive/actions/update-deal/update-deal.mjs
+++ b/components/pipedrive/actions/update-deal/update-deal.mjs
@@ -1,0 +1,116 @@
+// legacy_hash_id: a_vgi48J
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "pipedrive-update-deal",
+  name: "Update Deal",
+  description: "Updates the properties of a deal.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    pipedrive: {
+      type: "app",
+      app: "pipedrive",
+    },
+    companydomain: {
+      type: "string",
+      description: "Your company name as registered in Pipedrive, which becomes part of Pipedrive API base url.",
+    },
+    id: {
+      type: "string",
+      description: "ID of the deal",
+    },
+    title: {
+      type: "string",
+      description: "Deal title",
+      optional: true,
+    },
+    value: {
+      type: "string",
+      description: "Value of the deal. If omitted, value will be set to 0.",
+      optional: true,
+    },
+    currency: {
+      type: "string",
+      description: "Currency of the deal. Accepts a 3-character currency code. If omitted, currency will be set to the default currency of the authorized user.",
+      optional: true,
+    },
+    user_id: {
+      type: "integer",
+      description: "ID of the user who will be marked as the owner of this deal. If omitted, the authorized user ID will be used.",
+      optional: true,
+    },
+    person_id: {
+      type: "integer",
+      description: "ID of the person this deal will be associated with",
+      optional: true,
+    },
+    org_id: {
+      type: "integer",
+      description: "ID of the organization this deal will be associated with",
+      optional: true,
+    },
+    stage_id: {
+      type: "integer",
+      description: "ID of the stage this deal will be placed in a pipeline (note that you can't supply the ID of the pipeline as this will be assigned automatically based on stage_id). If omitted, the deal will be placed in the first stage of the default pipeline.",
+      optional: true,
+    },
+    status: {
+      type: "string",
+      description: "open = Open, won = Won, lost = Lost, deleted = Deleted. If omitted, status will be set to open.",
+      optional: true,
+      options: [
+        "open",
+        "won",
+        "lost",
+        "deleted",
+      ],
+    },
+    probability: {
+      type: "integer",
+      description: "Deal success probability percentage. Used/shown only when deal_probability for the pipeline of the deal is enabled.",
+      optional: true,
+    },
+    lost_reason: {
+      type: "string",
+      description: "Optional message about why the deal was lost (to be used when status=lost)",
+      optional: true,
+    },
+    visible_to: {
+      type: "string",
+      description: "Visibility of the deal. If omitted, visibility will be set to the default visibility setting of this item type for the authorized user.\n1 - Owner & followers (private)\n3 - Entire company (shared)",
+      optional: true,
+      options: [
+        "1",
+        "3",
+      ],
+    },
+  },
+  async run({ $ }) {
+  //See the Pipedrive API docs for Deals here: https://developers.pipedrive.com/docs/api/v1/#!/Deals
+    const config = {
+      method: "put",
+      url: `https://${this.companydomain}.pipedrive.com/v1/deals/${this.id}`,
+      data: {
+        title: this.title,
+        value: this.value,
+        currency: this.currency,
+        user_id: this.user_id,
+        person_id: this.person_id,
+        org_id: this.org_id,
+        stage_id: this.stage_id, //Get the stage_id from https://developers.pipedrive.com/docs/api/v1/#!/Stages/get_stages
+        //getting all stages requires a pipeline_id, pipelines can be obtained
+        //from https://developers.pipedrive.com/docs/api/v1/#!/Pipelines/get_pipelines
+        status: this.status,
+        probability: this.probability,
+        lost_reason: this.lost_reason,
+        visible_to: this.visible_to,
+      },
+      headers: {
+        Authorization: `Bearer ${this.pipedrive.$auth.oauth_access_token}`,
+      },
+
+    };
+    return await axios($, config);
+  },
+};

--- a/components/ringcentral/actions/create-meeting/create-meeting.mjs
+++ b/components/ringcentral/actions/create-meeting/create-meeting.mjs
@@ -1,0 +1,118 @@
+// legacy_hash_id: a_Xzi1MW
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "ringcentral-create-meeting",
+  name: "Create Meeting",
+  description: "Creates a new meeting.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    ringcentral: {
+      type: "app",
+      app: "ringcentral",
+    },
+    serverURL: {
+      type: "string",
+      description: "The base endpoint host used for the RingCentral API.",
+      optional: true,
+    },
+    account_id: {
+      type: "string",
+      description: "Internal identifier of a RingCentral account.",
+    },
+    extension_id: {
+      type: "string",
+      description: "Internal identifier of an extension.",
+    },
+    topic: {
+      type: "string",
+      description: "Topic of the meeting.",
+      optional: true,
+    },
+    meeting_type: {
+      type: "string",
+      description: "Meeting type.",
+      optional: true,
+      options: [
+        "Instant",
+        "Scheduled",
+        "ScheduledRecurring",
+        "Recurring",
+      ],
+    },
+    schedule: {
+      type: "object",
+      optional: true,
+    },
+    meeting_password: {
+      type: "string",
+      optional: true,
+    },
+    host: {
+      type: "object",
+      optional: true,
+    },
+    allow_join_before_host: {
+      type: "boolean",
+      optional: true,
+    },
+    start_host_video: {
+      type: "boolean",
+      optional: true,
+    },
+    start_participants_video: {
+      type: "boolean",
+      optional: true,
+    },
+    user_personal_meeting_id: {
+      type: "boolean",
+      optional: true,
+    },
+    audio_options: {
+      type: "any",
+      optional: true,
+    },
+    recurrence: {
+      type: "object",
+      description: "Recurrence settings.",
+      optional: true,
+    },
+    auto_record_type: {
+      type: "string",
+      description: "Automatic record type.",
+      optional: true,
+      options: [
+        "local",
+        "cloud",
+        "none",
+      ],
+    },
+  },
+  async run({ $ }) {
+  // See the API docs here: https://developers.ringcentral.com/api-reference/Meeting-Management/createMeeting
+
+    const config = {
+      method: "post",
+      url: `${this.serverURL}/restapi/v1.0/account/${this.account_id}/extension/${this.extension_id}/meeting`,
+      headers: {
+        Authorization: `Bearer ${this.ringcentral.$auth.oauth_access_token}`,
+      },
+      data: {
+        topic: this.topic,
+        meetingType: this.meeting_type,
+        schedule: this.schedule,
+        password: this.meeting_password,
+        host: this.host,
+        allowJoinBeforeHost: this.allow_join_before_host,
+        startHostVideo: this.start_host_video,
+        startParticipantsVideo: this.start_participants_video,
+        usePersonalMeetingId: this.user_personal_meeting_id,
+        audioOptions: this.audio_options,
+        recurrence: this.recurrence,
+        autoRecordType: this.auto_record_type,
+      },
+    };
+    return await axios($, config);
+  },
+};

--- a/components/ringcentral/actions/make-callout/make-callout.mjs
+++ b/components/ringcentral/actions/make-callout/make-callout.mjs
@@ -1,0 +1,51 @@
+// legacy_hash_id: a_oViVNz
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "ringcentral-make-callout",
+  name: "Make  CallOut",
+  description: "Creates a new outbound call out session.",
+  version: "0.3.1",
+  type: "action",
+  props: {
+    ringcentral: {
+      type: "app",
+      app: "ringcentral",
+    },
+    serverURL: {
+      type: "string",
+      description: "The base endpoint host used for the RingCentral API.",
+      optional: true,
+    },
+    account_id: {
+      type: "string",
+      description: "Internal identifier of a RingCentral account.",
+    },
+    device_id: {
+      type: "string",
+      description: "Instance id of the caller. It corresponds to the 1st leg of the CallOut call.",
+    },
+    to: {
+      type: "object",
+      description: "Phone number of the called party. This number corresponds to the 2nd leg of a CallOut call.",
+    },
+  },
+  async run({ $ }) {
+  //See the API docs here: https://developers.ringcentral.com/api-reference/Call-Control/createCallOutCallSession
+
+    const config = {
+      method: "post",
+      url: `${this.serverURL}/restapi/v1.0/account/${this.account_id}/telephony/call-out`,
+      headers: {
+        Authorization: `Bearer ${this.ringcentral.$auth.oauth_access_token}`,
+      },
+      data: {
+        from: {
+          deviceId: this.device_id,
+        },
+        to: this.to,
+      },
+    };
+    return await axios($, config);
+  },
+};

--- a/components/ringcentral/actions/send-sms/send-sms.mjs
+++ b/components/ringcentral/actions/send-sms/send-sms.mjs
@@ -1,0 +1,64 @@
+// legacy_hash_id: a_8Ki7KQ
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "ringcentral-send-sms",
+  name: "Send SMS",
+  description: "Creates and sends a new text message.",
+  version: "0.4.1",
+  type: "action",
+  props: {
+    ringcentral: {
+      type: "app",
+      app: "ringcentral",
+    },
+    serverURL: {
+      type: "string",
+      description: "The base endpoint host used for the RingCentral API.",
+    },
+    account_id: {
+      type: "string",
+      description: "Internal identifier of a RingCentral account.",
+    },
+    extension_id: {
+      type: "string",
+      description: "Internal identifier of an extension.",
+    },
+    phone_number: {
+      type: "string",
+      description: "The phoneNumber for the sender of an SMS message. Property must be filled to correspond to one of the account phone numbers which is allowed to send SMS.",
+    },
+    to: {
+      type: "any",
+      description: "Receiver of an SMS message. The phoneNumber property must be filled.",
+    },
+    text: {
+      type: "string",
+      description: "Text of a message. Max length is 1000 symbols (2-byte UTF-16 encoded). If a character is encoded in 4 bytes in UTF-16 it is treated as 2 characters, thus restricting the maximum message length to 500 symbols.",
+    },
+    country: {
+      type: "object",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  //See the API docs here: https://developers.ringcentral.com/api-reference/SMS/createSMSMessage
+
+    const config = {
+      method: "post",
+      url: `${this.serverURL}/restapi/v1.0/account/${this.account_id}/extension/${this.extension_id}/sms`,
+      headers: {
+        Authorization: `Bearer ${this.ringcentral.$auth.oauth_access_token}`,
+      },
+      data: {
+        from: {
+          phoneNumber: this.phone_number,
+        },
+        to: this.to,
+        text: this.text,
+        country: this.country,
+      },
+    };
+    return await axios($, config);
+  },
+};

--- a/components/sendfox/actions/create-contact/create-contact.mjs
+++ b/components/sendfox/actions/create-contact/create-contact.mjs
@@ -1,0 +1,46 @@
+// legacy_hash_id: a_WYiebr
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "sendfox-create-contact",
+  name: "Create contact",
+  description: "Creates new contact",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    sendfox: {
+      type: "app",
+      app: "sendfox",
+    },
+    email: {
+      type: "string",
+    },
+    first_name: {
+      type: "string",
+      optional: true,
+    },
+    last_name: {
+      type: "string",
+      optional: true,
+    },
+    lists: {
+      type: "any",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    return await axios($, {
+      url: "https://api.sendfox.com/contacts",
+      method: "post",
+      headers: {
+        Authorization: `Bearer ${this.sendfox.$auth.access_token}`,
+      },
+      data: {
+        email: this.email,
+        first_name: this.first_name,
+        last_name: this.last_name,
+        lists: this.lists,
+      },
+    });
+  },
+};

--- a/components/sendfox_personal_access_token/actions/create-contact/create-contact.mjs
+++ b/components/sendfox_personal_access_token/actions/create-contact/create-contact.mjs
@@ -2,15 +2,15 @@
 import { axios } from "@pipedream/platform";
 
 export default {
-  key: "sendfox-create-contact",
+  key: "sendfox_personal_access_token-create-contact",
   name: "Create contact",
   description: "Creates new contact",
   version: "0.1.1",
   type: "action",
   props: {
-    sendfox: {
+    sendfox_personal_access_token: {
       type: "app",
-      app: "sendfox",
+      app: "sendfox_personal_access_token",
     },
     email: {
       type: "string",
@@ -33,7 +33,7 @@ export default {
       url: "https://api.sendfox.com/contacts",
       method: "post",
       headers: {
-        Authorization: `Bearer ${this.sendfox.$auth.access_token}`,
+        Authorization: `Bearer ${this.sendfox_personal_access_token.$auth.access_token}`,
       },
       data: {
         email: this.email,

--- a/components/sftp/actions/upload-file/upload-file.mjs
+++ b/components/sftp/actions/upload-file/upload-file.mjs
@@ -1,0 +1,44 @@
+// legacy_hash_id: a_8Ki7G7
+import Client from "ssh2-sftp-client";
+
+export default {
+  key: "sftp-upload-file",
+  name: "Upload String as File",
+  description: "Uploads a UTF-8 string as a file on an SFTP server",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    sftp: {
+      type: "app",
+      app: "sftp",
+    },
+    data: {
+      type: "string",
+      description: "A UTF-8 string to upload as a file on the remote server.",
+    },
+    remotePath: {
+      type: "string",
+      label: "Remote Path",
+      description: "The path to the remote file to be created on the server.",
+    },
+  },
+  async run({ $ }) {
+    const {
+      host,
+      username,
+      privateKey,
+    } = this.sftp.$auth;
+
+    const config = {
+      host,
+      username,
+      privateKey,
+    };
+
+    const sftp = new Client();
+
+    await sftp.connect(config);
+    $.export("putResponse", await sftp.put(Buffer.from(this.data), this.remotePath));
+    await sftp.end();
+  },
+};

--- a/components/smugmug/actions/create-album/create-album.mjs
+++ b/components/smugmug/actions/create-album/create-album.mjs
@@ -1,0 +1,48 @@
+// legacy_hash_id: a_Vpi75e
+import axios from "axios";
+import { axios as pipedreamAxios } from "@pipedream/platform";
+
+export default {
+  key: "smugmug-create-album",
+  name: "Create Smugmug Album",
+  description: "This action creates an album in a folder. Specify the folder and the JSON document (as a Javascript object) in parameters. A minimal object might look like {\n  UrlName: \"weddings-smith-2020-06-02\",\n  Name: \"Mr & Mrs Smith's June Wedding\",\n  Privacy: 2, \n  SecurityType: 1\n}\nMore fields documented at https://api.smugmug.com/api/v2/folder",
+  version: "1.0.1",
+  type: "action",
+  props: {
+    smugmug: {
+      type: "app",
+      app: "smugmug",
+    },
+    folder: {
+      type: "string",
+    },
+    data: {
+      type: "string",
+    },
+  },
+  async run({ $ }) {
+    const token = {
+      key: this.smugmug.$auth.oauth_access_token,
+      secret: this.smugmug.$auth.oauth_refresh_token,
+    };
+
+    const config = {
+      url: `https://api.smugmug.com/api/v2/folder/user/${this.smugmug.$auth.oauth_uid}/${this.folder}!albums`,
+      method: "POST",
+    };
+
+    const payload = {
+      requestData: config,
+      token,
+    };
+
+    config.headers = {
+      "Authorization": (await axios.post(this.smugmug.$auth.oauth_signer_uri, payload)).data,
+      "Accept": "application/json",
+    };
+
+    config.data = this.data;
+
+    return pipedreamAxios( $, config );
+  },
+};

--- a/components/smugmug/actions/get-album/get-album.mjs
+++ b/components/smugmug/actions/get-album/get-album.mjs
@@ -1,0 +1,40 @@
+// legacy_hash_id: a_B0ip6w
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "smugmug-get-album",
+  name: "Get Album",
+  description: "Gets an album given its id.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    smugmug: {
+      type: "app",
+      app: "smugmug",
+    },
+    album_id: {
+      type: "string",
+      description: "Id  of the album to retrieve.",
+    },
+  },
+  async run({ $ }) {
+  //See the API docs here: https://api.smugmug.com/api/v2/doc/reference/album.html
+
+    const config = {
+      url: `https://www.smugmug.com/api/v2/album/${this.album_id}`,
+      headers: {
+        Accept: "application/json",
+      },
+    };
+
+    const signature = {
+      token: {
+        key: this.smugmug.$auth.oauth_access_token,
+        secret: this.smugmug.$auth.oauth_refresh_token,
+      },
+      oauthSignerUri: this.smugmug.$auth.oauth_signer_uri,
+    };
+
+    return await axios($, config, signature);
+  },
+};

--- a/components/smugmug/actions/get-user-profile/get-user-profile.mjs
+++ b/components/smugmug/actions/get-user-profile/get-user-profile.mjs
@@ -1,0 +1,40 @@
+// legacy_hash_id: a_xqiqM0
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "smugmug-get-user-profile",
+  name: "Get User Profile",
+  description: "Gets a user profile. A user profile is the data provided by a user to establish that user's public presence. This may include social networking links, biographical text, and bio and cover images.",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    smugmug: {
+      type: "app",
+      app: "smugmug",
+    },
+    nickname: {
+      type: "string",
+      description: "Nickname of the user's profile to query.",
+    },
+  },
+  async run({ $ }) {
+  //See the API docs here: https://api.smugmug.com/api/v2/user/cmac!profile
+
+    const config = {
+      url: `https://www.smugmug.com/api/v2/user/${this.nickname}!profile`,
+      headers: {
+        Accept: "application/json",
+      },
+    };
+
+    const signature = {
+      token: {
+        key: this.smugmug.$auth.oauth_access_token,
+        secret: this.smugmug.$auth.oauth_refresh_token,
+      },
+      oauthSignerUri: this.smugmug.$auth.oauth_signer_uri,
+    };
+
+    return await axios($, config, signature);
+  },
+};

--- a/components/trello/actions/add-checklist/add-checklist.mjs
+++ b/components/trello/actions/add-checklist/add-checklist.mjs
@@ -1,0 +1,68 @@
+// legacy_hash_id: a_WYieM3
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "trello-add-checklist",
+  name: "Create a Checklist",
+  description: "Adds a new checklist to a card.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    trello: {
+      type: "app",
+      app: "trello",
+    },
+    id: {
+      type: "string",
+      description: "The ID of the card.",
+    },
+    name: {
+      type: "string",
+      description: "The name of the checklist.",
+      optional: true,
+    },
+    idChecklistSource: {
+      type: "string",
+      description: "The ID of a source checklist to copy into the new one.",
+      optional: true,
+    },
+    pos: {
+      type: "string",
+      description: "The position of the checklist on the card. One of: top, bottom, or a positive number.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const oauthSignerUri = this.trello.$auth.oauth_signer_uri;
+
+    let id = this.id;
+    const trelloParams = [
+      "name",
+      "idChecklistSource",
+      "pos",
+    ];
+    let p = this;
+
+    const queryString = trelloParams.filter((param) => p[param]).map((param) => `${param}=${p[param]}`)
+      .join("&");
+
+    const config = {
+      url: `https://api.trello.com/1/cards/${id}/checklists?${queryString}`,
+      method: "POST",
+      data: "",
+    };
+
+    const token = {
+      key: this.trello.$auth.oauth_access_token,
+      secret: this.trello.$auth.oauth_refresh_token,
+    };
+
+    const signConfig = {
+      token,
+      oauthSignerUri,
+    };
+
+    const resp = await axios($, config, signConfig);
+    return resp;
+  },
+};

--- a/components/trello/actions/add-comment/add-comment.mjs
+++ b/components/trello/actions/add-comment/add-comment.mjs
@@ -1,0 +1,55 @@
+// legacy_hash_id: a_Xzi26w
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "trello-add-comment",
+  name: "Create a Comment",
+  description: "Create a new comment on a specific card.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    trello: {
+      type: "app",
+      app: "trello",
+    },
+    id: {
+      type: "string",
+      description: "The ID of the card.",
+    },
+    text: {
+      type: "string",
+      description: "The comment to add.",
+    },
+  },
+  async run({ $ }) {
+    const oauthSignerUri = this.trello.$auth.oauth_signer_uri;
+
+    let id = this.id;
+    const trelloParams = [
+      "text",
+    ];
+    let p = this;
+
+    const queryString = trelloParams.filter((param) => p[param]).map((param) => `${param}=${p[param]}`)
+      .join("&");
+
+    const config = {
+      url: `https://api.trello.com/1/cards/${id}/actions/comments?${queryString}`,
+      method: "POST",
+      data: "",
+    };
+
+    const token = {
+      key: this.trello.$auth.oauth_access_token,
+      secret: this.trello.$auth.oauth_refresh_token,
+    };
+
+    const signConfig = {
+      token,
+      oauthSignerUri,
+    };
+
+    const resp = await axios($, config, signConfig);
+    return resp;
+  },
+};

--- a/components/trello/actions/add-label-to-card/add-label-to-card.mjs
+++ b/components/trello/actions/add-label-to-card/add-label-to-card.mjs
@@ -1,0 +1,55 @@
+// legacy_hash_id: a_xqi4E7
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "trello-add-label-to-card",
+  name: "Add Existing Label to Card",
+  description: "Add an existing label to a card.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    trello: {
+      type: "app",
+      app: "trello",
+    },
+    id: {
+      type: "string",
+      description: "The ID of the card.",
+    },
+    value: {
+      type: "string",
+      description: "The ID of the label to add",
+    },
+  },
+  async run({ $ }) {
+    const oauthSignerUri = this.trello.$auth.oauth_signer_uri;
+
+    let id = this.id;
+    const trelloParams = [
+      "value",
+    ];
+    let p = this;
+
+    const queryString = trelloParams.filter((param) => p[param]).map((param) => `${param}=${p[param]}`)
+      .join("&");
+
+    const config = {
+      url: `https://api.trello.com/1/cards/${id}/idLabels?${queryString}`,
+      method: "POST",
+      data: "",
+    };
+
+    const token = {
+      key: this.trello.$auth.oauth_access_token,
+      secret: this.trello.$auth.oauth_refresh_token,
+    };
+
+    const signConfig = {
+      token,
+      oauthSignerUri,
+    };
+
+    const resp = await axios($, config, signConfig);
+    return resp;
+  },
+};

--- a/components/trello/actions/add-member-to-card/add-member-to-card.mjs
+++ b/components/trello/actions/add-member-to-card/add-member-to-card.mjs
@@ -1,0 +1,56 @@
+// legacy_hash_id: a_poikVg
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "trello-add-member-to-card",
+  name: "Add a Member to a Card",
+  description: "Adds a member to a particular card.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    trello: {
+      type: "app",
+      app: "trello",
+    },
+    id: {
+      type: "string",
+      description: "The ID of the card.",
+    },
+    value: {
+      type: "string",
+      description: "The ID of the member to add to the card.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const oauthSignerUri = this.trello.$auth.oauth_signer_uri;
+
+    let id = this.id;
+    const trelloParams = [
+      "value",
+    ];
+    let p = this;
+
+    const queryString = trelloParams.filter((param) => p[param]).map((param) => `${param}=${p[param]}`)
+      .join("&");
+
+    const config = {
+      url: `https://api.trello.com/1/cards/${id}/idMembers?${queryString}`,
+      method: "POST",
+      data: "",
+    };
+
+    const token = {
+      key: this.trello.$auth.oauth_access_token,
+      secret: this.trello.$auth.oauth_refresh_token,
+    };
+
+    const signConfig = {
+      token,
+      oauthSignerUri,
+    };
+
+    const resp = await axios($, config, signConfig);
+    return resp;
+  },
+};

--- a/components/trello/actions/archive-card/archive-card.mjs
+++ b/components/trello/actions/archive-card/archive-card.mjs
@@ -1,0 +1,44 @@
+// legacy_hash_id: a_njiaR8
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "trello-archive-card",
+  name: "Archive Card",
+  description: "Archives the specified card.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    trello: {
+      type: "app",
+      app: "trello",
+    },
+    id: {
+      type: "string",
+      description: "The ID of the card to archive.",
+    },
+  },
+  async run({ $ }) {
+    const oauthSignerUri = this.trello.$auth.oauth_signer_uri;
+
+    let id = this.id;
+
+    const config = {
+      url: `https://api.trello.com/1/cards/${id}?closed=true`,
+      method: "PUT",
+      data: "",
+    };
+
+    const token = {
+      key: this.trello.$auth.oauth_access_token,
+      secret: this.trello.$auth.oauth_refresh_token,
+    };
+
+    const signConfig = {
+      token,
+      oauthSignerUri,
+    };
+
+    const resp = await axios($, config, signConfig);
+    return resp;
+  },
+};

--- a/components/trello/actions/complete-checklist-item/complete-checklist-item.mjs
+++ b/components/trello/actions/complete-checklist-item/complete-checklist-item.mjs
@@ -1,0 +1,49 @@
+// legacy_hash_id: a_EViowW
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "trello-complete-checklist-item",
+  name: "Complete a Checklist Item",
+  description: "Completes an existing checklist item in a card.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    trello: {
+      type: "app",
+      app: "trello",
+    },
+    id: {
+      type: "string",
+      description: "The ID of the card.",
+    },
+    idCheckItem: {
+      type: "string",
+      description: "The ID of the checklist item to complete.",
+    },
+  },
+  async run({ $ }) {
+    const oauthSignerUri = this.trello.$auth.oauth_signer_uri;
+
+    let id = this.id;
+    let idCheckItem = this.idCheckItem;
+
+    const config = {
+      url: `https://api.trello.com/1/cards/${id}/checkItem/${idCheckItem}?state=complete`,
+      method: "PUT",
+      data: "",
+    };
+
+    const token = {
+      key: this.trello.$auth.oauth_access_token,
+      secret: this.trello.$auth.oauth_refresh_token,
+    };
+
+    const signConfig = {
+      token,
+      oauthSignerUri,
+    };
+
+    const resp = await axios($, config, signConfig);
+    return resp;
+  },
+};

--- a/components/trello/actions/copy-board/copy-board.mjs
+++ b/components/trello/actions/copy-board/copy-board.mjs
@@ -1,0 +1,174 @@
+// legacy_hash_id: a_B0izQg
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "trello-copy-board",
+  name: "Copy a Board",
+  description: "Creates a copy of an existing board.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    trello: {
+      type: "app",
+      app: "trello",
+    },
+    name: {
+      type: "string",
+      description: "The new name for the board. 1 to 16384 characters long.",
+    },
+    defaultLabels: {
+      type: "boolean",
+      description: "Determines whether to use the default set of labels.",
+      optional: true,
+    },
+    defaultLists: {
+      type: "boolean",
+      description: "Determines whether to add the default set of lists to a board (To Do, Doing, Done). It is ignored if idBoardSource is provided.",
+      optional: true,
+    },
+    desc: {
+      type: "string",
+      description: "A new description for the board, 0 to 16384 characters long.",
+      optional: true,
+    },
+    idOrganization: {
+      type: "string",
+      description: "The id or name of the team the board should belong to.",
+      optional: true,
+    },
+    idBoardSource: {
+      type: "string",
+      description: "The id of a board to copy into the new board.",
+    },
+    keepFromSource: {
+      type: "string",
+      description: "To keep cards from the original board pass in the value \"cards\".",
+      optional: true,
+      options: [
+        "none",
+        "cards",
+      ],
+    },
+    powerUps: {
+      type: "string",
+      description: "The Power-Ups that should be enabled on the new board. One of: all, calendar, cardAging, recap, voting.",
+      optional: true,
+    },
+    prefs_permissionLevel: {
+      type: "string",
+      description: "The permissions level of the board. One of: org, private, public.",
+      optional: true,
+      options: [
+        "org",
+        "private",
+        "public",
+      ],
+    },
+    prefs_voting: {
+      type: "string",
+      label: "Prefs Voting",
+      description: "Who can vote on this board. One of disabled, members, observers, org, public.",
+      optional: true,
+      options: [
+        "disabled",
+        "members",
+        "observers",
+        "org",
+        "public",
+      ],
+    },
+    prefs_comments: {
+      type: "string",
+      label: "Prefs Comments",
+      description: "Who can comment on cards on this board. One of: disabled, members, observers, org, public.",
+      optional: true,
+      options: [
+        "disabled",
+        "members",
+        "observers",
+        "org",
+        "public",
+      ],
+    },
+    prefs_invitations: {
+      type: "string",
+      label: "Prefs Invitations",
+      description: "Determines what types of members can invite users to join. One of: admins, members.",
+      optional: true,
+      options: [
+        "admins",
+        "members",
+      ],
+    },
+    prefs_selfJoin: {
+      type: "boolean",
+      description: "Determines whether users can join the boards themselves or whether they have to be invited.",
+      optional: true,
+    },
+    prefs_cardCovers: {
+      type: "string",
+      description: "Determines whether card covers are enabled.",
+      optional: true,
+    },
+    prefs_background: {
+      type: "string",
+      label: "Prefs Background",
+      description: "The id of a custom background or one of: blue, orange, green, red, purple, pink, lime, sky, grey.",
+      optional: true,
+    },
+    prefs_cardAging: {
+      type: "string",
+      description: "Determines the type of card aging that should take place on the board if card aging is enabled. One of: pirate, regular.",
+      optional: true,
+      options: [
+        "pirate",
+        "regular",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const oauthSignerUri = this.trello.$auth.oauth_signer_uri;
+
+    const trelloParams = [
+      "name",
+      "defaultLabels",
+      "defaultLists",
+      "desc",
+      "idOrganization",
+      "idBoardSource",
+      "keepFromSource",
+      "powerUps",
+      "prefs_permissionLevel",
+      "prefs_voting",
+      "prefs_comments",
+      "prefs_invitations",
+      "prefs_selfJoin",
+      "prefs_cardCovers",
+      "prefs_background",
+      "prefs_cardAging",
+    ];
+    let p = this;
+
+    const queryString = trelloParams.filter((param) => p[param]).map((param) => `${param}=${p[param]}`)
+      .join("&");
+
+    const config = {
+      url: `https://api.trello.com/1/boards?${queryString}`,
+      method: "POST",
+      data: "",
+    };
+
+    const token = {
+      key: this.trello.$auth.oauth_access_token,
+      secret: this.trello.$auth.oauth_refresh_token,
+    };
+
+    const signConfig = {
+      token,
+      oauthSignerUri,
+    };
+
+    const resp = await axios($, config, signConfig);
+    return resp;
+  },
+};

--- a/components/trello/actions/create-board/create-board.mjs
+++ b/components/trello/actions/create-board/create-board.mjs
@@ -1,0 +1,175 @@
+// legacy_hash_id: a_Nqi0GV
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "trello-create-board",
+  name: "Create a Board",
+  description: "Creates a new Trello board.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    trello: {
+      type: "app",
+      app: "trello",
+    },
+    name: {
+      type: "string",
+      description: "The new name for the board. 1 to 16384 characters long.",
+    },
+    defaultLabels: {
+      type: "boolean",
+      description: "Determines whether to use the default set of labels.",
+      optional: true,
+    },
+    defaultLists: {
+      type: "boolean",
+      description: "Determines whether to add the default set of lists to a board (To Do, Doing, Done). It is ignored if idBoardSource is provided.",
+      optional: true,
+    },
+    desc: {
+      type: "string",
+      description: "A new description for the board, 0 to 16384 characters long",
+      optional: true,
+    },
+    idOrganization: {
+      type: "string",
+      description: "The id or name of the team the board should belong to.",
+      optional: true,
+    },
+    idBoardSource: {
+      type: "string",
+      description: "The id of a board to copy into the new board.",
+      optional: true,
+    },
+    keepFromSource: {
+      type: "string",
+      description: "To keep cards from the original board pass in the value \"cards\".",
+      optional: true,
+      options: [
+        "none",
+        "cards",
+      ],
+    },
+    powerUps: {
+      type: "string",
+      description: "The Power-Ups that should be enabled on the new board. One of: all, calendar, cardAging, recap, voting.",
+      optional: true,
+    },
+    prefs_permissionLevel: {
+      type: "string",
+      description: "The permissions level of the board. One of: org, private, public.",
+      optional: true,
+      options: [
+        "org",
+        "private",
+        "public",
+      ],
+    },
+    prefs_voting: {
+      type: "string",
+      label: "Prefs Voting",
+      description: "Who can vote on this board. One of disabled, members, observers, org, public.",
+      optional: true,
+      options: [
+        "disabled",
+        "members",
+        "observers",
+        "org",
+        "public",
+      ],
+    },
+    prefs_comments: {
+      type: "string",
+      label: "Prefs Comments",
+      description: "Who can comment on cards on this board. One of: disabled, members, observers, org, public.",
+      optional: true,
+      options: [
+        "disabled",
+        "members",
+        "observers",
+        "org",
+        "public",
+      ],
+    },
+    prefs_invitations: {
+      type: "string",
+      label: "Prefs Invitations",
+      description: "Determines what types of members can invite users to join. One of: admins, members.",
+      optional: true,
+      options: [
+        "admins",
+        "members",
+      ],
+    },
+    prefs_selfJoin: {
+      type: "boolean",
+      description: "Determines whether users can join the boards themselves or whether they have to be invited.",
+      optional: true,
+    },
+    prefs_cardCovers: {
+      type: "boolean",
+      description: "Determines whether card covers are enabled.",
+      optional: true,
+    },
+    prefs_background: {
+      type: "string",
+      label: "Prefs Background",
+      description: "The id of a custom background or one of: blue, orange, green, red, purple, pink, lime, sky, grey.",
+      optional: true,
+    },
+    prefs_cardAging: {
+      type: "string",
+      description: "Determines the type of card aging that should take place on the board if card aging is enabled. One of: pirate, regular.",
+      optional: true,
+      options: [
+        "pirate",
+        "regular",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const oauthSignerUri = this.trello.$auth.oauth_signer_uri;
+
+    const trelloParams = [
+      "name",
+      "defaultLabels",
+      "defaultLists",
+      "desc",
+      "idOrganization",
+      "idBoardSource",
+      "keepFromSource",
+      "powerUps",
+      "prefs_permissionLevel",
+      "prefs_voting",
+      "prefs_comments",
+      "prefs_invitations",
+      "prefs_selfJoin",
+      "prefs_cardCovers",
+      "prefs_background",
+      "prefs_cardAging",
+    ];
+    let p = this;
+
+    const queryString = trelloParams.filter((param) => p[param]).map((param) => `${param}=${p[param]}`)
+      .join("&");
+
+    const config = {
+      url: `https://api.trello.com/1/boards?${queryString}`,
+      method: "POST",
+      data: "",
+    };
+
+    const token = {
+      key: this.trello.$auth.oauth_access_token,
+      secret: this.trello.$auth.oauth_refresh_token,
+    };
+
+    const signConfig = {
+      token,
+      oauthSignerUri,
+    };
+
+    const resp = await axios($, config, signConfig);
+    return resp;
+  },
+};

--- a/components/trello/actions/create-checklist-item/create-checklist-item.mjs
+++ b/components/trello/actions/create-checklist-item/create-checklist-item.mjs
@@ -1,0 +1,67 @@
+// legacy_hash_id: a_bKiP4j
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "trello-create-checklist-item",
+  name: "Create a Checklist Item",
+  description: "Creates a new checklist item in a card.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    trello: {
+      type: "app",
+      app: "trello",
+    },
+    id: {
+      type: "string",
+      description: "ID of a checklist.",
+    },
+    name: {
+      type: "string",
+      description: "The name of the new check item on the checklist. Should be a string of length 1 to 16384.",
+    },
+    pos: {
+      type: "string",
+      description: "The position of the check item in the checklist. One of: top, bottom, or a positive number.",
+      optional: true,
+    },
+    checked: {
+      type: "boolean",
+      description: "Determines whether the check item is already checked when created.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const oauthSignerUri = this.trello.$auth.oauth_signer_uri;
+
+    let id = this.id;
+    const trelloParams = [
+      "name",
+      "pos",
+      "checked",
+    ];
+    let p = this;
+
+    const queryString = trelloParams.filter((param) => p[param]).map((param) => `${param}=${p[param]}`)
+      .join("&");
+
+    const config = {
+      url: `https://api.trello.com/1/checklists/${id}/checkItems?${queryString}`,
+      method: "POST",
+      data: "",
+    };
+
+    const token = {
+      key: this.trello.$auth.oauth_access_token,
+      secret: this.trello.$auth.oauth_refresh_token,
+    };
+
+    const signConfig = {
+      token,
+      oauthSignerUri,
+    };
+
+    const resp = await axios($, config, signConfig);
+    return resp;
+  },
+};

--- a/components/trello/actions/create-label/create-label.mjs
+++ b/components/trello/actions/create-label/create-label.mjs
@@ -1,0 +1,73 @@
+// legacy_hash_id: a_l0iLRL
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "trello-create-label",
+  name: "Create Label",
+  description: "Creates a new label on the specified board.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    trello: {
+      type: "app",
+      app: "trello",
+    },
+    name: {
+      type: "string",
+      description: "Name for the label.",
+    },
+    color: {
+      type: "string",
+      description: "The color for the label. One of: yellow, purple, blue, red, green, orange, black, sky, pink, lime, null (null means no color, and the label will not show on the front of cards)",
+      options: [
+        "yellow",
+        "purple",
+        "blue",
+        "red",
+        "green",
+        "orange",
+        "black",
+        "sky",
+        "pink",
+        "lime",
+        "null",
+      ],
+    },
+    idBoard: {
+      type: "string",
+      description: "The ID of the board to create the label on.",
+    },
+  },
+  async run({ $ }) {
+    const oauthSignerUri = this.trello.$auth.oauth_signer_uri;
+
+    const trelloParams = [
+      "name",
+      "color",
+      "idBoard",
+    ];
+    let p = this;
+
+    const queryString = trelloParams.filter((param) => p[param]).map((param) => `${param}=${p[param]}`)
+      .join("&");
+
+    const config = {
+      url: `https://api.trello.com/1/labels?${queryString}`,
+      method: "POST",
+      data: "",
+    };
+
+    const token = {
+      key: this.trello.$auth.oauth_access_token,
+      secret: this.trello.$auth.oauth_refresh_token,
+    };
+
+    const signConfig = {
+      token,
+      oauthSignerUri,
+    };
+
+    const resp = await axios($, config, signConfig);
+    return resp;
+  },
+};

--- a/components/trello/actions/create-list/create-list.mjs
+++ b/components/trello/actions/create-list/create-list.mjs
@@ -1,0 +1,67 @@
+// legacy_hash_id: a_G1iBG7
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "trello-create-list",
+  name: "Create a List",
+  description: "Creates a new list on a board",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    trello: {
+      type: "app",
+      app: "trello",
+    },
+    name: {
+      type: "string",
+      description: "Name for the list.",
+    },
+    idBoard: {
+      type: "string",
+      description: "The long ID of the board the list should be created on.",
+    },
+    idListSource: {
+      type: "string",
+      description: "ID of the list to copy into the new list.",
+      optional: true,
+    },
+    pos: {
+      type: "string",
+      description: "Position of the list. top, bottom, or a positive floating point number.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const oauthSignerUri = this.trello.$auth.oauth_signer_uri;
+
+    const trelloParams = [
+      "name",
+      "idBoard",
+      "idListSource",
+      "pos",
+    ];
+    let p = this;
+
+    const queryString = trelloParams.filter((param) => p[param]).map((param) => `${param}=${p[param]}`)
+      .join("&");
+
+    const config = {
+      url: `https://api.trello.com/1/lists?${queryString}`,
+      method: "POST",
+      data: "",
+    };
+
+    const token = {
+      key: this.trello.$auth.oauth_access_token,
+      secret: this.trello.$auth.oauth_refresh_token,
+    };
+
+    const signConfig = {
+      token,
+      oauthSignerUri,
+    };
+
+    const resp = await axios($, config, signConfig);
+    return resp;
+  },
+};

--- a/components/trello/actions/delete-checklist/delete-checklist.mjs
+++ b/components/trello/actions/delete-checklist/delete-checklist.mjs
@@ -1,0 +1,44 @@
+// legacy_hash_id: a_RAiav3
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "trello-delete-checklist",
+  name: "Delete a Checklist",
+  description: "Deletes an existing checklist on a card.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    trello: {
+      type: "app",
+      app: "trello",
+    },
+    id: {
+      type: "string",
+      description: "ID of the checklist to delete.",
+    },
+  },
+  async run({ $ }) {
+    const oauthSignerUri = this.trello.$auth.oauth_signer_uri;
+
+    let id = this.id;
+
+    const config = {
+      url: `https://api.trello.com/1/checklists/${id}`,
+      method: "DELETE",
+      data: "",
+    };
+
+    const token = {
+      key: this.trello.$auth.oauth_access_token,
+      secret: this.trello.$auth.oauth_refresh_token,
+    };
+
+    const signConfig = {
+      token,
+      oauthSignerUri,
+    };
+
+    const resp = await axios($, config, signConfig);
+    return resp;
+  },
+};

--- a/components/trello/actions/find-labels/find-labels.mjs
+++ b/components/trello/actions/find-labels/find-labels.mjs
@@ -1,0 +1,67 @@
+// legacy_hash_id: a_gniNJJ
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "trello-find-labels",
+  name: "Find a Label",
+  description: "Finds a label on a specific board by name.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    trello: {
+      type: "app",
+      app: "trello",
+    },
+    id: {
+      type: "string",
+      description: "The ID of the board.",
+    },
+    query: {
+      type: "string",
+      description: "The query to search for.",
+    },
+    fields: {
+      type: "string",
+      description: "all or a comma-separated list of label fields (id, idBoard, name, color).",
+      optional: true,
+    },
+    limit: {
+      type: "integer",
+      description: "0 to 1000",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    let id = this.id;
+    let query = this.query;
+    const trelloParams = [
+      "fields",
+      "limit",
+    ];
+    let p = this;
+    let labels = null;
+    let matches = [];
+
+    const queryString = trelloParams.filter((param) => p[param]).map((param) => `${param}=${p[param]}`)
+      .join("&");
+
+    labels = await axios($, {
+      url: `https://api.trello.com/1/boards/${id}/labels?${queryString}`,
+      method: "GET",
+    }, {
+      token: {
+        key: this.trello.$auth.oauth_access_token,
+        secret: this.trello.$auth.oauth_refresh_token,
+      },
+      oauthSignerUri: this.trello.$auth.oauth_signer_uri,
+    });
+    if (labels) {
+      labels.forEach(function(label) {
+        if (label.name.includes(query))
+          matches.push(label);
+      });
+    }
+
+    return matches;
+  },
+};

--- a/components/trello/actions/find-list/find-list.mjs
+++ b/components/trello/actions/find-list/find-list.mjs
@@ -1,0 +1,92 @@
+// legacy_hash_id: a_m8iXqE
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "trello-find-list",
+  name: "Find a List",
+  description: "Finds a list on a specific board by name.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    trello: {
+      type: "app",
+      app: "trello",
+    },
+    id: {
+      type: "string",
+      description: "The ID of the board.",
+    },
+    query: {
+      type: "string",
+      description: "The query to search for.",
+    },
+    cards: {
+      type: "string",
+      description: "One of: all, closed, none, open.",
+      optional: true,
+      options: [
+        "all",
+        "closed",
+        "none",
+        "open",
+      ],
+    },
+    card_fields: {
+      type: "string",
+      label: "Card Fields",
+      description: "all or a comma-separated list of card fields (id, badges, checkItemStates, closed, dateLastActivity, desc, descData, due, dueComplete, idAttachmentCover, idBoard, idChecklists, idLabels, idList, idMembers, idMembersVoted, idShort, labels, manualCoverAttachment, name, pos, shortlink, shortUrl, subscribed, url, address, locationName, coordinates).",
+      optional: true,
+    },
+    filter: {
+      type: "string",
+      description: "One of all, closed, none, open.",
+      optional: true,
+      options: [
+        "all",
+        "closed",
+        "none",
+        "open",
+      ],
+    },
+    fields: {
+      type: "string",
+      description: "all or a comma-separated list of list fields (id, name, closed, idBoard, pos, subscribed, softLimit).",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    let id = this.id;
+    let query = this.query;
+    const trelloParams = [
+      "cards",
+      "card_fields",
+      "filter",
+      "fields",
+    ];
+    let p = this;
+    let lists = null;
+    let matches = [];
+
+    const queryString = trelloParams.filter((param) => p[param]).map((param) => `${param}=${p[param]}`)
+      .join("&");
+
+    lists = await axios($, {
+      url: `https://api.trello.com/1/boards/${id}/lists?${queryString}`,
+      method: "GET",
+    }, {
+      token: {
+        key: this.trello.$auth.oauth_access_token,
+        secret: this.trello.$auth.oauth_refresh_token,
+      },
+      oauthSignerUri: this.trello.$auth.oauth_signer_uri,
+    });
+    if (lists) {
+      lists.forEach(function(list) {
+        if (list.name.includes(query))
+          matches.push(list);
+      });
+    }
+
+    return matches;
+  },
+};

--- a/components/trello/actions/move-card-to-list/move-card-to-list.mjs
+++ b/components/trello/actions/move-card-to-list/move-card-to-list.mjs
@@ -1,0 +1,139 @@
+// legacy_hash_id: a_vgi8nA
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "trello-move-card-to-list",
+  name: "Move Card to List",
+  description: "Moves a specific card to a list on the specified board.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    trello: {
+      type: "app",
+      app: "trello",
+    },
+    id: {
+      type: "string",
+      description: "The ID of the card to move.",
+    },
+    name: {
+      type: "string",
+      description: "The new name for the card.",
+      optional: true,
+    },
+    desc: {
+      type: "string",
+      description: "The new description for the card.",
+      optional: true,
+    },
+    closed: {
+      type: "boolean",
+      description: "Whether the card should be archived (closed: true).",
+      optional: true,
+    },
+    idMembers: {
+      type: "string",
+      description: "Comma-separated list of member IDs.",
+      optional: true,
+    },
+    idAttachmentCover: {
+      type: "string",
+      description: "The ID of the image attachment the card should use as its cover, or null for none.",
+      optional: true,
+    },
+    idList: {
+      type: "string",
+      description: "The ID of the list the card should be in.",
+    },
+    idLabels: {
+      type: "string",
+      description: "Comma-separated list of label IDs.",
+      optional: true,
+    },
+    idBoard: {
+      type: "string",
+      description: "The ID of the board the card should be on.",
+      optional: true,
+    },
+    pos: {
+      type: "string",
+      description: "The position of the card in its list. top, bottom, or a positive float.",
+      optional: true,
+    },
+    due: {
+      type: "string",
+      description: "When the card is due, or null.",
+      optional: true,
+    },
+    dueComplete: {
+      type: "boolean",
+      description: "Whether the due date should be marked complete.",
+      optional: true,
+    },
+    subscribed: {
+      type: "boolean",
+      description: "Whether the member is should be subscribed to the card.",
+      optional: true,
+    },
+    address: {
+      type: "string",
+      description: "For use with/by the Map Power-Up.",
+      optional: true,
+    },
+    locationName: {
+      type: "string",
+      description: "For use with/by the Map Power-Up.",
+      optional: true,
+    },
+    coordinates: {
+      type: "string",
+      description: "For use with/by the Map Power-Up. Should be latitude, longitude.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const oauthSignerUri = this.trello.$auth.oauth_signer_uri;
+
+    let id = this.id;
+    const trelloParams = [
+      "name",
+      "desc",
+      "closed",
+      "idMembers",
+      "idAttachmentCover",
+      "idList",
+      "idLabels",
+      "idBoard",
+      "pos",
+      "due",
+      "dueComplete",
+      "subscribed",
+      "address",
+      "locationName",
+      "coordinates",
+    ];
+    let p = this;
+
+    const queryString = trelloParams.filter((param) => p[param]).map((param) => `${param}=${p[param]}`)
+      .join("&");
+
+    const config = {
+      url: `https://api.trello.com/1/cards/${id}?${queryString}`,
+      method: "PUT",
+      data: "",
+    };
+
+    const token = {
+      key: this.trello.$auth.oauth_access_token,
+      secret: this.trello.$auth.oauth_refresh_token,
+    };
+
+    const signConfig = {
+      token,
+      oauthSignerUri,
+    };
+
+    const resp = await axios($, config, signConfig);
+    return resp;
+  },
+};

--- a/components/trello/actions/remove-label-from-card/remove-label-from-card.mjs
+++ b/components/trello/actions/remove-label-from-card/remove-label-from-card.mjs
@@ -1,0 +1,49 @@
+// legacy_hash_id: a_k6iY7Q
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "trello-remove-label-from-card",
+  name: "Remove Label From Card",
+  description: "Removes an existing label from a card.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    trello: {
+      type: "app",
+      app: "trello",
+    },
+    id: {
+      type: "string",
+      description: "The ID of the card.",
+    },
+    idLabel: {
+      type: "string",
+      description: "The ID of the label to remove.",
+    },
+  },
+  async run({ $ }) {
+    const oauthSignerUri = this.trello.$auth.oauth_signer_uri;
+
+    let id = this.id;
+    let idLabel = this.idLabel;
+
+    const config = {
+      url: `https://api.trello.com/1/cards/${id}/idLabels/${idLabel}`,
+      method: "DELETE",
+      data: "",
+    };
+
+    const token = {
+      key: this.trello.$auth.oauth_access_token,
+      secret: this.trello.$auth.oauth_refresh_token,
+    };
+
+    const signConfig = {
+      token,
+      oauthSignerUri,
+    };
+
+    const resp = await axios($, config, signConfig);
+    return resp;
+  },
+};

--- a/components/trello/actions/search-boards/search-boards.mjs
+++ b/components/trello/actions/search-boards/search-boards.mjs
@@ -1,0 +1,72 @@
+// legacy_hash_id: a_jQiB5z
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "trello-search-boards",
+  name: "Search Boards",
+  description: "Search for a Trello Board",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    trello: {
+      type: "app",
+      app: "trello",
+    },
+    query: {
+      type: "string",
+      description: "The search query with a length of 1 to 16384 characters",
+    },
+    idBoards: {
+      type: "string",
+      description: "mine or a comma-separated list of board ids",
+      optional: true,
+    },
+    idOrganizations: {
+      type: "string",
+      description: "A comma-separated list of team ids",
+      optional: true,
+    },
+    board_fields: {
+      type: "string",
+      label: "Board Fields",
+      description: "all or a comma-separated list of: closed, dateLastActivity, dateLastView, desc, descData, idOrganization, invitations, invited, labelNames, memberships, name, pinned, powerUps, prefs, shortLink, shortUrl, starred, subscribed, url",
+      optional: true,
+    },
+    boards_limit: {
+      type: "integer",
+      label: "Boards Limit",
+      description: "The maximum number of boards returned. Maximum: 1000",
+      optional: true,
+    },
+    partial: {
+      type: "string",
+      description: "By default, Trello searches for each word in your query against exactly matching words within Member content. Specifying partial to be true means that we will look for content that starts with any of the words in your query. If you are looking for a Card titled \"My Development Status Report\", by default you would need to search for \"Development\". If you have partial enabled, you will be able to search for \"dev\" but not \"velopment\".",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const trelloParams = [
+      "query",
+      "idBoards",
+      "idOrganizations",
+      "board_fields",
+      "boards_limit",
+      "partial",
+    ];
+    let p = this;
+
+    const queryString = trelloParams.filter((param) => p[param]).map((param) => `${param}=${p[param]}`)
+      .join("&");
+
+    return await axios($, {
+      url: `https://api.trello.com/1/search?modelTypes=boards&${queryString}`,
+      method: "GET",
+    }, {
+      token: {
+        key: this.trello.$auth.oauth_access_token,
+        secret: this.trello.$auth.oauth_refresh_token,
+      },
+      oauthSignerUri: this.trello.$auth.oauth_signer_uri,
+    });
+  },
+};

--- a/components/trello/actions/search-cards/search-cards.mjs
+++ b/components/trello/actions/search-cards/search-cards.mjs
@@ -1,0 +1,147 @@
+// legacy_hash_id: a_oVi3WN
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "trello-search-cards",
+  name: "Search Cards",
+  description: "Finds a Trello card by name.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    trello: {
+      type: "app",
+      app: "trello",
+    },
+    query: {
+      type: "string",
+      description: "The search query with a length of 1 to 16384 characters.",
+    },
+    idBoards: {
+      type: "string",
+      description: "mine or a comma-separated list of board ids.",
+      optional: true,
+    },
+    idOrganizations: {
+      type: "string",
+      description: "A comma-separated list of team ids.",
+      optional: true,
+    },
+    idCards: {
+      type: "string",
+      description: "A comma-separated list of card ids.",
+      optional: true,
+    },
+    card_fields: {
+      type: "string",
+      label: "Card Fields",
+      description: "all or a comma-separated list of: badges, checkItemStates, closed, dateLastActivity, desc, descData, due, email, idAttachmentCover, idBoard, idChecklists, idLabels, idList, idMembers, idMembersVoted, idShort, labels, manualCoverAttachment, name, pos, shortLink, shortUrl, subscribed, url",
+      optional: true,
+    },
+    cards_limit: {
+      type: "integer",
+      label: "Cards Limit",
+      description: "The maximum number of cards to return. Maximum: 1000",
+      optional: true,
+    },
+    cards_page: {
+      type: "integer",
+      label: "Cards Page",
+      description: "The page of results for cards. Maximum: 100",
+      optional: true,
+    },
+    card_board: {
+      type: "boolean",
+      label: "Card Board",
+      description: "Whether to include the parent board with card results.",
+      optional: true,
+    },
+    card_list: {
+      type: "boolean",
+      label: "Card List",
+      description: "Whether to include the parent list with card results.",
+      optional: true,
+    },
+    card_members: {
+      type: "boolean",
+      label: "Card Members",
+      description: "Whether to include member objects with card results.",
+      optional: true,
+    },
+    card_stickers: {
+      type: "boolean",
+      label: "Card Stickers",
+      description: "Whether to include sticker objects with card results.",
+      optional: true,
+    },
+    card_attachments: {
+      type: "boolean",
+      label: "Card Attachments",
+      description: "Whether to include attachment objects with card results. A boolean value (true or false) or cover for only card cover attachments.",
+      optional: true,
+    },
+    organization_fields: {
+      type: "string",
+      label: "Organization Fields",
+      description: "all or a comma-separated list of billableMemberCount, desc, descData, displayName, idBoards, invitations, invited, logoHash, memberships, name, powerUps, prefs, premiumFeatures, products, url, website",
+      optional: true,
+    },
+    organizations_limit: {
+      type: "integer",
+      label: "Organziations Limit",
+      description: "The maximum number of teams to return. Maximum 1000.",
+      optional: true,
+    },
+    member_fields: {
+      type: "string",
+      label: "Member Fields",
+      description: "all or a comma-separated list of: avatarHash, bio, bioData, confirmed, fullName, idPremOrgsAdmin, initials, memberType, products, status, url, username",
+      optional: true,
+    },
+    members_limit: {
+      type: "integer",
+      description: "The maximum number of members to return. Maximum 1000.",
+      optional: true,
+    },
+    partial: {
+      type: "boolean",
+      description: "By default, Trello searches for each word in your query against exactly matching words within Member content. Specifying partial to be true means that we will look for content that starts with any of the words in your query. If you are looking for a Card titled \"My Development Status Report\", by default you would need to search for \"Development\". If you have partial enabled, you will be able to search for \"dev\" but not \"velopment\".",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const trelloParams = [
+      "query",
+      "idBoards",
+      "idOrganizations",
+      "idCards",
+      "card_fields",
+      "cards_limit",
+      "cards_page",
+      "card_board",
+      "card_list",
+      "card_members",
+      "card_stickers",
+      "card_attachments",
+      "organization_fields",
+      "organizations_limit",
+      "member_fields",
+      "members_limit",
+      "partial",
+    ];
+    let p = this;
+
+    const queryString = trelloParams.filter((param) => p[param]).map((param) => `${param}=${p[param]}`)
+      .join("&");
+
+    return await axios($, {
+      url: `https://api.trello.com/1/search?modelTypes=cards&${queryString}`,
+      method: "GET",
+    }, {
+      token: {
+        key: this.trello.$auth.oauth_access_token,
+        secret: this.trello.$auth.oauth_refresh_token,
+      },
+      oauthSignerUri: this.trello.$auth.oauth_signer_uri,
+    });
+  },
+};

--- a/components/trello/actions/search-checklists/search-checklists.mjs
+++ b/components/trello/actions/search-checklists/search-checklists.mjs
@@ -1,0 +1,110 @@
+// legacy_hash_id: a_1WiqM5
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "trello-search-checklists",
+  name: "Find Checklist",
+  description: "Find a checklist on a particular board or card by name.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    trello: {
+      type: "app",
+      app: "trello",
+    },
+    type: {
+      type: "string",
+      description: "Whether to search boards or cards for the checklist.",
+      options: [
+        "board",
+        "card",
+      ],
+    },
+    id: {
+      type: "string",
+      description: "The ID of the board or card.",
+    },
+    query: {
+      type: "string",
+      description: "The query to search for.",
+    },
+    checkItems: {
+      type: "string",
+      description: "all or none",
+      optional: true,
+      options: [
+        "all",
+        "none",
+      ],
+    },
+    checkItem_fields: {
+      type: "string",
+      label: "CheckItem Fields",
+      description: "all or a comma-separated list of: name, nameData, pos, state, type",
+      optional: true,
+    },
+    filter: {
+      type: "string",
+      description: "all or none",
+      optional: true,
+      options: [
+        "all",
+        "none",
+      ],
+    },
+    fields: {
+      type: "string",
+      description: "all or a comma-separated list of: idBoard, idCard, name, pos",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    let type = this.type;
+    let id = this.id;
+    let query = this.query;
+    const trelloParams = [
+      "checkItems",
+      "checkItem_fields",
+      "filter",
+      "fields",
+    ];
+    let p = this;
+    let checklists = null;
+    let matches = [];
+
+    const queryString = trelloParams.filter((param) => p[param]).map((param) => `${param}=${p[param]}`)
+      .join("&");
+
+    if (type == "board") {
+      checklists = await axios($, {
+        url: `https://api.trello.com/1/boards/${id}/checklists?${queryString}`,
+        method: "GET",
+      }, {
+        token: {
+          key: this.trello.$auth.oauth_access_token,
+          secret: this.trello.$auth.oauth_refresh_token,
+        },
+        oauthSignerUri: this.trello.$auth.oauth_signer_uri,
+      });
+    } else if (type == "card") {
+      checklists = await axios($, {
+        url: `https://api.trello.com/1/cards/${id}/checklists?${queryString}`,
+        method: "GET",
+      }, {
+        token: {
+          key: this.trello.$auth.oauth_access_token,
+          secret: this.trello.$auth.oauth_refresh_token,
+        },
+        oauthSignerUri: this.trello.$auth.oauth_signer_uri,
+      });
+    }
+    if (checklists) {
+      checklists.forEach(function(checklist) {
+        if (checklist.name.includes(query))
+          matches.push(checklist);
+      });
+    }
+
+    return matches;
+  },
+};

--- a/components/trello/actions/search-members/search-members.mjs
+++ b/components/trello/actions/search-members/search-members.mjs
@@ -1,0 +1,61 @@
+// legacy_hash_id: a_8KiV84
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "trello-search-members",
+  name: "Search Members",
+  description: "Search for Trello members.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    trello: {
+      type: "app",
+      app: "trello",
+    },
+    query: {
+      type: "string",
+      description: "Search query 1 to 16384 characters long",
+    },
+    limit: {
+      type: "integer",
+      description: "The maximum number of results to return. Maximum of 20.",
+      optional: true,
+    },
+    idBoard: {
+      type: "string",
+      optional: true,
+    },
+    idOrganization: {
+      type: "string",
+      optional: true,
+    },
+    onlyOrgMembers: {
+      type: "boolean",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const trelloParams = [
+      "query",
+      "limit",
+      "idBoard",
+      "idOrganization",
+      "onlyOrgMembers",
+    ];
+    let p = this;
+
+    const queryString = trelloParams.filter((param) => p[param]).map((param) => `${param}=${p[param]}`)
+      .join("&");
+
+    return await axios($, {
+      url: `https://api.trello.com/1/search/members?${queryString}`,
+      method: "GET",
+    }, {
+      token: {
+        key: this.trello.$auth.oauth_access_token,
+        secret: this.trello.$auth.oauth_refresh_token,
+      },
+      oauthSignerUri: this.trello.$auth.oauth_signer_uri,
+    });
+  },
+};

--- a/components/trello/actions/update-card/update-card.mjs
+++ b/components/trello/actions/update-card/update-card.mjs
@@ -1,0 +1,140 @@
+// legacy_hash_id: a_2wimVb
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "trello-update-card",
+  name: "Update Card",
+  description: "Updates the specified card.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    trello: {
+      type: "app",
+      app: "trello",
+    },
+    id: {
+      type: "string",
+      description: "The ID of the card to update.",
+    },
+    name: {
+      type: "string",
+      description: "The new name for the card.",
+      optional: true,
+    },
+    desc: {
+      type: "string",
+      description: "The new description for the card.",
+      optional: true,
+    },
+    closed: {
+      type: "boolean",
+      description: "Whether the card should be archived (closed: true).",
+      optional: true,
+    },
+    idMembers: {
+      type: "string",
+      description: "Comma-separated list of member IDs.",
+      optional: true,
+    },
+    idAttachmentCover: {
+      type: "string",
+      description: "The ID of the image attachment the card should use as its cover, or null for none.",
+      optional: true,
+    },
+    idList: {
+      type: "string",
+      description: "The ID of the list the card should be in.",
+      optional: true,
+    },
+    idLabels: {
+      type: "string",
+      description: "Comma-separated list of label IDs.",
+      optional: true,
+    },
+    idBoard: {
+      type: "string",
+      description: "The ID of the board the card should be on.",
+      optional: true,
+    },
+    pos: {
+      type: "string",
+      description: "The position of the card in its list. top, bottom, or a positive float.",
+      optional: true,
+    },
+    due: {
+      type: "string",
+      description: "When the card is due, or null.",
+      optional: true,
+    },
+    dueComplete: {
+      type: "boolean",
+      description: "Whether the due date should be marked complete.",
+      optional: true,
+    },
+    subscribed: {
+      type: "boolean",
+      description: "Whether the member is should be subscribed to the card.",
+      optional: true,
+    },
+    address: {
+      type: "string",
+      description: "For use with/by the Map Power-Up,",
+      optional: true,
+    },
+    locationName: {
+      type: "string",
+      description: "For use with/by the Map Power-Up.",
+      optional: true,
+    },
+    coordinates: {
+      type: "string",
+      description: "For use with/by the Map Power-Up. Should be latitude, longitude.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const oauthSignerUri = this.trello.$auth.oauth_signer_uri;
+
+    let id = this.id;
+    const trelloParams = [
+      "name",
+      "desc",
+      "closed",
+      "idMembers",
+      "idAttachmentCover",
+      "idList",
+      "idLabels",
+      "idBoard",
+      "pos",
+      "due",
+      "dueComplete",
+      "subscribed",
+      "address",
+      "locationName",
+      "coordinates",
+    ];
+    let p = this;
+
+    const queryString = trelloParams.filter((param) => p[param]).map((param) => `${param}=${p[param]}`)
+      .join("&");
+
+    const config = {
+      url: `https://api.trello.com/1/cards/${id}?${queryString}`,
+      method: "PUT",
+      data: "",
+    };
+
+    const token = {
+      key: this.trello.$auth.oauth_access_token,
+      secret: this.trello.$auth.oauth_refresh_token,
+    };
+
+    const signConfig = {
+      token,
+      oauthSignerUri,
+    };
+
+    const resp = await axios($, config, signConfig);
+    return resp;
+  },
+};

--- a/components/webflow/actions/create-collection-item/create-collection-item.mjs
+++ b/components/webflow/actions/create-collection-item/create-collection-item.mjs
@@ -1,0 +1,53 @@
+// legacy_hash_id: a_q1ioGv
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "webflow-create-collection-item",
+  name: "Create Item",
+  description: "Create new collection item",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    webflow: {
+      type: "app",
+      app: "webflow",
+    },
+    collection_id: {
+      type: "string",
+    },
+    name: {
+      type: "string",
+    },
+    slug: {
+      type: "string",
+    },
+    _archived: {
+      type: "boolean",
+    },
+    _draft: {
+      type: "boolean",
+    },
+  },
+  async run({ $ }) {
+
+    return await axios($, {
+      method: "post",
+      url: `https://api.webflow.com/collections/${this.collection_id}/items`,
+
+      headers: {
+        "Authorization": `Bearer ${this.webflow.$auth.oauth_access_token}`,
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "accept-version": "1.0.0",
+      },
+      data: {
+        fields: {
+          name: this.name,
+          slug: this.slug,
+          _archived: this._archived,
+          _draft: this._draft,
+        },
+      },
+    });
+  },
+};

--- a/components/webflow/actions/create-live-collection-item/create-live-collection-item.mjs
+++ b/components/webflow/actions/create-live-collection-item/create-live-collection-item.mjs
@@ -1,0 +1,55 @@
+// legacy_hash_id: a_RAiabk
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "webflow-create-live-collection-item",
+  name: "Create Live Item",
+  description: "Create new live collection item",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    webflow: {
+      type: "app",
+      app: "webflow",
+    },
+    collection_id: {
+      type: "string",
+    },
+    name: {
+      type: "string",
+    },
+    slug: {
+      type: "string",
+    },
+    _archived: {
+      type: "boolean",
+      optional: true,
+    },
+    _draft: {
+      type: "boolean",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+
+    return await axios($, {
+      method: "post",
+      url: `https://api.webflow.com/collections/${this.collection_id}/items?live=true`,
+
+      headers: {
+        "Authorization": `Bearer ${this.webflow.$auth.oauth_access_token}`,
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "accept-version": "1.0.0",
+      },
+      data: {
+        fields: {
+          name: this.name,
+          slug: this.slug,
+          _archived: this._archived || false,
+          _draft: this._draft || false,
+        },
+      },
+    });
+  },
+};

--- a/components/webflow/actions/update-collection-item/update-collection-item.mjs
+++ b/components/webflow/actions/update-collection-item/update-collection-item.mjs
@@ -1,0 +1,56 @@
+// legacy_hash_id: a_OOiaG4
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "webflow-update-collection-item",
+  name: "Update Item",
+  description: "Update collection item",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    webflow: {
+      type: "app",
+      app: "webflow",
+    },
+    collection_id: {
+      type: "string",
+    },
+    item_id: {
+      type: "string",
+    },
+    name: {
+      type: "string",
+    },
+    slug: {
+      type: "string",
+    },
+    _archived: {
+      type: "boolean",
+    },
+    _draft: {
+      type: "boolean",
+    },
+  },
+  async run({ $ }) {
+
+    return await axios($, {
+      method: "put",
+      url: `https://api.webflow.com/collections/${this.collection_id}/items/${this.item_id}`,
+
+      headers: {
+        "Authorization": `Bearer ${this.webflow.$auth.oauth_access_token}`,
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "accept-version": "1.0.0",
+      },
+      data: {
+        fields: {
+          name: this.name,
+          slug: this.slug,
+          _archived: this._archived,
+          _draft: this._draft,
+        },
+      },
+    });
+  },
+};

--- a/components/webflow/actions/update-live-collection-item/update-live-collection-item.mjs
+++ b/components/webflow/actions/update-live-collection-item/update-live-collection-item.mjs
@@ -1,0 +1,56 @@
+// legacy_hash_id: a_LgijGX
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "webflow-update-live-collection-item",
+  name: "Update Live Item",
+  description: "Update live collection ltem",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    webflow: {
+      type: "app",
+      app: "webflow",
+    },
+    collection_id: {
+      type: "string",
+    },
+    item_id: {
+      type: "string",
+    },
+    name: {
+      type: "string",
+    },
+    slug: {
+      type: "string",
+    },
+    _archived: {
+      type: "boolean",
+    },
+    _draft: {
+      type: "boolean",
+    },
+  },
+  async run({ $ }) {
+
+    return await axios($, {
+      method: "put",
+      url: `https://api.webflow.com/collections/${this.collection_id}/items/${this.item_id}?live=true`,
+
+      headers: {
+        "Authorization": `Bearer ${this.webflow.$auth.oauth_access_token}`,
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "accept-version": "1.0.0",
+      },
+      data: {
+        fields: {
+          name: this.name,
+          slug: this.slug,
+          _archived: this._archived,
+          _draft: this._draft,
+        },
+      },
+    });
+  },
+};

--- a/components/wrike/actions/new-task/new-task.mjs
+++ b/components/wrike/actions/new-task/new-task.mjs
@@ -1,0 +1,122 @@
+// legacy_hash_id: a_0Mioz8
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "wrike-new-task",
+  name: "Wrike: Create Task",
+  description: "Create a Wrike task under a specified folder ID.",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    wrike: {
+      type: "app",
+      app: "wrike",
+    },
+    folder: {
+      type: "string",
+      label: "Folder ID",
+    },
+    title: {
+      type: "string",
+    },
+    desc: {
+      type: "string",
+      label: "Description",
+    },
+    priority: {
+      type: "string",
+      optional: true,
+    },
+    status: {
+      type: "string",
+      optional: true,
+    },
+    assignee: {
+      type: "string",
+      label: "Contact ID",
+      optional: true,
+    },
+    custID1: {
+      type: "string",
+      label: "Custom Field ID",
+      optional: true,
+    },
+    custVal1: {
+      type: "string",
+      label: "Custom Field Value",
+      optional: true,
+    },
+    custID2: {
+      type: "string",
+      label: "Custom Field ID",
+      optional: true,
+    },
+    custVal2: {
+      type: "string",
+      label: "Custom Field Value",
+      optional: true,
+    },
+    custID3: {
+      type: "string",
+      label: "Custom Field ID",
+      optional: true,
+    },
+    custVal3: {
+      type: "string",
+      label: "Custom Field Value",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    var info = {
+      title: this.title,
+      description: this.desc,
+    };
+    if (this.priority) {
+      info.importance = this.priority;
+    }
+    if (this.status) {
+      info.status = this.status;
+    }
+    if (this.assignee) {
+      info.responsibles = [
+        this.assignee,
+      ];
+    }
+
+    var customFields = [];
+    if (this.custID1 && this.custVal1) {
+      customFields.push({
+        id: this.custID1,
+        value: this.custVal1,
+      });
+    }
+    if (this.custID2 && this.custVal2) {
+      customFields.push({
+        id: this.custID2,
+        value: this.custVal2,
+      });
+    }
+    if (this.custID3 && this.custVal3) {
+      customFields.push({
+        id: this.custID3,
+        value: this.custVal3,
+      });
+    }
+    if (customFields.length > 0) {
+      info.customFields = customFields;
+    }
+
+    const task = await axios($, {
+      method: "POST",
+      url: `https://www.wrike.com/api/v4/folders/${this.folder}/tasks`,
+      headers: {
+        Authorization: `Bearer ${this.wrike.$auth.oauth_access_token}`,
+      },
+      data: info,
+    });
+    console.log(`Created new task ID "${task.data[0].id}".`);
+
+    return task;
+  },
+};

--- a/components/zoom/actions/add-meeting-registrant/add-meeting-registrant.mjs
+++ b/components/zoom/actions/add-meeting-registrant/add-meeting-registrant.mjs
@@ -1,0 +1,143 @@
+// legacy_hash_id: a_zNiweO
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "zoom-add-meeting-registrant",
+  name: "Add Meeting Registrant",
+  description: "Registers a participant for a meeting.",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    zoom: {
+      type: "app",
+      app: "zoom",
+    },
+    meeting_id: {
+      type: "string",
+      description: "The meeting ID.",
+    },
+    occurrence_ids: {
+      type: "string",
+      description: "Occurrence IDs. You can find these with the meeting get API. Multiple values separated by comma.",
+      optional: true,
+    },
+    email: {
+      type: "string",
+      description: "A valid email address of the registrant.",
+    },
+    first_name: {
+      type: "string",
+      description: "Registrant's first name.",
+    },
+    last_name: {
+      type: "string",
+      description: "Registrant's last name.",
+    },
+    address: {
+      type: "string",
+      description: "Registrant's address.",
+      optional: true,
+    },
+    city: {
+      type: "string",
+      description: "Registrant's city.",
+      optional: true,
+    },
+    country: {
+      type: "string",
+      description: "Registrant's country.",
+      optional: true,
+    },
+    zip: {
+      type: "string",
+      description: "Registrant's Zip/Postal code.",
+      optional: true,
+    },
+    state: {
+      type: "string",
+      description: "Registrant's State/Province.",
+      optional: true,
+    },
+    phone: {
+      type: "string",
+      description: "Registrant's Phone number.",
+      optional: true,
+    },
+    industry: {
+      type: "string",
+      description: "Registrant's industry.",
+      optional: true,
+    },
+    org: {
+      type: "string",
+      description: "Registrant's Organization.",
+      optional: true,
+    },
+    job_title: {
+      type: "string",
+      description: "Registrant's job title.",
+      optional: true,
+    },
+    purchasing_time_frame: {
+      type: "string",
+      description: "This field can be included to gauge interest of webinar attendees towards buying your product or service.",
+      optional: true,
+    },
+    role_in_purchase_process: {
+      type: "string",
+      description: "Role in Purchase Process.",
+      optional: true,
+    },
+    no_of_employees: {
+      type: "string",
+      description: "Number of Employees.",
+      optional: true,
+    },
+    comments: {
+      type: "string",
+      description: "A field that allows registrants to provide any questions or comments that they might have.",
+      optional: true,
+    },
+    custom_questions: {
+      type: "any",
+      description: "Custom questions.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  //See the API docs here: https://marketplace.zoom.us/docs/api-reference/zoom-api/meetings/meetingregistrantcreate
+    const config = {
+      method: "post",
+      url: `https://api.zoom.us/v2/meetings/${this.meeting_id}/registrants`,
+      params: {
+        occurrence_ids: this.occurrence_ids,
+      },
+      data: {
+        email: this.email,
+        first_name: this.first_name,
+        last_name: this.last_name,
+        address: this.address,
+        city: this.city,
+        country: this.country,
+        zip: this.zip,
+        state: this.state,
+        phone: this.phone,
+        industry: this.industry,
+        org: this.org,
+        job_title: this.job_title,
+        purchasing_time_frame: this.purchasing_time_frame,
+        role_in_purchase_process: this.role_in_purchase_process,
+        no_of_employees: this.no_of_employees,
+        comments: this.comments,
+        custom_questions: typeof this.custom_questions == "undefined"
+          ? this.custom_questions
+          : JSON.parse(this.custom_questions),
+      },
+      headers: {
+        "Authorization": `Bearer ${this.zoom.$auth.oauth_access_token}`,
+        "Content-Type": "application/json",
+      },
+    };
+    return await axios($, config);
+  },
+};

--- a/components/zoom/actions/add-webinar-registrant/add-webinar-registrant.mjs
+++ b/components/zoom/actions/add-webinar-registrant/add-webinar-registrant.mjs
@@ -1,0 +1,143 @@
+// legacy_hash_id: a_YEiPgP
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "zoom-add-webinar-registrant",
+  name: "Add Webinar Registrant",
+  description: "Registers a participant for a webinar.",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    zoom: {
+      type: "app",
+      app: "zoom",
+    },
+    webinar_id: {
+      type: "string",
+      description: "The webinar ID.",
+    },
+    occurrence_ids: {
+      type: "string",
+      description: "Occurrence IDs. You can find these with the meeting get API. Multiple values separated by comma.",
+      optional: true,
+    },
+    email: {
+      type: "string",
+      description: "A valid email address of the registrant.",
+    },
+    first_name: {
+      type: "string",
+      description: "Registrant's first name.",
+    },
+    last_name: {
+      type: "string",
+      description: "Registrant's last name.",
+    },
+    address: {
+      type: "string",
+      description: "Registrant's address.",
+      optional: true,
+    },
+    city: {
+      type: "string",
+      description: "Registrant's city.",
+      optional: true,
+    },
+    country: {
+      type: "string",
+      description: "Registrant's country.",
+      optional: true,
+    },
+    zip: {
+      type: "string",
+      description: "Registrant's Zip/Postal code.",
+      optional: true,
+    },
+    state: {
+      type: "string",
+      description: "Registrant's State/Province.",
+      optional: true,
+    },
+    phone: {
+      type: "string",
+      description: "Registrant's Phone number.",
+      optional: true,
+    },
+    industry: {
+      type: "string",
+      description: "Registrant's industry.",
+      optional: true,
+    },
+    org: {
+      type: "string",
+      description: "Registrant's Organization.",
+      optional: true,
+    },
+    job_title: {
+      type: "string",
+      description: "Registrant's job title.",
+      optional: true,
+    },
+    purchasing_time_frame: {
+      type: "string",
+      description: "This field can be included to gauge interest of webinar attendees towards buying your product or service.",
+      optional: true,
+    },
+    role_in_purchase_process: {
+      type: "string",
+      description: "Role in Purchase Process.",
+      optional: true,
+    },
+    no_of_employees: {
+      type: "string",
+      description: "Number of Employees.",
+      optional: true,
+    },
+    comments: {
+      type: "string",
+      description: "A field that allows registrants to provide any questions or comments that they might have.",
+      optional: true,
+    },
+    custom_questions: {
+      type: "any",
+      description: "Custom questions.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  //See the API docs here: https://marketplace.zoom.us/docs/api-reference/zoom-api/webinars/webinarregistrantcreate
+    const config = {
+      method: "post",
+      url: `https://api.zoom.us/v2/webinars/${this.webinar_id}/registrants`,
+      params: {
+        occurrence_ids: this.occurrence_ids,
+      },
+      data: {
+        email: this.email,
+        first_name: this.first_name,
+        last_name: this.last_name,
+        address: this.address,
+        city: this.city,
+        country: this.country,
+        zip: this.zip,
+        state: this.state,
+        phone: this.phone,
+        industry: this.industry,
+        org: this.org,
+        job_title: this.job_title,
+        purchasing_time_frame: this.purchasing_time_frame,
+        role_in_purchase_process: this.role_in_purchase_process,
+        no_of_employees: this.no_of_employees,
+        comments: this.comments,
+        custom_questions: typeof this.custom_questions == "undefined"
+          ? this.custom_questions
+          : JSON.parse(this.custom_questions),
+      },
+      headers: {
+        "Authorization": `Bearer ${this.zoom.$auth.oauth_access_token}`,
+        "Content-Type": "application/json",
+      },
+    };
+    return await axios($, config);
+  },
+};

--- a/components/zoom/actions/create-meeting/create-meeting.mjs
+++ b/components/zoom/actions/create-meeting/create-meeting.mjs
@@ -1,0 +1,96 @@
+// legacy_hash_id: a_l0i2Mn
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "zoom-create-meeting",
+  name: "Create Meeting",
+  description: "Creates a meeting for a user. A maximum of 100 meetings can be created for a user in a day.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    zoom: {
+      type: "app",
+      app: "zoom",
+    },
+    topic: {
+      type: "string",
+      description: "Meeting topic",
+      optional: true,
+    },
+    type: {
+      type: "integer",
+      description: "Meeting type:\n1 - Instant meeting.\n2 - Scheduled meeting.\n3 - Recurring meeting with no fixed time.\n8 - Recurring meeting with fixed time.",
+      optional: true,
+    },
+    start_time: {
+      type: "string",
+      description: "Meeting start time. We support two formats for start_time - local time and GMT.\nTo set time as GMT the format should be yyyy-MM-ddTHH:mm:ssZ.\nTo set time using a specific timezone, use yyyy-MM-ddTHH:mm:ss format and specify the timezone ID in the timezone field OR leave it blank and the timezone set on your Zoom account will be used. You can also set the time as UTC as the timezone field.\nThe start_time should only be used for scheduled and / or recurring webinars with fixed time.",
+      optional: true,
+    },
+    duration: {
+      type: "integer",
+      description: "Meeting duration (minutes). Used for scheduled meetings only.",
+      optional: true,
+    },
+    timezone: {
+      type: "string",
+      description: "Time zone to format start_time. For example, America/Los_Angeles. For scheduled meetings only. Please reference our time [zone list](https://marketplace.zoom.us/docs/api-reference/other-references/abbreviation-lists#timezones) for supported time zones and their formats.",
+      optional: true,
+    },
+    password: {
+      type: "string",
+      description: "Password to join the meeting. Password may only contain the following characters: [a-z A-Z 0-9 @ - _ *]. Max of 10 characters.",
+      optional: true,
+    },
+    agenda: {
+      type: "string",
+      description: "Meeting description.",
+      optional: true,
+    },
+    tracking_fields: {
+      type: "any",
+      description: "Tracking fields.",
+      optional: true,
+    },
+    recurrence: {
+      type: "object",
+      description: "Recurrence object",
+      optional: true,
+    },
+    settings: {
+      type: "string",
+      description: "Meeting settings.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  //See the API docs here: https://marketplace.zoom.us/docs/api-reference/zoom-api/meetings/meetingcreate
+    const config = {
+      method: "post",
+      url: "https://api.zoom.us/v2/users/me/meetings",
+      data: {
+        topic: this.topic,
+        type: this.type,
+        start_time: this.start_time,
+        duration: this.duration,
+        timezone: this.timezone,
+        password: this.password,
+        agenda: this.agenda,
+        tracking_fields: typeof this.tracking_fields == "undefined"
+          ? this.tracking_fields
+          : JSON.parse(this.tracking_fields),
+        recurrence: typeof this.recurrence == "undefined"
+          ? this.recurrence
+          : JSON.parse(this.recurrence),
+        settings: typeof this.settings == "undefined"
+          ? this.settings
+          : JSON.parse(this.settings),
+      },
+      headers: {
+        "Authorization": `Bearer ${this.zoom.$auth.oauth_access_token}`,
+        "Content-Type": "application/json",
+      },
+    };
+    return await axios($, config);
+  },
+};

--- a/components/zoom/actions/create-user/create-user.mjs
+++ b/components/zoom/actions/create-user/create-user.mjs
@@ -1,0 +1,48 @@
+// legacy_hash_id: a_poikQ1
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "zoom-create-user",
+  name: "Create User",
+  description: "Creates a new user in your account.",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    zoom: {
+      type: "app",
+      app: "zoom",
+    },
+    action: {
+      type: "string",
+      description: "Specify how to create the new user: <br>`create` - User will get an email sent from Zoom. There is a confirmation link in this email. The user will then need to use the link to activate their Zoom account. The user can then set or change their password.<br>`autoCreate` - This action is provided for the enterprise customer who has a managed domain. This feature is disabled by default because of the security risk involved in creating a user who does not belong to your domain.<br>`custCreate` - Users created via this option do not have passwords and will not have the ability to log into the Zoom Web Portal or the Zoom Client. To use this option, you must contact the ISV Platform Sales team at isv@zoom.us.<br>`ssoCreate` - This action is provided for the enabled Pre-provisioning SSO User option. A user created in this way has no password. If not a basic user, a personal vanity URL using the user name (no domain) of the provisioning email will be generated. If the user name or PMI is invalid or occupied, it will use a random number or random personal vanity URL.",
+      options: [
+        "create",
+        "autoCreate",
+        "custCreate",
+        "ssoCreate",
+      ],
+    },
+    user_info: {
+      type: "object",
+      description: "Object with the user information. It has the following properties:\nemail: User email address\ntype: User type:<br>`1` - Basic.<br>`2` - Licensed.<br>`3` - On-prem.\nfirst_name: User's first name: cannot contain more than 5 Chinese words.\nlast_name: User's last name: cannot contain more than 5 Chinese words.\npassword: User password. Only used for the \\\"autoCreate\\\" function. The password has to have a minimum of 8 characters and maximum of 32 characters. It must have at least one letter (a, b, c..), at least one number (1, 2, 3...) and include both uppercase and lowercase letters. It should not contain only one identical character repeatedly ('11111111' or 'aaaaaaaa') and it cannot contain consecutive characters ('12345678' or 'abcdefgh').",
+    },
+  },
+  async run({ $ }) {
+  //See the API docs here: https://marketplace.zoom.us/docs/api-reference/zoom-api/users/usercreate
+    const config = {
+      method: "post",
+      url: "https://api.zoom.us/v2/users",
+      data: {
+        action: this.action,
+        user_info: typeof this.user_info == "undefined"
+          ? this.user_info
+          : JSON.parse(this.user_info),
+      },
+      headers: {
+        "Authorization": `Bearer ${this.zoom.$auth.oauth_access_token}`,
+        "Content-Type": "application/json",
+      },
+    };
+    return await axios($, config);
+  },
+};

--- a/components/zoom/actions/delete-user/delete-user.mjs
+++ b/components/zoom/actions/delete-user/delete-user.mjs
@@ -1,0 +1,68 @@
+// legacy_hash_id: a_a4iKYo
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "zoom-delete-user",
+  name: "Delete User",
+  description: "Disassociates (unlinks) a user from the associated account or permanently deletes a user.",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    zoom: {
+      type: "app",
+      app: "zoom",
+    },
+    user_id: {
+      type: "string",
+      description: "The user ID or email address of the user.",
+    },
+    action: {
+      type: "string",
+      description: "Delete action options:<br>`disassociate` - Disassociate a user.<br>`delete`-  Permanently delete a user.<br>Note: To delete pending user in the account, use `disassociate",
+      optional: true,
+      options: [
+        "disassociate",
+        "delete",
+      ],
+    },
+    transfer_email: {
+      type: "string",
+      description: "Transfer email.",
+      optional: true,
+    },
+    transfer_meeting: {
+      type: "boolean",
+      description: "Transfer meeting.",
+      optional: true,
+    },
+    transfer_webinar: {
+      type: "boolean",
+      description: "Transfer webinar.",
+      optional: true,
+    },
+    transfer_recording: {
+      type: "boolean",
+      description: "Transfer recording.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  //See the API docs here: https://marketplace.zoom.us/docs/api-reference/zoom-api/users/userdelete
+    const config = {
+      method: "delete",
+      url: `https://api.zoom.us/v2/users/${this.user_id}`,
+      params: {
+        action: this.action,
+        transfer_email: this.transfer_email,
+        transfer_meeting: this.transfer_meeting,
+        transfer_webinar: this.transfer_webinar,
+        transfer_recording: this.transfer_recording,
+      },
+      headers: {
+        "Authorization": `Bearer ${this.zoom.$auth.oauth_access_token}`,
+        "Content-Type": "application/json",
+      },
+    };
+    return await axios($, config);
+  },
+};

--- a/components/zoom/actions/get-meeting-details/get-meeting-details.mjs
+++ b/components/zoom/actions/get-meeting-details/get-meeting-details.mjs
@@ -1,0 +1,38 @@
+// legacy_hash_id: a_Xzi12a
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "zoom-get-meeting-details",
+  name: "Get Meeting Details",
+  description: "Retrieves the details of a meeting.",
+  version: "0.3.1",
+  type: "action",
+  props: {
+    zoom: {
+      type: "app",
+      app: "zoom",
+    },
+    meeting_id: {
+      type: "integer",
+      description: "The meeting ID.",
+    },
+    occurrence_id: {
+      type: "string",
+      description: "Meeting occurrence ID.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  //See the API docs here: https://marketplace.zoom.us/docs/api-reference/zoom-api/meetings/meeting
+    const config = {
+      url: `https://api.zoom.us/v2/meetings/${this.meeting_id}`,
+      params: {
+        occurrence_id: this.occurrence_id,
+      },
+      headers: {
+        Authorization: `Bearer ${this.zoom.$auth.oauth_access_token}`,
+      },
+    };
+    return await axios($, config);
+  },
+};

--- a/components/zoom/actions/get-webinar-details/get-webinar-details.mjs
+++ b/components/zoom/actions/get-webinar-details/get-webinar-details.mjs
@@ -1,0 +1,38 @@
+// legacy_hash_id: a_WYie0m
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "zoom-get-webinar-details",
+  name: "Get Webinar Details",
+  description: "Gets details of a scheduled webinar.",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    zoom: {
+      type: "app",
+      app: "zoom",
+    },
+    webinar_id: {
+      type: "integer",
+      description: "The webinar ID.",
+    },
+    occurrence_id: {
+      type: "string",
+      description: "Unique Identifier that identifies an occurrence of a recurring webinar.  Recurring webinars can have a maximum of 50 occurrences.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  //See the API docs here: https://marketplace.zoom.us/docs/api-reference/zoom-api/webinars/webinar
+    const config = {
+      url: `https://api.zoom.us/v2/webinars/${this.webinar_id}`,
+      params: {
+        occurrence_id: this.occurrence_id,
+      },
+      headers: {
+        Authorization: `Bearer ${this.zoom.$auth.oauth_access_token}`,
+      },
+    };
+    return await axios($, config);
+  },
+};

--- a/components/zoom/actions/view-user/view-user.mjs
+++ b/components/zoom/actions/view-user/view-user.mjs
@@ -1,0 +1,24 @@
+// legacy_hash_id: a_Q3iw4N
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "zoom-view-user",
+  name: "View User",
+  description: "View your user information",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    zoom: {
+      type: "app",
+      app: "zoom",
+    },
+  },
+  async run({ $ }) {
+    return await axios($, {
+      url: "https://api.zoom.us/v2/users/me",
+      headers: {
+        Authorization: `Bearer ${this.zoom.$auth.oauth_access_token}`,
+      },
+    });
+  },
+};


### PR DESCRIPTION
Adds component actions converted from legacy actions for these apps:
`gitlab`, `linear_app`, `bitbucket`, `asana`, `trello`, `webflow`, `coinbase`, `buildkite`, `paypal`, `coinmarketcap`, `digital_ocean`, `frontapp`, `instapaper`, `sendfox`, `moosend`, `openweather_api`, `onesignal_rest_api`, `klaviyo`, `medium`, `zoom`, `cloudflare_api_key`, `aws`, `feedbin`, `browserless`, `jira`, `pipedrive`, `sftp`, `wrike`, `honeybadger`, `algolia`, `smugmug`, `ringcentral`