### PR TITLE
Adding aspect ratio to YT embed

### DIFF
--- a/docs/docs/.vuepress/components/VideoPlayer.vue
+++ b/docs/docs/.vuepress/components/VideoPlayer.vue
@@ -2,12 +2,16 @@
 iframe {
   margin: auto;
 }
+
+.video {
+  aspect-ratio: 16 / 9;
+  width: 100%;
+}
 </style>
 
 <template>
   <iframe
-    width="660"
-    height="371"
+    class="video"
     :src="embedUrl"
     :title="title"
     frameborder="0"


### PR DESCRIPTION
Fixes docs responsiveness with the YT embeds by making them responsive with `aspect-ratio` prop instead of hard width/height.

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/3280"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

