### PR TITLE
Fix data stores object parsing

### DIFF
--- a/components/data_stores/actions/add-update-multiple-records/add-update-multiple-records.mjs
+++ b/components/data_stores/actions/add-update-multiple-records/add-update-multiple-records.mjs
@@ -68,8 +68,7 @@ export default {
      */
     populateHashMapOfData(data, map) {
       if (!Array.isArray(data) && typeof(data) === "object") {
-        Object.keys(data)
-          .forEach((key) => map[key] = this.convertString(data[key]));
+        Object.keys(data).forEach((key) => map[key] = this.convertString(data[key]));
         return;
       }
 

--- a/components/data_stores/actions/add-update-multiple-records/add-update-multiple-records.mjs
+++ b/components/data_stores/actions/add-update-multiple-records/add-update-multiple-records.mjs
@@ -98,5 +98,6 @@ export default {
     } else {
       $.export("$summary", `Successfully added or updated ${keys.length} record(s)`);
     }
+    return map;
   },
 };

--- a/components/data_stores/actions/add-update-multiple-records/add-update-multiple-records.mjs
+++ b/components/data_stores/actions/add-update-multiple-records/add-update-multiple-records.mjs
@@ -95,7 +95,8 @@ export default {
     if (keys.length === 0) {
       $.export("$summary", "No data was added to the data store.");
     } else {
-      $.export("$summary", `Successfully added or updated ${keys.length} record(s)`);
+      // eslint-disable-next-line multiline-ternary
+      $.export("$summary", `Successfully added or updated ${keys.length} record${keys.length === 1 ? "" : "s"}`);
     }
     return map;
   },

