### PR TITLE
New Relic - rename source new-deployment-event

### DIFF
--- a/components/new_relic/sources/new-deployment-event/new-deployment-event.mjs
+++ b/components/new_relic/sources/new-deployment-event/new-deployment-event.mjs
@@ -4,7 +4,7 @@ import common from "../../common/common-sources.mjs";
 export default {
   dedupe: "unique",
   type: "source",
-  key: "new_relic-new-deployment",
+  key: "new_relic-new-deployment-event",
   name: "New Deployment",
   description: "Emit new event when a new deployment is created.",
   version: "0.0.1",


### PR DESCRIPTION
Renaming because there is already an action with the key `new_relic-new-deployment`.

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/3970"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

