### PR TITLE
Zonka Feeback New Components

### DIFF
--- a/components/zonka_feedback/actions/send-email-survey/send-email-survey.mjs
+++ b/components/zonka_feedback/actions/send-email-survey/send-email-survey.mjs
@@ -1,0 +1,62 @@
+import zonkaFeedback from "../../zonka_feedback.app.mjs";
+
+export default {
+  key: "zonka_feedback-send-email-survey",
+  name: "Send Email Survey",
+  description: "Send a survey by email. [See docs](https://apidocs.zonkafeedback.com/?version=latest#97c28279-79ce-47e8-ac73-a3077f37631e)",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    zonkaFeedback,
+    surveyId: {
+      propDefinition: [
+        zonkaFeedback,
+        "surveyId",
+      ],
+    },
+    email: {
+      type: "string",
+      label: "Email",
+      description: "Email address of the recipient to which the email is to be sent",
+    },
+    subject: {
+      type: "string",
+      label: "Subject",
+      description: "Subject of the email",
+      optional: true,
+    },
+    message: {
+      type: "string",
+      label: "Message",
+      description: "Content for message body of the email",
+      optional: true,
+    },
+    signature: {
+      type: "string",
+      label: "Signature",
+      description: "Signature content at the end of the email",
+      optional: true,
+    },
+    attributes: {
+      propDefinition: [
+        zonkaFeedback,
+        "attributes",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.zonkaFeedback.sendEmailSurvey({
+      $,
+      data: {
+        surveyId: this.surveyId,
+        email: this.email,
+        subject: this.subject,
+        message: this.message,
+        signature: this.signature,
+        attributes: this.attributes,
+      },
+    });
+    $.export("$summary", `Survey sent to ${this.email}`);
+    return response;
+  },
+};

--- a/components/zonka_feedback/actions/send-sms-survey/send-sms-survey.mjs
+++ b/components/zonka_feedback/actions/send-sms-survey/send-sms-survey.mjs
@@ -1,0 +1,48 @@
+import zonkaFeedback from "../../zonka_feedback.app.mjs";
+
+export default {
+  key: "zonka_feedback-send-sms-survey",
+  name: "Send SMS Survey",
+  description: "Send a survey by SMS. Please ensure you have enough SMS credits. [See docs](https://apidocs.zonkafeedback.com/?version=latest#9b6a1283-fb22-457e-8031-cf18d51d26f7)",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    zonkaFeedback,
+    surveyId: {
+      propDefinition: [
+        zonkaFeedback,
+        "surveyId",
+      ],
+    },
+    mobile: {
+      type: "string",
+      label: "Mobile Number",
+      description: "Mobile number of the recipient to which the survey is to be sent. Please include the country code, e.g., +9198XXXXXXXX.",
+    },
+    name: {
+      type: "string",
+      label: "Name",
+      description: "Name of the recipient",
+      optional: true,
+    },
+    attributes: {
+      propDefinition: [
+        zonkaFeedback,
+        "attributes",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.zonkaFeedback.sendSmsSurvey({
+      $,
+      data: {
+        surveyId: this.surveyId,
+        mobile: this.mobile,
+        name: this.name,
+        attributes: this.attributes,
+      },
+    });
+    $.export("$summary", `Survey sent to ${this.mobile}. If you do not have enough SMS credits, then the message won't be sent.`);
+    return response;
+  },
+};

--- a/components/zonka_feedback/package.json
+++ b/components/zonka_feedback/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@pipedream/zonka_feedback",
+  "version": "0.0.1",
+  "description": "Pipedream Zonka Feedback Components",
+  "main": "zonka_feedback.app.js",
+  "keywords": [
+    "pipedream",
+    "zonka",
+    "zonka_feedback"
+  ],
+  "homepage": "https://pipedream.com/apps/zonka_feedback",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^1.1.0"
+  }
+}

--- a/components/zonka_feedback/sources/new-survey-response/new-survey-response.mjs
+++ b/components/zonka_feedback/sources/new-survey-response/new-survey-response.mjs
@@ -15,7 +15,8 @@ export default {
         intervalSeconds: 60 * 15,
       },
     },
