### PR TITLE
[Actions] JIRA (Create Issue)

### DIFF
--- a/components/jira/actions/create-issue/create-issue.mjs
+++ b/components/jira/actions/create-issue/create-issue.mjs
@@ -38,7 +38,7 @@ export default {
       description: "The ID of the project where the issue will be created.",
     },
     description: {
-      type: "object",
+      type: "string",
       description: "Description object of the issue.",
       optional: true,
     },

--- a/components/jira/actions/create-issue/create-issue.mjs
+++ b/components/jira/actions/create-issue/create-issue.mjs
@@ -158,10 +158,6 @@ export default {
       project: {
         id: this.projectID,
       },
-      description: this.description,
-      reporter: {
-        id: this.reporter_id,
-      },
       fixVersions: this.fixVersions,
       labels: this.labels,
       environment: this.environment,

--- a/components/jira/actions/create-issue/create-issue.mjs
+++ b/components/jira/actions/create-issue/create-issue.mjs
@@ -182,11 +182,11 @@ export default {
             content: [
               {
                 text: this.description,
-                type: "text"
-              }
-            ]
-          }
-        ]
+                type: "text",
+              },
+            ],
+          },
+        ],
       };
     }
 

--- a/components/jira/actions/create-issue/create-issue.mjs
+++ b/components/jira/actions/create-issue/create-issue.mjs
@@ -40,9 +40,11 @@ export default {
     description: {
       type: "object",
       description: "Description object of the issue.",
+      optional: true,
     },
     reporter_id: {
       type: "string",
+      optional: true,
     },
     fixVersions: {
       type: "any",

--- a/components/jira/actions/create-issue/create-issue.mjs
+++ b/components/jira/actions/create-issue/create-issue.mjs
@@ -172,6 +172,30 @@ export default {
       },
     };
 
+    if (this.description) {
+      fields["description"] = {
+        type: "doc",
+        version: 1,
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              {
+                text: this.description,
+                type: "text"
+              }
+            ]
+          }
+        ]
+      };
+    }
+
+    if (this.reporter_id) {
+      fields["reporter"] = {
+        id: this.reporter_id,
+      };
+    }
+
     if (this.priority_id) {
       fields["priority"] = {
         id: this.priority_id,


### PR DESCRIPTION
### Issue:
The current version of the `jira-create-issue` action requires both a `description` and a `reporter_id`. This leaves the action incompatible with some projects. 

- `description` requires use of the  'Atlassian Document Format' object structure to complete the API call. As of 2022-05-20 the API rejects calls that include an empty object (the props default) instead of a complete structure.
- Presence of `reporter` in the body triggers a '400 Bad Request' response when issuing the API call for team managed projects.

Additionally, in the V2 workflow editor, the code for a prebuilt action cannot be modified inline to remove this requirement. Forcing the user to choose the `jira-make-api-call` action and then copy code from this Github repo to selectively modify the action.

### Solution:
Make both `description` and `reporter_id` optional and implement conditionals to handle their presence.

- `description` is now optional, and has been changed to a string format prop. The new conditional creates a valid 'Atlassian Document Format' object from the value if it's included by the user.
- `reporter_id` is now optional, and the property `reporter` is now defined inside the conditional for `reporter_id`