### PR TITLE
Add bannerbear create image action

### DIFF
--- a/components/bannerbear/actions/create-image/create-image.mjs
+++ b/components/bannerbear/actions/create-image/create-image.mjs
@@ -1,4 +1,4 @@
-import bannerbear from '../../bannerbear.app.mjs'
+import bannerbear from "../../bannerbear.app.mjs";
 
 export default {
   key: "bannerbear-create-image",
@@ -15,17 +15,18 @@ export default {
       ],
     },
     modifications: {
-      type: 'string',
-      description: 'A list of modifications in JSON string format, for example: "[{"name": "message", "text": "test message"}]". [See the docs](https://developers.bannerbear.com/#post-v2-images)',
-    }
+      type: "string",
+      label: "Modifications",
+      description: "A list of modifications in JSON string format, for example: \"[{\"name\": \"message\", \"text\": \"test message\"}]\". [See the docs](https://developers.bannerbear.com/#post-v2-images)",
+    },
   },
   async run({ $ }) {
-    const rawModification = this.modifications
-    let modifications
+    const rawModification = this.modifications;
+    let modifications;
     try {
-      modifications = JSON.parse(rawModification)
-    } catch(err){
-      throw new Error('Failed to parse `modifications` as JSON. Please fix your input and try again.')
+      modifications = JSON.parse(rawModification);
+    } catch (err) {
+      throw new Error("Failed to parse `modifications` as JSON. Please fix your input and try again.");
     }
 
     const response = await this.bannerbear.createImage(

--- a/components/bannerbear/actions/create-image/create-image.mjs
+++ b/components/bannerbear/actions/create-image/create-image.mjs
@@ -1,0 +1,41 @@
+import bannerbear from '../../bannerbear.app.mjs'
+
+export default {
+  key: "bannerbear-create-image",
+  name: "Create an Image",
+  description: "Create an image using template and modifications. [See the docs](https://developers.bannerbear.com/#post-v2-images)",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    bannerbear,
+    template: {
+      propDefinition: [
+        bannerbear,
+        "template",
+      ],
+    },
+    modifications: {
+      type: 'string',
+      description: 'A list of modifications in JSON string format, for example: "[{"name": "message", "text": "test message"}]". [See the docs](https://developers.bannerbear.com/#post-v2-images)',
+    }
+  },
+  async run({ $ }) {
+    const rawModification = this.modifications
+    let modifications
+    try {
+      modifications = JSON.parse(rawModification)
+    } catch(err){
+      throw new Error('Failed to parse `modifications` as JSON. Please fix your input and try again.')
+    }
+
+    const response = await this.bannerbear.createImage(
+      $,
+      this.template,
+      modifications,
+    );
+
+    $.export("$summary", "Create image successfully.");
+
+    return response;
+  },
+};

--- a/components/bannerbear/bannerbear.app.mjs
+++ b/components/bannerbear/bannerbear.app.mjs
@@ -9,8 +9,10 @@ export default {
       label: "Template",
       description: "BannerBear template. [See the docs](https://developers.bannerbear.com/#get-v2-templates)",
       async options({ prevContext }) {
-        const currentPage = prevContext.nextPage || 1
-        const templates = await this.fetchTemplates(this, { page: currentPage });
+        const currentPage = prevContext.nextPage || 1;
+        const templates = await this.fetchTemplates(this, {
+          page: currentPage,
+        });
         const options = this._extractTemplateOptions(templates);
 
         return this._buildPaginatedOptions(options, currentPage);
@@ -20,23 +22,23 @@ export default {
   methods: {
     async fetchTemplates(ctx = this, params = {}) {
       const response = await axios(ctx, this._getRequestParams({
-        method: 'GET',
-        url: 'https://api.bannerbear.com/v2/templates',
-        ...params
-      }))
+        method: "GET",
+        url: "https://api.bannerbear.com/v2/templates",
+        ...params,
+      }));
 
-      return response
+      return response;
     },
     async createImage(ctx = this, template, modifications, params = {}) {
       const response = await axios(ctx, this._getRequestParams({
-        method: 'POST',
-        url: 'https://sync.api.bannerbear.com/v2/images',
+        method: "POST",
+        url: "https://sync.api.bannerbear.com/v2/images",
         data: {
           template,
           modifications,
         },
-        ...params
-      }))
+        ...params,
+      }));
 
       return response;
     },