-    surveyId: {
+    surveyIds: {
+      type: "string[]",
       propDefinition: [
         zonkaFeedback,
         "surveyId",
@@ -23,6 +24,9 @@ export default {
     },
   },
   methods: {
+    isRelevant(event) {
+      return this.surveyIds.includes(event.surveyId);
+    },
     generateMeta(event) {
       const {
         receivedDate: ts,
@@ -46,17 +50,18 @@ export default {
 
     while (true) {
       const responses = await this.zonkaFeedback.getSurveyResponses({
-        surveyId: this.surveyId,
-        page: page++,
+        params: {
+          page: page++,
+        },
       });
       events.push(...responses);
-      if (responses.length < 25 || responses[0].id === events[events.length - 1].id) {
+      if (responses.length < 25) {
         break;
       }
     }
 
     for (const event of events) {
-      this.processEvent(event);
+      this.isRelevant(event) && this.processEvent(event);
     }
   },
 };

--- a/components/zonka_feedback/sources/new-survey-response/new-survey-response.mjs
+++ b/components/zonka_feedback/sources/new-survey-response/new-survey-response.mjs
@@ -1,0 +1,62 @@
+import zonkaFeedback from "../../zonka_feedback.app.mjs";
+
+export default {
+  key: "zonka_feedback-new-survey-response",
+  name: "New Survey Response",
+  description: "Emit new event for each survey response. [See docs](https://apidocs.zonkafeedback.com/?version=latest#156e4f44-d620-4d70-87f9-9d24462c23a2)",
+  version: "0.0.1",
+  type: "source",
+  dedupe: "unique",
+  props: {
+    zonkaFeedback,
+    timer: {
+      type: "$.interface.timer",
+      default: {
+        intervalSeconds: 60 * 15,
+      },
+    },
+    surveyId: {
+      propDefinition: [
+        zonkaFeedback,
+        "surveyId",
+      ],
+    },
+  },
+  methods: {
+    generateMeta(event) {
+      const {
+        receivedDate: ts,
+        id,
+        surveyName,
+      } = event;
+      return {
+        id,
+        summary: `New response for: ${surveyName}`,
+        ts,
+      };
+    },
+    processEvent(event) {
+      const meta = this.generateMeta(event);
+      this.$emit(event, meta);
+    },
+  },
+  async run() {
+    const events = [];
+    let page = 1;
+
+    while (true) {
+      const responses = await this.zonkaFeedback.getSurveyResponses({
+        surveyId: this.surveyId,
+        page: page++,
+      });
+      events.push(...responses);
+      if (responses.length < 25 || responses[0].id === events[events.length - 1].id) {
+        break;
+      }
+    }
+
+    for (const event of events) {
+      this.processEvent(event);
+    }
+  },
+};

--- a/components/zonka_feedback/zonka_feedback.app.mjs
+++ b/components/zonka_feedback/zonka_feedback.app.mjs
@@ -1,11 +1,72 @@
+import { axios } from "@pipedream/platform";
+
 export default {
   type: "app",
   app: "zonka_feedback",
-  propDefinitions: {},
+  propDefinitions: {
+    // eslint-disable-next-line pipedream/props-description
+    surveyId: {
+      type: "string",
+      label: "Survey ID",
+      async options(page) {
+        const surveys = await this.listSurveys({
+          surveyStatus: "active",
+          params: {
+            page,
+          },
+        });
+        return surveys.map((survey) => ({
+          label: survey.name,
+          value: survey.id,
+        }));
+      },
+    },
+    attributes: {
+      type: "object",
+      label: "Survey Attributes",
+      description: "Key-value pair of survey attributes",
+      optional: true,
+    },
+  },
   methods: {
-    // this.$auth contains connected account data
-    authKeys() {
-      console.log(Object.keys(this.$auth));
+    async _makeRequest({
+      $ = this,
+      method = "get",
+      path,
+      ...opts
+    } = {}) {
+      try {
+        return await axios($, {
+          headers: {
+            "Z-API-TOKEN": this.$auth.auth_token,
+          },
+          url: `https://apis.zonkafeedback.com${path}`,
+          method,
+          ...opts,
+        });
+      } catch (error) {
+        throw new Error(JSON.stringify(error.response.data, null, 2));
+      }
+    },
+    async listSurveys(opts = {}) {
+      return this._makeRequest({
+        path: "/surveys",
+        ...opts,
+      });
+    },
+    async sendEmailSurvey(opts) {
+      return this._makeRequest({
+        path: "/sendemail",
+        method: "post",
+        ...opts,
+      });
+    },
+    async sendSmsSurvey(opts) {
+      return this._makeRequest({
+        path: "/sendsms",
+        method: "post",
+        ...opts,
+      });
     },
   },
 };

--- a/components/zonka_feedback/zonka_feedback.app.mjs
+++ b/components/zonka_feedback/zonka_feedback.app.mjs
@@ -48,7 +48,7 @@ export default {
         throw new Error(JSON.stringify(error.response.data, null, 2));
       }
     },
-    async listSurveys(opts = {}) {
+    async listSurveys(opts) {
       return this._makeRequest({
         path: "/surveys",
         ...opts,
@@ -65,6 +65,12 @@ export default {
       return this._makeRequest({
         path: "/sendsms",
         method: "post",
+        ...opts,
+      });
+    },
+    async getSurveyResponses(opts) {
+      return this._makeRequest({
+        path: "/responses",
         ...opts,
       });
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1907,6 +1907,12 @@ importers:
     dependencies:
       '@pipedream/platform': 0.10.0
 
+  components/zonka_feedback:
+    specifiers:
+      '@pipedream/platform': ^1.1.0
+    dependencies:
+      '@pipedream/platform': 1.1.0
+
   components/zoom:
     specifiers:
       '@pipedream/platform': ^1.1.0


### PR DESCRIPTION
Using [API v2.1](https://apidocs.zonkafeedback.com/?version=latest).
Webhooks can be configured only by UI.

**Triggers**

- [x] New Survey Response

**Actions**

- [x] Send Email Survey
- [x] Send SMS Survey

Resolves #3854.

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/4013"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

