### PR TITLE
bug in create or update customer in customer.io put

### DIFF
--- a/components/customer_io/actions/create-or-update-customer/create-or-update-customer.mjs
+++ b/components/customer_io/actions/create-or-update-customer/create-or-update-customer.mjs
@@ -5,7 +5,7 @@ export default {
   key: "customer_io-create-or-update-customer",
   name: "Create or Update Customer",
   description: "Creates or update a customer.",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
   props: {
     customer_io: {

--- a/components/customer_io/actions/create-or-update-customer/create-or-update-customer.mjs
+++ b/components/customer_io/actions/create-or-update-customer/create-or-update-customer.mjs
@@ -44,7 +44,7 @@ export default {
 
     const config = {
       method: "put",
-      url: `https://track.customer.io/api/v1/customers/$${this.customer_id}`,
+      url: `https://track.customer.io/api/v1/customers/${this.customer_id}`,
       headers: {
         Authorization: `Basic ${base64BasicauthUserPwd}`,
       },


### PR DESCRIPTION
minor issue ... extra $ left in as typo

You now always get the error
`email attribute and identifier are not the same email address`

Testing the same thing in cURL works