### PR TITLE
[BUG] pCloud Watch Folder trigger does not pick up events

### DIFF
--- a/components/pcloud/actions/copy-file/copy-file.mjs
+++ b/components/pcloud/actions/copy-file/copy-file.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Copy File",
   description:
     "Copy a file to the specified destination. [See the docs here](https://docs.pcloud.com/methods/file/copyfile.html)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     ...common.props,

--- a/components/pcloud/actions/copy-folder/copy-folder.mjs
+++ b/components/pcloud/actions/copy-folder/copy-folder.mjs
@@ -6,7 +6,7 @@ export default {
   key: "pcloud-copy-folder",
   name: "Copy Folder",
   description: "Copy a folder to the specified folder. [See the docs here](https://docs.pcloud.com/methods/folder/copyfolder.html)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     ...common.props,

--- a/components/pcloud/actions/create-folder/create-folder.mjs
+++ b/components/pcloud/actions/create-folder/create-folder.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Create Folder",
   description:
     "Create a folder in the specified folder. [See the docs here](https://docs.pcloud.com/methods/folder/createfolder.html)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     ...common.props,

--- a/components/pcloud/actions/download-files/download-files.mjs
+++ b/components/pcloud/actions/download-files/download-files.mjs
@@ -6,7 +6,7 @@ export default {
   key: "pcloud-download-files",
   name: "Download File(s)",
   description: "Download one or more files to a folder. [See the docs here](https://docs.pcloud.com/methods/file/downloadfile.html)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     ...common.props,

--- a/components/pcloud/actions/list-contents/list-contents.mjs
+++ b/components/pcloud/actions/list-contents/list-contents.mjs
@@ -6,7 +6,7 @@ export default {
   key: "pcloud-list-contents",
   name: "List Contents",
   description: "Get the contents of the specified folder. [See the docs here](https://docs.pcloud.com/methods/folder/listfolder.html)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     ...common.props,

--- a/components/pcloud/actions/upload-file/upload-file.mjs
+++ b/components/pcloud/actions/upload-file/upload-file.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Upload File",
   description:
     "Upload a file to the specified folder. [See the docs here](https://docs.pcloud.com/methods/file/uploadfile.html)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     ...common.props,

--- a/components/pcloud/pcloud.app.mjs
+++ b/components/pcloud/pcloud.app.mjs
@@ -84,6 +84,8 @@ export default {
       const retryOpts = {
         retries: 3,
         factor: 2,
+        minTimeout: 500,
+        maxTimeout: 1500,
       };
       return retry(async (bail) => {
         try {

--- a/components/pcloud/sources/watch-folder/watch-folder.mjs
+++ b/components/pcloud/sources/watch-folder/watch-folder.mjs
@@ -1,14 +1,12 @@
 import pcloud from "../../pcloud.app.mjs";
-import get from "lodash/get.js";
 
 export default {
   key: "pcloud-watch-folder",
   name: "Watch Folder",
-  description:
-    "Emit new event when a file is created or modified in the specified folder.",
-  version: "0.0.1",
+  description: "Emit new event when a file is created or modified in the specified folder.",
+  version: "0.0.2",
   type: "source",
-  dedupe: "last",
+  dedupe: "unique",
   props: {
     pcloud,
     db: "$.service.db",
@@ -25,9 +23,7 @@ export default {
         pcloud,
         "folderId",
       ],
-      description: `Select a **Folder** to watch for changes.
-        \\
-        Alternatively, you can provide a custom *Folder ID*.`,
+      description: "Select a **Folder** to watch for changes. Alternatively, you can provide a custom *Folder ID*.",
     },
     event: {
       type: "string",
@@ -36,8 +32,7 @@ export default {
         "Created",
         "Modified",
       ],
-      description:
-        "Specify when to emit an event related to a given folder. Note that pCloud preserves files' `created` and `modified` timestamps on upload. If manually uploading via pCloud's `uploadfile` API, these timestamps can be set by specifying the `mtime` and `ctime` parameters, respectively.",
+      description: "Specify when to emit an event related to a given folder.",
       default: "Created",
     },
     showDeleted: {
@@ -50,27 +45,38 @@ export default {
   hooks: {
     async deploy() {
       const files = [];
-      const pCloudContentsData = await this.getContents();
-      const hasContents = get(pCloudContentsData, [
-        "contents",
-      ]);
-      if (hasContents) {
-        for (const folderItem of pCloudContentsData.contents) {
-          if (!folderItem.isfolder) {
-            files.push(folderItem);
-            if (files.length == 10) {
-              break;
-            }
+      const { contents } = await this.getContents();
+      if (!contents) {
+        return;
+      }
+      for (const folderItem of contents) {
+        if (this.isRelevant(folderItem)) {
+          files.push(folderItem);
+          if (files.length == 10) {
+            break;
           }
         }
-      } else {
-        console.log("No data available, skipping iteration");
       }
       files.forEach(this.emitpCloudEvent);
-      this.db.set("lastPolledTime", +Date.now());
+      this._setPreviousFiles(contents);
     },
   },
   methods: {
+    _getPreviousFiles() {
+      return this.db.get("previousFiles");
+    },
+    _setPreviousFiles(files) {
+      const key = this.getFileKey();
+      const previousFiles = files.filter((file) => file[key]).map((file) => ({
+        [file[key]]: true,
+      }));
+      this.db.set("previousFiles", previousFiles);
+    },
+    getFileKey() {
+      return this.event === "Created"
+        ? "fileid"
+        : "hash";
+    },
     async getContents() {
       return this.pcloud._withRetries(() =>
         this.pcloud.listContents(
@@ -86,35 +92,32 @@ export default {
       this.$emit(pCloudEvent, metadata);
     },
     getEventData(pcloudEvent) {
-      const eventDate = pcloudEvent[this.event.toLowerCase()];
-      const ts = +new Date(eventDate);
+      const key = this.getFileKey();
       return {
-        id: ts,
+        id: pcloudEvent[key],
         summary: `${this.event} file "${pcloudEvent.name}"`,
-        ts,
+        ts: Date.now(),
       };
+    },
+    isRelevant(folderItem, previousFiles = []) {
+      const key = this.getFileKey();
+      return !folderItem.isFolder && !previousFiles[folderItem[key]];
     },
   },
   async run() {
-    const lastPolledTime = this.db.get("lastPolledTime");
+    const previousFiles = this._getPreviousFiles();
     const files = [];
-    const pCloudContentsData = await this.getContents();
-    const hasContents = get(pCloudContentsData, [
-      "contents",
-    ]);
-    if (hasContents) {
-      for (const folderItem of pCloudContentsData.contents) {
-        if (!folderItem.isfolder) {
-          let fileTime = +new Date(folderItem[this.event.toLowerCase()]);
-          if (fileTime > lastPolledTime) {
-            files.push(folderItem);
-          }
-        }
-      }
-    } else {
+    const { contents } = await this.getContents();
+    if (!contents) {
       console.log("No data available, skipping iteration");
+      return;
+    }
+    for (const folderItem of contents) {
+      if (this.isRelevant(folderItem, previousFiles)) {
+        files.push(folderItem);
+      }
     }
     files.forEach(this.emitpCloudEvent);
-    this.db.set("lastPolledTime", +Date.now());
+    this._setPreviousFiles(contents);
   },
 };


### PR DESCRIPTION
Resolves #4136

The `created` and `modified` file dates from pCloud do not represent dates that the file was uploaded or modified within pCloud, but the original creation/modification dates of the file being uploaded.

I updated the component to dedupe on `fileid` to find newly created files, and `hash` [(64 bit integer representing hash of the contents of the file can be used to determine if two files are the same or to monitor file contents for changes)](https://docs.pcloud.com/structures/metadata.html) to find modified files.

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/4167"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

