### PR TITLE
Update dateTime format

### DIFF
--- a/components/google_calendar/actions/create-event/create-event.mjs
+++ b/components/google_calendar/actions/create-event/create-event.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_calendar-create-event",
   name: "Create Event",
   description: "Create an event to the Google Calendar. [See the docs here](https://googleapis.dev/nodejs/googleapis/latest/calendar/classes/Resource$Events.html#insert)",
-  version: "0.1.2",
+  version: "0.1.3",
   type: "action",
   props: {
     googleCalendar,

--- a/components/google_calendar/actions/create-event/create-event.mjs
+++ b/components/google_calendar/actions/create-event/create-event.mjs
@@ -41,12 +41,12 @@ export default {
     eventStartDate: {
       label: "Event Date",
       type: "string",
-      description: "Enter the Event day in the format 'yyyy-mm-dd', if this is an all-day event.",
+      description: "For all-day events, enter the Event day in the format 'yyyy-mm-dd'. For events with time, format according to [RFC3339](https://www.rfc-editor.org/rfc/rfc3339.html#section-1): 'yyyy-mm-ddThh:mm:ss+01:00'. A time zone offset is required unless a time zone is explicitly specified in timeZone.",
     },
     eventEndDate: {
       label: "Event End Date",
       type: "string",
-      description: "Enter the Event day in the format 'yyyy-mm-dd', if this is an all-day event.",
+      description: "For all-day events, enter the Event day in the format 'yyyy-mm-dd'. For events with time, format according to [RFC3339](https://www.rfc-editor.org/rfc/rfc3339.html#section-1): 'yyyy-mm-ddThh:mm:ss+01:00'. A time zone offset is required unless a time zone is explicitly specified in timeZone.",
     },
     sendUpdates: {
       label: "Send Updates",


### PR DESCRIPTION
Information on how to format dateTime for non-all-day events is unclear. Updated description of date start and end.
See documentation here: https://developers.google.com/calendar/api/v3/reference/events/insert

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/3948"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

