### PR TITLE
Fix reference errors with named exports in converted legacy actions

### DIFF
--- a/components/asana/actions/search-user-projects/search-user-projects.mjs
+++ b/components/asana/actions/search-user-projects/search-user-projects.mjs
@@ -5,7 +5,7 @@ export default {
   key: "asana-search-user-projects",
   name: "Asana - Get list of user projects",
   description: "Return list of projects given the user and workspace gid",
-  version: "0.3.1",
+  version: "0.3.2",
   type: "action",
   props: {
     asana: {

--- a/components/asana/actions/search-user-projects/search-user-projects.mjs
+++ b/components/asana/actions/search-user-projects/search-user-projects.mjs
@@ -40,7 +40,7 @@ export default {
     const optFields = this.opt_fields;
     const limit = this.limit; // returned number of items per call
     const workspace = this.workspace;
-    $.export("projects", []);
+    let userProjects = [];
     let uri = `https://app.asana.com/api/1.0/projects/?opt_fields=${optFields}&archived=false&limit=${limit}&workspace=${workspace}`;
     const user = this.user_id;
 
@@ -58,7 +58,7 @@ export default {
             let member = item.members.find((m) => m.gid == user);
 
             if (typeof member !== "undefined") {
-              this.projects.push(item);
+              userProjects.push(item);
             }
           }
         }
@@ -73,11 +73,13 @@ export default {
       }
     }
 
-    if (this.projects.length == 0) {
-      console.log("No project found for user: " + email);
+    $.export("projects", userProjects);
+
+    if (userProjects.length == 0) {
+      console.log("No project found for user: " + this.user_id);
       return null;
     }
 
-    return this.projects;
+    return userProjects;
   },
 };

--- a/components/frontapp/actions/import-message/import-message.mjs
+++ b/components/frontapp/actions/import-message/import-message.mjs
@@ -5,7 +5,7 @@ export default {
   key: "frontapp-import-message",
   name: "Import Message",
   description: "Appends a new message into an inbox.",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
   props: {
     frontapp: {

--- a/components/frontapp/actions/import-message/import-message.mjs
+++ b/components/frontapp/actions/import-message/import-message.mjs
@@ -153,7 +153,8 @@ export default {
       },
     };
 
-    $.export("effective_request_body", JSON.stringify(messageToImportData));
+    const effectiveRequestBody = JSON.stringify(messageToImportData);
+    $.export("effective_request_body", effectiveRequestBody);
 
     return await axios($, {
       method: "post",
@@ -163,7 +164,7 @@ export default {
         "Content-Type": "application/json",
         "Accept": "application/json",
       },
-      data: this.effective_request_body,
+      data: effectiveRequestBody,
     });
   },
 };

--- a/components/frontapp/actions/update-conversation/update-conversation.mjs
+++ b/components/frontapp/actions/update-conversation/update-conversation.mjs
@@ -5,7 +5,7 @@ export default {
   key: "frontapp-update-conversation",
   name: "Update Conversation",
   description: "Updates a conversation",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
   props: {
     frontapp: {

--- a/components/frontapp/actions/update-conversation/update-conversation.mjs
+++ b/components/frontapp/actions/update-conversation/update-conversation.mjs
@@ -57,7 +57,8 @@ export default {
         : JSON.parse(this.tag_ids),
     };
 
-    $.export("effective_request_body", JSON.stringify(conversationData));
+    const effectiveRequestBody = JSON.stringify(conversationData);
+    $.export("effective_request_body", effectiveRequestBody);
 
     return await axios($, {
       method: "patch",
@@ -67,7 +68,7 @@ export default {
         "Content-Type": "application/json",
         "Accept": "application/json",
       },
-      data: this.effective_request_body,
+      data: effectiveRequestBody,
     });
   },
 };

--- a/components/webflow/actions/get-collection-item/get-collection-item.mjs
+++ b/components/webflow/actions/get-collection-item/get-collection-item.mjs
@@ -4,7 +4,7 @@ import { axios } from "@pipedream/platform";
 export default {
   key: "webflow-get-collection-item",
   name: "Get a collection item",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
   props: {
     webflow: {

--- a/components/webflow/actions/get-collection-item/get-collection-item.mjs
+++ b/components/webflow/actions/get-collection-item/get-collection-item.mjs
@@ -19,7 +19,7 @@ export default {
     },
   },
   async run({ $ }) {
-    $.export("request", {
+    const request = {
       method: "get",
       url: `https://api.webflow.com/collections/${this.collection_id}/items/${this.item_id}`,
 
@@ -28,11 +28,10 @@ export default {
         "Content-Type": "application/json",
         "accept-version": "1.0.0",
       },
-    });
-    $.export(
-      "response",
-      await axios($, this.request),
-    );
-    $.export("item", this.response.items[0]);
+    };
+    $.export("request", request);
+    const response = await axios($, request);
+    $.export("response", response);
+    $.export("item", response.items[0]);
   },
 };

--- a/components/xero_accounting_api/actions/download-invoice/download-invoice.mjs
+++ b/components/xero_accounting_api/actions/download-invoice/download-invoice.mjs
@@ -43,8 +43,9 @@ export default {
     const invoicePdf = resp.data.toString("base64");
     const buffer = Buffer.from(invoicePdf, "base64");
     const tmpDir = "/tmp";
-    $.export("invoice_path", `${tmpDir}/${this.invoice_id}.pdf`); //This is where the invoice is saved at the workflow's temporary files.
-    fs.writeFileSync(this.invoice_path, buffer);
-    console.log(`Invoice saved at: ${this.invoice_path}`);
+    const invoicePath = `${tmpDir}/${this.invoice_id}.pdf`;
+    $.export("invoice_path", invoicePath); //This is where the invoice is saved at the workflow's temporary files.
+    fs.writeFileSync(invoicePath, buffer);
+    console.log(`Invoice saved at: ${invoicePath}`);
   },
 };

--- a/components/xero_accounting_api/actions/download-invoice/download-invoice.mjs
+++ b/components/xero_accounting_api/actions/download-invoice/download-invoice.mjs
@@ -6,7 +6,7 @@ export default {
   key: "xero_accounting_api-download-invoice",
   name: "Download Invoice",
   description: "Downloads an invoice as pdf file. File will be placed at the action's associated workflow temporary folder.",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
   props: {
     xero_accounting_api: {


### PR DESCRIPTION
Fixes reference errors in the following actions:
- Frontapp **Update Conversation**
- Frontapp **Import Message**
- Webflow **Get a collection item**
- Xero Accounting API **Download Invoice**
- Asana **Get list of user projects**

**Context**
In converted legacy actions, references to [named exports](https://pipedream.com/docs/v1/workflows/steps/#use-named-exports) after `$.export` were left unconverted (i.e., referencing a variable that was removed). For example:

In legacy action:
```js
this.projects = [];
this.projects.push("project1");
return this.projects;
```

In converted action (error ❌):
```js
$.export("projects", []);
this.projects.push("project1");
return this.projects;
```

Fixed ✅:
```js
let projects = [];
projects.push("project1");
$.export("projects", projects);
return projects;
```