### PR TITLE
Slack: remove "ignore myself" from sources

### DIFF
--- a/components/slack/slack.app.mjs
+++ b/components/slack/slack.app.mjs
@@ -381,7 +381,7 @@ export default {
       type: "boolean",
       label: "Ignore myself",
       description: "Ignore messages from me",
-      default: true,
+      default: false,
     },
     word: {
       type: "string",

--- a/components/slack/sources/new-direct-message/new-direct-message.mjs
+++ b/components/slack/sources/new-direct-message/new-direct-message.mjs
@@ -4,7 +4,7 @@ export default {
   ...common,
   key: "slack-new-direct-message",
   name: "New Direct Message (Instant)",
-  version: "0.0.1",
+  version: "1.0.0",
   description: "Emit new event when a message was posted in a direct message channel",
   type: "source",
   dedupe: "unique",

--- a/components/slack/sources/new-mention/new-mention.mjs
+++ b/components/slack/sources/new-mention/new-mention.mjs
@@ -4,7 +4,7 @@ export default {
   ...common,
   key: "slack-new-mention",
   name: "New Mention (Instant)",
-  version: "0.0.1",
+  version: "1.0.0",
   description: "Emit new event when a username or specific word is mentioned in a channel",
   type: "source",
   dedupe: "unique",
@@ -29,12 +29,6 @@ export default {
           "message",
         ];
       },
-    },
-    ignoreMyself: {
-      propDefinition: [
-        common.props.slack,
-        "ignoreMyself",
-      ],
     },
     word: {
       propDefinition: [
@@ -71,9 +65,6 @@ export default {
       // events, we are ignoring them for now. If you want to handle these types of
       // events, feel free to change this code!!
         console.log("Ignoring message with subtype.");
-        return;
-      }
-      if (this.ignoreMyself && event.user == this.slack.mySlackId()) {
         return;
       }
       if ((this.ignoreBot) && (event.subtype == "bot_message" || event.bot_id)) {

--- a/components/slack/sources/new-message-in-channels/new-message-in-channels.mjs
+++ b/components/slack/sources/new-message-in-channels/new-message-in-channels.mjs
@@ -4,7 +4,7 @@ export default {
   ...common,
   key: "slack-new-message-in-channels",
   name: "New Message In Channels (Instant)",
-  version: "0.0.7",
+  version: "1.0.0",
   description: "Emit new event when a new message is posted to one or more channels",
   type: "source",
   dedupe: "unique",
@@ -29,12 +29,6 @@ export default {
           "message",
         ];
       },
-    },
-    ignoreMyself: {
-      propDefinition: [
-        common.props.slack,
-        "ignoreMyself",
-      ],
     },
     resolveNames: {
       propDefinition: [
@@ -65,9 +59,6 @@ export default {
         // events, we are ignoring them for now. If you want to handle these types of
         // events, feel free to change this code!!
         console.log("Ignoring message with subtype.");
-        return;
-      }
-      if (this.ignoreMyself && event.user == this.slack.mySlackId()) {
         return;
       }
       if ((this.ignoreBot) && (event.subtype == "bot_message" || event.bot_id)) {

--- a/components/slack/sources/new-reaction-added/new-reaction-added.mjs
+++ b/components/slack/sources/new-reaction-added/new-reaction-added.mjs
@@ -4,7 +4,7 @@ export default {
   ...common,
   key: "slack-new-reaction-added",
   name: "New Reaction Added (Instant)",
-  version: "0.0.1",
+  version: "1.0.0",
   description: "Emit new event when a member has added an emoji reaction to an item",
   type: "source",
   dedupe: "unique",
@@ -38,12 +38,6 @@ export default {
         ];
       },
     },
-    ignoreMyself: {
-      propDefinition: [
-        common.props.slack,
-        "ignoreMyself",
-      ],
-    },
     ignoreBot: {
       propDefinition: [
         common.props.slack,
@@ -56,9 +50,6 @@ export default {
       return "New reaction added";
     },
     async processEvent(event) {
-      if (this.ignoreMyself && event.user == this.slack.mySlackId()) {
-        return;
-      }
       if ((this.ignoreBot) && (event.subtype == "bot_message" || event.bot_id)) {
         return;
       }


### PR DESCRIPTION
**Changes**
- Removes `ignoreMyself` prop from Slack **New Mention**, **New Message in Channels**, and **New Reaction Added** sources
- Changes default of `ignoreMyself` to false in **New Direct Message** source

**Context**
With the `ignoreMyself` default of `true`, it was more difficult to generate test events when configuring Slack triggers in a workflow. When I would send a message in a channel to try to generate an event, an event wouldn't be generated unless I switched `ignoreMyself` to `false`. The option to ignore myself seems undesirable in most cases, and removing the prop may improve usability ([[docs] props guidelines](https://pipedream.com/docs/components/guidelines/#props)).
For the **New Direct Message** source, I still want to be able to easily ignore my own messages.

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/3944"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

