### PR TITLE
fix for  [warning] object was filtered for serialization in Tweet code

### DIFF
--- a/components/twitter/sources/common/tweets.mjs
+++ b/components/twitter/sources/common/tweets.mjs
@@ -26,23 +26,15 @@ export default {
     },
   },
   methods: {
-    _addParsedId(tweet) {
-      // This is needed since the numeric value of a Tweet's ID can exceed the
-      // maximum supported value of `number`
-      const parsedId = BigInt(tweet.id_str);
-      return {
-        ...tweet,
-        parsedId,
-      };
-    },
-    _compareByIdAsc({ parsedId: a }, { parsedId: b }) {
-      if (a < b) return -1;
-      if (a > b) return 1;
+    _compareByIdAsc({ id_str: a }, { id_str: b }) {
+      const A = BigInt(a);
+      const B = BigInt(b);
+      if (A < B) return -1;
+      if (A > B) return 1;
       return 0;
     },
     sortTweets(tweets) {
       return tweets
-        .map(this._addParsedId)
         .sort(this._compareByIdAsc);
     },
     /**

--- a/components/twitter/sources/my-tweets/my-tweets.mjs
+++ b/components/twitter/sources/my-tweets/my-tweets.mjs
@@ -5,7 +5,7 @@ export default {
   key: "twitter-my-tweets",
   name: "My Tweets",
   description: "Emit new Tweets you post to Twitter",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "source",
   props: {
     ...base.props,

--- a/components/twitter/sources/new-tweet-in-list/new-tweet-in-list.mjs
+++ b/components/twitter/sources/new-tweet-in-list/new-tweet-in-list.mjs
@@ -5,7 +5,7 @@ export default {
   key: "twitter-new-tweet-in-list",
   name: "New Tweet in List",
   description: "Emit new Tweets posted by members of a list",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "source",
   props: {
     ...base.props,

--- a/components/twitter/sources/user-tweets/user-tweets.mjs
+++ b/components/twitter/sources/user-tweets/user-tweets.mjs
@@ -5,7 +5,7 @@ export default {
   key: "twitter-user-tweets",
   name: "User Tweets",
   description: "Emit new Tweets posted by a user",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "source",
   props: {
     ...base.props,

--- a/components/twitter/sources/watch-retweets-of-me/watch-retweets-of-me.mjs
+++ b/components/twitter/sources/watch-retweets-of-me/watch-retweets-of-me.mjs
@@ -4,7 +4,7 @@ export default {
   ...base,
   key: "twitter-watch-retweets-of-me",
   name: "Watch Retweets of Me",
-  version: "0.0.4",
+  version: "0.0.5",
   description: "Emit new event when recent Tweets authored by the authenticating user that have been retweeted by others",
   type: "source",
   props: {

--- a/components/twitter/sources/watch-retweets-of-my-tweet/watch-retweets-of-my-tweet.mjs
+++ b/components/twitter/sources/watch-retweets-of-my-tweet/watch-retweets-of-my-tweet.mjs
@@ -5,7 +5,7 @@ export default {
   key: "twitter-watch-retweets-of-my-tweet",
   name: "Watch Retweets of My Tweet",
   description: "Emit new event when a specific Tweet from the authenticated user is retweeted",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "source",
   props: {
     ...base.props,

--- a/components/twitter/sources/watch-retweets-of-user-tweet/watch-retweets-of-user-tweet.mjs
+++ b/components/twitter/sources/watch-retweets-of-user-tweet/watch-retweets-of-user-tweet.mjs
@@ -6,7 +6,7 @@ export default {
   key: "twitter-watch-retweets-of-user-tweet",
   name: "Watch Retweets of User Tweet",
   description: "Emit new event when a specific Tweet from a user is retweeted",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "source",
   props: {
     ...base.props,


### PR DESCRIPTION
When _addParseId() is called on a tweet, it adds a BigInt version of the ID on the end of the object and uses it to sort, which works fine.

If you subsequently do anything to the tweet object (console.log it, update it etc), the BigInt is stripped with the warning: [warning] object was filtered for serialization  - it;s too big for the parser.

Given that it's only used for this one sort and not needed anyway, I dropped the map and did the work in the sort code. Advantage is no extra additions to the object and no map needed.

Warning fixed as a result.