### PR TITLE
More Stripe actions

### DIFF
--- a/components/stripe/actions/retrieve-checkout-line-item-product/retrieve-checkout-line-item-product.js
+++ b/components/stripe/actions/retrieve-checkout-line-item-product/retrieve-checkout-line-item-product.js
@@ -1,0 +1,30 @@
+import { axios } from "@pipedream/platform";
+const stripe = require("../../stripe.app.js");
+
+export default {
+  name: "Retrieve Checkout Line Item Product",
+  description: "Given a checkout session line item, retrieve the associated product. [See the docs](https://stripe.com/docs/api/products/retrieve)",
+  key: "retrieve_product_from_line_item",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    stripe,
+    product_id: {
+      type: "string",
+      label: "Product ID",
+      description: "A Stripe Product ID. [See the docs](https://stripe.com/docs/api/products/object#product_object-id)",
+      optional: false,
+    },
+  },
+  async run ({ $ }) {
+    const resp = await axios($, {
+      url: `https://api.stripe.com/v1/products/${this.product_id}`,
+      auth: {
+        username: `${this.stripe.$auth.api_key}`,
+        password: "",
+      },
+    });
+    $.export("$summary", `Successfully retrieved the line item product, "${resp.name || resp.id}"`);
+    return resp;
+  },
+};

