### PR TITLE
docs/code/go: fix warning text

### DIFF
--- a/docs/docs/code/go/README.md
+++ b/docs/docs/code/go/README.md
@@ -9,7 +9,7 @@ Go steps are available in a limited alpha release.
 
 You can still run arbitrary Go code, including [sharing data between steps](/code/go/#sharing-data-between-steps) as well as [accessing environment variables](/code/go/#using-environment-variables).
 
-However, features available in [Node.js steps](/code/nodejs) like `$.respond`, `$.end`, and `$.auth` are not yet available in bash. If you have any questions please [contact support](https://pipedream.com/support).
+However, you can't connect accounts, return HTTP responses, or take advantage of other features available in the [Node.js](/code/nodejs/) environment at this time. If you have any questions please [contact support](https://pipedream.com/support).
 :::
 
 


### PR DESCRIPTION
Uses the warning text from python docs for better clarity, also removes "bash" typo