### PR TITLE
1542-google-sheets-component-improvements

### DIFF
--- a/components/google_drive/sources/new-files-instant/new-files-instant.mjs
+++ b/components/google_drive/sources/new-files-instant/new-files-instant.mjs
@@ -8,9 +8,8 @@ export default {
   ...common,
   key: "google_drive-new-files-instant",
   name: "New Files (Instant)",
-  description:
-    "Emits a new event any time a new file is added in your linked Google Drive",
-  version: "0.0.14",
+  description: "Emit new event any time a new file is added in your linked Google Drive",
+  version: "0.0.15",
   type: "source",
   dedupe: "unique",
   props: {
@@ -83,7 +82,7 @@ export default {
         }
 
         this.$emit(fileInfo, {
-          summary: `New File ID: ${file.id}`,
+          summary: `New File: ${fileInfo.name}`,
           id: file.id,
           ts: createdTime,
         });

--- a/components/google_sheets/sources/new-spreadsheet/new-spreadsheet.mjs
+++ b/components/google_sheets/sources/new-spreadsheet/new-spreadsheet.mjs
@@ -5,9 +5,23 @@ export default {
   key: "google_sheets-new-spreadsheet",
   type: "source",
   name: "New Spreadsheet (Instant)",
-  description:
-    "Emit new event each time a new spreadsheet is created in a drive.",
-  version: "0.0.11",
+  description: "Emit new event each time a new spreadsheet is created in a drive.",
+  version: "0.0.12",
+  hooks: {
+    ...newFilesInstant.hooks,
+    async deploy() {
+      // Emit sample records on the first run
+      const spreadsheets = await this.getSpreadsheets(10);
+      for (const fileInfo of spreadsheets) {
+        const createdTime = Date.parse(fileInfo.createdTime);
+        this.$emit(fileInfo, {
+          summary: `New File: ${fileInfo.name}`,
+          id: fileInfo.id,
+          ts: createdTime,
+        });
+      }
+    },
+  },
   methods: {
     ...newFilesInstant.methods,
     shouldProcess(file) {
@@ -15,6 +29,34 @@ export default {
         file.mimeType.includes("spreadsheet") &&
         newFilesInstant.methods.shouldProcess.bind(this)(file)
       );
+    },
+    getSpreadsheetsFromFolderOpts(folderId) {
+      const mimeQuery = "mimeType = 'application/vnd.google-apps.spreadsheet'";
+      let opts = {};
+      if (!this.isMyDrive()) {
+        opts = {
+          corpora: "drive",
+          driveId: this.getDriveId(),
+          includeItemsFromAllDrives: true,
+          supportsAllDrives: true,
+        };
+      }
+      opts.q = `${mimeQuery} and parents in '${folderId}' and trashed = false`;
+      return opts;
+    },
+    async getSpreadsheets(limit) {
+      const spreadsheets = [];
+      const foldersIds = this.folders;
+      for (const folderId of foldersIds) {
+        const opts = this.getSpreadsheetsFromFolderOpts(folderId);
+        const filesWrapper = await this.googleDrive.listFilesInPage(null, opts);
+        for (const file of filesWrapper.files) {
+          const fileInfo = await this.googleDrive.getFile(file.id);
+          spreadsheets.push(fileInfo);
+          if (spreadsheets.length >= limit) { return spreadsheets; }
+        }
+      }
+      return spreadsheets;
     },
   },
 };

--- a/components/google_sheets/sources/new-spreadsheet/new-spreadsheet.mjs
+++ b/components/google_sheets/sources/new-spreadsheet/new-spreadsheet.mjs
@@ -32,16 +32,18 @@ export default {
     },
     getSpreadsheetsFromFolderOpts(folderId) {
       const mimeQuery = "mimeType = 'application/vnd.google-apps.spreadsheet'";
-      let opts = {};
+      let opts = {
+        q: `${mimeQuery} and parents in '${folderId}' and trashed = false`,
+      };
       if (!this.isMyDrive()) {
         opts = {
           corpora: "drive",
           driveId: this.getDriveId(),
           includeItemsFromAllDrives: true,
           supportsAllDrives: true,
+          ...opts,
         };
       }
-      opts.q = `${mimeQuery} and parents in '${folderId}' and trashed = false`;
       return opts;
     },
     async getSpreadsheets(limit) {


### PR DESCRIPTION
**Improving New Spreadsheet (Instant) source**
- Adding a deploy hook, to emit sample records on the first run (first 10 files)
- Changing summary on `New Spreadsheet (Instant)` and `New Files (Instant)` from `New File: ${file.id}` to `New File: ${fileInfo.name}`