### PR TITLE
fix: Fix zoho server name by using properties

### DIFF
--- a/components/zoho_mail/actions/create-task/create-task.mjs
+++ b/components/zoho_mail/actions/create-task/create-task.mjs
@@ -4,7 +4,7 @@ export default {
   key: "zoho_mail-create-task",
   name: "Create Task",
   description: "Creates a new task. [See the docs here](https://www.zoho.com/mail/help/api/post-add-new-task.html)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     zohoMail,

--- a/components/zoho_mail/actions/send-email/send-email.mjs
+++ b/components/zoho_mail/actions/send-email/send-email.mjs
@@ -4,7 +4,7 @@ export default {
   key: "zoho_mail-send-email",
   name: "Send Email",
   description: "Send an email. [See the docs here](https://www.zoho.com/mail/help/api/post-send-an-email.html)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     zohoMail,

--- a/components/zoho_mail/package.json
+++ b/components/zoho_mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/zoho_mail",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Zoho Mail Components",
   "main": "zoho_mail.app.mjs",
   "keywords": [

--- a/components/zoho_mail/sources/new-email/new-email.mjs
+++ b/components/zoho_mail/sources/new-email/new-email.mjs
@@ -4,7 +4,7 @@ export default {
   key: "zoho_mail-new-email",
   name: "New Email",
   description: "Emit new event each time a new email is received",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/zoho_mail/zoho_mail.app.mjs
+++ b/components/zoho_mail/zoho_mail.app.mjs
@@ -120,7 +120,7 @@ export default {
       } = args;
       const config = {
         method,
-        url: `https://mail.zoho.com/api/${path}`,
+        url: `https://mail.${this.$auth.base_api_uri}/api/${path}`,
         headers: {
           "Authorization": `Zoho-oauthtoken ${this.$auth.oauth_access_token}`,
           "User-Agent": "@PipedreamHQ/pipedream v0.1",


### PR DESCRIPTION
Details of the bug here: https://pipedream.com/community/t/zoho-email-not-picking-the-right-server/3073

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/4067"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

