### PR TITLE
Fix incremental build & publish of TS components

### DIFF
--- a/.github/workflows/publish-components.yaml
+++ b/.github/workflows/publish-components.yaml
@@ -142,6 +142,11 @@ jobs:
       - name: Compile TypeScript
         id: compile
         run: npm run build > files.txt
+      - name: Get Changed Files
+        id: files
+        uses: jitterbit/get-changed-files@v1
+        with:
+          format: 'csv'
       - name: Publish TypeScript components (dry run)
         env:
             PD_API_KEY: ${{ secrets.PD_API_KEY }}
@@ -151,7 +156,8 @@ jobs:
           IFS=$'\n'
           echo "The following files will be published on merge:"
           # Remove initial tsc output
-          for f in $(cat files.txt | sed 1,3d)
+          output_files=$(cat files.txt | sed 1,3d)
+          for f in $output_files
           do
             echo "$f"
           done
@@ -159,29 +165,53 @@ jobs:
           PUBLISHED=""
           ERRORS=""
           SKIPPED=""
-          # included in the components dir, ends with .*js (e.g. .js and .mjs) and not app.js,
-          # doesn't end with /common*.*js, and doesn't follow */common/
-          for f in $(cat files.txt | sed 1,3d); do
-            echo "Checking if $f is publishable"
-            if [[ $f == */components/* ]] && [[ $f == *.*js ]] && [[ $f != *.app.*js ]] \
-              && [[ $f != */common*.*js ]] && [[ $f != */common/* ]]
+          mapfile -d ',' -t added_modified_renamed_files < <(printf '%s,%s' '${{ steps.files.outputs.added_modified }}' '${{ steps.files.outputs.renamed }}')
+          # included in the components dir, ends with .ts and not app.ts,
+          # doesn't end with /common*.ts, and doesn't follow */common/
+          for added_modified_file in "${added_modified_renamed_files[@]}";
+          do
+            echo "Checking if $added_modified_file is a publishable ts file"
+            if [[ $added_modified_file == components/* ]] && [[ $added_modified_file == *.ts ]] && [[ $added_modified_file != *.app.ts ]] \
+                && [[ $added_modified_file != */common*.ts ]] && [[ $added_modified_file != */common/* ]]
             then
-              echo "attempting to publish ${f}"
-              PD_OUTPUT=`./pd publish ${f} --json`
-              if [ $? -eq 0 ]
+              # XXX This is a hacky way to publish only TS components with changes. If a changed
+              # file "path-a/path-b/c.ts" has a corresponding compiled output file
+              # "path-a/dist/path-b/c.mjs", attempt to publish the output `.mjs` file.
+              changed_output_file=""
+              for f in $output_files; # check each output file for a match
+              do
+                # Replaces /dist/path/filename.mjs with /path/filename.ts
+                maybe_source_file=$(echo "$f" | sed 's/\/dist\//\//;s/.mjs/\.ts/')
+                if [[ ${maybe_source_file} == **/${added_modified_file} ]]
+                then
+                  changed_output_file=${f}
+                  break
+                fi
+              done
+              if [[ $changed_output_file == "" ]]
               then
-                KEY=`echo $PD_OUTPUT | jq -r ".key"`
-                echo "published ${KEY}"
-                echo "${KEY} will be added to the registry"
-                curl "https://api.pipedream.com/graphql" -H "Content-Type: application/json" -H "Authorization: Bearer ${PD_API_KEY}" --data-binary $'{"query":"mutation($key: String!, $registry: Boolean!, $gitPath: String){\\n  setComponentRegistry(key: $key, registry: $registry, gitPath: $gitPath){\\n    savedComponent{\\n      id\\n      key\\n      gitPath\\n    }\\n  }\\n}","variables":{"key":"'${KEY}'","registry":'true',"gitPath":"'${f}'"}}'
-                PUBLISHED+="*${f}"
-              else
-                ERROR=`echo $PD_OUTPUT | jq -r ".error"`
-                ERROR_MESSAGE="${ERROR} with ${f}"
+                ERROR_MESSAGE="cannot find an output .mjs file with ${added_modified_file}"
                 echo $ERROR_MESSAGE
                 ERRORS+="*${ERROR_MESSAGE}"
-                UNPUBLISHED+="*${f}"
-                # add to array to spit out later
+                UNPUBLISHED+="*${added_modified_file}"
+              else
+                echo "attempting to publish ${changed_output_file}"
+                PD_OUTPUT=`./pd publish ${changed_output_file} --json`
+                if [ $? -eq 0 ]
+                then
+                  KEY=`echo $PD_OUTPUT | jq -r ".key"`
+                  echo "published ${KEY}"
+                  echo "${KEY} will be added to the registry"
+                  curl "https://api.pipedream.com/graphql" -H "Content-Type: application/json" -H "Authorization: Bearer ${PD_API_KEY}" --data-binary $'{"query":"mutation($key: String!, $registry: Boolean!, $gitPath: String){\\n  setComponentRegistry(key: $key, registry: $registry, gitPath: $gitPath){\\n    savedComponent{\\n      id\\n      key\\n      gitPath\\n    }\\n  }\\n}","variables":{"key":"'${KEY}'","registry":'true',"gitPath":"'${changed_output_file}'"}}'
+                  PUBLISHED+="*${changed_output_file}"
+                else
+                  ERROR=`echo $PD_OUTPUT | jq -r ".error"`
+                  ERROR_MESSAGE="${ERROR} with ${changed_output_file}"
+                  echo $ERROR_MESSAGE
+                  ERRORS+="*${ERROR_MESSAGE}"
+                  UNPUBLISHED+="*${changed_output_file}"
+                  # add to array to spit out later
+                fi
               fi
             else
               echo "${f} will not be added to the registry"

--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -224,15 +224,39 @@ jobs:
       - name: Compile TypeScript
         id: compile
         run: npm run build > files.txt
+      - name: Get Changed Files
+        id: files
+        uses: jitterbit/get-changed-files@v1
+        with:
+          format: 'csv'
       - name: Publish TypeScript components (dry run)
         shell: bash {0} # don't fast fail
         run: |
           IFS=$'\n'
-          echo "The following files will be published on merge:"
+          mapfile -d ',' -t added_modified_renamed_files < <(printf '%s,%s' '${{ steps.files.outputs.added_modified }}' '${{ steps.files.outputs.renamed }}')
           # Remove initial tsc output
-          for f in $(cat files.txt | sed 1,3d)
+          output_files=$(cat files.txt | sed 1,3d)
+          echo "The following files will be published on merge:"
+          for added_modified_file in "${added_modified_renamed_files[@]}";
           do
-            echo "$f"
+            # starts with components, ends with .ts and not app.ts, doesn't end with /common*.ts,
+            # and doesn't follow */common/
+            if [[ $added_modified_file == components/* ]] && [[ $added_modified_file == *.ts ]] && [[ $added_modified_file != *.app.ts ]] \
+                && [[ $added_modified_file != */common*.ts ]] && [[ $added_modified_file != */common/* ]]
+            then
+              # XXX This is a hacky way to publish only TS components with changes. If a changed
+              # file "path-a/path-b/c.ts" has a corresponding compiled output file
+              # "path-a/dist/path-b/c.mjs", attempt to publish the output `.mjs` file.
+              for f in $output_files;
+              do
+                # Replaces /dist/path/filename.mjs with /path/filename.ts
+                maybe_source_file=$(echo "$f" | sed 's/\/dist\//\//;s/.mjs/\.ts/')
+                if [[ ${maybe_source_file} == **/${added_modified_file} ]]
+                then
+                  echo "$f"
+                fi
+              done
+            fi
           done
           unset IFS
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9460,9 +9460,9 @@
       }
     },
     "tsc-esm-fix": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/tsc-esm-fix/-/tsc-esm-fix-2.15.0.tgz",