@@ -61,7 +63,10 @@ export default {
     },
     _extractTemplateOptions(templates) {
       const options = templates.map((template) => {
-        const {name, uid} = template
+        const {
+          name,
+          uid,
+        } = template;
 
         return {
           label: name || "Untitled",

--- a/components/bannerbear/bannerbear.app.mjs
+++ b/components/bannerbear/bannerbear.app.mjs
@@ -1,11 +1,75 @@
+import { axios } from "@pipedream/platform";
+
 export default {
   type: "app",
   app: "bannerbear",
-  propDefinitions: {},
+  propDefinitions: {
+    template: {
+      type: "string",
+      label: "Template",
+      description: "BannerBear template. [See the docs](https://developers.bannerbear.com/#get-v2-templates)",
+      async options({ prevContext }) {
+        const currentPage = prevContext.nextPage || 1
+        const templates = await this.fetchTemplates(this, { page: currentPage });
+        const options = this._extractTemplateOptions(templates);
+
+        return this._buildPaginatedOptions(options, currentPage);
+      },
+    },
+  },
   methods: {
-    // this.$auth contains connected account data
-    authKeys() {
-      console.log(Object.keys(this.$auth));
+    async fetchTemplates(ctx = this, params = {}) {
+      const response = await axios(ctx, this._getRequestParams({
+        method: 'GET',
+        url: 'https://api.bannerbear.com/v2/templates',
+        ...params
+      }))
+
+      return response
+    },
+    async createImage(ctx = this, template, modifications, params = {}) {
+      const response = await axios(ctx, this._getRequestParams({
+        method: 'POST',
+        url: 'https://sync.api.bannerbear.com/v2/images',
+        data: {
+          template,
+          modifications,
+        },
+        ...params
+      }))
+
+      return response;
+    },
+    _getHeaders() {
+      return {
+        "Authorization": `Bearer ${this.$auth.api_key}`,
+      };
+    },
+    _getRequestParams(opts = {}) {
+      return {
+        ...opts,
+        headers: this._getHeaders(),
+      };
+    },
+    _buildPaginatedOptions(options, currentPage) {
+      return {
+        options,
+        context: {
+          nextPage: currentPage + 1,
+        },
+      };
+    },
+    _extractTemplateOptions(templates) {
+      const options = templates.map((template) => {
+        const {name, uid} = template
+
+        return {
+          label: name || "Untitled",
+          value: uid,
+        };
+      });
+
+      return options;
     },
   },
 };


### PR DESCRIPTION
This PR adds BannerBear create an image action. Related to this issue https://github.com/PipedreamHQ/pipedream/issues/753

This PR replaces the closed PR here: https://github.com/PipedreamHQ/pipedream/pull/2709

BannerBear API Doc can be found here: https://developers.bannerbear.com/#introduction

BannerBear Create Image API Doc can be found here: https://developers.bannerbear.com/#post-v2-images

Select templates
![Screen Shot 2022-04-29 at 08 29 11](https://user-images.githubusercontent.com/18277920/165872646-c7ee596e-a8da-495f-b406-2f6712e9360a.png)


Set `modifications`
![Screen Shot 2022-04-29 at 08 28 54](https://user-images.githubusercontent.com/18277920/165872655-9b141481-92af-4ed4-845a-f635ed87e912.png)


Additionally I have added the user-friendly user message in case that the modifications field is incorrect
![Screen Shot 2022-04-29 at 08 32 58](https://user-images.githubusercontent.com/18277920/165872560-2650075d-f0be-4dda-82ae-cc91dc8e1dc2.png)

 