### PR TITLE
[Actions] JIRA (Transition Issue)

### DIFF
--- a/components/jira/actions/transition-issue/transition-issue.mjs
+++ b/components/jira/actions/transition-issue/transition-issue.mjs
@@ -5,7 +5,7 @@ export default {
   key: "jira-transition-issue",
   name: "Transition Issue",
   description: "Performs an issue transition and, if the transition has a screen, updates the fields from the transition screen.",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
   props: {
     jira: {

--- a/components/jira/actions/transition-issue/transition-issue.mjs
+++ b/components/jira/actions/transition-issue/transition-issue.mjs
@@ -123,6 +123,7 @@ export default {
         "Authorization": `Bearer ${this.jira.$auth.oauth_access_token}`,
         "Accept": "application/json",
       },
+      method: 'post',
       data: {
         "transition": this.transition,
         "fields": this.fields,


### PR DESCRIPTION
### Issue:
The `jira-transition-issue` action fails to commit the transition due to a malformed API request.

- Currently this action functions as a interrogative action (a query) rather than an imperative action. 
- The result of the current action is not a failure but a return of valid transition ids. (Similar to `jira-get-transitions`)

### Solution
Update the API call to properly declare intent according to the current JIRA API. (2022-05-20)

- Added `method: "post"` to the API request. (See [Transition Issue](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-transitions-post))