### PR TITLE
Fixing package.json due to error in deployment

### DIFF
--- a/components/symbl_ai/package.json
+++ b/components/symbl_ai/package.json
@@ -1,20 +1,20 @@
 {
-    "name": "@pipedream/symbl_ai",
-    "version": "0.3.3",
-    "description": "Pipedream Symbl_ai Components",
-    "main": "symbl_ai.app.mjs",
-    "keywords": [
-      "pipedream",
-      "symbl_ai"
-    ],
-    "homepage": "https://pipedream.com/apps/symbl_ai",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-      "@pipedream/platform": "^0.9.0",
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-      "access": "public"
-    }
+  "name": "@pipedream/symbl_ai",
+  "version": "0.3.3",
+  "description": "Pipedream Symbl_ai Components",
+  "main": "symbl_ai.app.mjs",
+  "keywords": [
+    "pipedream",
+    "symbl_ai"
+  ],
+  "homepage": "https://pipedream.com/apps/symbl_ai",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "@pipedream/platform": "^0.9.0"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
   }
+}


### PR DESCRIPTION
Fixed format in [package.json](https://github.com/mjabali/pipedream/blob/3c1bcb6fd00e418d8a32083426bc64f24f7f8167/components/symbl_ai/package.json)