### PR TITLE
A homebrew formula for pipedream cli

### DIFF
--- a/homebrew/pipedream.rb
+++ b/homebrew/pipedream.rb
@@ -1,0 +1,20 @@
+class Pipedream < Formula
+    desc "CLI utility for Pipedream"
+    homepage "https://pipedream.com"
+    url "https://cli.pipedream.com/darwin/amd64/0.2.5/pd.zip"
+    sha256 "bd1a23ce2428c0c2e35eb80cf69a6069f70d11f1389a9656a27f8a7c1bdf5f9f"
+  
+    def install
+      bin.install "pd"
+    end
+  
+    def caveats; <<~EOS
+      ❤ Thanks for installing the Pipedream CLI! If this is your first time using the CLI, be sure to run `pd login` first.
+    EOS
+    end
+  
+    test do
+      system "#{bin}/pd", "--version"
+    end
+  end
+  


### PR DESCRIPTION
This version contains a homebrew formula for the pipedream cli.
Once live, it can be installed as such:

```
brew install PipedreamHQ/pipedream/homebrew/pipedream
```

This is, albeit, a bit verbose. You might want to consider moving it into a separate github project (eg: PipedreamHQ/pipedream-cli) like stripe did (theirs is stripe/stripe-cli, so install is: `brew install stripe/stripe-cli/stripe`).

Example verbose output of homebrew install:
```
$ brew install --build-from-source --verbose --debug pipedream                                        
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FormulaLoader): loading /opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/pipedream.rb
==> Downloading https://cli.pipedream.com/darwin/amd64/0.2.5/pd.zip
/opt/homebrew/Library/Homebrew/shims/shared/curl --disable --cookie /dev/null --globoff --show-error --user-agent Homebrew/3.4.6-76-g97b0162\ \(Macintosh\;\ arm64\ Mac\ OS\ X\ 12.0.1\)\ curl/7.77.0 --header Accept-Language:\ en --retry 3 --location --silent --head --request GET https://cli.pipedream.com/darwin/amd64/0.2.5/pd.zip
Already downloaded: /Users/nathan/Library/Caches/Homebrew/downloads/8d7751eecc47973d3eb8c2164aed25ec27617606319da9a3c3984ea127e9b967--pd.zip
==> Verifying checksum for '8d7751eecc47973d3eb8c2164aed25ec27617606319da9a3c3984ea127e9b967--pd.zip'
/opt/homebrew/Library/Homebrew/shims/shared/git --version
/opt/homebrew/Library/Homebrew/build.rb (Formulary::FormulaLoader): loading /opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/unzip.rb
/usr/bin/env PATH=/opt/homebrew/opt/unzip/bin:/opt/homebrew/Library/Homebrew/shims/mac/super:/usr/bin:/bin:/usr/sbin:/sbin unzip -o /Users/nathan/Library/Caches/Homebrew/downloads/8d7751eecc47973d3eb8c2164aed25ec27617606319da9a3c3984ea127e9b967--pd.zip -d /private/tmp/d20220414-7580-1hy1hy3
chmod +rw /private/tmp/d20220414-7580-1hy1hy3/pd
hdiutil imageinfo -format /private/tmp/d20220414-7580-1hy1hy3/pd
cp -p /private/tmp/d20220414-7580-1hy1hy3/pd /private/tmp/pipedream-20220414-7580-nmulvn/pd
/opt/homebrew/Library/Homebrew/shims/shared/git --version
==> Cleaning
==> Fixing /opt/homebrew/Cellar/pipedream/0.2.5/bin/pd permissions from 777 to 555
==> Finishing up
ln -s ../Cellar/pipedream/0.2.5/bin/pd pd
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromPathLoader): loading /opt/homebrew/opt/pipedream/.brew/pipedream.rb
==> Caveats
❤ Thanks for installing the Pipedream CLI! If this is your first time using the CLI, be sure to run `pd login` first.
==> Summary
🍺  /opt/homebrew/Cellar/pipedream/0.2.5: 3 files, 13.6MB, built in 1 second
$ pd --version
pd version 0.2.5
```