### PR TITLE
[TRIGGERS] Zoho CRM @pipedream/platform axios usage

### DIFF
--- a/components/zoho_crm/package.json
+++ b/components/zoho_crm/package.json
@@ -11,7 +11,7 @@
     "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
     "license": "MIT",
     "dependencies": {
-        "@pipedream/platform": "^0.10.0",
+        "@pipedream/platform": "^1.1.0",
         "crypto": "^1.0.1",
         "lodash.sortby": "^4.7.0"
     },

--- a/components/zoho_crm/sources/new-contact/new-contact.mjs
+++ b/components/zoho_crm/sources/new-contact/new-contact.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoho_crm-new-contact",
   name: "New Contact (Instant)",
   description: "Emits an event each time a new contact is created in Zoho CRM",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "source",
   methods: {
     ...common.methods,

--- a/components/zoho_crm/sources/new-event/new-event.mjs
+++ b/components/zoho_crm/sources/new-event/new-event.mjs
@@ -7,7 +7,7 @@ export default {
   key: "zoho_crm-new-event",
   name: "New Event (Instant)",
   description: "Emit new custom events from Zoho CRM",
-  version: "0.0.12",
+  version: "0.0.13",
   type: "source",
   props: {
     ...common.props,

--- a/components/zoho_crm/sources/new-lead/new-lead.mjs
+++ b/components/zoho_crm/sources/new-lead/new-lead.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoho_crm-new-lead",
   name: "New Lead (Instant)",
   description: "Emits an event each time a new lead is created in Zoho CRM",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "source",
   methods: {
     ...common.methods,

--- a/components/zoho_crm/sources/new-module-entry/new-module-entry.mjs
+++ b/components/zoho_crm/sources/new-module-entry/new-module-entry.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoho_crm-new-module-entry",
   name: "New Module Entry (Instant)",
   description: "Emit new events each time a new module/record is created in Zoho CRM",
-  version: "0.0.10",
+  version: "0.0.11",
   type: "source",
   methods: {
     ...common.methods,

--- a/components/zoho_crm/sources/new-or-updated-contact/new-or-updated-contact.mjs
+++ b/components/zoho_crm/sources/new-or-updated-contact/new-or-updated-contact.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoho_crm-new-or-updated-contact",
   name: "New or Updated Contact (Instant)",
   description: "Emits an event each time a new contact is created or updated in Zoho CRM",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "source",
   methods: {
     ...common.methods,

--- a/components/zoho_crm/sources/new-or-updated-lead/new-or-updated-lead.mjs
+++ b/components/zoho_crm/sources/new-or-updated-lead/new-or-updated-lead.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoho_crm-new-or-updated-lead",
   name: "New or Updated Lead (Instant)",
   description: "Emits an event each time a new lead is created or updated in Zoho CRM",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "source",
   methods: {
     ...common.methods,

--- a/components/zoho_crm/sources/new-or-updated-module-entry/new-or-updated-module-entry.mjs
+++ b/components/zoho_crm/sources/new-or-updated-module-entry/new-or-updated-module-entry.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoho_crm-new-or-updated-module-entry",
   name: "New or Updated Module Entry (Instant)",
   description: "Emits an event each time a module/record is created or edited in Zoho CRM",
-  version: "0.0.9",
+  version: "0.0.10",
   type: "source",
   methods: {
     ...common.methods,

--- a/components/zoho_crm/sources/new-user/new-user.mjs
+++ b/components/zoho_crm/sources/new-user/new-user.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoho_crm-new-user",
   name: "New User",
   description: "Emits an event each time a new user is created in Zoho CRM",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/zoho_crm/sources/updated-module-entry/updated-module-entry.mjs
+++ b/components/zoho_crm/sources/updated-module-entry/updated-module-entry.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoho_crm-updated-module-entry",
   name: "Updated Module Entry (Instant)",
   description: "Emits an event each time a new module/record is updated in Zoho CRM",
-  version: "0.0.9",
+  version: "0.0.10",
   type: "source",
   methods: {
     ...common.methods,

--- a/components/zoho_crm/zoho_crm.app.mjs
+++ b/components/zoho_crm/zoho_crm.app.mjs
@@ -1,5 +1,4 @@
 import { axios } from "@pipedream/platform";
-import standardAxios from "axios";
 
 export default {
   type: "app",
@@ -215,8 +214,7 @@ export default {
         url,
         ...requestConfig,
       };
-      const { data } = await standardAxios(config);
-      return data;
+      return axios(this, config);
     },
     async createHook(opts) {
       const {
@@ -249,8 +247,7 @@ export default {
         data: requestData,
         ...requestConfig,
       };
-      const { data } = await axios(this, config);
-      return data;
+      return axios(this, config);
     },
     async deleteHook(channelId) {
       const url = this._watchActionsUrl();
@@ -306,7 +303,7 @@ export default {
         data: requestData,
         ...requestConfig,
       };
-      const { data } = await axios(this, config);
+      const data  = await axios(this, config);
       const watch = data.watch[0];
       console.log(watch);
       console.log(watch.details);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1687,11 +1687,11 @@ importers:
 
   components/zoho_crm:
     specifiers:
-      '@pipedream/platform': ^0.10.0
+      '@pipedream/platform': ^1.1.0
       crypto: ^1.0.1
       lodash.sortby: ^4.7.0
     dependencies:
-      '@pipedream/platform': 0.10.0
+      '@pipedream/platform': link:../../platform
       crypto: 1.0.1
       lodash.sortby: 4.7.0
 


### PR DESCRIPTION
- [x] update `@pipedream/platform/axios` version to `1.1.0`.
- [x] `return data` instead of `return { data }` when calling `@pipedream/platform/axios`.
- [x] bump sources patch versions

All triggers were affected.

Resolves #3351.

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/3417"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

