### PR TITLE
4009 bug slack new reaction instant missing message text

### DIFF
--- a/components/slack/sources/common/base.mjs
+++ b/components/slack/sources/common/base.mjs
@@ -61,6 +61,19 @@ export default {
         }
       });
     },
+    async getLastMessage({
+      channel, event_ts,
+    }) {
+      return this.maybeCached(`lastMessage:${channel}:${event_ts}`, async () => {
+        const info = await this.slack.sdk().conversations.history({
+          channel,
+          latest: event_ts,
+          limit: 1,
+          inclusive: true,
+        });
+        return info;
+      });
+    },
     processEvent(event) {
       return event;
     },

--- a/components/slack/sources/new-reaction-added/new-reaction-added.mjs
+++ b/components/slack/sources/new-reaction-added/new-reaction-added.mjs
@@ -46,6 +46,7 @@ export default {
     },
   },
   methods: {
+    ...common.methods,
     getSummary() {
       return "New reaction added";
     },
@@ -53,6 +54,11 @@ export default {
       if ((this.ignoreBot) && (event.subtype == "bot_message" || event.bot_id)) {
         return;
       }
+      event.message = await this.getLastMessage({
+        channel: event.item.channel,
+        event_ts: event.item.ts,
+      });
+
       return event;
     },
   },

--- a/components/slack/sources/new-reaction-added/new-reaction-added.mjs
+++ b/components/slack/sources/new-reaction-added/new-reaction-added.mjs
@@ -4,7 +4,7 @@ export default {
   ...common,
   key: "slack-new-reaction-added",
   name: "New Reaction Added (Instant)",
-  version: "1.0.0",
+  version: "1.1.0",
   description: "Emit new event when a member has added an emoji reaction to an item",
   type: "source",
   dedupe: "unique",


### PR DESCRIPTION
Add the reacted message

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/4027"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

