### PR TITLE
typo fix (YouTube > Twitter)

### DIFF
--- a/components/twitter/sources/common/followers.mjs
+++ b/components/twitter/sources/common/followers.mjs
@@ -6,7 +6,7 @@ export default {
     twitter,
     timer: {
       label: "Polling interval",
-      description: "Pipedream will poll the YouTube API on this schedule",
+      description: "Pipedream will poll the Twitter API on this schedule",
       type: "$.interface.timer",
       default: {
         intervalSeconds: 60 * 15,

--- a/components/twitter/sources/my-liked-tweets/my-liked-tweets.mjs
+++ b/components/twitter/sources/my-liked-tweets/my-liked-tweets.mjs
@@ -10,7 +10,7 @@ export default {
     twitter,
     timer: {
       label: "Polling interval",
-      description: "Pipedream will poll the YouTube API on this schedule",
+      description: "Pipedream will poll the Twitter API on this schedule",
       type: "$.interface.timer",
       default: {
         intervalSeconds: 60 * 15,

--- a/components/twitter/sources/new-trends-by-geo/new-trends-by-geo.mjs
+++ b/components/twitter/sources/new-trends-by-geo/new-trends-by-geo.mjs
@@ -16,7 +16,7 @@ export default {
     },
     timer: {
       label: "Polling interval",
-      description: "Pipedream will poll the YouTube API on this schedule",
+      description: "Pipedream will poll the Twitter API on this schedule",
       type: "$.interface.timer",
       default: {
         intervalSeconds: 60 * 15,

--- a/components/twitter/sources/search-mentions/search-mentions.mjs
+++ b/components/twitter/sources/search-mentions/search-mentions.mjs
@@ -72,7 +72,7 @@ export default {
     },
     timer: {
       label: "Polling interval",
-      description: "Pipedream will poll the YouTube API on this schedule",
+      description: "Pipedream will poll the Twitter API on this schedule",
       type: "$.interface.timer",
       default: {
         intervalSeconds: 60 * 15,

--- a/components/twitter/sources/tweets-liked-by-user/tweets-liked-by-user.mjs
+++ b/components/twitter/sources/tweets-liked-by-user/tweets-liked-by-user.mjs
@@ -16,7 +16,7 @@ export default {
     },
     timer: {
       label: "Polling interval",
-      description: "Pipedream will poll the YouTube API on this schedule",
+      description: "Pipedream will poll the Twitter API on this schedule",
       type: "$.interface.timer",
       default: {
         intervalSeconds: 60 * 15,


### PR DESCRIPTION
Small typo which said `YouTube` instead of `Twitter` in the timer description (probably a remnant of copypasta)