### PR TITLE
Fix axios debug export printing

### DIFF
--- a/platform/dist/axios.js
+++ b/platform/dist/axios.js
@@ -116,5 +116,5 @@ function stepExport(step, message, key) {
         }
         step[key] = message;
     }
-    console.log(`export: ${key} - ${message}`);
+    console.log(`export: ${key} - ${JSON.stringify(message, null, 2)}`);
 }

--- a/platform/lib/axios.ts
+++ b/platform/lib/axios.ts
@@ -117,5 +117,5 @@ function stepExport(step: any, message: any, key: string) {
     step[key] = message;
   }
 
-  console.log(`export: ${key} - ${message}`);
+  console.log(`export: ${key} - ${JSON.stringify(message, null, 2)}`);
 }

--- a/platform/package-lock.json
+++ b/platform/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "axios": "^0.21.2",
         "fp-ts": "^2.0.2",
-        "io-ts": "^2.0.0"
+        "io-ts": "^2.0.0",
+        "querystring": "^0.2.1"
       },
       "devDependencies": {
         "@octokit/core": "^3.6.0",
@@ -5149,6 +5150,15 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/querystring": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
+      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "engines": {
+        "node": ">=0.4.x"
       }
     },
     "node_modules/react-is": {
@@ -10882,6 +10892,11 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
+    },
+    "querystring": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
+      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg=="
     },
     "react-is": {
       "version": "16.13.1",

--- a/platform/package.json
+++ b/platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/platform",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Pipedream platform globals (typing and runtime type checking)",
   "homepage": "https://pipedream.com",
   "main": "dist/index.js",
@@ -19,7 +19,8 @@
   "dependencies": {
     "axios": "^0.21.2",
     "fp-ts": "^2.0.2",
-    "io-ts": "^2.0.0"
+    "io-ts": "^2.0.0",
+    "querystring": "^0.2.1"
   },
   "devDependencies": {
     "husky": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1840,11 +1840,13 @@ importers:
       husky: ^3.0.0
       io-ts: ^2.0.0
       jest: ^24.8.0
+      querystring: ^0.2.1
       typescript: ^3.5.3
     dependencies:
       axios: 0.21.4
       fp-ts: 2.12.1
       io-ts: 2.2.16_fp-ts@2.12.1
+      querystring: 0.2.1
     devDependencies:
       '@octokit/core': 3.6.0
       husky: 3.1.0
@@ -16331,6 +16333,7 @@ packages:
   /querystring/0.2.1:
     resolution: {integrity: sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==}
     engines: {node: '>=0.4.x'}
+    deprecated: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
     dev: false
 
   /querystringify/2.2.0:


### PR DESCRIPTION
When using `@pipedream/platform/axios` and setting `debug = true`, if the export is an object, the `console.log` would not print correctly.

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/3913"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

