### PR TITLE
Including HTTP response action in Docs

### DIFF
--- a/docs/docs/workflows/steps/triggers/README.md
+++ b/docs/docs/workflows/steps/triggers/README.md
@@ -270,7 +270,17 @@ When you're processing HTTP requests, you often don't need to issue any special 
 
 #### Customizing the HTTP response
 
-If you need to issue a custom HTTP response from a workflow, **you can use the `$.respond()` function in a Code or Action step**.
+If you need to issue a custom HTTP response from a workflow, you can either:
+- **use the `Return HTTP response` Action**, available on the `HTTP / Webhook` app, or
+- **use the `$.respond()` function in a Code or Action step**.
+
+#### Using the HTTP Response Action
+
+With this action, you do not need to write any custom code. You can customize the response status code, and optionally specify response headers and body.
+
+This action uses `$.respond()` and will always [respond immediately](#returning-a-response-immediately) when called in your workflow. A [response error](#errors-with-http-responses) will still occur if your workflow throws an Error before this action runs.
+
+#### Using custom code with `$.respond()`
 
 `$.respond()` takes a single argument: an object with properties that specify the body, headers, and HTTP status code you'd like to respond with:
 

--- a/docs/docs/workflows/steps/triggers/README.md
+++ b/docs/docs/workflows/steps/triggers/README.md
@@ -271,8 +271,8 @@ When you're processing HTTP requests, you often don't need to issue any special 
 #### Customizing the HTTP response
 
 If you need to issue a custom HTTP response from a workflow, you can either:
-- **use the `Return HTTP response` Action**, available on the `HTTP / Webhook` app, or
-- **use the `$.respond()` function in a Code or Action step**.
+- Use the **Return HTTP response** action, available on the **HTTP / Webhook** app, or
+- **Use the `$.respond()` function in a Code or Action step**.
 
 #### Using the HTTP Response Action
 


### PR DESCRIPTION
This is a complement for #3331 , to keep the docs up-to-date

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/3362"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

