### PR TITLE
Google Calendar - New or Update Event (Instant) source fails to renew subscriptions after some period of time

### DIFF
--- a/components/google_calendar/sources/new-or-updated-event-instant/new-or-updated-event-instant.mjs
+++ b/components/google_calendar/sources/new-or-updated-event-instant/new-or-updated-event-instant.mjs
@@ -6,7 +6,7 @@ export default {
   type: "source",
   name: "New or Updated Event (Instant)",
   description: "Emit new calendar events when an event is created or updated (does not emit cancelled events)",
-  version: "0.1.2",
+  version: "0.1.3",
   dedupe: "unique",
   props: {
     googleCalendar,
@@ -195,8 +195,8 @@ export default {
 
       // if now + interval > expiration, refresh watch
       if (now.getTime() + intervalMs > expireDate.getTime()) {
-        await this.makeWatchRequest();
         await this.stopWatchRequest();
+        await this.makeWatchRequest();
       }
     } else {
       // Verify channel ID


### PR DESCRIPTION
Resolves #2472 

The method `stopWatchRequest` sets the webhook suscription data in the `db` to null. I moved `stopWatchRequest` to before `makeWatchRequest` so that the new subscription data is not overwritten when renewing the subscription.