### PR TITLE
Updating type for Source run() parameter 

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17044,7 +17044,6 @@ packages:
   /semver/7.3.7:
     resolution: {integrity: sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==}
     engines: {node: '>=10'}
-    hasBin: true
     dependencies:
       lru-cache: 6.0.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17044,6 +17044,7 @@ packages:
   /semver/7.3.7:
     resolution: {integrity: sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==}
     engines: {node: '>=10'}
+    hasBin: true
     dependencies:
       lru-cache: 6.0.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17038,7 +17038,6 @@ packages:
   /semver/7.3.7:
     resolution: {integrity: sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==}
     engines: {node: '>=10'}
-    hasBin: true
     dependencies:
       lru-cache: 6.0.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14722,6 +14722,7 @@ packages:
 
   /mkdirp/0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
+    hasBin: true
     dependencies:
       minimist: 1.2.6
     dev: true
@@ -16875,6 +16876,7 @@ packages:
 
   /rimraf/2.7.1:
     resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
+    hasBin: true
     dependencies:
       glob: 7.2.0
     dev: true
@@ -17027,6 +17029,7 @@ packages:
 
   /semver/6.3.0:
     resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
+    hasBin: true
 
   /semver/7.0.0:
     resolution: {integrity: sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==}
@@ -17035,6 +17038,7 @@ packages:
   /semver/7.3.7:
     resolution: {integrity: sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==}
     engines: {node: '>=10'}
+    hasBin: true
     dependencies:
       lru-cache: 6.0.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1539,6 +1539,9 @@ importers:
     dependencies:
       twilio: 3.77.1
 
+  components/twitch_developer_app:
+    specifiers: {}
+
   components/twitter:
     specifiers:
       axios: ^0.21.1
@@ -1576,6 +1579,9 @@ importers:
       '@pipedream/platform': 0.10.0
 
   components/vbout:
+    specifiers: {}
+
+  components/vectera:
     specifiers: {}
 
   components/vend:

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pipedream/types",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "description": "Pipedream TypeScript types",
     "keywords": [
         "pipedream",

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -236,7 +236,7 @@ export interface Hooks {
 }
 
 // https://pipedream.com/docs/components/api/#http-event-shape
-export interface SourceRunOptions {
+export interface SourceHttpRunOptions {
   method: string;
   path: string;
   query: object;
@@ -244,6 +244,14 @@ export interface SourceRunOptions {
   bodyRaw?: string;
   body?: object;
 }
+
+// https://pipedream.com/docs/components/api/#timer
+export interface SourceTimerRunOptions {
+  timestamp: number;
+  interval_seconds: number;
+}
+
+export type SourceRunOptions = SourceHttpRunOptions | SourceTimerRunOptions;
 
 export interface ActionRunOptions {
   $: Pipedream;

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -235,8 +235,14 @@ export interface Hooks {
   deactivate?: () => Promise<void>;
 }
 
+// https://pipedream.com/docs/components/api/#http-event-shape
 export interface SourceRunOptions {
-  event: JSONValue;
+  method: string;
+  path: string;
+  query: object;
+  headers: object;
+  bodyRaw?: string;
+  body?: object;
 }
 
 export interface ActionRunOptions {

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -236,17 +236,23 @@ export interface Hooks {
 }
 
 // https://pipedream.com/docs/components/api/#http-event-shape
-export interface SourceHttpRunOptions {
+export type SourceHttpRunOptions = {
   method: string;
   path: string;
-  query: object;
-  headers: object;
+  query: {
+    [key: string]: string;
+  };
+  headers: {
+    [key: string]: string;
+  };
   bodyRaw?: string;
-  body?: object;
+  body?: {
+    [key: string]: JSONValue;
+  };
 }
 
 // https://pipedream.com/docs/components/api/#timer
-export interface SourceTimerRunOptions {
+export type SourceTimerRunOptions = {
   timestamp: number;
   interval_seconds: number;
 }


### PR DESCRIPTION
The TypeScript definition for the source's run() method parameter did not correspond to the argument being passed at runtime.

This can be confirmed by sending a request to a source running with the following method:
```
async run(data) {
  this.http.respond({
    status: 200,
    body: data
  });
  // ...
}
```
The response will be the exact request that was sent.

[The docs also note the structure of the event argument correctly,](https://pipedream.com/docs/components/api/#http-event-shape) and I've left them as a comment in the type updated.

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/3455"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

