### PR TITLE
Hubspot fix custom properties

### DIFF
--- a/components/hubspot/actions/common-create-object.mjs
+++ b/components/hubspot/actions/common-create-object.mjs
@@ -36,6 +36,15 @@ export default {
     } = this;
     const objectType = this.getObjectType();
 
+    // checkbox (string[]) props must be semicolon separated strings
+    Object.keys(properties)
+      .forEach((key) => {
+        let value = properties[key];
+        if (Array.isArray(value)) {
+          properties[key] = value.join(";");
+        }
+      });
+
     const response = await hubspot.createObject(objectType, properties, $);
 
     const objectName = hubspot.getObjectTypeName(objectType);

--- a/components/hubspot/actions/common-create.mjs
+++ b/components/hubspot/actions/common-create.mjs
@@ -56,7 +56,7 @@ export default {
         && (!property.options || property.options.length <= 500); // too many prop options cause the action to fail
     },
     makeLabelValueOptions(property) {
-      return property.options
+      const options = property.options
         .filter((o) => !o.hidden)
         .map(({
           label, value,
@@ -65,6 +65,10 @@ export default {
           value,
         }))
         .filter(({ label }) => label);
+
+      return options.length
+        ? options
+        : undefined;
     },
     makePropDefinition(property, requiredProperties) {
       let type = "string";

--- a/components/hubspot/actions/create-company/create-company.mjs
+++ b/components/hubspot/actions/create-company/create-company.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-create-company",
   name: "Create Company",
   description: "Create a company in Hubspot. [See the docs here](https://developers.hubspot.com/docs/api/crm/companies#endpoint?spec=POST-/crm/v3/objects/companies)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   methods: {
     ...common.methods,

--- a/components/hubspot/actions/create-contact/create-contact.mjs
+++ b/components/hubspot/actions/create-contact/create-contact.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-create-contact",
   name: "Create Contact",
   description: "Create a contact in Hubspot. [See the docs here](https://developers.hubspot.com/docs/api/crm/contacts#endpoint?spec=POST-/crm/v3/objects/contacts)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   methods: {
     ...common.methods,

--- a/components/hubspot/actions/create-deal/create-deal.mjs
+++ b/components/hubspot/actions/create-deal/create-deal.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-create-deal",
   name: "Create Deal",
   description: "Create a deal in Hubspot. [See the docs here](https://developers.hubspot.com/docs/api/crm/deals#endpoint?spec=POST-/crm/v3/objects/deals)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   methods: {
     ...common.methods,

--- a/components/hubspot/actions/create-engagement/create-engagement.mjs
+++ b/components/hubspot/actions/create-engagement/create-engagement.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-create-engagement",
   name: "Create Engagement",
   description: "Create a new engagement for a contact. [See the docs here](https://developers.hubspot.com/docs/api/crm/engagements)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     ...common.props,

--- a/components/hubspot/hubspot.app.mjs
+++ b/components/hubspot/hubspot.app.mjs
@@ -238,6 +238,15 @@ export default {
       };
       return axios($ ?? this, config);
     },
+    getObjectTypeName(objectType) {
+      if (!objectType.endsWith("s")) {
+        return objectType.toLowerCase();
+      }
+      if (objectType === "companies") {
+        return "company";
+      }
+      return objectType.toLowerCase().slice(0, -1);
+    },
     /**
      * Returns a label for a CRM object, intended to be used as the label for
      * prop options


### PR DESCRIPTION
Fixes:

- [X] There were a few custom properties that caused the `Unknown configuration error`: `radio`, `select` and `checkbox`. After filtering blank labels in options, they were fixed.
- [X] The `additionalProps` are set as `optional: true/false` depending on the schema. - **I couldn't find any required property to be able to test this**

Improvements:
  - [X] Enables `checkbox` properties by converting from csv (Pipedream) to semi colon separated values (HubSpot).

Resolves #2895.