### PR TITLE
Make prop labels & descriptions optional

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,8 +27,8 @@
         "pipedream/required-properties-version": "error",
         "pipedream/required-properties-description": "error",
         "pipedream/required-properties-type": "error",
-        "pipedream/props-label": "error",
-        "pipedream/props-description": "error",
+        "pipedream/props-label": "warn",
+        "pipedream/props-description": "warn",
         "pipedream/source-name": "warn",
         "pipedream/source-description": "warn",
         "pipedream/no-ts-version": "error"
@@ -56,8 +56,8 @@
         "**/*.app.*js"
       ],
       "rules": {
-        "pipedream/props-label": "error",
-        "pipedream/props-description": "error"
+        "pipedream/props-label": "warn",
+        "pipedream/props-description": "warn"
       }
     }
   ],


### PR DESCRIPTION
Updates `pipedream/props-label` & `pipedream/props-description` ESLint rules from "error" to "warn" to allow for commits that break these rules. 

For examples of props without labels or descriptions, see the Discord Bot [**New Message**
](https://github.com/PipedreamHQ/pipedream/blob/master/components/discord_bot/discord/sources/new-message/new-message.js#L19) source or [`stripe.app.js`](https://github.com/PipedreamHQ/pipedream/blob/master/components/stripe/stripe.app.js).

**Context**:
Commit bb002de added a pre-commit hook which aborts commits with changes that fail the lint check. So new or  props without labels or descriptions cannot be commited.
Since prop labels and descriptions aren't required by the guidelines or for a component to be published and run successfully they can be safely omitted.