### PR TITLE
add pnpm lockfile pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,9 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx pnpm install -r
+
+if ! (git diff HEAD --quiet pnpm-lock.yaml); then
+    echo "modified pnpm-lock.yaml - please commit the file"
+    exit 1
+fi


### PR DESCRIPTION
Checks if `pnpm-lock.yaml` needs to be updated and committed to the repo in a `pre-push` hook, as spoken with @dylburger.

Submitted a separate PR to be easily reverted if needed.

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/3415"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

