### PR TITLE
Notion - Fix triggers description

### DIFF
--- a/components/notion/sources/new-page/new-page.mjs
+++ b/components/notion/sources/new-page/new-page.mjs
@@ -6,8 +6,8 @@ export default {
   ...base,
   key: "notion-new-page",
   name: "New Page",
-  description: "Emit new event when a page is created",
-  version: "0.0.1",
+  description: "Emit new event when a page in a database is created",
+  version: "0.0.2",
   type: "source",
   props: {
     ...base.props,

--- a/components/notion/sources/updated-page/updated-page.mjs
+++ b/components/notion/sources/updated-page/updated-page.mjs
@@ -6,8 +6,8 @@ export default {
   ...base,
   key: "notion-updated-page",
   name: "Updated Page", /* eslint-disable-line pipedream/source-name */
-  description: "Emit new event when a page is updated",
-  version: "0.0.2",
+  description: "Emit new event when a page in a database is updated",
+  version: "0.0.3",
   type: "source",
   dedupe: "unique",
   props: {


### PR DESCRIPTION
Changes description for `new-page` and `updated-page` triggers.

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/3875"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

