### PR TITLE
[BUG] Jira component only shows first 50 projects

### DIFF
--- a/components/jira/actions/add-attachment-to-issue/add-attachment-to-issue.mjs
+++ b/components/jira/actions/add-attachment-to-issue/add-attachment-to-issue.mjs
@@ -8,7 +8,7 @@ export default {
   key: "jira-add-attachment-to-issue",
   name: "Add Attachment To Issue",
   description: "Adds an attachment to an issue, [See the docs](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-attachments/#api-rest-api-3-issue-issueidorkey-attachments-post)",
-  version: "0.2.4",
+  version: "0.2.5",
   type: "action",
   props: {
     jira,

--- a/components/jira/actions/add-comment-to-issue/add-comment-to-issue.mjs
+++ b/components/jira/actions/add-comment-to-issue/add-comment-to-issue.mjs
@@ -5,7 +5,7 @@ export default {
   key: "jira-add-comment-to-issue",
   name: "Add Comment To Issue",
   description: "Adds a new comment to an issue, [See the docs](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-comments/#api-rest-api-3-issue-issueidorkey-comment-post)",
-  version: "0.1.2",
+  version: "0.1.3",
   type: "action",
   props: {
     jira,

--- a/components/jira/actions/add-multiple-attachments-to-issue/add-multiple-attachments-to-issue.mjs
+++ b/components/jira/actions/add-multiple-attachments-to-issue/add-multiple-attachments-to-issue.mjs
@@ -8,7 +8,7 @@ export default {
   key: "jira-add-multiple-attachments-to-issue",
   name: "Add Multiple Attachments To Issue",
   description: "Adds multiple attachments to an issue, [See the docs](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-attachments/#api-rest-api-3-issue-issueidorkey-attachments-post)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     jira,

--- a/components/jira/actions/add-watcher-to-issue/add-watcher-to-issue.mjs
+++ b/components/jira/actions/add-watcher-to-issue/add-watcher-to-issue.mjs
@@ -3,7 +3,7 @@ import jira from "../../jira.app.mjs";
 export default {
   key: "jira-add-watcher-to-issue",
   name: "Add Watcher To Issue",
-  version: "0.0.1",
+  version: "0.0.2",
   description: "Adds a user as a watcher of an issue by passing the account ID of the user, For example, `5b10ac8d82e05b22cc7d4ef5`, If no user is specified the calling user is added. [See the docs](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-watchers/#api-rest-api-3-issue-issueidorkey-watchers-post)",
   type: "action",
   props: {

--- a/components/jira/actions/assign-issue/assign-issue.mjs
+++ b/components/jira/actions/assign-issue/assign-issue.mjs
@@ -3,7 +3,7 @@ import jira from "../../jira.app.mjs";
 export default {
   key: "jira-assign-issue",
   name: "Assign Issue",
-  version: "0.0.1",
+  version: "0.0.2",
   description: "Assigns an issue to a user. [See the docs](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-assignee-put)",
   type: "action",
   props: {

--- a/components/jira/actions/create-issue/create-issue.mjs
+++ b/components/jira/actions/create-issue/create-issue.mjs
@@ -5,7 +5,7 @@ export default {
   key: "jira-create-issue",
   name: "Create Issue",
   description: "Creates an issue or, where the option to create subtasks is enabled in Jira, a subtask, [See the docs](https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-rest-api-3-issue-post)",
-  version: "0.1.5",
+  version: "0.1.6",
   type: "action",
   props: {
     jira,

--- a/components/jira/actions/create-version/create-version.mjs
+++ b/components/jira/actions/create-version/create-version.mjs
@@ -4,7 +4,7 @@ export default {
   key: "jira-create-version",
   name: "Create Jira Version in project",
   description: "Creates a project version., [See the docs](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-project-versions/#api-rest-api-3-version-post)",
-  version: "0.1.2",
+  version: "0.1.3",
   type: "action",
   props: {
     jira,

--- a/components/jira/actions/delete-project/delete-project.mjs
+++ b/components/jira/actions/delete-project/delete-project.mjs
@@ -4,7 +4,7 @@ export default {
   key: "jira-delete-project",
   name: "Delete Project",
   description: "Deletes a project, [See the docs](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-projects/#api-rest-api-3-project-projectidorkey-delete)",
-  version: "0.1.2",
+  version: "0.1.3",
   type: "action",
   props: {
     jira,

--- a/components/jira/actions/get-issue/get-issue.mjs
+++ b/components/jira/actions/get-issue/get-issue.mjs
@@ -4,7 +4,7 @@ export default {
   key: "jira-get-issue",
   name: "Get Issue",
   description: "Gets the details for an issue. [See the docs](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-get)",
-  version: "0.1.2",
+  version: "0.1.3",
   type: "action",
   props: {
     jira,

--- a/components/jira/actions/get-transitions/get-transitions.mjs
+++ b/components/jira/actions/get-transitions/get-transitions.mjs
@@ -4,7 +4,7 @@ export default {
   key: "jira-get-transitions",
   name: "Get Transitions",
   description: "Gets either all transitions or a transition that can be performed by the user on an issue, based on the issue's status, [See the docs](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-transitions-get)",
-  version: "0.1.2",
+  version: "0.1.3",
   type: "action",
   props: {
     jira,

--- a/components/jira/actions/get-user/get-user.mjs
+++ b/components/jira/actions/get-user/get-user.mjs
@@ -4,7 +4,7 @@ export default {
   key: "jira-get-user",
   name: "Get User",
   description: "Gets details of user, [See the docs](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-users/#api-rest-api-3-user-get)",
-  version: "0.1.2",
+  version: "0.1.3",
   type: "action",
   props: {
     jira,

--- a/components/jira/actions/list-issue-comments/list-issue-comments.mjs
+++ b/components/jira/actions/list-issue-comments/list-issue-comments.mjs
@@ -4,7 +4,7 @@ export default {
   key: "jira-list-issue-comments",
   name: "List Issue Comments",
   description: "Lists all comments for an issue, [See the docs](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-comments/#api-rest-api-3-issue-issueidorkey-comment-get)",
-  version: "0.1.2",
+  version: "0.1.3",
   type: "action",
   props: {
     jira,

--- a/components/jira/actions/transition-issue/transition-issue.mjs
+++ b/components/jira/actions/transition-issue/transition-issue.mjs
@@ -5,7 +5,7 @@ export default {
   key: "jira-transition-issue",
   name: "Transition Issue",
   description: "Performs an issue transition and, if the transition has a screen, updates the fields from the transition screen, [See the docs](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-transitions-post)",
-  version: "0.1.4",
+  version: "0.1.5",
   type: "action",
   props: {
     jira,

--- a/components/jira/actions/update-comment/update-comment.mjs
+++ b/components/jira/actions/update-comment/update-comment.mjs
@@ -5,7 +5,7 @@ export default {
   key: "jira-update-comment",
   name: "Update Comment",
   description: "Updates a comment, [See the docs](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-comments/#api-rest-api-3-issue-issueidorkey-comment-id-put)",
-  version: "0.1.2",
+  version: "0.1.3",
   type: "action",
   props: {
     jira,

--- a/components/jira/actions/update-issue/update-issue.mjs
+++ b/components/jira/actions/update-issue/update-issue.mjs
@@ -5,7 +5,7 @@ export default {
   key: "jira-update-issue",
   name: "Update Issue",
   description: "Updates an issue. A transition may be applied and issue properties updated as part of the edit, [See the docs](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-put)",
-  version: "0.2.0",
+  version: "0.2.1",
   type: "action",
   props: {
     jira,

--- a/components/jira/jira.app.mjs
+++ b/components/jira/jira.app.mjs
@@ -8,6 +8,7 @@ export default {
       type: "string",
       label: "Project ID",
       description: "The project ID.",
+      useQuery: true,
       async options({ prevContext }) {
         let { startAt } = prevContext || {};
         const pageSize = 50;
@@ -61,7 +62,7 @@ export default {
       label: "Issue id or key",
       description: "The ID or key of the issue where the attachment will be added to.",
       async options({ prevContext }) {
-        const { startAt } = prevContext || {};
+        let { startAt } = prevContext || {};
         const pageSize = 50;
         const resp = await this.getIssues({
           params: {
@@ -69,13 +70,16 @@ export default {
             maxResults: pageSize,
           },
         });
+        startAt = startAt > 0
+          ? startAt + pageSize
+          : pageSize;
         return {
           options: resp?.issues?.map((issue) => ({
             value: issue.id,
             label: issue.key,
           })),
           context: {
-            after: startAt,
+            startAt,
           },
         };
       },
@@ -85,7 +89,7 @@ export default {
       label: "Assignee Id",
       description: "The account ID of the user, which uniquely identifies the user across all Atlassian products, For example, `5b10ac8d82e05b22cc7d4ef5`, ",
       async options({ prevContext }) {
-        const { startAt } = prevContext || {};
+        let { startAt } = prevContext || {};
         const pageSize = 50;
         const resp = await this.getUsers({
           params: {
@@ -93,13 +97,16 @@ export default {
             maxResults: pageSize,
           },
         });
+        startAt = startAt > 0
+          ? startAt + pageSize
+          : pageSize;
         return {
           options: resp?.map((user) => ({
             value: user.accountId,
             label: user.displayName,
           })),
           context: {
-            after: startAt,
+            startAt,
           },
         };
       },
@@ -135,7 +142,7 @@ export default {
       async options({
         prevContext, issueIdOrKey,
       }) {
-        const { startAt } = prevContext || {};
+        let { startAt } = prevContext || {};
         const pageSize = 50;
         const resp = await this.getTransitions({
           issueIdOrKey,
@@ -144,13 +151,16 @@ export default {
             maxResults: pageSize,
           },
         });
+        startAt = startAt > 0
+          ? startAt + pageSize
+          : pageSize;
         return {
           options: resp?.transitions?.map((issue) => ({
             value: issue.id,
             label: issue.name,
           })),
           context: {
-            after: startAt,
+            startAt,
           },
         };
       },

--- a/components/jira/jira.app.mjs
+++ b/components/jira/jira.app.mjs
@@ -9,7 +9,7 @@ export default {
       label: "Project ID",
       description: "The project ID.",
       async options({ prevContext }) {
-        const { startAt } = prevContext || {};
+        let { startAt } = prevContext || {};
         const pageSize = 50;
         const resp = await this.getAllProjects({
           params: {
@@ -17,13 +17,16 @@ export default {
             maxResults: pageSize,
           },
         });
+        startAt = startAt > 0
+          ? startAt + pageSize
+          : pageSize;
         return {
           options: resp?.values.map((e) => ({
             label: e.name,
             value: e.id,
           })),
           context: {
-            after: startAt,
+            startAt,
           },
         };
       },

--- a/components/jira/jira.app.mjs
+++ b/components/jira/jira.app.mjs
@@ -9,13 +9,16 @@ export default {
       label: "Project ID",
       description: "The project ID.",
       useQuery: true,
-      async options({ prevContext }) {
+      async options({
+        prevContext, query,
+      }) {
         let { startAt } = prevContext || {};
         const pageSize = 50;
         const resp = await this.getAllProjects({
           params: {
             startAt,
             maxResults: pageSize,
+            query,
           },
         });
         startAt = startAt > 0
@@ -87,14 +90,18 @@ export default {
     accountId: {
       type: "string",
       label: "Assignee Id",
-      description: "The account ID of the user, which uniquely identifies the user across all Atlassian products, For example, `5b10ac8d82e05b22cc7d4ef5`, ",
-      async options({ prevContext }) {
+      description: "The account ID of the user, which uniquely identifies the user across all Atlassian products, For example, `5b10ac8d82e05b22cc7d4ef5`",
+      useQuery: true,
+      async options({
+        prevContext, query,
+      }) {
         let { startAt } = prevContext || {};
         const pageSize = 50;
         const resp = await this.getUsers({
           params: {
             startAt,
             maxResults: pageSize,
+            query,
           },
         });
         startAt = startAt > 0


### PR DESCRIPTION
Resolves #4127 

Updated to allow props with async options to load more than 50 results. 
Props `projectID` and `accountId` will now use `opts.query` if available to search for matching options.