### PR TITLE
Rev version of SF New Outbound Message source to re-publish

### DIFF
--- a/components/salesforce_rest_api/sources/new-outbound-message/new-outbound-message.mjs
+++ b/components/salesforce_rest_api/sources/new-outbound-message/new-outbound-message.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Outbound Message (Instant)",
   key: "salesforce_rest_api-new-outbound-message",
   description: "Emit new event when a new outbound message is received in Salesforce. See Salesforce's guide on setting up [Outbound Messaging](https://sforce.co/3JbZJom). Set the Outbound Message's Endpoint URL to the endpoint of the created source. The \"Send Session ID\" option must be enabled for validating outbound messages from Salesforce.",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
   props: {
     db: "$.service.db",
@@ -87,15 +87,19 @@ export default {
       console.log("Skipping event from unrecognized source");
       return;
     }
-    
+
     let notifications = data.Notification;
     if (!Array.isArray(notifications)) {
-      notifications = [data.Notification];
+      notifications = [
+        data.Notification,
+      ];
     }
 
-    notifications.forEach(n => {
-      const notification = Object.assign(data, {Notification: n});
+    notifications.forEach((n) => {
+      const notification = Object.assign(data, {
+        Notification: n,
+      });
       this.$emit(notification, this.generateMeta(notification));
-    })
+    });
   },
 };


### PR DESCRIPTION
- Bumps patch version of `new-outbound-message.mjs`
- Fixes linter errors in `new-outbound-message.mjs`

**Context**:
The [Publish Components workflow](https://github.com/PipedreamHQ/pipedream/blob/167cd3eba3ab4b779a9fc17cfe6cb536e1d2eaf1/.github/workflows/publish-components.yaml) run to publish changes in #2321 failed to publish `new-outbound-message.mjs`, [with error](https://github.com/PipedreamHQ/pipedream/runs/5337102201?check_suite_focus=true#step:5:47):
```
Validation failed: Semantic version 0.0.1 is not publishable, it must be greater than 0.0.1 with components/salesforce_rest_api/sources/new-outbound-message/new-outbound-message.mjs
```