### PR TITLE
check for previous version of published component

### DIFF
--- a/.github/workflows/publish-components.yaml
+++ b/.github/workflows/publish-components.yaml
@@ -54,6 +54,7 @@ jobs:
           ENDPOINT: ${{ secrets.ENDPOINT }}
         shell: bash {0} # don't fast fail
         run: |
+          PD_URL: https://api.pipedream.com/v1/components/registry
           UNPUBLISHED=""
           PUBLISHED=""
           ERRORS=""
@@ -65,6 +66,10 @@ jobs:
           if [[ $added_modified_file == components/* ]] && [[ $added_modified_file == *.*js ]] && [[ $added_modified_file != *.app.*js ]] \
               && [[ $added_modified_file != */common*.*js ]] && [[ $added_modified_file != */common/* ]]
             then
+              echo "retrieving previous version for ${added_modified_file}"
+              KEY=`echo $added_modified_file | tr '/' ' ' | awk '{ print $2 "-" $4 }'`
+              GLOBAL_REGISTRY_COMP=`curl "$PD_URL/$KEY" -H "Authorization: Bearer $PD_API_KEY" -H "Accept: application/json"`
+              PREV_VERSION=`echo $GLOBAL_REGISTRY_COMP | jq -r ".version"`
               echo "attempting to publish ${added_modified_file}"
               PD_OUTPUT=`./pd publish ${added_modified_file} --json`
               if [ $? -eq 0 ]
@@ -73,7 +78,7 @@ jobs:
                 echo "published ${KEY}"
                 echo "${KEY} will be added to the registry"
                 curl "https://api.pipedream.com/graphql" -H "Content-Type: application/json" -H "Authorization: Bearer ${PD_API_KEY}" --data-binary $'{"query":"mutation setComponentRegistry($key: String!, $registry: Boolean!, $gitPath: String){\\n  setComponentRegistry(key: $key, registry: $registry, gitPath: $gitPath){\\n    savedComponent{\\n      id\\n      key\\n      gitPath\\n    }\\n  }\\n}","variables":{"key":"'${KEY}'","registry":'true',"gitPath":"'${added_modified_file}'"}}'
-                PUBLISHED+="*${added_modified_file}"
+                [[ -n "$PREV_VERSION" ]] && PUBLISHED+="*${added_modified_file}~$PREV_VERSION" || PUBLISHED+="*${added_modified_file}"
               else
                 ERROR=`echo $PD_OUTPUT | jq -r ".error"`
                 ERROR_MESSAGE="${ERROR} with ${added_modified_file}"
@@ -157,6 +162,7 @@ jobs:
           do
             echo "$f"
           done
+          PD_URL: https://api.pipedream.com/v1/components/registry
           UNPUBLISHED=""
           PUBLISHED=""
           ERRORS=""
@@ -191,6 +197,10 @@ jobs:
                 ERRORS+="*${ERROR_MESSAGE}"
                 UNPUBLISHED+="*${added_modified_file}"
               else
+                echo "retrieving previous version for ${added_modified_file}"
+                KEY=`echo $added_modified_file | tr '/' ' ' | awk '{ print $2 "-" $4 }'`
+                GLOBAL_REGISTRY_COMP=`curl "$PD_URL/$KEY" -H "Authorization: Bearer $PD_API_KEY" -H "Accept: application/json"`
+                PREV_VERSION=`echo $GLOBAL_REGISTRY_COMP | jq -r ".version"`
                 echo "attempting to publish ${changed_output_file}"
                 PD_OUTPUT=`./pd publish ${changed_output_file} --json`
                 if [ $? -eq 0 ]
@@ -199,7 +209,7 @@ jobs:
                   echo "published ${KEY}"
                   echo "${KEY} will be added to the registry"
                   curl "https://api.pipedream.com/graphql" -H "Content-Type: application/json" -H "Authorization: Bearer ${PD_API_KEY}" --data-binary $'{"query":"mutation setComponentRegistry($key: String!, $registry: Boolean!, $gitPath: String){\\n  setComponentRegistry(key: $key, registry: $registry, gitPath: $gitPath){\\n    savedComponent{\\n      id\\n      key\\n      gitPath\\n    }\\n  }\\n}","variables":{"key":"'${KEY}'","registry":'true',"gitPath":"'${changed_output_file}'"}}'
-                  PUBLISHED+="*${changed_output_file}"
+                  [[ -n "$PREV_VERSION" ]] && PUBLISHED+="*${changed_output_file}~$PREV_VERSION" || PUBLISHED+="*${changed_output_file}"
                 else
                   ERROR=`echo $PD_OUTPUT | jq -r ".error"`
                   ERROR_MESSAGE="${ERROR} with ${changed_output_file}"


### PR DESCRIPTION
- [X] Fetches previous version of published component from the Global Registry.
- [X] Sends the previous version to Pipedream workflow.

Must update `$ENDPOINT` GitHub Secret before merge.

Resolves #3277.

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/3311"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

