### PR TITLE
75 watch an url

### DIFF
--- a/components/http/package-lock.json
+++ b/components/http/package-lock.json
@@ -1,0 +1,31 @@
+{
+    "name": "@pipedream/http",
+    "version": "0.3.3",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "@pipedream/http",
+            "version": "0.3.3",
+            "license": "MIT",
+            "dependencies": {
+                "object-hash": "^3.0.0"
+            }
+        },
+        "node_modules/object-hash": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+            "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+            "engines": {
+                "node": ">= 6"
+            }
+        }
+    },
+    "dependencies": {
+        "object-hash": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+            "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="
+        }
+    }
+}

--- a/components/http/package.json
+++ b/components/http/package.json
@@ -13,5 +13,8 @@
     "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
     "publishConfig": {
         "access": "public"
+    },
+    "dependencies": {
+        "object-hash": "^3.0.0"
     }
 }

--- a/components/http/sources/watch-url/watch-url.mjs
+++ b/components/http/sources/watch-url/watch-url.mjs
@@ -1,0 +1,126 @@
+import http from "../../http.app.mjs";
+import axios from "axios";
+import hash from "object-hash";
+import { ConfigurationError } from "@pipedream/platform";
+
+export default {
+  key: "http-watch-url",
+  name: "New item from Watching URL",
+  description: "Emit new item when the response of the watched URL changes.",
+  version: "0.0.1",
+  type: "source",
+  props: {
+    timer: {
+      type: "$.interface.timer",
+      label: "Watching timer",
+      description: "How often to watch the URL.",
+      default: {
+        intervalSeconds: 60 * 15,
+      },
+    },
+    method: {
+      label: "Method",
+      description: "The configured HTTP Method for this request.",
+      type: "string",
+      default: "GET",
+      options: [
+        "GET",
+        "POST",
+        "PUT",
+        "DELETE",
+      ],
+    },
+    url: {
+      label: "URL",
+      description: "The watched URL.",
+      type: "string",
+    },
+    params: {
+      label: "Query params",
+      description: "Data to be sent on the `Request URL` as query parameters.",
+      type: "object",
+      optional: true,
+      default: {},
+    },
+    body: {
+      label: "Body",
+      description: "Data to be sent on the `Request Body`.",
+      type: "string",
+      optional: true,
+    },
+    headers: {
+      label: "Headers",
+      description: "Headers to be sent on the `Request Headers`.",
+      type: "object",
+      optional: true,
+      default: {},
+    },
+    emitAsArray: {
+      label: "Emit as array",
+      description: "Is expected that the provided URL should return a JSON Array, on this case this source will emit changes individually for each item of the array",
+      type: "boolean",
+      optional: false,
+    },
+    emitBodyOnly: {
+      label: "Emit body only",
+      description: "If set as true the emitted item will contain only the body, else it will also contain status information of the request.",
+      type: "boolean",
+      optional: false,
+    },
+    http,
+  },
+  methods: {
+    getMeta(data, status) {
+      if (this.emitBodyOnly) {
+        return data;
+      }
+      return {
+        data,
+        status,
+      };
+    },
+    emitArray(event, response) {
+      if (!Array.isArray(response.data)) {
+        throw new ConfigurationError("Response is not a JSON Array.");
+      }
+      for (const item of response.data) {
+        const meta = this.getMeta(item, response.status);
+        this.emit(event, meta);
+      }
+    },
+    emitAny(event, response) {
+      const meta = this.getMeta(response.data, response.status);
+      this.emit(event, meta);
+    },
+    emit(event, meta) {
+      const timestamp = event.timestamp || Math.round(Date.now() / 1000);
+      const summary = `${timestamp} ${this.method} ${this.url} `;
+      this.$emit(meta, {
+        summary,
+        id: hash(meta),
+      });
+    },
+  },
+  async run(event) {
+    const headers = {
+      "User-Agent": "pipedream/1",
+      ...this.headers,
+    };
+    const data = this.body || undefined;
+    const params = this.params || undefined;
+
+    const response = await axios({
+      method: this.method,
+      url: this.url,
+      params,
+      data,
+      headers,
+    });
+
+    if (this.emitAsArray) {
+      this.emitArray(event, response);
+    } else {
+      this.emitAny(event, response);
+    }
+  },
+};

--- a/components/http/sources/watch-url/watch-url.mjs
+++ b/components/http/sources/watch-url/watch-url.mjs
@@ -1,15 +1,15 @@
 import http from "../../http.app.mjs";
-import axios from "axios";
 import hash from "object-hash";
