### PR TITLE
[Telegram Bot] Missing Update Types

### DIFF
--- a/components/telegram_bot_api/actions/create-chat-invite-link/create-chat-invite-link.mjs
+++ b/components/telegram_bot_api/actions/create-chat-invite-link/create-chat-invite-link.mjs
@@ -4,7 +4,7 @@ export default {
   key: "telegram_bot_api-create-chat-invite-link",
   name: "Create Chat Invite Link",
   description: "Create an additional invite link for a chat, [See the docs](https://core.telegram.org/bots/api#createchatinvitelink) for more information",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     telegramBotApi,

--- a/components/telegram_bot_api/actions/delete-message/delete-message.mjs
+++ b/components/telegram_bot_api/actions/delete-message/delete-message.mjs
@@ -4,7 +4,7 @@ export default {
   key: "telegram_bot_api-delete-message",
   name: "Delete a Message",
   description: "Deletes a message. [See the docs](https://core.telegram.org/bots/api#deletemessage) for more information",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     telegramBotApi,

--- a/components/telegram_bot_api/actions/edit-media-message/edit-media-message.mjs
+++ b/components/telegram_bot_api/actions/edit-media-message/edit-media-message.mjs
@@ -8,7 +8,7 @@ export default {
   key: "telegram_bot_api-edit-media-message",
   name: "Edit a Media Message",
   description: "Edits photo or video messages. [See the docs](https://core.telegram.org/bots/api#editmessagemedia) for more information",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     telegramBotApi,

--- a/components/telegram_bot_api/actions/edit-text-message/edit-text-message.mjs
+++ b/components/telegram_bot_api/actions/edit-text-message/edit-text-message.mjs
@@ -4,7 +4,7 @@ export default {
   key: "telegram_bot_api-edit-text-message",
   name: "Edit a Text Message",
   description: "Edits text or game messages. [See the docs](https://core.telegram.org/bots/api#editmessagetext) for more information",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     telegramBotApi,

--- a/components/telegram_bot_api/actions/export-chat-invite-link/export-chat-invite-link.mjs
+++ b/components/telegram_bot_api/actions/export-chat-invite-link/export-chat-invite-link.mjs
@@ -4,7 +4,7 @@ export default {
   key: "telegram_bot_api-export-chat-invite-link",
   name: "Export Chat Invite Link",
   description: "Generate a new primary invite link for a chat, [See the docs](https://core.telegram.org/bots/api#createchatinvitelink) for more information",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     telegramBotApi,

--- a/components/telegram_bot_api/actions/forward-message/forward-message.mjs
+++ b/components/telegram_bot_api/actions/forward-message/forward-message.mjs
@@ -4,7 +4,7 @@ export default {
   key: "telegram_bot_api-forward-message",
   name: "Forward a Message",
   description: "Forwards messages of any kind. [See the docs](https://core.telegram.org/bots/api#forwardmessage) for more information",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     telegramBotApi,

--- a/components/telegram_bot_api/actions/get-num-members-in-chat/get-num-members-in-chat.mjs
+++ b/components/telegram_bot_api/actions/get-num-members-in-chat/get-num-members-in-chat.mjs
@@ -4,7 +4,7 @@ export default {
   key: "telegram_bot_api-get-num-members-in-chat",
   name: "Get the Number of Members in a Chat",
   description: "Use this module to get the number of members in a chat. [See the docs](https://core.telegram.org/bots/api#getchatmembercount) for more information",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     telegramBotApi,

--- a/components/telegram_bot_api/actions/kick-chat-member/kick-chat-member.mjs
+++ b/components/telegram_bot_api/actions/kick-chat-member/kick-chat-member.mjs
@@ -4,7 +4,7 @@ export default {
   key: "telegram_bot_api-kick-chat-member",
   name: "Kick a Chat Member",
   description: "Use this method to kick a user from a group, a supergroup or channel. [See the docs](https://core.telegram.org/bots/api#banchatmember) for more information",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     telegramBotApi,

--- a/components/telegram_bot_api/actions/list-administrators-in-chat/list-administrators-in-chat.mjs
+++ b/components/telegram_bot_api/actions/list-administrators-in-chat/list-administrators-in-chat.mjs
@@ -4,7 +4,7 @@ export default {
   key: "telegram_bot_api-list-administrators-in-chat",
   name: "List Administrators In Chat",
   description: "Use this module to get a list of administrators in a chat. [See the docs](https://core.telegram.org/bots/api#getchatadministrators) for more information",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     telegramBotApi,

--- a/components/telegram_bot_api/actions/list-chats/list-chats.mjs
+++ b/components/telegram_bot_api/actions/list-chats/list-chats.mjs
@@ -4,7 +4,7 @@ export default {
   key: "telegram_bot_api-list-chats",
   name: "List Chats",
   description: "List available Telegram chats. [See the docs](https://core.telegram.org/bots/api#getupdates) for more information",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     telegramBotApi,

--- a/components/telegram_bot_api/actions/list-updates/list-updates.mjs
+++ b/components/telegram_bot_api/actions/list-updates/list-updates.mjs
@@ -4,7 +4,7 @@ export default {
   key: "telegram_bot_api-list-updates",
   name: "List Updates",
   description: "Retrieves a list of updates from the Telegram server. [See the docs](https://core.telegram.org/bots/api#getupdates) for more information",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     telegramBotApi,

--- a/components/telegram_bot_api/actions/pin-message/pin-message.mjs
+++ b/components/telegram_bot_api/actions/pin-message/pin-message.mjs
@@ -4,7 +4,7 @@ export default {
   key: "telegram_bot_api-pin-message",
   name: "Pin a Message",
   description: "Pins a message. [See the docs](https://core.telegram.org/bots/api#pinchatmessage) for more information",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     telegramBotApi,

--- a/components/telegram_bot_api/actions/promote-chat-member/promote-chat-member.mjs
+++ b/components/telegram_bot_api/actions/promote-chat-member/promote-chat-member.mjs
@@ -4,7 +4,7 @@ export default {
   key: "telegram_bot_api-promote-chat-member",
   name: "Promote a Chat Member",
   description: "Use this method to promote or demote a user in a supergroup or a channel. [See the docs](https://core.telegram.org/bots/api#promotechatmember) for more information",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     telegramBotApi,

--- a/components/telegram_bot_api/actions/restrict-chat-member/restrict-chat-member.mjs
+++ b/components/telegram_bot_api/actions/restrict-chat-member/restrict-chat-member.mjs
@@ -4,7 +4,7 @@ export default {
   key: "telegram_bot_api-restrict-chat-member",
   name: "Restrict a Chat Member",
   description: "Use this method to restrict a user in a supergroup. [See the docs](https://core.telegram.org/bots/api#restrictchatmember) for more information",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     telegramBotApi,

--- a/components/telegram_bot_api/actions/send-album/send-album.mjs
+++ b/components/telegram_bot_api/actions/send-album/send-album.mjs
@@ -5,7 +5,7 @@ export default {
   key: "telegram_bot_api-send-album",
   name: "Send an Album (Media Group)",
   description: "Sends a group of photos or videos as an album. [See the docs](https://core.telegram.org/bots/api#sendmediagroup) for more information",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     telegramBotApi,

--- a/components/telegram_bot_api/actions/send-audio-file/send-audio-file.mjs
+++ b/components/telegram_bot_api/actions/send-audio-file/send-audio-file.mjs
@@ -5,7 +5,7 @@ export default {
   key: "telegram_bot_api-send-audio-file",
   name: "Send an Audio File",
   description: "Sends an audio file to your Telegram Desktop application. [See the docs](https://core.telegram.org/bots/api#sendaudio) for more information",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     telegramBotApi,

--- a/components/telegram_bot_api/actions/send-document-or-image/send-document-or-image.mjs
+++ b/components/telegram_bot_api/actions/send-document-or-image/send-document-or-image.mjs
@@ -5,7 +5,7 @@ export default {
   key: "telegram_bot_api-send-document-or-image",
   name: "Send a Document/Image",
   description: "Sends a document or an image to your Telegram Desktop application. [See the docs](https://core.telegram.org/bots/api#senddocument) for more information",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     telegramBotApi,

--- a/components/telegram_bot_api/actions/send-media-by-url-or-id/send-media-by-url-or-id.mjs
+++ b/components/telegram_bot_api/actions/send-media-by-url-or-id/send-media-by-url-or-id.mjs
@@ -5,7 +5,7 @@ export default {
   key: "telegram_bot_api-send-media-by-url-or-id",
   name: "Send Media by URL or ID",
   description: "Sends a file (document, photo, video, audio, ...) by HTTP URL or by ID that exists on the Telegram servers. [See the docs](https://core.telegram.org/bots/api#inputmedia) for more information",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     telegramBotApi,

--- a/components/telegram_bot_api/actions/send-photo/send-photo.mjs
+++ b/components/telegram_bot_api/actions/send-photo/send-photo.mjs
@@ -5,7 +5,7 @@ export default {
   key: "telegram_bot_api-send-photo",
   name: "Send a Photo",
   description: "Sends a photo to your Telegram Desktop application. [See the docs](https://core.telegram.org/bots/api#sendphoto) for more information",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     telegramBotApi,

--- a/components/telegram_bot_api/actions/send-sticker/send-sticker.mjs
+++ b/components/telegram_bot_api/actions/send-sticker/send-sticker.mjs
@@ -4,7 +4,7 @@ export default {
   key: "telegram_bot_api-send-sticker",
   name: "Send a Sticker",
   description: "Sends a .webp sticker to you Telegram Desktop application. [See the docs](https://core.telegram.org/bots/api#sendsticker) for more information",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     telegramBotApi,

--- a/components/telegram_bot_api/actions/send-text-message-or-reply/send-text-message-or-reply.mjs
+++ b/components/telegram_bot_api/actions/send-text-message-or-reply/send-text-message-or-reply.mjs
@@ -4,7 +4,7 @@ export default {
   key: "telegram_bot_api-send-text-message-or-reply",
   name: "Send a Text Message or Reply",
   description: "Sends a text message or a reply to your Telegram Desktop application. [See the docs](https://core.telegram.org/bots/api#sendmessage) for more information",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     telegramBotApi,

--- a/components/telegram_bot_api/actions/send-video-note/send-video-note.mjs
+++ b/components/telegram_bot_api/actions/send-video-note/send-video-note.mjs
@@ -5,7 +5,7 @@ export default {
   key: "telegram_bot_api-send-video-note",
   name: "Send a Video Note",
   description: "As of v.4.0, Telegram clients support rounded square mp4 videos of up to 1 minute long. Use this method to send video messages. [See the docs](https://core.telegram.org/bots/api#sendvideonote) for more information",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     telegramBotApi,

--- a/components/telegram_bot_api/actions/send-video/send-video.mjs
+++ b/components/telegram_bot_api/actions/send-video/send-video.mjs
@@ -5,7 +5,7 @@ export default {
   key: "telegram_bot_api-send-video",
   name: "Send a Video",
   description: "Sends a video file to your Telegram Desktop application. [See the docs](https://core.telegram.org/bots/api#sendvideo) for more information",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     telegramBotApi,

--- a/components/telegram_bot_api/actions/send-voice-message/send-voice-message.mjs
+++ b/components/telegram_bot_api/actions/send-voice-message/send-voice-message.mjs
@@ -5,7 +5,7 @@ export default {
   key: "telegram_bot_api-send-voice-message",
   name: "Send a Voice Message",
   description: "Sends a voice message. [See the docs](https://core.telegram.org/bots/api#sendvoice) for more information",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     telegramBotApi,

--- a/components/telegram_bot_api/actions/set-chat-permissions/set-chat-permissions.mjs
+++ b/components/telegram_bot_api/actions/set-chat-permissions/set-chat-permissions.mjs
@@ -4,7 +4,7 @@ export default {
   key: "telegram_bot_api-set-chat-permissions",
   name: "Set Chat Permissions",
   description: "Set default chat permissions for all members. [See the docs](https://core.telegram.org/bots/api#setchatpermissions) for more information",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     telegramBotApi,

--- a/components/telegram_bot_api/actions/unpin-message/unpin-message.mjs
+++ b/components/telegram_bot_api/actions/unpin-message/unpin-message.mjs
@@ -4,7 +4,7 @@ export default {
   key: "telegram_bot_api-unpin-message",
   name: "Unpin a Message",
   description: "Unpins a message. [See the docs](https://core.telegram.org/bots/api#unpinchatmessage) for more information",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     telegramBotApi,

--- a/components/telegram_bot_api/common/update-types.mjs
+++ b/components/telegram_bot_api/common/update-types.mjs
@@ -47,4 +47,16 @@ export default [
     label: "Poll Answer",
     value: "poll_answer",
   },
+  {
+    label: "My Chat Member",
+    value: "my_chat_member",
+  },
+  {
+    label: "Chat Member",
+    value: "chat_member",
+  },
+  {
+    label: "Chat Join Request",
+    value: "chat_join_request",
+  },
 ];

--- a/components/telegram_bot_api/sources/channel-updates/channel-updates.mjs
+++ b/components/telegram_bot_api/sources/channel-updates/channel-updates.mjs
@@ -5,7 +5,7 @@ export default {
   key: "telegram_bot_api-channel-updates",
   name: "New Channel Updates (Instant)",
   description: "Emit new event each time a channel post is created or updated.",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/telegram_bot_api/sources/message-updates/message-updates.mjs
+++ b/components/telegram_bot_api/sources/message-updates/message-updates.mjs
@@ -5,7 +5,7 @@ export default {
   key: "telegram_bot_api-message-updates",
   name: "New Message Updates (Instant)",
   description: "Emit new event each time a Telegram message is created or updated.",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/telegram_bot_api/sources/new-updates/new-updates.mjs
+++ b/components/telegram_bot_api/sources/new-updates/new-updates.mjs
@@ -5,7 +5,7 @@ export default {
   key: "telegram_bot_api-new-updates",
   name: "New Updates (Instant)",
   description: "Emit new event for each new Telegram event.",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "source",
   dedupe: "unique",
   props: {


### PR DESCRIPTION
Adds missing [update types](https://core.telegram.org/bots/api#update).

Resolves #4085.

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/4083"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

