### PR TITLE
fix github json data being sent to workflow

### DIFF
--- a/.github/workflows/publish-components.yaml
+++ b/.github/workflows/publish-components.yaml
@@ -98,7 +98,7 @@ jobs:
             printf '%s\n' "${UNPUBLISHED[@]}"
           fi
           # curl with form
-          curl -X POST -d "type=javascript" -d "event=$(cat "$GITHUB_EVENT_PATH")" -d "github=$(printenv | grep "GITHUB_*")" -d "skipped=${SKIPPED}" -d "errors=${ERRORS}" -d "unpublished=${UNPUBLISHED}" -d "published=${PUBLISHED}" $ENDPOINT
+          curl -X POST -d "type=javascript" --data-urlencode event@$GITHUB_EVENT_PATH -d "github=$(printenv | grep "GITHUB_*")" -d "skipped=${SKIPPED}" -d "errors=${ERRORS}" -d "unpublished=${UNPUBLISHED}" -d "published=${PUBLISHED}" $ENDPOINT
       - name: Remove pd cli config
         run: |
           rm $HOME/.config/pipedream/config
@@ -230,7 +230,7 @@ jobs:
             printf '%s\n' "${UNPUBLISHED[@]}"
           fi
           # curl with form
-          curl -X POST -d "type=typescript" -d "event=$(cat "$GITHUB_EVENT_PATH")" -d "github=$(printenv | grep "GITHUB_*")" -d "skipped=${SKIPPED}" -d "errors=${ERRORS}" -d "unpublished=${UNPUBLISHED}" -d "published=${PUBLISHED}" $ENDPOINT
+          curl -X POST -d "type=typescript" --data-urlencode event@$GITHUB_EVENT_PATH -d "github=$(printenv | grep "GITHUB_*")" -d "skipped=${SKIPPED}" -d "errors=${ERRORS}" -d "unpublished=${UNPUBLISHED}" -d "published=${PUBLISHED}" $ENDPOINT
           unset IFS
       - name: Remove pd cli config
         run: |


### PR DESCRIPTION
Fixes JSON `curl` data being sent to workflow.
Some combinations of characters weren't being parsed correctly.

Example:
![Screen Shot 2022-07-11 at 2 56 41 PM](https://user-images.githubusercontent.com/15385076/178327578-1c0eecf2-0ee4-4a70-a099-851bf5e1ddbb.png)

