### PR TITLE
Fix unfurling of link in "Sent via Pipedream" text in Slack actions

### DIFF
--- a/components/discord_webhook/actions/send-message-advanced/send-message-advanced.mjs
+++ b/components/discord_webhook/actions/send-message-advanced/send-message-advanced.mjs
@@ -5,7 +5,7 @@ export default {
   key: "discord_webhook-send-message-advanced",
   name: "Send Message (Advanced)",
   description: "Send a simple or structured message (using embeds) to a Discord channel",
-  version: "0.2.0",
+  version: "0.2.1",
   type: "action",
   props: {
     ...common.props,

--- a/components/discord_webhook/actions/send-message-common.mjs
+++ b/components/discord_webhook/actions/send-message-common.mjs
@@ -43,7 +43,7 @@ export default {
       const workflowId = process.env.PIPEDREAM_WORKFLOW_ID;
       // The link text is a URL without a protocol for consistency with the "Send via link" text in
       // Slack messages
-      const linkText = `pipedream.com/@/${workflowId}?o=action&a=discord_webhook`;
+      const linkText = `pipedream.com/@/${workflowId}?o=a&a=discord_webhook`;
       const link = `https://${linkText}`;
       return `Sent via [${linkText}](<${link}>)`;
     },

--- a/components/discord_webhook/actions/send-message-common.mjs
+++ b/components/discord_webhook/actions/send-message-common.mjs
@@ -39,14 +39,13 @@ export default {
     },
   },
   methods: {
-    _getWorkflowUrl() {
-      const workflowId = process.env.PIPEDREAM_WORKFLOW_ID;
-      const traceId = process.env.PIPEDREAM_TRACE_ID;
-      return `https://pipedream.com/@/${workflowId}/inspect/${traceId}?origin=action&a=discord_webhook`;
-    },
     getSentViaPipedreamText() {
-      const link = this._getWorkflowUrl();
-      return `Sent via [pipedream.com](<${link}>)`;
+      const workflowId = process.env.PIPEDREAM_WORKFLOW_ID;
+      // The link text is a URL without a protocol for consistency with the "Send via link" text in
+      // Slack messages
+      const linkText = `pipedream.com/@/${workflowId}?o=action&a=discord_webhook`;
+      const link = `https://${linkText}`;
+      return `Sent via [${linkText}](<${link}>)`;
     },
   },
 };

--- a/components/discord_webhook/actions/send-message-common.mjs
+++ b/components/discord_webhook/actions/send-message-common.mjs
@@ -46,7 +46,7 @@ export default {
     },
     getSentViaPipedreamText() {
       const link = this._getWorkflowUrl();
-      return `Sent via [Pipedream](<${link}>)`;
+      return `Sent via [pipedream.com](<${link}>)`;
     },
   },
 };

