### PR TITLE
Raindrop.io - add optional title and description

### DIFF
--- a/components/raindrop/actions/save/save.mjs
+++ b/components/raindrop/actions/save/save.mjs
@@ -4,7 +4,7 @@ export default {
   key: "raindrop-save",
   name: "Save to Raindrop Collection",
   description: "Receive a link and save it into a specified collection. [See docs](https://developer.raindrop.io/v1/raindrops/single)",
-  version: "1.1.0",
+  version: "1.2.0",
   type: "action",
   props: {
     raindrop,
@@ -27,6 +27,18 @@ export default {
       description: "A list of tags for the bookmark",
       optional: true,
     },
+    title: {
+      type: "string",
+      label: "Title",
+      description: "Title of the bookmark",
+      optional: true,
+    },
+    excerpt: {
+      type: "string",
+      label: "Excerpt",
+      description: "Description of the bookmark",
+      optional: true,
+    },
   },
   async run({ $ }) {
     const bookmarkData = {
@@ -35,6 +47,8 @@ export default {
         $id: this.collectionId,
       },
       tags: this.tags ?? [],
+      title: this.title,
+      excerpt: this.excerpt,
     };
 
     const response = await this.raindrop.postBookmark($, bookmarkData);


### PR DESCRIPTION
Resolves #3511.

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/3930"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

