### PR TITLE
Netlify Fix Webhook Triggers

### DIFF
--- a/components/netlify/netlify.app.mjs
+++ b/components/netlify/netlify.app.mjs
@@ -203,7 +203,6 @@ export default {
       // See https://docs.netlify.com/site-deploys/notifications/#payload-signature
       const signature = headers["x-webhook-signature"];
       const token = db.get("token");
-      console.log(headers);
       const { sha256 } = jwt.decode(signature, token);
       const encoded = createHash("sha256")
         .update(bodyRaw)

--- a/components/netlify/netlify.app.mjs
+++ b/components/netlify/netlify.app.mjs
@@ -162,7 +162,7 @@ export default {
         event,
         data: {
           url,
-          signatureSecret: token,
+          signature_secret: token,
         },
       };
       const requestParams = {
@@ -203,6 +203,7 @@ export default {
       // See https://docs.netlify.com/site-deploys/notifications/#payload-signature
       const signature = headers["x-webhook-signature"];
       const token = db.get("token");
+      console.log(headers);
       const { sha256 } = jwt.decode(signature, token);
       const encoded = createHash("sha256")
         .update(bodyRaw)

--- a/components/netlify/sources/new-deploy-failure/new-deploy-failure.mjs
+++ b/components/netlify/sources/new-deploy-failure/new-deploy-failure.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Deploy Failure (Instant)",
   description: "Emit new event when a new deployment fails",
   type: "source",
-  version: "0.0.2",
+  version: "0.0.3",
   dedupe: "unique",
   methods: {
     ...webhook.methods,

--- a/components/netlify/sources/new-deploy-start/new-deploy-start.mjs
+++ b/components/netlify/sources/new-deploy-start/new-deploy-start.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Deploy Start (Instant)",
   description: "Emit new event when a new deployment is started",
   type: "source",
-  version: "0.0.2",
+  version: "0.0.3",
   dedupe: "unique",
   methods: {
     ...webhook.methods,

--- a/components/netlify/sources/new-deploy-success/new-deploy-success.mjs
+++ b/components/netlify/sources/new-deploy-success/new-deploy-success.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Deploy Success (Instant)",
   description: "Emit new event when a new deployment is completed",
   type: "source",
-  version: "0.0.2",
+  version: "0.0.3",
   dedupe: "unique",
   methods: {
     ...webhook.methods,

--- a/components/netlify/sources/new-form-submission/new-form-submission.mjs
+++ b/components/netlify/sources/new-form-submission/new-form-submission.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Form Submission (Instant)",
   description: "Emit new event when a user submits a form",
   type: "source",
-  version: "0.0.2",
+  version: "0.0.3",
   dedupe: "unique",
   methods: {
     ...webhook.methods,


### PR DESCRIPTION
[According to the docs](https://github.com/netlify/js-client#response--await-clientoperationidparams-opts), `netlify/js-client` accepts camelCase in params only.
`params.body` is automatically JSON-serialized.
Therefore `params.body.signatureSecret` should be `params.body.signature_secret`.

Resolves #3293.

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/3320"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