--- a/components/discord_webhook/actions/send-message-with-file/send-message-with-file.mjs
+++ b/components/discord_webhook/actions/send-message-with-file/send-message-with-file.mjs
@@ -7,7 +7,7 @@ export default {
   key: "discord_webhook-send-message-with-file",
   name: "Send Message With File",
   description: "Post a message with an attached file",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "action",
   props: {
     ...common.props,

--- a/components/discord_webhook/actions/send-message/send-message.mjs
+++ b/components/discord_webhook/actions/send-message/send-message.mjs
@@ -5,7 +5,7 @@ export default {
   key: "discord_webhook-send-message",
   name: "Send Message",
   description: "Send a simple message to a Discord channel",
-  version: "0.2.0",
+  version: "0.2.1",
   type: "action",
   props: {
     ...common.props,

--- a/components/slack/actions/send-block-kit-message/send-block-kit-message.mjs
+++ b/components/slack/actions/send-block-kit-message/send-block-kit-message.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack-send-block-kit-message",
   name: "Send Message Using Block Kit",
   description: "Send a message using Slack's Block Kit UI framework to a channel, group or user",
-  version: "0.2.0",
+  version: "0.2.1",
   type: "action",
   props: {
     ...common.props,

--- a/components/slack/actions/send-custom-message/send-custom-message.mjs
+++ b/components/slack/actions/send-custom-message/send-custom-message.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack-send-custom-message",
   name: "Send a Custom Message",
   description: "Customize advanced setttings and send a message to a channel, group or user",
-  version: "0.2.0",
+  version: "0.2.1",
   type: "action",
   props: {
     ...common.props,

--- a/components/slack/actions/send-direct-message/send-direct-message.mjs
+++ b/components/slack/actions/send-direct-message/send-direct-message.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack-send-direct-message",
   name: "Send a Direct Message",
   description: "Send a direct message to a single user",
-  version: "0.2.0",
+  version: "0.2.1",
   type: "action",
   props: {
     ...common.props,

--- a/components/slack/actions/send-group-message/send-group-message.mjs
+++ b/components/slack/actions/send-group-message/send-group-message.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack-send-group-message",
   name: "Send Group Message",
   description: "Send a direct message to a group of users",
-  version: "0.2.0",
+  version: "0.2.1",
   type: "action",
   props: {
     ...common.props,

--- a/components/slack/actions/send-message-common.mjs
+++ b/components/slack/actions/send-message-common.mjs
@@ -43,7 +43,7 @@ export default {
       const workflowId = process.env.PIPEDREAM_WORKFLOW_ID;
       // The link is a URL without a protocol to prevent link unfurling. See
       // https://api.slack.com/reference/messaging/link-unfurling#classic_unfurl
-      const link = `pipedream.com/@/${workflowId}?o=action&a=slack`;
+      const link = `pipedream.com/@/${workflowId}?o=a&a=slack`;
       return {
         "type": "context",
         "elements": [

--- a/components/slack/actions/send-message-common.mjs
+++ b/components/slack/actions/send-message-common.mjs
@@ -39,22 +39,22 @@ export default {
     },
   },
   methods: {
-    _getWorkflowId() {
-      return process.env.PIPEDREAM_WORKFLOW_ID;
-    },
-    _getTraceId() {
-      return process.env.PIPEDREAM_TRACE_ID;
+    _getWorkflowUrl() {
+      const workflowId = process.env.PIPEDREAM_WORKFLOW_ID;
+      const traceId = process.env.PIPEDREAM_TRACE_ID;
+      return `https://pipedream.com/@/${workflowId}/inspect/${traceId}?origin=action&a=slack`;
+
     },
     _makeSentViaPipedreamBlock() {
-      const workflowId = this._getWorkflowId();
-      const traceId = this._getTraceId();
-      const link = `https://pipedream.com/@/${workflowId}/inspect/${traceId}?origin=action&a=slack`;
+      const workflowUrl = this._getWorkflowUrl();
       return {
         "type": "context",
         "elements": [
           {
             "type": "mrkdwn",
-            "text": `Sent via <${link}|Pipedream>`,
+            // The label is a URL without a protocol to prevent link unfurling. See
+            // https://api.slack.com/reference/messaging/link-unfurling#classic_unfurl
+            "text": `Sent via <${workflowUrl}|pipedream.com>`,
           },
         ],
       };

--- a/components/slack/actions/send-message-common.mjs
+++ b/components/slack/actions/send-message-common.mjs
@@ -43,7 +43,6 @@ export default {
       const workflowId = process.env.PIPEDREAM_WORKFLOW_ID;
       const traceId = process.env.PIPEDREAM_TRACE_ID;
       return `https://pipedream.com/@/${workflowId}/inspect/${traceId}?origin=action&a=slack`;
-
     },
     _makeSentViaPipedreamBlock() {
       const workflowUrl = this._getWorkflowUrl();

--- a/components/slack/actions/send-message-common.mjs
+++ b/components/slack/actions/send-message-common.mjs
@@ -39,21 +39,17 @@ export default {
     },
   },
   methods: {
-    _getWorkflowUrl() {
-      const workflowId = process.env.PIPEDREAM_WORKFLOW_ID;
-      const traceId = process.env.PIPEDREAM_TRACE_ID;
-      return `https://pipedream.com/@/${workflowId}/inspect/${traceId}?origin=action&a=slack`;
-    },
     _makeSentViaPipedreamBlock() {
-      const workflowUrl = this._getWorkflowUrl();
+      const workflowId = process.env.PIPEDREAM_WORKFLOW_ID;
+      // The link is a URL without a protocol to prevent link unfurling. See
+      // https://api.slack.com/reference/messaging/link-unfurling#classic_unfurl
+      const link = `pipedream.com/@/${workflowId}?o=action&a=slack`;
       return {
         "type": "context",
         "elements": [
           {
             "type": "mrkdwn",
-            // The label is a URL without a protocol to prevent link unfurling. See
-            // https://api.slack.com/reference/messaging/link-unfurling#classic_unfurl
-            "text": `Sent via <${workflowUrl}|pipedream.com>`,
+            "text": `Sent via ${link}`,
           },
         ],
       };

--- a/components/slack/actions/send-message-private-channel/send-message-private-channel.mjs
+++ b/components/slack/actions/send-message-private-channel/send-message-private-channel.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack-send-message-private-channel",
   name: "Send Message to a Private Channel",
   description: "Send a message to a private channel and customize the name and avatar of the bot that posts the message",
-  version: "0.2.1",
+  version: "0.2.2",
   type: "action",
   props: {
     ...common.props,

--- a/components/slack/actions/send-message-public-channel/send-message-public-channel.mjs
+++ b/components/slack/actions/send-message-public-channel/send-message-public-channel.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack-send-message-public-channel",
   name: "Send Message to a Public Channel",
   description: "Send a message to a public channel and customize the name and avatar of the bot that posts the message",
-  version: "0.2.0",
+  version: "0.2.1",
   type: "action",
   props: {
     ...common.props,


### PR DESCRIPTION
- Changes text to "Sent via pipedream.com" in Slack actions to prevent unfurling, and Discord Webhook actions for consistency
- Bumps patch version of affected Discord Webhook and Slack actions