### PR TITLE
Fix Salesforce new-outbound-message source with batched notifications

### DIFF
--- a/components/salesforce_rest_api/sources/new-outbound-message/new-outbound-message.mjs
+++ b/components/salesforce_rest_api/sources/new-outbound-message/new-outbound-message.mjs
@@ -87,6 +87,15 @@ export default {
       console.log("Skipping event from unrecognized source");
       return;
     }
-    this.$emit(data, this.generateMeta(data));
+    
+    let notifications = data.Notification;
+    if (!Array.isArray(notifications)) {
+      notifications = [data.Notification];
+    }
+
+    notifications.forEach(n => {
+      const notification = Object.assign(data, {Notification: n});
+      this.$emit(notification, this.generateMeta(notification));
+    })
   },
 };


### PR DESCRIPTION
In some scenarios, salesforce will queue messages and send them in one batched SOAP message.

This causes:
1. Multiple notifications only triggered one pipedream event
2. The unique dedup is misfunctioning because when generating meta info from the message, the current logic is not able to fetch an id from the notifications array. causes the event id to become the action_id alone.

Refs:
https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_om_outboundmessaging_notifications.htm