--- a/components/data_stores/actions/add-update-multiple-records/add-update-multiple-records.mjs
+++ b/components/data_stores/actions/add-update-multiple-records/add-update-multiple-records.mjs
@@ -4,7 +4,7 @@ export default {
   key: "data_stores-add-update-multiple-records",
   name: "Add or update multiple records",
   description: "Add or update multiple records to your [Pipedream Data Store](https://pipedream.com/data-stores/).",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   props: {
     app,

--- a/components/data_stores/actions/add-update-multiple-records/add-update-multiple-records.mjs
+++ b/components/data_stores/actions/add-update-multiple-records/add-update-multiple-records.mjs
@@ -1,5 +1,4 @@
 import app from "../../data_stores.app.mjs";
-import xss from "xss";
 
 export default {
   key: "data_stores-add-update-multiple-records",
@@ -53,13 +52,7 @@ export default {
         }
       }
 
-      // Try to evaluate string as javascript, using xss as extra security
-      // If some problem occurs, return the original string
-      try {
-        return eval(`(${xss(value)})`);
-      } catch {
-        return value;
-      }
+      return this.app.evaluate(value);
     },
     /**
      * Add all the key-value pairs in the map object to be used in the data store
@@ -86,7 +79,7 @@ export default {
   },
   async run({ $ }) {
     if (typeof this.data === "string") {
-      this.data = eval(`(${this.data})`);
+      this.data = this.app.evaluate(this.data);
     }
     const map = this.getHashMapOfData(this.data);
     const keys = Object.keys(map);

--- a/components/data_stores/actions/add-update-record/add-update-record.mjs
+++ b/components/data_stores/actions/add-update-record/add-update-record.mjs
@@ -4,7 +4,7 @@ export default {
   key: "data_stores-add-update-record",
   name: "Add or update a single record",
   description: "Add or update a single record in your [Pipedream Data Store](https://pipedream.com/data-stores/).",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   props: {
     app,

--- a/components/data_stores/actions/add-update-record/add-update-record.mjs
+++ b/components/data_stores/actions/add-update-record/add-update-record.mjs
@@ -42,7 +42,7 @@ export default {
     $.export("$summary", `Successfully ${record ? "updated the record for" : "added a new record with the"} key, \`${key}\`.`);
     return {
       key,
-      value,
+      value: parsedValue,
     };
   },
 };

--- a/components/data_stores/actions/add-update-record/add-update-record.mjs
+++ b/components/data_stores/actions/add-update-record/add-update-record.mjs
@@ -25,9 +25,10 @@ export default {
       description: "Enter a key for the record you'd like to create or select an existing key to update.",
     },
     value: {
-      label: "Value",
-      type: "any",
-      description: "Enter a string, object, or array.",
+      propDefinition: [
+        app,
+        "value",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/data_stores/actions/add-update-record/add-update-record.mjs
+++ b/components/data_stores/actions/add-update-record/add-update-record.mjs
@@ -36,11 +36,11 @@ export default {
       key,
       value,
     } = this;
-    const record = await this.dataStore.get(key);
+    const exists = await this.dataStore.has(key);
     const parsedValue = this.app.parseValue(value);
     await this.dataStore.set(key, parsedValue);
     // eslint-disable-next-line multiline-ternary
-    $.export("$summary", `Successfully ${record ? "updated the record for" : "added a new record with the"} key, \`${key}\`.`);
+    $.export("$summary", `Successfully ${exists ? "updated the record for" : "added a new record with the"} key, \`${key}\`.`);
     return {
       key,
       value: parsedValue,

--- a/components/data_stores/actions/delete-single-record/delete-single-record.mjs
+++ b/components/data_stores/actions/delete-single-record/delete-single-record.mjs
@@ -4,7 +4,7 @@ export default {
   key: "data_stores-delete-single-record",
   name: "Delete a single record",
   description: "Delete a single record in your [Pipedream Data Store](https://pipedream.com/data-stores/).",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   props: {
     app,

--- a/components/data_stores/actions/delete-single-record/delete-single-record.mjs
+++ b/components/data_stores/actions/delete-single-record/delete-single-record.mjs
@@ -31,6 +31,7 @@ export default {
     if (record) {
       await this.dataStore.delete(this.key);
       $.export("$summary", "Successfully deleted the record for key, `" + this.key + "`.");
+      return record;
     } else {
       $.export("$summary", "No record found for key, `" + this.key + "`. No data was deleted.");
     }

--- a/components/data_stores/actions/delete-single-record/delete-single-record.mjs
+++ b/components/data_stores/actions/delete-single-record/delete-single-record.mjs
@@ -30,10 +30,10 @@ export default {
 
     if (record) {
       await this.dataStore.delete(this.key);
-      $.export("$summary", "Successfully deleted the record for key, `" + this.key + "`.");
+      $.export("$summary", `Successfully deleted the record for key, \`${this.key}\`.`);
       return record;
-    } else {
-      $.export("$summary", "No record found for key, `" + this.key + "`. No data was deleted.");
     }
+
+    $.export("$summary", `No record found for key, \`${this.key}\`. No data was deleted.`);
   },
 };

--- a/components/data_stores/actions/get-record-or-create/get-record-or-create.mjs
+++ b/components/data_stores/actions/get-record-or-create/get-record-or-create.mjs
@@ -4,7 +4,7 @@ export default {
   key: "data_stores-get-record-or-create",
   name: "Get record (or create one if not found)",
   description: "Get a single record in your [Pipedream Data Store](https://pipedream.com/data-stores/) or create one if it doesn't exist.",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   props: {
     app,

--- a/components/data_stores/actions/get-record-or-create/get-record-or-create.mjs
+++ b/components/data_stores/actions/get-record-or-create/get-record-or-create.mjs
@@ -33,7 +33,7 @@ export default {
   },
   async additionalProps() {
     if (this.app.shouldAddRecord(this.addRecordIfNotFound)) {
-      return this.app.valueProp();
+      return this.app.propDefinitions.value;
     }
     return {};
   },

--- a/components/data_stores/actions/get-record-or-create/get-record-or-create.mjs
+++ b/components/data_stores/actions/get-record-or-create/get-record-or-create.mjs
@@ -41,19 +41,18 @@ export default {
     const record = await this.dataStore.get(this.key);
 
     if (record) {
-      $.export("$summary", "Found data for the key, `" + this.key + "`.");
+      $.export("$summary", `Found data for the key, \`${this.key}\`.`);
       return record;
-    } else {
-      if (this.app.shouldAddRecord(this.addRecordIfNotFound)) {
-        const parsedValue = this.app.parseValue(this.value);
-        await this.dataStore.set(this.key, parsedValue);
-        $.export("$summary", "Successfully added a new record with the key, `" + this.key + "`.");
-        return parsedValue;
-      } else {
-        $.export("$summary", "No data found for key, `" + this.key + "`.");
-      }
     }
 
-    return record;
+    if (!this.app.shouldAddRecord(this.addRecordIfNotFound)) {
+      $.export("$summary", `No data found for key, \`${this.key}\`.`);
+      return;
+    }
+
+    const parsedValue = this.app.parseValue(this.value);
+    await this.dataStore.set(this.key, parsedValue);
+    $.export("$summary", `Successfully added a new record with the key, \`${this.key}\`.`);
+    return parsedValue;
   },
 };

--- a/components/data_stores/actions/get-record-or-create/get-record-or-create.mjs
+++ b/components/data_stores/actions/get-record-or-create/get-record-or-create.mjs
@@ -32,10 +32,11 @@ export default {
     },
   },
   async additionalProps() {
+    const props = {};
     if (this.app.shouldAddRecord(this.addRecordIfNotFound)) {
-      return this.app.propDefinitions.value;
+      props.value = app.propDefinitions.value;
     }
-    return {};
+    return props;
   },
   async run({ $ }) {
     const record = await this.dataStore.get(this.key);

--- a/components/data_stores/actions/get-record-or-create/get-record-or-create.mjs
+++ b/components/data_stores/actions/get-record-or-create/get-record-or-create.mjs
@@ -42,12 +42,13 @@ export default {
 
     if (record) {
       $.export("$summary", "Found data for the key, `" + this.key + "`.");
+      return record;
     } else {
       if (this.app.shouldAddRecord(this.addRecordIfNotFound)) {
         const parsedValue = this.app.parseValue(this.value);
         await this.dataStore.set(this.key, parsedValue);
         $.export("$summary", "Successfully added a new record with the key, `" + this.key + "`.");
-        return this.dataStore.get(this.key);
+        return parsedValue;
       } else {
         $.export("$summary", "No data found for key, `" + this.key + "`.");
       }

--- a/components/data_stores/actions/has-key-or-create/has-key-or-create.mjs
+++ b/components/data_stores/actions/has-key-or-create/has-key-or-create.mjs
@@ -4,7 +4,7 @@ export default {
   key: "data_stores-has-key-or-create",
   name: "Check for existence of key",
   description: "Check if a key exists in your [Pipedream Data Store](https://pipedream.com/data-stores/) or create one if it doesn't exist.",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   props: {
     app,

--- a/components/data_stores/actions/has-key-or-create/has-key-or-create.mjs
+++ b/components/data_stores/actions/has-key-or-create/has-key-or-create.mjs
@@ -33,7 +33,7 @@ export default {
   },
   async additionalProps() {
     if (this.app.shouldAddRecord(this.addRecordIfNotFound)) {
-      return this.app.valueProp();
+      return this.app.propDefinitions.value;
     }
     return {};
   },

--- a/components/data_stores/actions/has-key-or-create/has-key-or-create.mjs
+++ b/components/data_stores/actions/has-key-or-create/has-key-or-create.mjs
@@ -32,10 +32,11 @@ export default {
     },
   },
   async additionalProps() {
+    const props = {};
     if (this.app.shouldAddRecord(this.addRecordIfNotFound)) {
-      return this.app.propDefinitions.value;
+      props.value = app.propDefinitions.value;
     }
-    return {};
+    return props;
   },
   async run ({ $ }) {
     if (await this.dataStore.has(this.key)) {

--- a/components/data_stores/actions/has-key-or-create/has-key-or-create.mjs
+++ b/components/data_stores/actions/has-key-or-create/has-key-or-create.mjs
@@ -47,7 +47,7 @@ export default {
       const parsedValue = this.app.parseValue(this.value);
       await this.dataStore.set(this.key, parsedValue);
       $.export("$summary", `Key "${this.key}" was not found. Successfully added a new record.`);
-      return this.dataStore.get(this.key);
+      return parsedValue;
     }
 
     $.export("$summary", `Key "${this.key}" does not exist.`);

--- a/components/data_stores/actions/has-key-or-create/has-key-or-create.mjs
+++ b/components/data_stores/actions/has-key-or-create/has-key-or-create.mjs
@@ -39,18 +39,18 @@ export default {
   },
   async run ({ $ }) {
     if (await this.dataStore.has(this.key)) {
-      $.export("$summary", `Key "${this.key}" exists.`);
+      $.export("$summary", `Key \`${this.key}\` exists.`);
       return true;
     }
 
-    if (this.app.shouldAddRecord(this.addRecordIfNotFound)) {
-      const parsedValue = this.app.parseValue(this.value);
-      await this.dataStore.set(this.key, parsedValue);
-      $.export("$summary", `Key "${this.key}" was not found. Successfully added a new record.`);
-      return parsedValue;
+    if (!this.app.shouldAddRecord(this.addRecordIfNotFound)) {
+      $.export("$summary", `Key \`${this.key}\` does not exist.`);
+      return false;
     }
 
-    $.export("$summary", `Key "${this.key}" does not exist.`);
-    return false;
+    const parsedValue = this.app.parseValue(this.value);
+    await this.dataStore.set(this.key, parsedValue);
+    $.export("$summary", `Key \`${this.key}\` was not found. Successfully added a new record.`);
+    return parsedValue;
   },
 };

--- a/components/data_stores/data_stores.app.mjs
+++ b/components/data_stores/data_stores.app.mjs
@@ -15,6 +15,11 @@ export default {
         return dataStore.keys();
       },
     },
+    value: {
+      label: "Value",
+      type: "any",
+      description: "Enter a string, object, or array.",
+    },
     addRecordIfNotFound: {
       label: "Create a new record if the key is not found?",
       description: "Create a new record if no records are found for the specified key.",
@@ -30,15 +35,6 @@ export default {
   methods: {
     shouldAddRecord(option) {
       return option === "Yes";
-    },
-    valueProp() {
-      return {
-        value: {
-          label: "Value",
-          type: "any",
-          description: "Enter a string, object, or array.",
-        },
-      };
     },
     parseValue(value) {
       if (typeof value !== "string") {


### PR DESCRIPTION
**Primary fix:**

- [x] Using `Function` to evaluate JSON / JS objects - regex failed on some cases: on `time` values (containing `:`) and if there were spaces in between the key/value (e.g. `{key : "value"}` - note space before `:`)

**Refactors:**

- [x] return `parsedValue` whenever possible
- [x] new `value` propDefinition
- [x] change some logic of summary exports (affects order of execution only)
- [x] minor changes

Resolves #3515.

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/3895"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

