### PR TITLE
Browserless take-screenshot improvments

### DIFF
--- a/components/browserless/actions/take-screenshot/take-screenshot.mjs
+++ b/components/browserless/actions/take-screenshot/take-screenshot.mjs
@@ -4,7 +4,7 @@ import puppeteer from "puppeteer-core";
 export default {
   key: "browserless-take-screenshot",
   name: "Take a Screenshot",
-  version: "0.5.1",
+  version: "0.5.3",
   type: "action",
   props: {
     browserless: {
@@ -16,16 +16,29 @@ export default {
       label: "URL",
       description: "Enter the URL you'd like to take a screenshot of here",
     },
+    screenshotOptions: {
+      type: "object",
+      label: "Screenshot Options",
+      optional: true,
+      description: "Pass options directly to the `Page.screenshot()` method. [Full list available here](https://puppeteer.github.io/puppeteer/docs/9.1.1/puppeteer.page.screenshot/)."
+    },
+    viewportOptions: {
+      type: "object",
+      label: "Viewport Options",
+      optional: true,
+      description: "Set the browsers viewport options. Passed to the `page.setViewport()` method."
+    }
   },
   async run({ $ }) {
     const browser = await puppeteer.connect({
       browserWSEndpoint: `wss://chrome.browserless.io?token=${this.browserless.$auth.api_key}`,
     });
     const page = await browser.newPage();
+    page.setViewport(this.viewportOptions)
 
     const { url } = this;
     await page.goto(url);
-    const screenshot = await page.screenshot();
+    const screenshot = await page.screenshot(this.screenshotOptions ?? {});
 
     // export the base64-encoded screenshot for use in future steps,
     // along with the image type and filename

--- a/components/gitlab/actions/create-new-merge-request-thread/create-new-merge-request-thread.mjs
+++ b/components/gitlab/actions/create-new-merge-request-thread/create-new-merge-request-thread.mjs
@@ -1,0 +1,33 @@
+import gitlab from "../../gitlab.app.mjs";
+
+export default {
+  name: "Create New Merge Request Thread",
+  version: "0.0.1",
+  key: "create-new-merge-request-thread",
+  description: "Create a new thread on a Merge Request",
+  props: {
+    gitlab,
+    projectId: {
+      propDefinition: [
+        gitlab,
+        "projectId",
+      ],
+    },
+    mergeRequestIid: {
+      type: "integer",
+      label: "Merge Request ID",
+      description: "The ID of the Merge Request (integer)"
+    },
+    body: {
+      type: "string",
+      label: "Body",
+      description: "The body of the comment on the new thread. Markdown is supported."
+    }
+  },
+  type: "action",
+  methods: {},
+  async run({ $ }) {
+    const { data } = await this.gitlab.createNewMergeRequestThread(this.projectId, this.mergeRequestIid, { body: this.body });
+    return data;
+  },
+};

--- a/components/gitlab/actions/upload-project-file/upload-project-file.mjs
+++ b/components/gitlab/actions/upload-project-file/upload-project-file.mjs
@@ -2,7 +2,7 @@ import gitlab from "../../gitlab.app.mjs";
 
 export default {
   name: "Upload Project File",
-  version: "0.0.2",
+  version: "0.0.1",
   key: "upload-project-file",
   description: "Upload a file to a project",
   props: {

--- a/components/gitlab/actions/upload-project-file/upload-project-file.mjs
+++ b/components/gitlab/actions/upload-project-file/upload-project-file.mjs
@@ -1,0 +1,34 @@
+import gitlab from "../../gitlab.app.mjs";
+
+export default {
+  name: "Upload Project File",
+  version: "0.0.2",
+  key: "upload-project-file",
+  description: "Upload a file to a project",
+  props: {
+    gitlab,
+    projectId: {
+      propDefinition: [
+        gitlab,
+        "projectId",
+      ],
+    },
+    file: {
+      type: "string",
+      label: "File to upload",
+      description: "A valid base64 encoded string representing the file"
+    },
+    fileName: {
+      type: "string",
+      label: "The name of the file",
+      description: "Example: image.png if an PNG image is passed to the `file` prop"
+    }
+  },
+  type: "action",
+  methods: {},
+  async run({ $ }) {
+    const { data } = await this.gitlab.uploadFile(this.projectId, this.file, this.fileName)
+
+    return data;
+  },
+};

--- a/components/gitlab/gitlab.app.mjs
+++ b/components/gitlab/gitlab.app.mjs
@@ -1,4 +1,6 @@
 import { Gitlab } from "@gitbeaker/node";
+import axios from 'axios';
+import FormData from 'form-data';
 import constants from "./common/constants.mjs";
 import { v4 } from "uuid";
 
@@ -314,5 +316,26 @@ export default {
       }
       return api.all(params);
     },
+    async uploadFile(projectId, file, fileName) {
+      // Read file as a Buffer
+      const image = Buffer.from(file, "base64");
+      // Create a form and append image with additional fields
+      const form = new FormData();
+      form.append('file', image, fileName);
+
+      return axios.post(`https://gitlab.com/api/v4/projects/${projectId}/uploads`, form, {
+        headers: {
+          Authorization: `Bearer ${this.$auth.oauth_access_token}`,
+          "Content-Type": "multipart/form-data"
+        }
+      })
+    },
+    async createNewMergeRequestThread(projectId, mergeRequestIid, opts = {}) {
+      return axios.post(`https://gitlab.com/api/v4/projects/${projectId}/merge_requests/${mergeRequestIid}/discussions`, opts, {
+        headers: {
+          Authorization: `Bearer ${this.$auth.oauth_access_token}`
+        }
+      })
+    }
   },
 };


### PR DESCRIPTION
This includes two new props to pass options to: `viewportOptions` and `screenshotOptions`.


## Commits
- Adding new actions
- Revert to 0.0.1
- Adding viewport and screenshot options
