### PR TITLE
Fix errors publishing converted s3 & gitlab action

### DIFF
--- a/components/aws/actions/stream-file-to-s3/stream-file-to-s3.mjs
+++ b/components/aws/actions/stream-file-to-s3/stream-file-to-s3.mjs
@@ -1,6 +1,6 @@
 // legacy_hash_id: a_a4i84m
 import AWS from "aws-sdk";
-import { get } from "axios";
+import axios from "axios";
 
 export default {
   key: "aws-stream-file-to-s3",
@@ -43,7 +43,7 @@ export default {
       accessKeyId,
       secretAccessKey,
     });
-    const urlResponse = await get(fileUrl, {
+    const urlResponse = await axios.get(fileUrl, {
       responseType: "stream",
     });
     const s3Response = await s3.upload({

--- a/components/gitlab/actions/list-project-issues/list-project-issues.mjs
+++ b/components/gitlab/actions/list-project-issues/list-project-issues.mjs
@@ -1,5 +1,5 @@
 // legacy_hash_id: a_EVioWG
-import requestPromise from "request-promise";
+import { axios } from "@pipedream/platform";
 
 export default {
   key: "gitlab-list-project-issues",
@@ -276,8 +276,8 @@ export default {
     }
 
     try {
-      $.export("resp", await requestPromise({
-        uri: `https://gitlab.com/api/v4/projects/${this.id}/issues${queryString}`,
+      $.export("resp", await axios($, {
+        url: `https://gitlab.com/api/v4/projects/${this.id}/issues${queryString}`,
         headers: {
           Authorization: `Bearer ${this.gitlab.$auth.oauth_access_token}`,
         },


### PR DESCRIPTION
**Changes**
- In the Gitlab **List Project Issues** action, replaces `request-promise` package with `@pipedream/platform` axios
- In the AWS **Stream File to S3** action, changes the `axios` pkg `import` statement from a named import to default import

**Context**

- Gitlab **List Project Issues** ([error message](https://github.com/PipedreamHQ/pipedream/runs/5222557755?check_suite_focus=true#step:5:331))

There was an error publishing the Gitlab List Project Issues action:
```
status: 500, body: {"error":"unexpected error, please contact support@pipedream.com"}
```

The action becomes publishable when the "request-promise" package is replaced with "@pipedream/platform" in `list-project-issues.mjs`.

- AWS **Stream File to S3** ([error message](https://github.com/PipedreamHQ/pipedream/runs/5222557755?check_suite_focus=true#step:5:153))

Attempting to publish `stream-file-to-s3.mjs` produced the error:
```
400, body: {"error":"{\"name\":\"UserError\",\"message\":\"SyntaxError: The requested module 'axios' does not provide an export named 'get'\"}"}
```

'axios' is a CommonJS module, which does not support 'get' as a named export.

The action becomes publishable after replacing the named import with the default import and calling `.get` from the default import:

```
import axios from "axios";
axios.get({
```