### PR TITLE
Fix git push repeatedly failing with required commit of pnpm-lock.yaml

### DIFF
--- a/.github/workflows/publish-components.yaml
+++ b/.github/workflows/publish-components.yaml
@@ -25,7 +25,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
       - name: Install dependencies
-        run: pnpm install -r --no-frozen-lockfile --fix-lockfile
+        run: pnpm install -r --no-frozen-lockfile
       - name: Setup Node Env
         uses: actions/setup-node@v3.4.1
         with:
@@ -131,7 +131,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
           cache: 'pnpm'
       - name: Install Dependencies
-        run: pnpm install -r --no-frozen-lockfile --fix-lockfile
+        run: pnpm install -r --no-frozen-lockfile
       - name: Install pd cli
         env:
           PD_API_KEY: ${{ secrets.PD_API_KEY }}

--- a/.github/workflows/publish-packages.yaml
+++ b/.github/workflows/publish-packages.yaml
@@ -18,7 +18,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
           cache: 'pnpm'
       - name: pnpm install
-        run: pnpm install -r --no-frozen-lockfile --fix-lockfile
+        run: pnpm install -r --no-frozen-lockfile
       - name: Compile TypeScript
         run: npm run build
       # See https://pnpm.io/using-changesets

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx pnpm install -r --fix-lockfile
+npx pnpm install -r

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,7 +1,7 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx pnpm install -r --fix-lockfile
+npx pnpm install -r
 
 if ! (git diff HEAD --quiet pnpm-lock.yaml); then
     echo "modified pnpm-lock.yaml - please commit the file"


### PR DESCRIPTION
Removes `--fix-lockfile` flag from `pnpm install` in git hooks & GitHub jobs

**Context**
`--fix-lockfile` in the `pre-push` hook caused the `pre-push` hook to fail repeatedly after minor changes to `pnpm-lock.yaml` on each push.

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/3485"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

