### PR TITLE
Rev version for Jira Create Issue action to re-attempt publish

### DIFF
--- a/components/jira/actions/create-issue/create-issue.mjs
+++ b/components/jira/actions/create-issue/create-issue.mjs
@@ -5,7 +5,7 @@ export default {
   key: "jira-create-issue",
   name: "Create Issue",
   description: "Creates an issue or, where the option to create subtasks is enabled in Jira, a subtask.",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
   props: {
     jira: {


### PR DESCRIPTION
Fixes `Validation failed: Semantic version 0.1.1 is not publishable, it must be greater than 0.1.1 with components/jira/actions/create-issue/create-issue.mjs`