### PR TITLE
Correct typo in code example

### DIFF
--- a/docs/docs/migrate-from-v1/README.md
+++ b/docs/docs/migrate-from-v1/README.md
@@ -239,7 +239,7 @@ import { axios } from "@pipedream/platform"
 
 export default defineComponent({
   props: {
-    twitter: {
+    slack: {
       type: "app",
       app: "slack",
     }


### PR DESCRIPTION
The code in 'Connecting apps' mixed Twitter and Slack in the example. Just bringing them in line.