--- a/components/stripe/actions/retrieve-checkout-line-item-product/retrieve-checkout-line-item-product.js
+++ b/components/stripe/actions/retrieve-checkout-line-item-product/retrieve-checkout-line-item-product.js
@@ -4,7 +4,7 @@ const stripe = require("../../stripe.app.js");
 export default {
   name: "Retrieve Product",
   description: "Retrieve a product by ID. [See the docs](https://stripe.com/docs/api/products/retrieve)",
-  key: "retrieve_product",
+  key: "stripe-retrieve-product",
   version: "0.0.1",
   type: "action",
   props: {

--- a/components/stripe/actions/retrieve-checkout-line-item-product/retrieve-checkout-line-item-product.js
+++ b/components/stripe/actions/retrieve-checkout-line-item-product/retrieve-checkout-line-item-product.js
@@ -2,9 +2,9 @@ import { axios } from "@pipedream/platform";
 const stripe = require("../../stripe.app.js");
 
 export default {
-  name: "Retrieve Checkout Line Item Product",
-  description: "Given a checkout session line item, retrieve the associated product. [See the docs](https://stripe.com/docs/api/products/retrieve)",
-  key: "retrieve_product_from_line_item",
+  name: "Retrieve Product",
+  description: "Retrieve a product by ID. [See the docs](https://stripe.com/docs/api/products/retrieve)",
+  key: "retrieve_product",
   version: "0.0.1",
   type: "action",
   props: {

--- a/components/stripe/actions/retrieve-checkout-line-item-product/retrieve-checkout-line-item-product.js
+++ b/components/stripe/actions/retrieve-checkout-line-item-product/retrieve-checkout-line-item-product.js
@@ -1,4 +1,3 @@
-import { axios } from "@pipedream/platform";
 const stripe = require("../../stripe.app.js");
 
 export default {
@@ -17,13 +16,7 @@ export default {
     },
   },
   async run ({ $ }) {
-    const resp = await axios($, {
-      url: `https://api.stripe.com/v1/products/${this.product_id}`,
-      auth: {
-        username: `${this.stripe.$auth.api_key}`,
-        password: "",
-      },
-    });
+    const resp = await this.stripe.sdk().products.retrieve(this.product_id);
     $.export("$summary", `Successfully retrieved the line item product, "${resp.name || resp.id}"`);
     return resp;
   },

--- a/components/stripe/actions/retrieve-checkout-line-items/retrieve-checkout-line-items.js
+++ b/components/stripe/actions/retrieve-checkout-line-items/retrieve-checkout-line-items.js
@@ -1,4 +1,3 @@
-import { axios } from "@pipedream/platform";
 const stripe = require("../../stripe.app.js");
 
 export default {
@@ -26,12 +25,8 @@ export default {
     },
   },
   async run ({ $ }) {
-    const resp = await axios($, {
-      url: `https://api.stripe.com/v1/checkout/sessions/${this.checkout_session_id}/line_items?limit=${this.line_items_limit}`,
-      auth: {
-        username: `${this.stripe.$auth.api_key}`,
-        password: "",
-      },
+    const resp = await this.stripe.sdk().checkout.sessions.listLineItems(this.checkout_session_id, {
+      limit: this.line_items_limit,
     });
     $.export("$summary", `Successfully retrieved ${resp.data.length} checkout session line items`);
     return resp;

--- a/components/stripe/actions/retrieve-checkout-line-items/retrieve-checkout-line-items.js
+++ b/components/stripe/actions/retrieve-checkout-line-items/retrieve-checkout-line-items.js
@@ -2,9 +2,9 @@ import { axios } from "@pipedream/platform";
 const stripe = require("../../stripe.app.js");
 
 export default {
-  name: "Retrieve Checkout Line Items",
+  name: "Retrieve Checkout Session Line Items",
   description: "Given a checkout session ID, retrieve the line items. [See the docs](https://stripe.com/docs/api/checkout/sessions/line_items)",
-  key: "retrieve_checkout_line_items",
+  key: "retrieve_checkout_session_line_items",
   version: "0.0.1",
   type: "action",
   props: {

--- a/components/stripe/actions/retrieve-checkout-line-items/retrieve-checkout-line-items.js
+++ b/components/stripe/actions/retrieve-checkout-line-items/retrieve-checkout-line-items.js
@@ -4,7 +4,7 @@ const stripe = require("../../stripe.app.js");
 export default {
   name: "Retrieve Checkout Session Line Items",
   description: "Given a checkout session ID, retrieve the line items. [See the docs](https://stripe.com/docs/api/checkout/sessions/line_items)",
-  key: "retrieve_checkout_session_line_items",
+  key: "stripe-retrieve-checkout-session-line-items",
   version: "0.0.1",
   type: "action",
   props: {

--- a/components/stripe/actions/retrieve-checkout-line-items/retrieve-checkout-line-items.js
+++ b/components/stripe/actions/retrieve-checkout-line-items/retrieve-checkout-line-items.js
@@ -1,0 +1,39 @@
+import { axios } from "@pipedream/platform";
+const stripe = require("../../stripe.app.js");
+
+export default {
+  name: "Retrieve Checkout Line Items",
+  description: "Given a checkout session ID, retrieve the line items. [See the docs](https://stripe.com/docs/api/checkout/sessions/line_items)",
+  key: "retrieve_checkout_line_items",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    stripe,
+    checkout_session_id: {
+      type: "string",
+      label: "Checkout Session ID",
+      description: "The ID of a Stripe Checkout Session. [See the docs](https://stripe.com/docs/api/checkout/sessions/object#checkout_session_object-id)",
+      optional: false,
+    },
+    line_items_limit: {
+      type: "integer",
+      label: "Number of Line Items",
+      description: "The number of line items to retrieve (min: 1, max: 100)",
+      optional: false,
+      default: 1,
+      min: 1,
+      max: 100,
+    },
+  },
+  async run ({ $ }) {
+    const resp = await axios($, {
+      url: `https://api.stripe.com/v1/checkout/sessions/${this.checkout_session_id}/line_items?limit=${this.line_items_limit}`,
+      auth: {
+        username: `${this.stripe.$auth.api_key}`,
+        password: "",
+      },
+    });
+    $.export("$summary", `Successfully retrieved ${resp.data.length} checkout session line items`);
+    return resp;
+  },
+};

--- a/components/stripe/actions/retrieve-checkout-line-items/retrieve-checkout-line-items.js
+++ b/components/stripe/actions/retrieve-checkout-line-items/retrieve-checkout-line-items.js
@@ -12,13 +12,11 @@ export default {
       type: "string",
       label: "Checkout Session ID",
       description: "The ID of a Stripe Checkout Session. [See the docs](https://stripe.com/docs/api/checkout/sessions/object#checkout_session_object-id)",
-      optional: false,
     },
     line_items_limit: {
       type: "integer",
       label: "Number of Line Items",
       description: "The number of line items to retrieve (min: 1, max: 100)",
-      optional: false,
       default: 1,
       min: 1,
       max: 100,

--- a/components/stripe/actions/retrieve-product/retrieve-product.js
+++ b/components/stripe/actions/retrieve-product/retrieve-product.js
@@ -12,7 +12,6 @@ export default {
       type: "string",
       label: "Product ID",
       description: "A Stripe Product ID. [See the docs](https://stripe.com/docs/api/products/object#product_object-id)",
-      optional: false,
     },
   },
   async run ({ $ }) {


### PR DESCRIPTION
In this version the following two actions have been added for the Stripe app:

1. Retrieve Checkout Session Line Items - this retrieves a given number of line items (between 1 and 100, being Stripe API limits) for a given Checkout Session.
2. Retrieve Product - this retrieves a product given a product ID

## Rationale
My own use case for these actions was as follows:
I have a workflow that listens to `checkout.session.completed` events from Stripe, retrieves the product (via a step to fetch the checkout session's line items) and then uses a metadata property on the product to add the purchaser to the correct mailerlite group in my mailerlite account.

This means that I can sign users up to different mailerlite groups based on what products they've purchased, and take advantage of mailerlite automations to, for example, deliver secure access to the digital product that the person bought, or target them in future marketing emails.
