### PR TITLE
Fix elmah.io source

### DIFF
--- a/components/elmah_io/package.json
+++ b/components/elmah_io/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pipedream/elmah_io",
   "version": "0.0.1",
-  "description": "Pipedream Elmah.io Components",
+  "description": "Pipedream elmah.io Components",
   "main": "elmah_io.app.mjs",
   "keywords": [
     "pipedream",

--- a/components/elmah_io/sources/new-error/new-error.mjs
+++ b/components/elmah_io/sources/new-error/new-error.mjs
@@ -1,9 +1,11 @@
 import elmah_io from "../../elmah_io.app.mjs";
 import constants from "../common/constants.mjs";
 
+const QUERY = "isNew:true AND (severity:Error OR severity:Fatal)";
+
 export default {
   name: "New Error",
-  version: "0.0.1",
+  version: "0.0.2",
   key: "elmah_io-new-error",
   description: "Emit new event on each new error",
   type: "source",
@@ -45,7 +47,7 @@ export default {
         logId: this.logId,
         params: {
           pageSize: 10,
-          query: "isNew:true AND (severity:Error OR severity:Fatal)",
+          query: QUERY,
         },
       });
 
@@ -61,6 +63,7 @@ export default {
         params: {
           pageIndex: page,
           pageSize: constants.DEFAULT_PAGE_SIZE,
+          query: QUERY,
         },
       });
 

--- a/components/elmah_io/sources/new-error/new-error.mjs
+++ b/components/elmah_io/sources/new-error/new-error.mjs
@@ -45,6 +45,7 @@ export default {
         logId: this.logId,
         params: {
           pageSize: 10,
+          query: "isNew:true AND (severity:Error OR severity:Fatal)",
         },
       });
 


### PR DESCRIPTION
When looking for 'New Error' it only makes sense to look for messages where isNew is true and the severity is either Error or Fatal.

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/3956"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