-import { ConfigurationError } from "@pipedream/platform";
 
 export default {
   key: "http-watch-url",
-  name: "New item from Watching URL",
-  description: "Emit new item when the response of the watched URL changes.",
+  name: "New event when the content of an URL changes.",
+  description: "Emit new event when the content of an URL changes.",
   version: "0.0.1",
   type: "source",
+  dedupe: "unique",
   props: {
+    http,
     timer: {
       type: "$.interface.timer",
       label: "Watching timer",
@@ -18,56 +18,26 @@ export default {
         intervalSeconds: 60 * 15,
       },
     },
-    method: {
-      label: "Method",
-      description: "The configured HTTP Method for this request.",
-      type: "string",
-      default: "GET",
-      options: [
-        "GET",
-        "POST",
-        "PUT",
-        "DELETE",
-      ],
-    },
-    url: {
-      label: "URL",
-      description: "The watched URL.",
-      type: "string",
-    },
-    params: {
-      label: "Query params",
-      description: "Data to be sent on the `Request URL` as query parameters.",
-      type: "object",
-      optional: true,
-      default: {},
-    },
-    body: {
-      label: "Body",
-      description: "Data to be sent on the `Request Body`.",
-      type: "string",
-      optional: true,
-    },
-    headers: {
-      label: "Headers",
-      description: "Headers to be sent on the `Request Headers`.",
-      type: "object",
-      optional: true,
-      default: {},
-    },
-    emitAsArray: {
-      label: "Emit as array",
-      description: "Is expected that the provided URL should return a JSON Array, on this case this source will emit changes individually for each item of the array.",
-      type: "boolean",
-      optional: false,
+    httpRequest: {
+      type: "http_request",
+      label: "HTTP Request Configuration",
+      description: "HTTP Request Configuration",
+      default: {
+        method: "GET",
+      },
     },
     emitBodyOnly: {
       label: "Emit body only",
-      description: "If set as true the emitted item will contain only the response body, otherwise, it will be included the request status information.",
+      description: "If set as true the emitted item will contain only the response body, otherwise, it will include the request status code.",
       type: "boolean",
-      optional: false,
+      default: true,
     },
-    http,
+    emitAsArray: {
+      label: "Emit as array",
+      description: "If the request responds with an array, this source will emit changes individually for each item of the array.",
+      type: "boolean",
+      default: false,
+    },
   },
   methods: {
     getMeta(data, status) {
@@ -81,7 +51,7 @@ export default {
     },
     emitArray(event, response) {
       if (!Array.isArray(response.data)) {
-        throw new ConfigurationError("Response is not a JSON Array.");
+        return this.emitAny(event, response);
       }
       for (const item of response.data) {
         const meta = this.getMeta(item, response.status);
@@ -93,30 +63,16 @@ export default {
       this.emit(event, meta);
     },
     emit(event, meta) {
-      const timestamp = event.timestamp || Math.round(Date.now() / 1000);
-      const summary = `${timestamp} ${this.method} ${this.url} `;
+      const ts = event.timestamp || Math.round(Date.now() / 1000);
       this.$emit(meta, {
-        summary,
         id: hash(meta),
+        summary: `Requested at ${ts}`,
+        ts,
       });
     },
   },
   async run(event) {
-    const headers = {
-      "User-Agent": "pipedream/1",
-      ...this.headers,
-    };
-    const data = this.body || undefined;
-    const params = this.params || undefined;
-
-    const response = await axios({
-      method: this.method,
-      url: this.url,
-      params,
-      data,
-      headers,
-    });
-
+    const response = await this.httpRequest.execute();
     if (this.emitAsArray) {
       this.emitArray(event, response);
     } else {

--- a/components/http/sources/watch-url/watch-url.mjs
+++ b/components/http/sources/watch-url/watch-url.mjs
@@ -57,13 +57,13 @@ export default {
     },
     emitAsArray: {
       label: "Emit as array",
-      description: "Is expected that the provided URL should return a JSON Array, on this case this source will emit changes individually for each item of the array",
+      description: "Is expected that the provided URL should return a JSON Array, on this case this source will emit changes individually for each item of the array.",
       type: "boolean",
       optional: false,
     },
     emitBodyOnly: {
       label: "Emit body only",
-      description: "If set as true the emitted item will contain only the body, else it will also contain status information of the request.",
+      description: "If set as true the emitted item will contain only the response body, otherwise, it will be included the request status information.",
       type: "boolean",
       optional: false,
     },

--- a/components/http/sources/watch-url/watch-url.mjs
+++ b/components/http/sources/watch-url/watch-url.mjs
@@ -3,8 +3,8 @@ import hash from "object-hash";
 
 export default {
   key: "http-watch-url",
-  name: "New event when the content of an URL changes.",
-  description: "Emit new event when the content of an URL changes.",
+  name: "New event when the content of the URL changes.",
+  description: "Emit new event when the content of the URL changes.",
   version: "0.0.1",
   type: "source",
   dedupe: "unique",


### PR DESCRIPTION
**New event when the content of the URL changes.**

**Emit body only:**
If set as true the emitted item will contain only the response body, otherwise, it will include the request status code.

**Emit as array:**
If the request responds with an array, this source will emit changes individually for each item of the array.

FYI:
This source uses a prop of type `http_request` that is not supported by the CLI;
For testing, use the web interface, see: https://pipedream-users.slack.com/archives/G01J50YGJGP/p1652141349624249?thread_ts=1652140519.202669&cid=G01J50YGJGP