### PR TITLE
[ACTION] Google Drive - Create document from template

### DIFF
--- a/components/google_drive/actions/create-file-from-template/create-file-from-template.mjs
+++ b/components/google_drive/actions/create-file-from-template/create-file-from-template.mjs
@@ -1,14 +1,14 @@
 import googleDrive from "../../google_drive.app.mjs";
 import Mustaches from "google-docs-mustaches";
 
-const MODE_GOOGLE_DOC = 0;
-const MODE_PDF = 1;
-const MODE_GOOGLE_DOC_PDF = 2;
+const MODE_GOOGLE_DOC = "Google Doc";
+const MODE_PDF = "Pdf";
+const MODE_GOOGLE_DOC_PDF = "Google Doc & Pdf";
 
 export default {
   key: "google_drive-create-file-from-template",
   name: "Create New File From Template",
-  description: "Create a new google doc file from template",
+  description: "Create a new google doc file from template. [See documentation](https://www.npmjs.com/package/google-docs-mustaches)",
   version: "0.0.1",
   type: "action",
   props: {
@@ -43,18 +43,9 @@ export default {
       description: "Select if you want to create the google doc, the pdf or both files.",
       async options() {
         return [
-          {
-            label: "Google doc",
-            value: 0,
-          },
-          {
-            label: "Pdf",
-            value: 1,
-          },
-          {
-            label: "Google doc & Pdf",
-            value: 2,
-          },
+          MODE_GOOGLE_DOC,
+          MODE_PDF,
+          MODE_GOOGLE_DOC_PDF,
         ];
       },
     },
@@ -65,11 +56,11 @@ export default {
       optional: true,
     },
   },
-  async run() {
+  async run({ $ }) {
     const result = {
       folderId: this.folderId,
       name: this.name,
-	  mode: this.mode,
+      mode: this.mode,
     };
 
     const client = new Mustaches.default({
@@ -78,7 +69,7 @@ export default {
 
     /* CREATE THE GOOGLE DOC */
 
-    var googleDocId = await client.interpolate({
+    const googleDocId = await client.interpolate({
       source: this.templateId,
       destination: this.folderId,
       name: this.name,
@@ -88,8 +79,8 @@ export default {
 
     /* CREATE THE PDF */
 
-    if(this.mode != MODE_GOOGLE_DOC) {
-      var pdfId = await client.export({
+    if (this.mode != MODE_GOOGLE_DOC) {
+      const pdfId = await client.export({
         file: googleDocId,
         mimeType: 'application/pdf',
         name: this.name,
@@ -100,10 +91,11 @@ export default {
 
     /* REMOVE THE GOOGLE DOC */
 
-    if(this.mode == MODE_PDF) {
+    if (this.mode == MODE_PDF) {
       await this.googleDrive.deleteFile(googleDocId);
     }
 
+    $.export("$summary", "New file successfully created");
     return result;
   },
 };

--- a/components/google_drive/actions/create-file-from-template/create-file-from-template.mjs
+++ b/components/google_drive/actions/create-file-from-template/create-file-from-template.mjs
@@ -3,7 +3,6 @@ import Mustaches from "google-docs-mustaches";
 
 const MODE_GOOGLE_DOC = "Google Doc";
 const MODE_PDF = "Pdf";
-const MODE_GOOGLE_DOC_PDF = "Google Doc & Pdf";
 
 export default {
   key: "google_drive-create-file-from-template",
@@ -36,18 +35,16 @@ export default {
       ],
       description:
         "Name of the file you want to create (eg. `myFile` will create a google doc called `myFile` and a pdf called `myFile.pdf`)",
-    },
+      optional: false,
+	},
     mode: {
-      type: "string",
+      type: "string[]",
       label: "Mode",
       description: "Select if you want to create the google doc, the pdf or both files.",
-      async options() {
-        return [
-          MODE_GOOGLE_DOC,
-          MODE_PDF,
-          MODE_GOOGLE_DOC_PDF,
-        ];
-      },
+      options: [
+        MODE_GOOGLE_DOC,
+        MODE_PDF,
+      ],
     },
     replaceValues: {
       type: "object",
@@ -79,7 +76,7 @@ export default {
 
     /* CREATE THE PDF */
 
-    if (this.mode != MODE_GOOGLE_DOC) {
+    if (this.mode.includes(MODE_PDF)) {
       const pdfId = await client.export({
         file: googleDocId,
         mimeType: 'application/pdf',
@@ -91,7 +88,7 @@ export default {
 
     /* REMOVE THE GOOGLE DOC */
 
-    if (this.mode == MODE_PDF) {
+    if (!this.mode.includes(MODE_GOOGLE_DOC)) {
       await this.googleDrive.deleteFile(googleDocId);
     }
 


### PR DESCRIPTION
This new action create a google doc from a template and replace placeholder variables in the text. It can also export to pdf.

This is a contribution to #1487:
> Create Document from Template | Creates a new doc based on an existing one and can replace any placeholder variables found in your template doc, like {{name}}, {{email}}, etc.