### PR TITLE
Google calendar: Add ability to send updates

### DIFF
--- a/components/google_calendar/actions/create-event/create-event.mjs
+++ b/components/google_calendar/actions/create-event/create-event.mjs
@@ -111,7 +111,7 @@ export default {
           timeZone,
         },
         attendees,
-        sendUpdates: this.sendUpdates || false
+        sendUpdates: this.sendUpdates ?? false
       },
     });
 

--- a/components/google_calendar/actions/create-event/create-event.mjs
+++ b/components/google_calendar/actions/create-event/create-event.mjs
@@ -48,6 +48,11 @@ export default {
       type: "string",
       description: "Enter the Event day in the format 'yyyy-mm-dd', if this is an all-day event.",
     },
+    sendUpdates: {
+      label: "Send Updates",
+      type: "string",
+      description: "Whether to send notifications about the creation of the new event.",
+    },
     timeZone: {
       propDefinition: [
         googleCalendar,
@@ -106,6 +111,7 @@ export default {
           timeZone,
         },
         attendees,
+        sendUpdates: this.sendUpdates || false
       },
     });
 

--- a/components/google_calendar/actions/create-event/create-event.mjs
+++ b/components/google_calendar/actions/create-event/create-event.mjs
@@ -52,6 +52,12 @@ export default {
       label: "Send Updates",
       type: "string",
       description: "Whether to send notifications about the creation of the new event.",
+      optional: true,
+      options: [
+        "all",
+        "externalOnly",
+        "none",
+      ],
     },
     timeZone: {
       propDefinition: [
@@ -88,6 +94,7 @@ export default {
 
     const response = await this.googleCalendar.createEvent({
       calendarId: this.calendarId,
+      sendUpdates: this.sendUpdates ?? false,
       resource: {
         summary: this.summary,
         location: this.location,
@@ -111,7 +118,6 @@ export default {
           timeZone,
         },
         attendees,
-        sendUpdates: this.sendUpdates ?? false
       },
     });
 

--- a/components/google_calendar/actions/create-event/create-event.mjs
+++ b/components/google_calendar/actions/create-event/create-event.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_calendar-create-event",
   name: "Create Event",
   description: "Create an event to the Google Calendar. [See the docs here](https://googleapis.dev/nodejs/googleapis/latest/calendar/classes/Resource$Events.html#insert)",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
   props: {
     googleCalendar,


### PR DESCRIPTION
Adds support for sending invitees notifications when they are invited to a calendar invite, as per https://developers.google.com/calendar/api/v3/reference/events/insert ( `|| false` is to cater for it defaulting to false - as per docs) 

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/3505"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

