### PR TITLE
Notion New Trigger Updated Page ID

### DIFF
--- a/components/notion/sources/new-page/new-page.mjs
+++ b/components/notion/sources/new-page/new-page.mjs
@@ -5,9 +5,9 @@ import constants from "../common/constants.mjs";
 export default {
   ...base,
   key: "notion-new-page",
-  name: "New Page",
-  description: "Emit new event when a page is created",
-  version: "0.0.1",
+  name: "New Page in Database",
+  description: "Emit new event when a page in a database is created",
+  version: "0.0.2",
   type: "source",
   props: {
     ...base.props,

--- a/components/notion/sources/updated-page-id/updated-page-id.mjs
+++ b/components/notion/sources/updated-page-id/updated-page-id.mjs
@@ -1,0 +1,38 @@
+import notion from "../../notion.app.mjs";
+import base from "../common/base.mjs";
+import constants from "../common/constants.mjs";
+
+export default {
+  ...base,
+  key: "notion-updated-page-id",
+  name: "Updated Page ID", /* eslint-disable-line pipedream/source-name */
+  description: "Emit new event when a selected page is updated",
+  version: "0.0.1",
+  type: "source",
+  dedupe: "unique",
+  props: {
+    ...base.props,
+    pageId: {
+      propDefinition: [
+        notion,
+        "pageId",
+      ],
+    },
+  },
+  async run() {
+    const page = await this.notion.retrievePage(this.pageId);
+
+    if (this.isResultNew(page.last_edited_time, this.getLastUpdatedTimestamp())) {
+      const meta = this.generateMeta(
+        page,
+        constants.types.PAGE,
+        constants.timestamps.LAST_EDITED_TIME,
+        constants.summaries.PAGE_UPDATED,
+        true,
+      );
+
+      this.$emit(page, meta);
+      this.setLastUpdatedTimestamp(Date.parse(page.last_edited_time));
+    }
+  },
+};

--- a/components/notion/sources/updated-page/updated-page.mjs
+++ b/components/notion/sources/updated-page/updated-page.mjs
@@ -5,9 +5,9 @@ import constants from "../common/constants.mjs";
 export default {
   ...base,
   key: "notion-updated-page",
-  name: "Updated Page", /* eslint-disable-line pipedream/source-name */
-  description: "Emit new event when a page is updated",
-  version: "0.0.2",
+  name: "Updated Page in Database", /* eslint-disable-line pipedream/source-name */
+  description: "Emit new event when a page in a database is updated. To select a specific page, use `Updated Page ID` instead",
+  version: "0.0.3",
   type: "source",
   dedupe: "unique",
   props: {


### PR DESCRIPTION
Add trigger for watching updates for a specific page ID.

Resolves #3890.

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/3899"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

