### PR TITLE
[Actions] Mautic

### DIFF
--- a/components/mautic/actions/create-contacts/create-contacts.mjs
+++ b/components/mautic/actions/create-contacts/create-contacts.mjs
@@ -5,7 +5,7 @@ export default {
   key: "mautic-create-contacts",
   name: "Create Contact",
   description: "Creates a new contact.",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
   props: {
     mautic: {
@@ -196,6 +196,11 @@ export default {
       description: "If true, then empty values are set to fields. Otherwise empty values are skipped",
       optional: true,
     },
+    tags: {
+      type: "string[]",
+      description: "Tags that will be assigned to new contact.",
+      optional: true,
+    },
   },
   async run({ $ }) {
   //See the API docs at: https://developer.mautic.org/#create-contact
@@ -252,6 +257,7 @@ export default {
         lastActive: this.lastActive,
         owner: this.owner,
         overwriteWithBlank: this.overwriteWithBlank,
+        tags: this.tags,
       },
     });
   },


### PR DESCRIPTION
  - Updated "create-contacts" action, added new "tags" option.
  - Tags can be created and assiged to new contact.

Tested scenarios:
  - No tags option provided (user created, tags not created)
  - Empty tags provided (user created, tags not created)
  - Tags provided ( user created with tags )