-      "integrity": "sha512-Mc+9WkBS49EzrXL3dxOuudgWvWiJ18+CuanVkizeWX93xX+8hg9iVNdhkT3qak46T9PbTDCaTmpgIh85Piphqw==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/tsc-esm-fix/-/tsc-esm-fix-2.18.0.tgz",
+      "integrity": "sha512-hW3OoQhrwctRm/K761oBLlPnKMg9MGYwigiDsNb+F0gN0ACbym5A+SB3a2rA/SX0rG/rdKnZCg5AkCz5Y93B9g==",
       "dev": true,
       "requires": {
         "@types/fs-extra": "^9.0.13",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "prepare": "husky install",
-    "build": "npx tsc --build --force | node scripts/tsPostBuild.mjs",
+    "build": "npx tsc --build | node scripts/tsPostBuild.mjs",
     "test": "jest --passWithNoTests"
   },
   "devDependencies": {
@@ -45,7 +45,7 @@
     "putout": ">=20",
     "renamer": "^4.0.0",
     "ts-jest": "^27.1.4",
-    "tsc-esm-fix": "^2.15.0",
+    "tsc-esm-fix": "^2.18.0",
     "tsc-watch": "^5.0.3",
     "typescript": "^4.7.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.4
+lockfileVersion: 5.3
 
 importers:
 
@@ -21,7 +21,7 @@ importers:
       putout: '>=20'
       renamer: ^4.0.0
       ts-jest: ^27.1.4
-      tsc-esm-fix: ^2.15.0
+      tsc-esm-fix: ^2.18.0
       tsc-watch: ^5.0.3
       typescript: ^4.7.2
       vue: ^2.6.14
@@ -32,20 +32,20 @@ importers:
       '@pipedream/types': 0.1.0
       '@tsconfig/node14': 1.0.1
       '@types/jest': 27.5.0
-      '@typescript-eslint/eslint-plugin': 5.27.1_y3w3ponleabb7gvsfqc375rw6q
-      '@typescript-eslint/parser': 5.23.0_ex7m3ygoyrpywhuxopuhp3yrbq
+      '@typescript-eslint/eslint-plugin': 5.27.1_c6edb7b9ab20021f9ab22c05bff636f4
+      '@typescript-eslint/parser': 5.23.0_eslint@8.15.0+typescript@4.7.2
       eslint: 8.15.0
       eslint-plugin-jsonc: 1.7.0_eslint@8.15.0
       eslint-plugin-pipedream: 0.2.4
-      eslint-plugin-putout: 15.1.1_3bxrxekybkfptnqbb2foewzini
+      eslint-plugin-putout: 15.1.1_eslint@8.15.0+putout@26.0.1
       husky: 7.0.4
       jest: 27.5.1
       lint-staged: 12.4.1
       pnpm: 7.0.1
       putout: 26.0.1
       renamer: 4.0.0
-      ts-jest: 27.1.4_b2l2z5zb7yu4r6dlp35tmkx42a
-      tsc-esm-fix: 2.15.0
+      ts-jest: 27.1.4_0e97acf721fe29c8f86b7efb362afcd0
+      tsc-esm-fix: 2.18.0
       tsc-watch: 5.0.3_typescript@4.7.2
       typescript: 4.7.2
 
@@ -357,7 +357,7 @@ importers:
       '@firebase/app-compat': 0.1.25
       '@firebase/app-types': 0.7.0
       '@pipedream/platform': 0.9.0
-      firebase-admin: 10.2.0_rpd4ipbmnh3eak32lkxgflhihy
+      firebase-admin: 10.2.0_8bc7c43c2c69f6402b7a5aae62ace83e
       google-auth-library: 7.14.1
 
   components/formstack:
@@ -2908,7 +2908,7 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/eslint-parser/7.17.0_annt2i75qyqp7sfsklqkwkfeaa:
+  /@babel/eslint-parser/7.17.0_035b3d23fd8620ffc8b252e0ab28a400:
     resolution: {integrity: sha512-PUEJ7ZBXbRkbq3qqM/jZ2nIuakUBqCYc7Qf52Lj7dlZ6zERnqisdHioL0l4wwQZnmskMeasqUNzLBFKs3nylXA==}
     engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
     peerDependencies:
@@ -3322,7 +3322,7 @@ packages:
       tslib: 2.4.0
     dev: false
 
-  /@firebase/auth-interop-types/0.1.6_uzaylzqz7y23sj27ypdw6yti3m:
+  /@firebase/auth-interop-types/0.1.6_a64185e619fe35b9275fc3c76f6268db:
     resolution: {integrity: sha512-etIi92fW3CctsmR9e3sYM3Uqnoq861M0Id9mdOPF6PWIg38BXL5k4upCNBggGUpLIS0H1grMOvy/wn1xymwe2g==}
     peerDependencies:
       '@firebase/app-types': 0.x
@@ -3346,7 +3346,7 @@ packages:
       tslib: 2.4.0
     dev: false
 
-  /@firebase/database-compat/0.1.8_rpd4ipbmnh3eak32lkxgflhihy:
+  /@firebase/database-compat/0.1.8_8bc7c43c2c69f6402b7a5aae62ace83e:
     resolution: {integrity: sha512-dhXr5CSieBuKNdU96HgeewMQCT9EgOIkfF1GNy+iRrdl7BWLxmlKuvLfK319rmIytSs/vnCzcD9uqyxTeU/A3A==}
     peerDependencies:
       '@firebase/app-compat': 0.x
@@ -3379,7 +3379,7 @@ packages:
   /@firebase/database/0.12.8_@firebase+app-types@0.7.0:
     resolution: {integrity: sha512-JBQVfFLzfhxlQbl4OU6ov9fdsddkytBQdtSSR49cz48homj38ccltAhK6seum+BI7f28cV2LFHF9672lcN+qxA==}
     dependencies:
-      '@firebase/auth-interop-types': 0.1.6_uzaylzqz7y23sj27ypdw6yti3m
+      '@firebase/auth-interop-types': 0.1.6_a64185e619fe35b9275fc3c76f6268db
       '@firebase/component': 0.5.13
       '@firebase/logger': 0.3.2
       '@firebase/util': 1.5.2
@@ -3857,8 +3857,6 @@ packages:
     dependencies:
       dotenv: 8.6.0
       superagent: 3.8.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /@microsoft/microsoft-graph-client/3.0.2:
@@ -3978,8 +3976,6 @@ packages:
       axios: 0.19.2
       fp-ts: 2.12.1
       io-ts: 2.2.16_fp-ts@2.12.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /@pipedream/platform/0.9.0:
@@ -3988,8 +3984,6 @@ packages:
       axios: 0.19.2
       fp-ts: 2.12.1
       io-ts: 2.2.16_fp-ts@2.12.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /@pipedream/types/0.0.5:
@@ -4010,8 +4004,6 @@ packages:
       axios: 0.19.2
       fp-ts: 2.12.1
       io-ts: 2.2.16_fp-ts@2.12.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /@protobufjs/aspromise/1.1.2:
@@ -5783,7 +5775,7 @@ packages:
       '@types/yargs-parser': 21.0.0
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.27.1_y3w3ponleabb7gvsfqc375rw6q:
+  /@typescript-eslint/eslint-plugin/5.27.1_c6edb7b9ab20021f9ab22c05bff636f4:
     resolution: {integrity: sha512-6dM5NKT57ZduNnJfpY81Phe9nc9wolnMCnknb1im6brWi1RYv84nbMS3olJa27B6+irUVV1X/Wb+Am0FjJdGFw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5794,10 +5786,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.23.0_ex7m3ygoyrpywhuxopuhp3yrbq
+      '@typescript-eslint/parser': 5.23.0_eslint@8.15.0+typescript@4.7.2
       '@typescript-eslint/scope-manager': 5.27.1
-      '@typescript-eslint/type-utils': 5.27.1_ex7m3ygoyrpywhuxopuhp3yrbq
-      '@typescript-eslint/utils': 5.27.1_ex7m3ygoyrpywhuxopuhp3yrbq
+      '@typescript-eslint/type-utils': 5.27.1_eslint@8.15.0+typescript@4.7.2
+      '@typescript-eslint/utils': 5.27.1_eslint@8.15.0+typescript@4.7.2
       debug: 4.3.4
       eslint: 8.15.0
       functional-red-black-tree: 1.0.1
@@ -5810,7 +5802,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.23.0_ex7m3ygoyrpywhuxopuhp3yrbq:
+  /@typescript-eslint/parser/5.23.0_eslint@8.15.0+typescript@4.7.2:
     resolution: {integrity: sha512-V06cYUkqcGqpFjb8ttVgzNF53tgbB/KoQT/iB++DOIExKmzI9vBJKjZKt/6FuV9c+zrDsvJKbJ2DOCYwX91cbw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5846,7 +5838,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.27.1
     dev: true
 
-  /@typescript-eslint/type-utils/5.27.1_ex7m3ygoyrpywhuxopuhp3yrbq:
+  /@typescript-eslint/type-utils/5.27.1_eslint@8.15.0+typescript@4.7.2:
     resolution: {integrity: sha512-+UC1vVUWaDHRnC2cQrCJ4QtVjpjjCgjNFpg8b03nERmkHv9JV9X5M19D7UFMd+/G7T/sgFwX2pGmWK38rqyvXw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5856,7 +5848,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/utils': 5.27.1_ex7m3ygoyrpywhuxopuhp3yrbq
+      '@typescript-eslint/utils': 5.27.1_eslint@8.15.0+typescript@4.7.2
       debug: 4.3.4
       eslint: 8.15.0
       tsutils: 3.21.0_typescript@4.7.2
@@ -5938,7 +5930,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils/5.27.1_ex7m3ygoyrpywhuxopuhp3yrbq:
+  /@typescript-eslint/utils/5.27.1_eslint@8.15.0+typescript@4.7.2:
     resolution: {integrity: sha512-mZ9WEn1ZLDaVrhRaYgzbkXBkTPghPFsup8zDbbsYTxC5OmqrFE7skkKS/sraVsLP3TcT3Ki5CSyEFBRkLH/H/w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5980,8 +5972,6 @@ packages:
       create-hmac: 1.1.7
       oauth-1.0a: 2.2.6
       url-parse: 1.5.10
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /abab/2.0.6:
@@ -6376,8 +6366,6 @@ packages:
     deprecated: Critical security vulnerability fixed in v0.21.1. For more information, see https://github.com/axios/axios/pull/3410
     dependencies:
       follow-redirects: 1.5.10
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /axios/0.21.4:
@@ -7313,22 +7301,12 @@ packages:
 
   /debug/3.1.0:
     resolution: {integrity: sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
     dependencies:
       ms: 2.0.0
     dev: false
 
   /debug/3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
     dependencies:
       ms: 2.1.3
     dev: false
@@ -7948,7 +7926,7 @@ packages:
     resolution: {integrity: sha512-mKgRf5DFJnxcDantRh0b7CoSNRqPiDZMlAP9Ab/Pha8Uq7ZseIEiRGtWOJwp9tHSZnNOe1+MCN1X6yXnWC39sA==}
     dev: true
 
-  /eslint-plugin-putout/15.1.1_3bxrxekybkfptnqbb2foewzini:
+  /eslint-plugin-putout/15.1.1_eslint@8.15.0+putout@26.0.1:
     resolution: {integrity: sha512-fgJqV0j+0mYbLx440CLBvOIj09Ia+oF421fJyhlogOecKx3H8fjiV2VnVe0Ilc0YRXHi23ec40zZ7YTvQthrAA==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -7956,13 +7934,13 @@ packages:
       putout: '>=25'
     dependencies:
       '@babel/core': 7.17.10
-      '@babel/eslint-parser': 7.17.0_annt2i75qyqp7sfsklqkwkfeaa
+      '@babel/eslint-parser': 7.17.0_035b3d23fd8620ffc8b252e0ab28a400
       '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.17.10
       '@babel/traverse': 7.17.10
       '@putout/engine-parser': 5.0.0
       '@putout/eslint-config': 7.0.0_eslint@8.15.0
-      '@typescript-eslint/eslint-plugin': 5.27.1_y3w3ponleabb7gvsfqc375rw6q
-      '@typescript-eslint/parser': 5.23.0_ex7m3ygoyrpywhuxopuhp3yrbq
+      '@typescript-eslint/eslint-plugin': 5.27.1_c6edb7b9ab20021f9ab22c05bff636f4
+      '@typescript-eslint/parser': 5.23.0_eslint@8.15.0+typescript@4.7.2
       align-spaces: 1.0.4
       eslint: 8.15.0
       eslint-plugin-node: 11.1.0_eslint@8.15.0
@@ -8408,11 +8386,11 @@ packages:
       path-exists: 5.0.0
     dev: true
 
-  /firebase-admin/10.2.0_rpd4ipbmnh3eak32lkxgflhihy:
+  /firebase-admin/10.2.0_8bc7c43c2c69f6402b7a5aae62ace83e:
     resolution: {integrity: sha512-6ehn5J9UEFgi4+naqYvozmGpnZae3cJLdwSkSsDc8/Y0eTBjVMFdf9N2ft7N81UNHA0N5DknOyXhlsdAdyBLCA==}
     engines: {node: '>=12.7.0'}
     dependencies:
-      '@firebase/database-compat': 0.1.8_rpd4ipbmnh3eak32lkxgflhihy
+      '@firebase/database-compat': 0.1.8_8bc7c43c2c69f6402b7a5aae62ace83e
       '@firebase/database-types': 0.9.8
       '@types/node': 17.0.31
       dicer: 0.3.1
@@ -8495,8 +8473,6 @@ packages:
     engines: {node: '>=4.0'}
     dependencies:
       debug: 3.1.0
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /forever-agent/0.6.1:
@@ -10471,7 +10447,7 @@ packages:
     resolution: {integrity: sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==}
     dev: false
 
-  /ky-universal/0.8.2_pkdcfzdjosae4cy3uef4ugd56u:
+  /ky-universal/0.8.2_7a8622e46974804e0b1ba10bca187df5:
     resolution: {integrity: sha512-xe0JaOH9QeYxdyGLnzUOVGK4Z6FGvDVzcXFTdrYA1f33MZdEa45sUDaMBy98xQMcsd2XIBrTXRrRYnegcSdgVQ==}
     engines: {node: '>=10.17'}
     peerDependencies:
@@ -10824,7 +10800,7 @@ packages:
       base-64: 1.0.0
       bluebird: 3.7.2
       ky: 0.25.1
-      ky-universal: 0.8.2_pkdcfzdjosae4cy3uef4ugd56u
+      ky-universal: 0.8.2_7a8622e46974804e0b1ba10bca187df5
       url: 0.11.0
       url-join: 0.0.1
       web-streams-polyfill: 3.2.1
@@ -11383,7 +11359,7 @@ packages:
     optional: true
 
   /nano-memoize/1.3.0:
-    resolution: {integrity: sha512-yM/gMQHvA5EOtNGfEbJ8tmAveNjbckhzZ1hkNtMjY8zps3ocjPfp1kuJ1++OgtVHAhsGSTJttG3S6UV+FZZzxQ==}
+    resolution: {integrity: sha512-yM/gMQHvA5EOtNGfEbJ8tmAveNjbckhzZ1hkNtMjY8zps3ocjPfp1kuJ1++OgtVHAhsGSTJttG3S6UV+FZZzxQ==, tarball: nano-memoize/-/nano-memoize-1.3.0.tgz}
     dev: true
 
   /nanoid/3.3.4:
@@ -11539,8 +11515,6 @@ packages:
       pump: 2.0.1
       request: 2.88.2
       request-promise: 4.2.6_request@2.88.2
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /normalize-package-data/2.5.0:
@@ -13068,16 +13042,12 @@ packages:
       debug: 3.2.7
       rhea: 2.0.8
       tslib: 2.4.0
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /rhea/2.0.8:
     resolution: {integrity: sha512-IgwlP4D2lzinBSll5f35tAWa30dGCZhG9Ujd1DiaB7MUGegIjAaLzqATCw3ha+h9oq9mXcitqayBbNIXYdvtFg==}
     dependencies:
       debug: 3.2.7
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /rimraf/2.7.1:
@@ -13853,8 +13823,6 @@ packages:
       mime: 1.6.0
       qs: 6.10.3
       readable-stream: 2.3.7
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /superagent/4.1.0:
@@ -14197,7 +14165,7 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /ts-jest/27.1.4_b2l2z5zb7yu4r6dlp35tmkx42a:
+  /ts-jest/27.1.4_0e97acf721fe29c8f86b7efb362afcd0:
     resolution: {integrity: sha512-qjkZlVPWVctAezwsOD1OPzbZ+k7zA5z3oxII4dGdZo5ggX/PL7kvwTM0pXTr10fAtbiVpJaL3bWd502zAhpgSQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     hasBin: true
@@ -14231,8 +14199,8 @@ packages:
       yargs-parser: 20.2.9
     dev: true
 
-  /tsc-esm-fix/2.15.0:
-    resolution: {integrity: sha512-Mc+9WkBS49EzrXL3dxOuudgWvWiJ18+CuanVkizeWX93xX+8hg9iVNdhkT3qak46T9PbTDCaTmpgIh85Piphqw==}
+  /tsc-esm-fix/2.18.0:
+    resolution: {integrity: sha512-hW3OoQhrwctRm/K761oBLlPnKMg9MGYwigiDsNb+F0gN0ACbym5A+SB3a2rA/SX0rG/rdKnZCg5AkCz5Y93B9g==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     hasBin: true
     dependencies:

--- a/scripts/tsPostBuild.mjs
+++ b/scripts/tsPostBuild.mjs
@@ -1,6 +1,6 @@
 import path from 'path'
 import readline from 'readline';
-import { fix } from 'tsc-esm-fix'
+import { fix } from 'tsc-esm-fix';
 
 (async () => {
   // Input comes from stdin, where each line is a file emitted by tsc
@@ -27,9 +27,12 @@ import { fix } from 'tsc-esm-fix'
       // https://github.com/microsoft/TypeScript/issues/16577#issuecomment-309169829
       // for more information on the problem.
 
-      // tsc-esm-fix takes directories as input, but it needs to be the root outDir
-      // of the component. This is defined in the tsconfig for a given package, but
-      // tsc-esm-fix doesn't appear to respect references in the root tsconfig
+      // tsc-esm-fix takes directories as input, but it needs to be the root
+      // outDir of the component. This is defined in the tsconfig for a given
+      // package, but tsc-esm-fix doesn't appear to respect references in the
+      // root tsconfig. Alternatively, a custom glob pattern for the compiled
+      // output files can be specified. For example:
+      // `components/rss/dist/**/*.{js,mjs,d.ts}`
       const dir = path.dirname(filename);
       // XXX we should really read the tsconfig for the given package and get the outDir from there
       const outDir = dir.match(/(.*dist\/).*/)[1];
@@ -44,10 +47,14 @@ import { fix } from 'tsc-esm-fix'
     })
   })
 
-  for (const target of outDirs) {
+  for (const outDir of outDirs) {
     await fix({
       ext: '.mjs',
-      target,
+      // tsc-esm-fix includes only `.js` and `.d.ts` files in outDir when making
+      // fixes, by default: `${outDir}/**/*.{js,d.ts}`. Include `.mjs` files in
+      // `target` to allow tsc-esm-fix to modify imports of those files to
+      // `.mjs`.
+      target: `${outDir}/**/*.{js,mjs,d.ts}`,
     })
   }
 


### PR DESCRIPTION
* Re-supports incremental builds by:
  - updating `tsc-esm-fix` to v2.18.0, which adds support for custom glob patterns ([`tsc-esm-fix` changelog](https://github.com/antongolub/tsc-esm-fix/blob/master/CHANGELOG.md#2180-2022-06-06))!
  - adding `.mjs` to target glob pattern for `tsc-esm-fix` in `tsPostBuild.mjs` (to support previously built `.mjs` files)
  - removing `--force` option from tsc command in build script
* Fixes attempting to republish TS components: Updates "Publish Typescript Components" step in `publish-components.yaml` and `pull-request-checks.yaml` to publish only compiled TS components with a source file in "files changed"

**Context**
Slack thread: https://pipedream-users.slack.com/archives/G01K0RGR1QR/p1654736405487759?thread_ts=1654729967.469349&cid=G01K0RGR1QR