### PR TITLE
Include props for Emergency priority

### DIFF
--- a/components/pushover/actions/emergency-push-notification/emergency-push-notification.mjs
+++ b/components/pushover/actions/emergency-push-notification/emergency-push-notification.mjs
@@ -7,7 +7,7 @@ export default {
   description: `Sends an Emergency Push Notification to devices with Pushover.
     Notifications are repeated until they are acknowledged by the user.
     More information at [Pushing Messages](https://pushover.net/api#messages) and [Message Priority](https://pushover.net/api#priority)`,
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     pushover,

--- a/components/pushover/actions/emergency-push-notification/emergency-push-notification.mjs
+++ b/components/pushover/actions/emergency-push-notification/emergency-push-notification.mjs
@@ -18,16 +18,16 @@ export default {
       ],
     },
     retry: {
-      type: "integer",
-      label: "Retry",
-      description: "How often, in seconds, Pushover will send the same notification. In a situation where your user might be in a noisy environment or sleeping, retrying the notification (with sound and vibration) will help get his or her attention. This parameter must have a value of at least 30 seconds between retries.",
-      min: 30,
+      propDefinition: [
+        pushover,
+        "retry",
+      ],
     },
     expire: {
-      type: "integer",
-      label: "Expire",
-      description: "Notification expiration time, in seconds. If the notification has not been acknowledged in expire seconds, it will be marked as expired and will stop being sent to the user. Note that the notification is still shown to the user after it is expired, but it will not prompt the user for acknowledgement. This parameter must have a maximum value of at most 10800 seconds (3 hours).",
-      max: 10800,
+      propDefinition: [
+        pushover,
+        "expire",
+      ],
     },
     callback: {
       type: "string",
@@ -74,5 +74,7 @@ export default {
         priority: constants.PRIORITY.EMERGENCY,
       });
     $.export("$summary", "Sent emergency notification");
+
+    return response;
   },
 };

--- a/components/pushover/actions/push-notification/push-notification.mjs
+++ b/components/pushover/actions/push-notification/push-notification.mjs
@@ -46,6 +46,20 @@ export default {
       optional: true,
       options: constants.PRIORITY_OPTIONS,
     },
+    retry: {
+      // Consider making this a dynamic prop: https://pipedream.com/docs/components/api/#dynamic-props
+      type: "integer",
+      label: "Retry",
+      description: "Required when using Emergency priority (2). Specifies how often (in seconds) the Pushover servers will send the same notification to the user.",
+      optional: true,
+    },
+    expire: {
+      // Consider making this a dynamic prop: https://pipedream.com/docs/components/api/#dynamic-props
+      type: "integer",
+      label: "Expire",
+      description: "Required when using Emergency priority (2). Specifies how many seconds in total your notification will continue to be retried for. Maximum value of 10800 seconds (3 hours).",
+      optional: true,
+    },
   },
   async run({ $ }) {
     const response =
@@ -56,6 +70,8 @@ export default {
         url_title: this.urlTitle,
         device: this.device,
         priority: this.priority,
+        retry: this.retry,
+        expire: this.expire,
       });
     $.export("$summary", "Sent notification");
     return response;

--- a/components/pushover/actions/push-notification/push-notification.mjs
+++ b/components/pushover/actions/push-notification/push-notification.mjs
@@ -47,17 +47,17 @@ export default {
       options: constants.PRIORITY_OPTIONS,
     },
     retry: {
-      // Consider making this a dynamic prop: https://pipedream.com/docs/components/api/#dynamic-props
-      type: "integer",
-      label: "Retry",
-      description: "Required when using Emergency priority (2). Specifies how often (in seconds) the Pushover servers will send the same notification to the user.",
+      propDefinition: [
+        pushover,
+        "retry",
+      ],
       optional: true,
     },
     expire: {
-      // Consider making this a dynamic prop: https://pipedream.com/docs/components/api/#dynamic-props
-      type: "integer",
-      label: "Expire",
-      description: "Required when using Emergency priority (2). Specifies how many seconds in total your notification will continue to be retried for. Maximum value of 10800 seconds (3 hours).",
+      propDefinition: [
+        pushover,
+        "expire",
+      ],
       optional: true,
     },
   },

--- a/components/pushover/actions/push-notification/push-notification.mjs
+++ b/components/pushover/actions/push-notification/push-notification.mjs
@@ -5,7 +5,7 @@ export default {
   key: "pushover-push-notification",
   name: "Push Notification",
   description: "Sends a Push Notification to devices with Pushover. More information at [Pushing Messages](https://pushover.net/api#messages)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     pushover,

--- a/components/pushover/common/constants.mjs
+++ b/components/pushover/common/constants.mjs
@@ -23,6 +23,10 @@ const PRIORITY_OPTIONS = [
     value: PRIORITY.HIGH,
     label: "High priority, bypass quiet hours",
   },
+  {
+    value: PRIORITY.EMERGENCY,
+    label: "Emergency priority, bypass quiet hours, and repeat until the notification is acknowledged by user",
+  },
 ]
 
 export default {

--- a/components/pushover/pushover.app.mjs
+++ b/components/pushover/pushover.app.mjs
@@ -66,6 +66,18 @@ export default {
         Otherwise it is the time the message is received by the API`,
       optional: true,
     },
+    retry: {
+      type: "integer",
+      label: "Retry",
+      description: "How often, in seconds, Pushover will send the same notification. In a situation where your user might be in a noisy environment or sleeping, retrying the notification (with sound and vibration) will help get his or her attention. This parameter must have a value of at least 30 seconds between retries.",
+      min: 30,
+    },
+    expire: {
+      type: "integer",
+      label: "Expire",
+      description: "Notification expiration time, in seconds. If the notification has not been acknowledged in expire seconds, it will be marked as expired and will stop being sent to the user. Note that the notification is still shown to the user after it is expired, but it will not prompt the user for acknowledgement. This parameter must have a maximum value of at most 10800 seconds (3 hours).",
+      max: 10800,
+    },
   },
   methods: {
     async makeRequest(config) {


### PR DESCRIPTION
Update pushover app to include required emergency priority props.

Improve on top of PR https://github.com/PipedreamHQ/pipedream/pull/4073

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/4082"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

