### PR TITLE
[BUG] Sendinblue Transactional Email action fails when trying to add recipients to **To** field

### DIFF
--- a/components/sendinblue/actions/send-transactional-email/send-transactional-email.mjs
+++ b/components/sendinblue/actions/send-transactional-email/send-transactional-email.mjs
@@ -109,7 +109,10 @@ export default {
     return props;
   },
   methods: {
-    formatEmailProp(prop) {
+    formatEmailProp(prop, field) {
+      if (!Array.isArray(prop)) {
+        throw new Error(`Field ${field} should be an array`, prop);
+      }
       if (typeof prop[0] === "string") {
         return Object.keys(prop).map((key) => JSON.parse(prop[key]));
       }
@@ -131,13 +134,13 @@ export default {
       Object.keys(this.tags).map((key) => this.tags[key])
       : null;
     const to = this.to
-      ? this.formatEmailProp(this.to)
+      ? this.formatEmailProp(this.to, "To")
       : null;
     const cc = this.cc
-      ? this.formatEmailProp(this.cc)
+      ? this.formatEmailProp(this.cc, "CC")
       : null;
     const bcc = this.bcc
-      ? this.formatEmailProp(this.bcc)
+      ? this.formatEmailProp(this.bcc, "BCC")
       : null;
 
     if (!Array.isArray(to) || to.length === 0) {

--- a/components/sendinblue/actions/send-transactional-email/send-transactional-email.mjs
+++ b/components/sendinblue/actions/send-transactional-email/send-transactional-email.mjs
@@ -2,9 +2,9 @@ import sendinBlueApp from "../../sendinblue.app.mjs";
 
 export default {
   key: "sendinblue-send-transactional-email",
-  name: "Send transactional email",
-  description: "Send transactional email",
-  version: "0.0.2",
+  name: "Send Transactional Email",
+  description: "Send transactional email. [See the docs here](https://developers.sendinblue.com/reference/sendtransacemail)",
+  version: "0.0.3",
   type: "action",
   props: {
     sendinBlueApp,
@@ -108,6 +108,14 @@ export default {
 
     return props;
   },
+  methods: {
+    formatEmailProp(prop) {
+      if (typeof prop[0] === "string") {
+        return Object.keys(prop).map((key) => JSON.parse(prop[key]));
+      }
+      return prop;
+    },
+  },
   async run({ $ }) {
     const sender = this.sender ?
       JSON.parse(this.sender) :
@@ -123,13 +131,13 @@ export default {
       Object.keys(this.tags).map((key) => this.tags[key])
       : null;
     const to = this.to
-      ? Object.keys(this.to).map((key) => JSON.parse(this.to[key]))
+      ? this.formatEmailProp(this.to)
       : null;
     const cc = this.cc
-      ? Object.keys(this.cc).map((key) => JSON.parse(this.cc[key]))
+      ? this.formatEmailProp(this.cc)
       : null;
     const bcc = this.bcc
-      ? Object.keys(this.bcc).map((key) => JSON.parse(this.bcc[key]))
+      ? this.formatEmailProp(this.bcc)
       : null;
 
     if (!Array.isArray(to) || to.length === 0) {


### PR DESCRIPTION
Resolves #3514 

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/3679"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

