### PR TITLE
Fix Google Sheets SheetName with '/'

### DIFF
--- a/components/google_sheets/actions/add-multiple-rows/add-multiple-rows.mjs
+++ b/components/google_sheets/actions/add-multiple-rows/add-multiple-rows.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_sheets-add-multiple-rows",
   name: "Add Multiple Rows",
   description: "Add multiple rows of data to a Google Sheet",
-  version: "0.1.4",
+  version: "0.1.5",
   type: "action",
   props: {
     googleSheets,

--- a/components/google_sheets/actions/add-single-row/add-single-row.mjs
+++ b/components/google_sheets/actions/add-single-row/add-single-row.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_sheets-add-single-row",
   name: "Add Single Row",
   description: "Add a single row of data to Google Sheets",
-  version: "2.0.7",
+  version: "2.0.8",
   type: "action",
   props: {
     googleSheets,

--- a/components/google_sheets/actions/upsert-row/upsert-row.mjs
+++ b/components/google_sheets/actions/upsert-row/upsert-row.mjs
@@ -21,7 +21,7 @@ export default {
   key: "google_sheets-upsert-row",
   name: "Upsert Row",
   description: "Upsert a row of data in a Google Sheet",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   props: {
     googleSheets,

--- a/components/google_sheets/google_sheets.app.mjs
+++ b/components/google_sheets/google_sheets.app.mjs
@@ -393,7 +393,7 @@ export default {
     }) {
       const resp = await axios({
         method: "POST",
-        url: `https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}/values/${encodeURI(range)}:append`,
+        url: `https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}/values/${encodeURIComponent(range)}:append`,
         headers: {
           "Authorization": `Bearer ${this.$auth.oauth_access_token}`,
         },


### PR DESCRIPTION
Change `encodeURI()` to `encodeURIComponent()`.

Resolves #2943.