### PR TITLE
Republish - Ghost Admin new Actions

### DIFF
--- a/components/ghost_org_admin_api/actions/create-member/create-member.mjs
+++ b/components/ghost_org_admin_api/actions/create-member/create-member.mjs
@@ -4,7 +4,7 @@ export default {
   key: "ghost_org_admin_api-create-member",
   name: "Create Member",
   description: "Create a new member in Ghost. [See the docs here](https://ghost.org/docs/admin-api/#creating-a-member)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     app,

--- a/components/ghost_org_admin_api/actions/update-member/update-member.mjs
+++ b/components/ghost_org_admin_api/actions/update-member/update-member.mjs
@@ -4,7 +4,7 @@ export default {
   key: "ghost_org_admin_api-update-member",
   name: "Update Member",
   description: "Update a member in Ghost. [See the docs here](https://ghost.org/docs/admin-api/#updating-a-member)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     app,


### PR DESCRIPTION
We need to republish these components related to PR #3408
We had a bug with typescript components as you can see [here](https://github.com/PipedreamHQ/pipedream/actions/runs/2670122533)

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/3450"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

