### PR TITLE
Youtube - new liked videos action

### DIFF
--- a/components/youtube_data_api/sources/new-liked-videos/new-liked-videos.mjs
+++ b/components/youtube_data_api/sources/new-liked-videos/new-liked-videos.mjs
@@ -1,0 +1,49 @@
+import common from "../common.mjs";
+
+export default {
+  ...common,
+  type: "source",
+  key: "youtube_data_api-new-liked-videos",
+  name: "New Liked Videos",
+  description: "Emit new event for each new Youtube video liked by the authenticated user.",
+  version: "0.0.1",
+  dedupe: "unique",
+  hooks: {
+    ...common.hooks,
+    deploy() {},
+  },
+  props: {
+    ...common.props,
+    maxResults: {
+      propDefinition: [
+        common.props.youtubeDataApi,
+        "maxResults",
+      ],
+    },
+  },
+  methods: {
+    ...common.methods,
+    generateMeta(video) {
+      const {
+        id,
+        snippet,
+      } = video;
+      return {
+        id,
+        summary: snippet.title,
+        ts: Date.parse(snippet.publishedAt),
+      };
+    },
+    isRelevant() {
+      return true;
+    },
+  },
+  async run() {
+    const params = {
+      part: "contentDetails,id,snippet,status",
+      playlistId: "LL",
+      maxResults: this.maxResults,
+    };
+    await this.paginatePlaylistItems(params);
+  },
+};

--- a/components/youtube_data_api/sources/new-videos-in-playlist/new-videos-in-playlist.mjs
+++ b/components/youtube_data_api/sources/new-videos-in-playlist/new-videos-in-playlist.mjs
@@ -6,7 +6,7 @@ export default {
   key: "youtube_data_api-new-videos-in-playlist",
   name: "New Videos in Playlist",
   description: "Emit new event for each new Youtube video added to a Playlist.",
-  version: "0.0.5",
+  version: "0.0.6",
   dedupe: "unique",
   hooks: {
     ...common.hooks,
@@ -50,31 +50,6 @@ export default {
       if (!publishedAfter) return true;
       const publishedAt = video.snippet.publishedAt;
       return Date.parse(publishedAt) > Date.parse(publishedAfter);
-    },
-    async paginatePlaylistItems(params, publishedAfter = null) {
-      let totalResults = 1;
-      let count = 0;
-      let countEmitted = 0;
-      let lastPublished;
-
-      while (count < totalResults && countEmitted < params.maxResults) {
-        const results = (await this.youtubeDataApi.getPlaylistItems(params)).data;
-        totalResults = results.pageInfo.totalResults;
-        for (const video of results.items) {
-          if (this.isRelevant(video, publishedAfter)) {
-            if (
-              !lastPublished ||
-              Date.parse(video.snippet.publishedAt) > Date.parse(lastPublished)
-            )
-              lastPublished = video.snippet.publishedAt;
-            this.emitEvent(video);
-            countEmitted++;
-          }
-          count++;
-        }
-        params.pageToken = results.nextPageToken;
-      }
-      return lastPublished;
     },
   },
   async run() {


### PR DESCRIPTION
**New Liked Videos** | Emit new event for each new Youtube video liked by the authenticated user.

Addresses issue https://github.com/PipedreamHQ/pipedream/issues/1971