### PR TITLE
Additional Gitlab Actions

### DIFF
--- a/components/gitlab/actions/create-new-merge-request-thread/create-new-merge-request-thread.mjs
+++ b/components/gitlab/actions/create-new-merge-request-thread/create-new-merge-request-thread.mjs
@@ -1,0 +1,33 @@
+import gitlab from "../../gitlab.app.mjs";
+
+export default {
+  name: "Create New Merge Request Thread",
+  version: "0.0.1",
+  key: "create-new-merge-request-thread",
+  description: "Create a new thread on a Merge Request",
+  props: {
+    gitlab,
+    projectId: {
+      propDefinition: [
+        gitlab,
+        "projectId",
+      ],
+    },
+    mergeRequestIid: {
+      type: "integer",
+      label: "Merge Request ID",
+      description: "The ID of the Merge Request (integer)"
+    },
+    body: {
+      type: "string",
+      label: "Body",
+      description: "The body of the comment on the new thread. Markdown is supported."
+    }
+  },
+  type: "action",
+  methods: {},
+  async run({ $ }) {
+    const { data } = await this.gitlab.createNewMergeRequestThread(this.projectId, this.mergeRequestIid, { body: this.body });
+    return data;
+  },
+};

--- a/components/gitlab/actions/upload-project-file/upload-project-file.mjs
+++ b/components/gitlab/actions/upload-project-file/upload-project-file.mjs
@@ -2,7 +2,7 @@ import gitlab from "../../gitlab.app.mjs";
 
 export default {
   name: "Upload Project File",
-  version: "0.0.2",
+  version: "0.0.1",
   key: "upload-project-file",
   description: "Upload a file to a project",
   props: {

--- a/components/gitlab/actions/upload-project-file/upload-project-file.mjs
+++ b/components/gitlab/actions/upload-project-file/upload-project-file.mjs
@@ -1,0 +1,34 @@
+import gitlab from "../../gitlab.app.mjs";
+
+export default {
+  name: "Upload Project File",
+  version: "0.0.2",
+  key: "upload-project-file",
+  description: "Upload a file to a project",
+  props: {
+    gitlab,
+    projectId: {
+      propDefinition: [
+        gitlab,
+        "projectId",
+      ],
+    },
+    file: {
+      type: "string",
+      label: "File to upload",
+      description: "A valid base64 encoded string representing the file"
+    },
+    fileName: {
+      type: "string",
+      label: "The name of the file",
+      description: "Example: image.png if an PNG image is passed to the `file` prop"
+    }
+  },
+  type: "action",
+  methods: {},
+  async run({ $ }) {
+    const { data } = await this.gitlab.uploadFile(this.projectId, this.file, this.fileName)
+
+    return data;
+  },
+};

--- a/components/gitlab/gitlab.app.mjs
+++ b/components/gitlab/gitlab.app.mjs
@@ -1,4 +1,6 @@
 import { Gitlab } from "@gitbeaker/node";
+import axios from 'axios';
+import FormData from 'form-data';
 import constants from "./common/constants.mjs";
 import { v4 } from "uuid";
 
@@ -314,5 +316,26 @@ export default {
       }
       return api.all(params);
     },
+    async uploadFile(projectId, file, fileName) {
+      // Read file as a Buffer
+      const image = Buffer.from(file, "base64");
+      // Create a form and append image with additional fields
+      const form = new FormData();
+      form.append('file', image, fileName);
+
+      return axios.post(`https://gitlab.com/api/v4/projects/${projectId}/uploads`, form, {
+        headers: {
+          Authorization: `Bearer ${this.$auth.oauth_access_token}`,
+          "Content-Type": "multipart/form-data"
+        }
+      })
+    },
+    async createNewMergeRequestThread(projectId, mergeRequestIid, opts = {}) {
+      return axios.post(`https://gitlab.com/api/v4/projects/${projectId}/merge_requests/${mergeRequestIid}/discussions`, opts, {
+        headers: {
+          Authorization: `Bearer ${this.$auth.oauth_access_token}`
+        }
+      })
+    }
   },
 };


### PR DESCRIPTION
This PR introduces 2 new actions used during this week's Speed Run video.

A couple style notes.

1. I did not use `platform/axios` because I was unable to upload an image using the `data` field and setting the content headers to a multipart form. I think this is just a bug in the axios implementation.
2. I quickly added another action that just used the axios package instead of using the Gitlab package, which I couldn't see support for the endpoint I needed

But if you find fixes for either, I'm happy to accept any commits directly to this branch. I just don't have the time to actually implement them, or modify axios itself to fix the underlying file upload bug.

## Commits
- Adding new actions
- Revert to 0.0.1
