### PR TITLE
add --no-frozen-lockfile to github publish actions

### DIFF
--- a/.github/workflows/publish-components.yaml
+++ b/.github/workflows/publish-components.yaml
@@ -25,7 +25,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
       - name: Install dependencies
-        run: pnpm install -r
+        run: pnpm install -r --no-frozen-lockfile
       - name: Setup Node Env
         uses: actions/setup-node@v3.3.0
         with:
@@ -131,7 +131,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
           cache: 'pnpm'
       - name: Install Dependencies
-        run: pnpm install -r
+        run: pnpm install -r --no-frozen-lockfile
       - name: Install pd cli
         env:
           PD_API_KEY: ${{ secrets.PD_API_KEY }}

--- a/.github/workflows/publish-packages.yaml
+++ b/.github/workflows/publish-packages.yaml
@@ -1,4 +1,4 @@
-on: 
+on:
   push:
     branches:
       - master
@@ -18,7 +18,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
           cache: 'pnpm'
       - name: pnpm install
-        run: pnpm install -r
+        run: pnpm install -r --no-frozen-lockfile
       - name: Compile TypeScript
         run: npm run build
       # See https://pnpm.io/using-changesets


### PR DESCRIPTION
Does not let the GitHub Actions fail because of frozen lockfile when installing npm dependencies after merging to master, as spoken with @dylburger.

![Screen Shot 2022-07-12 at 11 29 01 AM](https://user-images.githubusercontent.com/15385076/178514624-fd08742a-93eb-432b-b1b7-3bde74967168.png)

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/3412"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

