### PR TITLE
Add converted legacy actions: Calendly-Xero

### DIFF
--- a/components/activecampaign/actions/add-contact-to-automation/add-contact-to-automation.mjs
+++ b/components/activecampaign/actions/add-contact-to-automation/add-contact-to-automation.mjs
@@ -1,0 +1,74 @@
+// legacy_hash_id: a_xqig4J
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "activecampaign-add-contact-to-automation",
+  name: "Add Contact to Automation",
+  description: "Adds an existing contact to an existing automation.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    activecampaign: {
+      type: "app",
+      app: "activecampaign",
+    },
+    automation: {
+      type: "string",
+      description: "List segment ID (0 for no segment).",
+      optional: true,
+    },
+    contact_id: {
+      type: "string",
+      optional: true,
+    },
+    contact_email: {
+      type: "string",
+      optional: true,
+    },
+    api_output: {
+      type: "string",
+      description: "Response format: `xml`, `json`, or `serialize` (default is `xml`)",
+      optional: true,
+      options: [
+        "xml",
+        "json",
+        "serialize",
+      ],
+    },
+  },
+  async run({ $ }) {
+  // See the API docs: https://www.activecampaign.com/api/example.php?call=automation_contact_add
+
+    if (!this.automation || (!this.contact_id && !this.contact_email)) {
+      throw new Error("Must provide automation, and one of contact_id or contact_email parameters.");
+    }
+
+    //Prepares query string parameters object of the request
+    var queryParams = {
+      api_action: "automation_contact_add",
+      api_key: this.activecampaign.$auth.api_key,
+      api_output: this.api_output,
+    };
+
+    //Prepares body parameters of the recrets. API endpoint not taking object, works as string.
+    var data = `automation=${this.automation}&`;
+    if (this.contact_id) {
+      data += `contact_id=${this.contact_id}`;
+    } else {
+      data += `contact_email=${this.contact_email}`;
+    }
+
+    //Sends the request against Active Campaign API
+    const config = {
+      method: "post",
+      url: `${this.activecampaign.$auth.base_url}/admin/api.php`,
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      params: queryParams,
+      data,
+    };
+
+    return axios($, config);
+  },
+};

--- a/components/activecampaign/actions/create-deal/create-deal.mjs
+++ b/components/activecampaign/actions/create-deal/create-deal.mjs
@@ -1,0 +1,105 @@
+// legacy_hash_id: a_Mdi7Jj
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "activecampaign-create-deal",
+  name: "Create Deal",
+  description: "Creates a new deal.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    activecampaign: {
+      type: "app",
+      app: "activecampaign",
+    },
+    title: {
+      type: "string",
+      description: "Deal's title.",
+    },
+    value: {
+      type: "integer",
+      description: "Deal's value in cents. (i.e. $456.78 => 45678). Must be greater than or equal to zero.",
+    },
+    currency: {
+      type: "string",
+      description: "Deal's currency in 3-digit ISO format, lowercased.",
+    },
+    description: {
+      type: "string",
+      description: "Deal's description.",
+      optional: true,
+    },
+    account: {
+      type: "string",
+      description: "Deal's account id.",
+      optional: true,
+    },
+    contact: {
+      type: "string",
+      description: "Deal's primary contact's id.",
+      optional: true,
+    },
+    group: {
+      type: "string",
+      description: "Deal's pipeline id. Required if `deal.stage` is not provided. If `deal.group` is not provided, the stage's pipeline will be assigned to the deal automatically.",
+      optional: true,
+    },
+    stage: {
+      type: "string",
+      description: "Deal's stage id. Required if `deal.group` is not provided. If `deal.stage` is not provided, the deal will be assigned with the first stage in the pipeline provided in `deal.group`.",
+      optional: true,
+    },
+    owner: {
+      type: "string",
+      description: "Deal's owner id. Required if pipeline's auto-assign option is disabled.",
+      optional: true,
+    },
+    percent: {
+      type: "integer",
+      description: "Deal's percentage.",
+      optional: true,
+    },
+    status: {
+      type: "integer",
+      description: "Deal's status. Valid values:\n* `0` - Open\n* `1` - Won\n* `2` - Lost",
+      optional: true,
+    },
+    fields: {
+      type: "any",
+      description: "Deal's custom field values [{customFieldId, fieldValue}]",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  // See the API docs: https://developers.activecampaign.com/reference#create-a-deal-new
+
+    if (!this.title || !this.value || !this.currency) {
+      throw new Error("Must provide title, value, and currency parameters.");
+    }
+
+    const config = {
+      method: "post",
+      url: `${this.activecampaign.$auth.base_url}/api/3/deals`,
+      headers: {
+        "Api-Token": `${this.activecampaign.$auth.api_key}`,
+      },
+      data: {
+        deal: {
+          title: this.title,
+          description: this.description,
+          account: this.account,
+          contact: this.contact,
+          value: parseInt(this.value),
+          currency: this.currency,
+          group: this.group,
+          stage: this.stage,
+          owner: this.owner,
+          percent: parseInt(this.percent),
+          status: parseInt(this.status),
+          fields: this.fields,
+        },
+      },
+    };
+    return await axios($, config);
+  },
+};

--- a/components/activecampaign/actions/create-note/create-note.mjs
+++ b/components/activecampaign/actions/create-note/create-note.mjs
@@ -1,0 +1,58 @@
+// legacy_hash_id: a_zNiJ3R
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "activecampaign-create-note",
+  name: "Create Note",
+  description: "Adds a note, arbitrary information to a contact, deal, or other Active Campaign objects.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    activecampaign: {
+      type: "app",
+      app: "activecampaign",
+    },
+    note: {
+      type: "string",
+      description: "The note's text.",
+    },
+    reltype: {
+      type: "string",
+      description: "The related type where the note will be added to. Possible Values: `Activity`, `Deal`, `DealTask`, `Subscriber`, `CustomerAccount`",
+      options: [
+        "Activity",
+        "Deal",
+        "DealTask",
+        "Subscriber",
+        "CustomerAccount",
+      ],
+    },
+    relid: {
+      type: "integer",
+      description: "Id of the related object where the note is being added.",
+    },
+  },
+  async run({ $ }) {
+  // See the API docs: https://developers.activecampaign.com/reference#notes
+
+    if (!this.note || !this.reltype || !this.relid) {
+      throw new Error("Must provide note, reltype, and relid parameters.");
+    }
+
+    const config = {
+      method: "post",
+      url: `${this.activecampaign.$auth.base_url}/api/3/notes`,
+      headers: {
+        "Api-Token": `${this.activecampaign.$auth.api_key}`,
+      },
+      data: {
+        note: {
+          note: this.note,
+          reltype: this.reltype,
+          relid: parseInt(this.relid),
+        },
+      },
+    };
+    return await axios($, config);
+  },
+};

--- a/components/activecampaign/actions/create-or-update-contact/create-or-update-contact.mjs
+++ b/components/activecampaign/actions/create-or-update-contact/create-or-update-contact.mjs
@@ -1,0 +1,77 @@
+// legacy_hash_id: a_poiz1V
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "activecampaign-create-or-update-contact",
+  name: "Create or Update Contact",
+  description: "Creates a new contact or updates an existing contact.",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    activecampaign: {
+      type: "app",
+      app: "activecampaign",
+    },
+    email: {
+      type: "string",
+      description: "Email address of the contact. Example: 'test@example.com'.",
+    },
+    firstName: {
+      type: "string",
+      description: "First name of the contact.",
+      optional: true,
+    },
+    lastName: {
+      type: "string",
+      description: "Last name of the contact.",
+      optional: true,
+    },
+    phone: {
+      type: "integer",
+      description: "Phone number of the contact.",
+      optional: true,
+    },
+    fieldValues: {
+      type: "any",
+      description: "Contact's custom field values [{field, value}]",
+      optional: true,
+    },
+    orgid: {
+      type: "integer",
+      description: "(Deprecated) Please use Account-Contact end points.",
+      optional: true,
+    },
+    deleted: {
+      type: "boolean",
+      description: "(Deprecated) Please use the DELETE endpoint.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  // See the API docs: https://developers.activecampaign.com/reference#create-or-update-contact-new
+
+    if (!this.email) {
+      throw new Error("Must provide email parameter.");
+    }
+
+    const config = {
+      method: "post",
+      url: `${this.activecampaign.$auth.base_url}/api/3/contact/sync`,
+      headers: {
+        "Api-Token": `${this.activecampaign.$auth.api_key}`,
+      },
+      data: {
+        contact: {
+          email: this.email,
+          firstName: this.firstName,
+          lastName: this.lastName,
+          phone: parseInt(this.phone),
+          fieldValues: this.fieldValues,
+          orgid: parseInt(this.orgid),
+          deleted: this.deleted,
+        },
+      },
+    };
+    return await axios($, config);
+  },
+};

--- a/components/activecampaign/actions/create-tracked-event/create-tracked-event.mjs
+++ b/components/activecampaign/actions/create-tracked-event/create-tracked-event.mjs
@@ -2,12 +2,16 @@
 import { axios } from "@pipedream/platform";
 
 export default {
-  key: "app_placeholder-activecampaign-tracked-event",
+  key: "activecampaign-create-tracked-event",
   name: "Create Tracked Event",
   description: "Tracks an event using event tracking.",
   version: "0.1.1",
   type: "action",
   props: {
+    activecampaign: {
+      type: "app",
+      app: "activecampaign",
+    },
     key: {
       type: "string",
       description: "This value is unique to your ActiveCampaign account and can be found named \"Event Key\" on Settings > Tracking > Event Tracking inside your ActiveCampaign account.",

--- a/components/activecampaign/actions/find-contact/find-contact.mjs
+++ b/components/activecampaign/actions/find-contact/find-contact.mjs
@@ -1,0 +1,39 @@
+// legacy_hash_id: a_bKilPw
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "activecampaign-find-contact",
+  name: "Find Contact",
+  description: "Finds a contact by email address.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    activecampaign: {
+      type: "app",
+      app: "activecampaign",
+    },
+    email: {
+      type: "string",
+      description: "Email address of the contact you want to get.",
+    },
+  },
+  async run({ $ }) {
+  // See the API docs: https://developers.activecampaign.com/reference#list-all-contacts
+
+    if (!this.email) {
+      throw new Error("Must provide email parameter.");
+    }
+
+    const config = {
+      url: `${this.activecampaign.$auth.base_url}/api/3/contacts`,
+      headers: {
+        "Api-Token": `${this.activecampaign.$auth.api_key}`,
+      },
+      params: {
+        "email": this.email,
+      },
+    };
+
+    return await axios($, config);
+  },
+};

--- a/components/activecampaign/actions/find-deal/find-deal.mjs
+++ b/components/activecampaign/actions/find-deal/find-deal.mjs
@@ -1,0 +1,46 @@
+// legacy_hash_id: a_l0i8LA
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "activecampaign-find-deal",
+  name: "Find Deal",
+  description: "Finds an existing deal by title or email.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    activecampaign: {
+      type: "app",
+      app: "activecampaign",
+    },
+    filters_title: {
+      type: "string",
+      description: "Filter by deal's title.",
+      optional: true,
+    },
+    filters_email: {
+      type: "string",
+      description: "Filter by deal's contact email.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  // See the API docs: https://developers.activecampaign.com/reference#list-all-deals
+
+    if (!this.filters_title && !this.filters_email) {
+      throw new Error("Must provide filters_title or filters_email parameter.");
+    }
+
+    const config = {
+      url: `${this.activecampaign.$auth.base_url}/api/3/deals`,
+      headers: {
+        "Api-Token": `${this.activecampaign.$auth.api_key}`,
+      },
+      params: {
+        "filters[title]": this.filters_title,
+        "filters[email]": this.filters_email,
+      },
+    };
+
+    return await axios($, config);
+  },
+};

--- a/components/activecampaign/actions/get-ac-contact-by-email/get-ac-contact-by-email.mjs
+++ b/components/activecampaign/actions/get-ac-contact-by-email/get-ac-contact-by-email.mjs
@@ -1,0 +1,32 @@
+// legacy_hash_id: a_oVi7Vk
+import axiosModule from "axios";
+
+export default {
+  key: "activecampaign-get-ac-contact-by-email",
+  name: "Get ActiveCampaign Contact by Email",
+  version: "0.9.1",
+  type: "action",
+  props: {
+    activecampaign: {
+      type: "app",
+      app: "activecampaign",
+    },
+    email: {
+      type: "string",
+    },
+  },
+  async run() {
+    let axios = axiosModule.default;
+
+    const config = {
+      method: "get",
+      url: `${this.activecampaign.$auth.base_url}/api/3/contacts?search=${this.email}`, // todo: api path
+      headers: {
+        "Api-Token": `${this.activecampaign.$auth.api_key}`,
+      },
+    };
+    return await axios(config).then((res) => {
+      return res.data.contacts || [];
+    });
+  },
+};

--- a/components/activecampaign/actions/get-all-lists/get-all-lists.mjs
+++ b/components/activecampaign/actions/get-all-lists/get-all-lists.mjs
@@ -1,0 +1,28 @@
+// legacy_hash_id: a_67iLjr
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "activecampaign-get-all-lists",
+  name: "Get All Lists",
+  description: "Retrieves all contact lists.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    activecampaign: {
+      type: "app",
+      app: "activecampaign",
+    },
+  },
+  async run({ $ }) {
+  // See the API docs: https://developers.activecampaign.com/reference#retrieve-all-lists
+
+    const config = {
+      url: `${this.activecampaign.$auth.base_url}/api/3/lists`,
+      headers: {
+        "Api-Token": `${this.activecampaign.$auth.api_key}`,
+      },
+    };
+
+    return await axios($, config);
+  },
+};

--- a/components/activecampaign/actions/get-contact/get-contact.mjs
+++ b/components/activecampaign/actions/get-contact/get-contact.mjs
@@ -1,0 +1,36 @@
+// legacy_hash_id: a_G1iLx4
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "activecampaign-get-contact",
+  name: "Get Contact",
+  description: "Retrieves an existing contact.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    activecampaign: {
+      type: "app",
+      app: "activecampaign",
+    },
+    contact_id: {
+      type: "string",
+      description: "ID of the contact to retrieve.",
+    },
+  },
+  async run({ $ }) {
+  // See the API docs: https://developers.activecampaign.com/reference#get-contact
+
+    if (!this.contact_id) {
+      throw new Error("Must provide contact_id parameter.");
+    }
+
+    const config = {
+      url: `${this.activecampaign.$auth.base_url}/api/3/contacts/${this.contact_id}`,
+      headers: {
+        "Api-Token": `${this.activecampaign.$auth.api_key}`,
+      },
+    };
+
+    return await axios($, config);
+  },
+};

--- a/components/activecampaign/actions/get-deal/get-deal.mjs
+++ b/components/activecampaign/actions/get-deal/get-deal.mjs
@@ -1,0 +1,36 @@
+// legacy_hash_id: a_l0i8kA
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "activecampaign-get-deal",
+  name: "Get Deal",
+  description: "Retrieves an existing deal.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    activecampaign: {
+      type: "app",
+      app: "activecampaign",
+    },
+    deal_id: {
+      type: "string",
+      description: "ID of the deal to retrieve.",
+    },
+  },
+  async run({ $ }) {
+  // See the API docs: https://developers.activecampaign.com/reference#retrieve-a-deal
+
+    if (!this.deal_id) {
+      throw new Error("Must provide deal_id parameter.");
+    }
+
+    const config = {
+      url: `${this.activecampaign.$auth.base_url}/api/3/deals/${this.deal_id}`,
+      headers: {
+        "Api-Token": `${this.activecampaign.$auth.api_key}`,
+      },
+    };
+
+    return await axios($, config);
+  },
+};

--- a/components/activecampaign/actions/get-tags-for-contact/get-tags-for-contact.mjs
+++ b/components/activecampaign/actions/get-tags-for-contact/get-tags-for-contact.mjs
@@ -1,0 +1,32 @@
+// legacy_hash_id: a_2wipeG
+import axiosModule from "axios";
+
+export default {
+  key: "activecampaign-get-tags-for-contact",
+  name: "Get Contact Tags",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    activecampaign: {
+      type: "app",
+      app: "activecampaign",
+    },
+    contact_id: {
+      type: "string",
+    },
+  },
+  async run() {
+    const axios = axiosModule.default;
+
+    const config = {
+      method: "get",
+      url: `${this.activecampaign.$auth.base_url}/api/3/contacts/${this.contact_id}/contactTags`,
+      headers: {
+        "Api-Token": `${this.activecampaign.$auth.api_key}`,
+      },
+    };
+    return await axios(config).then((res) => {
+      return res.data || [];
+    });
+  },
+};

--- a/components/activecampaign/actions/list-all-contacts/list-all-contacts.mjs
+++ b/components/activecampaign/actions/list-all-contacts/list-all-contacts.mjs
@@ -1,0 +1,214 @@
+// legacy_hash_id: a_bKilj2
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "activecampaign-list-all-contacts",
+  name: "List All Contacts",
+  description: "Retrieve all existing contacts.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    activecampaign: {
+      type: "app",
+      app: "activecampaign",
+    },
+    ids: {
+      type: "string",
+      description: "Filter contacts by ID. Can be repeated for multiple IDs. Example: ids[]=1&ids[]=2&ids[]=42",
+      optional: true,
+    },
+    email: {
+      type: "string",
+      description: "Email address of the contact you want to get",
+      optional: true,
+    },
+    email_like: {
+      type: "string",
+      description: "Filter contacts that contain the given value in the email address",
+      optional: true,
+    },
+    exclude: {
+      type: "string",
+      description: "Exclude from the response the contact with the given ID",
+      optional: true,
+    },
+    formid: {
+      type: "string",
+      description: "Filter contacts associated with the given form",
+      optional: true,
+    },
+    id_greater: {
+      type: "string",
+      description: "Only include contacts with an ID greater than the given ID",
+      optional: true,
+    },
+    id_less: {
+      type: "string",
+      description: "Only include contacts with an ID less than the given ID",
+      optional: true,
+    },
+    listid: {
+      type: "string",
+      description: "Filter contacts associated with the given list",
+      optional: true,
+    },
+    organization: {
+      type: "string",
+      description: "(Deprecated) Please use Account-Contact end points. Filter contacts associated with the given organization ID",
+      optional: true,
+    },
+    search: {
+      type: "string",
+      description: "Filter contacts that match the given value in the contact names, organization, phone or email",
+      optional: true,
+    },
+    segmentid: {
+      type: "string",
+      description: "Return only contacts that match a list segment (this param initially returns segment information, when it is run a second time it will return contacts that match the segment)",
+      optional: true,
+    },
+    seriesid: {
+      type: "string",
+      description: "Filter contacts associated with the given automation",
+      optional: true,
+    },
+    status: {
+      type: "string",
+      description: "See [available values](https://developers.activecampaign.com/reference#section-contact-parameters-available-values)",
+      optional: true,
+    },
+    tagid: {
+      type: "string",
+      description: "Filter contacts associated with the given tag",
+      optional: true,
+    },
+    created_before: {
+      type: "string",
+      description: "Filter contacts that were created prior to this date",
+      optional: true,
+    },
+    created_after: {
+      type: "string",
+      description: "Filter contacts that were created after this date",
+      optional: true,
+    },
+    updated_before: {
+      type: "string",
+      description: "Filter contacts that were updated before this date",
+      optional: true,
+    },
+    updated_after: {
+      type: "string",
+      description: "Filter contacts that were updated after this date",
+      optional: true,
+    },
+    waitid: {
+      type: "string",
+      description: "Filter by contacts in the wait queue of an automation block",
+      optional: true,
+    },
+    cdate: {
+      type: "string",
+      description: "Order contacts by creation date",
+      optional: true,
+      options: [
+        "ASC",
+        "DESC",
+      ],
+    },
+    oemail: {
+      type: "string",
+      description: "Order contacts by email",
+      optional: true,
+      options: [
+        "ASC",
+        "DESC",
+      ],
+    },
+    first_name: {
+      type: "string",
+      description: "Order contacts by first name",
+      optional: true,
+      options: [
+        "ASC",
+        "DESC",
+      ],
+    },
+    last_name: {
+      type: "string",
+      description: "Order contacts by last name",
+      optional: true,
+      options: [
+        "ASC",
+        "DESC",
+      ],
+    },
+    name: {
+      type: "string",
+      description: "Order contacts by full name",
+      optional: true,
+      options: [
+        "ASC",
+        "DESC",
+      ],
+    },
+    score: {
+      type: "string",
+      description: "Order contacts by score",
+      optional: true,
+      options: [
+        "ASC",
+        "DESC",
+      ],
+    },
+    in_group_lists: {
+      type: "string",
+      description: "Set this to `true` in order to return only contacts that the current user has permissions to see.",
+      optional: true,
+      options: [
+        "ASC",
+        "DESC",
+      ],
+    },
+  },
+  async run({ $ }) {
+  //See the API docs: https://developers.activecampaign.com/reference#list-all-contacts
+
+    const config = {
+      url: `${this.activecampaign.$auth.base_url}/api/3/contacts`,
+      headers: {
+        "Api-Token": `${this.activecampaign.$auth.api_key}`,
+      },
+      params: {
+        "ids": this.ids,
+        "email": this.email,
+        "email_like": this.email_like,
+        "exclude": this.exclude,
+        "formid": this.formid,
+        "id_greater": this.id_greater,
+        "id_less": this.id_less,
+        "listid": this.listid,
+        "organization": this.organization,
+        "search": this.search,
+        "segmentid": this.segmentid,
+        "seriesid": this.seriesid,
+        "status": this.status,
+        "tagid": this.tagid,
+        "filters[created_before]": this.created_before,
+        "filters[created_after]": this.created_after,
+        "filters[updated_before]": this.updated_before,
+        "filters[updated_after]": this.updated_after,
+        "waitid": this.waitid,
+        "orders[cdate]": this.cdate,
+        "orders[email]": this.oemail,
+        "orders[first_name]": this.first_name,
+        "orders[last_name]": this.last_name,
+        "orders[name]": this.name,
+        "orders[score]": this.score,
+        "in_group_lists": this.in_group_lists,
+      },
+    };
+
+    return await axios($, config);
+  },
+};

--- a/components/activecampaign/actions/tag-ac-contact/tag-ac-contact.mjs
+++ b/components/activecampaign/actions/tag-ac-contact/tag-ac-contact.mjs
@@ -1,0 +1,44 @@
+// legacy_hash_id: a_PNiBWG
+import axiosModule from "axios";
+
+export default {
+  key: "activecampaign-tag-ac-contact",
+  name: "Tag ActiveCampaign Contact",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    activecampaign: {
+      type: "app",
+      app: "activecampaign",
+    },
+    contact_id: {
+      type: "string",
+      label: "Contact ID",
+      description: "Activecampaign contact id",
+    },
+    tag_id: {
+      type: "string",
+      label: "Tag ID",
+      description: "Activecampaign tag id",
+    },
+  },
+  async run() {
+    let axios = axiosModule.default;
+
+    const config = {
+      method: "post",
+      url: `${this.activecampaign.$auth.base_url}/api/3/contactTags`, // todo: api path
+      headers: {
+        "Api-Token": `${this.activecampaign.$auth.api_key}`,
+      },
+      // todo: data
+      data: {
+        contactTag: {
+          contact: this.contact_id,
+          tag: this.tag_id,
+        },
+      },
+    };
+    return await axios(config);
+  },
+};

--- a/components/activecampaign/actions/update-deal/update-deal.mjs
+++ b/components/activecampaign/actions/update-deal/update-deal.mjs
@@ -1,0 +1,117 @@
+// legacy_hash_id: a_Q3ixw3
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "activecampaign-update-deal",
+  name: "Update Deal",
+  description: "Updates an existing deal.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    activecampaign: {
+      type: "app",
+      app: "activecampaign",
+    },
+    deal_id: {
+      type: "string",
+      description: "Id of the deal to update.",
+    },
+    title: {
+      type: "string",
+      description: "Deal's title.",
+      optional: true,
+    },
+    description: {
+      type: "string",
+      description: "Deal's description.",
+      optional: true,
+    },
+    account: {
+      type: "string",
+      description: "Deal's account id.",
+      optional: true,
+    },
+    contact: {
+      type: "string",
+      description: "Deal's primary contact id.",
+      optional: true,
+    },
+    value: {
+      type: "string",
+      description: "Deal's value in cents. (i.e. $456.78 => 45678). Must be greater than or equal to zero. int32 datatype.",
+      optional: true,
+    },
+    currency: {
+      type: "string",
+      description: "Deal's currency in 3-digit ISO format, lowercased.",
+      optional: true,
+    },
+    group: {
+      type: "string",
+      description: "Deal's pipeline id. Deal's stage or `deal.stage` should belong to `deal.group`.",
+      optional: true,
+    },
+    stage: {
+      type: "string",
+      description: "Deal's stage id. `deal.stage` should belong to Deal's pipeline or `deal.group`.",
+      optional: true,
+    },
+    owner: {
+      type: "string",
+      description: "Deal's owner id.",
+      optional: true,
+    },
+    percent: {
+      type: "string",
+      description: "Deal's percentage. int32 datatype.",
+      optional: true,
+    },
+    status: {
+      type: "string",
+      description: "Deal's status. Available values:\n* `0` - Open\n* `1` - Won\n* `2` - Lost",
+      optional: true,
+      options: [
+        "0",
+        "1",
+        "2",
+      ],
+    },
+    fields: {
+      type: "any",
+      description: "Deal's custom field values [{customFieldId, fieldValue}].",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  // See the API docs: https://developers.activecampaign.com/reference#update-a-deal-new
+
+    if (!this.deal_id) {
+      throw new Error("Must provide deal_id parameter.");
+    }
+
+    const config = {
+      method: "put",
+      url: `${this.activecampaign.$auth.base_url}/api/3/deals/${this.deal_id}`,
+      headers: {
+        "Api-Token": `${this.activecampaign.$auth.api_key}`,
+      },
+      data: {
+        deal: {
+          title: this.title,
+          description: this.description,
+          account: this.account,
+          contact: this.contact,
+          value: this.value,
+          currency: this.currency,
+          group: this.group,
+          stage: this.stage,
+          owner: this.owner,
+          percent: this.percent,
+          status: this.status,
+          fields: this.fields,
+        },
+      },
+    };
+    return await axios($, config);
+  },
+};

--- a/components/app_placeholder/actions/activecampaign-tracked-event/activecampaign-tracked-event.mjs
+++ b/components/app_placeholder/actions/activecampaign-tracked-event/activecampaign-tracked-event.mjs
@@ -1,0 +1,60 @@
+// legacy_hash_id: a_3Lie1M
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "app_placeholder-activecampaign-tracked-event",
+  name: "Create Tracked Event",
+  description: "Tracks an event using event tracking.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    key: {
+      type: "string",
+      description: "This value is unique to your ActiveCampaign account and can be found named \"Event Key\" on Settings > Tracking > Event Tracking inside your ActiveCampaign account.",
+    },
+    event: {
+      type: "string",
+      description: "The name of the event you wish to track.",
+    },
+    actid: {
+      type: "string",
+      description: "This value is unique to your ActiveCampaign account and can be found named \"actid\" on Settings > Tracking > Event Tracking API.",
+    },
+    visit_email_address: {
+      type: "string",
+      description: "The url encoded email address of the contact you wish to track this event for. (e.g. visit={\"email\":\"email_address_here\"})",
+    },
+    eventdata: {
+      type: "string",
+      description: "A value you wish to store for the event.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  // See the API docs: https://developers.activecampaign.com/reference#track-event
+  // Note: Event Tracking must be enabled on in your ActiveCampaign account on Settings > Tracking > Event Tracking
+
+    if (!this.key || !this.event || !this.actid || !this.visit_email_address) {
+      throw new Error("Must provide key, event, actid, and visit_email_address parameters.");
+    }
+
+    const config = {
+      method: "post",
+      url: "https://trackcmp.net/event",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      params: {
+        actid: this.actid,
+        key: this.key,
+        event: this.event,
+        eventdata: this.eventdata,
+        visit: {
+          email: encodeURIComponent(this.visit_email_address),
+        },
+      },
+    };
+
+    return await axios($, config);
+  },
+};

--- a/components/aws/actions/dynamodb-create-table/dynamodb-create-table.mjs
+++ b/components/aws/actions/dynamodb-create-table/dynamodb-create-table.mjs
@@ -1,0 +1,111 @@
+// legacy_hash_id: a_dvirB4
+import AWS from "aws-sdk";
+
+export default {
+  key: "aws-dynamodb-create-table",
+  name: "DynamoDB - Create Table",
+  description: "Adds a new table to your account.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    aws: {
+      type: "app",
+      app: "aws",
+    },
+    stream_specification: {
+      type: "object",
+      description: "The settings parameter for DynamoDB Streams on the table. This settings parameter consists of the following properties: \n* `StreamEnabled`: Indicates whether DynamoDB Streams is to be enabled (true) or disabled (false), boolean, required.\n* `StreamViewType`: When an item in the table is modified, `StreamViewType` determines what information is written to the table's stream. Valid values: `KEYS_ONLY`, `NEW_IMAGE`, `OLD_IMAGE`, `NEW_AND_OLD_IMAGES`",
+      optional: true,
+    },
+    attribute_definitions: {
+      type: "any",
+      description: "An Array < map > of attributes that describe the key schema for the table and indexes. Each map element has the following properties:\n\n* `AttributeName`: Name for the attribute, required.\n\n* `AttributeType`:  The data type for the attribute, required; possible values: `S` for data type String, `N` for data type Number, and `B` for data type Binary.",
+      optional: true,
+    },
+    table_name: {
+      type: "string",
+      description: "The name of the table to create.",
+      optional: true,
+    },
+    key_schema: {
+      type: "any",
+      description: "An Array < map > that specifies the attributes that make up the primary key for a table or an index. The attributes in `KeySchema` must also be defined in the `AttributeDefinitions` array. For more information, see [Data Model](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DataModel.html) in the *Amazon DynamoDB Developer Guide*. Each `KeySchemaElement` in the array is composed of:\n\n* `AttributeName`, The name of this key attribute.\n\n* `KeyType` - The role that key attribute will assume. Possible values: `HASH` - for partition key, and `RANGE` for sort key.",
+      optional: true,
+    },
+    region: {
+      type: "string",
+      description: "The region to send service requests to.",
+    },
+    provisioned_throughput: {
+      type: "object",
+      description: "Represents the provisioned throughput settings for a specified table or index. If you set BillingMode as PROVISIONED, you must specify this property. Parameters properties are:\n* `ReadCapacityUnits`, required integer, max. number of strongly consistent reads consumed per second before DynamoDB returns a `ThrottlingException`.\n* `WriteCapacityUnits`, required integer, max. number of writes consumed per second before DynamoDB returns a `ThrottlingException`.",
+      optional: true,
+    },
+    local_secondary_indexes: {
+      type: "any",
+      description: "An Array < map > that specifies that one or more local secondary indexes (the maximum is 5) to be created on the table. Each index is scoped to a given partition key value. There is a 10 GB size limit per partition key value; otherwise, the size of a local secondary index is unconstrained.",
+      optional: true,
+    },
+    global_secondary_indexes: {
+      type: "any",
+      description: "An Array < map > that specifies that one or more global secondary indexes (the maximum is 20) to be created on the table.",
+      optional: true,
+    },
+    billing_mode: {
+      type: "string",
+      description: "Controls how you are charged for read and write throughput and how you manage capacity. This setting can be changed later.\n\n* `PROVISIONED` - We recommend using `PROVISIONED` for predictable workloads. `PROVISIONED` sets the billing mode to [Provisioned Mode](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.ProvisionedThroughput.Manual).\n\n* `PAY_PER_REQUEST` - We recommend using `PAY_PER_REQUEST` for unpredictable workloads. `PAY_PER_REQUEST` sets the billing mode to [On-Demand Mode](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.OnDemand).",
+      optional: true,
+      options: [
+        "PROVISIONED",
+        "PAY_PER_REQUEST",
+      ],
+    },
+    sse_specification: {
+      type: "object",
+      description: "Represents the settings used to enable server-side encryption.",
+      optional: true,
+    },
+    tags: {
+      type: "any",
+      description: "A list of key-value pairs to label the table. For more information, see [Tagging for DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tagging.html). \n* `Key`: The key of the tag. Tag keys are case sensitive. Each DynamoDB table can only have up to one tag with the same key. If you try to add an existing tag (same key), the existing tag value will be updated to the new value.\n* `Value`: The value of the tag. Tag values are case-sensitive and can be null.",
+      optional: true,
+    },
+  },
+  async run() {
+    // See the API docs: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#createTable-property
+
+    const {
+      accessKeyId,
+      secretAccessKey,
+    } = this.aws.$auth;
+    const streamSpecification = this.stream_specification;
+
+    if (!this.attribute_definitions || !this.table_name || !this.key_schema ||
+          !this.region || (typeof streamSpecification.StreamEnabled == "undefined") || !this.provisioned_throughput) {
+      throw new Error("Must provide attribute_definitions, table_name, key_schema, region, stream_specification.StreamEnabled, provisioned_throughput parameters.");
+    }
+
+    const dynamodb = new AWS.DynamoDB({
+      accessKeyId,
+      secretAccessKey,
+      region: this.region,
+    });
+
+    //Prepares parameters of the request
+    var dynamoDbParams = {
+      AttributeDefinitions: this.attribute_definitions,
+      TableName: this.table_name,
+      KeySchema: this.key_schema,
+      LocalSecondaryIndexes: this.local_secondary_indexes,
+      GlobalSecondaryIndexes: this.global_secondary_indexes,
+      BillingMode: this.billing_mode,
+      ProvisionedThroughput: this.provisioned_throughput,
+      StreamSpecification: this.stream_specification,
+      SSESpecification: this.sse_specification,
+      Tags: this.tags,
+    };
+
+    //Sends the request using the DynamoDB AWS object
+    return await dynamodb.createTable(dynamoDbParams).promise();
+  },
+};

--- a/components/aws/actions/dynamodb-execute-statement/dynamodb-execute-statement.mjs
+++ b/components/aws/actions/dynamodb-execute-statement/dynamodb-execute-statement.mjs
@@ -1,0 +1,57 @@
+// legacy_hash_id: a_l0i7r1
+import AWS from "aws-sdk";
+
+export default {
+  key: "aws-dynamodb-execute-statement",
+  name: "DynamoDB - Execute Statement",
+  description: "This operation allows you to perform transactional reads or writes on data stored in DynamoDB, using PartiQL.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    aws: {
+      type: "app",
+      app: "aws",
+    },
+    transact_statements: {
+      type: "any",
+      description: "Array < map > of PartiQL statements representing the transaction to run. Each element in the  array is composed of:\n* Statement - A PartiQL statment that uses parameters (required).\n* Parameters - Array <map>with the parameter values.",
+    },
+    region: {
+      type: "string",
+      description: "The region to send service requests to.",
+      optional: true,
+    },
+    client_request_token: {
+      type: "string",
+      description: "Set this value to get remaining results, if `NextToken` was returned in the statement response.",
+      optional: true,
+    },
+  },
+  async run() {
+    //See the API docs: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#executeTransaction-property
+
+    const {
+      accessKeyId,
+      secretAccessKey,
+    } = this.aws.$auth;
+
+    if (!this.transact_statements || !this.region) {
+      throw new Error("Must provide transact_statements, and region parameters.");
+    }
+
+    const dynamodb = new AWS.DynamoDB({
+      accessKeyId,
+      secretAccessKey,
+      region: this.region,
+    });
+
+    //Prepares parameters of the request
+    var dynamoDbParams = {
+      TransactStatements: this.transact_statements,
+      ClientRequestToken: this.client_request_token,
+    };
+
+    //Sends the request using the DynamoDB AWS object
+    return await dynamodb.executeTransaction(dynamoDbParams).promise();
+  },
+};

--- a/components/aws/actions/dynamodb-get-item/dynamodb-get-item.mjs
+++ b/components/aws/actions/dynamodb-get-item/dynamodb-get-item.mjs
@@ -1,0 +1,59 @@
+// legacy_hash_id: a_3Li6pk
+import AWS from "aws-sdk";
+
+export default {
+  key: "aws-dynamodb-get-item",
+  name: "DynamoDB - Get Item",
+  description: "The GetItem operation returns a set of attributes for the item with the given primary key. If there is no matching item, GetItem does not return any data and there will be no Item element in the response.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    aws: {
+      type: "app",
+      app: "aws",
+    },
+    table_name: {
+      type: "string",
+      description: "Name of table where item to get is located.",
+    },
+    table_keys: {
+      type: "string",
+      description: "A map of attribute names to `AttributeValue` objects, representing the primary key of the item to retrieve.\n\nFor the primary key, you must provide all of the attributes. For example, with a simple primary key, you only need to provide a value for the partition key. For a composite primary key, you must provide values for both the partition key and the sort key.",
+    },
+    region: {
+      type: "string",
+      description: "The AWS region to send service requests to.",
+    },
+  },
+  async run() {
+    //See the API docs: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#getItem-property
+
+    const {
+      table_name,
+      table_keys,
+      region,
+    } = this;
+    const {
+      accessKeyId,
+      secretAccessKey,
+    } = this.aws.$auth;
+
+    if (!table_name || !table_keys || !region) {
+      throw new Error("Must provide table_name, table_keys, and region parameters.");
+    }
+
+    const dynamodb = new AWS.DynamoDB({
+      accessKeyId,
+      secretAccessKey,
+      region,
+    });
+
+    //Prepares requets parameters and sends the AWS service request
+    const dynamoDbParams = {
+      Key: table_keys,
+      TableName: table_name,
+    };
+
+    return await dynamodb.getItem(dynamoDbParams).promise();
+  },
+};

--- a/components/aws/actions/dynamodb-put-item/dynamodb-put-item.mjs
+++ b/components/aws/actions/dynamodb-put-item/dynamodb-put-item.mjs
@@ -1,0 +1,118 @@
+// legacy_hash_id: a_RAiXL5
+import AWS from "aws-sdk";
+
+export default {
+  key: "aws-dynamodb-put-item",
+  name: "DynamoDB - Put Item",
+  description: "Creates a new item, or replaces an old item with a new item.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    aws: {
+      type: "app",
+      app: "aws",
+    },
+    table_name: {
+      type: "string",
+      description: "The name of the table to contain the item.",
+    },
+    item: {
+      type: "object",
+      description: "A map of attribute name/value pairs, one for each attribute. Only the primary key attributes are required; you can optionally provide other attribute name-value pairs for the item.\n\nYou must provide all of the attributes for the primary key. For example, with a simple primary key, you only need to provide a value for the partition key. For a composite primary key, you must provide both values for both the partition key and the sort key.\n\nIf you specify any attributes that are part of an index key, then the data types for those attributes must match those of the schema in the table's attribute definition.",
+      optional: true,
+    },
+    region: {
+      type: "string",
+      description: "The region to send service requests to.",
+      optional: true,
+    },
+    expected: {
+      type: "object",
+      description: "This is a legacy parameter. Use |ConditionExpression| instead. For more information, see [Expected](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.Expected.html) in the *Amazon DynamoDB Developer Guide.*",
+      optional: true,
+    },
+    return_values: {
+      type: "string",
+      description: "Use `ReturnValues` if you want to get the item attributes as they appeared before they were updated with the `PutItem` request. For `PutItem`, the valid values are:\n\n`NONE` - If `ReturnValues` is not specified, or if its value is `NONE`, then nothing is returned. (This setting is the default for `ReturnValues`.)\n\n`ALL_OLD` - If `PutItem` overwrote an attribute name-value pair, then the content of the old item is returned.",
+      optional: true,
+      options: [
+        "NONE",
+        "ALL_OLD",
+      ],
+    },
+    return_consumed_capacity: {
+      type: "string",
+      description: "Determines the level of detail about provisioned throughput consumption that is returned in the response. Possible values include: `INDEXES`, `TOTAL`, `NONE`.",
+      optional: true,
+      options: [
+        "INDEXES",
+        "TOTAL",
+        "NONE",
+      ],
+    },
+    return_item_collection_metrics: {
+      type: "string",
+      description: "Determines whether item collection metrics are returned. If set to `SIZE`, the response includes statistics about item collections, if any, that were modified during the operation are returned in the response. If set to `NONE` (the default), no statistics are returned. Possible values include: `SIZE`, `NONE`.",
+      optional: true,
+      options: [
+        "SIZE",
+        "NONE",
+      ],
+    },
+    conditional_operator: {
+      type: "string",
+      description: "This is a legacy parameter. Use `ConditionExpression` instead. For more information, see [ConditionalOperator](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.ConditionalOperator.html) in the *Amazon DynamoDB Developer Guide*.",
+      optional: true,
+    },
+    condition_expression: {
+      type: "string",
+      description: "A condition that must be satisfied in order for a conditional `PutItem` to succeed. An expression can contain any of the following: functions, comparison operators, logical operators. For more information about condition expressions, see [Condition Expressions](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html) in the *Amazon DynamoDB Developer Guide*.",
+      optional: true,
+    },
+    expression_attributeNames: {
+      type: "object",
+      description: "One or more substitution tokens for attribute names in an expression. The following are some use cases for using `ExpressionAttributeNames`:\n\n* To access an attribute whose name conflicts with a DynamoDB reserved word.\n* To create a placeholder for repeating occurrences of an attribute name in an expression.\n* To prevent special characters in an attribute name from being misinterpreted in an expression.\n\nUse the # character in an expression to dereference an attribute name.",
+      optional: true,
+    },
+    expression_attribute_values: {
+      type: "object",
+      description: "One or more values that can be substituted in an expression. Use the : (colon) character in an expression to dereference an attribute value. For more information on expression attribute values, see [Condition Expressions](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html) in the *Amazon DynamoDB Developer Guide*.",
+      optional: true,
+    },
+  },
+  async run() {
+    //See the API docs: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#putItem-property
+
+    const {
+      accessKeyId,
+      secretAccessKey,
+    } = this.aws.$auth;
+
+    if (!this.table_name || !this.item || !this.region) {
+      throw new Error("Must provide table_name, item, and region parameters.");
+    }
+
+    const dynamodb = new AWS.DynamoDB({
+      accessKeyId,
+      secretAccessKey,
+      region: this.region,
+    });
+
+    //Prepares parameters of the request
+    var dynamoDbParams = {
+      TableName: this.table_name,
+      Item: this.item,
+      Expected: this.expected,
+      ReturnValues: this.return_values,
+      ReturnConsumedCapacity: this.return_consumed_capacity,
+      ReturnItemCollectionMetrics: this.return_item_collection_metrics,
+      ConditionalOperator: this.conditional_operator,
+      ConditionExpression: this.condition_expression,
+      ExpressionAttributeNames: this.expression_attributeNames,
+      ExpressionAttributeValues: this.expression_attribute_values,
+    };
+
+    //Sends the request using the DynamoDB AWS object
+    return await dynamodb.putItem(dynamoDbParams).promise();
+  },
+};

--- a/components/aws/actions/dynamodb-query/dynamodb-query.mjs
+++ b/components/aws/actions/dynamodb-query/dynamodb-query.mjs
@@ -1,0 +1,153 @@
+// legacy_hash_id: a_OOibob
+import AWS from "aws-sdk";
+
+export default {
+  key: "aws-dynamodb-query",
+  name: "DynamoDB - Query",
+  description: "The query operation finds items based on primary key values.",
+  version: "0.4.1",
+  type: "action",
+  props: {
+    aws: {
+      type: "app",
+      app: "aws",
+    },
+    key_condition_expression: {
+      type: "string",
+      description: "The condition that specifies the key values for items to be retrieved by the `Query` action. The condition must perform an equality test on a single partition key value. The condition can optionally perform one of several comparison tests on a single sort key value. This allows `Query` to retrieve one item with a given partition key value and sort key value, or several items that have the same partition key value but different sort key values.",
+      optional: true,
+    },
+    key_conditions: {
+      type: "object",
+      description: "This is a legacy parameter. Use `KeyConditionExpression` instead. For more information, see [KeyConditions](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.KeyConditions.html) in the *Amazon DynamoDB Developer Guide.*",
+      optional: true,
+    },
+    table_name: {
+      type: "string",
+      description: "The name of the table containing the requested items.",
+    },
+    region: {
+      type: "string",
+      description: "The region to send service requests to.",
+    },
+    index_name: {
+      type: "string",
+      description: "The name of an index to query. This index can be any local secondary index or global secondary index on the table. Note that if you use the `IndexName` parameter, you must also provide `TableName`.",
+      optional: true,
+    },
+    select: {
+      type: "string",
+      description: "The attributes to be returned in the result. You can retrieve all item attributes, specific item attributes, the count of matching items, or in the case of an index, some or all of the attributes projected into the index. Possible values: `ALL_ATTRIBUTES`, `ALL_PROJECTED_ATTRIBUTES`, `COUNT`, `SPECIFIC_ATTRIBUTES`",
+      optional: true,
+    },
+    attributes_to_get: {
+      type: "string",
+      description: "This is a legacy parameter. Use `ProjectionExpression` instead. For more information, see [AttributesToGet](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.AttributesToGet.html) in the *Amazon DynamoDB Developer Guide.*",
+      optional: true,
+    },
+    limit: {
+      type: "integer",
+      description: "The maximum number of items to evaluate (not necessarily the number of matching items). If DynamoDB processes the number of items up to the limit while processing the results, it stops the operation and returns the matching values up to that point, and a key in `LastEvaluatedKey` to apply in a subsequent operation, so that you can pick up where you left off. Also, if the processed dataset size exceeds 1 MB before DynamoDB reaches this limit, it stops the operation and returns the matching values up to the limit, and a key in `LastEvaluatedKey` to apply in a subsequent operation to continue the operation. For more information, see [Query and Scan](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScan.html) in the *Amazon DynamoDB Developer Guide.*",
+      optional: true,
+    },
+    consistent_read: {
+      type: "boolean",
+      description: "Determines the read consistency model: If set to `true`, then the operation uses strongly consistent reads; otherwise, the operation uses eventually consistent reads. Strongly consistent reads are not supported on global secondary indexes. If you query a global secondary index with `ConsistentRead` set to `true`, you will receive a `ValidationException`.",
+      optional: true,
+    },
+    query_filter: {
+      type: "object",
+      description: "This is a legacy parameter. Use `FilterExpression` instead. For more information, see [QueryFilter](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.QueryFilter.html) in the *Amazon DynamoDB Developer Guide.*",
+      optional: true,
+    },
+    conditional_operator: {
+      type: "string",
+      description: "This is a legacy parameter. Use `FilterExpression` instead. For more information, see [ConditionalOperator](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.ConditionalOperator.html) in the *Amazon DynamoDB Developer Guide.*",
+      optional: true,
+    },
+    scan_index_forward: {
+      type: "boolean",
+      description: "Specifies the order for index traversal: If `true` (default), the traversal is performed in ascending order; if `false`, the traversal is performed in descending order.",
+      optional: true,
+    },
+    exclusive_startKey: {
+      type: "object",
+      description: "The primary key of the first item that this operation will evaluate. Use the value that was returned for `LastEvaluatedKey` in the previous operation.",
+      optional: true,
+    },
+    return_consumed_capacity: {
+      type: "string",
+      description: "Determines the level of detail about provisioned throughput consumption that is returned in the response. Possible values include:  `INDEXES`, `TOTAL`, `NONE`.",
+      optional: true,
+      options: [
+        "INDEXES",
+        "TOTAL",
+        "NONE",
+      ],
+    },
+    projection_expression: {
+      type: "string",
+      description: "A string that identifies one or more attributes to retrieve from the table. These attributes can include scalars, sets, or elements of a JSON document. The attributes in the expression must be separated by commas. If no attribute names are specified, then all attributes will be returned. If any of the requested attributes are not found, they will not appear in the result. For more information, see [Accessing Item Attributes](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html) in the *Amazon DynamoDB Developer Guide.*",
+      optional: true,
+    },
+    filter_expression: {
+      type: "string",
+      description: "A string that contains conditions that DynamoDB applies after the `Query` operation, but before the data is returned to you. Items that do not satisfy the `FilterExpression` criteria are not returned.\n\nA `FilterExpression` does not allow key attributes. You cannot define a filter expression based on a partition key or a sort key.",
+      optional: true,
+    },
+    expression_attributeNames: {
+      type: "object",
+      description: "One or more substitution tokens for attribute names in an expression. The following are some use cases for using `ExpressionAttributeNames`:\n\n* To access an attribute whose name conflicts with a DynamoDB reserved word.\n* To create a placeholder for repeating occurrences of an attribute name in an expression.\n* To prevent special characters in an attribute name from being misinterpreted in an expression.\n\nUse the # character in an expression to dereference an attribute name.",
+      optional: true,
+    },
+    expression_attribute_values: {
+      type: "object",
+      description: "One or more values that can be substituted in an expression. Use the : (colon) character in an expression to dereference an attribute value. For more information on expression attribute values, see [Condition Expressions](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html) in the *Amazon DynamoDB Developer Guide*.",
+      optional: true,
+    },
+  },
+  async run() {
+    //See the API docs: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#query-property
+
+    const {
+      accessKeyId,
+      secretAccessKey,
+    } = this.aws.$auth;
+
+    if ( !(this.key_condition_expression
+      ? !this.key_conditions
+      : this.key_conditions ) || !this.table_name || !this.region) {
+      throw new Error("Must provide exclusively key_condition_expression or key_conditions, and table_name, region  parameters.");
+    }
+
+    const dynamodb = new AWS.DynamoDB({
+      accessKeyId,
+      secretAccessKey,
+      region: this.region,
+    });
+
+    //Prepares parameters of the request
+    var dynamoDbParams = {
+      TableName: this.table_name,
+      IndexName: this.index_name,
+      Select: this.select,
+      AttributesToGet: this.attributes_to_get,
+      Limit: this.limit,
+      ConsistentRead: this.consistent_read,
+      KeyConditions: this.key_conditions,
+      QueryFilter: this.query_filter,
+      ConditionalOperator: this.conditional_operator,
+      ScanIndexForward: this.scan_index_forward,
+      ExclusiveStartKey: this.exclusive_startKey,
+      ReturnConsumedCapacity: this.return_consumed_capacity,
+      ProjectionExpression: this.projection_expression,
+      FilterExpression: this.filter_expression,
+      KeyConditionExpression: this.key_condition_expression,
+      ExpressionAttributeNames: this.expression_attributeNames,
+      ExpressionAttributeValues: this.expression_attribute_values,
+    };
+
+    //Sends the request using the DynamoDB AWS object
+    return await dynamodb.query(dynamoDbParams).promise();
+  },
+};

--- a/components/aws/actions/dynamodb-scan/dynamodb-scan.mjs
+++ b/components/aws/actions/dynamodb-scan/dynamodb-scan.mjs
@@ -1,0 +1,152 @@
+// legacy_hash_id: a_bKirwV
+import AWS from "aws-sdk";
+
+export default {
+  key: "aws-dynamodb-scan",
+  name: "DynamoDB - Scan",
+  description: "The Scan operation returns one or more items and item attributes by accessing every item in a table or a secondary index.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    aws: {
+      type: "app",
+      app: "aws",
+    },
+    table_name: {
+      type: "string",
+      description: "The name of the table containing the requested items.",
+    },
+    region: {
+      type: "string",
+      description: "The region to send service requests to.",
+    },
+    index_name: {
+      type: "string",
+      description: "The name of a secondary index to scan. This index can be any local secondary index or global secondary index. Note that if you use the `IndexName` parameter, you must also provide `TableName`.",
+      optional: true,
+    },
+    select: {
+      type: "string",
+      description: "The attributes to be returned in the result. You can retrieve all item attributes, specific item attributes, the count of matching items, or in the case of an index, some or all of the attributes projected into the index. Possible values: `ALL_ATTRIBUTES`, `ALL_PROJECTED_ATTRIBUTES`, `COUNT`, `SPECIFIC_ATTRIBUTES`",
+      optional: true,
+      options: [
+        "ALL_ATTRIBUTES",
+        "ALL_PROJECTED_ATTRIBUTES",
+        "COUNT",
+        "SPECIFIC_ATTRIBUTES",
+      ],
+    },
+    attributes_to_get: {
+      type: "any",
+      description: "This is a legacy parameter. Use `ProjectionExpression` instead. For more information, see [AttributesToGet](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.AttributesToGet.html) in the *Amazon DynamoDB Developer Guide.*",
+      optional: true,
+    },
+    limit: {
+      type: "integer",
+      description: "The maximum number of items to evaluate (not necessarily the number of matching items). If DynamoDB processes the number of items up to the limit while processing the results, it stops the operation and returns the matching values up to that point, and a key in `LastEvaluatedKey` to apply in a subsequent operation, so that you can pick up where you left off. Also, if the processed dataset size exceeds 1 MB before DynamoDB reaches this limit, it stops the operation and returns the matching values up to the limit, and a key in `LastEvaluatedKey` to apply in a subsequent operation to continue the operation. For more information, see [Query and Scan](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScan.html) in the *Amazon DynamoDB Developer Guide.*",
+      optional: true,
+    },
+    consistent_read: {
+      type: "boolean",
+      description: "A Boolean value that determines the read consistency model during the scan:\nIf `ConsistentRead` is `false`, then the data returned from `Scan` might not contain the results from other recently completed write operations (`PutItem`, `UpdateItem`, or `DeleteItem`).\n\nIf `ConsistentRead` is `true`, then all of the write operations that completed before the `Scan` began are guaranteed to be contained in the `Scan` response.",
+      optional: true,
+    },
+    total_segments: {
+      type: "integer",
+      description: "For a parallel `Scan` request, `TotalSegments` represents the total number of segments into which the `Scan` operation will be divided. The value of `TotalSegments` corresponds to the number of application workers that will perform the parallel scan. For example, if you want to use four application threads to scan a table or an index, specify a `TotalSegments` value of 4. The value for `TotalSegments` must be greater than or equal to 1, and less than or equal to 1000000. If you specify a `TotalSegments` value of 1, the `Scan` operation will be sequential rather than parallel.\n\nIf you specify `TotalSegments,` you must also specify `Segment`.",
+      optional: true,
+    },
+    segment: {
+      type: "boolean",
+      description: "For a parallel `Scan` request, `Segment` identifies an individual segment to be scanned by an application worker.\n\nSegment IDs are zero-based, so the first segment is always 0. For example, if you want to use four application threads to scan a table or an index, then the first thread specifies a `Segment` value of 0, the second thread specifies 1, and so on.\n\nThe value of `LastEvaluatedKey` returned from a parallel Scan request must be used as ExclusiveStartKey with the same segment ID in a subsequent `Scan` operation.\n\nThe value for `Segment` must be greater than or equal to 0, and less than the value provided for `TotalSegments`.\n\nIf you provide `Segment`, you must also provide `TotalSegments`.",
+      optional: true,
+    },
+    scan_filter: {
+      type: "object",
+      description: "This is a legacy parameter. Use `FilterExpression` instead. For more information, see `ScanFilter` in the *Amazon DynamoDB Developer Guide.*",
+      optional: true,
+    },
+    conditional_operator: {
+      type: "string",
+      description: "This is a legacy parameter. Use `FilterExpression` instead. For more information, see [ConditionalOperator](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.ConditionalOperator.html) in the *Amazon DynamoDB Developer Guide.*",
+      optional: true,
+    },
+    exclusive_startKey: {
+      type: "object",
+      description: "The primary key of the first item that this operation will evaluate. Use the value that was returned for `LastEvaluatedKey` in the previous operation.",
+      optional: true,
+    },
+    return_consumed_capacity: {
+      type: "string",
+      description: "Determines the level of detail about provisioned throughput consumption that is returned in the response. Possible values include:  `INDEXES`, `TOTAL`, `NONE`.",
+      optional: true,
+      options: [
+        "INDEXES",
+        "TOTAL",
+        "NONE",
+      ],
+    },
+    projection_expression: {
+      type: "string",
+      description: "A string that identifies one or more attributes to retrieve from the specified table or index. These attributes can include scalars, sets, or elements of a JSON document. The attributes in the expression must be separated by commas.\n\nIf no attribute names are specified, then all attributes will be returned. If any of the requested attributes are not found, they will not appear in the result.\n\nFor more information, see [Specifying Item Attributes](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html) in the *Amazon DynamoDB Developer Guide.*",
+      optional: true,
+    },
+    filter_expression: {
+      type: "string",
+      description: "A string that contains conditions that DynamoDB applies after the `Scan` operation, but before the data is returned to you. Items that do not satisfy the `FilterExpression` criteria are not returned. Note: A `FilterExpression` is applied after the items have already been read; the process of filtering does not consume any additional read capacity units. For more information, see [Filter Expressions](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScan.html#FilteringResults) in the *Amazon DynamoDB Developer Guide.*",
+      optional: true,
+    },
+    expression_attributeNames: {
+      type: "object",
+      description: "One or more substitution tokens for attribute names in an expression. The following are some use cases for using `ExpressionAttributeNames`:\n\n* To access an attribute whose name conflicts with a DynamoDB reserved word.\n* To create a placeholder for repeating occurrences of an attribute name in an expression.\n* To prevent special characters in an attribute name from being misinterpreted in an expression.\n\nUse the # character in an expression to dereference an attribute name.",
+      optional: true,
+    },
+    expression_attribute_values: {
+      type: "object",
+      description: "One or more values that can be substituted in an expression. Use the : (colon) character in an expression to dereference an attribute value. For more information on expression attribute values, see [Condition Expressions](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html) in the *Amazon DynamoDB Developer Guide*.",
+      optional: true,
+    },
+  },
+  async run() {
+    //See the API docs: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#scan-property
+
+    const {
+      accessKeyId,
+      secretAccessKey,
+    } = this.aws.$auth;
+
+    if (!this.table_name || !this.region) {
+      throw new Error("Must provide exclusively key_condition_expression or key_conditions, and table_name, region  parameters.");
+    }
+
+    const dynamodb = new AWS.DynamoDB({
+      accessKeyId,
+      secretAccessKey,
+      region: this.region,
+    });
+
+    //Prepares parameters of the request
+    var dynamoDbParams = {
+      TableName: this.table_name,
+      IndexName: this.index_name,
+      Select: this.select,
+      AttributesToGet: this.attributes_to_get,
+      Limit: parseInt(this.limit),
+      ConsistentRead: this.consistent_read,
+      TotalSegments: parseInt(this.total_segments),
+      Segment: parseInt(this.segment),
+      ScanFilter: this.scan_filter,
+      ConditionalOperator: this.conditional_operator,
+      ExclusiveStartKey: this.exclusive_startKey,
+      ReturnConsumedCapacity: this.return_consumed_capacity,
+      ProjectionExpression: this.projection_expression,
+      FilterExpression: this.filter_expression,
+      ExpressionAttributeNames: this.expression_attributeNames,
+      ExpressionAttributeValues: this.expression_attribute_values,
+
+    };
+
+    //Sends the request using the DynamoDB AWS object
+    return await dynamodb.scan(dynamoDbParams).promise();
+  },
+};

--- a/components/aws/actions/dynamodb-update-item/dynamodb-update-item.mjs
+++ b/components/aws/actions/dynamodb-update-item/dynamodb-update-item.mjs
@@ -1,0 +1,136 @@
+// legacy_hash_id: a_WYi4nE
+import AWS from "aws-sdk";
+
+export default {
+  key: "aws-dynamodb-update-item",
+  name: "DynamoDB - Update Item",
+  description: "Updates an existing item's attributes, or adds a new item to the table if it does not already exist.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    aws: {
+      type: "app",
+      app: "aws",
+    },
+    table_name: {
+      type: "string",
+      description: "The name of the table containing the item to update.",
+    },
+    table_keys: {
+      type: "object",
+      description: "The primary key of the item to be updated. Each element consists of an attribute name and a value for that attribute.\n\nFor the primary key, you must provide all of the attributes. For example, with a simple primary key, you only need to provide a value for the partition key. For a composite primary key, you must provide values for both the partition key and the sort key.",
+    },
+    region: {
+      type: "string",
+      description: "The region to send service requests to.",
+    },
+    attribute_updates: {
+      type: "object",
+      description: "This is a legacy parameter. Use `UpdateExpression` instead. For more information, see [AttributeUpdates](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.AttributeUpdates.html) in the *Amazon DynamoDB Developer Guide*.",
+      optional: true,
+    },
+    expected: {
+      type: "object",
+      description: "This is a legacy parameter. Use `ConditionExpression` instead. For more information, see [Expected](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.Expected.html) in the *Amazon DynamoDB Developer Guide*.",
+      optional: true,
+    },
+    conditional_operator: {
+      type: "string",
+      description: "This is a legacy parameter. Use `ConditionExpression` instead. For more information, see [ConditionalOperator](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.ConditionalOperator.html) in the *Amazon DynamoDB Developer Guide*.",
+      optional: true,
+    },
+    return_values: {
+      type: "string",
+      description: "Use `ReturnValues` if you want to get the item attributes as they appear before or after they are updated. For `UpdateItem`, the valid, possible values are:\n\n* `NONE` - If `ReturnValues` is not specified, or if its value is `NONE`, then nothing is returned. (This setting is the default for `ReturnValues`.)\n\n* `ALL_OLD` - Returns all of the attributes of the item, as they appeared before the `UpdateItem` operation.\n\n* `UPDATED_OLD` - Returns only the updated attributes, as they appeared before the `UpdateItem` operation.\n\n* `ALL_NEW` - Returns all of the attributes of the item, as they appear after the `UpdateItem` operation.\n\n* `UPDATED_NEW` - Returns only the updated attributes, as they appear after the UpdateItem operation.",
+      optional: true,
+      options: [
+        "NONE",
+        "ALL_OLD",
+        "UPDATED_OLD",
+        "ALL_NEW",
+        "UPDATED_NEW",
+      ],
+    },
+    return_consumed_capacity: {
+      type: "string",
+      description: "Determines the level of detail about provisioned throughput consumption that is returned in the response. Possible values include:  `INDEXES`, `TOTAL`, `NONE`.",
+      optional: true,
+      options: [
+        "INDEXES",
+        "TOTAL",
+        "NONE",
+      ],
+    },
+    return_item_collection_metrics: {
+      type: "string",
+      description: "Determines whether item collection metrics are returned. If set to `SIZE`, the response includes statistics about item collections, if any, that were modified during the operation are returned in the response. If set to `NONE` (the default), no statistics are returned. Possible values include: `SIZE`, `NONE`.",
+      optional: true,
+      options: [
+        "SIZE",
+        "NOTE",
+      ],
+    },
+    update_expression: {
+      type: "string",
+      description: "An expression that defines one or more attributes to be updated, the action to be performed on them, and new values for them. The following action values are available for `UpdateExpression`: `SET`, `REMOVE`, `ADD`, `DELETE`. You can have many actions in a single expression, such as the following: `SET a=:value1, b=:value2 DELETE :value3, :value4, :value5`\n\nFor more information on update expressions, see [Modifying Items and Attributes](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.Modifying.html) in the *Amazon DynamoDB Developer Guide*.",
+      optional: true,
+    },
+    condition_expression: {
+      type: "string",
+      description: "A condition that must be satisfied in order for a conditional update to succeed. An expression can contain any of the following: functions, comparison operators, logical operators. For more information about condition expressions, see [Condition Expressions](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html) in the *Amazon DynamoDB Developer Guide*.",
+      optional: true,
+    },
+    expression_attribute_names: {
+      type: "object",
+      description: "One or more substitution tokens for attribute names in an expression. The following are some use cases for using `ExpressionAttributeNames`:\n\n* To access an attribute whose name conflicts with a DynamoDB reserved word.\n* To create a placeholder for repeating occurrences of an attribute name in an expression.\n* To prevent special characters in an attribute name from being misinterpreted in an expression.\n\nUse the # character in an expression to dereference an attribute name.",
+      optional: true,
+    },
+    expression_attribute_values: {
+      type: "object",
+      description: "One or more values that can be substituted in an expression. Use the : (colon) character in an expression to dereference an attribute value. For more information on expression attribute values, see [Condition Expressions](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html) in the *Amazon DynamoDB Developer Guide*.",
+      optional: true,
+    },
+  },
+  async run() {
+    // See the API docs: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#updateItem-property
+
+    const {
+      table_name,
+      table_keys,
+      region,
+    } = this;
+    const {
+      accessKeyId,
+      secretAccessKey,
+    } = this.aws.$auth;
+
+    if (!table_name || !table_keys || !region) {
+      throw new Error("Must provide table_name, table_keys, and region parameters.");
+    }
+
+    const dynamodb = new AWS.DynamoDB({
+      accessKeyId,
+      secretAccessKey,
+      region,
+    });
+
+    //Prepares parameters of the request
+    var dynamoDbParams = {
+      Key: this.table_keys,
+      TableName: this.table_name,
+      AttributeUpdates: this.attribute_updates,
+      Expected: this.expected,
+      ConditionalOperator: this.conditional_operator,
+      ReturnValues: this.return_values,
+      ReturnConsumedCapacity: this.return_consumed_capacity,
+      ReturnItemCollectionMetrics: this.return_item_collection_metrics,
+      UpdateExpression: this.update_expression,
+      ConditionExpression: this.condition_expression,
+      ExpressionAttributeNames: this.expression_attribute_names,
+      ExpressionAttributeValues: this.expression_attribute_values,
+    };
+
+    //Sends the request using the DynamoDB AWS object
+    return await dynamodb.updateItem(dynamoDbParams).promise();
+  },
+};

--- a/components/aws/actions/dynamodb-update-table/dynamodb-update-table.mjs
+++ b/components/aws/actions/dynamodb-update-table/dynamodb-update-table.mjs
@@ -1,0 +1,97 @@
+// legacy_hash_id: a_nji8GN
+import AWS from "aws-sdk";
+
+export default {
+  key: "aws-dynamodb-update-table",
+  name: "DynamoDB - Update Table",
+  description: "Modifies the provisioned throughput settings, global secondary indexes, or DynamoDB Streams settings for a given table.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    aws: {
+      type: "app",
+      app: "aws",
+    },
+    table_name: {
+      type: "string",
+      description: "The name of the table to update.",
+      optional: true,
+    },
+    provisioned_throughput: {
+      type: "object",
+      description: "The new provisioned throughput settings for the specified table or index. Parameters properties are:\n* `ReadCapacityUnits`, required integer, max. number of strongly consistent reads consumed per second before DynamoDB returns a `ThrottlingException`.\n* `WriteCapacityUnits`, required integer, max. number of writes consumed per second before DynamoDB returns a `ThrottlingException`.",
+      optional: true,
+    },
+    region: {
+      type: "string",
+      description: "The region to send service requests to.",
+    },
+    attribute_definitions: {
+      type: "any",
+      description: "An Array < map > of attributes that describe the key schema for the table and indexes. If you are adding a new global secondary index to the table, `AttributeDefinitions` must include the key element(s) of the new index. Each map element has the following properties:\n\n* `AttributeName`: Name for the attribute, required.\n\n* `AttributeType`:  The data type for the attribute, required; possible values: `S` for data type String, `N` for data type Number, and `B` for data type Binary.",
+      optional: true,
+    },
+    global_secondary_index_updates: {
+      type: "any",
+      description: "An Array < map > of one or more global secondary indexes for the table. For each index in the array, you can request one action:\n* Create - add a new global secondary index to the table.\n* Update - modify the provisioned throughput settings of an existing global secondary index.\n* Delete - remove a global secondary index from the table.\nYou can create or delete only one global secondary index per `UpdateTable` operation.\nFor more information, see [Managing Global Secondary Indexes](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GSI.OnlineOps.html) in the *Amazon DynamoDB Developer Guide.*",
+      optional: true,
+    },
+    billing_mode: {
+      type: "string",
+      description: "Controls how you are charged for read and write throughput and how you manage capacity. When switching from pay-per-request to provisioned capacity, initial provisioned capacity values must be set. The initial provisioned capacity values are estimated based on the consumed read and write capacity of your table and global secondary indexes over the past 30 minutes.\n\n* `PROVISIONED` - We recommend using `PROVISIONED` for predictable workloads. `PROVISIONED` sets the billing mode to [Provisioned Mode](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.ProvisionedThroughput.Manual).\n* `PAY_PER_REQUEST` - We recommend using `PAY_PER_REQUEST` for unpredictable workloads. `PAY_PER_REQUEST` sets the billing mode to [On-Demand Mode](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.OnDemand).",
+      optional: true,
+      options: [
+        "PROVISIONED",
+        "PAY_PER_REQUEST",
+      ],
+    },
+    stream_specification: {
+      type: "object",
+      description: "Represents the DynamoDB Streams configuration for the table. Note: You receive a `ResourceInUseException` if you try to enable a stream on a table that already has a stream, or if you try to disable a stream on a table that doesn't have a stream. This settings parameter consists of the following properties: \n* `StreamEnabled`: Indicates whether DynamoDB Streams is to be enabled (true) or disabled (false), boolean, required.\n* `StreamViewType`: When an item in the table is modified, `StreamViewType` determines what information is written to the table's stream. Valid values: `KEYS_ONLY`, `NEW_IMAGE`, `OLD_IMAGE`, `NEW_AND_OLD_IMAGES`",
+      optional: true,
+    },
+    sse_specification: {
+      type: "object",
+      description: "The new server-side encryption settings for the specified table.",
+      optional: true,
+    },
+    replica_updates: {
+      type: "any",
+      description: "Array < map > of replica update actions (create, delete, or update) for the table. This property only applies to [Version 2019.11.21](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.V2.html) of global tables.",
+      optional: true,
+    },
+  },
+  async run() {
+    //See the API docs: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#updateTable-property
+
+    const {
+      accessKeyId,
+      secretAccessKey,
+    } = this.aws.$auth;
+
+    if (!this.table_name || !this.provisioned_throughput || !this.region) {
+      throw new Error("Must provide table_name, provisioned_throughput, and region parameters.");
+    }
+
+    const dynamodb = new AWS.DynamoDB({
+      accessKeyId,
+      secretAccessKey,
+      region: this.region,
+    });
+
+    //Prepares parameters of the request
+    var dynamoDbParams = {
+      AttributeDefinitions: this.attribute_definitions,
+      TableName: this.table_name,
+      GlobalSecondaryIndexUpdates: this.global_secondary_index_updates,
+      BillingMode: this.billing_mode,
+      ProvisionedThroughput: this.provisioned_throughput,
+      StreamSpecification: this.stream_specification,
+      SSESpecification: this.sse_specification,
+      ReplicaUpdates: this.replica_updates,
+    };
+
+    //Sends the request using the DynamoDB AWS object
+    return await dynamodb.updateTable(dynamoDbParams).promise();
+  },
+};

--- a/components/calendly_v2/actions/get-event/get-event.mjs
+++ b/components/calendly_v2/actions/get-event/get-event.mjs
@@ -1,0 +1,34 @@
+// legacy_hash_id: a_poiwMj
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "calendly_v2-get-event",
+  name: "Get Event",
+  description: "Gets information about an Event associated with a URI.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    calendly_v2: {
+      type: "app",
+      app: "calendly_v2",
+    },
+    event_uuid: {
+      type: "string",
+      description: "The event's unique identifier.",
+    },
+  },
+  async run({ $ }) {
+  //See the API docs: https://developer.calendly.com/docs/api-docs/reference/calendly-api/openapi.yaml/paths/~1scheduled_events~1%7Buuid%7D/get
+
+    if (!this.event_uuid) {
+      throw new Error("Must provide event_uuid parameter.");
+    }
+
+    return await axios($, {
+      url: `https://api.calendly.com/scheduled_events/${this.event_uuid}`,
+      headers: {
+        Authorization: `Bearer ${this.calendly_v2.$auth.oauth_access_token}`,
+      },
+    });
+  },
+};

--- a/components/calendly_v2/actions/list-webhook-subscriptions/list-webhook-subscriptions.mjs
+++ b/components/calendly_v2/actions/list-webhook-subscriptions/list-webhook-subscriptions.mjs
@@ -1,0 +1,74 @@
+// legacy_hash_id: a_k6ij8Q
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "calendly_v2-list-webhook-subscriptions",
+  name: "List Webhook Subscriptions",
+  description: "Get a list of Webhook Subscriptions for an Organization or User with a UUID.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    calendly_v2: {
+      type: "app",
+      app: "calendly_v2",
+    },
+    scope: {
+      type: "string",
+      description: "Filter the list by organization or user.",
+      options: [
+        "organization",
+        "user",
+      ],
+    },
+    organization_uri: {
+      type: "string",
+      description: "Indicates if the results should be filtered by organization, by entering an organization 's URI, such as `https://api.calendly.com/organizations/012345678901234567890`.",
+    },
+    user_uri: {
+      type: "string",
+      description: "Indicates if the results should be filtered by user, by entering a user's URI, such as `https://api.calendly.com/users/CAFHCZWDQLKQ73HX`. You can use the [Get User](https://developer.calendly.com/docs/api-docs/reference/calendly-api/openapi.yaml/paths/~1users~1me/get) endpoint to find a user's URI.",
+      optional: true,
+    },
+    count: {
+      type: "string",
+      description: "The number of rows to return.",
+      optional: true,
+    },
+    page_token: {
+      type: "string",
+      description: "The token to pass to get the next portion of the collection.",
+      optional: true,
+    },
+    sort: {
+      type: "string",
+      description: "Order results by the specified field and direction. Accepts comma-separated list of {field}:{direction} values. Supported fields are: created_at. Sort direction is specified as: asc, desc.",
+      optional: true,
+      options: [
+        "created_at:asc",
+        "created_at:desc",
+      ],
+    },
+  },
+  async run({ $ }) {
+  //See the API docs: https://developer.calendly.com/docs/api-docs/reference/calendly-api/openapi.yaml/paths/~1webhook_subscriptions/get
+
+    if (!this.scope || !this.organization_uri) {
+      throw new Error("Must provide scope, and organization_uri parameters.");
+    }
+
+    return await axios($, {
+      url: "https://api.calendly.com/webhook_subscriptions",
+      headers: {
+        Authorization: `Bearer ${this.calendly_v2.$auth.oauth_access_token}`,
+      },
+      params: {
+        scope: this.scope,
+        user: this.user_uri,
+        count: this.count,
+        organization: this.organization_uri,
+        page_token: this.page_token,
+        sort: this.sort,
+      },
+    });
+  },
+};

--- a/components/pipefy/actions/create-card/create-card.mjs
+++ b/components/pipefy/actions/create-card/create-card.mjs
@@ -1,0 +1,51 @@
+// legacy_hash_id: a_52ie7G
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "pipefy-create-card",
+  name: "Create Card",
+  description: "Create a new Card in a Pipe",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    pipefy: {
+      type: "app",
+      app: "pipefy",
+    },
+    graphql_query: {
+      type: "object",
+    },
+  },
+  async run({ $ }) {
+  /* See the API docs: https://api-docs.pipefy.com/reference/mutations/createCard/
+
+  Example query:
+
+  mutation{
+    createCard( input: {
+      pipe_id: 219739
+      fields_attributes: [
+        {field_id: "assignee", field_value:[00000, 00001]}
+        {field_id: "checklist_vertical", field_value: ["a", "b"]}
+        {field_id: "email", field_value: "rocky.balboa@email.com"}
+      ]
+      parent_ids: ["2750027"]
+    })
+    { card { id title } }
+  }
+  */
+
+    if (!this.graphql_query) {
+      throw new Error("Must provide graphql_query parameter.");
+    }
+
+    return await axios($, {
+      method: "post",
+      url: "https://api.pipefy.com/graphql",
+      headers: {
+        Authorization: `Bearer ${this.pipefy.$auth.token}`,
+      },
+      data: this.graphql_query,
+    });
+  },
+};

--- a/components/pipefy/actions/create-pipe/create-pipe.mjs
+++ b/components/pipefy/actions/create-pipe/create-pipe.mjs
@@ -1,0 +1,47 @@
+// legacy_hash_id: a_nji3rP
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "pipefy-create-pipe",
+  name: "Create Pipe",
+  description: "Creates a pipe.",
+  version: "0.3.1",
+  type: "action",
+  props: {
+    pipefy: {
+      type: "app",
+      app: "pipefy",
+    },
+    graphql_mutation: {
+      type: "object",
+      description: "A graphql mutation as per [CreatePipe](https://api-docs.pipefy.com/reference/mutations/createPipe/) specification.",
+    },
+  },
+  async run({ $ }) {
+  /* See the API docs: https://api-docs.pipefy.com/reference/mutations/createPipe/
+
+  Example query:
+
+  mutation createNewPipe{
+    createPipe(
+        input: {name: "UsersPipe", organization_id: 300455771 } ) {
+            pipe{id name}
+      }
+  }
+
+  */
+
+    if (!this.graphql_mutation) {
+      throw new Error("Must provide graphql_mutation parameter.");
+    }
+
+    return await axios($, {
+      method: "post",
+      url: "https://api.pipefy.com/graphql",
+      headers: {
+        Authorization: `Bearer ${this.pipefy.$auth.token}`,
+      },
+      data: this.graphql_mutation,
+    });
+  },
+};

--- a/components/pipefy/actions/create-table-record/create-table-record.mjs
+++ b/components/pipefy/actions/create-table-record/create-table-record.mjs
@@ -1,0 +1,46 @@
+// legacy_hash_id: a_2wipLx
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "pipefy-create-table-record",
+  name: "Create Table Record",
+  description: "Creates a new table record.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    pipefy: {
+      type: "app",
+      app: "pipefy",
+    },
+    graphql_mutation: {
+      type: "object",
+      description: "A graphql mutation as per [CreateTableRecord](https://api-docs.pipefy.com/reference/mutations/createTableRecord/) specification.",
+    },
+  },
+  async run({ $ }) {
+  /* See the API docs: https://api-docs.pipefy.com/reference/mutations/createTableRecord/
+
+  Example query:
+
+  mutation createNewTableRecord{
+    createTableRecord(
+        input: {id: 301501717, title: "Test Record" } ) {
+            table_record{id status title}
+        }
+    }
+  */
+
+    if (!this.graphql_mutation) {
+      throw new Error("Must provide graphql_mutation parameter.");
+    }
+
+    return await axios($, {
+      method: "post",
+      url: "https://api.pipefy.com/graphql",
+      headers: {
+        Authorization: `Bearer ${this.pipefy.$auth.token}`,
+      },
+      data: this.graphql_mutation,
+    });
+  },
+};

--- a/components/pipefy/actions/delete-card/delete-card.mjs
+++ b/components/pipefy/actions/delete-card/delete-card.mjs
@@ -1,0 +1,47 @@
+// legacy_hash_id: a_m8ijLV
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "pipefy-delete-card",
+  name: "Delete Card",
+  description: "Deletes a card.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    pipefy: {
+      type: "app",
+      app: "pipefy",
+    },
+    graphql_mutation: {
+      type: "object",
+      description: "A graphql mutation as per [DeleteCard](https://api-docs.pipefy.com/reference/mutations/deleteCard/) specification.",
+    },
+  },
+  async run({ $ }) {
+  /* See the API docs: https://api-docs.pipefy.com/reference/mutations/deleteCard/
+
+  Example query:
+
+  mutation deleteExistingCard{
+      deleteCard(
+          input: {id: 398480509 } ) {
+              success
+          }
+      }
+
+  */
+
+    if (!this.graphql_mutation) {
+      throw new Error("Must provide graphql_mutation parameter.");
+    }
+
+    return await axios($, {
+      method: "post",
+      url: "https://api.pipefy.com/graphql",
+      headers: {
+        Authorization: `Bearer ${this.pipefy.$auth.token}`,
+      },
+      data: this.graphql_mutation,
+    });
+  },
+};

--- a/components/pipefy/actions/get-all-cards/get-all-cards.mjs
+++ b/components/pipefy/actions/get-all-cards/get-all-cards.mjs
@@ -1,0 +1,44 @@
+// legacy_hash_id: a_74ijXz
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "pipefy-get-all-cards",
+  name: "Get All Cards",
+  description: "Fetches all pipe cards based on arguments.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    pipefy: {
+      type: "app",
+      app: "pipefy",
+    },
+    graphql_query: {
+      type: "object",
+      description: "A graphql query as per [All Cards](https://api-docs.pipefy.com/reference/queries/#allCards) specification.",
+    },
+  },
+  async run({ $ }) {
+  /* See the API docs: https://api-docs.pipefy.com/reference/queries/#allCards
+
+  Example query:
+
+  {
+    allCards(pipeId: 301498507) {
+    pageInfo{hasNextPage} edges{node{title}}
+  }
+  */
+
+    if (!this.graphql_query) {
+      throw new Error("Must provide graphql_query parameter.");
+    }
+
+    return await axios($, {
+      method: "post",
+      url: "https://api.pipefy.com/graphql",
+      headers: {
+        Authorization: `Bearer ${this.pipefy.$auth.token}`,
+      },
+      data: this.graphql_query,
+    });
+  },
+};

--- a/components/pipefy/actions/get-current-user/get-current-user.mjs
+++ b/components/pipefy/actions/get-current-user/get-current-user.mjs
@@ -1,0 +1,38 @@
+// legacy_hash_id: a_oViLoO
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "pipefy-get-current-user",
+  name: "Get Current User",
+  description: "Gets information of the current authenticated user.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    pipefy: {
+      type: "app",
+      app: "pipefy",
+    },
+    user_fields: {
+      type: "string",
+      description: "Comma separated list of User fields to retrieve. Defaults to `name`. See the [List of user information](https://api-docs.pipefy.com/reference/objects/User/) for the User object fields.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  // See the API docs: https://api-docs.pipefy.com/reference/queries/me
+
+    const userFields = this.user_fields || "name";
+    const data = {
+      "query": `{ me { ${userFields} } }`,
+    };
+
+    return await axios($, {
+      method: "post",
+      url: "https://api.pipefy.com/graphql",
+      headers: {
+        Authorization: `Bearer ${this.pipefy.$auth.token}`,
+      },
+      data,
+    });
+  },
+};

--- a/components/pipefy/actions/get-table-records/get-table-records.mjs
+++ b/components/pipefy/actions/get-table-records/get-table-records.mjs
@@ -1,0 +1,46 @@
+// legacy_hash_id: a_eliYqY
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "pipefy-get-table-records",
+  name: "Get Table Records",
+  description: "Fetches a group of records based on arguments.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    pipefy: {
+      type: "app",
+      app: "pipefy",
+    },
+    graphql_query: {
+      type: "object",
+      description: "A graphql query as per [TableRecords](https://api-docs.pipefy.com/reference/queries/#table_records) specification.",
+    },
+  },
+  async run({ $ }) {
+  /* See the API docs: https://api-docs.pipefy.com/reference/queries/#table_records
+
+  Example query:
+
+  {
+    table_records(table_id: 301501717) {
+      matchCount
+    }
+  }
+
+  */
+
+    if (!this.graphql_query) {
+      throw new Error("Must provide graphql_query parameter.");
+    }
+
+    return await axios($, {
+      method: "post",
+      url: "https://api.pipefy.com/graphql",
+      headers: {
+        Authorization: `Bearer ${this.pipefy.$auth.token}`,
+      },
+      data: this.graphql_query,
+    });
+  },
+};

--- a/components/pipefy/actions/look-up-card-by-id/look-up-card-by-id.mjs
+++ b/components/pipefy/actions/look-up-card-by-id/look-up-card-by-id.mjs
@@ -1,0 +1,45 @@
+// legacy_hash_id: a_Mdie0r
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "pipefy-look-up-card-by-id",
+  name: "Look up Card by ID",
+  description: "Looks up a card by its ID.",
+  version: "0.3.1",
+  type: "action",
+  props: {
+    pipefy: {
+      type: "app",
+      app: "pipefy",
+    },
+    graphql_query: {
+      type: "object",
+      description: "A graphql query as per [Card](https://api-docs.pipefy.com/reference/queries/#card) specification.",
+    },
+  },
+  async run({ $ }) {
+  /* See the API docs: https://api-docs.pipefy.com/reference/queries/#card
+
+  Example query:
+
+  {
+    card(id: 301498507) {
+      title url comments{text}
+    }
+  }
+  */
+
+    if (!this.graphql_query) {
+      throw new Error("Must provide graphql_query parameter.");
+    }
+
+    return await axios($, {
+      method: "post",
+      url: "https://api.pipefy.com/graphql",
+      headers: {
+        Authorization: `Bearer ${this.pipefy.$auth.token}`,
+      },
+      data: this.graphql_query,
+    });
+  },
+};

--- a/components/pipefy/actions/look-up-phase-by-id/look-up-phase-by-id.mjs
+++ b/components/pipefy/actions/look-up-phase-by-id/look-up-phase-by-id.mjs
@@ -1,0 +1,45 @@
+// legacy_hash_id: a_gnirYL
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "pipefy-look-up-phase-by-id",
+  name: "Look Up Phase By Id",
+  description: "Looks up a phase by its ID.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    pipefy: {
+      type: "app",
+      app: "pipefy",
+    },
+    graphql_query: {
+      type: "object",
+      description: "A graphql query as per [Phase](https://api-docs.pipefy.com/reference/objects/Phase/) specification.",
+    },
+  },
+  async run({ $ }) {
+  /* See the API docs: https://api-docs.pipefy.com/reference/queries/#phase
+
+  Example query:
+
+  {
+      phase(id: 309926591) {
+      name description fields{label}
+    }
+  }
+  */
+
+    if (!this.graphql_query) {
+      throw new Error("Must provide graphql_query parameter.");
+    }
+
+    return await axios($, {
+      method: "post",
+      url: "https://api.pipefy.com/graphql",
+      headers: {
+        Authorization: `Bearer ${this.pipefy.$auth.token}`,
+      },
+      data: this.graphql_query,
+    });
+  },
+};

--- a/components/pipefy/actions/look-up-pipe-by-id/look-up-pipe-by-id.mjs
+++ b/components/pipefy/actions/look-up-pipe-by-id/look-up-pipe-by-id.mjs
@@ -1,0 +1,45 @@
+// legacy_hash_id: a_WYi4qr
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "pipefy-look-up-pipe-by-id",
+  name: "Look up Pipe by ID",
+  description: "Lookup a pipe by its ID.",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    pipefy: {
+      type: "app",
+      app: "pipefy",
+    },
+    graphql_query: {
+      type: "object",
+      description: "A graphql query as per [Pipe](https://api-docs.pipefy.com/reference/queries/#pipe) specification.",
+    },
+  },
+  async run({ $ }) {
+  /* See the API docs: https://api-docs.pipefy.com/reference/queries/#pipe
+
+  Example query:
+
+  {
+      pipe(id: 301498507) {
+      id name description members{user{name}}
+    }
+  }
+  */
+
+    if (!this.graphql_query) {
+      throw new Error("Must provide graphql_query parameter.");
+    }
+
+    return await axios($, {
+      method: "post",
+      url: "https://api.pipefy.com/graphql",
+      headers: {
+        Authorization: `Bearer ${this.pipefy.$auth.token}`,
+      },
+      data: this.graphql_query,
+    });
+  },
+};

--- a/components/pipefy/actions/look-up-table-by-id/look-up-table-by-id.mjs
+++ b/components/pipefy/actions/look-up-table-by-id/look-up-table-by-id.mjs
@@ -1,0 +1,45 @@
+// legacy_hash_id: a_m8iY1x
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "pipefy-look-up-table-by-id",
+  name: "Look Up Table by ID",
+  description: "Looks up a database table by its ID.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    pipefy: {
+      type: "app",
+      app: "pipefy",
+    },
+    graphql_query: {
+      type: "object",
+      description: "A graphql query as per [Table](https://api-docs.pipefy.com/reference/queries/#table) specification.",
+    },
+  },
+  async run({ $ }) {
+  /* See the API docs: https://api-docs.pipefy.com/reference/queries/#table
+
+  Example query:
+
+  {
+      table(id: 301501717) {
+      name url
+    }
+  }
+  */
+
+    if (!this.graphql_query) {
+      throw new Error("Must provide graphql_query parameter.");
+    }
+
+    return await axios($, {
+      method: "post",
+      url: "https://api.pipefy.com/graphql",
+      headers: {
+        Authorization: `Bearer ${this.pipefy.$auth.token}`,
+      },
+      data: this.graphql_query,
+    });
+  },
+};

--- a/components/pipefy/actions/update-card-field/update-card-field.mjs
+++ b/components/pipefy/actions/update-card-field/update-card-field.mjs
@@ -1,0 +1,47 @@
+// legacy_hash_id: a_bKilxA
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "pipefy-update-card-field",
+  name: "Update Card Field",
+  description: "Updates a Card Field in a Pipe",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    pipefy: {
+      type: "app",
+      app: "pipefy",
+    },
+    graphql_query: {
+      type: "object",
+    },
+  },
+  async run({ $ }) {
+  /* See the API docs: https://api-docs.pipefy.com/reference/mutations/updateCardField/
+
+  Example query:
+
+  mutation {
+    updateCardField( input: {
+      card_id: 2750027
+      field_id: "where_do_you_live"
+      new_value: "Auckland"
+    })
+    { card { id } }
+  }
+  */
+
+    if (!this.graphql_query) {
+      throw new Error("Must provide graphql_query parameter.");
+    }
+
+    return await axios($, {
+      method: "post",
+      url: "https://api.pipefy.com/graphql",
+      headers: {
+        Authorization: `Bearer ${this.pipefy.$auth.token}`,
+      },
+      data: this.graphql_query,
+    });
+  },
+};

--- a/components/pipefy/actions/update-card/update-card.mjs
+++ b/components/pipefy/actions/update-card/update-card.mjs
@@ -1,0 +1,47 @@
+// legacy_hash_id: a_PNiB3z
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "pipefy-update-card",
+  name: "Update Card",
+  description: "Updates an existing card.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    pipefy: {
+      type: "app",
+      app: "pipefy",
+    },
+    graphql_mutation: {
+      type: "object",
+      description: "A graphql mutation as per [UpdateCard](https://api-docs.pipefy.com/reference/mutations/updateCard/) specification.",
+    },
+  },
+  async run({ $ }) {
+  /* See the API docs: https://api-docs.pipefy.com/reference/mutations/updateCard/
+
+  Example query:
+
+  mutation updateExistingCard{
+    updateCard(
+        input: {id: 397325159, title: "UpdatedCard" } ) {
+            card{id title createdBy{name}}
+        }
+    }
+
+  */
+
+    if (!this.graphql_mutation) {
+      throw new Error("Must provide graphql_mutation parameter.");
+    }
+
+    return await axios($, {
+      method: "post",
+      url: "https://api.pipefy.com/graphql",
+      headers: {
+        Authorization: `Bearer ${this.pipefy.$auth.token}`,
+      },
+      data: this.graphql_mutation,
+    });
+  },
+};

--- a/components/pipefy/actions/update-table-record/update-table-record.mjs
+++ b/components/pipefy/actions/update-table-record/update-table-record.mjs
@@ -1,0 +1,47 @@
+// legacy_hash_id: a_rJidQX
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "pipefy-update-table-record",
+  name: "Update Table Record",
+  description: "Updates a table record.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    pipefy: {
+      type: "app",
+      app: "pipefy",
+    },
+    graphql_mutation: {
+      type: "object",
+      description: "A graphql mutation as per [UpdateTableRecord](https://api-docs.pipefy.com/reference/objects/TableRecord/) specification.",
+    },
+  },
+  async run({ $ }) {
+  /* See the API docs: https://api-docs.pipefy.com/reference/mutations/updateTableRecord/
+
+  Example query:
+
+  mutation updateTableRecord{
+    updateTableRecord(
+        input: {id: 397325159, title: "UpdatedTableRecord" } ) {
+            table_record{id title}
+        }
+    }
+
+  */
+
+    if (!this.graphql_mutation) {
+      throw new Error("Must provide graphql_mutation parameter.");
+    }
+
+    return await axios($, {
+      method: "post",
+      url: "https://api.pipefy.com/graphql",
+      headers: {
+        Authorization: `Bearer ${this.pipefy.$auth.token}`,
+      },
+      data: this.graphql_mutation,
+    });
+  },
+};

--- a/components/pipefy/actions/update-table/update-table.mjs
+++ b/components/pipefy/actions/update-table/update-table.mjs
@@ -1,0 +1,47 @@
+// legacy_hash_id: a_WYiwx5
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "pipefy-update-table",
+  name: "Update Table",
+  description: "Updates a table.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    pipefy: {
+      type: "app",
+      app: "pipefy",
+    },
+    graphql_mutation: {
+      type: "object",
+      description: "A graphql mutation as per [UpdateTable](https://api-docs.pipefy.com/reference/mutations/updateTable/) specification.",
+    },
+  },
+  async run({ $ }) {
+  /* See the API docs: https://api-docs.pipefy.com/reference/mutations/updateTable/
+
+  Example query:
+
+  mutation updateExistingTable{
+    updateTable(
+        input: {id: 301501717, description: "Updated Table" } ) {
+            table{id name}
+        }
+      }
+
+  */
+
+    if (!this.graphql_mutation) {
+      throw new Error("Must provide graphql_mutation parameter.");
+    }
+
+    return await axios($, {
+      method: "post",
+      url: "https://api.pipefy.com/graphql",
+      headers: {
+        Authorization: `Bearer ${this.pipefy.$auth.token}`,
+      },
+      data: this.graphql_mutation,
+    });
+  },
+};

--- a/components/raindrop/actions/save/save.mjs
+++ b/components/raindrop/actions/save/save.mjs
@@ -1,0 +1,47 @@
+// legacy_hash_id: a_NqilJ3
+export default {
+  key: "raindrop-save",
+  name: "Save to Raindrop Collection",
+  description: "Receive a link and save it into a specific collection. You can get the collection id by accessing you collection and grabbing the numbers at the end of the address.",
+  version: "1.0.1",
+  type: "action",
+  props: {
+    raindrop: {
+      type: "app",
+      app: "raindrop",
+    },
+    link: {
+      type: "string",
+    },
+    collectionid: {
+      type: "string",
+    },
+    bookmarktag: {
+      type: "string",
+    },
+  },
+  async run({ $ }) {
+    const {
+      link,
+      collectionid,
+      bookmarktag,
+    } = this;
+
+    $.send.http({
+      method: "POST",
+      url: "https://api.raindrop.io/rest/v1/raindrop",
+      headers: {
+        Authorization: `Bearer ${this.raindrop.$auth.oauth_access_token}`,
+      },
+      data: {
+        link,
+        collection: {
+          $id: collectionid,
+        },
+        tags: [
+          bookmarktag,
+        ],
+      },
+    });
+  },
+};

--- a/components/salesforce_rest_api/actions/salesforce-create-account/salesforce-create-account.mjs
+++ b/components/salesforce_rest_api/actions/salesforce-create-account/salesforce-create-account.mjs
@@ -1,0 +1,374 @@
+// legacy_hash_id: a_8Ki78k
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "salesforce_rest_api-salesforce-create-account",
+  name: "Create Account",
+  description: "Creates a Salesforce account, representing an individual account, which is an organization or person involved with your business (such as customers, competitors, and partners).",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    salesforce_rest_api: {
+      type: "app",
+      app: "salesforce_rest_api",
+    },
+    Name: {
+      type: "string",
+      description: "Name of the account. Maximum size is 255 characters. If the account has a record type of Person Account:\nThis value is the concatenation of the FirstName, MiddleName, LastName, and Suffix of the associated person contact.",
+    },
+    AccountNumber: {
+      type: "string",
+      description: "Account number assigned to this account (not the unique, system-generated ID assigned during creation). Maximum size is 40 characters.",
+      optional: true,
+    },
+    AccountSource: {
+      type: "string",
+      description: "The source of the account record. For example, Advertisement, Data.com, or Trade Show. The source is selected from a picklist of available values, which are set by an administrator in Salesforce. Each picklist value can have up to 40 characters.",
+      optional: true,
+    },
+    AnnualRevenue: {
+      type: "string",
+      description: "Estimated annual revenue of the account.",
+      optional: true,
+    },
+    BillingCity: {
+      type: "string",
+      description: "Details for the billing address of this account. Maximum size is 40 characters.",
+      optional: true,
+    },
+    BillingCountry: {
+      type: "string",
+      description: "Details for the billing address of this account. Maximum size is 80 characters.",
+      optional: true,
+    },
+    BillingCountryCode: {
+      type: "string",
+      description: "The ISO country code for the account's billing address.",
+      optional: true,
+    },
+    BillingGeocodeAccuracy: {
+      type: "string",
+      description: "Accuracy level of the geocode for the billing address. See [Compound Field Considerations and Limitations](https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/compound_fields_limitations.htm#compound_fields_limitations) for details on geolocation compound fields.",
+      optional: true,
+    },
+    BillingLatitude: {
+      type: "integer",
+      description: "Used with BillingLongitude to specify the precise geolocation of a billing address. Acceptable values are numbers between 90 and 90 with up to 15 decimal places. See [Compound Field Considerations and Limitations](https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/compound_fields_limitations.htm#compound_fields_limitations) for details on geolocation compound fields.",
+      optional: true,
+    },
+    BillingLongitude: {
+      type: "integer",
+      description: "Used with BillingLatitude to specify the precise geolocation of a billing address. Acceptable values are numbers between 180 and 180 with up to 15 decimal places. See [Compound Field Considerations and Limitations](https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/compound_fields_limitations.htm#compound_fields_limitations)  for details on geolocation compound fields.",
+      optional: true,
+    },
+    BillingPostalCode: {
+      type: "string",
+      description: "Details for the billing address of this account. Maximum size is 20 characters.",
+      optional: true,
+    },
+    BillingState: {
+      type: "string",
+      description: "Details for the billing address of this account. Maximum size is 80 characters.",
+      optional: true,
+    },
+    BillingStateCode: {
+      type: "string",
+      description: "The ISO state code for the account's billing address.",
+      optional: true,
+    },
+    BillingStreet: {
+      type: "string",
+      description: "Street address for the billing address of this account.",
+      optional: true,
+    },
+    ChannelProgramName: {
+      type: "string",
+      description: "Read only. Name of the channel program the account has enrolled.\nIf this account has enrolled more than one channel program, the oldest channel program name will be displayed.",
+      optional: true,
+    },
+    ChannelProgramLevelName: {
+      type: "string",
+      description: "Read only. Name of the channel program level the account has enrolled.\nIf this account has enrolled more than one channel program level, the oldest channel program name will be displayed.",
+      optional: true,
+    },
+    CleanStatus: {
+      type: "string",
+      description: "Indicates the record's clean status as compared with Data.com. Values are: Matched, Different, Acknowledged, NotFound, Inactive, Pending, SelectMatch, or Skipped. Several values for CleanStatus display with different labels on the account record detail page.\nMatched displays as In Sync\nAcknowledged displays as Reviewed\nPending displays as Not Compared",
+      optional: true,
+      options: [
+        " Matched",
+        " Different",
+        " Acknowledged",
+        " NotFound",
+        " Inactive",
+        " Pending",
+        " SelectMatch",
+        "Skipped",
+      ],
+    },
+    Description: {
+      type: "string",
+      description: "Text description of the account. Limited to 32,000 KB.",
+      optional: true,
+    },
+    DunsNumber: {
+      type: "string",
+      description: "The Data Universal Numbering System (D-U-N-S) number is a unique, nine-digit number assigned to every business location in the Dun & Bradstreet database that has a unique, separate, and distinct operation. D-U-N-S numbers are used by industries and organizations around the world as a global standard for business identification and tracking. Maximum size is 9 characters. This field is available on business accounts, not person accounts.\nThis field is only available to organizations that use Data.com Prospector or Data.com Clean.",
+      optional: true,
+    },
+    Fax: {
+      type: "string",
+      description: "Fax number for the account.",
+      optional: true,
+    },
+    HasOptedOutOfEmail: {
+      type: "boolean",
+      description: "Indicates whether the contact doesn't want to receive email from Salesforce (true) or does (false).",
+      optional: true,
+    },
+    Industry: {
+      type: "string",
+      description: "An industry associated with this account. Maximum size is 40 characters.",
+      optional: true,
+    },
+    IsCustomerPortal: {
+      type: "boolean",
+      description: "Indicates whether the account has at least one contact enabled to use the organization's Customer Portal (true) or not (false). This field is available if Customer Portal is enabled OR Communities is enabled and you have Customer Portal licenses.\nIf you change this field's value from true to false, you can disable up to 100 Customer Portal users associated with the account and permanently delete all of the account's Customer Portal roles and groups. You can't restore deleted Customer Portal roles and groups. This field can be updated in API version 16.0 and later. We recommend that you update up to 50 contacts simultaneously when changing the accounts on contacts enabled for a Customer Portal or partner portal. We also recommend that you make this update after business hours.",
+      optional: true,
+    },
+    Jigsaw: {
+      type: "string",
+      description: "References the ID of a company in Data.com. If an account has a value in this field, it means that the account was imported from Data.com. If the field value is null, the account was not imported from Data.com. Maximum size is 20 characters. Available in API version 22.0 and later. Label is Data.com Key. This field is available on business accounts, not person accounts. The Jigsaw field is exposed in the API to support troubleshooting for import errors and reimporting of corrected data. Do not modify the value in the Jigsaw field.",
+      optional: true,
+    },
+    NaicsCode: {
+      type: "string",
+      description: "The six-digit North American Industry Classification System (NAICS) code is the standard used by business and government to classify business establishments into industries, according to their economic activity for the purpose of collecting, analyzing, and publishing statistical data related to the U.S. business economy. Maximum size is 8 characters. This field is available on business accounts, not person accounts.\nThis field is only available to organizations that use Data.com Prospector or Data.com Clean.",
+      optional: true,
+    },
+    NaicsDesc: {
+      type: "string",
+      description: "A brief description of an organization's line of business, based on its NAICS code. Maximum size is 120 characters. This field is available on business accounts, not person accounts.\nThis field is only available to organizations that use Data.com Prospector or Data.com Clean.",
+      optional: true,
+    },
+    NumberOfEmployees: {
+      type: "integer",
+      description: "Number of employees working at the company represented by this account. Maximum size is eight digits.",
+      optional: true,
+    },
+    OperatingHoursId: {
+      type: "string",
+      description: "The operating hours associated with the account. Available only if Field Service Lightning is enabled.",
+      optional: true,
+    },
+    OwnerId: {
+      type: "string",
+      description: "The ID of the user who currently owns this account. Default value is the user logged in to the API to perform the create.\nIf you have set up account teams in your organization, updating this field has different consequences depending on your version of the API:\nFor API version 12.0 and later, sharing records are kept, as they are for all objects.\nFor API version before 12.0, sharing records are deleted.\nFor API version 16.0 and later, users must have the Transfer Record permission in order to update (transfer) account ownership using this field.",
+      optional: true,
+    },
+    Ownership: {
+      type: "string",
+      description: "Ownership type for the account, for example Private, Public, or Subsidiary.",
+      optional: true,
+    },
+    ParentId: {
+      type: "string",
+      description: "ID of the parent object, if any.",
+      optional: true,
+    },
+    PersonIndividualId: {
+      type: "string",
+      description: "ID of the data privacy record associated with this person's account. This field is available if you enabled Data Protection and Privacy in Setup.\nAvailable in API version 42.0 and later.",
+      optional: true,
+    },
+    Phone: {
+      type: "string",
+      description: "Phone number for this account. Maximum size is 40 characters.",
+      optional: true,
+    },
+    PhotoUrl: {
+      type: "string",
+      description: "Path to be combined with the URL of a Salesforce instance (for example, https://yourInstance.salesforce.com/) to generate a URL to request the social network profile image associated with the account. Generated URL returns an HTTP redirect (code 302) to the social network profile image for the account.\nBlank if Social Accounts and Contacts isn't enabled for the organization or if Social Accounts and Contacts is disabled for the requesting user.",
+      optional: true,
+    },
+    Rating: {
+      type: "string",
+      description: "The account's prospect rating, for example Hot, Warm, or Cold.",
+      optional: true,
+    },
+    RecordTypeId: {
+      type: "string",
+      description: "ID of the record type assigned to this object.",
+      optional: true,
+    },
+    Salutation: {
+      type: "string",
+      description: "Honorific added to the name for use in letters, etc.",
+      optional: true,
+    },
+    ShippingCity: {
+      type: "string",
+      description: "Details of the shipping address for this account. City maximum size is 40 characters",
+      optional: true,
+    },
+    ShippingCountry: {
+      type: "string",
+      description: "Details of the shipping address for this account. Country maximum size is 80 characters.",
+      optional: true,
+    },
+    ShippingCountryCode: {
+      type: "string",
+      description: "The ISO country code for the account's shipping address.",
+      optional: true,
+    },
+    ShippingGeocodeAccuracy: {
+      type: "string",
+      description: "Accuracy level of the geocode for the shipping address. See [Compound Field Considerations and Limitations](https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/compound_fields_limitations.htm#compound_fields_limitations) for details on geolocation compound fields.",
+      optional: true,
+    },
+    ShippingLatitude: {
+      type: "string",
+      description: "Used with ShippingLongitude to specify the precise geolocation of a shipping address. Acceptable values are numbers between 90 and 90 with up to 15 decimal places. See [Compound Field Considerations and Limitations](https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/compound_fields_limitations.htm#compound_fields_limitations) for details on geolocation compound fields",
+      optional: true,
+    },
+    ShippingLongitude: {
+      type: "integer",
+      description: "Used with ShippingLatitude to specify the precise geolocation of an address. Acceptable values are numbers between 180 and 180 with up to 15 decimal places. See [Compound Field Considerations and Limitations](https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/compound_fields_limitations.htm#compound_fields_limitations) for details on geolocation compound fields.",
+      optional: true,
+    },
+    ShippingPostalCode: {
+      type: "string",
+      description: "Details of the shipping address for this account. Postal code maximum size is 20 characters.",
+      optional: true,
+    },
+    ShippingState: {
+      type: "string",
+      description: "Details of the shipping address for this account. State maximum size is 80 characters.",
+      optional: true,
+    },
+    ShippingStateCode: {
+      type: "string",
+      description: "The ISO state code for the account's shipping address.",
+      optional: true,
+    },
+    ShippingStreet: {
+      type: "string",
+      description: "The street address of the shipping address for this account. Maximum of 255 characters.",
+      optional: true,
+    },
+    Sic: {
+      type: "string",
+      description: "Standard Industrial Classification code of the company's main business categorization, for example, 57340 for Electronics. Maximum of 20 characters. This field is available on business accounts, not person accounts.",
+      optional: true,
+    },
+    SicDesc: {
+      type: "string",
+      description: "A brief description of an organization's line of business, based on its SIC code. Maximum length is 80 characters. This field is available on business accounts, not person accounts.",
+      optional: true,
+    },
+    Site: {
+      type: "string",
+      description: "Name of the account's location, for example Headquarters or London. Label is Account Site. Maximum of 80 characters.",
+      optional: true,
+    },
+    TickerSymbol: {
+      type: "string",
+      description: "The stock market symbol for this account. Maximum of 20 characters. This field is available on business accounts, not person accounts.",
+      optional: true,
+    },
+    Tradestyle: {
+      type: "string",
+      description: "A name, different from its legal name, that an organization may use for conducting business. Similar to Doing business as or DBA. Maximum length is 255 characters. This field is available on business accounts, not person accounts. This field is only available to organizations that use Data.com Prospector or Data.com Clean.",
+      optional: true,
+    },
+    Type: {
+      type: "string",
+      description: "Type of account, for example, Customer, Competitor, or Partner.",
+      optional: true,
+    },
+    Website: {
+      type: "string",
+      description: "The website of this account. Maximum of 255 characters.",
+      optional: true,
+    },
+    YearStarted: {
+      type: "string",
+      description: "The date when an organization was legally established. Maximum length is 4 characters. This field is available on business accounts, not person accounts.\nThis field is only available to organizations that use Data.com Prospector or Data.com Clean.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  // See the API docs here: https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_sobject_create.htm
+  // Account object: https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_objects_account.htm
+
+    if (!this.Name) {
+      throw new Error("Must provide Name parameter.");
+    }
+
+    return await axios($, {
+      "method": "post",
+      "url": `${this.salesforce_rest_api.$auth.instance_url}/services/data/v20.0/sobjects/Account/`,
+      "Content-Type": "application/json",
+      "headers": {
+        Authorization: `Bearer ${this.salesforce_rest_api.$auth.oauth_access_token}`,
+      },
+      "data": {
+        AccountNumber: this.AccountNumber,
+        AccountSource: this.AccountSource,
+        AnnualRevenue: this.AnnualRevenue,
+        BillingCity: this.BillingCity,
+        BillingCountry: this.BillingCountry,
+        BillingCountryCode: this.BillingCountryCode,
+        BillingGeocodeAccuracy: this.BillingGeocodeAccuracy,
+        BillingLatitude: this.BillingLatitude,
+        BillingLongitude: this.BillingLongitude,
+        BillingPostalCode: this.BillingPostalCode,
+        BillingState: this.BillingState,
+        BillingStateCode: this.BillingStateCode,
+        BillingStreet: this.BillingStreet,
+        ChannelProgramName: this.ChannelProgramName,
+        ChannelProgramLevelName: this.ChannelProgramLevelName,
+        CleanStatus: this.CleanStatus,
+        Description: this.Description,
+        DunsNumber: this.DunsNumber,
+        Fax: this.Fax,
+        HasOptedOutOfEmail: this.HasOptedOutOfEmail,
+        Industry: this.Industry,
+        IsCustomerPortal: this.IsCustomerPortal,
+        Jigsaw: this.Jigsaw,
+        NaicsCode: this.NaicsCode,
+        NaicsDesc: this.NaicsDesc,
+        Name: this.Name,
+        NumberOfEmployees: this.NumberOfEmployees,
+        OperatingHoursId: this.OperatingHoursId,
+        OwnerId: this.OwnerId,
+        Ownership: this.Ownership,
+        ParentId: this.ParentId,
+        PersonIndividualId: this.PersonIndividualId,
+        Phone: this.Phone,
+        PhotoUrl: this.PhotoUrl,
+        Rating: this.Rating,
+        RecordTypeId: this.RecordTypeId,
+        Salutation: this.Salutation,
+        ShippingCity: this.ShippingCity,
+        ShippingCountry: this.ShippingCountry,
+        ShippingCountryCode: this.ShippingCountryCode,
+        ShippingGeocodeAccuracy: this.ShippingGeocodeAccuracy,
+        ShippingLatitude: this.ShippingLatitude,
+        ShippingLongitude: this.ShippingLongitude,
+        ShippingPostalCode: this.ShippingPostalCode,
+        ShippingState: this.ShippingState,
+        ShippingStateCode: this.ShippingStateCode,
+        ShippingStreet: this.ShippingStreet,
+        Sic: this.Sic,
+        SicDesc: this.SicDesc,
+        Site: this.Site,
+        TickerSymbol: this.TickerSymbol,
+        Tradestyle: this.Tradestyle,
+        Type: this.Type,
+        Website: this.Website,
+        YearStarted: this.YearStarted,
+      },
+    });
+  },
+};

--- a/components/salesforce_rest_api/actions/salesforce-create-attachment/salesforce-create-attachment.mjs
+++ b/components/salesforce_rest_api/actions/salesforce-create-attachment/salesforce-create-attachment.mjs
@@ -1,0 +1,73 @@
+// legacy_hash_id: a_Mdiz3x
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "salesforce_rest_api-salesforce-create-attachment",
+  name: "Create Attachment",
+  description: "Creates an attachment, which represents a file that a User has uploaded and attached to a parent object.",
+  version: "0.3.1",
+  type: "action",
+  props: {
+    salesforce_rest_api: {
+      type: "app",
+      app: "salesforce_rest_api",
+    },
+    Body: {
+      type: "string",
+      description: "Encoded file data.",
+    },
+    Name: {
+      type: "string",
+      description: "Name of the attached file. Maximum size is 255 characters.",
+    },
+    ParentId: {
+      type: "string",
+      description: "ID of the parent object of the attachment. The following objects are supported as parents of attachments:\n* Account\n* Asset\n* Campaign\n* Case\n* Contact\n* Contract\n* Custom objects\n* EmailMessage\n* EmailTemplate\n* Event\n* Lead\n* Opportunity\n* Product2\n*  Solution\n* Task",
+    },
+    ContentType: {
+      type: "string",
+      description: "The content type of the attachment.If the Don't allow HTML uploads as attachments or document records security setting is enabled for your organization, you cannot upload files with the following file extensions: .htm, .html, .htt, .htx, .mhtm, .mhtml, .shtm, .shtml, .acgi, .svg. When you insert a document or attachment through the API, make sure that this field is set to the appropriate MIME type.",
+      optional: true,
+    },
+    Description: {
+      type: "string",
+      description: "Description of the attachment. Maximum size is 500 characters. This field is available in API version 18.0 and later.",
+      optional: true,
+    },
+    IsPrivate: {
+      type: "boolean",
+      description: "Indicates whether this record is viewable only by the owner and administrators (true) or viewable by all otherwise-allowed users (false). During a create or update call, it is possible to mark an Attachment record as private even if you are not the owner. This can result in a situation in which you can no longer access the record that you just inserted or updated. Label is Private.Attachments on tasks or events can't be marked private.",
+      optional: true,
+    },
+    OwnerId: {
+      type: "string",
+      description: "ID of the User who owns the attachment. This field was required previous to release 9.0. Beginning with release 9.0, it can be null on create.The owner of an attachment on a task or event must be the same as the owner of the task or event.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  //See the API docs here: https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/intro_what_is_rest_api.htm
+  // Attachment object: https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_objects_attachment.htm
+
+    if (!this.Body || !this.Name || !this.ParentId) {
+      throw new Error("Must provide Body, Name and ParentId parameters.");
+    }
+
+    return await axios($, {
+      method: "post",
+      url: `${this.salesforce_rest_api.$auth.instance_url}/services/data/v20.0/sobjects/Attachment/`,
+      headers: {
+        Authorization: `Bearer ${this.salesforce_rest_api.$auth.oauth_access_token}`,
+      },
+      data: {
+  	 Body: this.Body,
+  	 ContentType: this.ContentType,
+  	 Description: this.Description,
+  	 IsPrivate: this.IsPrivate,
+  	 Name: this.Name,
+  	 OwnerId: this.OwnerId,
+        ParentId: this.ParentId,
+      },
+    });
+  },
+};

--- a/components/salesforce_rest_api/actions/salesforce-create-campaign/salesforce-create-campaign.mjs
+++ b/components/salesforce_rest_api/actions/salesforce-create-campaign/salesforce-create-campaign.mjs
@@ -1,0 +1,148 @@
+// legacy_hash_id: a_52idrP
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "salesforce_rest_api-salesforce-create-campaign",
+  name: "Create Campaign",
+  description: "Creates a marketing campaign, such as a direct mail promotion, webinar, or trade show.",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    salesforce_rest_api: {
+      type: "app",
+      app: "salesforce_rest_api",
+    },
+    Name: {
+      type: "string",
+      description: "Required. Name of the campaign. Limit: is 80 characters.",
+    },
+    ActualCost: {
+      type: "string",
+      description: "Amount of money spent to run the campaign.",
+      optional: true,
+    },
+    BudgetedCost: {
+      type: "string",
+      description: "Amount of money budgeted for the campaign.",
+      optional: true,
+    },
+    CampaignImageId: {
+      type: "string",
+      description: "ID of the campaign image. Available in API version 42.0 and later.",
+      optional: true,
+    },
+    CampaignMemberRecordTypeId: {
+      type: "string",
+      description: "The record type ID for CampaignMember records associated with the campaign.",
+      optional: true,
+    },
+    CurrencyIsoCode: {
+      type: "string",
+      description: "Available only for organizations with the multicurrency feature enabled. Contains the ISO code for any currency allowed by the organization.",
+      optional: true,
+    },
+    Description: {
+      type: "string",
+      description: "Description of the campaign. Limit: 32 KB. Only the first 255 characters display in reports.",
+      optional: true,
+    },
+    EndDate: {
+      type: "string",
+      description: "Ending date for the campaign. Responses received after this date are still counted.",
+      optional: true,
+    },
+    ExpectedResponse: {
+      type: "string",
+      description: "Percentage of responses you expect to receive for the campaign.",
+      optional: true,
+    },
+    ExpectedRevenue: {
+      type: "string",
+      description: "Amount of money you expect to generate from the campaign.",
+      optional: true,
+    },
+    IsActive: {
+      type: "boolean",
+      description: "Indicates whether this campaign is active (true) or not (false). Default value is false. Label is Active.",
+      optional: true,
+    },
+    NumberSent: {
+      type: "integer",
+      description: "Number of individuals targeted by the campaign. For example, the number of emails sent. Label is Num Sent.",
+      optional: true,
+    },
+    OwnerId: {
+      type: "string",
+      description: "ID of the user who owns this campaign. Default value is the user logging in to the API to perform the create.",
+      optional: true,
+    },
+    ParentCampaign: {
+      type: "string",
+      description: "The campaign above the selected campaign in the campaign hierarchy.",
+      optional: true,
+    },
+    ParentId: {
+      type: "string",
+      description: "ID of the parent Campaign record, if any.",
+      optional: true,
+    },
+    RecordTypeId: {
+      type: "string",
+      description: "ID of the record type assigned to this object.",
+      optional: true,
+    },
+    StartDate: {
+      type: "string",
+      description: "Starting date for the campaign.",
+      optional: true,
+    },
+    Status: {
+      type: "string",
+      description: "Status of the campaign, for example, Planned, In Progress. Limit: 40 characters.",
+      optional: true,
+    },
+    Type: {
+      type: "string",
+      description: "Type of campaign, for example, Direct Mail or Referral Program. Limit: 40 characters.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  // See the API docs here: https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_sobject_create.htm
+  // Campaign object: https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_objects_campaign.htm
+
+    if (!this.Name) {
+      throw new Error("Must provide Name parameter.");
+    }
+
+    return await axios($, {
+      "method": "post",
+      "url": `${this.salesforce_rest_api.$auth.instance_url}/services/data/v20.0/sobjects/Campaign/`,
+      "Content-Type": "application/json",
+      "headers": {
+        Authorization: `Bearer ${this.salesforce_rest_api.$auth.oauth_access_token}`,
+      },
+  	"data": {
+  		ActualCost: this.ActualCost,
+  		BudgetedCost: this.BudgetedCost,
+  		CampaignImageId: this.CampaignImageId,
+  		CampaignMemberRecordTypeId: this.CampaignMemberRecordTypeId,
+  		CurrencyIsoCode: this.CurrencyIsoCode,
+  		Description: this.Description,
+  		EndDate: this.EndDate,
+  		ExpectedResponse: this.ExpectedResponse,
+  		ExpectedRevenue: this.ExpectedRevenue,
+  		IsActive: this.IsActive,
+  		Name: this.Name,
+  		NumberSent: this.NumberSent,
+  		OwnerId: this.OwnerId,
+  		ParentCampaign: this.ParentCampaign,
+  		ParentId: this.ParentId,
+  		RecordTypeId: this.RecordTypeId,
+  		StartDate: this.StartDate,
+  		Status: this.Status,
+  		Type: this.Type,
+  	},
+    });
+  },
+};

--- a/components/salesforce_rest_api/actions/salesforce-create-case/salesforce-create-case.mjs
+++ b/components/salesforce_rest_api/actions/salesforce-create-case/salesforce-create-case.mjs
@@ -1,0 +1,179 @@
+// legacy_hash_id: a_WYiE7G
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "salesforce_rest_api-salesforce-create-case",
+  name: "Create Case",
+  description: "Creates a Salesforce case, which represents a customer issue or problem.",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    salesforce_rest_api: {
+      type: "app",
+      app: "salesforce_rest_api",
+    },
+    SuppliedEmail: {
+      type: "string",
+      description: "The email address that was entered when the case was created. Label is Email.If your organization has an active auto-response rule, SuppliedEmail is required when creating a case via the API. Auto-response rules use the email in the contact specified by ContactId. If no email address is in the contact record, the email specified here is used.",
+      optional: true,
+    },
+    AccountId: {
+      type: "string",
+      description: "ID of the account associated with this case.",
+      optional: true,
+    },
+    BusinessHoursId: {
+      type: "string",
+      description: "ID of the business hours associated with this case.",
+      optional: true,
+    },
+    ContactId: {
+      type: "string",
+      description: "ID of the associated Contact.",
+      optional: true,
+    },
+    CommunityId: {
+      type: "string",
+      description: "ID of the Community (Zone) associated with this case.",
+      optional: true,
+    },
+    Description: {
+      type: "string",
+      description: "A text description of the case. Limit: 32 KB.",
+      optional: true,
+    },
+    FeedItemId: {
+      type: "string",
+      description: "ID of the question in Chatter associated with the case. This field is available in API version 33.0 and later, and is only accessible in organizations where Question-to-Case is enabled.",
+      optional: true,
+    },
+    IsEscalated: {
+      type: "boolean",
+      description: "Indicates whether the case has been escalated (true) or not. A case's escalated state does not affect how you can use a case, or whether you can query, delete, or update it. You can set this flag via the API. Label is Escalated.",
+      optional: true,
+    },
+    Language: {
+      type: "string",
+      description: "The language of the case. This field is available in all Enterprise, Performance, and Unlimited orgs with the Service Cloud. Out of the box, it's used only by Einstein Case Classification.",
+      optional: true,
+    },
+    Origin: {
+      type: "string",
+      description: "The source of the case, such as Email, Phone, or Web. Label is Case Origin.",
+      optional: true,
+    },
+    OwnerId: {
+      type: "string",
+      description: "ID of the contact who owns the case.",
+      optional: true,
+    },
+    ParentId: {
+      type: "string",
+      description: "The ID of the parent case in the hierarchy. The label is Parent Case.",
+      optional: true,
+    },
+    Priority: {
+      type: "string",
+      description: "The importance or urgency of the case, such as High, Medium, or Low.",
+      optional: true,
+    },
+    QuestionId: {
+      type: "string",
+      description: "The question in the answers community that is associated with the case. This field does not appear if you don't have an answers community enabled.",
+      optional: true,
+    },
+    Reason: {
+      type: "string",
+      description: "The reason why the case was created, such as Instructions not clear, or User didn't attend training.",
+      optional: true,
+    },
+    RecordTypeId: {
+      type: "string",
+      description: "ID of the record type assigned to this object.",
+      optional: true,
+    },
+    SlaStartDate: {
+      type: "string",
+      description: "Shows the time that the case entered an entitlement process. If you have the Edit permission on cases, you can update or reset the time if you have the Edit permission on cases.",
+      optional: true,
+    },
+    SourceId: {
+      type: "string",
+      description: "The ID of the social post source.",
+      optional: true,
+    },
+    Status: {
+      type: "string",
+      description: "The status of the case, such as New, Closed, or Escalated. This field directly controls the IsClosed flag. Each predefined Status value implies an IsClosed flag value. For more information, see CaseStatus.",
+      optional: true,
+    },
+    Subject: {
+      type: "string",
+      description: "The subject of the case. Limit: 255 characters.",
+      optional: true,
+    },
+    SuppliedCompany: {
+      type: "string",
+      description: "The company name that was entered when the case was created. Label is Company.",
+      optional: true,
+    },
+    SuppliedName: {
+      type: "string",
+      description: "The name that was entered when the case was created. Label is Name.",
+      optional: true,
+    },
+    SuppliedPhone: {
+      type: "string",
+      description: "The phone number that was entered when the case was created. Label is Phone.",
+      optional: true,
+    },
+    Type: {
+      type: "string",
+      description: "The type of case, such as Feature Request or Question.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  // See the API docs here: https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_sobject_create.htm
+  // Case object: https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_objects_case.htm
+
+    if (!this.SuppliedEmail) {
+      throw new Error("Must provide SuppliedEmail parameter.");
+    }
+
+    return await axios($, {
+      "method": "post",
+      "url": `${this.salesforce_rest_api.$auth.instance_url}/services/data/v20.0/sobjects/Case/`,
+      "Content-Type": "application/json",
+      "headers": {
+        Authorization: `Bearer ${this.salesforce_rest_api.$auth.oauth_access_token}`,
+      },
+  	"data": {
+  		AccountId: this.AccountId,
+  		BusinessHoursId: this.BusinessHoursId,
+  		ContactId: this.ContactId,
+  		CommunityId: this.CommunityId,
+  		Description: this.Description,
+  		FeedItemId: this.FeedItemId,
+  		IsEscalated: this.IsEscalated,
+  		Language: this.Language,
+  		Origin: this.Origin,
+  		OwnerId: this.OwnerId,
+  		ParentId: this.ParentId,
+  		Priority: this.Priority,
+  		QuestionId: this.QuestionId,
+  		Reason: this.Reason,
+  		RecordTypeId: this.RecordTypeId,
+  		SlaStartDate: this.SlaStartDate,
+  		SourceId: this.SourceId,
+  		Status: this.Status,
+  		Subject: this.Subject,
+  		SuppliedCompany: this.SuppliedCompany,
+  		SuppliedEmail: this.SuppliedEmail,
+  		SuppliedName: this.SuppliedName,
+  		SuppliedPhone: this.SuppliedPhone,
+  		Type: this.Type,
+  	},
+    });
+  },
+};

--- a/components/salesforce_rest_api/actions/salesforce-create-casecomment/salesforce-create-casecomment.mjs
+++ b/components/salesforce_rest_api/actions/salesforce-create-casecomment/salesforce-create-casecomment.mjs
@@ -1,0 +1,58 @@
+// legacy_hash_id: a_wdiBxG
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "salesforce_rest_api-salesforce-create-casecomment",
+  name: "Create CaseComment",
+  description: "Creates a CaseComment that provides additional information about the associated Case.",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    salesforce_rest_api: {
+      type: "app",
+      app: "salesforce_rest_api",
+    },
+    ParentId: {
+      type: "string",
+      description: "Required. ID of the parent Case of the CaseComment.",
+    },
+    CommentBody: {
+      type: "string",
+      description: "Text of the CaseComment. The maximum size of the comment body is 4,000 bytes. Label is Body.",
+      optional: true,
+    },
+    IsNotificationSelected: {
+      type: "boolean",
+      description: "Indicates whether an email notification is sent to the case contact when a CaseComment is created or updated. When this field is queried, it always returns null. This field is available only when the Enable Case Comment Notification to Contacts setting is enabled on the Support Settings page in Setup. To send email notifications for CaseComment, you must use the EmailHeader triggerUserEmail. Available in API version 43.0 and later.",
+      optional: true,
+    },
+    IsPublished: {
+      type: "boolean",
+      description: "Indicates whether the CaseComment is visible to customers in the Self-Service portal (true) or not (false). Label is Published. This is the only CaseComment field that can be updated via the API.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  // See the API docs here: https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_sobject_create.htm
+  // CaseComment object: https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_objects_casecomment.htm
+
+    if (!this.ParentId) {
+      throw new Error("Must provide ParentId parameter.");
+    }
+
+    return await axios($, {
+      "method": "post",
+      "url": `${this.salesforce_rest_api.$auth.instance_url}/services/data/v20.0/sobjects/CaseComment/`,
+      "Content-Type": "application/json",
+      "headers": {
+        Authorization: `Bearer ${this.salesforce_rest_api.$auth.oauth_access_token}`,
+      },
+  	"data": {
+  		CommentBody: this.CommentBody,
+  		IsNotificationSelected: this.IsNotificationSelected,
+  		IsPublished: this.IsPublished,
+  		ParentId: this.ParentId,
+  	},
+    });
+  },
+};

--- a/components/salesforce_rest_api/actions/salesforce-create-contact/salesforce-create-contact.mjs
+++ b/components/salesforce_rest_api/actions/salesforce-create-contact/salesforce-create-contact.mjs
@@ -1,0 +1,340 @@
+// legacy_hash_id: a_k6iK7L
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "salesforce_rest_api-salesforce-create-contact",
+  name: "Create Contact",
+  description: "Creates a Contact, which is a person associated with an account.",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    salesforce_rest_api: {
+      type: "app",
+      app: "salesforce_rest_api",
+    },
+    LastName: {
+      type: "string",
+      description: "Required. Last name of the contact up to 80 characters.",
+    },
+    AccountId: {
+      type: "string",
+      description: "ID of the account that's the parent of this contact. We recommend that you update up to 50 contacts simultaneously when changing the accounts on contacts enabled for a Customer Portal or partner portal. We also recommend that you make this update after business hours.",
+      optional: true,
+    },
+    AssistantName: {
+      type: "string",
+      description: "The assistant's name.",
+      optional: true,
+    },
+    AssistantPhone: {
+      type: "string",
+      description: "The assistant's telephone number.",
+      optional: true,
+    },
+    Birthdate: {
+      type: "string",
+      description: "The contact's birthdate.Filter criteria for report filters, list view filters, and SOQL queries ignore the year portion of the Birthdate field. For example, this SOQL query returns contacts with birthdays later in the year than today:view sourceprint?1SELECT Name, Birthdate2FROM Contact3WHERE Birthdate &gt; TODAY",
+      optional: true,
+    },
+    CanAllowPortalSelfReg: {
+      type: "boolean",
+      description: "Indicates whether this contact can self-register for your Customer Portal (true) or not (false).",
+      optional: true,
+    },
+    CleanStatus: {
+      type: "string",
+      description: "Indicates the record's clean status as compared with Data.com. Values include: Matched, Different, Acknowledged, NotFound, Inactive, Pending, SelectMatch, or Skipped.Several values for CleanStatus appear with different labels on the contact record. Matched appears as In Sync Acknowledged appears as Reviewed Pending appears as Not Compared",
+      optional: true,
+    },
+    Department: {
+      type: "string",
+      description: "The contact's department.",
+      optional: true,
+    },
+    Description: {
+      type: "string",
+      description: "A description of the contact. Label is Contact Description up to 32 KB.",
+      optional: true,
+    },
+    DoNotCall: {
+      type: "boolean",
+      description: "Indicates that the contact does not want to receive calls.",
+      optional: true,
+    },
+    Email: {
+      type: "string",
+      description: "The contact's email address.",
+      optional: true,
+    },
+    EmailBouncedDate: {
+      type: "string",
+      description: "If bounce management is activated and an email sent to the contact bounces, the date and time of the bounce.",
+      optional: true,
+    },
+    EmailBouncedReason: {
+      type: "string",
+      description: "If bounce management is activated and an email sent to the contact bounces, the reason for the bounce.",
+      optional: true,
+    },
+    Fax: {
+      type: "string",
+      description: "The contact's fax number. Label is Business Fax.",
+      optional: true,
+    },
+    FirstName: {
+      type: "string",
+      description: "The contact's first name up to 40 characters.",
+      optional: true,
+    },
+    HasOptedOutOfEmail: {
+      type: "boolean",
+      description: "Indicates whether the contact doesn't want to receive email from Salesforce (true) or does (false). Label is Email Opt Out.",
+      optional: true,
+    },
+    HasOptedOutOfFax: {
+      type: "boolean",
+      description: "Indicates whether the contact prohibits receiving faxes.",
+      optional: true,
+    },
+    HomePhone: {
+      type: "string",
+      description: "The contact's home telephone number.",
+      optional: true,
+    },
+    IndividualId: {
+      type: "string",
+      description: "ID of the data privacy record associated with this contact. This field is available if Data Protection and Privacy is enabled.",
+      optional: true,
+    },
+    Jigsaw: {
+      type: "string",
+      description: "References the company's ID in Data.com. If an account has a value in this field, it means that the account was imported from Data.com. If the field value is null, the account was not imported from Data.com. Maximum size is 20 characters. Available in API version 22.0 and later. Label is Data.com Key. Important The Jigsaw field is exposed in the API to support troubleshooting for import errors and reimporting of corrected data. Do not modify this value.",
+      optional: true,
+    },
+    LeadSource: {
+      type: "string",
+      description: "The lead's source.",
+      optional: true,
+    },
+    MailingCity: {
+      type: "string",
+      description: "Mailing address details.",
+      optional: true,
+    },
+    MailingState: {
+      type: "string",
+      description: "Mailing address details.",
+      optional: true,
+    },
+    MailingCountry: {
+      type: "string",
+      description: "Mailing address details.",
+      optional: true,
+    },
+    MailingPostalCode: {
+      type: "string",
+      description: "Mailing address details.",
+      optional: true,
+    },
+    MailingCountryCode: {
+      type: "string",
+      description: "The ISO codes for the mailing address's country.",
+      optional: true,
+    },
+    MailingStateCode: {
+      type: "string",
+      description: "The ISO codes for the mailing address's state.",
+      optional: true,
+    },
+    MailingStreet: {
+      type: "string",
+      description: "Street address for mailing address.",
+      optional: true,
+    },
+    MailingGeocodeAccuracy: {
+      type: "string",
+      description: "Accuracy level of the geocode for the mailing address. For details on geolocation compound field, see Compound Field Considerations and Limitations.",
+      optional: true,
+    },
+    MailingLatitude: {
+      type: "integer",
+      description: "Used with MailingLongitude to specify the precise geolocation of a mailing address. Acceptable values are numbers between 90 and 90 up to 15 decimal places. For details on geolocation compound fields, see Compound Field Considerations and Limitations.",
+      optional: true,
+    },
+    MailingLongitude: {
+      type: "integer",
+      description: "Used with MailingLatitude to specify the precise geolocation of a mailing address. Acceptable values are numbers between 180 and 180 up to 15 decimal places. For details on geolocation compound fields, see Compound Field Considerations and Limitations.",
+      optional: true,
+    },
+    MiddleName: {
+      type: "string",
+      description: "The contact's middle name up to 40 characters. To enable this field, ask Salesforce Customer Support for help.",
+      optional: true,
+    },
+    MobilePhone: {
+      type: "string",
+      description: "Contact's mobile phone number.",
+      optional: true,
+    },
+    OtherCity: {
+      type: "string",
+      description: "Alternate address details.",
+      optional: true,
+    },
+    OtherCountry: {
+      type: "string",
+      description: "Alternate address details.",
+      optional: true,
+    },
+    OtherPostalCode: {
+      type: "string",
+      description: "Alternate address details.",
+      optional: true,
+    },
+    OtherState: {
+      type: "string",
+      description: "Alternate address details.",
+      optional: true,
+    },
+    OtherCountryCode: {
+      type: "string",
+      description: "The ISO codes for the alternate address's country.",
+      optional: true,
+    },
+    OtherStateCode: {
+      type: "string",
+      description: "The ISO codes for the alternate address's state.",
+      optional: true,
+    },
+    OtherGeocodeAccuracy: {
+      type: "string",
+      description: "Accuracy level of the geocode for the other address. For details on geolocation compound fields, see Compound Field Considerations and Limitations.",
+      optional: true,
+    },
+    OtherLatitude: {
+      type: "integer",
+      description: "Used with OtherLongitude to specify the precise geolocation of an alternate address. Acceptable values are numbers between 90 and 90 up to 15 decimal places. For details on geolocation compound fields, see Compound Field Considerations and Limitations.",
+      optional: true,
+    },
+    OtherLongitude: {
+      type: "integer",
+      description: "Used with OtherLatitude to specify the precise geolocation of an alternate address. Acceptable values are numbers between 180 and 180 up to 15 decimal places. For details on geolocation compound fields, see Compound Field Considerations and Limitations.",
+      optional: true,
+    },
+    OtherPhone: {
+      type: "string",
+      description: "Telephone for alternate address.",
+      optional: true,
+    },
+    OtherStreet: {
+      type: "string",
+      description: "Street for alternate address.",
+      optional: true,
+    },
+    OwnerId: {
+      type: "string",
+      description: "The ID of the owner of the account associated with this contact.",
+      optional: true,
+    },
+    Phone: {
+      type: "string",
+      description: "Telephone number for the contact. Label is Business Phone.",
+      optional: true,
+    },
+    RecordTypeId: {
+      type: "string",
+      description: "ID of the record type assigned to this object.",
+      optional: true,
+    },
+    ReportsToId: {
+      type: "string",
+      description: "This field doesn't appear if IsPersonAccount is true.",
+      optional: true,
+    },
+    Salutation: {
+      type: "string",
+      description: "Honorific abbreviation, word, or phrase to be used in front of name in greetings, such as Dr. or Mrs.",
+      optional: true,
+    },
+    Suffix: {
+      type: "string",
+      description: "Name suffix of the contact up to 40 characters. To enable this field, ask Salesforce Customer Support for help.",
+      optional: true,
+    },
+    Title: {
+      type: "string",
+      description: "Title of the contact, such as CEO or Vice President.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  // See the API docs here: https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_sobject_create.htm
+  // Contact object: https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_objects_contact.htm
+
+    if (!this.LastName) {
+      throw new Error("Must provide LastNameRo parameter.");
+    }
+
+    return await axios($, {
+      "method": "post",
+      "url": `${this.salesforce_rest_api.$auth.instance_url}/services/data/v20.0/sobjects/Contact/`,
+      "Content-Type": "application/json",
+      "headers": {
+        Authorization: `Bearer ${this.salesforce_rest_api.$auth.oauth_access_token}`,
+      },
+      "data": {
+        AccountId: this.AccountId,
+        AssistantName: this.AssistantName,
+        AssistantPhone: this.AssistantPhone,
+        Birthdate: this.Birthdate,
+        CanAllowPortalSelfReg: this.CanAllowPortalSelfReg,
+        CleanStatus: this.CleanStatus,
+        Department: this.Department,
+        Description: this.Description,
+        DoNotCall: this.DoNotCall,
+        Email: this.Email,
+        EmailBouncedDate: this.EmailBouncedDate,
+        EmailBouncedReason: this.EmailBouncedReason,
+        Fax: this.Fax,
+        FirstName: this.FirstName,
+        HasOptedOutOfEmail: this.HasOptedOutOfEmail,
+        HasOptedOutOfFax: this.HasOptedOutOfFax,
+        HomePhone: this.HomePhone,
+        IndividualId: this.IndividualId,
+        Jigsaw: this.Jigsaw,
+        LastName: this.LastName,
+        LeadSource: this.LeadSource,
+        MailingCity: this.MailingCity,
+        MailingState: this.MailingState,
+        MailingCountry: this.MailingCountry,
+        MailingPostalCode: this.MailingPostalCode,
+        MailingCountryCode: this.MailingCountryCode,
+        MailingStateCode: this.MailingStateCode,
+        MailingStreet: this.MailingStreet,
+        MailingGeocodeAccuracy: this.MailingGeocodeAccuracy,
+        MailingLatitude: this.MailingLatitude,
+        MailingLongitude: this.MailingLongitude,
+        MiddleName: this.MiddleName,
+        MobilePhone: this.MobilePhone,
+        OtherCity: this.OtherCity,
+        OtherCountry: this.OtherCountry,
+        OtherPostalCode: this.OtherPostalCode,
+        OtherState: this.OtherState,
+        OtherCountryCode: this.OtherCountryCode,
+        OtherStateCode: this.OtherStateCode,
+        OtherGeocodeAccuracy: this.OtherGeocodeAccuracy,
+        OtherLatitude: this.OtherLatitude,
+        OtherLongitude: this.OtherLongitude,
+        OtherPhone: this.OtherPhone,
+        OtherStreet: this.OtherStreet,
+        OwnerId: this.OwnerId,
+        Phone: this.Phone,
+        RecordTypeId: this.RecordTypeId,
+        ReportsToId: this.ReportsToId,
+        Salutation: this.Salutation,
+        Suffix: this.Suffix,
+        Title: this.Title,
+      },
+    });
+  },
+};

--- a/components/salesforce_rest_api/actions/salesforce-create-event/salesforce-create-event.mjs
+++ b/components/salesforce_rest_api/actions/salesforce-create-event/salesforce-create-event.mjs
@@ -1,0 +1,232 @@
+// legacy_hash_id: a_l0i2O5
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "salesforce_rest_api-salesforce-create-event",
+  name: "Create Event",
+  description: "Creates an event, which represents an event in the calendar.",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    salesforce_rest_api: {
+      type: "app",
+      app: "salesforce_rest_api",
+    },
+    DurationInMinutes: {
+      type: "integer",
+      description: "Contains the event length, in minutes. Even though this field represents a temporal value, it is an integer typenot a Date/Time type.Required in versions 12.0 and earlier if IsAllDayEvent is false. In versions 13.0 and later, this field is optional, depending on the following: If IsAllDayEvent is true, you can supply a value for either DurationInMinutes or EndDateTime. Supplying values in both fields is allowed if the values add up to the same amount of time. If both fields are null, the duration defaults to one day. If IsAllDayEvent is false, a value must be supplied for either DurationInMinutes or EndDateTime. Supplying values in both fields is allowed if the values add up to the same amount of time. If the multiday event feature is enabled, then API versions 13.0 and later support values greater than 1440 for the DurationInMinutes field. API versions 12.0 and earlier can't access event objects whose DurationInMinutes is greater than 1440. For more information, see Multiday Events. Depending on your API version, errors with the DurationInMinutes and EndDateTime fields may appear in different places. Versions 38.0 and beforeErrors always appear in the DurationInMinutes field. Versions 39.0 and laterIf there's no value for the DurationInMinutes field, errors appear in the EndDateTime field. Otherwise, they appear in the DurationInMinutes field.",
+    },
+    AcceptedEventInviteeIds: {
+      type: "string",
+      description: "A string array of contact or lead IDs who accepted this event. This JunctionIdList is linked to the AcceptedEventRelation child relationship. Warning Adding a JunctionIdList field name to the fieldsToNull property deletes all related junction records. This action can't be undone.",
+      optional: true,
+    },
+    ActivityDate: {
+      type: "string",
+      description: "Contains the event's due date if the IsAllDayEvent flag is set to true. This field is a date field with a timestamp that is always set to midnight in the Coordinated Universal Time (UTC) time zone. Don't attempt to alter the timestamp to account for time zone differences. Label is Due Date Only.This field is required in versions 12.0 and earlier if the IsAllDayEvent flag is set to true. The value for this field and StartDateTime must match, or one of them must be null.",
+      optional: true,
+    },
+    ActivityDateTime: {
+      type: "string",
+      description: "Contains the event's due date if the IsAllDayEvent flag is set to false. The time portion of this field is always transferred in the Coordinated Universal Time (UTC) time zone. Translate the time portion to or from a local time zone for the user or the application, as appropriate. Label is Due Date Time.This field is required in versions 12.0 and earlier if the IsAllDayEvent flag is set to false. The value for this field and StartDateTime must match, or one of them must be null.",
+      optional: true,
+    },
+    CurrencyIsoCode: {
+      type: "string",
+      description: "Available only for organizations with the multicurrency feature enabled. Contains the ISO code for any currency allowed by the organization.",
+      optional: true,
+    },
+    DeclinedEventInviteeIds: {
+      type: "string",
+      description: "A string array of contact, lead, or user IDs who declined this event. This JunctionIdList is linked to the DeclinedEventRelation child relationship. Warning Adding a JunctionIdList field name to the fieldsToNull property deletes all related junction records. This action can't be undone.",
+      optional: true,
+    },
+    Description: {
+      type: "string",
+      description: "Contains a text description of the event. Limit: 32,000 characters.",
+      optional: true,
+    },
+    EndDateTime: {
+      type: "string",
+      description: "Available in versions 13.0 and later. The time portion of this field is always transferred in the Coordinated Universal Time (UTC) time zone. Translate the time portion to or from a local time zone for the user or the application, as appropriate.This field is optional, depending on the following: If IsAllDayEvent is true, you can supply a value for either DurationInMinutes or EndDateTime. Supplying values in both fields is allowed if the values add up to the same amount of time. If both fields are null, the duration defaults to one day. If IsAllDayEvent is false, a value must be supplied for either DurationInMinutes or EndDateTime. Supplying values in both fields is allowed if the values add up to the same amount of time. Depending on your API version, errors with the DurationInMinutes and EndDateTime fields may appear in different places. Versions 38.0 and beforeErrors always appear in the DurationInMinutes field. Versions 39.0 and laterIf there's no value for the DurationInMinutes field, errors appear in the EndDateTime field. Otherwise, they appear in the DurationInMinutes field.",
+      optional: true,
+    },
+    EventSubtype: {
+      type: "string",
+      description: "Provides standard subtypes to facilitate creating and searching for events. This field isn't updateable.",
+      optional: true,
+    },
+    EventWhoIds: {
+      type: "string",
+      description: "A string array of contact or lead IDs used to create many-to-many relationships with a shared event. EventWhoIds is available when the shared activities setting is enabled. The first contact or lead ID in the list becomes the primary WhoId if you don't specify a primary WhoId. If you set the EventWhoIds field to null, all entries in the list are deleted and the value of WhoId is added as the first entry. Warning Adding a JunctionIdList field name to the fieldsToNull property deletes all related junction records. This action can't be undone.",
+      optional: true,
+    },
+    IsAllDayEvent: {
+      type: "boolean",
+      description: "Indicates whether the ActivityDate field (true) or the ActivityDateTime field (false) is used to define the date or time of the event. Label is All-Day Event. See also DurationInMinutes and EndDateTime.",
+      optional: true,
+    },
+    IsPrivate: {
+      type: "boolean",
+      description: "Indicates whether users other than the creator of the event can (false) or can't (true) see the event details when viewing the event user's calendar. However, users with the View All Data or Modify All Data permission can see private events in reports and searches, or when viewing other users' calendars. Private events can't be associated with opportunities, accounts, cases, campaigns, contracts, leads, or contacts. Label is Private.",
+      optional: true,
+    },
+    IsRecurrence: {
+      type: "boolean",
+      description: "Indicates whether a Salesforce Classic event is scheduled to repeat itself (true) or only occurs once (false). This is a read-only field when updating records, but not when creating them. If this field value is true, then RecurrenceEndDateOnly, RecurrenceStartDateTime, RecurrenceType, and any recurrence fields associated with the given recurrence type must be populated. Label is Create recurring series of events.",
+      optional: true,
+    },
+    IsReminderSet: {
+      type: "boolean",
+      description: "Indicates whether the activity is a reminder (true) or not (false).",
+      optional: true,
+    },
+    Location: {
+      type: "string",
+      description: "Contains the location of the event.",
+      optional: true,
+    },
+    OwnerId: {
+      type: "string",
+      description: "Contains the ID of the user or public calendar who owns the event. Label is Assigned to ID.",
+      optional: true,
+    },
+    RecurrenceDayOfMonth: {
+      type: "integer",
+      description: "Indicates the day of the month on which the event repeats.",
+      optional: true,
+    },
+    RecurrenceDayOfWeekMask: {
+      type: "integer",
+      description: "Indicates the day or days of the week on which the Salesforce Classic recurring event repeats. This field contains a bitmask. The values are as follows: Sunday = 1 Monday = 2 Tuesday = 4 Wednesday = 8 Thursday = 16 Friday = 32 Saturday = 64 Multiple days are represented as the sum of their numerical values. For example, Tuesday and Thursday = 4 + 16 = 20.",
+      optional: true,
+    },
+    RecurrenceEndDateOnly: {
+      type: "string",
+      description: "Indicates the last date on which the event repeats. For multiday Salesforce Classic recurring events, this is the day on which the last occurrence starts. This field is a date field with a timestamp that is always set to midnight in the Coordinated Universal Time (UTC) time zone. Don't attempt to alter the timestamp to account for time zone differences.",
+      optional: true,
+    },
+    RecurrenceInstance: {
+      type: "string",
+      description: "Indicates the frequency of the Salesforce Classic event's recurrence. For example, 2nd or 3rd.",
+      optional: true,
+    },
+    RecurrenceInterval: {
+      type: "integer",
+      description: "Indicates the interval between Salesforce Classic recurring events.",
+      optional: true,
+    },
+    RecurrenceMonthOfYear: {
+      type: "string",
+      description: "Indicates the month in which the Salesforce Classic recurring event repeats.",
+      optional: true,
+    },
+    RecurrenceStartDateTime: {
+      type: "string",
+      description: "Indicates the date and time when the Salesforce Classic recurring event begins. The value must precede the RecurrenceEndDateOnly. The time portion of this field is always transferred in the Coordinated Universal Time (UTC) time zone. Translate the time portion to or from a local time zone for the user or the application, as appropriate.",
+      optional: true,
+    },
+    RecurrenceTimeZoneSidKey: {
+      type: "string",
+      description: "Indicates the time zone associated with a Salesforce Classic recurring event. For example, UTC-8:00 for Pacific Standard Time.",
+      optional: true,
+    },
+    RecurrenceType: {
+      type: "string",
+      description: "Indicates how often the Salesforce Classic event repeats. For example, daily, weekly, or every nth month (where nth is defined in RecurrenceInstance).",
+      optional: true,
+    },
+    ReminderDateTime: {
+      type: "string",
+      description: "Represents the time when the reminder is scheduled to fire, if IsReminderSet is set to true. If IsReminderSet is set to false, then the user may have deselected the reminder checkbox in the Salesforce user interface, or the reminder has already fired at the time indicated by the value.",
+      optional: true,
+    },
+    ShowAs: {
+      type: "string",
+      description: "Indicates how this event appears when another user views the calendar: Busy, Out of Office, or Free. Label is Show Time As.",
+      optional: true,
+    },
+    StartDateTime: {
+      type: "string",
+      description: "Indicates the start date and time of the event. Available in versions 13.0 and later.If the Event IsAllDayEvent flag is set to true (indicating that it is an all-day Event), then the event start date information is contained in the StartDateTime field. The time portion of this field is always transferred in the Coordinated Universal Time (UTC) time zone. Translate the time portion to or from a local time zone for the user or the application, as appropriate. If the Event IsAllDayEvent flag is set to false (indicating that it is not an all-day event), then the event start date information is contained in the StartDateTime field. The time portion is always transferred in the Coordinated Universal Time (UTC) time zone. You need to translate the time portion to or from a local time zone for the user or the application, as appropriate. If this field has a value, then ActivityDate and ActivityDateTime must either be null or match the value of this field.",
+      optional: true,
+    },
+    Subject: {
+      type: "string",
+      description: "The subject line of the event, such as Call, Email, or Meeting. Limit: 255 characters.",
+      optional: true,
+    },
+    Type: {
+      type: "string",
+      description: "Indicates the event type, such as Call, Email, or Meeting.",
+      optional: true,
+    },
+    UndecidedEventInviteeIds: {
+      type: "string",
+      description: "A string array of contact, lead, or user IDs who are undecided about this event. This JunctionIdList is linked to the UndecidedEventRelation child relationship. Warning Adding a JunctionIdList field name to the fieldsToNull property deletes all related junction records. This action can't be undone.",
+      optional: true,
+    },
+    WhatId: {
+      type: "string",
+      description: "The WhatId represents nonhuman objects such as accounts, opportunities, campaigns, cases, or custom objects. WhatIds are polymorphic. Polymorphic means a WhatId is equivalent to the ID of a related object. The label is Related To ID.",
+      optional: true,
+    },
+    WhoId: {
+      type: "string",
+      description: "The WhoId represents a human such as a lead or a contact. WhoIds are polymorphic. Polymorphic means a WhoId is equivalent to a contact's ID or a lead's ID. The label is Name ID.If Shared Activities is enabled, the value of this field is the ID of the related lead or primary contact. If you add, update, or remove the WhoId field, you might encounter problems with triggers, workflows, and data validation rules that are associated with the record. The label is Name ID. If the JunctionIdList field is used, all WhoIds are included in the relationship list. Beginning in API version 37.0, if the contact or lead ID in the WhoId field is not in the EventWhoIds list, no error occurs and the ID is added to the EventWhoIds as the primary WhoId. If WhoId is set to null, an arbitrary ID from the existing EventWhoIds list is promoted to the primary position.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  // See the API docs here: https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_sobject_create.htm
+  // Event object: https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_objects_event.htm
+
+    if (!this.DurationInMinutes) {
+      throw new Error("Must provide DurationInMinutes parameter.");
+    }
+
+    return await axios($, {
+      "method": "post",
+      "url": `${this.salesforce_rest_api.$auth.instance_url}/services/data/v20.0/sobjects/Event/`,
+      "Content-Type": "application/json",
+      "headers": {
+        Authorization: `Bearer ${this.salesforce_rest_api.$auth.oauth_access_token}`,
+      },
+      "data": {
+        AcceptedEventInviteeIds: this.AcceptedEventInviteeIds,
+        ActivityDate: this.ActivityDate,
+        ActivityDateTime: this.ActivityDateTime,
+        CurrencyIsoCode: this.CurrencyIsoCode,
+        DeclinedEventInviteeIds: this.DeclinedEventInviteeIds,
+        Description: this.Description,
+        DurationInMinutes: this.DurationInMinutes,
+        EndDateTime: this.EndDateTime,
+        EventSubtype: this.EventSubtype,
+        EventWhoIds: this.EventWhoIds,
+        IsAllDayEvent: this.IsAllDayEvent,
+        IsPrivate: this.IsPrivate,
+        IsRecurrence: this.IsRecurrence,
+        IsReminderSet: this.IsReminderSet,
+        Location: this.Location,
+        OwnerId: this.OwnerId,
+        RecurrenceDayOfMonth: this.RecurrenceDayOfMonth,
+        RecurrenceDayOfWeekMask: this.RecurrenceDayOfWeekMask,
+        RecurrenceEndDateOnly: this.RecurrenceEndDateOnly,
+        RecurrenceInstance: this.RecurrenceInstance,
+        RecurrenceInterval: this.RecurrenceInterval,
+        RecurrenceMonthOfYear: this.RecurrenceMonthOfYear,
+        RecurrenceStartDateTime: this.RecurrenceStartDateTime,
+        RecurrenceTimeZoneSidKey: this.RecurrenceTimeZoneSidKey,
+        RecurrenceType: this.RecurrenceType,
+        ReminderDateTime: this.ReminderDateTime,
+        ShowAs: this.ShowAs,
+        StartDateTime: this.StartDateTime,
+        Subject: this.Subject,
+        Type: this.Type,
+        UndecidedEventInviteeIds: this.UndecidedEventInviteeIds,
+        WhatId: this.WhatId,
+        WhoId: this.WhoId,
+      },
+    });
+  },
+};

--- a/components/salesforce_rest_api/actions/salesforce-create-lead/salesforce-create-lead.mjs
+++ b/components/salesforce_rest_api/actions/salesforce-create-lead/salesforce-create-lead.mjs
@@ -1,0 +1,267 @@
+// legacy_hash_id: a_jQiWR4
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "salesforce_rest_api-salesforce-create-lead",
+  name: "Create Lead",
+  description: "Creates a lead, which represents a prospect or lead.",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    salesforce_rest_api: {
+      type: "app",
+      app: "salesforce_rest_api",
+    },
+    Company: {
+      type: "string",
+      description: "Required. The lead's company. Note If person account record types have been enabled, and if the value of Company is null, the lead converts to a person account.",
+    },
+    LastName: {
+      type: "string",
+      description: "Required. Last name of the lead up to 80 characters.",
+    },
+    AnnualRevenue: {
+      type: "string",
+      description: "Annual revenue for the lead's company.",
+      optional: true,
+    },
+    City: {
+      type: "string",
+      description: "City for the lead's address.",
+      optional: true,
+    },
+    CleanStatus: {
+      type: "string",
+      description: "Indicates the record's clean status compared with Data.com. Values include: Matched, Different, Acknowledged, NotFound, Inactive, Pending, SelectMatch, or Skipped.Several values for CleanStatus appear with different labels on the lead record. Matched appears as In Sync Acknowledged appears as Reviewed Pending appears as Not Compared",
+      optional: true,
+    },
+    CompanyDunsNumber: {
+      type: "string",
+      description: "The Data Universal Numbering System (D-U-N-S) number, which is a unique, nine-digit number assigned to every business location in the Dun &amp; Bradstreet database that has a unique, separate, and distinct operation. Industries and companies use D-U-N-S numbers as a global standard for business identification and tracking. Maximum size is 9 characters. Note This field is only available to organizations that use Data.com Prospector or Data.com Clean.",
+      optional: true,
+    },
+    Country: {
+      type: "string",
+      description: "The lead's country.",
+      optional: true,
+    },
+    CountryCode: {
+      type: "string",
+      description: "The ISO country code for the lead's address.",
+      optional: true,
+    },
+    CurrencyIsoCode: {
+      type: "string",
+      description: "Available only for organizations with the multicurrency feature enabled. Contains the ISO code for any currency allowed by the organization.",
+      optional: true,
+    },
+    Description: {
+      type: "string",
+      description: "The lead's description.",
+      optional: true,
+    },
+    Email: {
+      type: "string",
+      description: "The lead's email address.",
+      optional: true,
+    },
+    Fax: {
+      type: "string",
+      description: "The lead's fax number.",
+      optional: true,
+    },
+    FirstName: {
+      type: "string",
+      description: "The lead's first name up to 40 characters.",
+      optional: true,
+    },
+    HasOptedOutOfEmail: {
+      type: "boolean",
+      description: "Indicates whether the lead doesn't want to receive email from Salesforce (true) or does (false). Label is Email Opt Out.",
+      optional: true,
+    },
+    GeocodeAccuracy: {
+      type: "string",
+      description: "Accuracy level of the geocode for the address. For details on geolocation compound fields, see [Compound Field Considerations and Limitations](https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/compound_fields_limitations.htm#compound_fields_limitations).",
+      optional: true,
+    },
+    IndividualId: {
+      type: "string",
+      description: "ID of the data privacy record associated with this lead. This field is available if you enabled Data Protection and Privacy in Setup.",
+      optional: true,
+    },
+    Industry: {
+      type: "string",
+      description: "Industry in which the lead works.",
+      optional: true,
+    },
+    IsConverted: {
+      type: "boolean",
+      description: "Indicates whether the lead has been converted (true) or not (false). Label is Converted.",
+      optional: true,
+    },
+    IsUnreadByOwner: {
+      type: "boolean",
+      description: "If true, lead has been assigned, but not yet viewed. See Unread Leads for more information. Label is Unread By Owner.",
+      optional: true,
+    },
+    Jigsaw: {
+      type: "string",
+      description: "References the ID of a contact in Data.com. If a lead has a value in this field, it means that a contact was imported as a lead from Data.com. If the contact (converted to a lead) was not imported from Data.com, the field value is null. Maximum size is 20 characters.",
+      optional: true,
+    },
+    Latitude: {
+      type: "integer",
+      description: "Used with Longitude to specify the precise geolocation of an address. Acceptable values are numbers between 90 and 90 up to 15 decimal places. For details on geolocation compound fields, see [Compound Field Considerations and Limitations](https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/compound_fields_limitations.htm#compound_fields_limitations).",
+      optional: true,
+    },
+    Longitude: {
+      type: "integer",
+      description: "Used with Latitude to specify the precise geolocation of an address. Acceptable values are numbers between 180 and 180 up to 15 decimal places. For details on geolocation compound fields, see [Compound Field Considerations and Limitations](https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/compound_fields_limitations.htm#compound_fields_limitations).",
+      optional: true,
+    },
+    LeadSource: {
+      type: "string",
+      description: "The lead's source.",
+      optional: true,
+    },
+    MiddleName: {
+      type: "string",
+      description: "The lead's middle name up to 40 characters. To enable this field, ask Salesforce Customer Support for help.",
+      optional: true,
+    },
+    MobilePhone: {
+      type: "string",
+      description: "The lead's mobile phone number.",
+      optional: true,
+    },
+    NumberOfEmployees: {
+      type: "integer",
+      description: "Number of employees at the lead's company. Label is Employees.",
+      optional: true,
+    },
+    OwnerId: {
+      type: "string",
+      description: "ID of the lead's owner.",
+      optional: true,
+    },
+    Phone: {
+      type: "string",
+      description: "The lead's phone number.",
+      optional: true,
+    },
+    PostalCode: {
+      type: "string",
+      description: "Postal code for the address of the lead.",
+      optional: true,
+    },
+    Rating: {
+      type: "string",
+      description: "Rating of the lead.",
+      optional: true,
+    },
+    RecordTypeId: {
+      type: "string",
+      description: "ID of the record type assigned to this object.",
+      optional: true,
+    },
+    Salutation: {
+      type: "string",
+      description: "Salutation for the lead.",
+      optional: true,
+    },
+    State: {
+      type: "string",
+      description: "State for the address of the lead.",
+      optional: true,
+    },
+    StateCode: {
+      type: "string",
+      description: "The ISO state code for the lead's address.",
+      optional: true,
+    },
+    Status: {
+      type: "string",
+      description: "Status code for this converted lead. Status codes are defined in Status and represented in the API by the LeadStatus object.",
+      optional: true,
+    },
+    Street: {
+      type: "string",
+      description: "Street number and name for the address of the lead.",
+      optional: true,
+    },
+    Suffix: {
+      type: "string",
+      description: "The lead's name suffix up to 40 characters. To enable this field, ask Salesforce Customer Support for help.",
+      optional: true,
+    },
+    Title: {
+      type: "string",
+      description: "Title for the lead, such as CFO or CEO.",
+      optional: true,
+    },
+    Website: {
+      type: "string",
+      description: "Website for the lead.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  // See the API docs here: https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_sobject_create.htm
+  // Lead object: https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_objects_lead.htm
+
+    if (!this.Company || !this.LastName) {
+      throw new Error("Must provide Company and LastName parameters.");
+    }
+
+    return await axios($, {
+      "method": "post",
+      "url": `${this.salesforce_rest_api.$auth.instance_url}/services/data/v20.0/sobjects/Lead/`,
+      "Content-Type": "application/json",
+      "headers": {
+        Authorization: `Bearer ${this.salesforce_rest_api.$auth.oauth_access_token}`,
+      },
+      "data": {
+        AnnualRevenue: this.AnnualRevenue,
+        City: this.City,
+        CleanStatus: this.CleanStatus,
+        Company: this.Company,
+        CompanyDunsNumber: this.CompanyDunsNumber,
+        Country: this.Country,
+        CountryCode: this.CountryCode,
+        CurrencyIsoCode: this.CurrencyIsoCode,
+        Description: this.Description,
+        Email: this.Email,
+        Fax: this.Fax,
+        FirstName: this.FirstName,
+        HasOptedOutOfEmail: this.HasOptedOutOfEmail,
+        GeocodeAccuracy: this.GeocodeAccuracy,
+        IndividualId: this.IndividualId,
+        Industry: this.Industry,
+        IsConverted: this.IsConverted,
+        IsUnreadByOwner: this.IsUnreadByOwner,
+        Jigsaw: this.Jigsaw,
+        LastName: this.LastName,
+        Latitude: this.Latitude,
+        Longitude: this.Longitude,
+        LeadSource: this.LeadSource,
+        MiddleName: this.MiddleName,
+        MobilePhone: this.MobilePhone,
+        NumberOfEmployees: this.NumberOfEmployees,
+        OwnerId: this.OwnerId,
+        Phone: this.Phone,
+        PostalCode: this.PostalCode,
+        Rating: this.Rating,
+        RecordTypeId: this.RecordTypeId,
+        Salutation: this.Salutation,
+        State: this.State,
+        StateCode: this.StateCode,
+        Status: this.Status,
+        Street: this.Street,
+        Suffix: this.Suffix,
+        Title: this.Title,
+        Website: this.Website,
+      },
+    });
+  },
+};

--- a/components/salesforce_rest_api/actions/salesforce-create-note/salesforce-create-note.mjs
+++ b/components/salesforce_rest_api/actions/salesforce-create-note/salesforce-create-note.mjs
@@ -1,0 +1,63 @@
+// legacy_hash_id: a_Vpi7PO
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "salesforce_rest_api-salesforce-create-note",
+  name: "Create Note",
+  description: "Creates a note, which is text associated with a custom object or a standard object, such as a Contact, Contract, or Opportunity.",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    salesforce_rest_api: {
+      type: "app",
+      app: "salesforce_rest_api",
+    },
+    ParentId: {
+      type: "string",
+      description: "ID of the object associated with the note.",
+    },
+    Title: {
+      type: "string",
+      description: "Title of the note.",
+    },
+    Body: {
+      type: "string",
+      description: "Body of the note. Limited to 32 KB.",
+      optional: true,
+    },
+    IsPrivate: {
+      type: "boolean",
+      description: "If true, only the note owner or a user with the Modify All Data permission can view the note or query it via the API. Note that if a user who does not have the Modify All Data permission sets this field to true on a note that they do not own, then they can no longer query, delete, or update the note.",
+      optional: true,
+    },
+    OwnerId: {
+      type: "string",
+      description: "ID of the user who owns the note.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  // See the API docs here: https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_sobject_create.htm
+  // Note object: https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_objects_note.htm
+
+    if (!this.ParentId || !this.Title) {
+      throw new Error("Must provide ParentId and Title parameters.");
+    }
+
+    return await axios($, {
+      "method": "post",
+      "url": `${this.salesforce_rest_api.$auth.instance_url}/services/data/v20.0/sobjects/Note/`,
+      "Content-Type": "application/json",
+      "headers": {
+        Authorization: `Bearer ${this.salesforce_rest_api.$auth.oauth_access_token}`,
+      },
+      "data": {
+        Body: this.Body,
+        IsPrivate: this.IsPrivate,
+        OwnerId: this.OwnerId,
+        ParentId: this.ParentId,
+        Title: this.Title,
+      },
+    });
+  },
+};

--- a/components/salesforce_rest_api/actions/salesforce-create-opportunity/salesforce-create-opportunity.mjs
+++ b/components/salesforce_rest_api/actions/salesforce-create-opportunity/salesforce-create-opportunity.mjs
@@ -1,0 +1,170 @@
+// legacy_hash_id: a_oViVbR
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "salesforce_rest_api-salesforce-create-opportunity",
+  name: "Create Opportunity",
+  description: "Creates an opportunity, which represents an opportunity, which is a sale or pending deal.",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    salesforce_rest_api: {
+      type: "app",
+      app: "salesforce_rest_api",
+    },
+    CloseDate: {
+      type: "string",
+      description: "Date when the opportunity is expected to close.",
+    },
+    Name: {
+      type: "string",
+      description: "A name for this opportunity. Limit: 120 characters.",
+    },
+    StageName: {
+      type: "string",
+      description: "Current stage of this record. The StageName field controls several other fields on an opportunity. Each of the fields can be directly set or implied by changing the StageName field. In addition, the StageName field is a picklist, so it has additional members in the returned describeSObjectResult to indicate how it affects the other fields. To obtain the stage name values in the picklist, query the OpportunityStage object. If the StageName is updated, then the ForecastCategoryName, IsClosed, IsWon, and Probability are automatically updated based on the stage-category mapping.",
+    },
+    AccountId: {
+      type: "string",
+      description: "ID of the account associated with this opportunity.",
+      optional: true,
+    },
+    Amount: {
+      type: "string",
+      description: "Estimated total sale amount. For opportunities with products, the amount is the sum of the related products. Any attempt to update this field, if the record has products, will be ignored. The update call will not be rejected, and other fields will be updated as specified, but the Amount will be unchanged.",
+      optional: true,
+    },
+    CampaignId: {
+      type: "string",
+      description: "ID of a related Campaign. This field is defined only for those organizations that have the campaign feature Campaigns enabled. The User must have read access rights to the cross-referenced Campaign object in order to create or update that campaign into this field on the opportunity.",
+      optional: true,
+    },
+    ContactId: {
+      type: "string",
+      description: "ID of the contact associated with this opportunity, set as the primary contact. Read-only field that is derived from the opportunity contact role, which is created at the same time the opportunity is created. This field can only be populated when it's created, and can't be updated. To update the value in this field, change the IsPrimary flag on the OpportunityContactRole associated with this opportunity. Available in API version 46.0 and later.",
+      optional: true,
+    },
+    ContractId: {
+      type: "string",
+      description: "ID of the contract that's associated with this opportunity.",
+      optional: true,
+    },
+    CurrencyIsoCode: {
+      type: "string",
+      description: "Available only for organizations with the multicurrency feature enabled. Contains the ISO code for any currency allowed by the organization.",
+      optional: true,
+    },
+    Description: {
+      type: "string",
+      description: "Text description of the opportunity. Limit: 32,000 characters.",
+      optional: true,
+    },
+    ForecastCategoryName: {
+      type: "string",
+      description: "Available in API version 12.0 and later. The name of the forecast category. It is implied, but not directly controlled, by the StageName field. You can override this field to a different value than is implied by the StageName value.",
+      optional: true,
+    },
+    IsExcludedFromTerritory2Filter: {
+      type: "boolean",
+      description: "Used for Filter-Based Opportunity Territory Assignment (Pilot in Spring '15 / API version 33). Indicates whether the opportunity is excluded (True) or included (False) each time the APEX filter is executed.",
+      optional: true,
+    },
+    LeadSource: {
+      type: "string",
+      description: "Source of this opportunity, such as Advertisement or Trade Show.",
+      optional: true,
+    },
+    NextStep: {
+      type: "string",
+      description: "Description of next task in closing opportunity. Limit: 255 characters.",
+      optional: true,
+    },
+    OwnerId: {
+      type: "string",
+      description: "ID of the User who has been assigned to work this opportunity.If you update this field, the previous owner's access becomes Read Only or the access specified in your organization-wide default for opportunities, whichever is greater. If you have set up opportunity teams in your organization, updating this field has different consequences depending on your version of the API: For API version 12.0 and later, sharing records are kept, as they are for all objects. For API version before 12.0, sharing records are deleted. For API version 16.0 and later, users must have the Transfer Record permission in order to update (transfer) account ownership using this field.",
+      optional: true,
+    },
+    Pricebook2Id: {
+      type: "string",
+      description: "ID of a related Pricebook2 object. The Pricebook2Id field indicates which Pricebook2 applies to this opportunity. The Pricebook2Id field is defined only for those organizations that have products enabled as a feature. You can specify values for only one field (Pricebook2Id or PricebookId)not both fields. For this reason, both fields are declared nillable.",
+      optional: true,
+    },
+    PricebookId: {
+      type: "string",
+      description: "Unavailable as of version 3.0. As of version 8.0, the Pricebook object is no longer available. Use the Pricebook2Id field instead, specifying the ID of the Pricebook2 record.",
+      optional: true,
+    },
+    Probability: {
+      type: "string",
+      description: "Percentage of estimated confidence in closing the opportunity. It is implied, but not directly controlled, by the StageName field. You can override this field to a different value than what is implied by the StageName. Note If you're changing the Probability field through the API using a partner WSDL call, or an Apex before trigger, and the value may have several decimal places, we recommend rounding the value to a whole number. For example, the following Apex in a before trigger uses the round method to change the field value: o.probability = o.probability.round();",
+      optional: true,
+    },
+    RecordTypeId: {
+      type: "string",
+      description: "ID of the record type assigned to this object.",
+      optional: true,
+    },
+    SyncedQuoteID: {
+      type: "string",
+      description: "Read only in an Apex trigger. The ID of the Quote that syncs with the opportunity. Setting this field lets you start and stop syncing between the opportunity and a quote. The ID has to be for a quote that is a child of the opportunity.",
+      optional: true,
+    },
+    Territory2Id: {
+      type: "string",
+      description: "The ID of the territory that is assigned to the opportunity. Available only if Enterprise Territory Management has been enabled for your organization.",
+      optional: true,
+    },
+    TotalOpportunityQuantity: {
+      type: "integer",
+      description: "Number of items included in this opportunity. Used in quantity-based forecasting.",
+      optional: true,
+    },
+    Type: {
+      type: "string",
+      description: "Type of opportunity. For example, Existing Business or New Business.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  // See the API docs here: https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_sobject_create.htm
+  // Opportunity object: https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_objects_opportunity.htm
+
+    if (!this.CloseDate || !this.Name || !this.StageName) {
+      throw new Error("Must provide CloseDate, Name, and StageName parameters.");
+    }
+
+    return await axios($, {
+      "method": "post",
+      "url": `${this.salesforce_rest_api.$auth.instance_url}/services/data/v20.0/sobjects/Opportunity/`,
+      "Content-Type": "application/json",
+      "headers": {
+        Authorization: `Bearer ${this.salesforce_rest_api.$auth.oauth_access_token}`,
+      },
+      "data": {
+        AccountId: this.AccountId,
+        Amount: this.Amount,
+        CampaignId: this.CampaignId,
+        CloseDate: this.CloseDate,
+        ContactId: this.ContactId,
+        ContractId: this.ContractId,
+        CurrencyIsoCode: this.CurrencyIsoCode,
+        Description: this.Description,
+        ForecastCategoryName: this.ForecastCategoryName,
+        IsExcludedFromTerritory2Filter: this.IsExcludedFromTerritory2Filter,
+        LeadSource: this.LeadSource,
+        Name: this.Name,
+        NextStep: this.NextStep,
+        OwnerId: this.OwnerId,
+        Pricebook2Id: this.Pricebook2Id,
+        PricebookId: this.PricebookId,
+        Probability: this.Probability,
+        RecordTypeId: this.RecordTypeId,
+        StageName: this.StageName,
+        SyncedQuoteID: this.SyncedQuoteID,
+        Territory2Id: this.Territory2Id,
+        TotalOpportunityQuantity: this.TotalOpportunityQuantity,
+        Type: this.Type,
+      },
+    });
+  },
+};

--- a/components/salesforce_rest_api/actions/salesforce-create-record/salesforce-create-record.mjs
+++ b/components/salesforce_rest_api/actions/salesforce-create-record/salesforce-create-record.mjs
@@ -1,0 +1,36 @@
+// legacy_hash_id: a_vgi4Kv
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "salesforce_rest_api-salesforce-create-record",
+  name: "Create Record",
+  description: "Create new records of a given resource. Resource field values in the request data, and then use the POST method of the resource. The response body will contain the ID of the created record if the call is successful. Make user to include required fields of the resource you are creating.",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    salesforce_rest_api: {
+      type: "app",
+      app: "salesforce_rest_api",
+    },
+    sobject_name: {
+      type: "string",
+      description: "Salesforce standard object's name to retrive basic info for.",
+    },
+    sobject: {
+      type: "object",
+      description: "Data of the Salesforce standard object record to create.\nSalesforce standard objects are described in [Standard Objects](https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_objects_list.htm) section of the [SOAP API Developer Guide](https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_quickstart_intro.htm).",
+    },
+  },
+  async run({ $ }) {
+  //See the API docs here: https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/intro_what_is_rest_api.htm
+    return await axios($, {
+      "method": "post",
+      "url": `${this.salesforce_rest_api.$auth.instance_url}/services/data/v20.0/sobjects/${this.sobject_name}/`,
+      "Content-Type": "application/json",
+      "headers": {
+        Authorization: `Bearer ${this.salesforce_rest_api.$auth.oauth_access_token}`,
+      },
+      "data": this.sobject,
+    });
+  },
+};

--- a/components/salesforce_rest_api/actions/salesforce-create-task/salesforce-create-task.mjs
+++ b/components/salesforce_rest_api/actions/salesforce-create-task/salesforce-create-task.mjs
@@ -1,0 +1,219 @@
+// legacy_hash_id: a_RAiVGM
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "salesforce_rest_api-salesforce-create-task",
+  name: "Create Task",
+  description: "Creates a task, which represents a business activity such as making a phone call or other to-do items.",
+  version: "0.3.1",
+  type: "action",
+  props: {
+    salesforce_rest_api: {
+      type: "app",
+      app: "salesforce_rest_api",
+    },
+    Priority: {
+      type: "string",
+      description: "Required. Indicates the importance or urgency of a task, such as high or low.",
+    },
+    Status: {
+      type: "string",
+      description: "Required. The status of the task, such as In Progress or Completed. Each predefined Status field implies a value for the IsClosed flag. To obtain picklist values, query the TaskStatus object. Note This field can't be updated for recurring tasks (IsRecurrence is true).",
+    },
+    ActivityDate: {
+      type: "string",
+      description: "Represents the due date of the task. This field has a timestamp that is always set to midnight in the Coordinated Universal Time (UTC) time zone. The timestamp is not relevant; do not attempt to alter it to accommodate time zone differences. Note This field can't be set or updated for a recurring task (IsRecurrence is true).",
+      optional: true,
+    },
+    CallDisposition: {
+      type: "string",
+      description: "Represents the result of a given call, for example, we'll call back, or call unsuccessful. Limit is 255 characters. Not subject to field-level security, available for any user in an organization with Salesforce CRM Call Center.",
+      optional: true,
+    },
+    CallDurationInSeconds: {
+      type: "integer",
+      description: "Duration of the call in seconds. Not subject to field-level security, available for any user in an organization with Salesforce CRM Call Center.",
+      optional: true,
+    },
+    CallObject: {
+      type: "string",
+      description: "Name of a call center. Limit is 255 characters. Not subject to field-level security, available for any user in an organization with Salesforce CRM Call Center.",
+      optional: true,
+    },
+    CallType: {
+      type: "string",
+      description: "The type of call being answered: Inbound, Internal, or Outbound.",
+      optional: true,
+      options: [
+        "Inbound",
+        "Internal",
+        "Outbound",
+      ],
+    },
+    Description: {
+      type: "string",
+      description: "Contains a text description of the task.",
+      optional: true,
+    },
+    IsRecurrence: {
+      type: "boolean",
+      description: "Indicates whether the task is scheduled to repeat itself (true) or only occurs once (false). This field is read-only on update, but not on create. If this field value is true, then RecurrenceStartDateOnly, RecurrenceEndDateOnly, RecurrenceType, and any recurrence fields associated with the given recurrence type must be populated. See [Recurring Tasks](https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_objects_task.htm#RecurTasks).",
+      optional: true,
+    },
+    IsReminderSet: {
+      type: "boolean",
+      description: "Indicates whether a popup reminder has been set for the task (true) or not (false).",
+      optional: true,
+    },
+    OwnerId: {
+      type: "string",
+      description: "ID of the User or Group who owns the record. This field accepts Groups of type Queue only. In the user interface, Group IDs correspond with the queue's list view names. To create or update tasks assigned to Group, use v48.0 or later.",
+      optional: true,
+    },
+    RecurrenceDayOfMonth: {
+      type: "integer",
+      description: "The day of the month in which the task repeats.",
+      optional: true,
+    },
+    RecurrenceDayOfWeekMask: {
+      type: "integer",
+      description: "The day or days of the week on which the task repeats. This field contains a bitmask. The values are as follows: Sunday = 1 Monday = 2 Tuesday = 4 Wednesday = 8 Thursday = 16 Friday = 32 Saturday = 64 Multiple days are represented as the sum of their numerical values. For example, Tuesday and Thursday = 4 + 16 = 20.",
+      optional: true,
+    },
+    RecurrenceEndDateOnly: {
+      type: "string",
+      description: "The last date on which the task repeats. This field has a timestamp that is always set to midnight in the Coordinated Universal Time (UTC) time zone. The timestamp is not relevant; do not attempt to alter it to accommodate time zone differences.",
+      optional: true,
+    },
+    RecurrenceInstance: {
+      type: "string",
+      description: "The frequency of the recurring task. For example, 2nd or 3rd.",
+      optional: true,
+    },
+    RecurrenceInterval: {
+      type: "integer",
+      description: "The interval between recurring tasks.",
+      optional: true,
+    },
+    RecurrenceMonthOfYear: {
+      type: "string",
+      description: "The month of the year in which the task repeats.",
+      optional: true,
+    },
+    RecurrenceRegeneratedType: {
+      type: "string",
+      description: "Represents what triggers a repeating task to repeat. Add this field to a page layout together with the RecurrenceInterval field, which determines the number of days between the triggering date (due date or close date) and the due date of the next repeating task in the series.",
+      optional: true,
+      options: [
+        "None",
+        "After due date",
+        "After the task is closed",
+        "(Task closed)",
+      ],
+    },
+    RecurrenceStartDateOnly: {
+      type: "string",
+      description: "The date when the recurring task begins. Must be a date and time before RecurrenceEndDateOnly.",
+      optional: true,
+    },
+    RecurrenceTimeZoneSidKey: {
+      type: "string",
+      description: "The time zone associated with the recurring task. For example, UTC-8:00 for Pacific Standard Time.",
+      optional: true,
+    },
+    RecurrenceType: {
+      type: "string",
+      description: "Indicates how often the task repeats. For example, daily, weekly, or every nth month (where nth is defined in RecurrenceInstance).",
+      optional: true,
+    },
+    ReminderDateTime: {
+      type: "string",
+      description: "Represents the time when the reminder is scheduled to fire, if IsReminderSet is set to true. If IsReminderSet is set to false, then the user may have deselected the reminder checkbox in the Salesforce user interface, or the reminder has already fired at the time indicated by the value.",
+      optional: true,
+    },
+    Subject: {
+      type: "string",
+      description: "The subject line of the task, such as Call or Send Quote. Limit: 255 characters.",
+      optional: true,
+    },
+    TaskSubtype: {
+      type: "string",
+      description: "Provides standard subtypes to facilitate creating and searching for specific task subtypes. This field isn't updateable. TaskSubtype values: Task Email List Email Cadence Call Note The Cadence subtype is an internal value used by High Velocity Sales, and can't be set manually.",
+      optional: true,
+      options: [
+        "Task",
+        "Email",
+        "List Email",
+        "Cadence",
+        "Call",
+      ],
+    },
+    TaskWhoIds: {
+      type: "any",
+      description: "A string array of contact or lead IDs related to this task. This JunctionIdList field is linked to the TaskWhoRelations child relationship. TaskWhoIds is only available when the shared activities setting is enabled. The first contact or lead ID in the list becomes the primary WhoId if you don't specify a primary WhoId. If you set the EventWhoIds field to null, all entries in the list are deleted and the value of WhoId is added as the first entry. Warning Adding a JunctionIdList field name to the fieldsToNull property deletes all related junction records. This action can't be undone.",
+      optional: true,
+    },
+    Type: {
+      type: "string",
+      description: "The type of task, such as Call or Meeting.",
+      optional: true,
+    },
+    WhatId: {
+      type: "string",
+      description: "The WhatId represents nonhuman objects such as accounts, opportunities, campaigns, cases, or custom objects. WhatIds are polymorphic. Polymorphic means a WhatId is equivalent to the ID of a related object.",
+      optional: true,
+    },
+    WhoId: {
+      type: "string",
+      description: "The WhoId represents a human such as a lead or a contact. WhoIds are polymorphic. Polymorphic means a WhoId is equivalent to a contact's ID or a lead's ID. If Shared Activities is enabled, the value of this field is the ID of the related lead or primary contact. If you add, update, or remove the WhoId field, you might encounter problems with triggers, workflows, and data validation rules that are associated with the record. The label is Name ID. Beginning in API version 37.0, if the contact or lead ID in the WhoId field is not in the TaskWhoIds list, no error occurs and the ID is added to the TaskWhoIds as the primary WhoId. If WhoId is set to null, an arbitrary ID from the existing TaskWhoIds list is promoted to the primary position.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  // See the API docs here: https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_sobject_create.htm
+  // Task object: https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_objects_task.htm
+
+    if (!this.Priority || !this.Status) {
+      throw new Error("Must provide Priority and Status parameters.");
+    }
+
+    return await axios($, {
+      "method": "post",
+      "url": `${this.salesforce_rest_api.$auth.instance_url}/services/data/v20.0/sobjects/Task/`,
+      "Content-Type": "application/json",
+      "headers": {
+        Authorization: `Bearer ${this.salesforce_rest_api.$auth.oauth_access_token}`,
+      },
+      "data": {
+        ActivityDate: this.ActivityDate,
+        CallDisposition: this.CallDisposition,
+        CallDurationInSeconds: this.CallDurationInSeconds,
+        CallObject: this.CallObject,
+        CallType: this.CallType,
+        Description: this.Description,
+        IsRecurrence: this.IsRecurrence,
+        IsReminderSet: this.IsReminderSet,
+        OwnerId: this.OwnerId,
+        Priority: this.Priority,
+        RecurrenceDayOfMonth: this.RecurrenceDayOfMonth,
+        RecurrenceDayOfWeekMask: this.RecurrenceDayOfWeekMask,
+        RecurrenceEndDateOnly: this.RecurrenceEndDateOnly,
+        RecurrenceInstance: this.RecurrenceInstance,
+        RecurrenceInterval: this.RecurrenceInterval,
+        RecurrenceMonthOfYear: this.RecurrenceMonthOfYear,
+        RecurrenceRegeneratedType: this.RecurrenceRegeneratedType,
+        RecurrenceStartDateOnly: this.RecurrenceStartDateOnly,
+        RecurrenceTimeZoneSidKey: this.RecurrenceTimeZoneSidKey,
+        RecurrenceType: this.RecurrenceType,
+        ReminderDateTime: this.ReminderDateTime,
+        Status: this.Status,
+        Subject: this.Subject,
+        TaskSubtype: this.TaskSubtype,
+        TaskWhoIds: this.TaskWhoIds,
+        Type: this.Type,
+        WhatId: this.WhatId,
+        WhoId: this.WhoId,
+      },
+    });
+  },
+};

--- a/components/salesforce_rest_api/actions/salesforce-delete-opportunity/salesforce-delete-opportunity.mjs
+++ b/components/salesforce_rest_api/actions/salesforce-delete-opportunity/salesforce-delete-opportunity.mjs
@@ -1,0 +1,37 @@
+// legacy_hash_id: a_xqiqkn
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "salesforce_rest_api-salesforce-delete-opportunity",
+  name: "Delete Opportunity",
+  description: "Deletes an opportunity, which represents an opportunity, which is a sale or pending deal.",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    salesforce_rest_api: {
+      type: "app",
+      app: "salesforce_rest_api",
+    },
+    OpportunityId: {
+      type: "string",
+      description: "ID of the Opportunity to delete.",
+    },
+  },
+  async run({ $ }) {
+  // See the API docs here: https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_delete_record.htm
+  // Opportunity object: https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_objects_opportunity.htm
+
+    if (!this.OpportunityId) {
+      throw new Error("Must provide OpportunityId parameter.");
+    }
+
+    return await axios($, {
+      "method": "delete",
+      "url": `${this.salesforce_rest_api.$auth.instance_url}/services/data/v20.0/sobjects/Opportunity/${this.OpportunityId}`,
+      "Content-Type": "application/json",
+      "headers": {
+        Authorization: `Bearer ${this.salesforce_rest_api.$auth.oauth_access_token}`,
+      },
+    });
+  },
+};

--- a/components/salesforce_rest_api/actions/salesforce-get-sobject-fields-values/salesforce-get-sobject-fields-values.mjs
+++ b/components/salesforce_rest_api/actions/salesforce-get-sobject-fields-values/salesforce-get-sobject-fields-values.mjs
@@ -1,0 +1,37 @@
+// legacy_hash_id: a_Xzi1vA
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "salesforce_rest_api-salesforce-get-sobject-fields-values",
+  name: "Get Field Values from a Standard Object Record",
+  description: "Retrieve field values from a record. You can specify the fields you want to retrieve.",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    salesforce_rest_api: {
+      type: "app",
+      app: "salesforce_rest_api",
+    },
+    sobject_name: {
+      type: "string",
+      description: "Salesforce standard object type of the record to get field values from.",
+    },
+    sobject_id: {
+      type: "string",
+      description: "Id of the Salesforce standard object to get field values from.",
+    },
+    sobject_fields: {
+      type: "string",
+      description: "Comma separated list of the Salesforce standard object's fields to get values from.",
+    },
+  },
+  async run({ $ }) {
+  //See the API docs here: https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/intro_what_is_rest_api.htm
+    return await axios($, {
+      url: `${this.salesforce_rest_api.$auth.instance_url}/services/data/v20.0/sobjects/${encodeURI(this.sobject_name)}/${encodeURI(this.sobject_id)}?fields=${encodeURI(this.sobject_fields)}`,
+      headers: {
+        Authorization: `Bearer ${this.salesforce_rest_api.$auth.oauth_access_token}`,
+      },
+    });
+  },
+};

--- a/components/salesforce_rest_api/actions/salesforce-insert-blob-data/salesforce-insert-blob-data.mjs
+++ b/components/salesforce_rest_api/actions/salesforce-insert-blob-data/salesforce-insert-blob-data.mjs
@@ -1,0 +1,70 @@
+// legacy_hash_id: a_a4i8Gv
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "salesforce_rest_api-salesforce-insert-blob-data",
+  name: "Insert Blob Data",
+  description: "Inserts blob data in Salesforce standard objects.",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    salesforce_rest_api: {
+      type: "app",
+      app: "salesforce_rest_api",
+    },
+    entiy_name: {
+      type: "string",
+      description: "Name of the entity to insert as part of the form-data sent along the Salesforce API as a request with multipart/form-data content type. I.e. entity_document for Documents.",
+    },
+    entity_document: {
+      type: "string",
+      description: "Salesforce object entity to insert.",
+    },
+    form_content_name: {
+      type: "string",
+      description: "Name of the binary content to insert as part of  the form-data sent along the Salesforce API as a request with multipart/form-data content type.",
+    },
+    filename: {
+      type: "string",
+      description: "Filename of the blob data to insert.",
+    },
+    content_type: {
+      type: "string",
+      description: "Mime type of the content to insert.",
+    },
+    attachment_binarycontent: {
+      type: "string",
+      description: "Binary content of the blob data to insert.",
+    },
+    sobject_name: {
+      type: "string",
+      description: "Salesforce standard object type to insert.",
+    },
+  },
+  async run({ $ }) {
+  //See the API docs here: https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/intro_what_is_rest_api.htm
+
+    const payloadPart1 = `----------------------------932677621329676389151855
+    \r\nContent-Disposition: form-data; name=\"${this.entiy_name}\""
+    \r\nContent-Type: application/json
+    \r\n\r\n${this.entity_document}\r\n\r\n
+    \r\n\r\n----------------------------932677621329676389151855
+    \r\nContent-Disposition: form-data; name=\"${this.form_content_name}\"; filename=\"${this.filename}\"
+    \r\nContent-Type: ${this.content_type}
+    \r\n\r\n`;
+
+    const payloadPart2 = "\r\n\r\n----------------------------932677621329676389151855--";
+
+    const data = `${payloadPart1}${this.attachment_binarycontent}${payloadPart2}`;
+
+    return await axios($, {
+      method: "post",
+      url: `${this.salesforce_rest_api.$auth.instance_url}/services/data/v20.0/sobjects/${this.sobject_name}/`,
+      headers: {
+        "Authorization": `Bearer ${this.salesforce_rest_api.$auth.oauth_access_token}`,
+        "Content-Type": "multipart/form-data; boundary=--------------------------932677621329676389151855",
+      },
+      data,
+    });
+  },
+};

--- a/components/salesforce_rest_api/actions/salesforce-make-api-call/salesforce-make-api-call.mjs
+++ b/components/salesforce_rest_api/actions/salesforce-make-api-call/salesforce-make-api-call.mjs
@@ -1,0 +1,56 @@
+// legacy_hash_id: a_vgi4Mb
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "salesforce_rest_api-salesforce-make-api-call",
+  name: "Make API Call",
+  description: "Makes an aribitrary call to Salesforce API",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    salesforce_rest_api: {
+      type: "app",
+      app: "salesforce_rest_api",
+    },
+    query_string: {
+      type: "string",
+      description: "Query string of the request.",
+      optional: true,
+    },
+    request_method: {
+      type: "string",
+      description: "Http method to use in the request.",
+      options: [
+        "get",
+        "post",
+        "put",
+        "patch",
+        "delete",
+      ],
+    },
+    relative_url: {
+      type: "string",
+      description: "A path relative to the Salesforce instance to send the request against.",
+    },
+    headers: {
+      type: "object",
+      description: "Headers to send in the request.",
+    },
+    request_body: {
+      type: "object",
+      description: "Body of the request.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+
+    this.query_string = this.query_string || "";
+
+    return await axios($, {
+      method: this.request_method,
+      url: `${this.salesforce_rest_api.$auth.instance_url}/services/data/${this.relative_url}${this.query_string}`,
+      headers: this.headers,
+      data: this.request_body,
+    });
+  },
+};

--- a/components/salesforce_rest_api/actions/salesforce-soql-search/salesforce-soql-search.mjs
+++ b/components/salesforce_rest_api/actions/salesforce-soql-search/salesforce-soql-search.mjs
@@ -1,0 +1,29 @@
+// legacy_hash_id: a_RAiV1n
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "salesforce_rest_api-salesforce-soql-search",
+  name: "SOQL Search",
+  description: "Executes a SOQL query that returns all the results in a single response, or if needed, returns part of the results and an identifier used to retrieve the remaining results.",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    salesforce_rest_api: {
+      type: "app",
+      app: "salesforce_rest_api",
+    },
+    soql_search_string: {
+      type: "string",
+      description: "The search string in SOQL.\nFor more information on [SOSL see the SOQL and SOSL Reference.](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_query.htm)\nExample: [Execute SOQL Query](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_query.htm).",
+    },
+  },
+  async run({ $ }) {
+  // See the API docs here: https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/intro_what_is_rest_api.htm
+    return await axios($, {
+      url: `${this.salesforce_rest_api.$auth.instance_url}/services/data/v20.0/query/?q=${encodeURI(this.soql_search_string)}`,
+      headers: {
+        Authorization: `Bearer ${this.salesforce_rest_api.$auth.oauth_access_token}`,
+      },
+    });
+  },
+};

--- a/components/salesforce_rest_api/actions/salesforce-sosl-search/salesforce-sosl-search.mjs
+++ b/components/salesforce_rest_api/actions/salesforce-sosl-search/salesforce-sosl-search.mjs
@@ -1,0 +1,30 @@
+// legacy_hash_id: a_bKijKb
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "salesforce_rest_api-salesforce-sosl-search",
+  name: "SOSL Search",
+  description: "Executes the specified SOSL search.",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    salesforce_rest_api: {
+      type: "app",
+      app: "salesforce_rest_api",
+    },
+    sosl_search_string: {
+      type: "string",
+      description: "The search string in SOSL.\nFor more information on [SOSL see the SOQL and SOSL Reference.](http://www.salesforce.com/us/developer/docs/soql_sosl/index_Left.htm)\nExample: [Search for a String](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_search.htm).",
+    },
+  },
+  async run({ $ }) {
+  //See the API docs here: https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/intro_what_is_rest_api.htm
+    return await axios($, {
+      url: `${this.salesforce_rest_api.$auth.instance_url}/services/data/v20.0/search/?q=${encodeURI(this.sosl_search_string)}`,
+      headers: {
+        Authorization: `Bearer ${this.salesforce_rest_api.$auth.oauth_access_token}`,
+      },
+
+    });
+  },
+};

--- a/components/salesforce_rest_api/actions/salesforce-update-account/salesforce-update-account.mjs
+++ b/components/salesforce_rest_api/actions/salesforce-update-account/salesforce-update-account.mjs
@@ -1,0 +1,357 @@
+// legacy_hash_id: a_zNiORn
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "salesforce_rest_api-salesforce-update-account",
+  name: "Update Account",
+  description: "Updates a Salesforce account, representing an individual account, which is an organization or person involved with your business (such as customers, competitors, and partners).",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    salesforce_rest_api: {
+      type: "app",
+      app: "salesforce_rest_api",
+    },
+    AccountId: {
+      type: "string",
+      description: "ID of the Account to modify.",
+    },
+    AccountNumber: {
+      type: "string",
+      description: "Account number assigned to this account (not the unique, system-generated ID assigned during creation). Maximum size is 40 characters.",
+      optional: true,
+    },
+    AccountSource: {
+      type: "string",
+      description: "The source of the account record. For example, Advertisement, Data.com, or Trade Show. The source is selected from a picklist of available values, which are set by an administrator. Each picklist value can have up to 40 characters.",
+      optional: true,
+    },
+    AnnualRevenue: {
+      type: "string",
+      description: "Estimated annual revenue of the account.",
+      optional: true,
+    },
+    BillingCity: {
+      type: "string",
+      description: "Details for the billing address of this account. Maximum size is 40 characters.",
+      optional: true,
+    },
+    BillingCountry: {
+      type: "string",
+      description: "Details for the billing address of this account. Maximum size is 80 characters.",
+      optional: true,
+    },
+    BillingCountryCode: {
+      type: "string",
+      description: "The ISO country code for the account's billing address.",
+      optional: true,
+    },
+    BillingGeocodeAccuracy: {
+      type: "string",
+      description: "Accuracy level of the geocode for the billing address. See [Compound Field Considerations and Limitations](https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/compound_fields_limitations.htm#compound_fields_limitations) for details on geolocation compound fields.",
+      optional: true,
+    },
+    BillingLatitude: {
+      type: "integer",
+      description: "Used with BillingLongitude to specify the precise geolocation of a billing address. Acceptable values are numbers between 90 and 90 with up to 15 decimal places. See [Compound Field Considerations and Limitations](Accuracy level of the geocode for the billing address. See [Compound Field Considerations and Limitations](https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/compound_fields_limitations.htm#compound_fields_limitations) for details on geolocation compound fields.) for details on geolocation compound fields.",
+      optional: true,
+    },
+    BillingLongitude: {
+      type: "integer",
+      description: "Used with BillingLatitude to specify the precise geolocation of a billing address. Acceptable values are numbers between 180 and 180 with up to 15 decimal places. See [Compound Field Considerations and Limitations](atlas.en-us.api.meta/api/compound_fields_limitations.htm#compound_fields_limitations) for details on geolocation compound fields.",
+      optional: true,
+    },
+    BillingPostalCode: {
+      type: "string",
+      description: "Details for the billing address of this account. Maximum size is 20 characters.",
+      optional: true,
+    },
+    BillingState: {
+      type: "string",
+      description: "Details for the billing address of this account. Maximum size is 80 characters.",
+      optional: true,
+    },
+    BillingStateCode: {
+      type: "string",
+      description: "The ISO state code for the account's billing address.",
+      optional: true,
+    },
+    BillingStreet: {
+      type: "string",
+      description: "Street address for the billing address of this account.",
+      optional: true,
+    },
+    CleanStatus: {
+      type: "string",
+      description: "Indicates the record's clean status as compared with Data.com. Values are: Matched, Different, Acknowledged, NotFound, Inactive, Pending, SelectMatch, or Skipped.Several values for CleanStatus display with different labels on the account record detail page. Matched displays as In Sync Acknowledged displays as Reviewed Pending displays as Not Compared",
+      optional: true,
+    },
+    Description: {
+      type: "string",
+      description: "Text description of the account. Limited to 32,000 KB.",
+      optional: true,
+    },
+    DunsNumber: {
+      type: "string",
+      description: "The Data Universal Numbering System (D-U-N-S) number is a unique, nine-digit number assigned to every business location in the Dun &amp; Bradstreet database that has a unique, separate, and distinct operation. D-U-N-S numbers are used by industries and organizations around the world as a global standard for business identification and tracking. Maximum size is 9 characters. This field is available on business accounts, not person accounts. Note This field is only available to organizations that use Data.com Prospector or Data.com Clean.",
+      optional: true,
+    },
+    Fax: {
+      type: "string",
+      description: "Fax number for the account.",
+      optional: true,
+    },
+    HasOptedOutOfEmail: {
+      type: "boolean",
+      description: "Indicates whether the contact doesn't want to receive email from Salesforce (true) or does (false). Label is Email Opt Out.",
+      optional: true,
+    },
+    Industry: {
+      type: "string",
+      description: "An industry associated with this account. Maximum size is 40 characters.",
+      optional: true,
+    },
+    IsCustomerPortal: {
+      type: "boolean",
+      description: "Indicates whether the account has at least one contact enabled to use the organization's Customer Portal (true) or not (false). This field is available if Customer Portal is enabled OR Communities is enabled and you have Customer Portal licenses.If you change this field's value from true to false, you can disable up to 100 Customer Portal users associated with the account and permanently delete all of the account's Customer Portal roles and groups. You can't restore deleted Customer Portal roles and groups. This field can be updated in API version 16.0 and later. Tip We recommend that you update up to 50 contacts simultaneously when changing the accounts on contacts enabled for a Customer Portal or partner portal. We also recommend that you make this update after business hours.",
+      optional: true,
+    },
+    IsPartner: {
+      type: "boolean",
+      description: "Indicates whether the account has at least one contact enabled to use the organization's partner portal (true) or not (false). This field is available if partner relationship management (partner portal) is enabled OR Communities is enabled and you have partner portal licenses.If you change this field's value from true to false, you can disable up to 15 partner portal users associated with the account and permanently delete all of the account's partner portal roles and groups. You can't restore deleted partner portal roles and groups. Disabling a partner portal user in the Salesforce user interface or the API does not change this field's value from true to false. Even if this field's value is false, you can enable a contact on an account as a partner portal user via the API. This field can be updated in API version 16.0 and later. Tip We recommend that you update up to 50 contacts simultaneously when changing the accounts on contacts enabled for a Customer Portal or partner portal. We also recommend that you make this update after business hours.",
+      optional: true,
+    },
+    Jigsaw: {
+      type: "string",
+      description: "References the ID of a company in Data.com. If an account has a value in this field, it means that the account was imported from Data.com. If the field value is null, the account was not imported from Data.com. Maximum size is 20 characters. Available in API version 22.0 and later. Label is Data.com Key. This field is available on business accounts, not person accounts. Important The Jigsaw field is exposed in the API to support troubleshooting for import errors and reimporting of corrected data. Do not modify the value in the Jigsaw field.",
+      optional: true,
+    },
+    NaicsCode: {
+      type: "string",
+      description: "The six-digit North American Industry Classification System (NAICS) code is the standard used by business and government to classify business establishments into industries, according to their economic activity for the purpose of collecting, analyzing, and publishing statistical data related to the U.S. business economy. Maximum size is 8 characters. This field is available on business accounts, not person accounts. Note This field is only available to organizations that use Data.com Prospector or Data.com Clean.",
+      optional: true,
+    },
+    NaicsDesc: {
+      type: "string",
+      description: "A brief description of an organization's line of business, based on its NAICS code. Maximum size is 120 characters. This field is available on business accounts, not person accounts. Note This field is only available to organizations that use Data.com Prospector or Data.com Clean.",
+      optional: true,
+    },
+    Name: {
+      type: "string",
+      description: "Required. Label is Account Name. Name of the account. Maximum size is 255 characters. If the account has a record type of Person Account: This value is the concatenation of the FirstName, MiddleName, LastName, and Suffix of the associated person contact. You can't modify this value.",
+      optional: true,
+    },
+    NumberOfEmployees: {
+      type: "integer",
+      description: "Label is Employees. Number of employees working at the company represented by this account. Maximum size is eight digits.",
+      optional: true,
+    },
+    OperatingHoursId: {
+      type: "string",
+      description: "The operating hours associated with the account. Available only if Field Service Lightning is enabled.",
+      optional: true,
+    },
+    OwnerId: {
+      type: "string",
+      description: "The ID of the user who currently owns this account. Default value is the user logged in to the API to perform the create.If you have set up account teams in your organization, updating this field has different consequences depending on your version of the API: For API version 12.0 and later, sharing records are kept, as they are for all objects. For API version before 12.0, sharing records are deleted. For API version 16.0 and later, users must have the Transfer Record permission in order to update (transfer) account ownership using this field.",
+      optional: true,
+    },
+    Ownership: {
+      type: "string",
+      description: "Ownership type for the account, for example Private, Public, or Subsidiary.",
+      optional: true,
+    },
+    ParentId: {
+      type: "string",
+      description: "ID of the parent object, if any.",
+      optional: true,
+    },
+    PersonIndividualId: {
+      type: "string",
+      description: "ID of the data privacy record associated with this person's account. This field is available if you enabled Data Protection and Privacy in Setup.",
+      optional: true,
+    },
+    Phone: {
+      type: "string",
+      description: "Phone number for this account. Maximum size is 40 characters.",
+      optional: true,
+    },
+    Rating: {
+      type: "string",
+      description: "The account's prospect rating, for example Hot, Warm, or Cold.",
+      optional: true,
+    },
+    RecordTypeId: {
+      type: "string",
+      description: "ID of the record type assigned to this object.",
+      optional: true,
+    },
+    Salutation: {
+      type: "string",
+      description: "Honorific added to the name for use in letters, etc.",
+      optional: true,
+    },
+    ShippingCity: {
+      type: "string",
+      description: "Details of the shipping address for this account. City maximum size is 40 characters",
+      optional: true,
+    },
+    ShippingCountry: {
+      type: "string",
+      description: "Details of the shipping address for this account. Country maximum size is 80 characters.",
+      optional: true,
+    },
+    ShippingCountryCode: {
+      type: "string",
+      description: "The ISO country code for the account's shipping address.",
+      optional: true,
+    },
+    ShippingGeocodeAccuracy: {
+      type: "string",
+      description: "Accuracy level of the geocode for the shipping address. See [Compound Field Considerations and Limitations](Accuracy level of the geocode for the billing address. See [Compound Field Considerations and Limitations](https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/compound_fields_limitations.htm#compound_fields_limitations) for details on geolocation compound fields.) for details on geolocation compound fields.",
+      optional: true,
+    },
+    ShippingLatitude: {
+      type: "integer",
+      description: "Used with ShippingLongitude to specify the precise geolocation of a shipping address. Acceptable values are numbers between 90 and 90 with up to 15 decimal places. See [Compound Field Considerations and Limitations](Accuracy level of the geocode for the billing address. See [Compound Field Considerations and Limitations](https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/compound_fields_limitations.htm#compound_fields_limitations) for details on geolocation compound fields.) for details on geolocation compound fields.",
+      optional: true,
+    },
+    ShippingLongitude: {
+      type: "integer",
+      description: "Used with ShippingLatitude to specify the precise geolocation of an address. Acceptable values are numbers between 180 and 180 with up to 15 decimal places. See [Compound Field Considerations and Limitations](Accuracy level of the geocode for the billing address. See [Compound Field Considerations and Limitations](https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/compound_fields_limitations.htm#compound_fields_limitations) for details on geolocation compound fields.) for details on geolocation compound fields.",
+      optional: true,
+    },
+    ShippingPostalCode: {
+      type: "string",
+      description: "Details of the shipping address for this account. Postal code maximum size is 20 characters.",
+      optional: true,
+    },
+    ShippingState: {
+      type: "string",
+      description: "Details of the shipping address for this account. State maximum size is 80 characters.",
+      optional: true,
+    },
+    ShippingStateCode: {
+      type: "string",
+      description: "The ISO state code for the account's shipping address.",
+      optional: true,
+    },
+    ShippingStreet: {
+      type: "string",
+      description: "The street address of the shipping address for this account. Maximum of 255 characters.",
+      optional: true,
+    },
+    Sic: {
+      type: "string",
+      description: "Standard Industrial Classification code of the company's main business categorization, for example, 57340 for Electronics. Maximum of 20 characters. This field is available on business accounts, not person accounts.",
+      optional: true,
+    },
+    SicDesc: {
+      type: "string",
+      description: "A brief description of an organization's line of business, based on its SIC code. Maximum length is 80 characters. This field is available on business accounts, not person accounts.",
+      optional: true,
+    },
+    Site: {
+      type: "string",
+      description: "Name of the account's location, for example Headquarters or London. Label is Account Site. Maximum of 80 characters.",
+      optional: true,
+    },
+    TickerSymbol: {
+      type: "string",
+      description: "The stock market symbol for this account. Maximum of 20 characters. This field is available on business accounts, not person accounts.",
+      optional: true,
+    },
+    Tradestyle: {
+      type: "string",
+      description: "A name, different from its legal name, that an organization may use for conducting business. Similar to Doing business as or DBA. Maximum length is 255 characters. This field is available on business accounts, not person accounts. Note This field is only available to organizations that use Data.com Prospector or Data.com Clean.",
+      optional: true,
+    },
+    Type: {
+      type: "string",
+      description: "Type of account, for example, Customer, Competitor, or Partner.",
+      optional: true,
+    },
+    Website: {
+      type: "string",
+      description: "The website of this account. Maximum of 255 characters.",
+      optional: true,
+    },
+    YearStarted: {
+      type: "string",
+      description: "The date when an organization was legally established. Maximum length is 4 characters. This field is available on business accounts, not person accounts. Note This field is only available to organizations that use Data.com Prospector or Data.com Clean.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  // See the API docs here: https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_update_fields.htm
+  // Account object: https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_objects_account.htm
+
+    if (!this.AccountId) {
+      throw new Error("Must provide AccountId parameter.");
+    }
+
+    return await axios($, {
+      "method": "patch",
+      "url": `${this.salesforce_rest_api.$auth.instance_url}/services/data/v20.0/sobjects/Account/${this.AccountId}`,
+      "Content-Type": "application/json",
+      "headers": {
+        Authorization: `Bearer ${this.salesforce_rest_api.$auth.oauth_access_token}`,
+      },
+      "data": {
+        AccountNumber: this.AccountNumber,
+        AccountSource: this.AccountSource,
+        AnnualRevenue: this.AnnualRevenue,
+        BillingCity: this.BillingCity,
+        BillingCountry: this.BillingCountry,
+        BillingCountryCode: this.BillingCountryCode,
+        BillingGeocodeAccuracy: this.BillingGeocodeAccuracy,
+        BillingLatitude: this.BillingLatitude,
+        BillingLongitude: this.BillingLongitude,
+        BillingPostalCode: this.BillingPostalCode,
+        BillingState: this.BillingState,
+        BillingStateCode: this.BillingStateCode,
+        BillingStreet: this.BillingStreet,
+        CleanStatus: this.CleanStatus,
+        Description: this.Description,
+        DunsNumber: this.DunsNumber,
+        Fax: this.Fax,
+        HasOptedOutOfEmail: this.HasOptedOutOfEmail,
+        Industry: this.Industry,
+        IsCustomerPortal: this.IsCustomerPortal,
+        IsPartner: this.IsPartner,
+        Jigsaw: this.Jigsaw,
+        NaicsCode: this.NaicsCode,
+        NaicsDesc: this.NaicsDesc,
+        Name: this.Name,
+        NumberOfEmployees: this.NumberOfEmployees,
+        OperatingHoursId: this.OperatingHoursId,
+        OwnerId: this.OwnerId,
+        Ownership: this.Ownership,
+        ParentId: this.ParentId,
+        PersonIndividualId: this.PersonIndividualId,
+        Phone: this.Phone,
+        Rating: this.Rating,
+        RecordTypeId: this.RecordTypeId,
+        Salutation: this.Salutation,
+        ShippingCity: this.ShippingCity,
+        ShippingCountry: this.ShippingCountry,
+        ShippingCountryCode: this.ShippingCountryCode,
+        ShippingGeocodeAccuracy: this.ShippingGeocodeAccuracy,
+        ShippingLatitude: this.ShippingLatitude,
+        ShippingLongitude: this.ShippingLongitude,
+        ShippingPostalCode: this.ShippingPostalCode,
+        ShippingState: this.ShippingState,
+        ShippingStateCode: this.ShippingStateCode,
+        ShippingStreet: this.ShippingStreet,
+        Sic: this.Sic,
+        SicDesc: this.SicDesc,
+        Site: this.Site,
+        TickerSymbol: this.TickerSymbol,
+        Tradestyle: this.Tradestyle,
+        Type: this.Type,
+        Website: this.Website,
+        YearStarted: this.YearStarted,
+      },
+    });
+  },
+};

--- a/components/salesforce_rest_api/actions/salesforce-update-contact/salesforce-update-contact.mjs
+++ b/components/salesforce_rest_api/actions/salesforce-update-contact/salesforce-update-contact.mjs
@@ -1,0 +1,345 @@
+// legacy_hash_id: a_2wino7
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "salesforce_rest_api-salesforce-update-contact",
+  name: "Update Contact",
+  description: "Updates a Contact, which is a person associated with an account.",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    salesforce_rest_api: {
+      type: "app",
+      app: "salesforce_rest_api",
+    },
+    ContactId: {
+      type: "string",
+      description: "Id of the Contact to update.",
+    },
+    AccountId: {
+      type: "string",
+      description: "ID of the account that's the parent of this contact. We recommend that you update up to 50 contacts simultaneously when changing the accounts on contacts enabled for a Customer Portal or partner portal. We also recommend that you make this update after business hours.",
+      optional: true,
+    },
+    AssistantName: {
+      type: "string",
+      description: "The assistant's name.",
+      optional: true,
+    },
+    AssistantPhone: {
+      type: "string",
+      description: "The assistant's telephone number.",
+      optional: true,
+    },
+    Birthdate: {
+      type: "string",
+      description: "The contact's birthdate.Filter criteria for report filters, list view filters, and SOQL queries ignore the year portion of the Birthdate field. For example, this SOQL query returns contacts with birthdays later in the year than today:view sourceprint?1SELECT Name, Birthdate2FROM Contact3WHERE Birthdate &gt; TODAY",
+      optional: true,
+    },
+    CanAllowPortalSelfReg: {
+      type: "boolean",
+      description: "Indicates whether this contact can self-register for your Customer Portal (true) or not (false).",
+      optional: true,
+    },
+    CleanStatus: {
+      type: "string",
+      description: "Indicates the record's clean status as compared with Data.com. Values include: Matched, Different, Acknowledged, NotFound, Inactive, Pending, SelectMatch, or Skipped.Several values for CleanStatus appear with different labels on the contact record. Matched appears as In Sync Acknowledged appears as Reviewed Pending appears as Not Compared",
+      optional: true,
+    },
+    Department: {
+      type: "string",
+      description: "The contact's department.",
+      optional: true,
+    },
+    Description: {
+      type: "string",
+      description: "A description of the contact. Label is Contact Description up to 32 KB.",
+      optional: true,
+    },
+    DoNotCall: {
+      type: "boolean",
+      description: "Indicates that the contact does not want to receive calls.",
+      optional: true,
+    },
+    Email: {
+      type: "string",
+      description: "The contact's email address.",
+      optional: true,
+    },
+    EmailBouncedDate: {
+      type: "string",
+      description: "If bounce management is activated and an email sent to the contact bounces, the date and time of the bounce.",
+      optional: true,
+    },
+    EmailBouncedReason: {
+      type: "string",
+      description: "If bounce management is activated and an email sent to the contact bounces, the reason for the bounce.",
+      optional: true,
+    },
+    Fax: {
+      type: "string",
+      description: "The contact's fax number. Label is Business Fax.",
+      optional: true,
+    },
+    FirstName: {
+      type: "string",
+      description: "The contact's first name up to 40 characters.",
+      optional: true,
+    },
+    HasOptedOutOfEmail: {
+      type: "boolean",
+      description: "Indicates whether the contact doesn't want to receive email from Salesforce (true) or does (false). Label is Email Opt Out.",
+      optional: true,
+    },
+    HasOptedOutOfFax: {
+      type: "boolean",
+      description: "Indicates whether the contact prohibits receiving faxes.",
+      optional: true,
+    },
+    HomePhone: {
+      type: "string",
+      description: "The contact's home telephone number.",
+      optional: true,
+    },
+    IndividualId: {
+      type: "string",
+      description: "ID of the data privacy record associated with this contact. This field is available if Data Protection and Privacy is enabled.",
+      optional: true,
+    },
+    Jigsaw: {
+      type: "string",
+      description: "References the company's ID in Data.com. If an account has a value in this field, it means that the account was imported from Data.com. If the field value is null, the account was not imported from Data.com. Maximum size is 20 characters. Available in API version 22.0 and later. Label is Data.com Key. Important The Jigsaw field is exposed in the API to support troubleshooting for import errors and reimporting of corrected data. Do not modify this value.",
+      optional: true,
+    },
+    LastName: {
+      type: "string",
+      description: "Required. Last name of the contact up to 80 characters.",
+      optional: true,
+    },
+    LeadSource: {
+      type: "string",
+      description: "The lead's source.",
+      optional: true,
+    },
+    MailingCity: {
+      type: "string",
+      description: "Mailing address details.",
+      optional: true,
+    },
+    MailingState: {
+      type: "string",
+      description: "Mailing address details.",
+      optional: true,
+    },
+    MailingCountry: {
+      type: "string",
+      description: "Mailing address details.",
+      optional: true,
+    },
+    MailingPostalCode: {
+      type: "string",
+      description: "Mailing address details.",
+      optional: true,
+    },
+    MailingStateCode: {
+      type: "string",
+      description: "The ISO codes for the mailing address's state.",
+      optional: true,
+    },
+    MailingCountryCode: {
+      type: "string",
+      description: "The ISO codes for the mailing address's country.",
+      optional: true,
+    },
+    MailingStreet: {
+      type: "string",
+      description: "Street address for mailing address.",
+      optional: true,
+    },
+    MailingGeocodeAccuracy: {
+      type: "string",
+      description: "Accuracy level of the geocode for the mailing address. For details on geolocation compound field, see [Compound Field Considerations and Limitations](https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/compound_fields_limitations.htm#compound_fields_limitations).",
+      optional: true,
+    },
+    MailingLatitude: {
+      type: "integer",
+      description: "Used with MailingLongitude to specify the precise geolocation of a mailing address. Acceptable values are numbers between 90 and 90 up to 15 decimal places. For details on geolocation compound fields, see [Compound Field Considerations and Limitations](https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/compound_fields_limitations.htm#compound_fields_limitations).",
+      optional: true,
+    },
+    MailingLongitude: {
+      type: "integer",
+      description: "Used with MailingLatitude to specify the precise geolocation of a mailing address. Acceptable values are numbers between 180 and 180 up to 15 decimal places. For details on geolocation compound fields, see [Compound Field Considerations and Limitations](https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/compound_fields_limitations.htm#compound_fields_limitations).",
+      optional: true,
+    },
+    MiddleName: {
+      type: "string",
+      description: "The contact's middle name up to 40 characters. To enable this field, ask Salesforce Customer Support for help.",
+      optional: true,
+    },
+    MobilePhone: {
+      type: "string",
+      description: "Contact's mobile phone number.",
+      optional: true,
+    },
+    OtherCity: {
+      type: "string",
+      description: "Alternate address details.",
+      optional: true,
+    },
+    OtherCountry: {
+      type: "string",
+      description: "Alternate address details.",
+      optional: true,
+    },
+    OtherPostalCode: {
+      type: "string",
+      description: "Alternate address details.",
+      optional: true,
+    },
+    OtherState: {
+      type: "string",
+      description: "Alternate address details.",
+      optional: true,
+    },
+    OtherCountryCode: {
+      type: "string",
+      description: "The ISO codes for the alternate address's country.",
+      optional: true,
+    },
+    OtherStateCode: {
+      type: "string",
+      description: "The ISO codes for the alternate address's state.",
+      optional: true,
+    },
+    OtherGeocodeAccuracy: {
+      type: "string",
+      description: "Accuracy level of the geocode for the other address. For details on geolocation compound fields, see [Compound Field Considerations and Limitations](https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/compound_fields_limitations.htm#compound_fields_limitations).",
+      optional: true,
+    },
+    OtherLatitude: {
+      type: "integer",
+      description: "Used with OtherLongitude to specify the precise geolocation of an alternate address. Acceptable values are numbers between 90 and 90 up to 15 decimal places. For details on geolocation compound fields, see [Compound Field Considerations and Limitations](https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/compound_fields_limitations.htm#compound_fields_limitations).",
+      optional: true,
+    },
+    OtherLongitude: {
+      type: "integer",
+      description: "Used with OtherLatitude to specify the precise geolocation of an alternate address. Acceptable values are numbers between 180 and 180 up to 15 decimal places. For details on geolocation compound fields, see [Compound Field Considerations and Limitations](https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/compound_fields_limitations.htm#compound_fields_limitations).",
+      optional: true,
+    },
+    OtherPhone: {
+      type: "string",
+      description: "Telephone for alternate address.",
+      optional: true,
+    },
+    OtherStreet: {
+      type: "string",
+      description: "Street for alternate address.",
+      optional: true,
+    },
+    OwnerId: {
+      type: "string",
+      description: "The ID of the owner of the account associated with this contact.",
+      optional: true,
+    },
+    Phone: {
+      type: "string",
+      description: "Telephone number for the contact. Label is Business Phone.",
+      optional: true,
+    },
+    RecordTypeId: {
+      type: "string",
+      description: "ID of the record type assigned to this object.",
+      optional: true,
+    },
+    ReportsToId: {
+      type: "string",
+      description: "This field doesn't appear if IsPersonAccount is true.",
+      optional: true,
+    },
+    Salutation: {
+      type: "string",
+      description: "Honorific abbreviation, word, or phrase to be used in front of name in greetings, such as Dr. or Mrs.",
+      optional: true,
+    },
+    Suffix: {
+      type: "string",
+      description: "Name suffix of the contact up to 40 characters. To enable this field, ask Salesforce Customer Support for help.",
+      optional: true,
+    },
+    Title: {
+      type: "string",
+      description: "Title of the contact, such as CEO or Vice President.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  // See the API docs here: https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_sobject_create.htm
+  // Contact object: https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_objects_contact.htm
+
+    if (!this.ContactId) {
+      throw new Error("Must provide ContactId parameter.");
+    }
+
+    return await axios($, {
+      "method": "patch",
+      "url": `${this.salesforce_rest_api.$auth.instance_url}/services/data/v20.0/sobjects/Contact/${this.ContactId}`,
+      "Content-Type": "application/json",
+      "headers": {
+        Authorization: `Bearer ${this.salesforce_rest_api.$auth.oauth_access_token}`,
+      },
+      "data": {
+  	 AccountId: this.AccountId,
+  	 AssistantName: this.AssistantName,
+  	 AssistantPhone: this.AssistantPhone,
+  	 Birthdate: this.Birthdate,
+  	 CanAllowPortalSelfReg: this.CanAllowPortalSelfReg,
+  	 CleanStatus: this.CleanStatus,
+  	 Department: this.Department,
+  	 Description: this.Description,
+  	 DoNotCall: this.DoNotCall,
+  	 Email: this.Email,
+  	 EmailBouncedDate: this.EmailBouncedDate,
+  	 EmailBouncedReason: this.EmailBouncedReason,
+  	 Fax: this.Fax,
+  	 FirstName: this.FirstName,
+  	 HasOptedOutOfEmail: this.HasOptedOutOfEmail,
+  	 HasOptedOutOfFax: this.HasOptedOutOfFax,
+  	 HomePhone: this.HomePhone,
+  	 IndividualId: this.IndividualId,
+  	 Jigsaw: this.Jigsaw,
+  	 LastName: this.LastName,
+  	 LeadSource: this.LeadSource,
+  	 MailingCity: this.MailingCity,
+  	 MailingState: this.MailingState,
+  	 MailingCountry: this.MailingCountry,
+  	 MailingPostalCode: this.MailingPostalCode,
+  	 MailingStateCode: this.MailingStateCode,
+  	 MailingCountryCode: this.MailingCountryCode,
+  	 MailingStreet: this.MailingStreet,
+  	 MailingGeocodeAccuracy: this.MailingGeocodeAccuracy,
+  	 MailingLatitude: this.MailingLatitude,
+  	 MailingLongitude: this.MailingLongitude,
+  	 MiddleName: this.MiddleName,
+  	 MobilePhone: this.MobilePhone,
+  	 OtherCity: this.OtherCity,
+  	 OtherCountry: this.OtherCountry,
+  	 OtherPostalCode: this.OtherPostalCode,
+  	 OtherState: this.OtherState,
+  	 OtherCountryCode: this.OtherCountryCode,
+  	 OtherStateCode: this.OtherStateCode,
+  	 OtherGeocodeAccuracy: this.OtherGeocodeAccuracy,
+  	 OtherLatitude: this.OtherLatitude,
+  	 OtherLongitude: this.OtherLongitude,
+  	 OtherPhone: this.OtherPhone,
+  	 OtherStreet: this.OtherStreet,
+  	 OwnerId: this.OwnerId,
+  	 Phone: this.Phone,
+  	 RecordTypeId: this.RecordTypeId,
+  	 ReportsToId: this.ReportsToId,
+  	 Salutation: this.Salutation,
+  	 Suffix: this.Suffix,
+  	 Title: this.Title,
+  	},
+    });
+  },
+};

--- a/components/salesforce_rest_api/actions/salesforce-update-opportunity/salesforce-update-opportunity.mjs
+++ b/components/salesforce_rest_api/actions/salesforce-update-opportunity/salesforce-update-opportunity.mjs
@@ -1,0 +1,171 @@
+// legacy_hash_id: a_njiVg1
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "salesforce_rest_api-salesforce-update-opportunity",
+  name: "Update Opportunity",
+  description: "Updates an opportunity, which represents an opportunity, which is a sale or pending deal.",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    salesforce_rest_api: {
+      type: "app",
+      app: "salesforce_rest_api",
+    },
+    OpportunityId: {
+      type: "string",
+      description: "ID of the Opportunity to update.",
+    },
+    AccountId: {
+      type: "string",
+      description: "ID of the account associated with this opportunity.",
+      optional: true,
+    },
+    Amount: {
+      type: "string",
+      description: "Estimated total sale amount. For opportunities with products, the amount is the sum of the related products. Any attempt to update this field, if the record has products, will be ignored. The update call will not be rejected, and other fields will be updated as specified, but the Amount will be unchanged.",
+      optional: true,
+    },
+    CampaignId: {
+      type: "string",
+      description: "ID of a related Campaign. This field is defined only for those organizations that have the campaign feature Campaigns enabled. The User must have read access rights to the cross-referenced Campaign object in order to create or update that campaign into this field on the opportunity.",
+      optional: true,
+    },
+    CloseDate: {
+      type: "string",
+      description: "Required. Date when the opportunity is expected to close.",
+      optional: true,
+    },
+    ContractId: {
+      type: "string",
+      description: "ID of the contract that's associated with this opportunity.",
+      optional: true,
+    },
+    CurrencyIsoCode: {
+      type: "string",
+      description: "Available only for organizations with the multicurrency feature enabled. Contains the ISO code for any currency allowed by the organization.",
+      optional: true,
+    },
+    Description: {
+      type: "string",
+      description: "Text description of the opportunity. Limit: 32,000 characters.",
+      optional: true,
+    },
+    ForecastCategoryName: {
+      type: "string",
+      description: "Available in API version 12.0 and later. The name of the forecast category. It is implied, but not directly controlled, by the StageName field. You can override this field to a different value than is implied by the StageName value.",
+      optional: true,
+    },
+    IsExcludedFromTerritory2Filter: {
+      type: "boolean",
+      description: "Used for Filter-Based Opportunity Territory Assignment (Pilot in Spring '15 / API version 33). Indicates whether the opportunity is excluded (True) or included (False) each time the APEX filter is executed.",
+      optional: true,
+    },
+    LeadSource: {
+      type: "string",
+      description: "Source of this opportunity, such as Advertisement or Trade Show.",
+      optional: true,
+    },
+    Name: {
+      type: "string",
+      description: "Required. A name for this opportunity. Limit: 120 characters.",
+      optional: true,
+    },
+    NextStep: {
+      type: "string",
+      description: "Description of next task in closing opportunity. Limit: 255 characters.",
+      optional: true,
+    },
+    OwnerId: {
+      type: "string",
+      description: "ID of the User who has been assigned to work this opportunity.If you update this field, the previous owner's access becomes Read Only or the access specified in your organization-wide default for opportunities, whichever is greater. If you have set up opportunity teams in your organization, updating this field has different consequences depending on your version of the API: For API version 12.0 and later, sharing records are kept, as they are for all objects. For API version before 12.0, sharing records are deleted. For API version 16.0 and later, users must have the Transfer Record permission in order to update (transfer) account ownership using this field.",
+      optional: true,
+    },
+    Pricebook2Id: {
+      type: "string",
+      description: "ID of a related Pricebook2 object. The Pricebook2Id field indicates which Pricebook2 applies to this opportunity. The Pricebook2Id field is defined only for those organizations that have products enabled as a feature. You can specify values for only one field (Pricebook2Id or PricebookId)not both fields. For this reason, both fields are declared nillable.",
+      optional: true,
+    },
+    PricebookId: {
+      type: "string",
+      description: "Unavailable as of version 3.0. As of version 8.0, the Pricebook object is no longer available. Use the Pricebook2Id field instead, specifying the ID of the Pricebook2 record.",
+      optional: true,
+    },
+    Probability: {
+      type: "string",
+      description: "Percentage of estimated confidence in closing the opportunity. It is implied, but not directly controlled, by the StageName field. You can override this field to a different value than what is implied by the StageName. Note If you're changing the Probability field through the API using a partner WSDL call, or an Apex before trigger, and the value may have several decimal places, we recommend rounding the value to a whole number. For example, the following Apex in a before trigger uses the round method to change the field value: o.probability = o.probability.round();",
+      optional: true,
+    },
+    RecordTypeId: {
+      type: "string",
+      description: "ID of the record type assigned to this object.",
+      optional: true,
+    },
+    StageName: {
+      type: "string",
+      description: "Required. Current stage of this record. The StageName field controls several other fields on an opportunity. Each of the fields can be directly set or implied by changing the StageName field. In addition, the StageName field is a picklist, so it has additional members in the returned describeSObjectResult to indicate how it affects the other fields. To obtain the stage name values in the picklist, query the OpportunityStage object. If the StageName is updated, then the ForecastCategoryName, IsClosed, IsWon, and Probability are automatically updated based on the stage-category mapping.",
+      optional: true,
+    },
+    SyncedQuoteID: {
+      type: "string",
+      description: "Read only in an Apex trigger. The ID of the Quote that syncs with the opportunity. Setting this field lets you start and stop syncing between the opportunity and a quote. The ID has to be for a quote that is a child of the opportunity.",
+      optional: true,
+    },
+    Territory2Id: {
+      type: "string",
+      description: "The ID of the territory that is assigned to the opportunity. Available only if Enterprise Territory Management has been enabled for your organization.",
+      optional: true,
+    },
+    TotalOpportunityQuantity: {
+      type: "integer",
+      description: "Number of items included in this opportunity. Used in quantity-based forecasting.",
+      optional: true,
+    },
+    Type: {
+      type: "string",
+      description: "Type of opportunity. For example, Existing Business or New Business.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  // See the API docs here: https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_sobject_create.htm
+  // Opportunity object: https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_objects_opportunity.htm
+
+    if (!this.OpportunityId) {
+      throw new Error("Must provide OpportunityId parameter.");
+    }
+
+    return await axios($, {
+      "method": "patch",
+      "url": `${this.salesforce_rest_api.$auth.instance_url}/services/data/v20.0/sobjects/Opportunity/${this.OpportunityId}`,
+      "Content-Type": "application/json",
+      "headers": {
+        Authorization: `Bearer ${this.salesforce_rest_api.$auth.oauth_access_token}`,
+      },
+      "data": {
+        AccountId: this.AccountId,
+        Amount: this.Amount,
+        CampaignId: this.CampaignId,
+        CloseDate: this.CloseDate,
+        ContractId: this.ContractId,
+        CurrencyIsoCode: this.CurrencyIsoCode,
+        Description: this.Description,
+        ForecastCategoryName: this.ForecastCategoryName,
+        IsExcludedFromTerritory2Filter: this.IsExcludedFromTerritory2Filter,
+        LeadSource: this.LeadSource,
+        Name: this.Name,
+        NextStep: this.NextStep,
+        OwnerId: this.OwnerId,
+        Pricebook2Id: this.Pricebook2Id,
+        PricebookId: this.PricebookId,
+        Probability: this.Probability,
+        RecordTypeId: this.RecordTypeId,
+        StageName: this.StageName,
+        SyncedQuoteID: this.SyncedQuoteID,
+        Territory2Id: this.Territory2Id,
+        TotalOpportunityQuantity: this.TotalOpportunityQuantity,
+        Type: this.Type,
+      },
+    });
+  },
+};

--- a/components/salesforce_rest_api/actions/salesforce-update-record/salesforce-update-record.mjs
+++ b/components/salesforce_rest_api/actions/salesforce-update-record/salesforce-update-record.mjs
@@ -1,0 +1,40 @@
+// legacy_hash_id: a_l0i2Pq
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "salesforce_rest_api-salesforce-update-record",
+  name: "Update Record",
+  description: "Updates a record of a given resource, its id and fields values. Use resource field values in the request data.",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    salesforce_rest_api: {
+      type: "app",
+      app: "salesforce_rest_api",
+    },
+    sobject_name: {
+      type: "string",
+      description: "Type of Salesforce standard object to update.",
+    },
+    sobject_id: {
+      type: "string",
+      description: "Id of the Salesforce standard object record to update.",
+    },
+    sobject: {
+      type: "object",
+      description: "Data of the Salesforce standard object record to update.\nSalesforce standard objects are described in [Standard Objects](https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_objects_list.htm) section of the [SOAP API Developer Guide](https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_quickstart_intro.htm).",
+    },
+  },
+  async run({ $ }) {
+  //See the API docs here: https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/intro_what_is_rest_api.htm
+    return await axios($, {
+      "method": "patch",
+      "url": `${this.salesforce_rest_api.$auth.instance_url}/services/data/v20.0/sobjects/${this.sobject_name}/${this.sobject_id}`,
+      "Content-Type": "application/json",
+      "headers": {
+        Authorization: `Bearer ${this.salesforce_rest_api.$auth.oauth_access_token}`,
+      },
+      "data": this.sobject,
+    });
+  },
+};

--- a/components/sendinblue/actions/.mjs
+++ b/components/sendinblue/actions/.mjs
@@ -1,0 +1,42 @@
+// legacy_hash_id: a_0Mi7n5
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "sendinblue-",
+  name: "Add a new contact",
+  description: "Add a new contact and list",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    sendinblue: {
+      type: "app",
+      app: "sendinblue",
+    },
+    email: {
+      type: "string",
+    },
+    name: {
+      type: "string",
+    },
+    listID: {
+      type: "any",
+    },
+  },
+  async run({ $ }) {
+    return await axios($, {
+      url: "https://api.sendinblue.com/v3/contacts",
+      method: "post",
+      headers: {
+        "api-key": `${this.sendinblue.$auth.api_key}`,
+        "content-type": "application/json",
+      },
+      data: {
+        email: this.email,
+        attributes: {
+          "FIRSTNAME": `${this.name}`,
+        },
+        listIds: this.listID, //Find the List ID from https://my.sendinblue.com/users/list/id/{ListID}
+      },
+    });
+  },
+};

--- a/components/sendinblue/actions/add-new-contact/add-new-contact.mjs
+++ b/components/sendinblue/actions/add-new-contact/add-new-contact.mjs
@@ -2,7 +2,7 @@
 import { axios } from "@pipedream/platform";
 
 export default {
-  key: "sendinblue-",
+  key: "sendinblue-add-new-contact",
   name: "Add a new contact",
   description: "Add a new contact and list",
   version: "0.2.1",

--- a/components/servicenow/actions/create-table-record/create-table-record.mjs
+++ b/components/servicenow/actions/create-table-record/create-table-record.mjs
@@ -1,0 +1,123 @@
+// legacy_hash_id: a_k6irW7
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "servicenow-create-table-record",
+  name: "Create Table Record",
+  description: "Inserts one record in the specified table.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    servicenow: {
+      type: "app",
+      app: "servicenow",
+    },
+    table_name: {
+      type: "string",
+      description: "The name of the table where the record will be created.",
+    },
+    table_record: {
+      type: "object",
+      description: "The table record object. Use name-value pairs for each field of the record.",
+    },
+    api_version: {
+      type: "string",
+      description: "API version number. Version numbers identify the endpoint version that a URI accesses. By specifying a version number in your URIs, you can ensure that future updates to the REST API do not negatively impact your integration. Use `lastest` to use the latest REST endpoint for your instance version.",
+      optional: true,
+      options: [
+        "lastest",
+        "v1",
+        "v2",
+      ],
+    },
+    request_format: {
+      type: "string",
+      description: "Format of REST request body",
+      optional: true,
+      options: [
+        "application/json",
+        "application/xml",
+      ],
+    },
+    response_format: {
+      type: "string",
+      description: "Format of REST response body.",
+      optional: true,
+      options: [
+        "application/json",
+        "application/xml",
+      ],
+    },
+    x_no_response_body: {
+      type: "boolean",
+      description: "By default, responses include body content detailing the modified record. Set this request header to true to suppress the response body.",
+      optional: true,
+    },
+    sysparm_display_value: {
+      type: "string",
+      description: "Return field display values (true), actual values (false), or both (all) (default: false).",
+      optional: true,
+      options: [
+        "true",
+        "false",
+        "all",
+      ],
+    },
+    sysparm_exclude_reference_link: {
+      type: "boolean",
+      description: "Flag that indicates whether to exclude Table API links for reference fields.\n* `true`: Exclude Table API links for reference fields.\n* `false`: Include Table API links for reference fields.",
+      optional: true,
+    },
+    sysparm_fields: {
+      type: "string",
+      description: "A comma-separated list of fields to return in the response.",
+      optional: true,
+    },
+    sysparm_input_display_value: {
+      type: "boolean",
+      description: "Flag that indicates whether to set field values using the display value or the actual value.\n* `true`: Treats input values as display values and they are manipulated so they can be stored properly in the database.\n* `false`: Treats input values as actual values and stored them in the database without manipulation.",
+      optional: true,
+    },
+    sysparm_view: {
+      type: "string",
+      description: "Render the response according to the specified UI view (overridden by sysparm_fields).",
+      optional: true,
+      options: [
+        "desktop",
+        "mobile",
+        "both",
+      ],
+    },
+  },
+  async run({ $ }) {
+  // See the API docs: https://docs.servicenow.com/bundle/paris-application-development/page/integrate/inbound-rest/concept/c_TableAPI.html#table-POST
+
+    if (!this.table_name || !this.table_record) {
+      throw new Error("Must provide table_name, and table_record parameters.");
+    }
+
+    var apiVersion = "";
+    if (this.api_version == "v1" || this.api_version == "v2") {
+      apiVersion = this.api_version + "/";
+    }
+
+    return await axios($, {
+      method: "post",
+      url: `https://${this.servicenow.$auth.instance_name}.service-now.com/api/now/${apiVersion}table/${this.table_name}`,
+      headers: {
+        "Authorization": `Bearer ${this.servicenow.$auth.oauth_access_token}`,
+        "Accept": this.request_format || "application/json",
+        "Content-Type": this.response_format || "application/json",
+        "X-no-response-body": this.x_no_response_body,
+      },
+      params: {
+        sysparm_display_value: this.sysparm_display_value,
+        sysparm_exclude_reference_link: this.sysparm_exclude_reference_link,
+        sysparm_fields: this.sysparm_fields,
+        sysparm_input_display_value: this.sysparm_input_display_value,
+        sysparm_view: this.sysparm_view,
+      },
+      data: this.table_record,
+    });
+  },
+};

--- a/components/servicenow/actions/get-table-record-by-sysid/get-table-record-by-sysid.mjs
+++ b/components/servicenow/actions/get-table-record-by-sysid/get-table-record-by-sysid.mjs
@@ -1,0 +1,112 @@
+// legacy_hash_id: a_rJid2e
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "servicenow-get-table-record-by-sysid",
+  name: "Get Table Record By SysId",
+  description: "Retrieves the record identified by the specified sys_id from the specified table.",
+  version: "0.3.1",
+  type: "action",
+  props: {
+    servicenow: {
+      type: "app",
+      app: "servicenow",
+    },
+    table_name: {
+      type: "string",
+      description: "The name of the table containing the record to retrieve.",
+    },
+    sys_id: {
+      type: "string",
+      description: "Unique identifier of the record to retrieve.",
+    },
+    api_version: {
+      type: "string",
+      description: "API version number. Version numbers identify the endpoint version that a URI accesses. By specifying a version number in your URIs, you can ensure that future updates to the REST API do not negatively impact your integration. Use `lastest` to use the latest REST endpoint for your instance version.",
+      optional: true,
+      options: [
+        "lastest",
+        "v1",
+        "v2",
+      ],
+    },
+    request_format: {
+      type: "string",
+      description: "Format of REST request body",
+      optional: true,
+      options: [
+        "application/json",
+        "application/xml",
+        "text/xml",
+      ],
+    },
+    response_format: {
+      type: "string",
+      description: "Format of REST response body.",
+      optional: true,
+      options: [
+        "application/json",
+        "application/xml",
+        "text/xml",
+      ],
+    },
+    sysparm_display_value: {
+      type: "string",
+      description: "Return field display values (true), actual values (false), or both (all) (default: false).",
+      optional: true,
+      options: [
+        "true",
+        "false",
+        "all",
+      ],
+    },
+    sysparm_exclude_reference_link: {
+      type: "boolean",
+      description: "True to exclude Table API links for reference fields (default: false).",
+      optional: true,
+    },
+    sysparm_fields: {
+      type: "string",
+      description: "A comma-separated list of fields to return in the response.",
+      optional: true,
+    },
+    sysparm_view: {
+      type: "string",
+      description: "Render the response according to the specified UI view (overridden by sysparm_fields).",
+      optional: true,
+    },
+    sysparm_query_no_domain: {
+      type: "boolean",
+      description: "True to access data across domains if authorized (default: false).",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  // See the API docs: https://docs.servicenow.com/bundle/paris-application-development/page/integrate/inbound-rest/concept/c_TableAPI.html#table-GET-id                      */
+
+    if (!this.table_name || !this.sys_id) {
+      throw new Error("Must provide table_name, and sys_id parameters.");
+    }
+
+    var apiVersion = "";
+    if (this.api_version == "v1" || this.api_version == "v2") {
+      apiVersion = this.api_version + "/";
+    }
+
+    return await axios($, {
+      url: `https://${this.servicenow.$auth.instance_name}.service-now.com/api/now/${apiVersion}table/${this.table_name}/${this.sys_id}`,
+      headers: {
+        "Authorization": `Bearer ${this.servicenow.$auth.oauth_access_token}`,
+        "Accept": this.request_format || "application/json",
+        "Content-Type": this.response_format || "application/json",
+      },
+      params: {
+        sysparm_display_value: this.sysparm_display_value,
+        sysparm_exclude_reference_link: this.sysparm_exclude_reference_link,
+        sysparm_fields: this.sysparm_fields,
+        sysparm_view: this.sysparm_view,
+        sysparm_query_no_domain: this.sysparm_query_no_domain,
+      },
+    });
+  },
+};

--- a/components/servicenow/actions/get-table-records/get-table-records.mjs
+++ b/components/servicenow/actions/get-table-records/get-table-records.mjs
@@ -1,0 +1,137 @@
+// legacy_hash_id: a_wdid84
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "servicenow-get-table-records",
+  name: "Get Table Records",
+  description: "Retrieves multiple records for the specified table.",
+  version: "0.3.1",
+  type: "action",
+  props: {
+    servicenow: {
+      type: "app",
+      app: "servicenow",
+    },
+    table_name: {
+      type: "string",
+      description: "The name of the table containing the records to retrieve.",
+    },
+    api_version: {
+      type: "string",
+      description: "API version number. Version numbers identify the endpoint version that a URI accesses. By specifying a version number in your URIs, you can ensure that future updates to the REST API do not negatively impact your integration. Use `lastest` to use the latest REST endpoint for your instance version.",
+      optional: true,
+      options: [
+        "lastest",
+        "v1",
+        "v2",
+      ],
+    },
+    request_format: {
+      type: "string",
+      description: "Format of REST request body",
+      optional: true,
+      options: [
+        "application/json",
+        "application/xml",
+        "text/xml",
+      ],
+    },
+    response_format: {
+      type: "string",
+      description: "Format of REST response body.",
+      optional: true,
+      options: [
+        "application/json",
+        "application/xml",
+        "text/xml",
+      ],
+    },
+    sysparm_query: {
+      type: "string",
+      optional: true,
+    },
+    sysparm_display_value: {
+      type: "string",
+      description: "Return field display values (true), actual values (false), or both (all) (default: false).",
+      optional: true,
+      options: [
+        "true",
+        "false",
+        "all",
+      ],
+    },
+    sysparm_exclude_reference_link: {
+      type: "boolean",
+      description: "True to exclude Table API links for reference fields (default: false).",
+      optional: true,
+    },
+    sysparm_suppress_pagination_header: {
+      type: "boolean",
+      description: "True to supress pagination header (default: false).",
+      optional: true,
+    },
+    sysparm_fields: {
+      type: "string",
+      description: "A comma-separated list of fields to return in the response.",
+      optional: true,
+    },
+    sysparm_limit: {
+      type: "string",
+      description: "The maximum number of results returned per page (default: 10,000).",
+      optional: true,
+    },
+    sysparm_view: {
+      type: "string",
+      description: "Render the response according to the specified UI view (overridden by sysparm_fields).",
+      optional: true,
+    },
+    sysparm_query_category: {
+      type: "string",
+      description: "Name of the query category (read replica category) to use for queries.",
+      optional: true,
+    },
+    sysparm_query_no_domain: {
+      type: "boolean",
+      description: "True to access data across domains if authorized (default: false).",
+      optional: true,
+    },
+    sysparm_no_count: {
+      type: "boolean",
+      description: "Do not execute a select count(*) on table (default: false).",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  // See the API docs: https://docs.servicenow.com/bundle/paris-application-development/page/integrate/inbound-rest/concept/c_TableAPI.html#table-GET-id                    */
+
+    if (!this.table_name) {
+      throw new Error("Must provide table_name parameter.");
+    }
+
+    var apiVersion = "";
+    if (this.api_version == "v1" || this.api_version == "v2") {
+      apiVersion = this.api_version + "/";
+    }
+
+    return await axios($, {
+      url: `https://${this.servicenow.$auth.instance_name}.service-now.com/api/now/${apiVersion}table/${this.table_name}`,
+      headers: {
+        "Authorization": `Bearer ${this.servicenow.$auth.oauth_access_token}`,
+        "Accept": this.request_format || "application/json",
+        "Content-Type": this.response_format || "application/json",
+      },
+      params: {
+        sysparm_query: this.sysparm_query,
+        sysparm_display_value: this.sysparm_display_value,
+        sysparm_exclude_reference_link: this.sysparm_exclude_reference_link,
+        sysparm_suppress_pagination_header: this.sysparm_suppress_pagination_header,
+        sysparm_fields: this.sysparm_fields,
+        sysparm_limit: this.sysparm_limit,
+        sysparm_view: this.sysparm_view,
+        sysparm_query_category: this.sysparm_query_category,
+        sysparm_query_no_domain: this.sysparm_query_no_domain,
+        sysparm_no_count: this.sysparm_no_count,
+      },
+    });
+  },
+};

--- a/components/servicenow/actions/update-table-record/update-table-record.mjs
+++ b/components/servicenow/actions/update-table-record/update-table-record.mjs
@@ -1,0 +1,130 @@
+// legacy_hash_id: a_4riE2J
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "servicenow-update-table-record",
+  name: "Update Table Record",
+  description: "Updates the specified record with the name-value pairs included in the request body.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    servicenow: {
+      type: "app",
+      app: "servicenow",
+    },
+    table_name: {
+      type: "string",
+      description: "The name of the table containing the record to update.",
+    },
+    sys_id: {
+      type: "string",
+      description: "Unique identifier of the record to update.",
+    },
+    update_fields: {
+      type: "object",
+      description: "An object with name-value pairs with the fields to update in the specified record.\n**Note:** All fields within a record may not be available for update. For example, fields that have a prefix of \"sys_\" are typically system parameters that are automatically generated and cannot be updated.",
+    },
+    api_version: {
+      type: "string",
+      description: "API version number. Version numbers identify the endpoint version that a URI accesses. By specifying a version number in your URIs, you can ensure that future updates to the REST API do not negatively impact your integration. Use `lastest` to use the latest REST endpoint for your instance version.",
+      optional: true,
+      options: [
+        "lastest",
+        "v1",
+        "v2",
+      ],
+    },
+    request_format: {
+      type: "string",
+      description: "Format of REST request body",
+      optional: true,
+      options: [
+        "application/json",
+        "application/xml",
+        "text/xml",
+      ],
+    },
+    response_format: {
+      type: "string",
+      description: "Format of REST response body.",
+      optional: true,
+      options: [
+        "application/json",
+        "application/xml",
+        "text/xml",
+      ],
+    },
+    x_no_response_body: {
+      type: "boolean",
+      description: "By default, responses include body content detailing the modified record. Set this request header to true to suppress the response body.",
+      optional: true,
+    },
+    sysparm_display_value: {
+      type: "string",
+      description: "Return field display values (true), actual values (false), or both (all) (default: false).",
+      optional: true,
+      options: [
+        "true",
+        "false",
+        "all",
+      ],
+    },
+    sysparm_fields: {
+      type: "string",
+      description: "A comma-separated list of fields to return in the response.",
+      optional: true,
+    },
+    sysparm_input_display_value: {
+      type: "boolean",
+      description: "Flag that indicates whether to set field values using the display value or the actual value.\n* `true`: Treats input values as display values and they are manipulated so they can be stored properly in the database.\n* `false`: Treats input values as actual values and stored them in the database without manipulation.",
+      optional: true,
+    },
+    sysparm_view: {
+      type: "string",
+      description: "Render the response according to the specified UI view (overridden by sysparm_fields).",
+      optional: true,
+      options: [
+        "desktop",
+        "mobile",
+        "both",
+      ],
+    },
+    sysparm_query_no_domain: {
+      type: "boolean",
+      description: "True to access data across domains if authorized (default: false).",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  /* See the API docs: https://docs.servicenow.com/bundle/paris-application-development/page/integrate/inbound-rest/concept/c_TableAPI.html#c_TableAPI
+    Section Table - PATCH /now/table/{tableName}/{sys_id}                      */
+
+    if (!this.table_name || !this.sys_id || !this.update_fields) {
+      throw new Error("Must provide table_name, sys_id, and update_fields parameters.");
+    }
+
+    var apiVersion = "";
+    if (this.api_version == "v1" || this.api_version == "v2") {
+      apiVersion = this.api_version + "/";
+    }
+
+    return await axios($, {
+      method: "patch",
+      url: `https://${this.servicenow.$auth.instance_name}.service-now.com/api/now/${apiVersion}table/${this.table_name}/${this.sys_id}`,
+      headers: {
+        "Authorization": `Bearer ${this.servicenow.$auth.oauth_access_token}`,
+        "Accept": this.request_format || "application/json",
+        "Content-Type": this.response_format || "application/json",
+        "X-no-response-body": this.x_no_response_body,
+      },
+      params: {
+        sysparm_display_value: this.sysparm_display_value,
+        sysparm_fields: this.sysparm_fields,
+        sysparm_input_display_value: this.sysparm_input_display_value,
+        sysparm_view: this.sysparm_view,
+        sysparm_query_no_domain: this.sysparm_query_no_domain,
+      },
+      data: this.update_fields,
+    });
+  },
+};

--- a/components/trello/actions/get-card/get-card.mjs
+++ b/components/trello/actions/get-card/get-card.mjs
@@ -13,7 +13,9 @@ export default {
       app: "trello",
     },
   },
-  async run({ $ }) {
+  async run({
+    steps, $,
+  }) {
     return await axios($, {
 
       url: "https://api.trello.com/1/cards/" + steps.nodejs.$return_value,

--- a/components/trello/actions/get-card/get-card.mjs
+++ b/components/trello/actions/get-card/get-card.mjs
@@ -1,0 +1,28 @@
+// legacy_hash_id: a_74ijLO
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "trello-get-card",
+  name: "Trello Get Card",
+  description: "Get all parameters of a Card passing Card ID",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    trello: {
+      type: "app",
+      app: "trello",
+    },
+  },
+  async run({ $ }) {
+    return await axios($, {
+
+      url: "https://api.trello.com/1/cards/" + steps.nodejs.$return_value,
+    }, {
+      token: {
+        key: this.trello.$auth.oauth_access_token,
+        secret: this.trello.$auth.oauth_refresh_token,
+      },
+      oauthSignerUri: this.trello.$auth.oauth_signer_uri,
+    });
+  },
+};

--- a/components/twist/actions/add-comment/add-comment.mjs
+++ b/components/twist/actions/add-comment/add-comment.mjs
@@ -1,0 +1,97 @@
+// legacy_hash_id: a_a4irNP
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "twist-add-comment",
+  name: "Add Comment",
+  description: "Adds a new comment to a thread.",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    twist: {
+      type: "app",
+      app: "twist",
+    },
+    thread_id: {
+      type: "string",
+      description: "The id of the thread to the add the comment on.",
+    },
+    content: {
+      type: "string",
+      description: "The content of the new comment. Mentions can be used as `[Name](twist-mention://user_id)` for users or `[Group name](twist-group-mention://group_id)` for groups. Check [limits](https://api.twistapp.com/v3/#limits) for size restrictions for the content.",
+    },
+    attachments: {
+      type: "any",
+      description: "List of attachments to the new comment. It must follow the JSON format returned by [attachment#upload](https://api.twistapp.com/v3/#upload-an-attachment).",
+      optional: true,
+    },
+    actions: {
+      type: "string",
+      description: "List of action to the new comment. More information about the format of the object available at the [add an action button submenu](https://api.twistapp.com/v3/#add-an-action-button).",
+      optional: true,
+    },
+    direct_mentions: {
+      type: "any",
+      description: "The users that are directly mentioned.",
+      optional: true,
+    },
+    direct_group_mentions: {
+      type: "any",
+      description: "The groups that are directly mentioned.",
+      optional: true,
+    },
+    recipients: {
+      type: "any",
+      description: "An array of users (e.g. recipients: `[10000, 10001]`) to notify. It also accepts the strings `EVERYONE` or `EVERYONE_IN_THREAD`, which notifies everyone in the workspace or everyone mentioned in previous posts of this thread. If not provided, `EVERYONE_IN_THREAD` will be used.",
+      optional: true,
+    },
+    groups: {
+      type: "any",
+      description: "The groups that will be notified.",
+      optional: true,
+    },
+    temp_id: {
+      type: "string",
+      description: "The temporary id of the comment.",
+      optional: true,
+    },
+    mark_thread_position: {
+      type: "boolean",
+      description: "By default, the position of the thread is marked.",
+      optional: true,
+    },
+    send_as_integration: {
+      type: "boolean",
+      description: "Displays the integration as the comment creator.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  //See the API docs: https://api.twistapp.com/v3/#add-comment
+
+    if (!this.thread_id || !this.content) {
+      throw new Error("Must provide thread_id, and content parameters.");
+    }
+
+    return await axios($, {
+      method: "post",
+      url: "https://api.twist.com/api/v3/comments/add",
+      headers: {
+        Authorization: `Bearer ${this.twist.$auth.oauth_access_token}`,
+      },
+      data: {
+        thread_id: this.thread_id,
+        content: this.content,
+        attachments: this.attachments,
+        actions: this.actions,
+        direct_mentions: this.direct_mentions,
+        direct_group_mentions: this.direct_group_mentions,
+        recipients: this.recipients,
+        groups: this.groups,
+        temp_id: this.temp_id,
+        mark_thread_position: this.mark_thread_position,
+        send_as_integration: this.send_as_integration,
+      },
+    });
+  },
+};

--- a/components/twist/actions/add-message-to-conversation/add-message-to-conversation.mjs
+++ b/components/twist/actions/add-message-to-conversation/add-message-to-conversation.mjs
@@ -1,0 +1,67 @@
+// legacy_hash_id: a_zNiVnJ
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "twist-add-message-to-conversation",
+  name: "Add Message To Conversation",
+  description: "Adds a message to an existing conversation.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    twist: {
+      type: "app",
+      app: "twist",
+    },
+    conversation_id: {
+      type: "string",
+      description: "The id of the conversation where the message will be added.",
+    },
+    content: {
+      type: "string",
+      description: "The content of the new message. Mentions can be used as `[Name](twist-mention://user_id)` for users or `[Group name](twist-group-mention://group_id)` for groups. Check [limits](https://api.twistapp.com/v3/#limits) for size restrictions for the content.",
+    },
+    attachments: {
+      type: "any",
+      description: "List of attachments to the new comment. It must follow the JSON format returned by [attachment#upload](https://api.twistapp.com/v3/#upload-an-attachment).",
+      optional: true,
+    },
+    actions: {
+      type: "any",
+      description: "List of action to the new comment. More information about the format of the object available at the [add an action button submenu](https://api.twistapp.com/v3/#add-an-action-button).",
+      optional: true,
+    },
+    direct_mentions: {
+      type: "any",
+      description: "The users that are directly mentioned.",
+      optional: true,
+    },
+    direct_group_mentions: {
+      type: "string",
+      description: "The groups that are directly mentioned.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  //See the API docs: https://api.twistapp.com/v3/#add-message-to-conversation
+
+    if (!this.conversation_id || !this.content) {
+      throw new Error("Must provide conversation_id, content parameter.");
+    }
+
+    return await axios($, {
+      method: "post",
+      url: "https://api.twist.com/api/v3/conversation_messages/add",
+      headers: {
+        Authorization: `Bearer ${this.twist.$auth.oauth_access_token}`,
+      },
+      data: {
+        conversation_id: this.conversation_id,
+        content: this.content,
+        attachments: this.attachments,
+        actions: this.actions,
+        direct_mentions: this.direct_mentions,
+        direct_group_mentions: this.direct_group_mentions,
+      },
+    });
+  },
+};

--- a/components/twist/actions/add-thread/add-thread.mjs
+++ b/components/twist/actions/add-thread/add-thread.mjs
@@ -1,0 +1,96 @@
+// legacy_hash_id: a_elirJ5
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "twist-add-thread",
+  name: "Add Thread",
+  description: "Adds a new thread to a channel.",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    twist: {
+      type: "app",
+      app: "twist",
+    },
+    channel_id: {
+      type: "string",
+      description: "The id of the channel where the thread will be created.",
+    },
+    content: {
+      type: "string",
+      description: "The content of the new thread. Mentions can be used as `[Name](twist-mention://user_id)` for users or `[Group name](twist-group-mention://group_id)` for groups. Check [limits](https://api.twistapp.com/v3/#limits) for size restrictions for the content.",
+    },
+    title: {
+      type: "string",
+      description: "The title of the new thread.",
+    },
+    actions: {
+      type: "any",
+      description: "List of action to the new thread. More information about the format of the object available at the add an [action button submenu](https://api.twistapp.com/v3/#add-an-action-button).",
+      optional: true,
+    },
+    attachments: {
+      type: "any",
+      description: "List of attachments to the new thread. It must follow the JSON format returned by [attachment#upload.](https://api.twistapp.com/v3/#upload-an-attachment)",
+      optional: true,
+    },
+    direct_mentions: {
+      type: "any",
+      description: "The users that are directly mentioned.",
+      optional: true,
+    },
+    direct_group_mentions: {
+      type: "any",
+      description: "The groups that are directly mentioned.",
+      optional: true,
+    },
+    recipients: {
+      type: "any",
+      description: "An array of users (e.g. recipients: `[10000, 10001]`) that will be attached to the thread. It also accepts the string `EVERYONE`, which notifies everyone in the workspace. If not included, the value will default to `user_ids` of the target channel. If you specify `[]`, no Twist users will be notified, and the thread creator will become the sole participant.",
+      optional: true,
+    },
+    groups: {
+      type: "any",
+      description: "The groups that will be notified.",
+      optional: true,
+    },
+    temp_id: {
+      type: "string",
+      description: "The temporary id of the thread.",
+      optional: true,
+    },
+    send_as_integration: {
+      type: "boolean",
+      description: "Displays the integration as the thread creator.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  //See the API docs: https://api.twistapp.com/v3/#add-thread
+
+    if (!this.channel_id || !this.content || !this.title) {
+      throw new Error("Must provide thread_id, content, and title parameters.");
+    }
+
+    return await axios($, {
+      method: "post",
+      url: "https://api.twist.com/api/v3/threads/add",
+      headers: {
+        Authorization: `Bearer ${this.twist.$auth.oauth_access_token}`,
+      },
+      data: {
+        actions: this.actions,
+        attachments: this.attachments,
+        channel_id: this.channel_id,
+        content: this.content,
+        direct_mentions: this.direct_mentions,
+        direct_group_mentions: this.direct_group_mentions,
+        recipients: this.recipients,
+        groups: this.groups,
+        temp_id: this.temp_id,
+        title: this.title,
+        send_as_integration: this.send_as_integration,
+      },
+    });
+  },
+};

--- a/components/twist/actions/get-current-user/get-current-user.mjs
+++ b/components/twist/actions/get-current-user/get-current-user.mjs
@@ -1,0 +1,26 @@
+// legacy_hash_id: a_0Mi2Pj
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "twist-get-current-user",
+  name: "Get Current User",
+  description: "Gets the associated user for access token used in the request.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    twist: {
+      type: "app",
+      app: "twist",
+    },
+  },
+  async run({ $ }) {
+  //See the API docs: https://api.twistapp.com/v3/#get-current-user
+
+    return await axios($, {
+      url: "https://api.twist.com/api/v3/users/get_session_user",
+      headers: {
+        Authorization: `Bearer ${this.twist.$auth.oauth_access_token}`,
+      },
+    });
+  },
+};

--- a/components/twist/actions/get-thread/get-thread.mjs
+++ b/components/twist/actions/get-thread/get-thread.mjs
@@ -1,0 +1,38 @@
+// legacy_hash_id: a_Q3iRXl
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "twist-get-thread",
+  name: "Get Thread",
+  description: "Gets a thread object by id.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    twist: {
+      type: "app",
+      app: "twist",
+    },
+    thread_id: {
+      type: "string",
+      description: "The id of the thread to get details of.",
+    },
+  },
+  async run({ $ }) {
+  //See the API docs: https://api.twistapp.com/v3/#get-thread
+
+    if (!this.thread_id) {
+      throw new Error("Must provide thread_id parameter.");
+    }
+
+    return await axios($, {
+      url: "https://api.twist.com/api/v3/threads/getone",
+      headers: {
+        Authorization: `Bearer ${this.twist.$auth.oauth_access_token}`,
+      },
+      params: {
+        id: this.thread_id,
+      },
+
+    });
+  },
+};

--- a/components/twist/actions/get-user-by-email/get-user-by-email.mjs
+++ b/components/twist/actions/get-user-by-email/get-user-by-email.mjs
@@ -1,0 +1,41 @@
+// legacy_hash_id: a_Nqilma
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "twist-get-user-by-email",
+  name: "Get Workspace User By Email",
+  description: "Gets a workspace user by email.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    twist: {
+      type: "app",
+      app: "twist",
+    },
+    workspace_id: {
+      type: "string",
+      description: "The id of the workspace.",
+    },
+    email: {
+      type: "string",
+      description: "The user's email.",
+    },
+  },
+  async run({ $ }) {
+  //See the API docs: https://api.twistapp.com/v3/#get-user-by-email
+
+    if (!this.workspace_id || !this.email) {
+      throw new Error("Must provide workspace_id, and email parameters.");
+    }
+    return await axios($, {
+      url: "https://api.twist.com/api/v3/workspaces/get_user_by_email",
+      headers: {
+        Authorization: `Bearer ${this.twist.$auth.oauth_access_token}`,
+      },
+      params: {
+        id: this.workspace_id,
+        email: this.email,
+      },
+    });
+  },
+};

--- a/components/twist/actions/get-workspace-users/get-workspace-users.mjs
+++ b/components/twist/actions/get-workspace-users/get-workspace-users.mjs
@@ -1,0 +1,36 @@
+// legacy_hash_id: a_67i63O
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "twist-get-workspace-users",
+  name: "Get Workspace Users",
+  description: "Gets a list of users for the given workspace id.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    twist: {
+      type: "app",
+      app: "twist",
+    },
+    workspace_id: {
+      type: "string",
+    },
+  },
+  async run({ $ }) {
+  // See the API docs: https://api.twistapp.com/v3/#get-workspace-users
+
+    if (!this.workspace_id) {
+      throw new Error("Must provide workspace_id parameter.");
+    }
+
+    return await axios($, {
+      url: "https://api.twist.com/api/v3/workspaces/get_users",
+      headers: {
+        Authorization: `Bearer ${this.twist.$auth.oauth_access_token}`,
+      },
+      params: {
+        id: this.workspace_id,
+      },
+    });
+  },
+};

--- a/components/xero_accounting_api/actions/create-bank-transaction/create-bank-transaction.mjs
+++ b/components/xero_accounting_api/actions/create-bank-transaction/create-bank-transaction.mjs
@@ -1,0 +1,142 @@
+// legacy_hash_id: a_WYiwz2
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "xero_accounting_api-create-bank-transaction",
+  name: "Create Bank Transaction",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    xero_accounting_api: {
+      type: "app",
+      app: "xero_accounting_api",
+    },
+    bank_account_code: {
+      type: "string",
+      description: "The Account Code of the Bank Account of the transaction. If Code is not included then AccountID is required.",
+      optional: true,
+    },
+    bank_account_id: {
+      type: "string",
+      description: "The ID of the Bank Account transaction. If AccountID is not included then Code is required.",
+      optional: true,
+    },
+    contact_id: {
+      type: "string",
+      description: "Id of the contact associated to the bank transaction.",
+      optional: true,
+    },
+    contact_name: {
+      type: "string",
+      description: "Name of the contact associated to the bank transaction. If there is no contact matching this name, a new contact is created.",
+      optional: true,
+    },
+    tenant_id: {
+      type: "string",
+      description: "Id of the organization tenant to use on the Xero Accounting API. See [Get Tenant Connections](https://pipedream.com/@sergio/xero-accounting-api-get-tenant-connections-p_OKCzOgn/edit) for a workflow example on how to pull this data.",
+    },
+    type: {
+      type: "string",
+      description: "See [Bank Transaction Types](https://developer.xero.com/documentation/api/types#BankTransactionTypes)",
+      options: [
+        "RECEIVE",
+        "RECEIVE-OVERPAYMENT",
+        "RECEIVE-PREPAYMENT",
+        "SPEND",
+        "SPEND-OVERPAYMENT",
+        "SPEND-PREPAYMENT",
+      ],
+    },
+    line_items: {
+      type: "object",
+      description: "See [LineItems](https://developer.xero.com/documentation/api/banktransactions#LineItemsPOST). The LineItems element can contain any number of individual LineItem sub-elements. At least **one** is required to create a bank transaction.",
+    },
+    is_reonciled: {
+      type: "boolean",
+      description: "Boolean to show if transaction is reconciled. Conversion related apps can set the IsReconciled flag in scenarios when a matching bank statement line is not available. [Learn more](http://help.xero.com/#Q_BankRecNoImport)",
+      optional: true,
+    },
+    date: {
+      type: "string",
+      description: "Date of transaction - YYYY-MM-DD",
+      optional: true,
+    },
+    reference: {
+      type: "string",
+      description: "Reference for the transaction. Only supported for SPEND and RECEIVE transactions.",
+      optional: true,
+    },
+    currency_code: {
+      type: "string",
+      description: "The currency that bank transaction has been raised in (see [Currencies](https://developer.xero.com/documentation/api/currencies)). Setting currency is only supported on overpayments.",
+      optional: true,
+    },
+    currency_rate: {
+      type: "string",
+      description: "Exchange rate to base currency when money is spent or received. e.g. 0.7500 Only used for bank transactions in non base currency. If this isn't specified for non base currency accounts then either the user-defined rate (preference) or the [XE.com day rate](http://help.xero.com/#CurrencySettings$Rates) will be used. Setting currency is only supported on overpayments.",
+      optional: true,
+    },
+    url: {
+      type: "string",
+      description: "URL link to a source document - shown as \"Go to App Name\"",
+      optional: true,
+    },
+    status: {
+      type: "string",
+      description: "See [Bank Transaction Status Codes](https://developer.xero.com/documentation/api/types#BankTransactionStatuses)",
+      optional: true,
+      options: [
+        "AUTHORISED",
+        "DELETED",
+      ],
+    },
+    line_amount_types: {
+      type: "string",
+      description: "Line amounts are exclusive of tax by default if you don't specify this element. See [Line Amount Types](https://developer.xero.com/documentation/api/types#LineAmountTypes)",
+      optional: true,
+      options: [
+        "Exclusive",
+        "Inclusive",
+        "NoTax",
+      ],
+    },
+  },
+  async run({ $ }) {
+  //See the API docs: https://developer.xero.com/documentation/api/banktransactions#PUT
+
+    if ((!this.bank_account_code && !this.bank_account_id)
+    || (!this.contact_id && !this.contact_name)
+    || !this.tenant_id || !this.type || !this.line_items) {
+      throw new Error("Must provide one of bank_account_code or bank_account_id, contact_id or contact_name, tenant_id, type, and line_items parameters.");
+    }
+
+    return await axios($, {
+      method: "put",
+      url: "https://api.xero.com/api.xro/2.0/BankTransactions",
+      headers: {
+        "Authorization": `Bearer ${this.xero_accounting_api.$auth.oauth_access_token}`,
+        "xero-tenant-id": this.tenant_id,
+      },
+      data: {
+        Type: this.type,
+        BankAccount: {
+          Code: this.bank_account_code,
+          AccountID: this.bank_account_id,
+        },
+        Contact: {
+          ContactID: this.contact_id,
+          Name: this.contact_name,
+        },
+        IsReconciled: this.is_reonciled,
+        Date: this.date,
+        Reference: this.reference,
+        CurrencyCode: this.currency_code,
+        CurrencyRate: this.currency_rate,
+        Url: this.url,
+        Status: this.status,
+        Lineitems: this.line_items,
+        LineAmountTypes: this.line_amount_types,
+      },
+    });
+  },
+};

--- a/components/xero_accounting_api/actions/create-credit-note/create-credit-note.mjs
+++ b/components/xero_accounting_api/actions/create-credit-note/create-credit-note.mjs
@@ -1,0 +1,140 @@
+// legacy_hash_id: a_3Lieoo
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "xero_accounting_api-create-credit-note",
+  name: "Create Credit Note",
+  description: "Creates a new credit note.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    xero_accounting_api: {
+      type: "app",
+      app: "xero_accounting_api",
+    },
+    contact_id: {
+      type: "string",
+      description: "Id of the contact associated to the credit note.",
+      optional: true,
+    },
+    contact_name: {
+      type: "string",
+      description: "Name of the contact associated to the credit note. If there is no contact matching this name, a new contact is created.",
+      optional: true,
+    },
+    contact_number: {
+      type: "string",
+      description: "Number of the contact associated to the credit note. If there is no contact matching this name, a new contact is created.",
+      optional: true,
+    },
+    tenant_id: {
+      type: "string",
+      description: "Id of the organization tenant to use on the Xero Accounting API. See [Get Tenant Connections](https://pipedream.com/@sergio/xero-accounting-api-get-tenant-connections-p_OKCzOgn/edit) for a workflow example on how to pull this data.",
+    },
+    type: {
+      type: "string",
+      description: "See [Credit Note Types](https://developer.xero.com/documentation/api/types#CreditNoteTypes)",
+      options: [
+        "ACCPAYCREDIT",
+        "ACCRECCREDIT",
+      ],
+    },
+    date: {
+      type: "string",
+      description: "The date the credit note is issued YYYY-MM-DD. If the Date element is not specified then it will default to the current date based on the timezone setting of the organisation",
+      optional: true,
+    },
+    status: {
+      type: "string",
+      description: "See [Credit Note Status Codes](https://developer.xero.com/documentation/api/types#CreditNoteStatuses)",
+      optional: true,
+      options: [
+        "DRAFT",
+        "SUBMITTED",
+        "DELETED",
+        "AUTHORISED",
+        "PAID",
+        "VOIDED",
+      ],
+    },
+    line_amount_types: {
+      type: "string",
+      description: "See [Invoice Line Amount Types](https://developer.xero.com/documentation/api/Types#LineAmountTypes)",
+      optional: true,
+      options: [
+        "Exclusive",
+        "Inclusive",
+        "NoTax",
+      ],
+    },
+    line_items: {
+      type: "object",
+      description: "See [Invoice Line Items](https://developer.xero.com/documentation/api/Invoices#LineItems)",
+      optional: true,
+    },
+    currency_code: {
+      type: "string",
+      description: "Currency used for the Credit Note",
+      optional: true,
+    },
+    credit_note_number: {
+      type: "string",
+      description: "[ACCRECCREDIT](https://developer.xero.com/documentation/api/types#CreditNoteTypes) - Unique alpha numeric code identifying credit note ( *when missing will auto-generate from your Organisation Invoice Settings*)\n[ACCPAYCREDIT](https://developer.xero.com/documentation/api/types#CreditNoteTypes) - non-unique alpha numeric code identifying credit note. This value will also display as Reference in the UI.",
+      optional: true,
+    },
+    reference: {
+      type: "string",
+      description: "ACCRECCREDIT only - additional reference number",
+      optional: true,
+    },
+    sent_to_contact: {
+      type: "boolean",
+      description: "Boolean to indicate if a credit note has been sent to a contact via the Xero app (currently read only)",
+      optional: true,
+    },
+    currency_rate: {
+      type: "string",
+      description: "The currency rate for a multicurrency invoice. If no rate is specified, the [XE.com day rate](http://help.xero.com/#CurrencySettings$Rates) is used",
+      optional: true,
+    },
+    branding_theme_id: {
+      type: "string",
+      description: "See [BrandingThemes](https://developer.xero.com/documentation/api/branding-themes)",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  //See the API docs: https://developer.xero.com/documentation/api/credit-notes#POST
+
+    if ((!this.contact_id && !this.contact_name && !this.contact_number) || !this.tenant_id || !this.type) {
+      throw new Error("Must provide one of contact_id or contact_name or contact_number, and tenant_id, type parameters.");
+    }
+
+    return await axios($, {
+      method: "post",
+      url: "https://api.xero.com/api.xro/2.0/CreditNotes",
+      headers: {
+        "Authorization": `Bearer ${this.xero_accounting_api.$auth.oauth_access_token}`,
+        "xero-tenant-id": this.tenant_id,
+      },
+      data: {
+        Type: this.type,
+        Contact: {
+          ContactID: this.contact_id,
+          ContactNumber: this.contact_number,
+          Name: this.contact_name,
+        },
+        Date: this.date,
+        Status: this.status,
+        LineAmountTypes: this.line_amount_types,
+        LineItems: this.line_items,
+        CurrencyCode: this.currency_code,
+        CreditNoteNumber: this.credit_note_number,
+        Reference: this.reference,
+        SentToContact: this.sent_to_contact,
+        CurrencyRate: this.currency_rate,
+        BrandingThemeID: this.branding_theme_id,
+      },
+    });
+  },
+};

--- a/components/xero_accounting_api/actions/create-item/create-item.mjs
+++ b/components/xero_accounting_api/actions/create-item/create-item.mjs
@@ -1,0 +1,104 @@
+// legacy_hash_id: a_a4ivOG
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "xero_accounting_api-create-item",
+  name: "Create Item",
+  description: "Creates a new item.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    xero_accounting_api: {
+      type: "app",
+      app: "xero_accounting_api",
+    },
+    tenant_id: {
+      type: "string",
+      description: "Id of the organization tenant to use on the Xero Accounting API. See [Get Tenant Connections](https://pipedream.com/@sergio/xero-accounting-api-get-tenant-connections-p_OKCzOgn/edit) for a workflow example on how to pull this data.",
+    },
+    code: {
+      type: "string",
+      description: "User defined item code (max length = 30)",
+    },
+    inventory_asset_account_code: {
+      type: "string",
+      description: "The inventory asset [account](https://developer.xero.com/documentation/api/accounts/) for the item. The account must be of type INVENTORY. The COGSAccountCode in PurchaseDetails is also required to create a tracked item",
+      optional: true,
+    },
+    name: {
+      type: "string",
+      description: "The name of the item (max length = 50)",
+      optional: true,
+    },
+    is_sold: {
+      type: "boolean",
+      description: "Boolean value, defaults to true. When IsSold is true the item will be available on sales transactions in the Xero UI. If IsSold is updated to false then Description and SalesDetails values will be nulled.",
+      optional: true,
+    },
+    is_purchased: {
+      type: "boolean",
+      description: "Boolean value, defaults to true. When IsPurchased is true the item is available for purchase transactions in the Xero UI. If IsPurchased is updated to false then PurchaseDescription and PurchaseDetails values will be nulled.",
+      optional: true,
+    },
+    description: {
+      type: "string",
+      description: "The sales description of the item (max length = 4000)",
+      optional: true,
+    },
+    purchase_description: {
+      type: "string",
+      description: "The purchase description of the item (max length = 4000)",
+      optional: true,
+    },
+    purchase_details: {
+      type: "string",
+      description: "See Purchases & Sales. The [PurchaseDetails](https://developer.xero.com/documentation/api/items#PurchasesSales) element can contain a number of individual sub-elements.",
+      optional: true,
+    },
+    sales_details: {
+      type: "string",
+      description: "See Purchases & Sales. The [SalesDetails](https://developer.xero.com/documentation/api/items#PurchasesSales) element can contain a number of individual sub-elements.",
+      optional: true,
+    },
+    unitdp: {
+      type: "string",
+      description: "By default UnitPrice is returned to two decimal places.",
+      optional: true,
+      options: [
+        "2",
+        "4",
+      ],
+    },
+  },
+  async run({ $ }) {
+  //See the API docs: https://developer.xero.com/documentation/api/items#POST
+
+    if (!this.tenant_id || !this.code) {
+      throw new Error("Must provide tenant_id, and code parameters.");
+    }
+
+    return await axios($, {
+      method: "put",
+      url: "https://api.xero.com/api.xro/2.0/Items",
+      headers: {
+        "Authorization": `Bearer ${this.xero_accounting_api.$auth.oauth_access_token}`,
+        "Accept": "application/json",
+        "xero-tenant-id": this.tenant_id,
+      },
+      data: {
+        Code: this.code,
+        InventoryAssetAccountCode: this.inventory_asset_account_code,
+        Name: this.name,
+        IsSold: this.is_sold,
+        IsPurchased: this.is_purchased,
+        Description: this.description,
+        PurchaseDescription: this.purchase_description,
+        PurchaseDetails: this.purchase_details,
+        SalesDetails: this.sales_details,
+      },
+      params: {
+        unitdp: this.unitdp,
+      },
+    });
+  },
+};

--- a/components/xero_accounting_api/actions/create-payment/create-payment.mjs
+++ b/components/xero_accounting_api/actions/create-payment/create-payment.mjs
@@ -1,0 +1,158 @@
+// legacy_hash_id: a_k6irV0
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "xero_accounting_api-create-payment",
+  name: "Create Payment",
+  description: "Creates a new payment",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    xero_accounting_api: {
+      type: "app",
+      app: "xero_accounting_api",
+    },
+    account_id: {
+      type: "string",
+      description: "ID of account you are using to make the payment e.g. 294b1dc5-cc47-2afc-7ec8-64990b8761b8. This account needs to be either an account of type BANK or have enable payments to this accounts switched on (see [GET Accounts](https://developer.xero.com/documentation/api/Accounts)) . See the edit account screen of your Chart of Accounts in Xero if you wish to enable payments for an account other than a bank account",
+      optional: true,
+    },
+    account_code: {
+      type: "string",
+      description: "Code of account you are using to make the payment e.g. 001 ( note: *not all accounts have a code value*)",
+      optional: true,
+    },
+    invoice_id: {
+      type: "string",
+      description: "ID of the invoice you are applying payment to e.g. 297c2dc5-cc47-4afd-8ec8-74990b8761e9",
+      optional: true,
+    },
+    credit_note_id: {
+      type: "string",
+      description: "ID of the credit note you are applying payment to e.g. 297c2dc5-cc47-4afd-8ec8-74990b8761e9",
+      optional: true,
+    },
+    prepayment_id: {
+      type: "string",
+      description: "ID of the prepayment you are applying payment to e.g. 297c2dc5-cc47-4afd-8ec8-74990b8761e9",
+      optional: true,
+    },
+    overpayment_id: {
+      type: "string",
+      description: "ID of the overpayment you are applying payment to e.g. 297c2dc5-cc47-4afd-8ec8-74990b8761e9",
+      optional: true,
+    },
+    invoice_number: {
+      type: "string",
+      description: "Number of invoice you are applying payment to e.g. INV-4003",
+      optional: true,
+    },
+    credit_note_number: {
+      type: "string",
+      description: "Number of credit note you are applying payment to e.g. INV-4003",
+      optional: true,
+    },
+    tenant_id: {
+      type: "string",
+      description: "Id of the organization tenant to use on the Xero Accounting API. See [Get Tenant Connections](https://pipedream.com/@sergio/xero-accounting-api-get-tenant-connections-p_OKCzOgn/edit) for a workflow example on how to pull this data.",
+    },
+    date: {
+      type: "string",
+      description: "Date the payment is being made (YYYY-MM-DD) e.g. 2009-09-06",
+      optional: true,
+    },
+    currency_rate: {
+      type: "string",
+      description: "Exchange rate when payment is received. Only used for non base currency invoices and credit notes e.g. 0.7500",
+      optional: true,
+    },
+    amount: {
+      type: "string",
+      description: "The amount of the payment. Must be less than or equal to the outstanding amount owing on the invoice e.g. 200.00",
+      optional: true,
+    },
+    reference: {
+      type: "string",
+      description: "An optional description for the payment e.g. Direct Debit",
+      optional: true,
+    },
+    is_reconciled: {
+      type: "boolean",
+      description: "A boolean indicating whether the payment has been reconciled.",
+      optional: true,
+    },
+    status: {
+      type: "string",
+      description: "The [status](https://developer.xero.com/documentation/api/types#PaymentStatusCodes) of the payment.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  //See the API docs: https://developer.xero.com/documentation/api/payments#PUT
+
+    if ((!this.account_id && !this.account_code)
+      || (!this.invoice_id && !this.credit_note_id && !this.prepayment_id && !this.overpayment_id && !this.invoice_number && !this.credit_note_number)
+      || !this.tenant_id) {
+      throw new Error("Must provide account_id or account_code, and", "\n", "invoice_id or credit_note_id or prepayment_id or overpayment_id or invoice_number or credit_note_number,\nand tenant_id parameters.");
+    }
+
+    //Adds parameters to the requests body
+    var data = {
+      Date: this.date,
+      CurrencyRate: this.currency_rate,
+      Amount: this.amount,
+      Reference: this.reference,
+      IsReconciled: this.is_reconciled,
+      Status: this.status,
+    };
+
+    //Adds the account paramter to the request body
+    if (this.account_id) {
+      data["Account"] = {
+        AccountID: this.account_id,
+      };
+    } else {
+      data["Account"] = {
+        Code: this.account_code,
+      };
+    }
+
+    //Adds the related document object where payment is applied to the request body
+    if (this.invoice_id) {
+      data["Invoice"] = {
+        InvoiceID: this.invoice_id,
+      };
+    } else if (this.credit_note_id) {
+      data["CreditNote"] = {
+        CreditNoteID: this.credit_note_id,
+      };
+    } else if (this.prepayment_id) {
+      data["Prepayment"] = {
+        PrepaymentID: this.prepayment_id,
+      };
+    } else if (this.overpayment_id) {
+      data["Overpayment"] = {
+        OverpaymentID: this.overpayment_id,
+      };
+    } else if (this.invoice_number) {
+      data["Invoice"] = {
+        InvoiceNumber: this.invoice_number,
+      };
+    } else if (this.credit_note_number) {
+      data["CreditNote"] = {
+        CreditNoteNumber: this.credit_note_number,
+      };
+    }
+
+    //Sends the request against Xero Accounting API
+    return await axios($, {
+      method: "put",
+      url: "https://api.xero.com/api.xro/2.0/Payments",
+      headers: {
+        "Authorization": `Bearer ${this.xero_accounting_api.$auth.oauth_access_token}`,
+        "xero-tenant-id": this.tenant_id,
+      },
+      data,
+    });
+  },
+};

--- a/components/xero_accounting_api/actions/download-invoice/download-invoice.mjs
+++ b/components/xero_accounting_api/actions/download-invoice/download-invoice.mjs
@@ -1,0 +1,50 @@
+// legacy_hash_id: a_k6irBN
+import fs from "fs";
+import axios from "axios";
+
+export default {
+  key: "xero_accounting_api-download-invoice",
+  name: "Download Invoice",
+  description: "Downloads an invoice as pdf file. File will be placed at the action's associated workflow temporary folder.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    xero_accounting_api: {
+      type: "app",
+      app: "xero_accounting_api",
+    },
+    tenant_id: {
+      type: "string",
+      description: "Id of the organization tenant to use on the Xero Accounting API. See [Get Tenant Connections](https://pipedream.com/@sergio/xero-accounting-api-get-tenant-connections-p_OKCzOgn/edit) for a workflow example on how to pull this data.",
+    },
+    invoice_id: {
+      type: "string",
+      description: "Xero generated unique identifier for the invoice to download.",
+    },
+  },
+  async run({ $ }) {
+    //See the API docs: https://developer.xero.com/documentation/api/invoices#get and https://developer.xero.com/documentation/api/requests-and-responses#get-individual
+    //For an example of this action in an workflow, see: https://pipedream.com/@sergio/xero-accounting-api-download-invoice-p_vQCgy3o/edit
+
+    if (!this.tenant_id || !this.invoice_id) {
+      throw new Error("Must provide tenant_id, invoice_id parameters.");
+    }
+
+    const resp = await axios({
+      url: `https://api.xero.com/api.xro/2.0/Invoices/${this.invoice_id}`,
+      headers: {
+        "Authorization": `Bearer ${this.xero_accounting_api.$auth.oauth_access_token}`,
+        "Accept": "application/pdf",
+        "xero-tenant-id": this.tenant_id,
+      },
+      responseType: "arraybuffer",
+    });
+
+    const invoicePdf = resp.data.toString("base64");
+    const buffer = Buffer.from(invoicePdf, "base64");
+    const tmpDir = "/tmp";
+    $.export("invoice_path", `${tmpDir}/${this.invoice_id}.pdf`); //This is where the invoice is saved at the workflow's temporary files.
+    fs.writeFileSync(this.invoice_path, buffer);
+    console.log(`Invoice saved at: ${this.invoice_path}`);
+  },
+};

--- a/components/xero_accounting_api/actions/email-an-invoice/email-an-invoice.mjs
+++ b/components/xero_accounting_api/actions/email-an-invoice/email-an-invoice.mjs
@@ -1,0 +1,40 @@
+// legacy_hash_id: a_q1i3Aj
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "xero_accounting_api-email-an-invoice",
+  name: "Email an Invoice",
+  description: "Triggers the email of a sales invoice out of Xero.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    xero_accounting_api: {
+      type: "app",
+      app: "xero_accounting_api",
+    },
+    tenant_id: {
+      type: "string",
+      description: "Id of the organization tenant to use on the Xero Accounting API. See [Get Tenant Connections](https://pipedream.com/@sergio/xero-accounting-api-get-tenant-connections-p_OKCzOgn/edit) for a workflow example on how to pull this data.",
+    },
+    invoice_id: {
+      type: "string",
+      description: "Xero generated unique identifier for the invoice to send by email out of Xero. The invoice must be of Type ACCREC and a valid Status for sending (SUMBITTED,AUTHORISED or PAID).",
+    },
+  },
+  async run({ $ }) {
+  //See the API docs: https://developer.xero.com/documentation/api/invoices#email
+
+    if (!this.tenant_id || !this.invoice_id) {
+      throw new Error("Must provide tenant_id, invoice_id parameters.");
+    }
+
+    return await axios($, {
+      method: "post",
+      url: `https://api.xero.com/api.xro/2.0/Invoices/${this.invoice_id}/Email`,
+      headers: {
+        "Authorization": `Bearer ${this.xero_accounting_api.$auth.oauth_access_token}`,
+        "xero-tenant-id": this.tenant_id,
+      },
+    });
+  },
+};

--- a/components/xero_accounting_api/actions/get-bank-summary/get-bank-summary.mjs
+++ b/components/xero_accounting_api/actions/get-bank-summary/get-bank-summary.mjs
@@ -1,0 +1,49 @@
+// legacy_hash_id: a_K5i5rd
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "xero_accounting_api-get-bank-summary",
+  name: "Get Bank Summary",
+  description: "Gets the balances and cash movements for each bank account.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    xero_accounting_api: {
+      type: "app",
+      app: "xero_accounting_api",
+    },
+    tenant_id: {
+      type: "string",
+      description: "Id of the organization tenant to use on the Xero Accounting API. See [Get Tenant Connections](https://pipedream.com/@sergio/xero-accounting-api-get-tenant-connections-p_OKCzOgn/edit) for a workflow example on how to pull this data.",
+    },
+    form_date: {
+      type: "string",
+      description: "Get the balances and cash movements for each bank account from this date",
+      optional: true,
+    },
+    to_date: {
+      type: "string",
+      description: "Get the balances and cash movements for each bank account to this date",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  //See the API docs: https://developer.xero.com/documentation/api/reports#BankSummary
+
+    if (!this.tenant_id) {
+      throw new Error("Must provide tenant_id parameter.");
+    }
+
+    return await axios($, {
+      url: "https://api.xero.com/api.xro/2.0/Reports/BankSummary",
+      headers: {
+        "Authorization": `Bearer ${this.xero_accounting_api.$auth.oauth_access_token}`,
+        "xero-tenant-id": this.tenant_id,
+      },
+      params: {
+        fromDate: this.form_date,
+        toDate: this.to_date,
+      },
+    });
+  },
+};

--- a/components/xero_accounting_api/actions/get-contact/get-contact.mjs
+++ b/components/xero_accounting_api/actions/get-contact/get-contact.mjs
@@ -1,0 +1,39 @@
+// legacy_hash_id: a_67iL6R
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "xero_accounting_api-get-contact",
+  name: "Get Contact",
+  description: "Gets details of a contact.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    xero_accounting_api: {
+      type: "app",
+      app: "xero_accounting_api",
+    },
+    tenant_id: {
+      type: "string",
+      description: "Id of the organization tenant to use on the Xero Accounting API. See [Get Tenant Connections](https://pipedream.com/@sergio/xero-accounting-api-get-tenant-connections-p_OKCzOgn/edit) for a workflow example on how to pull this data.",
+    },
+    contact_identifier: {
+      type: "string",
+      description: "Xero identifier of the contact to get. Possible values: \n* **ContactID** - The Xero identifier for a contact e.g. 297c2dc5-cc47-4afd-8ec8-74990b8761e9\n* **ContactNumber** -  A custom identifier specified from another system e.g. a CRM system has a contact number of CUST100",
+    },
+  },
+  async run({ $ }) {
+  //See the API docs: https://developer.xero.com/documentation/api/contacts
+
+    if (!this.tenant_id || !this.contact_identifier) {
+      throw new Error("Must provide tenant_id, contact_identifier parameters.");
+    }
+
+    return await axios($, {
+      url: `https://api.xero.com/api.xro/2.0/Contacts/${this.contact_identifier}`,
+      headers: {
+        "Authorization": `Bearer ${this.xero_accounting_api.$auth.oauth_access_token}`,
+        "xero-tenant-id": this.tenant_id,
+      },
+    });
+  },
+};

--- a/components/xero_accounting_api/actions/get-history-of-changes/get-history-of-changes.mjs
+++ b/components/xero_accounting_api/actions/get-history-of-changes/get-history-of-changes.mjs
@@ -1,0 +1,58 @@
+// legacy_hash_id: a_a4ivAG
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "xero_accounting_api-get-history-of-changes",
+  name: "Get History of Changes",
+  description: "Gets the history of changes to a single existing document.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    xero_accounting_api: {
+      type: "app",
+      app: "xero_accounting_api",
+    },
+    tenant_id: {
+      type: "string",
+      description: "Id of the organization tenant to use on the Xero Accounting API. See [Get Tenant Connections](https://pipedream.com/@sergio/xero-accounting-api-get-tenant-connections-p_OKCzOgn/edit) for a workflow example on how to pull this data.",
+    },
+    endpoint: {
+      type: "string",
+      description: "The URL component, endpoint of the document type to get history changes. See [supported document types](https://developer.xero.com/documentation/api/history-and-notes#SupportedDocs)",
+      options: [
+        "BankTransactions",
+        "BatchPayments",
+        "Contacts",
+        "CreditNotes",
+        "Invoices",
+        "Items",
+        "ManualJournals",
+        "Overpayments",
+        "Payments",
+        "Prepayments",
+        "PurchaseOrders",
+        "RepeatingInvoices",
+        "Quotes",
+      ],
+    },
+    guid: {
+      type: "string",
+      description: "Xero identifier of the document to get history changes of.",
+    },
+  },
+  async run({ $ }) {
+  //See the API docs: https://developer.xero.com/documentation/api/history-and-notes#GET
+
+    if (!this.tenant_id || !this.endpoint || !this.guid) {
+      throw new Error("Must provide tenant_id, endpoint, and guid parameters.");
+    }
+
+    return await axios($, {
+      url: `https://api.xero.com/api.xro/2.0/${this.endpoint}/${this.guid}/history`,
+      headers: {
+        "Authorization": `Bearer ${this.xero_accounting_api.$auth.oauth_access_token}`,
+        "xero-tenant-id": this.tenant_id,
+      },
+    });
+  },
+};

--- a/components/xero_accounting_api/actions/get-invoice-online-url/get-invoice-online-url.mjs
+++ b/components/xero_accounting_api/actions/get-invoice-online-url/get-invoice-online-url.mjs
@@ -1,0 +1,39 @@
+// legacy_hash_id: a_gniWnr
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "xero_accounting_api-get-invoice-online-url",
+  name: "Get Sales Invoice Online URL",
+  description: "Retrieves the online sales invoice URL.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    xero_accounting_api: {
+      type: "app",
+      app: "xero_accounting_api",
+    },
+    tenant_id: {
+      type: "string",
+      description: "Id of the organization tenant to use on the Xero Accounting API. See [Get Tenant Connections](https://pipedream.com/@sergio/xero-accounting-api-get-tenant-connections-p_OKCzOgn/edit) for a workflow example on how to pull this data.",
+    },
+    invoice_id: {
+      type: "string",
+      description: "Xero generated unique identifier for the invoice to retrieve its online url.",
+    },
+  },
+  async run({ $ }) {
+  //See the API docs: https://developer.xero.com/documentation/api/invoices#onlineinvoice
+
+    if (!this.tenant_id || !this.invoice_id) {
+      throw new Error("Must provide tenant_id, invoice_id parameters.");
+    }
+
+    return await axios($, {
+      url: `https://api.xero.com/api.xro/2.0/Invoices/${this.invoice_id}/OnlineInvoice`,
+      headers: {
+        "Authorization": `Bearer ${this.xero_accounting_api.$auth.oauth_access_token}`,
+        "xero-tenant-id": this.tenant_id,
+      },
+    });
+  },
+};

--- a/components/xero_accounting_api/actions/get-invoice/get-invoice.mjs
+++ b/components/xero_accounting_api/actions/get-invoice/get-invoice.mjs
@@ -1,0 +1,37 @@
+// legacy_hash_id: a_52ieOd
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "xero_accounting_api-get-invoice",
+  name: "Get Invoice",
+  description: "Gets details of an invoice.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    xero_accounting_api: {
+      type: "app",
+      app: "xero_accounting_api",
+    },
+    tenant_id: {
+      type: "string",
+    },
+    invoice_id: {
+      type: "string",
+    },
+  },
+  async run({ $ }) {
+  //See the API docs: https://developer.xero.com/documentation/api/invoices#get
+
+    if (!this.tenant_id || !this.invoice_id) {
+      throw new Error("Must provide tenant_id, invoice_id parameters.");
+    }
+
+    return await axios($, {
+      url: `https://api.xero.com/api.xro/2.0/Invoices/${this.invoice_id}`,
+      headers: {
+        "Authorization": `Bearer ${this.xero_accounting_api.$auth.oauth_access_token}`,
+        "xero-tenant-id": this.tenant_id,
+      },
+    });
+  },
+};

--- a/components/xero_accounting_api/actions/get-item/get-item.mjs
+++ b/components/xero_accounting_api/actions/get-item/get-item.mjs
@@ -1,0 +1,39 @@
+// legacy_hash_id: a_8Ki04R
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "xero_accounting_api-get-item",
+  name: "Get Item",
+  description: "Gets details of an item.",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    xero_accounting_api: {
+      type: "app",
+      app: "xero_accounting_api",
+    },
+    tenant_id: {
+      type: "string",
+      description: "Id of the organization tenant to use on the Xero Accounting API. See [Get Tenant Connections](https://pipedream.com/@sergio/xero-accounting-api-get-tenant-connections-p_OKCzOgn/edit) for a workflow example on how to pull this data.",
+    },
+    item_id: {
+      type: "string",
+      description: "You can specify an individual record by appending the value to the endpoint, i.e.\n**GET https://.../Items/{identifier}**. Possible values:\n* **ItemID** - The Xero identifier for an Item e.g. 297c2dc5-cc47-4afd-8ec8-74990b8761e9\n* **Code**- The user defined code of an item e.g. ITEM-001",
+    },
+  },
+  async run({ $ }) {
+  //See the API docs: https://developer.xero.com/documentation/api/items#GET
+
+    if (!this.tenant_id || !this.item_id) {
+      throw new Error("Must provide tenant_id, item_id parameters.");
+    }
+
+    return await axios($, {
+      url: `https://api.xero.com/api.xro/2.0/Items/${this.item_id}`,
+      headers: {
+        "Authorization": `Bearer ${this.xero_accounting_api.$auth.oauth_access_token}`,
+        "xero-tenant-id": this.tenant_id,
+      },
+    });
+  },
+};

--- a/components/xero_accounting_api/actions/get-tenant-connections/get-tenant-connections.mjs
+++ b/components/xero_accounting_api/actions/get-tenant-connections/get-tenant-connections.mjs
@@ -1,0 +1,27 @@
+// legacy_hash_id: a_vgidpp
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "xero_accounting_api-get-tenant-connections",
+  name: "Get Tenant Connections",
+  description: "Gets the tenants connections the user is authorized to access",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    xero_accounting_api: {
+      type: "app",
+      app: "xero_accounting_api",
+    },
+  },
+  async run({ $ }) {
+  //See the API docs: https://developer.xero.com/documentation/oauth2/auth-flow
+  //Step 5. Check the tenants you're authorized to access
+
+    return await axios($, {
+      url: "https://api.xero.com/connections",
+      headers: {
+        Authorization: `Bearer ${this.xero_accounting_api.$auth.oauth_access_token}`,
+      },
+    });
+  },
+};

--- a/components/xero_accounting_api/actions/list-contacts/list-contacts.mjs
+++ b/components/xero_accounting_api/actions/list-contacts/list-contacts.mjs
@@ -1,0 +1,84 @@
+// legacy_hash_id: a_Q3ixRN
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "xero_accounting_api-list-contacts",
+  name: "List Contacts",
+  description: "Lists information from contacts in the given tenant id as per filter parameters.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    xero_accounting_api: {
+      type: "app",
+      app: "xero_accounting_api",
+    },
+    tenant_id: {
+      type: "string",
+      description: "Id of the organization tenant to use on the Xero Accounting API. See [Get Tenant Connections](https://pipedream.com/@sergio/xero-accounting-api-get-tenant-connections-p_OKCzOgn/edit) for a workflow example on how to pull this data.",
+    },
+    contact_identifier: {
+      type: "string",
+      description: "A contact identifier. Possible values: \n* **ContactID** - The Xero identifier for a contact e.g. 297c2dc5-cc47-4afd-8ec8-74990b8761e9\n* **ContactNumber** -  A custom identifier specified from another system e.g. a CRM system has a contact number of CUST100",
+      optional: true,
+    },
+    modified_after: {
+      type: "string",
+      optional: true,
+    },
+    ids: {
+      type: "string",
+      description: "Filter by a comma-separated list of ContactIDs. Allows you to retrieve a specific set of contacts in a single call. See [details.](https://developer.xero.com/documentation/api/contacts#optimised-queryparameters)",
+      optional: true,
+    },
+    where: {
+      type: "string",
+      description: "Filter using the where parameter. We recommend you limit filtering to the [optimised elements](https://developer.xero.com/documentation/api/contacts#optimised-parameters) only.",
+      optional: true,
+    },
+    order: {
+      type: "string",
+      description: "Order by any element returned ([*see Order By.*](https://developer.xero.com/documentation/api/requests-and-responses#ordering))",
+      optional: true,
+    },
+    page: {
+      type: "string",
+      description: "Up to 100 contacts will be returned per call when the page parameter is used e.g. page=1.",
+      optional: true,
+    },
+    includeArchived: {
+      type: "boolean",
+      description: "e.g. includeArchived=true - Contacts with a status of ARCHIVED will be included in the response.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  //See the API docs: https://developer.xero.com/documentation/api/contacts
+
+    if (!this.tenant_id) {
+      throw new Error("Must provide tenant_id parameter.");
+    }
+
+    const contactIdentifier = this.contact_identifier || "";
+
+    var headers = {
+      "Authorization": `Bearer ${this.xero_accounting_api.$auth.oauth_access_token}`,
+      "xero-tenant-id": this.tenant_id,
+    };
+
+    if (this.modified_after) {
+      headers["If-Modified-Since"] = this.modified_after;
+    }
+
+    return await axios($, {
+      url: `https://api.xero.com/api.xro/2.0/Contacts/${contactIdentifier}`,
+      headers,
+      params: {
+        IDs: this.ids,
+        Where: this.where,
+        order: this.order,
+        page: this.page,
+        includeArchived: this.includeArchived,
+      },
+    });
+  },
+};

--- a/components/xero_accounting_api/actions/list-credit-notes/list-credit-notes.mjs
+++ b/components/xero_accounting_api/actions/list-credit-notes/list-credit-notes.mjs
@@ -1,0 +1,73 @@
+// legacy_hash_id: a_a4ivba
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "xero_accounting_api-list-credit-notes",
+  name: "List Credit Notes",
+  description: "Lists information from credit notes in the given tenant id as per filter parameters.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    xero_accounting_api: {
+      type: "app",
+      app: "xero_accounting_api",
+    },
+    tenant_id: {
+      type: "string",
+      description: "Id of the organization tenant to use on the Xero Accounting API. See [Get Tenant Connections](https://pipedream.com/@sergio/xero-accounting-api-get-tenant-connections-p_OKCzOgn/edit) for a workflow example on how to pull this data.",
+    },
+    credit_note_identifier: {
+      type: "string",
+      description: "Credit note identifier of the contact to get. Possible values: \n* **CreditNoteID** - The Xero identifier for a contact note e.g. 297c2dc5-cc47-4afd-8ec8-74990b8761e9\n* **CreditNoteNumber** -  Identifier for Credit Note CN-8743802",
+      optional: true,
+    },
+    modified_after: {
+      type: "string",
+      description: "The ModifiedAfter filter is actually an HTTP header: **'If-Modified-Since'.**\nA UTC timestamp (yyyy-mm-ddThh:mm:ss). Only credit notes or modified since this timestamp will be returned e.g. 2009-11-12T00:00:00",
+      optional: true,
+    },
+    where: {
+      type: "string",
+      description: "Filter by an any element ( see [Filters](https://developer.xero.com/documentation/api/requests-and-responses#get-modified) )",
+      optional: true,
+    },
+    order: {
+      type: "string",
+      description: "Order by any element returned ( see [Order By](https://developer.xero.com/documentation/api/requests-and-responses#ordering) )",
+      optional: true,
+    },
+    page: {
+      type: "string",
+      description: "Up to 100 credit notes will be returned per call, with line items shown for each, when the page parameter is used e.g. page=1",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  //See the API docs: https://developer.xero.com/documentation/api/credit-notes#GET
+
+    if (!this.tenant_id) {
+      throw new Error("Must provide tenant_id parameter.");
+    }
+
+    const creditNoteIdentifier = this.credit_note_identifier || "";
+
+    var headers = {
+      "Authorization": `Bearer ${this.xero_accounting_api.$auth.oauth_access_token}`,
+      "xero-tenant-id": this.tenant_id,
+    };
+
+    if (this.modified_after) {
+      headers["If-Modified-Since"] = this.modified_after;
+    }
+
+    return await axios($, {
+      url: `https://api.xero.com/api.xro/2.0/CreditNotes/${creditNoteIdentifier}`,
+      headers,
+      params: {
+        Where: this.where,
+        order: this.order,
+        page: this.page,
+      },
+    });
+  },
+};

--- a/components/xero_accounting_api/actions/list-invoices/list-invoices.mjs
+++ b/components/xero_accounting_api/actions/list-invoices/list-invoices.mjs
@@ -1,0 +1,103 @@
+// legacy_hash_id: a_3Liezo
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "xero_accounting_api-list-invoices",
+  name: "List Invoices",
+  description: "Lists information from invoices in the given tenant id as per filter parameters.",
+  version: "0.2.1",
+  type: "action",
+  props: {
+    xero_accounting_api: {
+      type: "app",
+      app: "xero_accounting_api",
+    },
+    tenant_id: {
+      type: "string",
+      description: "Id of the organization tenant to use on the Xero Accounting API. See [Get Tenant Connections](https://pipedream.com/@sergio/xero-accounting-api-get-tenant-connections-p_OKCzOgn/edit) for a workflow example on how to pull this data.",
+    },
+    invoice_identifier: {
+      type: "string",
+      description: "An invoice identifier. Possible values:\n\n* **InvoiceID** - The Xero identifier for an Invoice e.g. 297c2dc5-cc47-4afd-8ec8-74990b8761e9\n* **InvoiceNumber** - The InvoiceNumber e.g. INV-01514",
+      optional: true,
+    },
+    modified_after: {
+      type: "string",
+      description: "The ModifiedAfter filter is actually an HTTP header: **'If-Modified-Since'.**\nA UTC timestamp (yyyy-mm-ddThh:mm:ss). Only invoices created or modified since this timestamp will be returned e.g. 2009-11-12T00:00:00",
+      optional: true,
+    },
+    ids: {
+      type: "string",
+      description: "Filter by a comma-separated list of InvoicesIDs. See [details](https://developer.xero.com/documentation/api/invoices#optimised-queryparameters).",
+      optional: true,
+    },
+    invoice_numbers: {
+      type: "string",
+      description: "Filter by a comma-separated list of InvoiceNumbers. See [details](https://developer.xero.com/documentation/api/invoices#optimised-queryparameters).",
+      optional: true,
+    },
+    contact_ids: {
+      type: "string",
+      description: "Filter by a comma-separated list of ContactIDs. See [details](https://developer.xero.com/documentation/api/invoices#optimised-queryparameters).",
+      optional: true,
+    },
+    statuses: {
+      type: "string",
+      description: "Filter by a comma-separated list of Statuses. See [details](https://developer.xero.com/documentation/api/invoices#optimised-queryparameters).",
+      optional: true,
+    },
+    where: {
+      type: "string",
+      description: "Filter using the *where* parameter. We recommend you limit filtering to the [optimised elements](https://developer.xero.com/documentation/api/invoices#optimised-parameters) only.",
+      optional: true,
+    },
+    created_by_my_app: {
+      type: "boolean",
+      description: "When set to true you'll only retrieve Invoices created by your app.",
+      optional: true,
+    },
+    order: {
+      type: "string",
+      description: "Order by any element returned ( see [Order By](https://developer.xero.com/documentation/api/requests-and-responses#ordering) ).",
+      optional: true,
+    },
+    page: {
+      type: "string",
+      description: "Up to 100 invoices will be returned per call, with line items shown for each, when the page parameter is used e.g. page=1",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  //See the API docs: https://developer.xero.com/documentation/api/invoices#get
+
+    if (!this.tenant_id) {
+      throw new Error("Must provide tenant_id parameter.");
+    }
+
+    const invoiceIdentifier = this.invoice_identifier || "";
+
+    var headers = {
+      "Authorization": `Bearer ${this.xero_accounting_api.$auth.oauth_access_token}`,
+      "xero-tenant-id": this.tenant_id,
+    };
+
+    if (this.modified_after) {
+      headers["If-Modified-Since"] = this.modified_after;
+    }
+
+    return await axios($, {
+      url: `https://api.xero.com/api.xro/2.0/Invoices/${invoiceIdentifier}`,
+      headers,
+      params: {
+        IDs: this.ids,
+        InvoiceNumbers: this.invoice_numbers,
+        ContactIDs: this.contact_ids,
+        Statuses: this.statuses,
+        Where: this.where,
+        createdByMyApp: this.created_by_my_app,
+        order: this.order,
+        page: this.page,
+      },
+    });
+  },
+};

--- a/components/xero_accounting_api/actions/list-manual-journals/list-manual-journals.mjs
+++ b/components/xero_accounting_api/actions/list-manual-journals/list-manual-journals.mjs
@@ -1,0 +1,73 @@
+// legacy_hash_id: a_rJid1r
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "xero_accounting_api-list-manual-journals",
+  name: "List Manual Journals",
+  description: "Lists information from manual journals in the given tenant id as per filter parameters.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    xero_accounting_api: {
+      type: "app",
+      app: "xero_accounting_api",
+    },
+    tenant_id: {
+      type: "string",
+      description: "Id of the organization tenant to use on the Xero Accounting API. See [Get Tenant Connections](https://pipedream.com/@sergio/xero-accounting-api-get-tenant-connections-p_OKCzOgn/edit) for a workflow example on how to pull this data.",
+    },
+    manual_journal_id: {
+      type: "string",
+      description: "You can specify an individual record by appending the ManualJournalID to the endpoint, i.e. **GET https://.../ManualJournals/{identifier}**",
+      optional: true,
+    },
+    modified_after: {
+      type: "string",
+      description: "The ModifiedAfter filter is actually an HTTP header: **'If-Modified-Since'**. A UTC timestamp (yyyy-mm-ddThh:mm:ss) . Only manual journals created or modified since this timestamp will be returned e.g. 2009-11-12T00:00:00",
+      optional: true,
+    },
+    where: {
+      type: "string",
+      description: "Filter by an any element (*see [Filters](https://developer.xero.com/documentation/api/requests-and-responses#get-modified)*)",
+      optional: true,
+    },
+    order: {
+      type: "string",
+      description: "Order by any element returned (*see [Order By](https://developer.xero.com/documentation/api/requests-and-responses#ordering)*)",
+      optional: true,
+    },
+    page: {
+      type: "string",
+      description: "Up to 100 manual journals will be returned per call, with journal lines shown for each, when the page parameter is used e.g. page=1",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  //See the API docs: https://developer.xero.com/documentation/api/manual-journals#GET
+
+    if (!this.tenant_id) {
+      throw new Error("Must provide tenant_id parameter.");
+    }
+
+    const manualJournalId = this.manual_journal_id || "";
+
+    var headers = {
+      "Authorization": `Bearer ${this.xero_accounting_api.$auth.oauth_access_token}`,
+      "xero-tenant-id": this.tenant_id,
+    };
+
+    if (this.modified_after) {
+      headers["If-Modified-Since"] = this.modified_after;
+    }
+
+    return await axios($, {
+      url: `https://api.xero.com/api.xro/2.0/ManualJournals/${manualJournalId}`,
+      headers,
+      params: {
+        Where: this.where,
+        order: this.order,
+        page: this.page,
+      },
+    });
+  },
+};

--- a/components/xero_accounting_api/actions/xero-accounting-create-employee/xero-accounting-create-employee.mjs
+++ b/components/xero_accounting_api/actions/xero-accounting-create-employee/xero-accounting-create-employee.mjs
@@ -1,0 +1,66 @@
+// legacy_hash_id: a_q1i3W6
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "xero_accounting_api-xero-accounting-create-employee",
+  name: "Create Employee",
+  description: "Creates a new employee.",
+  version: "0.3.1",
+  type: "action",
+  props: {
+    xero_accounting_api: {
+      type: "app",
+      app: "xero_accounting_api",
+    },
+    tenant_id: {
+      type: "string",
+      description: "Id of the organization tenant to use on the Xero Accounting API. See [Get Tenant Connections](https://pipedream.com/@sergio/xero-accounting-api-get-tenant-connections-p_OKCzOgn/edit) for a workflow example on how to pull this data.",
+    },
+    first_name: {
+      type: "string",
+      description: "First name of an employee (max length = 255). If an existing employee matches your `FirstName` and `LastName` then you will receive an error.",
+    },
+    last_name: {
+      type: "string",
+      description: "Last name of an employee (max length = 255). If an existing employee matches your `FirstName` and `LastName` then you will receive an error.",
+    },
+    status: {
+      type: "string",
+      description: "Current status of an employee - see contact status [types](https://developer.xero.com/documentation/api/types#ContactStatuses)",
+      optional: true,
+      options: [
+        "ACTIVE",
+        "ARCHIVED",
+        "GDPRREQUEST",
+      ],
+    },
+    external_link: {
+      type: "object",
+      description: "Link to an external resource, for example, an employee record in an external system. You can specify the URL element.\nThe description of the link is auto-generated in the form \"Go to <App name>\". <App name> refers to the [Xero application](https://api.xero.com/Application) name that is making the API call.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  //See the API docs: https://developer.xero.com/documentation/api/employees
+  //on section PUT Employees
+
+    if (!this.tenant_id || !this.first_name || !this.last_name) {
+      throw new Error("Must provide tenant_id, first_name, and last_name parameters.");
+    }
+
+    return await axios($, {
+      method: "put",
+      url: "https://api.xero.com/api.xro/2.0/Employees",
+      headers: {
+        "Authorization": `Bearer ${this.xero_accounting_api.$auth.oauth_access_token}`,
+        "xero-tenant-id": this.tenant_id,
+      },
+      data: {
+        Status: this.status,
+        FirstName: this.first_name,
+        LastName: this.last_name,
+        ExternalLink: this.external_link,
+      },
+    });
+  },
+};

--- a/components/xero_accounting_api/actions/xero-accounting-create-or-update-contact/xero-accounting-create-or-update-contact.mjs
+++ b/components/xero_accounting_api/actions/xero-accounting-create-or-update-contact/xero-accounting-create-or-update-contact.mjs
@@ -1,0 +1,212 @@
+// legacy_hash_id: a_0Mi723
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "xero_accounting_api-xero-accounting-create-or-update-contact",
+  name: "Create or Update Contact",
+  description: "Creates a new contact or updates if the contact exists.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    xero_accounting_api: {
+      type: "app",
+      app: "xero_accounting_api",
+    },
+    tenant_id: {
+      type: "string",
+      description: "Id of the organization tenant to use on the Xero Accounting API. See [Get Tenant Connections](https://pipedream.com/@sergio/xero-accounting-api-get-tenant-connections-p_OKCzOgn/edit) for a workflow example on how to pull this data.",
+    },
+    name: {
+      type: "string",
+      description: "Full name of contact/organisation (max length = 255). The following is required to create a contact.",
+      optional: true,
+    },
+    contact_id: {
+      type: "string",
+      description: "Xero identifier.",
+      optional: true,
+    },
+    contact_number: {
+      type: "string",
+      description: "This can be updated via the API only i.e. This field is read only on the Xero contact screen, used to identify contacts in external systems (max length = 50). If the Contact Number is used, this is displayed as Contact Code in the Contacts UI in Xero.",
+      optional: true,
+    },
+    account_number: {
+      type: "string",
+      description: "A user defined account number. This can be updated via the API and the [Xero UI](https://help.xero.com/ContactsAccountNumber) (max length = 50).",
+      optional: true,
+    },
+    contact_status: {
+      type: "string",
+      description: "Current status of a contact - see contact status [types](https://developer.xero.com/documentation/api/types#ContactStatuses)",
+      optional: true,
+      options: [
+        "ACTIVE",
+        "ARCHIVED",
+        "GDPRREQUEST",
+      ],
+    },
+    first_name: {
+      type: "string",
+      description: "First name of contact person (max length = 255).",
+      optional: true,
+    },
+    last_name: {
+      type: "string",
+      description: "Last name of contact person (max length = 255)",
+      optional: true,
+    },
+    email_address: {
+      type: "string",
+      description: "Email address of contact person (umlauts not supported) (max length = 255)",
+      optional: true,
+    },
+    skype_user_name: {
+      type: "string",
+      description: "Skype user name of contact.",
+      optional: true,
+    },
+    contact_persons: {
+      type: "any",
+      description: "See [contact persons](https://developer.xero.com/documentation/api/contacts#contact-persons).",
+      optional: true,
+    },
+    bank_account_details: {
+      type: "string",
+      description: "Bank account number of contact",
+      optional: true,
+    },
+    tax_number: {
+      type: "string",
+      description: "Tax number of contact - this is also known as the ABN (Australia), GST Number (New Zealand), VAT Number (UK) or Tax ID Number (US and global) in the Xero UI depending on which regionalized version of Xero you are using (max length = 50)",
+      optional: true,
+    },
+    account_receivable_tax_type: {
+      type: "string",
+      description: "Default tax type used for contact on AP invoices",
+      optional: true,
+    },
+    account_payable_type: {
+      type: "string",
+      description: "Store certain address types for a contact - see address types",
+      optional: true,
+    },
+    addresses: {
+      type: "any",
+      description: "Store certain address types for a contact - see address types",
+      optional: true,
+    },
+    phones: {
+      type: "any",
+      description: "Store certain phone types for a contact - see phone types.",
+      optional: true,
+    },
+    is_supplier: {
+      type: "boolean",
+      description: "true or false  Boolean that describes if a contact that has any AP invoices entered against them. Cannot be set via PUT or POST - it is automatically set when an accounts payable invoice is generated against this contact.",
+      optional: true,
+    },
+    is_customer: {
+      type: "boolean",
+      description: "true or false  Boolean that describes if a contact has any AR invoices entered against them. Cannot be set via PUT or POST - it is automatically set when an accounts receivable invoice is generated against this contact.",
+      optional: true,
+    },
+    default_currency: {
+      type: "string",
+      description: "Default currency for raising invoices against contact",
+      optional: true,
+    },
+    xero_network_key: {
+      type: "string",
+      description: "Store XeroNetworkKey for contacts.",
+      optional: true,
+    },
+    sales_default_account_code: {
+      type: "string",
+      description: "The default sales [account code](https://developer.xero.com/documentation/api/accounts) for contacts",
+      optional: true,
+    },
+    puchases_default_account_code: {
+      type: "string",
+      description: "The default purchases [account code](https://developer.xero.com/documentation/api/accounts) for contacts",
+      optional: true,
+    },
+    sales_tracking_categories: {
+      type: "string",
+      description: "The default sales [tracking categories](https://developer.xero.com/documentation/api/tracking-categories/) for contacts",
+      optional: true,
+    },
+    puechases_tracking_categories: {
+      type: "string",
+      description: "The default purchases [tracking categories](https://developer.xero.com/documentation/api/tracking-categories/) for contacts",
+      optional: true,
+    },
+    tracking_category_name: {
+      type: "string",
+      description: "The name of the Tracking Category assigned to the contact under SalesTrackingCategories and PurchasesTrackingCategories",
+      optional: true,
+    },
+    tracking_option_name: {
+      type: "string",
+      description: "The name of the Tracking Option assigned to the contact under SalesTrackingCategories and PurchasesTrackingCategories",
+      optional: true,
+    },
+    payment_terms: {
+      type: "string",
+      description: "The default payment terms for the contact - see Payment Terms",
+      optional: true,
+      options: [
+        "DAYSAFTERBILLDATE",
+        "DAYSAFTERBILLMONTH",
+        "OFCURRENTMONTH",
+        "OFFOLLOWINGMONTH",
+      ],
+    },
+  },
+  async run({ $ }) {
+  //See the API docs: https://developer.xero.com/documentation/api/contacts
+  //on section POST Contacts
+
+    if (!this.tenant_id) {
+      throw new Error("Must provide tenant_id parameter.");
+    }
+
+    return await axios($, {
+      method: "post",
+      url: "https://api.xero.com/api.xro/2.0/Contacts",
+      headers: {
+        "Authorization": `Bearer ${this.xero_accounting_api.$auth.oauth_access_token}`,
+        "xero-tenant-id": this.tenant_id,
+      },
+      data: {
+        Name: this.name,
+        ContactID: this.contact_id,
+        ContactNumber: this.contact_number,
+        AccountNumber: this.account_number,
+        ContactStatus: this.contact_status,
+        FirstName: this.first_name,
+        LastName: this.last_name,
+        EmailAddress: this.email_address,
+        SkypeUserName: this.skype_user_name,
+        ContactPersons: this.contact_persons,
+        BankAccountDetails: this.bank_account_details,
+        TaxNumber: this.tax_number,
+        AccountsReceivableTaxType: this.account_receivable_tax_type,
+        AccountsPayableTaxType: this.account_payable_type,
+        Addresses: this.addresses,
+        Phones: this.phones,
+        IsSupplier: this.is_supplier,
+        IsCustomer: this.is_customer,
+        DefaultCurrency: this.default_currency,
+        XeroNetworkKey: this.xero_network_key,
+        SalesDefaultAccountCode: this.sales_default_account_code,
+        PurchasesDefaultAccountCode: this.puchases_default_account_code,
+        SalesTrackingCategories: this.sales_tracking_categories,
+        PurchasesTrackingCategories: this.puechases_tracking_categories,
+        TrackingCategoryName: this.tracking_category_name,
+        TrackingOptionName: this.tracking_option_name,
+        PaymentTerms: this.payment_terms,
+      },
+    });
+  },
+};

--- a/components/xero_accounting_api/actions/xero-accounting-update-contact/xero-accounting-update-contact.mjs
+++ b/components/xero_accounting_api/actions/xero-accounting-update-contact/xero-accounting-update-contact.mjs
@@ -1,0 +1,211 @@
+// legacy_hash_id: a_dvinrY
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "xero_accounting_api-xero-accounting-update-contact",
+  name: "Update Contact",
+  description: "Updates a contact given its identifier.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    xero_accounting_api: {
+      type: "app",
+      app: "xero_accounting_api",
+    },
+    tenant_id: {
+      type: "string",
+      description: "Id of the organization tenant to use on the Xero Accounting API. See [Get Tenant Connections](https://pipedream.com/@sergio/xero-accounting-api-get-tenant-connections-p_OKCzOgn/edit) for a workflow example on how to pull this data.",
+    },
+    contact_id: {
+      type: "string",
+      description: "Contact identifier of the contact to update.",
+    },
+    name: {
+      type: "string",
+      description: "Full name of contact/organisation (max length = 255). The following is required to create a contact.",
+      optional: true,
+    },
+    contact_number: {
+      type: "string",
+      description: "This can be updated via the API only i.e. This field is read only on the Xero contact screen, used to identify contacts in external systems (max length = 50). If the Contact Number is used, this is displayed as Contact Code in the Contacts UI in Xero.",
+      optional: true,
+    },
+    account_number: {
+      type: "string",
+      description: "A user defined account number. This can be updated via the API and the [Xero UI](https://help.xero.com/ContactsAccountNumber) (max length = 50).",
+      optional: true,
+    },
+    contact_status: {
+      type: "string",
+      description: "Current status of a contact - see contact status [types](https://developer.xero.com/documentation/api/types#ContactStatuses)",
+      optional: true,
+      options: [
+        "ACTIVE",
+        "ARCHIVED",
+        "GDPRREQUEST",
+      ],
+    },
+    first_name: {
+      type: "string",
+      description: "First name of contact person (max length = 255).",
+      optional: true,
+    },
+    last_name: {
+      type: "string",
+      description: "Last name of contact person (max length = 255)",
+      optional: true,
+    },
+    email_address: {
+      type: "string",
+      description: "Email address of contact person (umlauts not supported) (max length = 255)",
+      optional: true,
+    },
+    skype_user_name: {
+      type: "string",
+      description: "Skype user name of contact.",
+      optional: true,
+    },
+    contact_persons: {
+      type: "any",
+      description: "See [contact persons](https://developer.xero.com/documentation/api/contacts#contact-persons).",
+      optional: true,
+    },
+    bank_account_details: {
+      type: "string",
+      description: "Bank account number of contact",
+      optional: true,
+    },
+    tax_number: {
+      type: "string",
+      description: "Tax number of contact - this is also known as the ABN (Australia), GST Number (New Zealand), VAT Number (UK) or Tax ID Number (US and global) in the Xero UI depending on which regionalized version of Xero you are using (max length = 50)",
+      optional: true,
+    },
+    account_receivable_tax_type: {
+      type: "string",
+      description: "Default tax type used for contact on AP invoices",
+      optional: true,
+    },
+    account_payable_type: {
+      type: "string",
+      description: "Store certain address types for a contact - see address types",
+      optional: true,
+    },
+    addresses: {
+      type: "any",
+      description: "Store certain address types for a contact - see address types",
+      optional: true,
+    },
+    phones: {
+      type: "any",
+      description: "Store certain phone types for a contact - see phone types.",
+      optional: true,
+    },
+    is_supplier: {
+      type: "boolean",
+      description: "true or false  Boolean that describes if a contact that has any AP invoices entered against them. Cannot be set via PUT or POST - it is automatically set when an accounts payable invoice is generated against this contact.",
+      optional: true,
+    },
+    is_customer: {
+      type: "boolean",
+      description: "true or false  Boolean that describes if a contact has any AR invoices entered against them. Cannot be set via PUT or POST - it is automatically set when an accounts receivable invoice is generated against this contact.",
+      optional: true,
+    },
+    default_currency: {
+      type: "string",
+      description: "Default currency for raising invoices against contact",
+      optional: true,
+    },
+    xero_network_key: {
+      type: "string",
+      description: "Store XeroNetworkKey for contacts.",
+      optional: true,
+    },
+    sales_default_account_code: {
+      type: "string",
+      description: "The default sales [account code](https://developer.xero.com/documentation/api/accounts) for contacts",
+      optional: true,
+    },
+    puchases_default_account_code: {
+      type: "string",
+      description: "The default purchases [account code](https://developer.xero.com/documentation/api/accounts) for contacts",
+      optional: true,
+    },
+    sales_tracking_categories: {
+      type: "string",
+      description: "The default sales [tracking categories](https://developer.xero.com/documentation/api/tracking-categories/) for contacts",
+      optional: true,
+    },
+    puechases_tracking_categories: {
+      type: "string",
+      description: "The default purchases [tracking categories](https://developer.xero.com/documentation/api/tracking-categories/) for contacts",
+      optional: true,
+    },
+    tracking_category_name: {
+      type: "string",
+      description: "The name of the Tracking Category assigned to the contact under SalesTrackingCategories and PurchasesTrackingCategories",
+      optional: true,
+    },
+    tracking_option_name: {
+      type: "string",
+      description: "The name of the Tracking Option assigned to the contact under SalesTrackingCategories and PurchasesTrackingCategories",
+      optional: true,
+    },
+    payment_terms: {
+      type: "string",
+      description: "The default payment terms for the contact - see Payment Terms",
+      optional: true,
+      options: [
+        "DAYSAFTERBILLDATE",
+        "DAYSAFTERBILLMONTH",
+        "OFCURRENTMONTH",
+        "OFFOLLOWINGMONTH",
+      ],
+    },
+  },
+  async run({ $ }) {
+  //See the API docs: https://developer.xero.com/documentation/api/contacts
+  //on section POST Contacts
+
+    if (!this.tenant_id || !this.contact_id) {
+      throw new Error("Must provide tenant_id, and contact_id parameters.");
+    }
+
+    return await axios($, {
+      method: "post",
+      url: `https://api.xero.com/api.xro/2.0/Contacts/${this.contact_id}`,
+      headers: {
+        "Authorization": `Bearer ${this.xero_accounting_api.$auth.oauth_access_token}`,
+        "xero-tenant-id": this.tenant_id,
+      },
+      data: {
+        Name: this.name,
+        ContactID: this.contact_id,
+        ContactNumber: this.contact_number,
+        AccountNumber: this.account_number,
+        ContactStatus: this.contact_status,
+        FirstName: this.first_name,
+        LastName: this.last_name,
+        EmailAddress: this.email_address,
+        SkypeUserName: this.skype_user_name,
+        ContactPersons: this.contact_persons,
+        BankAccountDetails: this.bank_account_details,
+        TaxNumber: this.tax_number,
+        AccountsReceivableTaxType: this.account_receivable_tax_type,
+        AccountsPayableTaxType: this.account_payable_type,
+        Addresses: this.addresses,
+        Phones: this.phones,
+        IsSupplier: this.is_supplier,
+        IsCustomer: this.is_customer,
+        DefaultCurrency: this.default_currency,
+        XeroNetworkKey: this.xero_network_key,
+        SalesDefaultAccountCode: this.sales_default_account_code,
+        PurchasesDefaultAccountCode: this.puchases_default_account_code,
+        SalesTrackingCategories: this.sales_tracking_categories,
+        PurchasesTrackingCategories: this.puechases_tracking_categories,
+        TrackingCategoryName: this.tracking_category_name,
+        TrackingOptionName: this.tracking_option_name,
+        PaymentTerms: this.payment_terms,
+      },
+    });
+  },
+};

--- a/components/xero_accounting_api/actions/xero-create-purchase-bill/xero-create-purchase-bill.mjs
+++ b/components/xero_accounting_api/actions/xero-create-purchase-bill/xero-create-purchase-bill.mjs
@@ -1,0 +1,130 @@
+// legacy_hash_id: a_xqigGY
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "xero_accounting_api-xero-create-purchase-bill",
+  name: "Create Purchase Bill",
+  description: "Creates a new purchase bill.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    xero_accounting_api: {
+      type: "app",
+      app: "xero_accounting_api",
+    },
+    contact_id: {
+      type: "string",
+      description: "Id of the contact associated to the invoice.",
+      optional: true,
+    },
+    contact_name: {
+      type: "string",
+      description: "Name of the contact associated to the invoice. If there is no contact matching this name, a new contact is created.",
+      optional: true,
+    },
+    tenant_id: {
+      type: "string",
+      description: "Id of the organization tenant to use on the Xero Accounting API. See [Get Tenant Connections](https://pipedream.com/@sergio/xero-accounting-api-get-tenant-connections-p_OKCzOgn/edit) for a workflow example on how to pull this data.",
+    },
+    line_items: {
+      type: "any",
+      description: "See [LineItems](https://developer.xero.com/documentation/api/invoices#LineItemsPOST). The LineItems collection can contain any number of individual LineItem sub-elements. At least * **one** * is required to create a complete Invoice.",
+    },
+    date: {
+      type: "string",
+      description: "Date invoice was issued - YYYY-MM-DD. If the Date element is not specified it will default to the current date based on the timezone setting of the organisation.",
+      optional: true,
+    },
+    due_date: {
+      type: "string",
+      description: "Date invoice is due - YYYY-MM-DD.",
+      optional: true,
+    },
+    line_amount_type: {
+      type: "string",
+      description: "Line amounts are exclusive of tax by default if you don't specify this element. See [Line Amount Types](https://developer.xero.com/documentation/api/types#LineAmountTypes)",
+      optional: true,
+    },
+    purchase_bill_number: {
+      type: "string",
+      description: "Non-unique alpha numeric code identifying purchase bill (printable ASCII characters only). This value will also display as Reference in the UI.",
+      optional: true,
+    },
+    reference: {
+      type: "string",
+      description: "Additional reference number (max length = 255)",
+      optional: true,
+    },
+    branding_theme_id: {
+      type: "string",
+      description: "See [BrandingThemes](https://developer.xero.com/documentation/api/branding-themes)",
+      optional: true,
+    },
+    url: {
+      type: "string",
+      description: "URL link to a source document - shown as \"Go to [appName]\" in the Xero app",
+      optional: true,
+    },
+    currency_code: {
+      type: "string",
+      description: "The currency that invoice has been raised in (see [Currencies](https://developer.xero.com/documentation/api/currencies))",
+      optional: true,
+    },
+    currency_rate: {
+      type: "string",
+      description: "The currency rate for a multicurrency invoice. If no rate is specified, the [XE.com day rate](http://help.xero.com/#CurrencySettings$Rates) is used. (max length = [18].[6])",
+      optional: true,
+    },
+    status: {
+      type: "string",
+      description: "See [Invoice Status Codes](https://developer.xero.com/documentation/api/invoices#status-codes)",
+      optional: true,
+    },
+    sent_to_contact: {
+      type: "string",
+      description: "Boolean to set whether the invoice in the Xero app should be marked as \"sent\". This can be set only on invoices that have been approved",
+      optional: true,
+    },
+    planned_payment_date: {
+      type: "string",
+      description: "Shown on purchase bills (Accounts Payable) when this has been set",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  //See the API docs: https://developer.xero.com/documentation/api/invoices#post
+
+    if ((!this.contact_id && !this.contact_name) || !this.tenant_id || !this.line_items) {
+      throw new Error("Must provide one of contact_id or contact_name, and tenant_id, type, line_items parameters.");
+    }
+
+    return await axios($, {
+      method: "post",
+      url: "https://api.xero.com/api.xro/2.0/Invoices",
+      headers: {
+        "Authorization": `Bearer ${this.xero_accounting_api.$auth.oauth_access_token}`,
+        "xero-tenant-id": this.tenant_id,
+      },
+      data: {
+        Type: "ACCPAY", //ACCPAY = Purchase Bill
+        Contact: {
+          ContactID: this.contact_id,
+          Name: this.contact_name,
+        },
+        LineItems: this.line_items,
+        Date: this.date,
+        DueDate: this.due_date,
+        LineAmountTypes: this.line_amount_type,
+        InvoiceNumber: this.purchase_bill_number,
+        Reference: this.reference,
+        BrandingThemeID: this.branding_theme_id,
+        Url: this.url,
+        CurrencyCode: this.currency_code,
+        CurrencyRate: this.currency_rate,
+        Status: this.status,
+        SentToContact: this.sent_to_contact,
+        PlannedPaymentDate: this.planned_payment_date,
+      },
+    });
+  },
+};

--- a/components/xero_accounting_api/actions/xero-create-sales-invoice/xero-create-sales-invoice.mjs
+++ b/components/xero_accounting_api/actions/xero-create-sales-invoice/xero-create-sales-invoice.mjs
@@ -1,0 +1,130 @@
+// legacy_hash_id: a_jQi84m
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "xero_accounting_api-xero-create-sales-invoice",
+  name: "Create Sales Invoice",
+  description: "Creates a new sales invoice.",
+  version: "0.3.1",
+  type: "action",
+  props: {
+    xero_accounting_api: {
+      type: "app",
+      app: "xero_accounting_api",
+    },
+    contact_id: {
+      type: "string",
+      description: "Id of the contact associated to the invoice.",
+      optional: true,
+    },
+    contact_name: {
+      type: "string",
+      description: "Name of the contact associated to the invoice. If there is no contact matching this name, a new contact is created.",
+      optional: true,
+    },
+    tenant_id: {
+      type: "string",
+      description: "Id of the organization tenant to use on the Xero Accounting API. See [Get Tenant Connections](https://pipedream.com/@sergio/xero-accounting-api-get-tenant-connections-p_OKCzOgn/edit) for a workflow example on how to pull this data.",
+    },
+    line_items: {
+      type: "any",
+      description: "See [LineItems](https://developer.xero.com/documentation/api/invoices#LineItemsPOST). The LineItems collection can contain any number of individual LineItem sub-elements. At least * **one** * is required to create a complete Invoice.",
+    },
+    date: {
+      type: "string",
+      description: "Date invoice was issued - YYYY-MM-DD. If the Date element is not specified it will default to the current date based on the timezone setting of the organisation.",
+      optional: true,
+    },
+    due_date: {
+      type: "string",
+      description: "Date invoice is due - YYYY-MM-DD.",
+      optional: true,
+    },
+    line_amount_type: {
+      type: "string",
+      description: "Line amounts are exclusive of tax by default if you don't specify this element. See [Line Amount Types](https://developer.xero.com/documentation/api/types#LineAmountTypes)",
+      optional: true,
+    },
+    invoice_number: {
+      type: "string",
+      description: "Unique alpha numeric code identifying invoice (* when missing will auto-generate from your Organisation Invoice Settings*) (max length = 255)",
+      optional: true,
+    },
+    reference: {
+      type: "string",
+      description: "Additional reference number (max length = 255)",
+      optional: true,
+    },
+    branding_theme_id: {
+      type: "string",
+      description: "See [BrandingThemes](https://developer.xero.com/documentation/api/branding-themes)",
+      optional: true,
+    },
+    url: {
+      type: "string",
+      description: "URL link to a source document - shown as \"Go to [appName]\" in the Xero app",
+      optional: true,
+    },
+    currency_code: {
+      type: "string",
+      description: "The currency that invoice has been raised in (see [Currencies](https://developer.xero.com/documentation/api/currencies))",
+      optional: true,
+    },
+    currency_rate: {
+      type: "string",
+      description: "The currency rate for a multicurrency invoice. If no rate is specified, the [XE.com day rate](http://help.xero.com/#CurrencySettings$Rates) is used. (max length = [18].[6])",
+      optional: true,
+    },
+    status: {
+      type: "string",
+      description: "See [Invoice Status Codes](https://developer.xero.com/documentation/api/invoices#status-codes)",
+      optional: true,
+    },
+    sent_to_contact: {
+      type: "string",
+      description: "Boolean to set whether the invoice in the Xero app should be marked as \"sent\". This can be set only on invoices that have been approved",
+      optional: true,
+    },
+    expected_payment_data: {
+      type: "string",
+      description: "Shown on the sales invoices when this has been set",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+  //See the API docs: https://developer.xero.com/documentation/api/invoices#post
+
+    if ((!this.contact_id && !this.contact_name) || !this.tenant_id || !this.line_items) {
+      throw new Error("Must provide one of contact_id or contact_name, and tenant_id, type, line_items parameters.");
+    }
+
+    return await axios($, {
+      method: "post",
+      url: "https://api.xero.com/api.xro/2.0/Invoices",
+      headers: {
+        "Authorization": `Bearer ${this.xero_accounting_api.$auth.oauth_access_token}`,
+        "xero-tenant-id": this.tenant_id,
+      },
+      data: {
+        Type: "ACCREC", //ACCREC = Sales Invoice
+        Contact: {
+          ContactID: this.contact_id,
+          Name: this.contact_name,
+        },
+        LineItems: this.line_items,
+        Date: this.date,
+        DueDate: this.due_date,
+        LineAmountTypes: this.line_amount_type,
+        InvoiceNumber: this.invoice_number,
+        Reference: this.reference,
+        BrandingThemeID: this.branding_theme_id,
+        Url: this.url,
+        CurrencyCode: this.currency_code,
+        CurrencyRate: this.currency_rate,
+        Status: this.status,
+        SentToContact: this.sent_to_contact,
+        ExpectedPaymentDate: this.expected_payment_data,
+      },
+    });
+  },
+};


### PR DESCRIPTION
- Adds component actions converted from legacy actions for the following apps:
`calendly_v2`, `twist`, `trello`, `aws`, `salesforce_rest_api`, `pipefy`, `raindrop`, `servicenow`, `activecampaign`, `xero_accounting_api`, `sendinblue`

**Notes**
- Fixes the filename and component key of new Sendinblue **Add a new contact** action
- Moves and updates new **Create Tracked Event** action to the `activecampaign` app (from app_placeholder)
- Omits the ActiveCampaign **Create Account** and **Create Contact** actions because component actions with those keys already exist