### PR TITLE
AWS S3 event sources v3 client

### DIFF
--- a/components/aws/common/common-s3.mjs
+++ b/components/aws/common/common-s3.mjs
@@ -6,6 +6,8 @@ import {
   GetObjectCommand,
   PutObjectCommand,
   PutBucketPolicyCommand,
+  GetBucketNotificationConfigurationCommand,
+  PutBucketNotificationConfigurationCommand,
 } from "@aws-sdk/client-s3";
 import axios from "axios"; // need axios response headers
 
@@ -85,6 +87,12 @@ export default {
       return axios.get(fileUrl, {
         responseType: "stream",
       });
+    },
+    async getBucketNotificationConfiguration(params) {
+      return this._clientS3().send(new GetBucketNotificationConfigurationCommand(params));
+    },
+    async putBucketNotificationConfiguration(params) {
+      return this._clientS3().send(new PutBucketNotificationConfigurationCommand(params));
     },
   },
 };

--- a/components/aws/sources/common/policies.mjs
+++ b/components/aws/sources/common/policies.mjs
@@ -1,22 +1,24 @@
-export default {
-  generateBucketSnsPolicy: (bucketName, topicArn) => ({
-    Version: "2012-10-17",
-    Id: `pd-bucket-sns-publish-${bucketName}`,
-    Statement: [
-      {
-        Sid: `pd-bucket-sns-publish-${bucketName}`,
-        Effect: "Allow",
-        Principal: {
-          Service: "s3.amazonaws.com",
-        },
-        Action: "SNS:Publish",
-        Resource: topicArn,
-        Condition: {
-          ArnLike: {
-            "aws:SourceArn": `arn:aws:s3:::${bucketName}`,
-          },
+const generateBucketSnsPolicy = (bucketName, topicArn) => ({
+  Version: "2012-10-17",
+  Id: `pd-bucket-sns-publish-${bucketName}`,
+  Statement: [
+    {
+      Sid: `pd-bucket-sns-publish-${bucketName}`,
+      Effect: "Allow",
+      Principal: {
+        Service: "s3.amazonaws.com",
+      },
+      Action: "SNS:Publish",
+      Resource: topicArn,
+      Condition: {
+        ArnLike: {
+          "aws:SourceArn": `arn:aws:s3:::${bucketName}`,
         },
       },
-    ],
-  }),
+    },
+  ],
+});
+
+export {
+  generateBucketSnsPolicy,
 };

--- a/components/aws/sources/common/s3.mjs
+++ b/components/aws/sources/common/s3.mjs
@@ -1,0 +1,135 @@
+import { v4 as uuid } from "uuid";
+import base from "./sns.mjs";
+import commonS3 from "../../common/common-s3.mjs";
+import { generateBucketSnsPolicy } from "./policies.mjs";
+
+export default {
+  ...base,
+  props: {
+    ...base.props,
+    bucket: commonS3.props.bucket,
+  },
+  hooks: {
+    ...base.hooks,
+    async activate() {
+      this._setRegion(this.region);
+
+      await base.hooks.activate.call(this);
+
+      const topicArn = this.getTopicArn();
+      await this._enableBucketNotifications(this.bucket, topicArn);
+    },
+    async deactivate() {
+      const topicArn = this.getTopicArn();
+      await this._disableBucketNotifications(this.bucket, topicArn);
+
+      await base.hooks.deactivate.call(this);
+
+      this._setRegion(null);
+    },
+  },
+  methods: {
+    ...base.methods,
+    ...commonS3.methods,
+    _setRegion(region) {
+      this.db.set("region", region);
+    },
+    async _grantNotificationPermissions(bucketName, topicArn) {
+      const attributeName = "Policy";
+      const attributeValue = JSON.stringify(
+        generateBucketSnsPolicy(bucketName, topicArn),
+      );
+      await this.setTopicAttribute(topicArn, attributeName, attributeValue);
+    },
+    async _getBucketNotifications(bucketName) {
+      const params = {
+        Bucket: bucketName,
+      };
+      return this.getBucketNotificationConfiguration(params);
+    },
+    async _setBucketNotifications(bucketName, config) {
+      const params = {
+        Bucket: bucketName,
+        NotificationConfiguration: config,
+      };
+      return this.putBucketNotificationConfiguration(params);
+    },
+    async _enableBucketNotifications(bucketName, topicArn) {
+      await this._grantNotificationPermissions(bucketName, topicArn);
+
+      const newSnsConfig = {
+        TopicArn: topicArn,
+        Events: this.getEvents(),
+      };
+
+      const {
+        TopicConfigurations: snsConfigs = [],
+        ...bucketNotifications
+      } = await this._getBucketNotifications(bucketName);
+
+      const newNotificationsConfig = {
+        ...bucketNotifications,
+        TopicConfigurations: [
+          ...snsConfigs,
+          newSnsConfig,
+        ],
+      };
+
+      await this._setBucketNotifications(bucketName, newNotificationsConfig);
+    },
+    async _disableBucketNotifications(bucketName, topicArn) {
+      const {
+        TopicConfigurations: snsConfigs = [],
+        ...bucketNotifications
+      } = await this._getBucketNotifications(bucketName);
+      const newSnsConfigs = snsConfigs.filter(
+        ({ TopicArn: configTopicArn }) => configTopicArn !== topicArn,
+      );
+      const newNotificationsConfig = {
+        ...bucketNotifications,
+        TopicConfigurations: newSnsConfigs,
+      };
+      await this._setBucketNotifications(bucketName, newNotificationsConfig);
+    },
+    getEvents() {
+      throw new Error("getEvents is not implemented");
+    },
+    getRegion() {
+      return this.db
+        ? this.db.get("region")
+        : undefined;
+    },
+    getTopicName() {
+      const topicNameCandidate = `pd-${this.bucket}-${uuid()}`;
+      return this.convertNameToValidSNSTopicName(topicNameCandidate);
+    },
+    generateMeta(data) {
+      const { "x-amz-request-id": id } = data.responseElements;
+      const { key: summary } = data.s3.object;
+      const { eventTime: isoTimestamp } = data;
+      return {
+        id,
+        summary,
+        ts: Date.parse(isoTimestamp),
+      };
+    },
+    processEvent(event) {
+      const { Message: rawMessage } = event.body;
+      const {
+        Records: s3Events = [],
+        Event: eventType,
+      } = JSON.parse(rawMessage);
+
+      if (eventType === "s3:TestEvent") {
+        console.log("Received initial test event. Skipping...");
+        return;
+      }
+
+      s3Events.forEach((s3Event) => {
+        const meta = this.generateMeta(s3Event);
+        const { s3: item } = s3Event;
+        this.$emit(item, meta);
+      });
+    },
+  },
+};

--- a/components/aws/sources/s3-deleted-file/s3-deleted-file.mjs
+++ b/components/aws/sources/s3-deleted-file/s3-deleted-file.mjs
@@ -1,0 +1,40 @@
+import base from "../common/s3.mjs";
+
+export default {
+  ...base,
+  type: "source",
+  key: "aws-s3-deleted-file",
+  name: "New Deleted S3 File",
+  description: "Emit new event when a file is deleted from a S3 bucket",
+  version: "0.0.1",
+  dedupe: "unique",
+  props: {
+    ...base.props,
+    ignoreDeleteMarkers: {
+      type: "boolean",
+      label: "Ignore Delete Markers",
+      description: "When ignoring delete markers this will only emit events for permanently deleted files",
+      default: false,
+    },
+  },
+  methods: {
+    ...base.methods,
+    getEvents() {
+      return [
+        this.ignoreDeleteMarkers
+          ? "s3:ObjectRemoved:Delete"
+          : "s3:ObjectRemoved:*",
+      ];
+    },
+    generateMeta(data) {
+      const { "x-amz-request-id": id } = data.responseElements;
+      const { key } = data.s3.object;
+      const { eventTime: isoTimestamp } = data;
+      return {
+        id,
+        summary: `Deleted file: '${key}'`,
+        ts: Date.parse(isoTimestamp),
+      };
+    },
+  },
+};

--- a/components/aws/sources/s3-new-event/s3-new-event.mjs
+++ b/components/aws/sources/s3-new-event/s3-new-event.mjs
@@ -1,0 +1,54 @@
+import base from "../common/s3.mjs";
+
+export default {
+  ...base,
+  type: "source",
+  key: "aws-s3-new-event",
+  name: "New S3 Event",
+  description: "Emit new S3 events for a given bucket",
+  version: "0.0.1",
+  dedupe: "unique",
+  props: {
+    ...base.props,
+    eventTypes: {
+      type: "string[]",
+      label: "Event Types",
+      description: "The type of events to watch",
+      options: [
+        // See the AWS docs for more information about the supported events emitted by S3: https://amzn.to/3AtmKy1
+        "s3:ObjectCreated:Put",
+        "s3:ObjectCreated:Post",
+        "s3:ObjectCreated:Copy",
+        "s3:ObjectCreated:CompleteMultipartUpload",
+        "s3:ObjectRemoved:Delete",
+        "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:Post",
+        "s3:ObjectRestore:Completed",
+        "s3:ReducedRedundancyLostObject",
+        "s3:Replication:OperationFailedReplication",
+        "s3:Replication:OperationMissedThreshold",
+        "s3:Replication:OperationReplicatedAfterThreshold",
+        "s3:Replication:OperationNotTracked",
+      ],
+    },
+  },
+  methods: {
+    ...base.methods,
+    getEvents() {
+      return this.eventTypes;
+    },
+    generateMeta(data) {
+      const { "x-amz-request-id": id } = data.responseElements;
+      const { key } = data.s3.object;
+      const {
+        eventTime: isoTimestamp,
+        eventName,
+      } = data;
+      return {
+        id,
+        summary: `'${eventName}' for '${key}'`,
+        ts: Date.parse(isoTimestamp),
+      };
+    },
+  },
+};

--- a/components/aws/sources/s3-new-file/s3-new-file.mjs
+++ b/components/aws/sources/s3-new-file/s3-new-file.mjs
@@ -1,0 +1,29 @@
+import base from "../common/s3.mjs";
+
+export default {
+  ...base,
+  type: "source",
+  key: "aws-s3-new-file",
+  name: "New S3 File",
+  description: "Emit new event when a file is added to an S3 bucket",
+  version: "0.0.1",
+  dedupe: "unique",
+  methods: {
+    ...base.methods,
+    getEvents() {
+      return [
+        "s3:ObjectCreated:*",
+      ];
+    },
+    generateMeta(data) {
+      const { "x-amz-request-id": id } = data.responseElements;
+      const { key } = data.s3.object;
+      const { eventTime: isoTimestamp } = data;
+      return {
+        id,
+        summary: `New file: '${key}'`,
+        ts: Date.parse(isoTimestamp),
+      };
+    },
+  },
+};

--- a/components/aws/sources/s3-restored-file/s3-restored-file.mjs
+++ b/components/aws/sources/s3-restored-file/s3-restored-file.mjs
@@ -1,0 +1,40 @@
+import base from "../common/s3.mjs";
+
+export default {
+  ...base,
+  type: "source",
+  key: "aws-s3-restored-file",
+  name: "New Restored S3 File",
+  description: "Emit new event when an file is restored into a S3 bucket",
+  version: "0.0.1",
+  dedupe: "unique",
+  props: {
+    ...base.props,
+    detectRestoreInitiation: {
+      type: "boolean",
+      label: "Detect Restore Initiation",
+      description: "When enabled, this event source will also emit events whenever a restore is initiated",
+      default: false,
+    },
+  },
+  methods: {
+    ...base.methods,
+    getEvents() {
+      return [
+        this.detectRestoreInitiation
+          ? "s3:ObjectRestore:*"
+          : "s3:ObjectRestore:Completed",
+      ];
+    },
+    generateMeta(data) {
+      const { "x-amz-request-id": id } = data.responseElements;
+      const { key } = data.s3.object;
+      const { eventTime: isoTimestamp } = data;
+      return {
+        id,
+        summary: `Restored file: '${key}'`,
+        ts: Date.parse(isoTimestamp),
+      };
+    },
+  },
+};


### PR DESCRIPTION
Continuation of #1797. Applies the changes and uses AWS v3 clients.

Please review this along with #2302, since it depends on it (this branch is one commit ahead).

Resolves #1797, Resolves #1194.