### PR TITLE
Fixing Shopify Partner API sources

### DIFF
--- a/components/shopify_partner/shopify_partner.app.mjs
+++ b/components/shopify_partner/shopify_partner.app.mjs
@@ -56,7 +56,7 @@ export default {
       hasNextPagePath = "transactions.pageInfo.hasNextPage",
       getCursor,
     }) {
-      const endpoint = `https://partners.shopify.com/${this.$auth.organization_id}/api/2021-04/graphql.json`;
+      const endpoint = `https://partners.shopify.com/${this.$auth.organization_id}/api/2021-07/graphql.json`;
       const client = new GraphQLClient(endpoint, {
         headers: {
           "Content-Type": "application/json",

--- a/components/shopify_partner/sources/new_app_charges.mjs
+++ b/components/shopify_partner/sources/new_app_charges.mjs
@@ -5,7 +5,7 @@ export default {
   key: "shopify_partner-new-app-charges",
   name: "New App Charges",
   type: "source",
-  version: "0.0.5",
+  version: "0.0.6",
   description:
     "Emit new events when new app charges made to your partner account.",
   ...common,

--- a/components/shopify_partner/sources/new_app_installs.mjs
+++ b/components/shopify_partner/sources/new_app_installs.mjs
@@ -6,7 +6,7 @@ export default {
   key: "shopify_partner-new-app-installs",
   name: "New App Installs",
   type: "source",
-  version: "0.0.6",
+  version: "0.0.7",
   description: "Emit new events when new shops install your app.",
   ...common,
   props: {

--- a/components/shopify_partner/sources/new_app_relationship_events.mjs
+++ b/components/shopify_partner/sources/new_app_relationship_events.mjs
@@ -6,7 +6,7 @@ export default {
   key: "shopify_partner-new-app-relationship-events",
   name: "New App Relationship Events",
   type: "source",
-  version: "0.0.2",
+  version: "0.0.3",
   description: "Emit new events when new shops installs, uninstalls, subscribes or unsubscribes your app.",
   ...common,
   props: {

--- a/components/shopify_partner/sources/new_app_uninstalls.mjs
+++ b/components/shopify_partner/sources/new_app_uninstalls.mjs
@@ -6,7 +6,7 @@ export default {
   key: "shopify_partner-new-app-uninstalls",
   name: "New App Uninstalls",
   type: "source",
-  version: "0.0.6",
+  version: "0.0.7",
   description: "Emit new events when new shops uninstall your app.",
   ...common,
   props: {


### PR DESCRIPTION

Fixes Shopify Partner integration by updating the URL to the latest stable version of their API.

Reported bug here: https://pipedream-users.slack.com/archives/CMZG4EBJ9/p1650282790338169
