### PR TITLE
[Formstack] Fix Handshake Validator for Webhooks

### DIFF
--- a/components/formstack/actions/create-form-submission/create-form-submission.mjs
+++ b/components/formstack/actions/create-form-submission/create-form-submission.mjs
@@ -6,7 +6,7 @@ export default {
   key: "formstack-create-form-submission",
   name: "Create Form Submission",
   description: "Create a new submission for the specified form. [See docs here](https://formstack.readme.io/docs/form-id-submission-post)",
-  version: "0.0.2",
+  version: "0.0.3",
   props: {
     formstack,
     formId: {

--- a/components/formstack/actions/create-form/create-form.mjs
+++ b/components/formstack/actions/create-form/create-form.mjs
@@ -6,7 +6,7 @@ export default {
   key: "formstack-create-form",
   name: "Create Form",
   description: "Create a new form in your account. [See docs here](https://formstack.readme.io/docs/form-post)",
-  version: "0.0.3",
+  version: "0.0.4",
   props: {
     formstack,
     name: {

--- a/components/formstack/actions/get-form/get-form.mjs
+++ b/components/formstack/actions/get-form/get-form.mjs
@@ -5,7 +5,7 @@ export default {
   key: "formstack-get-form",
   name: "Get Form",
   description: "Get the details of the specified form. [See docs here](https://formstack.readme.io/docs/form-id-get)",
-  version: "0.0.2",
+  version: "0.0.3",
   props: {
     formstack,
     formId: {

--- a/components/formstack/formstack.app.mjs
+++ b/components/formstack/formstack.app.mjs
@@ -46,11 +46,7 @@ export default {
     }) {
       return this._makeRequest(`form/${formId}/webhook`, {
         method: "post",
-        data: {
-          ...data,
-          content_type: "json",
-          handshake_key: this._accessToken(),
-        },
+        data,
       });
     },
     async removeWebhook(webhookId) {

--- a/components/formstack/sources/new-form-submission/new-form-submission.mjs
+++ b/components/formstack/sources/new-form-submission/new-form-submission.mjs
@@ -5,7 +5,7 @@ export default {
   key: "formstack-new-form-submission",
   name: "New Form Submission (Instant)",
   description: "Emit new event for each new form submission. [See docs here](https://formstack.readme.io/docs/form-id-webhook-post)",
-  version: "0.0.2",
+  version: "0.0.3",
   dedupe: "unique",
   type: "source",
   methods: {

--- a/components/formstack/sources/new-form/new-form.mjs
+++ b/components/formstack/sources/new-form/new-form.mjs
@@ -4,7 +4,7 @@ export default {
   key: "formstack-new-form",
   name: "New Form",
   description: "Emit new event for each new form added. [See docs here](https://formstack.readme.io/docs/form-id-webhook-post)",
-  version: "0.0.2",
+  version: "0.0.3",
   dedupe: "unique",
   type: "source",
   props: {


### PR DESCRIPTION
- Uses random UUID instead of Access Token
- Calculates hash to verify authenticity

Resolves #4116.

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/4140"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

