### PR TITLE
Rev version for Airtable Create Single Record

### DIFF
--- a/components/airtable/actions/create-single-record/create-single-record.mjs
+++ b/components/airtable/actions/create-single-record/create-single-record.mjs
@@ -10,7 +10,7 @@ export default {
   key: "airtable-create-single-record",
   name: "Create single record",
   description: "Adds a record to a table.",
-  version: "1.0.0",
+  version: "1.0.1",
   type: "action",
   props: {
     ...common.props,


### PR DESCRIPTION
This [publish-components job run](https://github.com/PipedreamHQ/pipedream/runs/6577787545?check_suite_focus=true#step:5:51) says `create_single_record` was published, but the new version does not appear in the builder. Revving version of `create_single_record` to republish.