### PR TITLE
Include package.json version on PR check

### DIFF
--- a/.github/actions/git-diff-on-components/dist/licenses.txt
+++ b/.github/actions/git-diff-on-components/dist/licenses.txt
@@ -237,6 +237,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
+@vercel/ncc
+MIT
+Copyright 2018 ZEIT, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 app-module-path
 BSD-2-Clause
 
@@ -351,31 +361,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
-
-buffer-from
-MIT
-MIT License
-
-Copyright (c) 2016, 2018 Linus Unnebäck
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 
 
 concat-map
@@ -1256,19 +1241,6 @@ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
-
-
-has-flag
-MIT
-MIT License
-
-Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ignore
@@ -2260,31 +2232,6 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-source-map-support
-MIT
-The MIT License (MIT)
-
-Copyright (c) 2014 Evan Wallace
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-
 stringify-object
 BSD-2-Clause
 Copyright (c) 2015, Yeoman team
@@ -2338,19 +2285,6 @@ THE SOFTWARE.
 
 stylus-lookup
 MIT
-
-supports-color
-MIT
-MIT License
-
-Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
 
 tapable
 MIT

--- a/components/action_builder/package.json
+++ b/components/action_builder/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/action_builder",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Action Builder Components",
   "main": "dist/app/action_builder.app.mjs",
   "keywords": [
     "pipedream",
     "action_builder"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/action_builder",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/action_network/package.json
+++ b/components/action_network/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/action_network",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Action Network Components",
   "main": "dist/app/action_network.app.mjs",
   "keywords": [
     "pipedream",
     "action_network"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/action_network",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/activecampaign/package.json
+++ b/components/activecampaign/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/activecampaign",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Pipedream Activecampaing Components",
   "main": "activecampaign.app.mjs",
   "keywords": [

--- a/components/acumbamail/package.json
+++ b/components/acumbamail/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/acumbamail",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Acumbamail  Components",
   "main": "dist/app/acumbamail.app.mjs",
   "keywords": [
     "pipedream",
     "acumbamail"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/acumbamail",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/adafruit_io/package.json
+++ b/components/adafruit_io/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/adafruit_io",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Adafruit IO Components",
   "main": "dist/app/adafruit_io.app.mjs",
   "keywords": [
     "pipedream",
     "adafruit_io"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/adafruit_io",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/adalo/package.json
+++ b/components/adalo/package.json
@@ -1,20 +1,20 @@
 {
-    "name": "@pipedream/adalo",
-    "version": "0.0.2",
-    "description": "Pipedream Adalo Components",
-    "main": "adalo.app.mjs",
-    "keywords": [
-        "pipedream",
-        "adalo"
-    ],
-    "homepage": "https://pipedream.com/apps/adalo",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    },
-    "dependencies": {
-        "@pipedream/platform": "^0.10.0"
-    }
+  "name": "@pipedream/adalo",
+  "version": "0.0.3",
+  "description": "Pipedream Adalo Components",
+  "main": "adalo.app.mjs",
+  "keywords": [
+    "pipedream",
+    "adalo"
+  ],
+  "homepage": "https://pipedream.com/apps/adalo",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^0.10.0"
+  }
 }

--- a/components/agendor/package.json
+++ b/components/agendor/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/agendor",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Agendor Components",
   "main": "dist/app/agendor.app.mjs",
   "keywords": [
     "pipedream",
     "agendor"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/agendor",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/agile_crm/package.json
+++ b/components/agile_crm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/agile_crm",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Agile CRM Components",
   "main": "agile_crm.app.mjs",
   "keywords": [

--- a/components/airnow/package.json
+++ b/components/airnow/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/airnow",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream AirNow Components",
   "main": "dist/app/airnow.app.mjs",
   "keywords": [
     "pipedream",
     "airnow"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/airnow",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/airtable/package.json
+++ b/components/airtable/package.json
@@ -1,26 +1,26 @@
 {
-    "name": "@pipedream/airtable",
-    "version": "0.3.3",
-    "description": "Pipedream Airtable Components",
-    "main": "airtable.app.mjs",
-    "keywords": [
-        "pipedream",
-        "airtable"
-    ],
-    "homepage": "https://pipedream.com/apps/airtable",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    },
-    "dependencies": {
-        "airtable": "^0.11.1",
-        "axios": "^0.21.1",
-        "bottleneck": "^2.19.5",
-        "lodash": "^4.17.21",
-        "lodash.chunk": "^4.2.0",
-        "lodash.isempty": "^4.4.0",
-        "moment": "^2.29.1"
-    }
+  "name": "@pipedream/airtable",
+  "version": "0.3.4",
+  "description": "Pipedream Airtable Components",
+  "main": "airtable.app.mjs",
+  "keywords": [
+    "pipedream",
+    "airtable"
+  ],
+  "homepage": "https://pipedream.com/apps/airtable",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "airtable": "^0.11.1",
+    "axios": "^0.21.1",
+    "bottleneck": "^2.19.5",
+    "lodash": "^4.17.21",
+    "lodash.chunk": "^4.2.0",
+    "lodash.isempty": "^4.4.0",
+    "moment": "^2.29.1"
+  }
 }

--- a/components/alchemy/package.json
+++ b/components/alchemy/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/alchemy",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Alchemy Components",
   "main": "dist/app/alchemy.app.mjs",
   "keywords": [
     "pipedream",
     "alchemy"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/alchemy",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/algolia/package.json
+++ b/components/algolia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/algolia",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Algolia Components",
   "main": "algolia.app.js",
   "keywords": [

--- a/components/amara/package.json
+++ b/components/amara/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/amara",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Pipedream Amara Components",
   "main": "amara.app.mjs",
   "keywords": [

--- a/components/amazon_ses/package.json
+++ b/components/amazon_ses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/amazon_ses",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Pipedream Amazon SES Components",
   "main": "amazon_ses.app.js",
   "keywords": [

--- a/components/ambient_weather/package.json
+++ b/components/ambient_weather/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/ambient_weather",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Ambient Weather Components",
   "main": "dist/app/ambient_weather.app.mjs",
   "keywords": [
     "pipedream",
     "ambient_weather"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/ambient_weather",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/amilia/package.json
+++ b/components/amilia/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/amilia",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Amilia Components",
   "main": "dist/app/amilia.app.mjs",
   "keywords": [
     "pipedream",
     "amilia"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/amilia",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/amplenote/package.json
+++ b/components/amplenote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/amplenote",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Amplenote Components",
   "main": "dist/app/amplenote.app.mjs",
   "keywords": [

--- a/components/amqp/package.json
+++ b/components/amqp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/amqp",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Pipedream AMQP Components",
   "main": "amqp.app.mjs",
   "keywords": [

--- a/components/apex_27/package.json
+++ b/components/apex_27/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/apex_27",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Apex 27 Components",
   "main": "dist/app/apex_27.app.mjs",
   "keywords": [
     "pipedream",
     "apex_27"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/apex_27",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/api2pdf/package.json
+++ b/components/api2pdf/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/api2pdf",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Api2pdf Components",
   "main": "dist/app/api2pdf.app.mjs",
   "keywords": [
     "pipedream",
     "api2pdf"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/api2pdf",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/apilio/package.json
+++ b/components/apilio/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/apilio",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Apilio Components",
   "main": "dist/app/apilio.app.mjs",
   "keywords": [
     "pipedream",
     "apilio"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/apilio",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/apitemplate_io/package.json
+++ b/components/apitemplate_io/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/apitemplate_io",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream APITemplate.io Components",
   "main": "dist/app/apitemplate_io.app.mjs",
   "keywords": [
     "pipedream",
     "apitemplate_io"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/apitemplate_io",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/asana/package.json
+++ b/components/asana/package.json
@@ -1,20 +1,20 @@
 {
-    "name": "@pipedream/asana",
-    "version": "0.3.3",
-    "description": "Pipedream Asana Components",
-    "main": "asana.app.js",
-    "keywords": [
-        "pipedream",
-        "asana"
-    ],
-    "homepage": "https://pipedream.com/apps/asana",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "axios": "^0.21.1"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/asana",
+  "version": "0.3.4",
+  "description": "Pipedream Asana Components",
+  "main": "asana.app.js",
+  "keywords": [
+    "pipedream",
+    "asana"
+  ],
+  "homepage": "https://pipedream.com/apps/asana",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "axios": "^0.21.1"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/autoklose/package.json
+++ b/components/autoklose/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/autoklose",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Autoklose Components",
   "main": "dist/app/autoklose.app.mjs",
   "keywords": [
     "pipedream",
     "autoklose"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/autoklose",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/aweber/package.json
+++ b/components/aweber/package.json
@@ -1,20 +1,20 @@
 {
   "name": "@pipedream/aweber",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Pipedream Aweber Components",
   "main": "aweber.app.mjs",
   "keywords": [
-      "pipedream",
-      "aweber"
+    "pipedream",
+    "aweber"
   ],
   "homepage": "https://pipedream.com/apps/aweber",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",
   "dependencies": {
-      "@pipedreamhq/platform": "^0.8.1"
+    "@pipedreamhq/platform": "^0.8.1"
   },
   "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
   "publishConfig": {
-      "access": "public"
+    "access": "public"
   }
 }

--- a/components/awork/package.json
+++ b/components/awork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/awork",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Awork Components",
   "main": "awork.app.mjs",
   "keywords": [

--- a/components/aws/package.json
+++ b/components/aws/package.json
@@ -1,33 +1,33 @@
 {
-    "name": "@pipedream/aws",
-    "version": "0.3.3",
-    "description": "Pipedream Aws Components",
-    "main": "aws.app.js",
-    "keywords": [
-        "pipedream",
-        "aws"
-    ],
-    "homepage": "https://pipedream.com/apps/aws",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "@aws-sdk/client-cloudwatch-logs": "^3.58.0",
-        "@aws-sdk/client-dynamodb": "^3.58.0",
-        "@aws-sdk/client-ec2": "^3.60.0",
-        "@aws-sdk/client-eventbridge": "^3.66.0",
-        "@aws-sdk/client-iam": "^3.58.0",
-        "@aws-sdk/client-lambda": "^3.65.0",
-        "@aws-sdk/client-s3": "^3.66.0",
-        "@aws-sdk/client-ses": "^3.58.0",
-        "@aws-sdk/client-sfn": "^3.58.0",
-        "@aws-sdk/client-sns": "^3.58.0",
-        "@aws-sdk/client-sqs": "^3.58.0",
-        "@aws-sdk/client-ssm": "^3.58.0",
-        "@aws-sdk/client-sts": "^3.58.0",
-        "mailparser-mit": "^1.0.0"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/aws",
+  "version": "0.3.4",
+  "description": "Pipedream Aws Components",
+  "main": "aws.app.js",
+  "keywords": [
+    "pipedream",
+    "aws"
+  ],
+  "homepage": "https://pipedream.com/apps/aws",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "@aws-sdk/client-cloudwatch-logs": "^3.58.0",
+    "@aws-sdk/client-dynamodb": "^3.58.0",
+    "@aws-sdk/client-ec2": "^3.60.0",
+    "@aws-sdk/client-eventbridge": "^3.66.0",
+    "@aws-sdk/client-iam": "^3.58.0",
+    "@aws-sdk/client-lambda": "^3.65.0",
+    "@aws-sdk/client-s3": "^3.66.0",
+    "@aws-sdk/client-ses": "^3.58.0",
+    "@aws-sdk/client-sfn": "^3.58.0",
+    "@aws-sdk/client-sns": "^3.58.0",
+    "@aws-sdk/client-sqs": "^3.58.0",
+    "@aws-sdk/client-ssm": "^3.58.0",
+    "@aws-sdk/client-sts": "^3.58.0",
+    "mailparser-mit": "^1.0.0"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/bandwidth/package.json
+++ b/components/bandwidth/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@pipedream/bandwidth",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Pipedream Bandwidth Components",
   "main": "index.js",
   "keywords": [
-      "pipedream",
-      "bandwidth"
+    "pipedream",
+    "bandwidth"
   ],
   "publishConfig": {
     "access": "public"

--- a/components/bannerbear/package.json
+++ b/components/bannerbear/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@pipedream/bannerbear",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Pipedream Bannerbear Components",
   "main": "bannerbear.app.mjs",
   "keywords": [
-      "pipedream",
-      "bannerbear"
+    "pipedream",
+    "bannerbear"
   ],
   "homepage": "https://pipedream.com/apps/bannerbear",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
@@ -15,6 +15,6 @@
   },
   "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
   "publishConfig": {
-      "access": "public"
+    "access": "public"
   }
 }

--- a/components/bart/package.json
+++ b/components/bart/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/bart",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream BART Components",
   "main": "dist/app/bart.app.mjs",
   "keywords": [
     "pipedream",
     "bart"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/bart",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/beehiiv/package.json
+++ b/components/beehiiv/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/beehiiv",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Beehiiv Components",
   "main": "dist/app/beehiiv.app.mjs",
   "keywords": [
     "pipedream",
     "beehiiv"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/beehiiv",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/bitbucket/package.json
+++ b/components/bitbucket/package.json
@@ -1,22 +1,22 @@
 {
-    "name": "@pipedream/bitbucket",
-    "version": "0.3.5",
-    "description": "Pipedream Bitbucket Components",
-    "main": "bitbucket.app.mjs",
-    "keywords": [
-        "pipedream",
-        "bitbucket"
-    ],
-    "homepage": "https://pipedream.com/apps/bitbucket",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "@pipedream/platform": "^0.10.0",
-        "axios": "^0.27.2",
-        "package-lock-only": "^0.0.4"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/bitbucket",
+  "version": "0.3.6",
+  "description": "Pipedream Bitbucket Components",
+  "main": "bitbucket.app.mjs",
+  "keywords": [
+    "pipedream",
+    "bitbucket"
+  ],
+  "homepage": "https://pipedream.com/apps/bitbucket",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "@pipedream/platform": "^0.10.0",
+    "axios": "^0.27.2",
+    "package-lock-only": "^0.0.4"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/bitrix24/package.json
+++ b/components/bitrix24/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/bitrix24",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Bitrix24 Components",
   "main": "dist/app/bitrix24.app.mjs",
   "keywords": [
     "pipedream",
     "bitrix24"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/bitrix24",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/blogger/package.json
+++ b/components/blogger/package.json
@@ -1,20 +1,20 @@
 {
-    "name": "@pipedream/blogger",
-    "version": "0.0.1",
-    "description": "Pipedream Blogger Components",
-    "main": "blogger.app.js",
-    "keywords": [
-        "pipedream",
-        "blogger"
-    ],
-    "homepage": "https://pipedream.com/apps/blogger",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    },
-    "dependencies": {
-        "@pipedream/platform": "^0.10.0"
-    }
+  "name": "@pipedream/blogger",
+  "version": "0.0.2",
+  "description": "Pipedream Blogger Components",
+  "main": "blogger.app.js",
+  "keywords": [
+    "pipedream",
+    "blogger"
+  ],
+  "homepage": "https://pipedream.com/apps/blogger",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^0.10.0"
+  }
 }

--- a/components/botbaba/package.json
+++ b/components/botbaba/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/botbaba",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Botbaba Components",
   "main": "dist/app/botbaba.app.mjs",
   "keywords": [
     "pipedream",
     "botbaba"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/botbaba",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/box/package.json
+++ b/components/box/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/box",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Box Components",
   "main": "box.app.mjs",
   "keywords": [

--- a/components/brex/package.json
+++ b/components/brex/package.json
@@ -1,20 +1,20 @@
 {
-    "name": "@pipedream/brex",
-    "version": "0.0.2",
-    "description": "Pipedream Brex Components",
-    "main": "brex.app.js",
-    "keywords": [
-        "pipedream",
-        "brex"
-    ],
-    "homepage": "https://pipedream.com/apps/brex",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "publishConfig": {
-        "access": "public"
-    },
-    "dependencies": {
-        "axios": "^0.25.0",
-        "uuid": "^8.3.2"
-    }
+  "name": "@pipedream/brex",
+  "version": "0.0.3",
+  "description": "Pipedream Brex Components",
+  "main": "brex.app.js",
+  "keywords": [
+    "pipedream",
+    "brex"
+  ],
+  "homepage": "https://pipedream.com/apps/brex",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "axios": "^0.25.0",
+    "uuid": "^8.3.2"
+  }
 }

--- a/components/brex_staging/package.json
+++ b/components/brex_staging/package.json
@@ -1,21 +1,21 @@
 {
-    "name": "@pipedream/brex_staging",
-    "version": "0.0.1",
-    "description": "Pipedream Brex Staging Components",
-    "main": "brex_staging.app.js",
-    "keywords": [
-        "pipedream",
-        "brex_staging"
-    ],
-    "homepage": "https://pipedream.com/apps/brex_staging",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "publishConfig": {
-        "access": "public"
-    },
-    "dependencies": {
-        "axios": "^0.25.0",
-        "crypto": "^1.0.1",
-        "uuid": "^8.3.2"
-    }
+  "name": "@pipedream/brex_staging",
+  "version": "0.0.2",
+  "description": "Pipedream Brex Staging Components",
+  "main": "brex_staging.app.js",
+  "keywords": [
+    "pipedream",
+    "brex_staging"
+  ],
+  "homepage": "https://pipedream.com/apps/brex_staging",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "axios": "^0.25.0",
+    "crypto": "^1.0.1",
+    "uuid": "^8.3.2"
+  }
 }

--- a/components/brosix/package.json
+++ b/components/brosix/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/brosix",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Brosix Components",
   "main": "dist/app/brosix.app.mjs",
   "keywords": [
     "pipedream",
     "brosix"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/brosix",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/cal_com/package.json
+++ b/components/cal_com/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/cal_com",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Cal.com Components",
   "main": "dist/app/cal_com.app.mjs",
   "keywords": [
     "pipedream",
     "cal_com"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/cal_com",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/calendarhero/package.json
+++ b/components/calendarhero/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/calendarhero",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream CalendarHero Components",
   "main": "dist/app/calendarhero.app.mjs",
   "keywords": [
     "pipedream",
     "calendarhero"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/calendarhero",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/calendly/package.json
+++ b/components/calendly/package.json
@@ -1,20 +1,20 @@
 {
-    "name": "@pipedream/calendly",
-    "version": "0.3.3",
-    "description": "Pipedream Calendly Components",
-    "main": "calendly.app.js",
-    "keywords": [
-        "pipedream",
-        "calendly"
-    ],
-    "homepage": "https://pipedream.com/apps/calendly",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "axios": "^0.21.1"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/calendly",
+  "version": "0.3.4",
+  "description": "Pipedream Calendly Components",
+  "main": "calendly.app.js",
+  "keywords": [
+    "pipedream",
+    "calendly"
+  ],
+  "homepage": "https://pipedream.com/apps/calendly",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "axios": "^0.21.1"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/captaindata/package.json
+++ b/components/captaindata/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/captaindata",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Captain Data Components",
   "main": "dist/app/captaindata.app.mjs",
   "keywords": [
     "pipedream",
     "captaindata"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/captaindata",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/cartes/package.json
+++ b/components/cartes/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/cartes",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Cartes Components",
   "main": "dist/app/cartes.app.mjs",
   "keywords": [
     "pipedream",
     "cartes"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/cartes",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/chaport/package.json
+++ b/components/chaport/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/chaport",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Chaport Components",
   "main": "dist/app/chaport.app.mjs",
   "keywords": [
     "pipedream",
     "chaport"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/chaport",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/chatbot/package.json
+++ b/components/chatbot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/chatbot",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Pipedream ChatBot Components",
   "main": "chatbot.app.js",
   "keywords": [

--- a/components/circle/package.json
+++ b/components/circle/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/circle",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Circle Components",
   "main": "dist/app/circle.app.mjs",
   "keywords": [
     "pipedream",
     "circle"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/circle",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/cisco_webex/package.json
+++ b/components/cisco_webex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/cisco_webex",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Pipedream Cisco_webex Components",
   "main": "cisco_webex.app.mjs",
   "keywords": [

--- a/components/clearbit/package.json
+++ b/components/clearbit/package.json
@@ -1,19 +1,19 @@
 {
-    "name": "@pipedream/clearbit",
-    "version": "0.0.1",
-    "description": "Pipedream Clearbit Components",
-    "main": "clearbit.app.mjs",
-    "keywords": [
-        "pipedream",
-        "clearbit"
-    ],
-    "homepage": "https://pipedream.com/apps/clearbit",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "publishConfig": {
-        "access": "public"
-    },
-    "dependencies": {
-        "@pipedream/platform": "^0.10.0"
-    }
+  "name": "@pipedream/clearbit",
+  "version": "0.0.2",
+  "description": "Pipedream Clearbit Components",
+  "main": "clearbit.app.mjs",
+  "keywords": [
+    "pipedream",
+    "clearbit"
+  ],
+  "homepage": "https://pipedream.com/apps/clearbit",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^0.10.0"
+  }
 }

--- a/components/clickmeeting/package.json
+++ b/components/clickmeeting/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/clickmeeting",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream ClickMeeting  Components",
   "main": "dist/app/clickmeeting.app.mjs",
   "keywords": [
     "pipedream",
     "clickmeeting"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/clickmeeting",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/clickup/package.json
+++ b/components/clickup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/clickup",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Pipedream Clickup Components",
   "main": "clickup.app.mjs",
   "keywords": [

--- a/components/cliniko/package.json
+++ b/components/cliniko/package.json
@@ -1,19 +1,19 @@
 {
-    "name": "@pipedream/cliniko",
-    "version": "0.0.1",
-    "description": "Pipedream Cliniko Components",
-    "main": "cliniko.app.js",
-    "keywords": [
-        "pipedream",
-        "cliniko"
-    ],
-    "homepage": "https://pipedream.com/apps/cliniko",
-    "author": "Adrian Edwards <adrian@ageuphealth.com.au> (https://ageuphealth.com.au/)",
-    "license": "MIT",
-    "dependencies": {
-        "@pipedreamhq/platform": "^0.8.1"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/cliniko",
+  "version": "0.0.2",
+  "description": "Pipedream Cliniko Components",
+  "main": "cliniko.app.js",
+  "keywords": [
+    "pipedream",
+    "cliniko"
+  ],
+  "homepage": "https://pipedream.com/apps/cliniko",
+  "author": "Adrian Edwards <adrian@ageuphealth.com.au> (https://ageuphealth.com.au/)",
+  "license": "MIT",
+  "dependencies": {
+    "@pipedreamhq/platform": "^0.8.1"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/close/package.json
+++ b/components/close/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/close",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Close Components",
   "main": "close.app.mjs",
   "keywords": [

--- a/components/cloudfill/package.json
+++ b/components/cloudfill/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/cloudfill",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream CloudFill Components",
   "main": "dist/app/cloudfill.app.mjs",
   "keywords": [
     "pipedream",
     "cloudfill"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/cloudfill",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/coinbase_commerce/package.json
+++ b/components/coinbase_commerce/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/coinbase_commerce",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Coinbase Commerce Components",
   "main": "dist/app/coinbase_commerce.app.mjs",
   "keywords": [
     "pipedream",
     "coinbase_commerce"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/coinbase_commerce",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/commercehq/package.json
+++ b/components/commercehq/package.json
@@ -1,16 +1,16 @@
 {
-    "name": "@pipedream/commercehq",
-    "version": "0.0.1",
-    "description": "Pipedream CommerceHQ Components",
-    "main": "commercehq.app.js",
-    "keywords": [
-      "pipedream",
-      "commercehq"
-    ],
-    "homepage": "https://pipedream.com/apps/commercehq",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "publishConfig": {
-      "access": "public"
-    }
+  "name": "@pipedream/commercehq",
+  "version": "0.0.2",
+  "description": "Pipedream CommerceHQ Components",
+  "main": "commercehq.app.js",
+  "keywords": [
+    "pipedream",
+    "commercehq"
+  ],
+  "homepage": "https://pipedream.com/apps/commercehq",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
   }
+}

--- a/components/confection/package.json
+++ b/components/confection/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.1",
+  "version": "0.0.2",
   "dependencies": {
     "@pipedream/platform": "^0.9.0",
     "axios": "^0.23.0"

--- a/components/convertkit/package.json
+++ b/components/convertkit/package.json
@@ -1,19 +1,19 @@
 {
-    "name": "@pipedream/bitbucket",
-    "version": "0.0.2",
-    "description": "Pipedream Convertkit Components",
-    "main": "convertkit.app.mjs",
-    "keywords": [
-        "pipedream",
-        "convertkit"
-    ],
-    "homepage": "https://pipedream.com/apps/convertkit",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "@pipedream/platform": "^0.10.0"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/bitbucket",
+  "version": "0.0.3",
+  "description": "Pipedream Convertkit Components",
+  "main": "convertkit.app.mjs",
+  "keywords": [
+    "pipedream",
+    "convertkit"
+  ],
+  "homepage": "https://pipedream.com/apps/convertkit",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "@pipedream/platform": "^0.10.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/conveyor/package.json
+++ b/components/conveyor/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/conveyor",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Conveyor Components",
   "main": "dist/app/conveyor.app.mjs",
   "keywords": [
     "pipedream",
     "conveyor"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/conveyor",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/craftmypdf/package.json
+++ b/components/craftmypdf/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/craftmypdf",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream CraftMyPDF Components",
   "main": "dist/app/craftmypdf.app.mjs",
   "keywords": [
     "pipedream",
     "craftmypdf"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/craftmypdf",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/crisp/package.json
+++ b/components/crisp/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/crisp",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Crisp Components",
   "main": "dist/app/crisp.app.mjs",
   "keywords": [
     "pipedream",
     "crisp"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/crisp",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/crove_app/package.json
+++ b/components/crove_app/package.json
@@ -1,16 +1,16 @@
 {
-    "name": "@pipedream/crove_app",
-    "version": "0.0.1",
-    "description": "Pipedream Crove Components",
-    "main": "crove_app.app.js",
-    "keywords": [
-      "pipedream",
-      "crove_app"
-    ],
-    "homepage": "https://pipedream.com/apps/crove_app",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "publishConfig": {
-      "access": "public"
-    }
+  "name": "@pipedream/crove_app",
+  "version": "0.0.2",
+  "description": "Pipedream Crove Components",
+  "main": "crove_app.app.js",
+  "keywords": [
+    "pipedream",
+    "crove_app"
+  ],
+  "homepage": "https://pipedream.com/apps/crove_app",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
   }
+}

--- a/components/curated/package.json
+++ b/components/curated/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/curated",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Curated Components",
   "main": "dist/app/curated.app.mjs",
   "keywords": [
     "pipedream",
     "curated"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/curated",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/customer_io/package.json
+++ b/components/customer_io/package.json
@@ -1,23 +1,23 @@
 {
   "name": "@pipedream/customer_io",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Pipedream Customer.io Components",
   "main": "customer_io.app.js",
   "keywords": [
-      "pipedream",
-      "customerio",
-      "customer-io",
-      "customer.io",
-      "customer_io"
+    "pipedream",
+    "customerio",
+    "customer-io",
+    "customer.io",
+    "customer_io"
   ],
   "homepage": "https://pipedream.com/apps/customer_io",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",
   "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
   "publishConfig": {
-      "access": "public"
+    "access": "public"
   },
   "dependencies": {
-      "@pipedream/platform": "^0.10.0"
+    "@pipedream/platform": "^0.10.0"
   }
 }

--- a/components/darwinbox/package.json
+++ b/components/darwinbox/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/darwinbox",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Darwinbox Components",
   "main": "dist/app/darwinbox.app.mjs",
   "keywords": [
     "pipedream",
     "darwinbox"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/darwinbox",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/data_stores/package.json
+++ b/components/data_stores/package.json
@@ -1,20 +1,20 @@
 {
-    "name": "@pipedream/data_stores",
-    "version": "0.0.1",
-    "description": "Pipedream Data Stores Components",
-    "main": "data_stores.app.js",
-    "keywords": [
-        "pipedream",
-        "blogger"
-    ],
-    "homepage": "https://pipedream.com/apps/data_stores",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    },
-    "dependencies": {
-        "xss": "^1.0.11"
-    }
+  "name": "@pipedream/data_stores",
+  "version": "0.0.2",
+  "description": "Pipedream Data Stores Components",
+  "main": "data_stores.app.js",
+  "keywords": [
+    "pipedream",
+    "blogger"
+  ],
+  "homepage": "https://pipedream.com/apps/data_stores",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "xss": "^1.0.11"
+  }
 }

--- a/components/datadog/package.json
+++ b/components/datadog/package.json
@@ -10,6 +10,9 @@
   "homepage": "https://pipedream.com/apps/datadog",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "uuid": "^8.3.2"
   }

--- a/components/datadog/package.json
+++ b/components/datadog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/datadog",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Datadog Components",
   "main": "datadog.app.mjs",
   "keywords": [

--- a/components/dear/package.json
+++ b/components/dear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/dear",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Pipedream Dear Components",
   "main": "dear.app.mjs",
   "keywords": [

--- a/components/deepgram/package.json
+++ b/components/deepgram/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/deepgram",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Deepgram Components",
   "main": "dist/app/deepgram.app.mjs",
   "keywords": [
     "pipedream",
     "deepgram"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/deepgram",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/degreed/package.json
+++ b/components/degreed/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/degreed",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Degreed Components",
   "main": "dist/app/degreed.app.mjs",
   "keywords": [
     "pipedream",
     "degreed"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/degreed",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/delighted/package.json
+++ b/components/delighted/package.json
@@ -1,20 +1,20 @@
 {
-    "name": "@pipedream/delighted",
-    "version": "0.3.4",
-    "description": "Pipedream Delighted Components",
-    "main": "delighted.app.mjs",
-    "keywords": [
-        "pipedream",
-        "delighted"
-    ],
-    "homepage": "https://pipedream.com/apps/delighted",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    },
-    "dependencies": {
-        "delighted": "^2.1.0"
-    }
+  "name": "@pipedream/delighted",
+  "version": "0.3.5",
+  "description": "Pipedream Delighted Components",
+  "main": "delighted.app.mjs",
+  "keywords": [
+    "pipedream",
+    "delighted"
+  ],
+  "homepage": "https://pipedream.com/apps/delighted",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "delighted": "^2.1.0"
+  }
 }

--- a/components/demio/package.json
+++ b/components/demio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/demio",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Pipedream Demio Components",
   "main": "demio.app.js",
   "keywords": [

--- a/components/detrack/package.json
+++ b/components/detrack/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/detrack",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream DeTrack Components",
   "main": "dist/app/detrack.app.mjs",
   "keywords": [
     "pipedream",
     "detrack"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/detrack",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/dev_to/package.json
+++ b/components/dev_to/package.json
@@ -1,17 +1,17 @@
 {
-    "name": "@pipedream/dev_to",
-    "version": "0.3.3",
-    "description": "Pipedream Dev_to Components",
-    "main": "dev_to.app.js",
-    "keywords": [
-        "pipedream",
-        "dev_to"
-    ],
-    "homepage": "https://pipedream.com/apps/dev_to",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/dev_to",
+  "version": "0.3.4",
+  "description": "Pipedream Dev_to Components",
+  "main": "dev_to.app.js",
+  "keywords": [
+    "pipedream",
+    "dev_to"
+  ],
+  "homepage": "https://pipedream.com/apps/dev_to",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/dialpad/package.json
+++ b/components/dialpad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/dialpad",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Pipedream Dialpad Components",
   "main": "dist/app/dialpad.app.mjs",
   "types": "dist/app/dialpad.app.d.ts",

--- a/components/dictionary_api/package.json
+++ b/components/dictionary_api/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/dictionary_api",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Free Dictionary Components",
   "main": "dist/app/dictionary_api.app.mjs",
   "keywords": [
     "pipedream",
     "dictionary_api"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/dictionary_api",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/digicert/package.json
+++ b/components/digicert/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/digicert",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream DigiCert Components",
   "main": "dist/app/digicert.app.mjs",
   "keywords": [
     "pipedream",
     "digicert"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/digicert",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/digital_ocean/package.json
+++ b/components/digital_ocean/package.json
@@ -1,20 +1,20 @@
 {
-    "name": "@pipedream/digital_ocean",
-    "version": "0.0.1",
-    "description": "Pipedream Digital Ocean Components",
-    "main": "digital_ocean.app.mjs",
-    "keywords": [
-        "pipedream",
-        "digital ocean"
-    ],
-    "homepage": "https://pipedream.com/apps/digital_ocean",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    },
-    "dependencies": {
-        "do-wrapper": "^4.5.1"
-    }
+  "name": "@pipedream/digital_ocean",
+  "version": "0.0.2",
+  "description": "Pipedream Digital Ocean Components",
+  "main": "digital_ocean.app.mjs",
+  "keywords": [
+    "pipedream",
+    "digital ocean"
+  ],
+  "homepage": "https://pipedream.com/apps/digital_ocean",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "do-wrapper": "^4.5.1"
+  }
 }

--- a/components/discord/package.json
+++ b/components/discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/discord",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Pipedream Discord Components",
   "main": "discord.app.mjs",
   "keywords": [

--- a/components/discord_bot/package.json
+++ b/components/discord_bot/package.json
@@ -1,20 +1,20 @@
 {
-    "name": "@pipedream/discord_bot",
-    "version": "0.3.3",
-    "description": "Pipedream Discord_bot Components",
-    "main": "discord_bot.app.js",
-    "keywords": [
-        "pipedream",
-        "discord_bot"
-    ],
-    "homepage": "https://pipedream.com/apps/discord_bot",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "@pipedreamhq/platform": "^0.8.1"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/discord_bot",
+  "version": "0.3.4",
+  "description": "Pipedream Discord_bot Components",
+  "main": "discord_bot.app.js",
+  "keywords": [
+    "pipedream",
+    "discord_bot"
+  ],
+  "homepage": "https://pipedream.com/apps/discord_bot",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "@pipedreamhq/platform": "^0.8.1"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/discord_webhook/package.json
+++ b/components/discord_webhook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/discord_webhook",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Pipedream Discord_Webook Components",
   "main": "discord_webhook.app.mjs",
   "keywords": [

--- a/components/docusign/package.json
+++ b/components/docusign/package.json
@@ -1,19 +1,19 @@
 {
-    "name": "@pipedream/docusign",
-    "version": "0.1.0",
-    "description": "Pipedream Docusign Components",
-    "main": "docusign.app.js",
-    "keywords": [
-        "pipedream",
-        "docusign"
-    ],
-    "homepage": "https://pipedream.com/apps/docusign",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "@pipedream/platform": "^1.1.1"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/docusign",
+  "version": "0.1.1",
+  "description": "Pipedream Docusign Components",
+  "main": "docusign.app.js",
+  "keywords": [
+    "pipedream",
+    "docusign"
+  ],
+  "homepage": "https://pipedream.com/apps/docusign",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "@pipedream/platform": "^1.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/docusign_developer/package.json
+++ b/components/docusign_developer/package.json
@@ -1,19 +1,19 @@
 {
-    "name": "@pipedream/docusign_developer",
-    "version": "0.1.0",
-    "description": "Pipedream Docusign_developer Components",
-    "main": "docusign_developer.app.js",
-    "keywords": [
-        "pipedream",
-        "docusign_developer"
-    ],
-    "homepage": "https://pipedream.com/apps/docusign_developer",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "@pipedream/platform": "^1.1.1"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/docusign_developer",
+  "version": "0.1.1",
+  "description": "Pipedream Docusign_developer Components",
+  "main": "docusign_developer.app.js",
+  "keywords": [
+    "pipedream",
+    "docusign_developer"
+  ],
+  "homepage": "https://pipedream.com/apps/docusign_developer",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "@pipedream/platform": "^1.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/doppler_ops/package.json
+++ b/components/doppler_ops/package.json
@@ -1,16 +1,16 @@
 {
-    "name": "@pipedream/doppler_ops",
-    "version": "0.0.1",
-    "description": "Pipedream Doppler Secrets Manager Components",
-    "main": "doppler_ops.app.js",
-    "keywords": [
-      "pipedream",
-      "doppler_ops"
-    ],
-    "homepage": "https://pipedream.com/apps/doppler_ops",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "publishConfig": {
-      "access": "public"
-    }
+  "name": "@pipedream/doppler_ops",
+  "version": "0.0.2",
+  "description": "Pipedream Doppler Secrets Manager Components",
+  "main": "doppler_ops.app.js",
+  "keywords": [
+    "pipedream",
+    "doppler_ops"
+  ],
+  "homepage": "https://pipedream.com/apps/doppler_ops",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
   }
+}

--- a/components/dots_/package.json
+++ b/components/dots_/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/dots_",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Dots! Components",
   "main": "dist/app/dots_.app.mjs",
   "keywords": [
     "pipedream",
     "dots_"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/dots_",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/dropbox/package.json
+++ b/components/dropbox/package.json
@@ -1,21 +1,21 @@
 {
-    "name": "@pipedream/dropbox",
-    "version": "0.3.3",
-    "description": "Pipedream Dropbox Components",
-    "main": "dropbox.app.js",
-    "keywords": [
-        "pipedream",
-        "dropbox"
-    ],
-    "homepage": "https://pipedream.com/apps/dropbox",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "dropbox": "^8.2.0",
-        "isomorphic-fetch": "^3.0.0"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/dropbox",
+  "version": "0.3.4",
+  "description": "Pipedream Dropbox Components",
+  "main": "dropbox.app.js",
+  "keywords": [
+    "pipedream",
+    "dropbox"
+  ],
+  "homepage": "https://pipedream.com/apps/dropbox",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "dropbox": "^8.2.0",
+    "isomorphic-fetch": "^3.0.0"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/e_conomic/package.json
+++ b/components/e_conomic/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/e_conomic",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream E-conomic Components",
   "main": "dist/app/e_conomic.app.mjs",
   "keywords": [
     "pipedream",
     "e_conomic"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/e_conomic",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/ecwid/package.json
+++ b/components/ecwid/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/ecwid",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream ecwid Components",
   "main": "dist/app/ecwid.app.mjs",
   "keywords": [
     "pipedream",
     "ecwid"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/ecwid",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/elmah_io/package.json
+++ b/components/elmah_io/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/elmah_io",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream elmah.io Components",
   "main": "elmah_io.app.mjs",
   "keywords": [

--- a/components/emailoctopus/package.json
+++ b/components/emailoctopus/package.json
@@ -1,16 +1,16 @@
 {
-    "name": "@pipedream/emailoctopus",
-    "version": "0.0.1",
-    "description": "Pipedream Emailoctopus Components",
-    "main": "emailoctopus.app.js",
-    "keywords": [
-      "pipedream",
-      "emailoctopus"
-    ],
-    "homepage": "https://pipedream.com/apps/emailoctopus",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "publishConfig": {
-      "access": "public"
-    }
+  "name": "@pipedream/emailoctopus",
+  "version": "0.0.2",
+  "description": "Pipedream Emailoctopus Components",
+  "main": "emailoctopus.app.js",
+  "keywords": [
+    "pipedream",
+    "emailoctopus"
+  ],
+  "homepage": "https://pipedream.com/apps/emailoctopus",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
   }
+}

--- a/components/enormail/package.json
+++ b/components/enormail/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/enormail",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Enormail Components",
   "main": "dist/app/enormail.app.mjs",
   "keywords": [
     "pipedream",
     "enormail"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/enormail",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/esignatures_io/package.json
+++ b/components/esignatures_io/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/esignatures_io",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Esignatures IO Components",
   "main": "esignatures_io.app.mjs",
   "keywords": [

--- a/components/esputnik/package.json
+++ b/components/esputnik/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/esputnik",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream eSputnik Components",
   "main": "esputnik.app.mjs",
   "keywords": [

--- a/components/ethereum/package.json
+++ b/components/ethereum/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/ethereum",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Etherscan Components",
   "main": "dist/app/ethereum.app.mjs",
   "keywords": [
     "pipedream",
     "ethereum"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/ethereum",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/exact/package.json
+++ b/components/exact/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/exact",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Exact Components",
   "main": "dist/app/exact.app.mjs",
   "keywords": [
     "pipedream",
     "exact"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/exact",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/expensify/package.json
+++ b/components/expensify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/expensify",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Expensify Components",
   "main": "dist/app/expensify.app.mjs",
   "keywords": [

--- a/components/f15five/package.json
+++ b/components/f15five/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/f15five",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream 15Five Components",
   "main": "dist/app/f15five.app.mjs",
   "keywords": [
     "pipedream",
     "f15five"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/f15five",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/faunadb/package.json
+++ b/components/faunadb/package.json
@@ -1,22 +1,22 @@
 {
-    "name": "@pipedream/faunadb",
-    "version": "0.3.4",
-    "description": "Pipedream Faunadb Components",
-    "main": "faunadb.app.mjs",
-    "keywords": [
-        "pipedream",
-        "faunadb"
-    ],
-    "homepage": "https://pipedream.com/apps/faunadb",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "@pipedream/platform": "^0.10.0",
-        "faunadb": "^4.5.4",
-        "lodash": "^4.17.21"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/faunadb",
+  "version": "0.3.5",
+  "description": "Pipedream Faunadb Components",
+  "main": "faunadb.app.mjs",
+  "keywords": [
+    "pipedream",
+    "faunadb"
+  ],
+  "homepage": "https://pipedream.com/apps/faunadb",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "@pipedream/platform": "^0.10.0",
+    "faunadb": "^4.5.4",
+    "lodash": "^4.17.21"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/fedex/package.json
+++ b/components/fedex/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/fedex",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream FedEx Components",
   "main": "dist/app/fedex.app.mjs",
   "keywords": [
     "pipedream",
     "fedex"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/fedex",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/feedbin/package.json
+++ b/components/feedbin/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@pipedream/feedbin",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Feedbin Components",
   "main": "feedbin.app.mjs",
   "keywords": [
-		"pipedream",
-		"feedbin"
+    "pipedream",
+    "feedbin"
   ],
   "homepage": "https://pipedream.com/apps/feedbin",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",

--- a/components/figma/package.json
+++ b/components/figma/package.json
@@ -1,19 +1,19 @@
 {
-    "name": "@pipedream/figma",
-    "version": "0.0.1",
-    "description": "Pipedream Figma Components",
-    "main": "figma.app.js",
-    "keywords": [
-        "pipedream",
-        "figma"
-    ],
-    "homepage": "https://pipedream.com/apps/figma",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "publishConfig": {
-        "access": "public"
-    },
-    "dependencies": {
-        "@pipedream/platform": "^0.10.0"
-    }
+  "name": "@pipedream/figma",
+  "version": "0.0.2",
+  "description": "Pipedream Figma Components",
+  "main": "figma.app.js",
+  "keywords": [
+    "pipedream",
+    "figma"
+  ],
+  "homepage": "https://pipedream.com/apps/figma",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^0.10.0"
+  }
 }

--- a/components/firebase_admin_sdk/package.json
+++ b/components/firebase_admin_sdk/package.json
@@ -1,24 +1,24 @@
 {
-    "name": "@pipedream/firebase_admin_sdk",
-    "version": "0.0.1",
-    "description": "Pipedream Firebase Admin SDK Components",
-    "main": "firebase_admin_sdk.app.mjs",
-    "keywords": [
-        "pipedream",
-        "firebase_admin_sdk"
-    ],
-    "homepage": "https://pipedream.com/apps/firebase_admin_sdk",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "@firebase/app-compat": "^0.1.25",
-        "@firebase/app-types": "^0.7.0",
-        "@pipedream/platform": "^0.9.0",
-        "firebase-admin": "^10.0.1",
-        "google-auth-library": "^7.11.0"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/firebase_admin_sdk",
+  "version": "0.0.2",
+  "description": "Pipedream Firebase Admin SDK Components",
+  "main": "firebase_admin_sdk.app.mjs",
+  "keywords": [
+    "pipedream",
+    "firebase_admin_sdk"
+  ],
+  "homepage": "https://pipedream.com/apps/firebase_admin_sdk",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "@firebase/app-compat": "^0.1.25",
+    "@firebase/app-types": "^0.7.0",
+    "@pipedream/platform": "^0.9.0",
+    "firebase-admin": "^10.0.1",
+    "google-auth-library": "^7.11.0"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/formstack/package.json
+++ b/components/formstack/package.json
@@ -1,20 +1,20 @@
 {
-    "name": "@pipedream/formstack",
-    "version": "0.3.4",
-    "description": "Pipedream Formstack Components",
-    "main": "formstack.app.mjs",
-    "keywords": [
-        "pipedream",
-        "formstack"
-    ],
-    "homepage": "https://pipedream.com/apps/formstack",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "@pipedream/platform": "^0.10.0"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/formstack",
+  "version": "0.3.5",
+  "description": "Pipedream Formstack Components",
+  "main": "formstack.app.mjs",
+  "keywords": [
+    "pipedream",
+    "formstack"
+  ],
+  "homepage": "https://pipedream.com/apps/formstack",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "@pipedream/platform": "^0.10.0"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/foxy/package.json
+++ b/components/foxy/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/foxy",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Foxy Components",
   "main": "dist/app/foxy.app.mjs",
   "keywords": [
     "pipedream",
     "foxy"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/foxy",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/fraudlabs_pro/package.json
+++ b/components/fraudlabs_pro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/fraudlabs_pro",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Pipedream Fraudlabs_pro Components",
   "main": "fraudlabs_pro.app.mjs",
   "keywords": [

--- a/components/freshdesk/package.json
+++ b/components/freshdesk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/freshdesk",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Freshdesk Components",
   "main": "freshdesk.app.mjs",
   "keywords": [
@@ -16,7 +16,6 @@
   "dependencies": {
     "@pipedream/platform": "^0.9.0",
     "async-retry": "^1.3.3",
-    "moment":"2.29.2"
+    "moment": "2.29.2"
   }
 }
-

--- a/components/frontapp/package.json
+++ b/components/frontapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/frontapp",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Pipedream Frontapp Components",
   "main": "frontapp.app.mjs",
   "keywords": [

--- a/components/getprospect/package.json
+++ b/components/getprospect/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/getprospect",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream GetProspect Components",
   "main": "dist/app/getprospect.app.mjs",
   "keywords": [
     "pipedream",
     "getprospect"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/getprospect",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/getscreenshot/package.json
+++ b/components/getscreenshot/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/getscreenshot",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream GetScreenshot Components",
   "main": "dist/app/getscreenshot.app.mjs",
   "keywords": [
     "pipedream",
     "getscreenshot"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/getscreenshot",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/ghost_org_admin_api/package.json
+++ b/components/ghost_org_admin_api/package.json
@@ -1,21 +1,21 @@
 {
-    "name": "@pipedream/ghost_org_admin_api",
-    "version": "0.1.0",
-    "description": "Pipedream Ghost_org_admin_api Components",
-    "main": "ghost_org_admin_api.app.mjs",
-    "keywords": [
-        "pipedream",
-        "ghost_org_admin_api"
-    ],
-    "homepage": "https://pipedream.com/apps/ghost_org_admin_api",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "@pipedream/platform": "^1.0.0",
-        "jsonwebtoken": "^8.5.1"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/ghost_org_admin_api",
+  "version": "0.1.1",
+  "description": "Pipedream Ghost_org_admin_api Components",
+  "main": "ghost_org_admin_api.app.mjs",
+  "keywords": [
+    "pipedream",
+    "ghost_org_admin_api"
+  ],
+  "homepage": "https://pipedream.com/apps/ghost_org_admin_api",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "@pipedream/platform": "^1.0.0",
+    "jsonwebtoken": "^8.5.1"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/ghost_org_content_api/package.json
+++ b/components/ghost_org_content_api/package.json
@@ -1,20 +1,20 @@
 {
-    "name": "@pipedream/ghost_org_content_api",
-    "version": "0.1.0",
-    "description": "Pipedream Ghost_org_content_api Components",
-    "main": "ghost_org_content_api.app.mjs",
-    "keywords": [
-        "pipedream",
-        "ghost"
-    ],
-    "homepage": "https://pipedream.com/apps/ghost_org_content_api",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "@pipedream/platform": "^1.0.0"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/ghost_org_content_api",
+  "version": "0.1.1",
+  "description": "Pipedream Ghost_org_content_api Components",
+  "main": "ghost_org_content_api.app.mjs",
+  "keywords": [
+    "pipedream",
+    "ghost"
+  ],
+  "homepage": "https://pipedream.com/apps/ghost_org_content_api",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "@pipedream/platform": "^1.0.0"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/giphy/package.json
+++ b/components/giphy/package.json
@@ -1,21 +1,21 @@
 {
-    "name": "@pipedream/giphy",
-    "version": "0.3.3",
-    "description": "Pipedream Giphy Components",
-    "main": "giphy.app.mjs",
-    "keywords": [
-        "pipedream",
-        "giphy"
-    ],
-    "homepage": "https://pipedream.com/apps/giphy",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    },
-    "dependencies": {
-        "@pipedream/platform": "^0.10.0",
-        "form-data": "^4.0.0"
-    }
+  "name": "@pipedream/giphy",
+  "version": "0.3.4",
+  "description": "Pipedream Giphy Components",
+  "main": "giphy.app.mjs",
+  "keywords": [
+    "pipedream",
+    "giphy"
+  ],
+  "homepage": "https://pipedream.com/apps/giphy",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^0.10.0",
+    "form-data": "^4.0.0"
+  }
 }

--- a/components/gist/package.json
+++ b/components/gist/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/gist",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Gist Components",
   "main": "dist/app/gist.app.mjs",
   "keywords": [
     "pipedream",
     "gist"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/gist",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/github/package.json
+++ b/components/github/package.json
@@ -1,23 +1,23 @@
 {
-    "name": "@pipedream/github",
-    "version": "0.3.3",
-    "description": "Pipedream Github Components",
-    "main": "github.app.mjs",
-    "keywords": [
-        "pipedream",
-        "github"
-    ],
-    "homepage": "https://pipedream.com/apps/github",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "@octokit/core": "^4.0.4",
-        "@octokit/plugin-paginate-rest": "^2.17.0",
-        "@octokit/webhooks-definitions": "^3.29.0",
-        "@pipedream/platform": "^1.0.0"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/github",
+  "version": "0.3.4",
+  "description": "Pipedream Github Components",
+  "main": "github.app.mjs",
+  "keywords": [
+    "pipedream",
+    "github"
+  ],
+  "homepage": "https://pipedream.com/apps/github",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "@octokit/core": "^4.0.4",
+    "@octokit/plugin-paginate-rest": "^2.17.0",
+    "@octokit/webhooks-definitions": "^3.29.0",
+    "@pipedream/platform": "^1.0.0"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/gitlab/package.json
+++ b/components/gitlab/package.json
@@ -1,22 +1,22 @@
 {
-    "name": "@pipedream/gitlab",
-    "version": "0.4.0",
-    "description": "Pipedream Gitlab Components",
-    "main": "gitlab.app.js",
-    "keywords": [
-        "pipedream",
-        "gitlab"
-    ],
-    "homepage": "https://pipedream.com/apps/gitlab",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "@gitbeaker/node": "^35.5.0",
-        "lodash": "^4.17.21",
-        "uuid": "^8.3.2"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/gitlab",
+  "version": "0.4.1",
+  "description": "Pipedream Gitlab Components",
+  "main": "gitlab.app.js",
+  "keywords": [
+    "pipedream",
+    "gitlab"
+  ],
+  "homepage": "https://pipedream.com/apps/gitlab",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "@gitbeaker/node": "^35.5.0",
+    "lodash": "^4.17.21",
+    "uuid": "^8.3.2"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/givebutter/package.json
+++ b/components/givebutter/package.json
@@ -1,16 +1,16 @@
 {
-    "name": "@pipedream/givebutter",
-    "version": "0.3.3",
-    "description": "Pipedream Givebutter Components",
-    "main": "givebutter.app.js",
-    "keywords": [
-      "pipedream",
-      "givebutter"
-    ],
-    "homepage": "https://pipedream.com/apps/givebutter",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "publishConfig": {
-      "access": "public"
-    }
+  "name": "@pipedream/givebutter",
+  "version": "0.3.4",
+  "description": "Pipedream Givebutter Components",
+  "main": "givebutter.app.js",
+  "keywords": [
+    "pipedream",
+    "givebutter"
+  ],
+  "homepage": "https://pipedream.com/apps/givebutter",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
   }
+}

--- a/components/gmail/package.json
+++ b/components/gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/gmail",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Gmail Components",
   "main": "gmail.app.mjs",
   "keywords": [

--- a/components/gmail_custom_oauth/package.json
+++ b/components/gmail_custom_oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/gmail_custom_oauth",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Gmail (Consumer) Components",
   "main": "dist/app/gmail_custom_oauth.app.mjs",
   "keywords": [

--- a/components/gobio_link/package.json
+++ b/components/gobio_link/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/gobio_link",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream gobio.link Components",
   "main": "dist/app/gobio_link.app.mjs",
   "keywords": [
     "pipedream",
     "gobio_link"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/gobio_link",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/godaddy/package.json
+++ b/components/godaddy/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/godaddy",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream GoDaddy Components",
   "main": "dist/app/godaddy.app.mjs",
   "keywords": [
     "pipedream",
     "godaddy"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/godaddy",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/godial/package.json
+++ b/components/godial/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/godial",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream GoDial Components",
   "main": "dist/app/godial.app.mjs",
   "keywords": [
     "pipedream",
     "godial"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/godial",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/google_ads/package.json
+++ b/components/google_ads/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/google_ads",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Google Ads Components",
   "main": "dist/app/google_ads.app.mjs",
   "keywords": [
     "pipedream",
     "google_ads"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/google_ads",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/google_appsheet/package.json
+++ b/components/google_appsheet/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/google_appsheet",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Google Appsheet Components",
   "main": "dist/app/google_appsheet.app.mjs",
   "keywords": [
     "pipedream",
     "google_appsheet"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/google_appsheet",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/google_calendar/package.json
+++ b/components/google_calendar/package.json
@@ -1,23 +1,23 @@
 {
-    "name": "@pipedream/google_calendar",
-    "version": "0.3.3",
-    "description": "Pipedream Google_calendar Components",
-    "main": "google_calendar.app.mjs",
-    "keywords": [
-        "pipedream",
-        "google_calendar"
-    ],
-    "homepage": "https://pipedream.com/apps/google_calendar",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "@googleapis/calendar": "^1.0.2",
-        "lodash.get": "^4.4.2",
-        "moment-timezone": "^0.5.33",
-        "uuid": "^8.3.2"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/google_calendar",
+  "version": "0.3.4",
+  "description": "Pipedream Google_calendar Components",
+  "main": "google_calendar.app.mjs",
+  "keywords": [
+    "pipedream",
+    "google_calendar"
+  ],
+  "homepage": "https://pipedream.com/apps/google_calendar",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "@googleapis/calendar": "^1.0.2",
+    "lodash.get": "^4.4.2",
+    "moment-timezone": "^0.5.33",
+    "uuid": "^8.3.2"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/google_cloud/package.json
+++ b/components/google_cloud/package.json
@@ -1,27 +1,27 @@
 {
-    "name": "@pipedream/google_cloud",
-    "version": "0.3.4",
-    "description": "Pipedream Google_cloud Components",
-    "main": "google_cloud.app.mjs",
-    "keywords": [
-        "pipedream",
-        "google_cloud"
-    ],
-    "homepage": "https://pipedream.com/apps/google_cloud",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    },
-    "dependencies": {
-        "@google-cloud/bigquery": "^6.0.0",
-        "@google-cloud/logging": "^10.0.3",
-        "@google-cloud/pubsub": "^3.0.1",
-        "@google-cloud/storage": "^6.0.1",
-        "@pipedream/platform": "^0.10.0",
-        "crypto": "^1.0.1",
-        "lodash-es": "^4.17.21",
-        "uuid": "^8.3.2"
-    }
+  "name": "@pipedream/google_cloud",
+  "version": "0.3.5",
+  "description": "Pipedream Google_cloud Components",
+  "main": "google_cloud.app.mjs",
+  "keywords": [
+    "pipedream",
+    "google_cloud"
+  ],
+  "homepage": "https://pipedream.com/apps/google_cloud",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@google-cloud/bigquery": "^6.0.0",
+    "@google-cloud/logging": "^10.0.3",
+    "@google-cloud/pubsub": "^3.0.1",
+    "@google-cloud/storage": "^6.0.1",
+    "@pipedream/platform": "^0.10.0",
+    "crypto": "^1.0.1",
+    "lodash-es": "^4.17.21",
+    "uuid": "^8.3.2"
+  }
 }

--- a/components/google_contacts/package.json
+++ b/components/google_contacts/package.json
@@ -1,21 +1,21 @@
 {
-    "name": "@pipedream/google_contacts",
-    "version": "0.0.1",
-    "description": "Pipedream Gooogle Contacts Components",
-    "main": "google_contacts.app.mjs",
-    "keywords": [
-        "pipedream",
-        "google_contacts"
-    ],
-    "homepage": "https://pipedream.com/apps/google_contacts",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "@pipedream/platform": "^0.10.0",
-        "googleapis": "^96.0.0"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/google_contacts",
+  "version": "0.0.2",
+  "description": "Pipedream Gooogle Contacts Components",
+  "main": "google_contacts.app.mjs",
+  "keywords": [
+    "pipedream",
+    "google_contacts"
+  ],
+  "homepage": "https://pipedream.com/apps/google_contacts",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "@pipedream/platform": "^0.10.0",
+    "googleapis": "^96.0.0"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/google_dialogflow/package.json
+++ b/components/google_dialogflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_dialogflow",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Google Dialogflow Components",
   "main": "google_dialogflow.app.mjs",
   "keywords": [

--- a/components/google_directory/package.json
+++ b/components/google_directory/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/google_directory",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Google Directory Components",
   "main": "dist/app/google_directory.app.mjs",
   "keywords": [
     "pipedream",
     "google_directory"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/google_directory",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/google_docs/package.json
+++ b/components/google_docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_docs",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Pipedream Google_docs Components",
   "main": "google_docs.app.mjs",
   "keywords": [

--- a/components/google_drive/package.json
+++ b/components/google_drive/package.json
@@ -1,24 +1,24 @@
 {
-    "name": "@pipedream/google_drive",
-    "version": "0.4.0",
-    "description": "Pipedream Google_drive Components",
-    "main": "google_drive.app.mjs",
-    "keywords": [
-        "pipedream",
-        "google_drive"
-    ],
-    "homepage": "https://pipedream.com/apps/google_drive",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "@googleapis/drive": "^2.3.0",
-        "@pipedream/platform": "^0.9.0",
-        "axios": "^0.21.1",
-        "mime-db": "^1.51.0",
-        "uuid": "^8.3.2"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/google_drive",
+  "version": "0.4.1",
+  "description": "Pipedream Google_drive Components",
+  "main": "google_drive.app.mjs",
+  "keywords": [
+    "pipedream",
+    "google_drive"
+  ],
+  "homepage": "https://pipedream.com/apps/google_drive",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "@googleapis/drive": "^2.3.0",
+    "@pipedream/platform": "^0.9.0",
+    "axios": "^0.21.1",
+    "mime-db": "^1.51.0",
+    "uuid": "^8.3.2"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/google_recaptcha/package.json
+++ b/components/google_recaptcha/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/google_recaptcha",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Google reCAPTCHA Components",
   "main": "dist/app/google_recaptcha.app.mjs",
   "keywords": [
     "pipedream",
     "google_recaptcha"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/google_recaptcha",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/google_sheets/package.json
+++ b/components/google_sheets/package.json
@@ -1,23 +1,23 @@
 {
-    "name": "@pipedream/google_sheets",
-    "version": "0.3.3",
-    "description": "Pipedream Google_sheets Components",
-    "main": "google_sheets.app.mjs",
-    "keywords": [
-        "pipedream",
-        "google_sheets"
-    ],
-    "homepage": "https://pipedream.com/apps/google_sheets",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "@googleapis/sheets": "^0.3.0",
-        "@pipedream/platform": "^0.10.0",
-        "axios": "^0.21.1",
-        "uuidv4": "^6.2.6"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/google_sheets",
+  "version": "0.3.4",
+  "description": "Pipedream Google_sheets Components",
+  "main": "google_sheets.app.mjs",
+  "keywords": [
+    "pipedream",
+    "google_sheets"
+  ],
+  "homepage": "https://pipedream.com/apps/google_sheets",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "@googleapis/sheets": "^0.3.0",
+    "@pipedream/platform": "^0.10.0",
+    "axios": "^0.21.1",
+    "uuidv4": "^6.2.6"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/google_slides/package.json
+++ b/components/google_slides/package.json
@@ -1,25 +1,25 @@
 {
-    "name": "@pipedream/google_slides",
-    "version": "0.0.1",
-    "description": "Pipedream Google Slides Components",
-    "main": "google_slides.app.mjs",
-    "keywords": [
-        "pipedream",
-        "google_slides"
-    ],
-    "homepage": "https://pipedream.com/apps/google_slides",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "@googleapis/slides": "^0.7.1",
-        "@googleapis/drive": "^2.3.0",
-        "@pipedream/platform": "^0.9.0",
-        "axios": "^0.21.1",
-        "mime-db": "^1.51.0",
-        "uuid": "^8.3.2"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/google_slides",
+  "version": "0.0.2",
+  "description": "Pipedream Google Slides Components",
+  "main": "google_slides.app.mjs",
+  "keywords": [
+    "pipedream",
+    "google_slides"
+  ],
+  "homepage": "https://pipedream.com/apps/google_slides",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "@googleapis/slides": "^0.7.1",
+    "@googleapis/drive": "^2.3.0",
+    "@pipedream/platform": "^0.9.0",
+    "axios": "^0.21.1",
+    "mime-db": "^1.51.0",
+    "uuid": "^8.3.2"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/google_workspace/package.json
+++ b/components/google_workspace/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/google_workspace",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Google Workspace Admin Components",
   "main": "dist/app/google_workspace.app.mjs",
   "keywords": [
     "pipedream",
     "google_workspace"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/google_workspace",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/gorgias/package.json
+++ b/components/gorgias/package.json
@@ -1,21 +1,21 @@
 {
-    "name": "@pipedream/gorgias",
-    "version": "0.3.3",
-    "description": "Pipedream Gorgias Components",
-    "main": "gorgias.app.mjs",
-    "keywords": [
-        "pipedream",
-        "gorgias"
-    ],
-    "homepage": "https://pipedream.com/apps/gorgias",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    },
-    "dependencies": {
-        "@pipedream/platform": "^0.10.0",
-        "lodash-es": "^4.17.21"
-    }
+  "name": "@pipedream/gorgias",
+  "version": "0.3.4",
+  "description": "Pipedream Gorgias Components",
+  "main": "gorgias.app.mjs",
+  "keywords": [
+    "pipedream",
+    "gorgias"
+  ],
+  "homepage": "https://pipedream.com/apps/gorgias",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^0.10.0",
+    "lodash-es": "^4.17.21"
+  }
 }

--- a/components/gorgias_oauth/package.json
+++ b/components/gorgias_oauth/package.json
@@ -1,21 +1,21 @@
 {
-    "name": "@pipedream/gorgias_oauth",
-    "version": "0.3.4",
-    "description": "Pipedream Gorgias OAuth Components",
-    "main": "gorgias_oauth.app.mjs",
-    "keywords": [
-        "pipedream",
-        "gorgias",
-        "gorgias_oauth"
-    ],
-    "homepage": "https://pipedream.com/apps/gorgias-oauth",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    },
-    "dependencies": {
-        "@pipedream/platform": "^0.10.0"
-    }
+  "name": "@pipedream/gorgias_oauth",
+  "version": "0.3.5",
+  "description": "Pipedream Gorgias OAuth Components",
+  "main": "gorgias_oauth.app.mjs",
+  "keywords": [
+    "pipedream",
+    "gorgias",
+    "gorgias_oauth"
+  ],
+  "homepage": "https://pipedream.com/apps/gorgias-oauth",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^0.10.0"
+  }
 }

--- a/components/grist/package.json
+++ b/components/grist/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/grist",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Grist Components",
   "main": "dist/app/grist.app.mjs",
   "keywords": [
     "pipedream",
     "grist"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/grist",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/growsurf/package.json
+++ b/components/growsurf/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/growsurf",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Growsurf Components",
   "main": "dist/app/growsurf.app.mjs",
   "keywords": [
     "pipedream",
     "growsurf"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/growsurf",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/guru/package.json
+++ b/components/guru/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/guru",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Guru Components",
   "main": "dist/app/guru.app.mjs",
   "keywords": [
     "pipedream",
     "guru"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/guru",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/hacker_news/package.json
+++ b/components/hacker_news/package.json
@@ -1,17 +1,17 @@
 {
-    "name": "@pipedream/hacker_news",
-    "version": "0.3.3",
-    "description": "Pipedream Hacker_news Components",
-    "main": "hacker_news.app.js",
-    "keywords": [
-        "pipedream",
-        "hacker_news"
-    ],
-    "homepage": "https://pipedream.com/apps/hacker_news",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/hacker_news",
+  "version": "0.3.4",
+  "description": "Pipedream Hacker_news Components",
+  "main": "hacker_news.app.js",
+  "keywords": [
+    "pipedream",
+    "hacker_news"
+  ],
+  "homepage": "https://pipedream.com/apps/hacker_news",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/harvest/package.json
+++ b/components/harvest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/harvest",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Harvest Components",
   "main": "harvest.app.mjs",
   "keywords": [
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@pipedream/platform": "^0.9.0",
-    "moment":"^2.29.3",
+    "moment": "^2.29.3",
     "async-retry": "^1.3.3"
   }
 }

--- a/components/heartbeat/package.json
+++ b/components/heartbeat/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/heartbeat",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Heartbeat Components",
   "main": "dist/app/heartbeat.app.mjs",
   "keywords": [
     "pipedream",
     "heartbeat"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/heartbeat",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/helcim/package.json
+++ b/components/helcim/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/helcim",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Helcim  Components",
   "main": "dist/app/helcim.app.mjs",
   "keywords": [
     "pipedream",
     "helcim"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/helcim",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/helper_functions/package.json
+++ b/components/helper_functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/helper_functions",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Pipedream Helper_functions Components",
   "main": "helper_functions.app.mjs",
   "keywords": [

--- a/components/helpwise/package.json
+++ b/components/helpwise/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/helpwise",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Helpwise Components",
   "main": "dist/app/helpwise.app.mjs",
   "keywords": [
     "pipedream",
     "helpwise"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/helpwise",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/here/package.json
+++ b/components/here/package.json
@@ -1,20 +1,20 @@
 {
-    "name": "@pipedream/here",
-    "version": "0.3.3",
-    "description": "Pipedream Here Components",
-    "main": "here.app.js",
-    "keywords": [
-        "pipedream",
-        "here"
-    ],
-    "homepage": "https://pipedream.com/apps/here",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "@pipedreamhq/platform": "^0.8.1"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/here",
+  "version": "0.3.4",
+  "description": "Pipedream Here Components",
+  "main": "here.app.js",
+  "keywords": [
+    "pipedream",
+    "here"
+  ],
+  "homepage": "https://pipedream.com/apps/here",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "@pipedreamhq/platform": "^0.8.1"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/html_css_to_image/package.json
+++ b/components/html_css_to_image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/html_css_to_image",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream HTML/CSS to Image Components",
   "main": "html_css_to_image.app.mjs",
   "keywords": [

--- a/components/http/package.json
+++ b/components/http/package.json
@@ -1,20 +1,20 @@
 {
-    "name": "@pipedream/http",
-    "version": "0.3.3",
-    "description": "Pipedream Http Components",
-    "main": "http.app.js",
-    "keywords": [
-        "pipedream",
-        "http"
-    ],
-    "homepage": "https://pipedream.com/apps/http",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    },
-    "dependencies": {
-        "object-hash": "^3.0.0"
-    }
+  "name": "@pipedream/http",
+  "version": "0.3.4",
+  "description": "Pipedream Http Components",
+  "main": "http.app.js",
+  "keywords": [
+    "pipedream",
+    "http"
+  ],
+  "homepage": "https://pipedream.com/apps/http",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "object-hash": "^3.0.0"
+  }
 }

--- a/components/hubspot/package.json
+++ b/components/hubspot/package.json
@@ -1,20 +1,20 @@
 {
-    "name": "@pipedream/hubspot",
-    "version": "0.3.4",
-    "description": "Pipedream Hubspot Components",
-    "main": "hubspot.app.mjs",
-    "keywords": [
-        "pipedream",
-        "hubspot"
-    ],
-    "homepage": "https://pipedream.com/apps/hubspot",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "@pipedream/platform": "^0.10.0"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/hubspot",
+  "version": "0.3.5",
+  "description": "Pipedream Hubspot Components",
+  "main": "hubspot.app.mjs",
+  "keywords": [
+    "pipedream",
+    "hubspot"
+  ],
+  "homepage": "https://pipedream.com/apps/hubspot",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "@pipedream/platform": "^0.10.0"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/ifttt/package.json
+++ b/components/ifttt/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@pipedream/ifttt",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Pipedream IFTTT Components",
   "main": "ifttt.app.mjs",
   "keywords": [
-      "pipedream",
-      "ifttt"
+    "pipedream",
+    "ifttt"
   ],
   "homepage": "https://pipedream.com/apps/ifttt",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
@@ -15,6 +15,6 @@
   },
   "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
   "publishConfig": {
-      "access": "public"
+    "access": "public"
   }
 }

--- a/components/infusionsoft/package.json
+++ b/components/infusionsoft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/infusionsoft",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream InfusionSoft Components",
   "main": "dist/app/infusionsoft.app.mjs",
   "keywords": [

--- a/components/inksprout/package.json
+++ b/components/inksprout/package.json
@@ -1,19 +1,19 @@
 {
-    "name": "@pipedream/inksprout",
-    "version": "0.0.1",
-    "description": "Pipedream Inksprout Components",
-    "main": "inksprout.app.js",
-    "keywords": [
-        "pipedream",
-        "inksprout"
-    ],
-    "homepage": "https://pipedream.com/apps/inksprout",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "publishConfig": {
-        "access": "public"
-    },
-    "dependencies": {
-        "@pipedream/platform": "^1.1.1"
-    }
+  "name": "@pipedream/inksprout",
+  "version": "0.0.2",
+  "description": "Pipedream Inksprout Components",
+  "main": "inksprout.app.js",
+  "keywords": [
+    "pipedream",
+    "inksprout"
+  ],
+  "homepage": "https://pipedream.com/apps/inksprout",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^1.1.1"
+  }
 }

--- a/components/intercom/package.json
+++ b/components/intercom/package.json
@@ -1,20 +1,20 @@
 {
-    "name": "@pipedream/intercom",
-    "version": "0.3.4",
-    "description": "Pipedream Intercom Components",
-    "main": "intercom.app.mjs",
-    "keywords": [
-        "pipedream",
-        "intercom"
-    ],
-    "homepage": "https://pipedream.com/apps/intercom",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    },
-    "dependencies": {
-        "@pipedream/platform": "^0.10.0"
-    }
+  "name": "@pipedream/intercom",
+  "version": "0.3.5",
+  "description": "Pipedream Intercom Components",
+  "main": "intercom.app.mjs",
+  "keywords": [
+    "pipedream",
+    "intercom"
+  ],
+  "homepage": "https://pipedream.com/apps/intercom",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^0.10.0"
+  }
 }

--- a/components/intuiface/package.json
+++ b/components/intuiface/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/intuiface",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Intuiface Components",
   "main": "dist/app/intuiface.app.mjs",
   "keywords": [
     "pipedream",
     "intuiface"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/intuiface",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/ip2location/package.json
+++ b/components/ip2location/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/ip2location",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Pipedream Ip2location Components",
   "main": "ip2location.app.mjs",
   "keywords": [

--- a/components/ip2proxy/package.json
+++ b/components/ip2proxy/package.json
@@ -1,20 +1,20 @@
 {
-    "name": "@pipedream/ip2proxy",
-    "version": "0.3.3",
-    "description": "Pipedream Ip2location Components",
-    "main": "ip2proxy.app.mjs",
-    "keywords": [
-      "pipedream",
-      "ip2proxy"
-    ],
-    "homepage": "https://pipedream.com/apps/ip2proxy",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-      "@pipedream/platform": "^0.9.0"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-      "access": "public"
-    }
+  "name": "@pipedream/ip2proxy",
+  "version": "0.3.4",
+  "description": "Pipedream Ip2location Components",
+  "main": "ip2proxy.app.mjs",
+  "keywords": [
+    "pipedream",
+    "ip2proxy"
+  ],
+  "homepage": "https://pipedream.com/apps/ip2proxy",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "@pipedream/platform": "^0.9.0"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
   }
+}

--- a/components/ip2whois/package.json
+++ b/components/ip2whois/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/ip2whois",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Pipedream Ip2whois Components",
   "main": "ip2whois.app.mjs",
   "keywords": [

--- a/components/iqair_airvisual/package.json
+++ b/components/iqair_airvisual/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/iqair_airvisual",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream IQAir AirVisual Components",
   "main": "dist/app/iqair_airvisual.app.mjs",
   "keywords": [
     "pipedream",
     "iqair_airvisual"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/iqair_airvisual",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/isn/package.json
+++ b/components/isn/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/isn",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream ISN Components",
   "main": "dist/app/isn.app.mjs",
   "keywords": [
     "pipedream",
     "isn"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/isn",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/jellyreach/package.json
+++ b/components/jellyreach/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/jellyreach",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Jellyreach Components",
   "main": "dist/app/jellyreach.app.mjs",
   "keywords": [
     "pipedream",
     "jellyreach"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/jellyreach",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/jira/package.json
+++ b/components/jira/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/jira",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Pipedream Jira Components",
   "main": "jira.app.mjs",
   "keywords": [

--- a/components/jobnimbus/package.json
+++ b/components/jobnimbus/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/jobnimbus",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Jobnimbus Components",
   "main": "dist/app/jobnimbus.app.mjs",
   "keywords": [
     "pipedream",
     "jobnimbus"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/jobnimbus",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/joomla/package.json
+++ b/components/joomla/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@pipedream/joomla",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Pipedream Joomla Components",
   "main": "joomla.app.mjs",
   "keywords": [
-      "pipedream",
-      "joomla"
+    "pipedream",
+    "joomla"
   ],
   "homepage": "https://pipedream.com/apps/joomla",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
@@ -15,6 +15,6 @@
   },
   "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
   "publishConfig": {
-      "access": "public"
+    "access": "public"
   }
 }

--- a/components/jotform/package.json
+++ b/components/jotform/package.json
@@ -1,21 +1,21 @@
 {
-    "name": "@pipedream/jotform",
-    "version": "0.3.4",
-    "description": "Pipedream Jotform Components",
-    "main": "jotform.app.js",
-    "keywords": [
-        "pipedream",
-        "jotform"
-    ],
-    "homepage": "https://pipedream.com/apps/jotform",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "axios": "^0.21.1",
-        "query-string": "^7.1.1"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/jotform",
+  "version": "0.3.5",
+  "description": "Pipedream Jotform Components",
+  "main": "jotform.app.js",
+  "keywords": [
+    "pipedream",
+    "jotform"
+  ],
+  "homepage": "https://pipedream.com/apps/jotform",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "axios": "^0.21.1",
+    "query-string": "^7.1.1"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/junip/package.json
+++ b/components/junip/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/junip",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Junip Components",
   "main": "dist/app/junip.app.mjs",
   "keywords": [
     "pipedream",
     "junip"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/junip",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/kanbanize/package.json
+++ b/components/kanbanize/package.json
@@ -1,20 +1,20 @@
 {
-    "name": "@pipedream/kanbanize",
-    "version": "0.0.1",
-    "description": "Pipedream Kanbanize Components",
-    "main": "kanbanize.app.mjs",
-    "keywords": [
-        "pipedream",
-        "kanbanize"
-    ],
-    "homepage": "https://pipedream.com/apps/kanbanize",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    },
-    "dependencies": {
-        "@pipedream/platform": "^0.10.0"
-    }
+  "name": "@pipedream/kanbanize",
+  "version": "0.0.2",
+  "description": "Pipedream Kanbanize Components",
+  "main": "kanbanize.app.mjs",
+  "keywords": [
+    "pipedream",
+    "kanbanize"
+  ],
+  "homepage": "https://pipedream.com/apps/kanbanize",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^0.10.0"
+  }
 }

--- a/components/knack/package.json
+++ b/components/knack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/knack",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Knack Components",
   "main": "knack.app.js",
   "keywords": [

--- a/components/knowbe4/package.json
+++ b/components/knowbe4/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/knowbe4",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream KnowBe4 Components",
   "main": "dist/app/knowbe4.app.mjs",
   "keywords": [
     "pipedream",
     "knowbe4"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/knowbe4",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/laposta/package.json
+++ b/components/laposta/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/laposta",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Laposta Components",
   "main": "dist/app/laposta.app.mjs",
   "keywords": [
     "pipedream",
     "laposta"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/laposta",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/lemlist/package.json
+++ b/components/lemlist/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/lemlist",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Lemlist Components",
   "main": "dist/app/lemlist.app.mjs",
   "keywords": [
     "pipedream",
     "lemlist"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/lemlist",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/linear/package.json
+++ b/components/linear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/linear",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Pipedream Linear Components",
   "main": "linear.app.mjs",
   "keywords": [

--- a/components/linear_app/package.json
+++ b/components/linear_app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/linear_app",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Pipedream Linear_app Components",
   "main": "linear_app.app.mjs",
   "keywords": [

--- a/components/linqs_cc/package.json
+++ b/components/linqs_cc/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/linqs_cc",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream linqs Components",
   "main": "dist/app/linqs_cc.app.mjs",
   "keywords": [
     "pipedream",
     "linqs_cc"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/linqs_cc",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/lob/package.json
+++ b/components/lob/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/lob",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Lob Components",
   "main": "dist/app/lob.app.mjs",
   "keywords": [
     "pipedream",
     "lob"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/lob",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/looker/package.json
+++ b/components/looker/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/looker",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Looker Components",
   "main": "dist/app/looker.app.mjs",
   "keywords": [
     "pipedream",
     "looker"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/looker",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/lusha/package.json
+++ b/components/lusha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/lusha",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Lusha Components",
   "main": "lusha.app.mjs",
   "keywords": [

--- a/components/mailchimp/package.json
+++ b/components/mailchimp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/mailchimp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Pipedream Mailchimp Components",
   "main": "mailchimp.app.js",
   "keywords": [

--- a/components/mailerlite/package.json
+++ b/components/mailerlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/mailerlite",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Pipedream Mailerlite Components",
   "main": "mailerlite.app.mjs",
   "keywords": [

--- a/components/mailgun/package.json
+++ b/components/mailgun/package.json
@@ -1,21 +1,21 @@
 {
-    "name": "@pipedream/mailgun",
-    "version": "0.0.2",
-    "description": "Pipedream Mailgun Components",
-    "main": "mailgun.app.mjs",
-    "keywords": [
-        "pipedream",
-        "mailgun"
-    ],
-    "homepage": "https://pipedream.com/apps/mailgun",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "publishConfig": {
-        "access": "public"
-    },
-    "dependencies": {
-        "form-data": "^4.0.0",
-        "lodash.get": "^4.4.2",
-        "mailgun.js": "^3.5.2"
-    }
+  "name": "@pipedream/mailgun",
+  "version": "0.0.3",
+  "description": "Pipedream Mailgun Components",
+  "main": "mailgun.app.mjs",
+  "keywords": [
+    "pipedream",
+    "mailgun"
+  ],
+  "homepage": "https://pipedream.com/apps/mailgun",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "form-data": "^4.0.0",
+    "lodash.get": "^4.4.2",
+    "mailgun.js": "^3.5.2"
+  }
 }

--- a/components/mailify/package.json
+++ b/components/mailify/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/mailify",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Mailify Components",
   "main": "dist/app/mailify.app.mjs",
   "keywords": [
     "pipedream",
     "mailify"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/mailify",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/mailjet/package.json
+++ b/components/mailjet/package.json
@@ -1,20 +1,20 @@
 {
   "name": "@pipedream/mailjet",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Pipedream Mailjet Components",
   "main": "mailjet.app.mjs",
   "keywords": [
-      "pipedream",
-      "mailjet"
+    "pipedream",
+    "mailjet"
   ],
   "homepage": "https://pipedream.com/apps/mailjet",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",
   "dependencies": {
-      "node-mailjet": "^3.3.13"
+    "node-mailjet": "^3.3.13"
   },
   "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
   "publishConfig": {
-      "access": "public"
+    "access": "public"
   }
 }

--- a/components/mailrefine/package.json
+++ b/components/mailrefine/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/mailrefine",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Mailrefine Components",
   "main": "dist/app/mailrefine.app.mjs",
   "keywords": [
     "pipedream",
     "mailrefine"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/mailrefine",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/mapbox/package.json
+++ b/components/mapbox/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/mapbox",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Mapbox Components",
   "main": "dist/app/mapbox.app.mjs",
   "keywords": [
     "pipedream",
     "mapbox"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/mapbox",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/marketing_master_io/package.json
+++ b/components/marketing_master_io/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/marketing_master_io",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Marketing Master IO Components",
   "main": "dist/app/marketing_master_io.app.mjs",
   "keywords": [
     "pipedream",
     "marketing_master_io"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/marketing_master_io",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/mautic/package.json
+++ b/components/mautic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/mautic",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Pipedream Mautic Components",
   "main": "mautic.app.mjs",
   "keywords": [

--- a/components/mediatoolkit/package.json
+++ b/components/mediatoolkit/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/mediatoolkit",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Mediatoolkit Components",
   "main": "dist/app/mediatoolkit.app.mjs",
   "keywords": [
     "pipedream",
     "mediatoolkit"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/mediatoolkit",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/meetup/package.json
+++ b/components/meetup/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/meetup",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Meetup Components",
   "main": "dist/app/meetup.app.mjs",
   "keywords": [
     "pipedream",
     "meetup"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/meetup",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/membervault/package.json
+++ b/components/membervault/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/membervault",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Membervault Components",
   "main": "dist/app/membervault.app.mjs",
   "keywords": [
     "pipedream",
     "membervault"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/membervault",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/microsoft_onedrive/package.json
+++ b/components/microsoft_onedrive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/microsoft_onedrive",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Pipedream Microsoft OneDrive components",
   "main": "microsoft_onedrive.app.js",
   "homepage": "https://pipedream.com/apps/microsoft-onedrive",

--- a/components/microsoft_outlook/package.json
+++ b/components/microsoft_outlook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/microsoft_outlook",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Pipedream Microsoft Outlook Components",
   "main": "microsoft_outlook.app.mjs",
   "keywords": [

--- a/components/microsoft_teams/package.json
+++ b/components/microsoft_teams/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pipedream/microsoft_teams",
+  "name": "@pipedream/microsoft_teams",
   "version": "0.0.2",
   "description": "Pipedream Microsoft Teams Components",
   "main": "microsoft_teams.app.mjs",
@@ -19,4 +19,3 @@
     "isomorphic-fetch": "^3.0.0"
   }
 }
-

--- a/components/microsoft_teams/package.json
+++ b/components/microsoft_teams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/microsoft_teams",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Pipedream Microsoft Teams Components",
   "main": "microsoft_teams.app.mjs",
   "keywords": [

--- a/components/mixmax/package.json
+++ b/components/mixmax/package.json
@@ -1,16 +1,16 @@
 {
-    "name": "@pipedream/mixmax",
-    "version": "0.0.1",
-    "description": "Pipedream MixMax Components",
-    "main": "mixmax.app.js",
-    "keywords": [
-      "pipedream",
-      "mixmax"
-    ],
-    "homepage": "https://pipedream.com/apps/mixmax",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "publishConfig": {
-      "access": "public"
-    }
+  "name": "@pipedream/mixmax",
+  "version": "0.0.2",
+  "description": "Pipedream MixMax Components",
+  "main": "mixmax.app.js",
+  "keywords": [
+    "pipedream",
+    "mixmax"
+  ],
+  "homepage": "https://pipedream.com/apps/mixmax",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
   }
+}

--- a/components/monday/package.json
+++ b/components/monday/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/monday",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Pipedream Monday Components",
   "main": "monday.app.mjs",
   "keywords": [

--- a/components/moneybird/package.json
+++ b/components/moneybird/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/moneybird",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Moneybird Components",
   "main": "moneybird.app.mjs",
   "keywords": [

--- a/components/mongodb/package.json
+++ b/components/mongodb/package.json
@@ -1,20 +1,20 @@
 {
-    "name": "@pipedream/mongodb",
-    "version": "0.0.1",
-    "description": "Pipedream MongoDB Components",
-    "main": "mongodb.app.mjs",
-    "keywords": [
-        "pipedream",
-        "mongo",
-        "mongodb"
-    ],
-    "homepage": "https://pipedream.com/apps/mongodb",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "publishConfig": {
-        "access": "public"
-    },
-    "dependencies": {
-        "mongodb": "^4.6.0"
-    }
+  "name": "@pipedream/mongodb",
+  "version": "0.0.2",
+  "description": "Pipedream MongoDB Components",
+  "main": "mongodb.app.mjs",
+  "keywords": [
+    "pipedream",
+    "mongo",
+    "mongodb"
+  ],
+  "homepage": "https://pipedream.com/apps/mongodb",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "mongodb": "^4.6.0"
+  }
 }

--- a/components/murlist/package.json
+++ b/components/murlist/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/murlist",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream MurList Components",
   "main": "dist/app/murlist.app.mjs",
   "keywords": [
     "pipedream",
     "murlist"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/murlist",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/mux/package.json
+++ b/components/mux/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/mux",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Mux Components",
   "main": "dist/app/mux.app.mjs",
   "keywords": [
     "pipedream",
     "mux"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/mux",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/mysql/package.json
+++ b/components/mysql/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pipedream/mysql",
+  "name": "@pipedream/mysql",
   "version": "0.0.1",
   "description": "Pipedream Mysql Components",
   "main": "mysql.app.mjs",

--- a/components/mysql/package.json
+++ b/components/mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/mysql",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Mysql Components",
   "main": "mysql.app.mjs",
   "keywords": [

--- a/components/namely/package.json
+++ b/components/namely/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/namely",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Namely Components",
   "main": "dist/app/namely.app.mjs",
   "keywords": [

--- a/components/nectar_crm/package.json
+++ b/components/nectar_crm/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/nectar_crm",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Nectar CRM Components",
   "main": "dist/app/nectar_crm.app.mjs",
   "keywords": [
     "pipedream",
     "nectar_crm"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/nectar_crm",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/netlify/package.json
+++ b/components/netlify/package.json
@@ -1,23 +1,23 @@
 {
-    "name": "@pipedream/netlify",
-    "version": "0.3.3",
-    "description": "Pipedream Netlify Components",
-    "main": "netlify.app.js",
-    "keywords": [
-        "pipedream",
-        "netlify"
-    ],
-    "homepage": "https://pipedream.com/apps/netlify",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "axios": "^0.21.1",
-        "jwt-simple": "^0.5.6",
-        "netlify": "^6.0.9",
-        "parse-link-header": "^1.0.1"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/netlify",
+  "version": "0.3.4",
+  "description": "Pipedream Netlify Components",
+  "main": "netlify.app.js",
+  "keywords": [
+    "pipedream",
+    "netlify"
+  ],
+  "homepage": "https://pipedream.com/apps/netlify",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "axios": "^0.21.1",
+    "jwt-simple": "^0.5.6",
+    "netlify": "^6.0.9",
+    "parse-link-header": "^1.0.1"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/new_relic/package.json
+++ b/components/new_relic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/new-relic",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream New Relic Components",
   "main": "new_relic.app.js",
   "keywords": [

--- a/components/nextdns/package.json
+++ b/components/nextdns/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/nextdns",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream NextDNS Components",
   "main": "dist/app/nextdns.app.mjs",
   "keywords": [
     "pipedream",
     "nextdns"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/nextdns",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/niceboard/package.json
+++ b/components/niceboard/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/niceboard",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Niceboard Components",
   "main": "dist/app/niceboard.app.mjs",
   "keywords": [
     "pipedream",
     "niceboard"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/niceboard",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/niftyimages/package.json
+++ b/components/niftyimages/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/niftyimages",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream NiftyImages Components",
   "main": "dist/app/niftyimages.app.mjs",
   "keywords": [
     "pipedream",
     "niftyimages"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/niftyimages",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/ninox/package.json
+++ b/components/ninox/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/ninox",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Ninox Components",
   "main": "dist/app/ninox.app.mjs",
   "keywords": [
     "pipedream",
     "ninox"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/ninox",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/nocrm_io/package.json
+++ b/components/nocrm_io/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/nocrm_io",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream noCRM.io Components",
   "main": "nocrm_io.app.mjs",
   "keywords": [

--- a/components/notion/package.json
+++ b/components/notion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/notion",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Pipedream Notion Components",
   "main": "notion.app.mjs",
   "keywords": [

--- a/components/npm/package.json
+++ b/components/npm/package.json
@@ -1,17 +1,17 @@
 {
-    "name": "@pipedream/npm",
-    "version": "0.3.3",
-    "description": "Pipedream Npm Components",
-    "main": "npm.app.js",
-    "keywords": [
-        "pipedream",
-        "npm"
-    ],
-    "homepage": "https://pipedream.com/apps/npm",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/npm",
+  "version": "0.3.4",
+  "description": "Pipedream Npm Components",
+  "main": "npm.app.js",
+  "keywords": [
+    "pipedream",
+    "npm"
+  ],
+  "homepage": "https://pipedream.com/apps/npm",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/ocassion/package.json
+++ b/components/ocassion/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/ocassion",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Ocassion Components",
   "main": "dist/app/ocassion.app.mjs",
   "keywords": [
     "pipedream",
     "ocassion"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/ocassion",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/oksign/package.json
+++ b/components/oksign/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/oksign",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream OKSign Components",
   "main": "dist/app/oksign.app.mjs",
   "keywords": [
     "pipedream",
     "oksign"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/oksign",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/oncehub/package.json
+++ b/components/oncehub/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/oncehub",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream OnceHub Components",
   "main": "dist/app/oncehub.app.mjs",
   "keywords": [
     "pipedream",
     "oncehub"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/oncehub",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/onesaas/package.json
+++ b/components/onesaas/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/onesaas",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream 1SaaS Components",
   "main": "dist/app/onesaas.app.mjs",
   "keywords": [
     "pipedream",
     "onesaas"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/onesaas",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/onesignal_rest_api/package.json
+++ b/components/onesignal_rest_api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/onesignal_rest_api",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream OneSignal (REST API) Components",
   "main": "onesignal_rest_api.app.mjs",
   "keywords": [

--- a/components/onfleet/package.json
+++ b/components/onfleet/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/onfleet",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Onfleet Components",
   "main": "dist/app/onfleet.app.mjs",
   "keywords": [
     "pipedream",
     "onfleet"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/onfleet",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/ongage/package.json
+++ b/components/ongage/package.json
@@ -1,21 +1,21 @@
 {
-    "name": "@pipedream/ongage",
-    "version": "0.0.4",
-    "description": "Pipedream Ongage Components",
-    "main": "ongage.app.js",
-    "keywords": [
-        "pipedream",
-        "ongage"
-    ],
-    "homepage": "https://pipedream.com/apps/ongage",
-    "author": "Jonathon Hill <jonathon@compwright.com> (https://compwright.com/)",
-    "license": "MIT",
-    "publishConfig": {
-        "access": "public"
-    },
-    "dependencies": {
-        "axios": "^0.21.1",
-        "node-fetch": "^2.6.7",
-        "ongage": "^1.1.6"
-    }
+  "name": "@pipedream/ongage",
+  "version": "0.0.5",
+  "description": "Pipedream Ongage Components",
+  "main": "ongage.app.js",
+  "keywords": [
+    "pipedream",
+    "ongage"
+  ],
+  "homepage": "https://pipedream.com/apps/ongage",
+  "author": "Jonathon Hill <jonathon@compwright.com> (https://compwright.com/)",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "axios": "^0.21.1",
+    "node-fetch": "^2.6.7",
+    "ongage": "^1.1.6"
+  }
 }

--- a/components/openweather_api/package.json
+++ b/components/openweather_api/package.json
@@ -1,19 +1,19 @@
 {
-    "name": "@pipedream/openweather_api",
-    "version": "0.0.1",
-    "description": "Pipedream Openweather Components",
-    "main": "openweather_api.app.mjs",
-    "keywords": [
-        "pipedream",
-        "openweather_api"
-    ],
-    "homepage": "https://pipedream.com/apps/openweather_api",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "@pipedream/platform": "^0.9.0"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/openweather_api",
+  "version": "0.0.2",
+  "description": "Pipedream Openweather Components",
+  "main": "openweather_api.app.mjs",
+  "keywords": [
+    "pipedream",
+    "openweather_api"
+  ],
+  "homepage": "https://pipedream.com/apps/openweather_api",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "@pipedream/platform": "^0.9.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/outgrow/package.json
+++ b/components/outgrow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/outgrow",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Outgrow Components",
   "main": "outgrow.app.mjs",
   "keywords": [

--- a/components/pagerduty/package.json
+++ b/components/pagerduty/package.json
@@ -1,20 +1,20 @@
 {
-    "name": "@pipedream/pagerduty",
-    "version": "0.3.3",
-    "description": "Pipedream Pagerduty Components",
-    "main": "pagerduty.app.mjs",
-    "keywords": [
-        "pipedream",
-        "pagerduty"
-    ],
-    "homepage": "https://pipedream.com/apps/pagerduty",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "@pipedream/platform": "^0.9.0"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/pagerduty",
+  "version": "0.3.4",
+  "description": "Pipedream Pagerduty Components",
+  "main": "pagerduty.app.mjs",
+  "keywords": [
+    "pipedream",
+    "pagerduty"
+  ],
+  "homepage": "https://pipedream.com/apps/pagerduty",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "@pipedream/platform": "^0.9.0"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/paperform/package.json
+++ b/components/paperform/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/paperform",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream PaperForm Components",
   "main": "dist/app/paperform.app.mjs",
   "keywords": [
     "pipedream",
     "paperform"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/paperform",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/payhere/package.json
+++ b/components/payhere/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/payhere",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Payhere Components",
   "main": "payhere.app.mjs",
   "keywords": [

--- a/components/paypro/package.json
+++ b/components/paypro/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/paypro",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream PayPro Components",
   "main": "dist/app/paypro.app.mjs",
   "keywords": [
     "pipedream",
     "paypro"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/paypro",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/paytrace/package.json
+++ b/components/paytrace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/paytrace",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Paytrace Components",
   "main": "paytrace.app.mjs",
   "keywords": [

--- a/components/pcloud/package.json
+++ b/components/pcloud/package.json
@@ -1,21 +1,21 @@
 {
-    "name": "@pipedream/pcloud",
-    "version": "0.3.3",
-    "description": "Pipedream pCloud Components",
-    "main": "pcloud.app.mjs",
-    "keywords": [
-        "pipedream",
-        "pcloud"
-    ],
-    "homepage": "https://pipedream.com/apps/pcloud",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "async-retry": "^1.3.1",
-        "lodash": "^4.17.20",
-        "pcloud-sdk-js": "^2.0.0"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/pcloud",
+  "version": "0.3.4",
+  "description": "Pipedream pCloud Components",
+  "main": "pcloud.app.mjs",
+  "keywords": [
+    "pipedream",
+    "pcloud"
+  ],
+  "homepage": "https://pipedream.com/apps/pcloud",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "async-retry": "^1.3.1",
+    "lodash": "^4.17.20",
+    "pcloud-sdk-js": "^2.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/pdfmonkey/package.json
+++ b/components/pdfmonkey/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/pdfmonkey",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream PDFMonkey Components",
   "main": "dist/app/pdfmonkey.app.mjs",
   "keywords": [
     "pipedream",
     "pdfmonkey"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/pdfmonkey",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/persistiq/package.json
+++ b/components/persistiq/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/persistiq",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream PersistIQ Components",
   "main": "dist/app/persistiq.app.mjs",
   "keywords": [
     "pipedream",
     "persistiq"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/persistiq",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/phone_com/package.json
+++ b/components/phone_com/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/phone_com",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Phone.com Components",
   "main": "dist/app/phone_com.app.mjs",
   "keywords": [
     "pipedream",
     "phone_com"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/phone_com",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/picky_assist/package.json
+++ b/components/picky_assist/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/picky_assist",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Picky Assist Components",
   "main": "dist/app/picky_assist.app.mjs",
   "keywords": [
     "pipedream",
     "picky_assist"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/picky_assist",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/pikaso/package.json
+++ b/components/pikaso/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/pikaso",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Pikaso Components",
   "main": "dist/app/pikaso.app.mjs",
   "keywords": [
     "pipedream",
     "pikaso"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/pikaso",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/pinterest/package.json
+++ b/components/pinterest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/pinterest",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Pinterest Components",
   "main": "pinterest.app.mjs",
   "keywords": [

--- a/components/pipedream/package.json
+++ b/components/pipedream/package.json
@@ -1,21 +1,21 @@
 {
-    "name": "@pipedream/pipedream",
-    "version": "0.3.4",
-    "description": "Pipedream Pipedream Components",
-    "main": "pipedream.app.js",
-    "keywords": [
-        "pipedream",
-        "pipedream"
-    ],
-    "homepage": "https://pipedream.com/apps/pipedream",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "axios": "^0.21.1",
-        "convert-array-to-csv": "^2.0.0"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/pipedream",
+  "version": "0.3.5",
+  "description": "Pipedream Pipedream Components",
+  "main": "pipedream.app.js",
+  "keywords": [
+    "pipedream",
+    "pipedream"
+  ],
+  "homepage": "https://pipedream.com/apps/pipedream",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "axios": "^0.21.1",
+    "convert-array-to-csv": "^2.0.0"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/pipedrive/package.json
+++ b/components/pipedrive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/pipedrive",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Pipedream Pipedrive Components",
   "main": "pipedrive.app.mjs",
   "keywords": [

--- a/components/pointagram/package.json
+++ b/components/pointagram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/pointagram",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Pointagram Components",
   "main": "pointagram.app.js",
   "keywords": [

--- a/components/pointerpro/package.json
+++ b/components/pointerpro/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/pointerpro",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Pointerpro Components",
   "main": "dist/app/pointerpro.app.mjs",
   "keywords": [
     "pipedream",
     "pointerpro"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/pointerpro",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/postgresql/package.json
+++ b/components/postgresql/package.json
@@ -1,24 +1,24 @@
 {
-    "name": "@pipedream/postgresql",
-    "version": "0.0.3",
-    "description": "Pipedream PostgreSQL Components",
-    "main": "postgresql.app.mjs",
-    "keywords": [
-        "pipedream",
-        "postgresql"
-    ],
-    "homepage": "https://pipedream.com/apps/postgresql",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "pg": "^8.7.1",
-        "pg-format": "^1.0.4",
-        "typescript": "^4.6.4"
-    },
-    "publishConfig": {
-        "access": "public"
-    },
-    "devDependencies": {
-        "dtslint": "^4.2.1"
-    }
+  "name": "@pipedream/postgresql",
+  "version": "0.0.4",
+  "description": "Pipedream PostgreSQL Components",
+  "main": "postgresql.app.mjs",
+  "keywords": [
+    "pipedream",
+    "postgresql"
+  ],
+  "homepage": "https://pipedream.com/apps/postgresql",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "pg": "^8.7.1",
+    "pg-format": "^1.0.4",
+    "typescript": "^4.6.4"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "dtslint": "^4.2.1"
+  }
 }

--- a/components/pretix/package.json
+++ b/components/pretix/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/pretix",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream pretix Components",
   "main": "dist/app/pretix.app.mjs",
   "keywords": [
     "pipedream",
     "pretix"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/pretix",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/productboard/package.json
+++ b/components/productboard/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/productboard",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Productboard Components",
   "main": "dist/app/productboard.app.mjs",
   "keywords": [
     "pipedream",
     "productboard"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/productboard",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/profitwell/package.json
+++ b/components/profitwell/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/profitwell",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream ProfitWell Components",
   "main": "dist/app/profitwell.app.mjs",
   "keywords": [
     "pipedream",
     "profitwell"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/profitwell",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/propelauth/package.json
+++ b/components/propelauth/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/propelauth",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream PropelAuth Components",
   "main": "dist/app/propelauth.app.mjs",
   "keywords": [
     "pipedream",
     "propelauth"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/propelauth",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/propeller/package.json
+++ b/components/propeller/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/propeller",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Propeller Components",
   "main": "dist/app/propeller.app.mjs",
   "keywords": [
     "pipedream",
     "propeller"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/propeller",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/pushshift_reddit_search/package.json
+++ b/components/pushshift_reddit_search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/pushshift_reddit_search",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Pushshift Reddit Search Components",
   "main": "pushshift_reddit_search.app.mjs",
   "keywords": [

--- a/components/quickbooks/package.json
+++ b/components/quickbooks/package.json
@@ -1,20 +1,20 @@
 {
-    "name": "@pipedream/quickbooks",
-    "version": "0.0.1",
-    "description": "Pipedream Quickbooks Components",
-    "main": "quickbooks.app.mjs",
-    "keywords": [
-        "pipedream",
-        "quickbooks"
-    ],
-    "homepage": "https://pipedream.com/apps/quickbooks",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    },
-    "dependencies": {
-        "@pipedream/platform": "^1.0.0"
-    }
+  "name": "@pipedream/quickbooks",
+  "version": "0.0.2",
+  "description": "Pipedream Quickbooks Components",
+  "main": "quickbooks.app.mjs",
+  "keywords": [
+    "pipedream",
+    "quickbooks"
+  ],
+  "homepage": "https://pipedream.com/apps/quickbooks",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^1.0.0"
+  }
 }

--- a/components/quickemailverification/package.json
+++ b/components/quickemailverification/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/quickemailverification",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream QuickEmailVerification Components",
   "main": "dist/app/quickemailverification.app.mjs",
   "keywords": [
     "pipedream",
     "quickemailverification"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/quickemailverification",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/qwilr/package.json
+++ b/components/qwilr/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/qwilr",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Qwilr Components",
   "main": "dist/app/qwilr.app.mjs",
   "keywords": [
     "pipedream",
     "qwilr"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/qwilr",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/radar/package.json
+++ b/components/radar/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/radar",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Radar Components",
   "main": "dist/app/radar.app.mjs",
   "keywords": [
     "pipedream",
     "radar"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/radar",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/raindrop/package.json
+++ b/components/raindrop/package.json
@@ -1,23 +1,23 @@
 {
   "name": "@pipedream/raindrop",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Pipedream Raindrop.io Components",
   "main": "raindrop.app.js",
   "keywords": [
-      "pipedream",
-      "raindrop",
-      "raindropio",
-      "raindrop-io",
-      "raindrop.io"
+    "pipedream",
+    "raindrop",
+    "raindropio",
+    "raindrop-io",
+    "raindrop.io"
   ],
   "homepage": "https://pipedream.com/apps/raindrop",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",
   "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
   "publishConfig": {
-      "access": "public"
+    "access": "public"
   },
   "dependencies": {
-      "@pipedream/platform": "^0.10.0"
+    "@pipedream/platform": "^0.10.0"
   }
 }

--- a/components/rd_station_crm/package.json
+++ b/components/rd_station_crm/package.json
@@ -1,16 +1,16 @@
 {
-    "name": "@pipedream/rd_station_crm",
-    "version": "0.0.1",
-    "description": "Pipedream RD Station CRM Components",
-    "main": "rd_station_crm.app.js",
-    "keywords": [
-      "pipedream",
-      "rd_station_crm"
-    ],
-    "homepage": "https://pipedream.com/apps/rd_station_crm",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "publishConfig": {
-      "access": "public"
-    }
+  "name": "@pipedream/rd_station_crm",
+  "version": "0.0.2",
+  "description": "Pipedream RD Station CRM Components",
+  "main": "rd_station_crm.app.js",
+  "keywords": [
+    "pipedream",
+    "rd_station_crm"
+  ],
+  "homepage": "https://pipedream.com/apps/rd_station_crm",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
   }
+}

--- a/components/readwise/package.json
+++ b/components/readwise/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/readwise",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Readwise Components",
   "main": "dist/app/readwise.app.mjs",
   "keywords": [
     "pipedream",
     "readwise"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/readwise",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/realphonevalidation/package.json
+++ b/components/realphonevalidation/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/realphonevalidation",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream RealPhoneValidation Components",
   "main": "dist/app/realphonevalidation.app.mjs",
   "keywords": [
     "pipedream",
     "realphonevalidation"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/realphonevalidation",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/referralrock/package.json
+++ b/components/referralrock/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/referralrock",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream ReferralRock Components",
   "main": "dist/app/referralrock.app.mjs",
   "keywords": [
     "pipedream",
     "referralrock"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/referralrock",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/refersion/package.json
+++ b/components/refersion/package.json
@@ -1,16 +1,16 @@
 {
-    "name": "@pipedream/refersion",
-    "version": "0.0.1",
-    "description": "Pipedream Refersion Components",
-    "main": "refersion.app.js",
-    "keywords": [
-      "pipedream",
-      "refersion"
-    ],
-    "homepage": "https://pipedream.com/apps/refersion",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "publishConfig": {
-      "access": "public"
-    }
+  "name": "@pipedream/refersion",
+  "version": "0.0.2",
+  "description": "Pipedream Refersion Components",
+  "main": "refersion.app.js",
+  "keywords": [
+    "pipedream",
+    "refersion"
+  ],
+  "homepage": "https://pipedream.com/apps/refersion",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
   }
+}

--- a/components/regfox/package.json
+++ b/components/regfox/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/regfox",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream RegFox Components",
   "main": "dist/app/regfox.app.mjs",
   "keywords": [
     "pipedream",
     "regfox"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/regfox",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/render/package.json
+++ b/components/render/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/render",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Render Components",
   "main": "dist/app/render.app.mjs",
   "keywords": [
     "pipedream",
     "render"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/render",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/reply_io/package.json
+++ b/components/reply_io/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/reply_io",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Reply.io Components",
   "main": "dist/app/reply_io.app.mjs",
   "keywords": [
     "pipedream",
     "reply_io"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/reply_io",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/repuso/package.json
+++ b/components/repuso/package.json
@@ -1,16 +1,16 @@
 {
-    "name": "@pipedream/repuso",
-    "version": "0.0.1",
-    "description": "Pipedream Repuso Components",
-    "main": "repuso.app.js",
-    "keywords": [
-      "pipedream",
-      "repuso"
-    ],
-    "homepage": "https://pipedream.com/apps/repuso",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "publishConfig": {
-      "access": "public"
-    }
+  "name": "@pipedream/repuso",
+  "version": "0.0.2",
+  "description": "Pipedream Repuso Components",
+  "main": "repuso.app.js",
+  "keywords": [
+    "pipedream",
+    "repuso"
+  ],
+  "homepage": "https://pipedream.com/apps/repuso",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
   }
+}

--- a/components/rewardful/package.json
+++ b/components/rewardful/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/rewardful",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Rewardful Components",
   "main": "dist/app/rewardful.app.mjs",
   "keywords": [
     "pipedream",
     "rewardful"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/rewardful",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/ringcentral/package.json
+++ b/components/ringcentral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/ringcentral",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Pipedream Ringcentral Components",
   "main": "ringcentral.app.mjs",
   "keywords": [

--- a/components/rise/package.json
+++ b/components/rise/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/rise",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Rise Components",
   "main": "dist/app/rise.app.mjs",
   "keywords": [
     "pipedream",
     "rise"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/rise",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/rocketreach/package.json
+++ b/components/rocketreach/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/rocketreach",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream RocketReach Components",
   "main": "rocketreach.app.mjs",
   "keywords": [

--- a/components/rss/package.json
+++ b/components/rss/package.json
@@ -1,34 +1,36 @@
 {
-    "name": "@pipedream/rss",
-    "version": "0.3.5",
-    "description": "Pipedream RSS Components",
-    "main": "dist/app/rss.app.mjs",
-    "types": "dist/app/rss.app.d.ts",
-    "files": ["dist"],
-    "keywords": [
-        "pipedream",
-        "rss"
-    ],
-    "homepage": "https://pipedream.com/apps/rss",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    },
-    "devDependencies": {
-        "@types/axios": "^0.14.0",
-        "@types/feedparser": "^2.2.5",
-        "@types/object-hash": "^2.2.1",
-        "@types/node": "^17.0.36"
-    },
-    "dependencies": {
-        "@pipedream/helpers": "^1.3.9",
-        "@pipedream/platform": "^0.10.0",
-        "axios": "^0.27.2",
-        "feedparser": "^2.2.10",
-        "object-hash": "^3.0.0",
-        "rss-parser": "^3.12.0",
-        "string-to-stream": "^3.0.1"
-    }
+  "name": "@pipedream/rss",
+  "version": "0.3.6",
+  "description": "Pipedream RSS Components",
+  "main": "dist/app/rss.app.mjs",
+  "types": "dist/app/rss.app.d.ts",
+  "files": [
+    "dist"
+  ],
+  "keywords": [
+    "pipedream",
+    "rss"
+  ],
+  "homepage": "https://pipedream.com/apps/rss",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@types/axios": "^0.14.0",
+    "@types/feedparser": "^2.2.5",
+    "@types/object-hash": "^2.2.1",
+    "@types/node": "^17.0.36"
+  },
+  "dependencies": {
+    "@pipedream/helpers": "^1.3.9",
+    "@pipedream/platform": "^0.10.0",
+    "axios": "^0.27.2",
+    "feedparser": "^2.2.10",
+    "object-hash": "^3.0.0",
+    "rss-parser": "^3.12.0",
+    "string-to-stream": "^3.0.1"
+  }
 }

--- a/components/sales_simplify/package.json
+++ b/components/sales_simplify/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/sales_simplify",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Sales Simplify Components",
   "main": "dist/app/sales_simplify.app.mjs",
   "keywords": [
     "pipedream",
     "sales_simplify"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/sales_simplify",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/salesblink/package.json
+++ b/components/salesblink/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/salesblink",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream SalesBlink Components",
   "main": "dist/app/salesblink.app.mjs",
   "keywords": [
     "pipedream",
     "salesblink"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/salesblink",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/salesforce_rest_api/package.json
+++ b/components/salesforce_rest_api/package.json
@@ -1,24 +1,24 @@
 {
-    "name": "@pipedream/salesforce_rest_api",
-    "version": "0.4.0",
-    "description": "Pipedream Salesforce (REST API) Components",
-    "main": "salesforce_rest_api.app.mjs",
-    "keywords": [
-        "pipedream",
-        "salesforce_rest_api"
-    ],
-    "homepage": "https://pipedream.com/apps/salesforce_rest_api",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "@pipedream/platform": "^0.9.0",
-        "handlebars": "^4.7.7",
-        "lodash": "^4.17.21",
-        "salesforce-webhooks": "^1.1.4",
-        "lodash-es":"^4.17.21"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/salesforce_rest_api",
+  "version": "0.4.1",
+  "description": "Pipedream Salesforce (REST API) Components",
+  "main": "salesforce_rest_api.app.mjs",
+  "keywords": [
+    "pipedream",
+    "salesforce_rest_api"
+  ],
+  "homepage": "https://pipedream.com/apps/salesforce_rest_api",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "@pipedream/platform": "^0.9.0",
+    "handlebars": "^4.7.7",
+    "lodash": "^4.17.21",
+    "salesforce-webhooks": "^1.1.4",
+    "lodash-es": "^4.17.21"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/salestown/package.json
+++ b/components/salestown/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/salestown",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Salestown Components",
   "main": "dist/app/salestown.app.mjs",
   "keywords": [
     "pipedream",
     "salestown"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/salestown",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/scopemaster/package.json
+++ b/components/scopemaster/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/scopemaster",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream ScopeMaster Components",
   "main": "dist/app/scopemaster.app.mjs",
   "keywords": [
     "pipedream",
     "scopemaster"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/scopemaster",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/segment/package.json
+++ b/components/segment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/segment",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Pipedream Segment Components",
   "main": "segment.app.mjs",
   "keywords": [

--- a/components/sellix/package.json
+++ b/components/sellix/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/sellix",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Sellix Components",
   "main": "dist/app/sellix.app.mjs",
   "keywords": [
     "pipedream",
     "sellix"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/sellix",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/sender/package.json
+++ b/components/sender/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/sender",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Sender Components",
   "main": "dist/app/sender.app.mjs",
   "keywords": [
     "pipedream",
     "sender"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/sender",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/sendgrid/package.json
+++ b/components/sendgrid/package.json
@@ -1,26 +1,26 @@
 {
-    "name": "@pipedream/sendgrid",
-    "version": "0.3.3",
-    "description": "Pipedream Sendgrid Components",
-    "main": "sendgrid.app.js",
-    "keywords": [
-        "pipedream",
-        "sendgrid"
-    ],
-    "homepage": "https://pipedream.com/apps/sendgrid",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "@pipedream/platform": "^0.10.0",
-        "@sendgrid/client": "^7.6.2",
-        "@sendgrid/eventwebhook": "^7.4.5",
-        "async-retry": "^1.3.1",
-        "lodash": "^4.17.20",
-        "uuid": "^8.3.2",
-        "validate.js": "^0.13.1"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/sendgrid",
+  "version": "0.3.4",
+  "description": "Pipedream Sendgrid Components",
+  "main": "sendgrid.app.js",
+  "keywords": [
+    "pipedream",
+    "sendgrid"
+  ],
+  "homepage": "https://pipedream.com/apps/sendgrid",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "@pipedream/platform": "^0.10.0",
+    "@sendgrid/client": "^7.6.2",
+    "@sendgrid/eventwebhook": "^7.4.5",
+    "async-retry": "^1.3.1",
+    "lodash": "^4.17.20",
+    "uuid": "^8.3.2",
+    "validate.js": "^0.13.1"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/sendle/package.json
+++ b/components/sendle/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/sendle",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Sendle Components",
   "main": "dist/app/sendle.app.mjs",
   "keywords": [
     "pipedream",
     "sendle"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/sendle",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/sentry/package.json
+++ b/components/sentry/package.json
@@ -1,22 +1,22 @@
 {
-    "name": "@pipedream/sentry",
-    "version": "0.3.3",
-    "description": "Pipedream Sentry Components",
-    "main": "sentry.app.js",
-    "keywords": [
-        "pipedream",
-        "sentry"
-    ],
-    "homepage": "https://pipedream.com/apps/sentry",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "axios": "^0.21.1",
-        "parse-link-header": "^1.0.1",
-        "slugify": "^1.4.6"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/sentry",
+  "version": "0.3.4",
+  "description": "Pipedream Sentry Components",
+  "main": "sentry.app.js",
+  "keywords": [
+    "pipedream",
+    "sentry"
+  ],
+  "homepage": "https://pipedream.com/apps/sentry",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "axios": "^0.21.1",
+    "parse-link-header": "^1.0.1",
+    "slugify": "^1.4.6"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/serveravatar/package.json
+++ b/components/serveravatar/package.json
@@ -1,28 +1,28 @@
 {
-    "name": "@pipedream/serveravatar",
-    "version": "0.0.1",
-    "description": "Pipedream Server Avatar Components",
-    "main": "dist/app/serveravatar.app.mjs",
-    "types": "dist/app/serveravatar.app.d.ts",
-    "files": [
-        "dist"
-    ],
-    "keywords": [
-        "pipedream",
-        "serveravatar"
-    ],
-    "homepage": "https://pipedream.com/apps/serveravatar",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    },
-    "devDependencies": {
-        "@types/node": "^17.0.36"
-    },
-    "dependencies": {
-        "@pipedream/helpers": "^1.3.9",
-        "@pipedream/platform": "^0.10.0"
-    }
+  "name": "@pipedream/serveravatar",
+  "version": "0.0.2",
+  "description": "Pipedream Server Avatar Components",
+  "main": "dist/app/serveravatar.app.mjs",
+  "types": "dist/app/serveravatar.app.d.ts",
+  "files": [
+    "dist"
+  ],
+  "keywords": [
+    "pipedream",
+    "serveravatar"
+  ],
+  "homepage": "https://pipedream.com/apps/serveravatar",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@types/node": "^17.0.36"
+  },
+  "dependencies": {
+    "@pipedream/helpers": "^1.3.9",
+    "@pipedream/platform": "^0.10.0"
+  }
 }

--- a/components/seventodos/package.json
+++ b/components/seventodos/package.json
@@ -1,19 +1,19 @@
 {
-    "name": "@pipedream/seventodos",
-    "version": "0.0.1",
-    "description": "Pipedream 7todos Components",
-    "main": "seventodos.app.js",
-    "keywords": [
-        "pipedream",
-        "seventodos"
-    ],
-    "homepage": "https://pipedream.com/apps/seventodos",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "publishConfig": {
-        "access": "public"
-    },
-    "dependencies": {
-        "axios": "^0.27.2"
-    }
+  "name": "@pipedream/seventodos",
+  "version": "0.0.2",
+  "description": "Pipedream 7todos Components",
+  "main": "seventodos.app.js",
+  "keywords": [
+    "pipedream",
+    "seventodos"
+  ],
+  "homepage": "https://pipedream.com/apps/seventodos",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "axios": "^0.27.2"
+  }
 }

--- a/components/sftp/package.json
+++ b/components/sftp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/sftp",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Pipedream SFTP Components",
   "main": "sftp.app.mjs",
   "keywords": [

--- a/components/sftp_password_based_auth/package.json
+++ b/components/sftp_password_based_auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/sftp_password_based_auth",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Pipedream SFTP Components",
   "main": "sftp_password_based_auth.app.mjs",
   "keywords": [

--- a/components/shipcloud/package.json
+++ b/components/shipcloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/shipcloud",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Shipcloud Components",
   "main": "dist/app/shipcloud.app.mjs",
   "keywords": [

--- a/components/shippotoken/package.json
+++ b/components/shippotoken/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/shippotoken",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream ShippoToken Components",
   "main": "dist/app/shippotoken.app.mjs",
   "keywords": [
     "pipedream",
     "shippotoken"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/shippotoken",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/shipstation/package.json
+++ b/components/shipstation/package.json
@@ -1,21 +1,20 @@
 {
-    "name": "@pipedream/shipstation",
-    "version": "0.0.1",
-    "description": "Pipedream ShipStation Components",
-    "main": "shipstation.app.mjs",
-    "keywords": [
-        "pipedream",
-        "shipstation"
-    ],
-    "homepage": "https://pipedream.com/apps/shipstation",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    },
-    "dependencies": {
-        "@pipedream/platform": "^0.10.0"
-    }
+  "name": "@pipedream/shipstation",
+  "version": "0.0.2",
+  "description": "Pipedream ShipStation Components",
+  "main": "shipstation.app.mjs",
+  "keywords": [
+    "pipedream",
+    "shipstation"
+  ],
+  "homepage": "https://pipedream.com/apps/shipstation",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^0.10.0"
+  }
 }
-

--- a/components/shopify/package.json
+++ b/components/shopify/package.json
@@ -1,22 +1,22 @@
 {
-    "name": "@pipedream/shopify",
-    "version": "0.3.3",
-    "description": "Pipedream Shopify Components",
-    "main": "shopify.app.mjs",
-    "keywords": [
-        "pipedream",
-        "shopify"
-    ],
-    "homepage": "https://pipedream.com/apps/shopify",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "axios": "^0.21.1",
-        "lodash.get": "^4.4.2",
-        "shopify-api-node": "^3.9.0"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/shopify",
+  "version": "0.3.4",
+  "description": "Pipedream Shopify Components",
+  "main": "shopify.app.mjs",
+  "keywords": [
+    "pipedream",
+    "shopify"
+  ],
+  "homepage": "https://pipedream.com/apps/shopify",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "axios": "^0.21.1",
+    "lodash.get": "^4.4.2",
+    "shopify-api-node": "^3.9.0"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/shopify_partner/package.json
+++ b/components/shopify_partner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/shopify_partner",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Shopify Partner Components",
   "main": "shopify_partner.app.js",
   "keywords": [

--- a/components/short/package.json
+++ b/components/short/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/short",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Short.io Components",
   "main": "short.app.mjs",
   "keywords": [

--- a/components/shortcut/package.json
+++ b/components/shortcut/package.json
@@ -1,23 +1,23 @@
 {
-    "name": "@pipedream/shortcut",
-    "version": "0.3.3",
-    "description": "Pipedream Shortcut Components",
-    "main": "shortcut.app.js",
-    "keywords": [
-        "pipedream",
-        "shortcut"
-    ],
-    "homepage": "https://pipedream.com/apps/shortcut",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "async-retry": "^1.3.1",
-        "axios": "^0.21.1",
-        "clubhouse-lib": "^0.12.0",
-        "lodash": "^4.17.20",
-        "validate.js": "^0.13.1"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/shortcut",
+  "version": "0.3.4",
+  "description": "Pipedream Shortcut Components",
+  "main": "shortcut.app.js",
+  "keywords": [
+    "pipedream",
+    "shortcut"
+  ],
+  "homepage": "https://pipedream.com/apps/shortcut",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "async-retry": "^1.3.1",
+    "axios": "^0.21.1",
+    "clubhouse-lib": "^0.12.0",
+    "lodash": "^4.17.20",
+    "validate.js": "^0.13.1"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/showpad/package.json
+++ b/components/showpad/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/showpad",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Showpad Components",
   "main": "dist/app/showpad.app.mjs",
   "keywords": [
     "pipedream",
     "showpad"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/showpad",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/sifter/package.json
+++ b/components/sifter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/sifter",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Sifter Components",
   "main": "sifter.app.mjs",
   "keywords": [

--- a/components/signwell/package.json
+++ b/components/signwell/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/signwell",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream SignWell  Components",
   "main": "dist/app/signwell.app.mjs",
   "keywords": [
     "pipedream",
     "signwell"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/signwell",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/slack/package.json
+++ b/components/slack/package.json
@@ -1,20 +1,20 @@
 {
-    "name": "@pipedream/slack",
-    "version": "0.4.0",
-    "description": "Pipedream Slack Components",
-    "main": "slack.app.mjs",
-    "keywords": [
-        "pipedream",
-        "slack"
-    ],
-    "homepage": "https://pipedream.com/apps/slack",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    },
-    "dependencies": {
-        "@slack/web-api": "^5.15.0"
-    }
+  "name": "@pipedream/slack",
+  "version": "0.4.1",
+  "description": "Pipedream Slack Components",
+  "main": "slack.app.mjs",
+  "keywords": [
+    "pipedream",
+    "slack"
+  ],
+  "homepage": "https://pipedream.com/apps/slack",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@slack/web-api": "^5.15.0"
+  }
 }

--- a/components/smaily/package.json
+++ b/components/smaily/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/smaily",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Smaily Components",
   "main": "dist/app/smaily.app.mjs",
   "keywords": [
     "pipedream",
     "smaily"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/smaily",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/smiirl/package.json
+++ b/components/smiirl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/smiirl",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Smiirl Components",
   "main": "smiirl.app.mjs",
   "keywords": [

--- a/components/smtp2go/package.json
+++ b/components/smtp2go/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/smtp2go",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream SMTP2GO  Components",
   "main": "dist/app/smtp2go.app.mjs",
   "keywords": [
     "pipedream",
     "smtp2go"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/smtp2go",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/snapchat_marketing/package.json
+++ b/components/snapchat_marketing/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/snapchat_marketing",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Snapchat Marketing Components",
   "main": "dist/app/snapchat_marketing.app.mjs",
   "keywords": [
     "pipedream",
     "snapchat_marketing"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/snapchat_marketing",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/snowflake/package.json
+++ b/components/snowflake/package.json
@@ -1,24 +1,24 @@
 {
-    "name": "@pipedream/snowflake",
-    "version": "0.3.4",
-    "description": "Pipedream Snowflake Components",
-    "main": "snowflake.app.mjs",
-    "keywords": [
-        "pipedream",
-        "snowflake"
-    ],
-    "homepage": "https://pipedream.com/apps/snowflake",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    },
-    "dependencies": {
-        "@pipedream/platform": "^0.10.0",
-        "snowflake-sdk": "^1.6.10",
-        "lodash-es": "^4.17.21",
-        "uuid": "^8.3.2",
-        "asn1.js": "^5.0.0"
-    }
+  "name": "@pipedream/snowflake",
+  "version": "0.3.5",
+  "description": "Pipedream Snowflake Components",
+  "main": "snowflake.app.mjs",
+  "keywords": [
+    "pipedream",
+    "snowflake"
+  ],
+  "homepage": "https://pipedream.com/apps/snowflake",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^0.10.0",
+    "snowflake-sdk": "^1.6.10",
+    "lodash-es": "^4.17.21",
+    "uuid": "^8.3.2",
+    "asn1.js": "^5.0.0"
+  }
 }

--- a/components/social_intents/package.json
+++ b/components/social_intents/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/social_intents",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Social Intents Components",
   "main": "dist/app/social_intents.app.mjs",
   "keywords": [
     "pipedream",
     "social_intents"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/social_intents",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/softr/package.json
+++ b/components/softr/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/softr",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Softr Components",
   "main": "dist/app/softr.app.mjs",
   "keywords": [
     "pipedream",
     "softr"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/softr",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/spotify/package.json
+++ b/components/spotify/package.json
@@ -1,17 +1,17 @@
 {
-    "name": "@pipedream/spotify",
-    "version": "0.3.3",
-    "description": "Pipedream Spotify Components",
-    "main": "spotify.app.js",
-    "keywords": [
-        "pipedream",
-        "spotify"
-    ],
-    "homepage": "https://pipedream.com/apps/spotify",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/spotify",
+  "version": "0.3.4",
+  "description": "Pipedream Spotify Components",
+  "main": "spotify.app.js",
+  "keywords": [
+    "pipedream",
+    "spotify"
+  ],
+  "homepage": "https://pipedream.com/apps/spotify",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/squarespace/package.json
+++ b/components/squarespace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/squarespace",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Squarespace Components",
   "main": "squarespace.app.js",
   "keywords": [

--- a/components/ssh/package.json
+++ b/components/ssh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/ssh",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream SSH Components",
   "main": "ssh.app.js",
   "keywords": [

--- a/components/stack_exchange/package.json
+++ b/components/stack_exchange/package.json
@@ -1,22 +1,22 @@
 {
-    "name": "@pipedream/stack_exchange",
-    "version": "0.3.3",
-    "description": "Pipedream Stack_exchange Components",
-    "main": "stack_exchange.app.js",
-    "keywords": [
-        "pipedream",
-        "stack_exchange"
-    ],
-    "homepage": "https://pipedream.com/apps/stack_exchange",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "axios": "^0.21.1",
-        "he": "^1.2.0",
-        "lodash": "^4.17.20"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/stack_exchange",
+  "version": "0.3.4",
+  "description": "Pipedream Stack_exchange Components",
+  "main": "stack_exchange.app.js",
+  "keywords": [
+    "pipedream",
+    "stack_exchange"
+  ],
+  "homepage": "https://pipedream.com/apps/stack_exchange",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "axios": "^0.21.1",
+    "he": "^1.2.0",
+    "lodash": "^4.17.20"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/status_hero/package.json
+++ b/components/status_hero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/status_hero",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Status Hero Components",
   "main": "status_hero.app.mjs",
   "keywords": [

--- a/components/stormglass_io/package.json
+++ b/components/stormglass_io/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/stormglass_io",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream stormglass.io Components",
   "main": "dist/app/stormglass_io.app.mjs",
   "keywords": [
     "pipedream",
     "stormglass_io"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/stormglass_io",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/strava/package.json
+++ b/components/strava/package.json
@@ -1,20 +1,20 @@
 {
-    "name": "@pipedream/strava",
-    "version": "0.3.3",
-    "description": "Pipedream Strava Components",
-    "main": "strava.app.js",
-    "keywords": [
-        "pipedream",
-        "strava"
-    ],
-    "homepage": "https://pipedream.com/apps/strava",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "axios": "^0.21.1"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/strava",
+  "version": "0.3.4",
+  "description": "Pipedream Strava Components",
+  "main": "strava.app.js",
+  "keywords": [
+    "pipedream",
+    "strava"
+  ],
+  "homepage": "https://pipedream.com/apps/strava",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "axios": "^0.21.1"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/streak/package.json
+++ b/components/streak/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/streak",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Streak Components",
   "main": "streak.app.mjs",
   "keywords": [

--- a/components/stripe/package.json
+++ b/components/stripe/package.json
@@ -1,22 +1,22 @@
 {
-    "name": "@pipedream/stripe",
-    "version": "0.3.4",
-    "description": "Pipedream Stripe Components",
-    "main": "stripe.app.mjs",
-    "keywords": [
-        "pipedream",
-        "stripe"
-    ],
-    "homepage": "https://pipedream.com/apps/stripe",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "lodash.pick": "^4.4.0",
-        "lodash.pickby": "^4.6.0",
-        "stripe": "^8.168.0"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/stripe",
+  "version": "0.3.5",
+  "description": "Pipedream Stripe Components",
+  "main": "stripe.app.mjs",
+  "keywords": [
+    "pipedream",
+    "stripe"
+  ],
+  "homepage": "https://pipedream.com/apps/stripe",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "lodash.pick": "^4.4.0",
+    "lodash.pickby": "^4.6.0",
+    "stripe": "^8.168.0"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/superdocu/package.json
+++ b/components/superdocu/package.json
@@ -1,16 +1,16 @@
 {
-    "name": "@pipedream/superdocu",
-    "version": "0.0.1",
-    "description": "Pipedream Superdocu Components",
-    "main": "superdocu.app.js",
-    "keywords": [
-      "pipedream",
-      "superdocu"
-    ],
-    "homepage": "https://pipedream.com/apps/superdocu",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "publishConfig": {
-      "access": "public"
-    }
+  "name": "@pipedream/superdocu",
+  "version": "0.0.2",
+  "description": "Pipedream Superdocu Components",
+  "main": "superdocu.app.js",
+  "keywords": [
+    "pipedream",
+    "superdocu"
+  ],
+  "homepage": "https://pipedream.com/apps/superdocu",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
   }
+}

--- a/components/supersaas/package.json
+++ b/components/supersaas/package.json
@@ -1,20 +1,20 @@
 {
-    "name": "@pipedream/supersaas",
-    "version": "0.3.3",
-    "description": "Pipedream Supersaas Components",
-    "main": "supersaas.app.js",
-    "keywords": [
-        "pipedream",
-        "supersaas"
-    ],
-    "homepage": "https://pipedream.com/apps/supersaas",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "@pipedreamhq/platform": "^0.8.1"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/supersaas",
+  "version": "0.3.4",
+  "description": "Pipedream Supersaas Components",
+  "main": "supersaas.app.js",
+  "keywords": [
+    "pipedream",
+    "supersaas"
+  ],
+  "homepage": "https://pipedream.com/apps/supersaas",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "@pipedreamhq/platform": "^0.8.1"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/supportivekoala/package.json
+++ b/components/supportivekoala/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/supportivekoala",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Supportivekoala Components",
   "main": "supportivekoala.app.js",
   "keywords": [

--- a/components/survey_monkey/package.json
+++ b/components/survey_monkey/package.json
@@ -10,6 +10,9 @@
   "homepage": "https://pipedream.com/apps/survey-monkey",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "uuid": "^8.3.2",
     "@pipedream/platform": "^0.9.0"

--- a/components/survey_monkey/package.json
+++ b/components/survey_monkey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/survey_monkey",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream SurveyMonkey Components",
   "main": "survey_monkey.app.mjs",
   "keywords": [

--- a/components/surveymethods/package.json
+++ b/components/surveymethods/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/surveymethods",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream SurveyMethods Components",
   "main": "surveymethods.app.mjs",
   "keywords": [

--- a/components/switchboard/package.json
+++ b/components/switchboard/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/switchboard",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Switchboard Components",
   "main": "dist/app/switchboard.app.mjs",
   "keywords": [
     "pipedream",
     "switchboard"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/switchboard",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/symbl_ai/package.json
+++ b/components/symbl_ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/symbl_ai",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Pipedream Symbl_ai Components",
   "main": "symbl_ai.app.mjs",
   "keywords": [

--- a/components/sympla/package.json
+++ b/components/sympla/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/sympla",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Sympla Components",
   "main": "dist/app/sympla.app.mjs",
   "keywords": [

--- a/components/syncro/package.json
+++ b/components/syncro/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/syncro",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Syncro Components",
   "main": "dist/app/syncro.app.mjs",
   "keywords": [
     "pipedream",
     "syncro"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/syncro",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/tally/package.json
+++ b/components/tally/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/tally",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Tally Components",
   "main": "tally.app.mjs",
   "keywords": [

--- a/components/teamdeck/package.json
+++ b/components/teamdeck/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/teamdeck",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Teamdeck Components",
   "main": "dist/app/teamdeck.app.mjs",
   "keywords": [
     "pipedream",
     "teamdeck"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/teamdeck",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/telegram_bot_api/package.json
+++ b/components/telegram_bot_api/package.json
@@ -1,22 +1,22 @@
 {
-    "name": "@pipedream/telegram_bot_api",
-    "version": "0.3.3",
-    "description": "Pipedream Telegram_bot_api Components",
-    "main": "telegram_bot_api.app.mjs",
-    "keywords": [
-        "pipedream",
-        "telegram_bot_api"
-    ],
-    "homepage": "https://pipedream.com/apps/telegram_bot_api",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "@pipedream/platform": "^0.9.0",
-        "node-telegram-bot-api": "^0.54.0",
-        "uuid": "^8.3.2"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/telegram_bot_api",
+  "version": "0.3.4",
+  "description": "Pipedream Telegram_bot_api Components",
+  "main": "telegram_bot_api.app.mjs",
+  "keywords": [
+    "pipedream",
+    "telegram_bot_api"
+  ],
+  "homepage": "https://pipedream.com/apps/telegram_bot_api",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "@pipedream/platform": "^0.9.0",
+    "node-telegram-bot-api": "^0.54.0",
+    "uuid": "^8.3.2"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/textit/package.json
+++ b/components/textit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/textit",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream TextIt Components",
   "main": "textit.app.mjs",
   "keywords": [

--- a/components/thanks_io/package.json
+++ b/components/thanks_io/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/thanks_io",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Thanks.io Components",
   "main": "thanks_io.app.mjs",
   "keywords": [

--- a/components/threescribe/package.json
+++ b/components/threescribe/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/threescribe",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream 3Scribe Components",
   "main": "dist/app/threescribe.app.mjs",
   "keywords": [
     "pipedream",
     "threescribe"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/threescribe",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/tick/package.json
+++ b/components/tick/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/tick",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Tick Components",
   "main": "tick.app.mjs",
   "keywords": [

--- a/components/ticket_tailor/package.json
+++ b/components/ticket_tailor/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/ticket_tailor",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Ticket Tailor Components",
   "main": "dist/app/ticket_tailor.app.mjs",
   "keywords": [
     "pipedream",
     "ticket_tailor"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/ticket_tailor",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/ticktick/package.json
+++ b/components/ticktick/package.json
@@ -1,19 +1,19 @@
 {
-    "name": "@pipedream/ticktick",
-    "version": "0.0.2",
-    "description": "Pipedream Ticktick Components",
-    "main": "ticktick.app.mjs",
-    "keywords": [
-        "pipedream",
-        "ticktick"
-    ],
-    "homepage": "https://pipedream.com/apps/ticktick",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "@pipedream/platform": "^0.10.0"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/ticktick",
+  "version": "0.0.3",
+  "description": "Pipedream Ticktick Components",
+  "main": "ticktick.app.mjs",
+  "keywords": [
+    "pipedream",
+    "ticktick"
+  ],
+  "homepage": "https://pipedream.com/apps/ticktick",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "@pipedream/platform": "^0.10.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/timecamp/package.json
+++ b/components/timecamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/timecamp",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream TimeCamp Components",
   "main": "timecamp.app.mjs",
   "keywords": [

--- a/components/tmetric/package.json
+++ b/components/tmetric/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/tmetric",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream TMetric Components",
   "main": "dist/app/tmetric.app.mjs",
   "keywords": [
     "pipedream",
     "tmetric"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/tmetric",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/todoist/package.json
+++ b/components/todoist/package.json
@@ -1,23 +1,23 @@
 {
-    "name": "@pipedream/todoist",
-    "version": "0.0.1",
-    "description": "Pipedream Todoist Components",
-    "main": "todoist.app.mjs",
-    "keywords": [
-        "pipedream",
-        "todoist"
-    ],
-    "homepage": "https://pipedream.com/apps/todoist",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "querystring": "^0.2.1",
-        "uuid": "^8.3.2",
-        "tmp-promise": "^3.0.3",
-        "json-2-csv": "^3.15.1"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/todoist",
+  "version": "0.0.2",
+  "description": "Pipedream Todoist Components",
+  "main": "todoist.app.mjs",
+  "keywords": [
+    "pipedream",
+    "todoist"
+  ],
+  "homepage": "https://pipedream.com/apps/todoist",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "querystring": "^0.2.1",
+    "uuid": "^8.3.2",
+    "tmp-promise": "^3.0.3",
+    "json-2-csv": "^3.15.1"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/toggl/package.json
+++ b/components/toggl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/toggl",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Toggl Components",
   "main": "toggl.app.js",
   "keywords": [

--- a/components/tolstoy/package.json
+++ b/components/tolstoy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/tolstoy",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Tolstoy Components",
   "main": "dist/app/tolstoy.app.mjs",
   "keywords": [

--- a/components/tomba/package.json
+++ b/components/tomba/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/tomba",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Tomba  Components",
   "main": "dist/app/tomba.app.mjs",
   "keywords": [
     "pipedream",
     "tomba"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/tomba",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/tookan/package.json
+++ b/components/tookan/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/tookan",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Tookan Components",
   "main": "dist/app/tookan.app.mjs",
   "keywords": [
     "pipedream",
     "tookan"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/tookan",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/totango/package.json
+++ b/components/totango/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/totango",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Totango Components",
   "main": "totango.app.mjs",
   "keywords": [

--- a/components/transistor_fm/package.json
+++ b/components/transistor_fm/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/transistor_fm",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Transistor.fm Components",
   "main": "dist/app/transistor_fm.app.mjs",
   "keywords": [
     "pipedream",
     "transistor_fm"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/transistor_fm",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/trello/package.json
+++ b/components/trello/package.json
@@ -1,24 +1,24 @@
 {
-    "name": "@pipedream/trello",
-    "version": "0.3.4",
-    "description": "Pipedream Trello Components",
-    "main": "trello.app.js",
-    "keywords": [
-        "pipedream",
-        "trello"
-    ],
-    "homepage": "https://pipedream.com/apps/trello",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "@pipedream/platform": "^0.10.0",
-        "crypto": "^1.0.1",
-        "lodash.pick": "^4.4.0",
-        "lodash.pickby": "^4.6.0",
-        "mime": "^3.0.0"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/trello",
+  "version": "0.3.5",
+  "description": "Pipedream Trello Components",
+  "main": "trello.app.js",
+  "keywords": [
+    "pipedream",
+    "trello"
+  ],
+  "homepage": "https://pipedream.com/apps/trello",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "@pipedream/platform": "^0.10.0",
+    "crypto": "^1.0.1",
+    "lodash.pick": "^4.4.0",
+    "lodash.pickby": "^4.6.0",
+    "mime": "^3.0.0"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/triggercmd/package.json
+++ b/components/triggercmd/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/triggercmd",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream TRIGGERcmd Components",
   "main": "dist/app/triggercmd.app.mjs",
   "keywords": [
     "pipedream",
     "triggercmd"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/triggercmd",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/turbohire/package.json
+++ b/components/turbohire/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/turbohire",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream TurboHire Components",
   "main": "dist/app/turbohire.app.mjs",
   "keywords": [
     "pipedream",
     "turbohire"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/turbohire",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/twilio/package.json
+++ b/components/twilio/package.json
@@ -1,20 +1,20 @@
 {
-    "name": "@pipedream/twilio",
-    "version": "0.3.3",
-    "description": "Pipedream Twilio Components",
-    "main": "twilio.app.mjs",
-    "keywords": [
-        "pipedream",
-        "twilio"
-    ],
-    "homepage": "https://pipedream.com/apps/twilio",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "twilio": "^3.54.2"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/twilio",
+  "version": "0.3.4",
+  "description": "Pipedream Twilio Components",
+  "main": "twilio.app.mjs",
+  "keywords": [
+    "pipedream",
+    "twilio"
+  ],
+  "homepage": "https://pipedream.com/apps/twilio",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "twilio": "^3.54.2"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/twitch/package.json
+++ b/components/twitch/package.json
@@ -1,23 +1,23 @@
 {
-    "name": "@pipedream/twitch",
-    "version": "0.0.1",
-    "description": "Pipedream Twitch Components",
-    "main": "twitch.app.mjs",
-    "keywords": [
-        "pipedream",
-        "twitch"
-    ],
-    "homepage": "https://pipedream.com/apps/twitch",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    },
-    "dependencies": {
-        "axios": "^0.27.2",
-        "crypto": "^1.0.1",
-        "qs": "^6.10.5",
-        "uuid": "^8.3.2"
-    }
+  "name": "@pipedream/twitch",
+  "version": "0.0.2",
+  "description": "Pipedream Twitch Components",
+  "main": "twitch.app.mjs",
+  "keywords": [
+    "pipedream",
+    "twitch"
+  ],
+  "homepage": "https://pipedream.com/apps/twitch",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "axios": "^0.27.2",
+    "crypto": "^1.0.1",
+    "qs": "^6.10.5",
+    "uuid": "^8.3.2"
+  }
 }

--- a/components/twitch_developer_app/package.json
+++ b/components/twitch_developer_app/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/twitch_developer_app",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Twitch Developer App Components",
   "main": "dist/app/twitch_developer_app.app.mjs",
   "keywords": [
     "pipedream",
     "twitch_developer_app"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/twitch_developer_app",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/twitter/package.json
+++ b/components/twitter/package.json
@@ -1,22 +1,22 @@
 {
-    "name": "@pipedream/twitter",
-    "version": "0.3.4",
-    "description": "Pipedream Twitter Components",
-    "main": "twitter.app.mjs",
-    "keywords": [
-        "pipedream",
-        "twitter"
-    ],
-    "homepage": "https://pipedream.com/apps/twitter",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "axios": "^0.21.1",
-        "moment": "^2.29.1",
-        "querystring": "^0.2.0"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/twitter",
+  "version": "0.3.5",
+  "description": "Pipedream Twitter Components",
+  "main": "twitter.app.mjs",
+  "keywords": [
+    "pipedream",
+    "twitter"
+  ],
+  "homepage": "https://pipedream.com/apps/twitter",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "axios": "^0.21.1",
+    "moment": "^2.29.1",
+    "querystring": "^0.2.0"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/twitter_developer_app/package.json
+++ b/components/twitter_developer_app/package.json
@@ -1,17 +1,17 @@
 {
-    "name": "@pipedream/twitter_developer_app",
-    "version": "0.3.3",
-    "description": "Pipedream Twitter_developer_app Components",
-    "main": "twitter_developer_app.app.js",
-    "keywords": [
-        "pipedream",
-        "twitter_developer_app"
-    ],
-    "homepage": "https://pipedream.com/apps/twitter_developer_app",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/twitter_developer_app",
+  "version": "0.3.4",
+  "description": "Pipedream Twitter_developer_app Components",
+  "main": "twitter_developer_app.app.js",
+  "keywords": [
+    "pipedream",
+    "twitter_developer_app"
+  ],
+  "homepage": "https://pipedream.com/apps/twitter_developer_app",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/typebot/package.json
+++ b/components/typebot/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/typebot",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Typebot Components",
   "main": "dist/app/typebot.app.mjs",
   "keywords": [
     "pipedream",
     "typebot"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/typebot",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/typeform/package.json
+++ b/components/typeform/package.json
@@ -1,21 +1,21 @@
 {
-    "name": "@pipedream/typeform",
-    "version": "0.3.3",
-    "description": "Pipedream Typeform Components",
-    "main": "typeform.app.mjs",
-    "keywords": [
-        "pipedream",
-        "typeform"
-    ],
-    "homepage": "https://pipedream.com/apps/typeform",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "axios": "^0.21.1",
-        "querystring": "^0.2.0"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/typeform",
+  "version": "0.3.4",
+  "description": "Pipedream Typeform Components",
+  "main": "typeform.app.mjs",
+  "keywords": [
+    "pipedream",
+    "typeform"
+  ],
+  "homepage": "https://pipedream.com/apps/typeform",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "axios": "^0.21.1",
+    "querystring": "^0.2.0"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/typless/package.json
+++ b/components/typless/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/typless",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Typless Components",
   "main": "dist/app/typless.app.mjs",
   "keywords": [
     "pipedream",
     "typless"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/typless",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/uchat/package.json
+++ b/components/uchat/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/uchat",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Uchat Components",
   "main": "dist/app/uchat.app.mjs",
   "keywords": [
     "pipedream",
     "uchat"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/uchat",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/ultramsg/package.json
+++ b/components/ultramsg/package.json
@@ -1,19 +1,19 @@
 {
-    "name": "@pipedream/ultramsg",
-    "version": "0.3.3",
-    "description": "Pipedream Ultramsg Components",
-    "main": "ultramsg.app.mjs",
-    "keywords": [
-        "pipedream",
-        "ultramsg"
-    ],
-    "homepage": "https://pipedream.com/apps/ultramsg",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "publishConfig": {
-        "access": "public"
-    },
-    "dependencies": {
-        "@pipedream/platform": "^0.10.0"
-    }
+  "name": "@pipedream/ultramsg",
+  "version": "0.3.4",
+  "description": "Pipedream Ultramsg Components",
+  "main": "ultramsg.app.mjs",
+  "keywords": [
+    "pipedream",
+    "ultramsg"
+  ],
+  "homepage": "https://pipedream.com/apps/ultramsg",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^0.10.0"
+  }
 }

--- a/components/uploadcare/package.json
+++ b/components/uploadcare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/uploadcare",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Uploadcare Components",
   "main": "uploadcare.app.mjs",
   "keywords": [

--- a/components/uptimerobot/package.json
+++ b/components/uptimerobot/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/uptimerobot",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream UptimeRobot Components",
   "main": "dist/app/uptimerobot.app.mjs",
   "keywords": [
     "pipedream",
     "uptimerobot"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/uptimerobot",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/user_com/package.json
+++ b/components/user_com/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/user_com",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream User.com Components",
   "main": "dist/app/user_com.app.mjs",
   "keywords": [
     "pipedream",
     "user_com"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/user_com",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/vbout/package.json
+++ b/components/vbout/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/vbout",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream VBOUT Components",
   "main": "dist/app/vbout.app.mjs",
   "keywords": [
     "pipedream",
     "vbout"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/vbout",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/vectera/package.json
+++ b/components/vectera/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/vectera",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Vectera Components",
   "main": "dist/app/vectera.app.mjs",
   "keywords": [
     "pipedream",
     "vectera"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/vectera",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/vend/package.json
+++ b/components/vend/package.json
@@ -1,20 +1,20 @@
 {
-    "name": "@pipedream/vend",
-    "version": "0.0.1",
-    "description": "Pipedream Vend Components",
-    "main": "vend.app.js",
-    "keywords": [
-        "pipedream",
-        "vend"
-    ],
-    "homepage": "https://pipedream.com/apps/vend",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    },
-    "dependencies": {
-        "@pipedream/platform": "^0.10.0"
-    }
+  "name": "@pipedream/vend",
+  "version": "0.0.2",
+  "description": "Pipedream Vend Components",
+  "main": "vend.app.js",
+  "keywords": [
+    "pipedream",
+    "vend"
+  ],
+  "homepage": "https://pipedream.com/apps/vend",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^0.10.0"
+  }
 }

--- a/components/vercel/package.json
+++ b/components/vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/vercel",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Vercel Components",
   "main": "vercel.app.js",
   "keywords": [

--- a/components/vercel_token_auth/package.json
+++ b/components/vercel_token_auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/vercel_token_auth",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Vercel (token-based auth) Components",
   "main": "vercel_token_auth.app.mjs",
   "keywords": [

--- a/components/verifalia/package.json
+++ b/components/verifalia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/verifalia",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Pipedream Verifalia Components",
   "main": "verifalia.app.mjs",
   "keywords": [

--- a/components/verifybee/package.json
+++ b/components/verifybee/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/verifybee",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream VerifyBee Components",
   "main": "dist/app/verifybee.app.mjs",
   "keywords": [
     "pipedream",
     "verifybee"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/verifybee",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/virustotal/package.json
+++ b/components/virustotal/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/virustotal",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream VirusTotal  Components",
   "main": "dist/app/virustotal.app.mjs",
   "keywords": [
     "pipedream",
     "virustotal"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/virustotal",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/vivifyscrum/package.json
+++ b/components/vivifyscrum/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/vivifyscrum",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream VivifyScrum Components",
   "main": "dist/app/vivifyscrum.app.mjs",
   "keywords": [
     "pipedream",
     "vivifyscrum"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/vivifyscrum",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/vk/package.json
+++ b/components/vk/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/vk",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream vk Components",
   "main": "dist/app/vk.app.mjs",
   "keywords": [
     "pipedream",
     "vk"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/vk",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/voice/package.json
+++ b/components/voice/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/voice",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Voiceflow Components",
   "main": "dist/app/voice.app.mjs",
   "keywords": [
     "pipedream",
     "voice"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/voice",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/voice_monkey/package.json
+++ b/components/voice_monkey/package.json
@@ -1,16 +1,16 @@
 {
-    "name": "@pipedream/voice_monkey",
-    "version": "0.0.1",
-    "description": "Pipedream Voice Monkey Components",
-    "main": "voice_monkey.app.js",
-    "keywords": [
-      "pipedream",
-      "voice_monkey"
-    ],
-    "homepage": "https://pipedream.com/apps/voice_monkey",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "publishConfig": {
-      "access": "public"
-    }
+  "name": "@pipedream/voice_monkey",
+  "version": "0.0.2",
+  "description": "Pipedream Voice Monkey Components",
+  "main": "voice_monkey.app.js",
+  "keywords": [
+    "pipedream",
+    "voice_monkey"
+  ],
+  "homepage": "https://pipedream.com/apps/voice_monkey",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
   }
+}

--- a/components/vosfactures/package.json
+++ b/components/vosfactures/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/vosfactures",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Vosfactures Components",
   "main": "dist/app/vosfactures.app.mjs",
   "keywords": [
     "pipedream",
     "vosfactures"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/vosfactures",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/waitwhile/package.json
+++ b/components/waitwhile/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/waitwhile",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Waitwhile Components",
   "main": "dist/app/waitwhile.app.mjs",
   "keywords": [
     "pipedream",
     "waitwhile"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/waitwhile",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/webflow/package.json
+++ b/components/webflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/webflow",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Pipedream Webflow Components",
   "main": "webflow.app.mjs",
   "keywords": [

--- a/components/webinargeek/package.json
+++ b/components/webinargeek/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/webinargeek",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream WebinarGeek Components",
   "main": "webinargeek.app.mjs",
   "keywords": [

--- a/components/weworkbook/package.json
+++ b/components/weworkbook/package.json
@@ -1,16 +1,16 @@
 {
-    "name": "@pipedream/weworkbook",
-    "version": "0.0.1",
-    "description": "Pipedream Weworkbook Components",
-    "main": "weworkbook.app.js",
-    "keywords": [
-      "pipedream",
-      "weworkbook"
-    ],
-    "homepage": "https://pipedream.com/apps/weworkbook",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "publishConfig": {
-      "access": "public"
-    }
+  "name": "@pipedream/weworkbook",
+  "version": "0.0.2",
+  "description": "Pipedream Weworkbook Components",
+  "main": "weworkbook.app.js",
+  "keywords": [
+    "pipedream",
+    "weworkbook"
+  ],
+  "homepage": "https://pipedream.com/apps/weworkbook",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
   }
+}

--- a/components/wildberries/package.json
+++ b/components/wildberries/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/wildberries",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Wildberries Components",
   "main": "dist/app/wildberries.app.mjs",
   "keywords": [
     "pipedream",
     "wildberries"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/wildberries",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/wistia/package.json
+++ b/components/wistia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/wistia",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Wistia Components",
   "main": "wistia.app.mjs",
   "keywords": [

--- a/components/withings/package.json
+++ b/components/withings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/withings",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Withings Components",
   "main": "withings.app.mjs",
   "keywords": [

--- a/components/woocommerce/package.json
+++ b/components/woocommerce/package.json
@@ -1,25 +1,25 @@
 {
-    "name": "@pipedream/woocommerce",
-    "version": "0.0.2",
-    "description": "Pipedream WooCommerce Components",
-    "main": "woocommerce.app.mjs",
-    "keywords": [
-        "pipedream",
-        "woocommerce"
-    ],
-    "homepage": "https://pipedream.com/apps/woocommerce",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "@pipedream/platform": "^0.10.0",
-        "@woocommerce/woocommerce-rest-api": "^1.0.1",
-        "crypto": "^1.0.1",
-        "lodash.pick": "^4.4.0",
-        "lodash.pickby": "^4.6.0",
-        "query-string": "^7.1.1"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/woocommerce",
+  "version": "0.0.3",
+  "description": "Pipedream WooCommerce Components",
+  "main": "woocommerce.app.mjs",
+  "keywords": [
+    "pipedream",
+    "woocommerce"
+  ],
+  "homepage": "https://pipedream.com/apps/woocommerce",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "@pipedream/platform": "^0.10.0",
+    "@woocommerce/woocommerce-rest-api": "^1.0.1",
+    "crypto": "^1.0.1",
+    "lodash.pick": "^4.4.0",
+    "lodash.pickby": "^4.6.0",
+    "query-string": "^7.1.1"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/wordpress_org/package.json
+++ b/components/wordpress_org/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/wordpress_org",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Pipedream Wordpress.org Components",
   "main": "wordpress_org.app.mjs",
   "keywords": [

--- a/components/workast/package.json
+++ b/components/workast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/workast",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Workast Components",
   "main": "dist/app/workast.app.mjs",
   "keywords": [

--- a/components/workiom/package.json
+++ b/components/workiom/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/workiom",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Workiom Components",
   "main": "dist/app/workiom.app.mjs",
   "keywords": [
     "pipedream",
     "workiom"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/workiom",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/worksnaps/package.json
+++ b/components/worksnaps/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/worksnaps",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Worksnaps Components",
   "main": "dist/app/worksnaps.app.mjs",
   "keywords": [
     "pipedream",
     "worksnaps"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/worksnaps",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/woxo/package.json
+++ b/components/woxo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/woxo",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream WOXO Components",
   "main": "woxo.app.js",
   "keywords": [

--- a/components/xendit/package.json
+++ b/components/xendit/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/xendit",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Xendit Components",
   "main": "dist/app/xendit.app.mjs",
   "keywords": [
     "pipedream",
     "xendit"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/xendit",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/xperiencify/package.json
+++ b/components/xperiencify/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/xperiencify",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Xperiencify Components",
   "main": "dist/app/xperiencify.app.mjs",
   "keywords": [
     "pipedream",
     "xperiencify"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/xperiencify",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/yahoo_fantasy_sports/package.json
+++ b/components/yahoo_fantasy_sports/package.json
@@ -1,20 +1,20 @@
 {
-    "name": "@pipedream/yahoo_fantasy_sports",
-    "version": "0.3.3",
-    "description": "Pipedream Yahoo_fantasy_sports Components",
-    "main": "yahoo_fantasy_sports.app.js",
-    "keywords": [
-        "pipedream",
-        "yahoo_fantasy_sports"
-    ],
-    "homepage": "https://pipedream.com/apps/yahoo_fantasy_sports",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "axios": "^0.21.1"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/yahoo_fantasy_sports",
+  "version": "0.3.4",
+  "description": "Pipedream Yahoo_fantasy_sports Components",
+  "main": "yahoo_fantasy_sports.app.js",
+  "keywords": [
+    "pipedream",
+    "yahoo_fantasy_sports"
+  ],
+  "homepage": "https://pipedream.com/apps/yahoo_fantasy_sports",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "axios": "^0.21.1"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/yotpo/package.json
+++ b/components/yotpo/package.json
@@ -1,21 +1,21 @@
 {
-    "name": "@pipedream/yotpo",
-    "version": "0.3.3",
-    "description": "Pipedream Yotpo Components",
-    "main": "yotpo.app.js",
-    "keywords": [
-        "pipedream",
-        "yotpo"
-    ],
-    "homepage": "https://pipedream.com/apps/yotpo",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "axios": "^0.21.1",
-        "lodash.get": "^4.4.2"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/yotpo",
+  "version": "0.3.4",
+  "description": "Pipedream Yotpo Components",
+  "main": "yotpo.app.js",
+  "keywords": [
+    "pipedream",
+    "yotpo"
+  ],
+  "homepage": "https://pipedream.com/apps/yotpo",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "axios": "^0.21.1",
+    "lodash.get": "^4.4.2"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/you_need_a_budget/package.json
+++ b/components/you_need_a_budget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/you_need_a_budget",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream You Need A Budget Components",
   "main": "you_need_a_budget.app.js",
   "keywords": [

--- a/components/youcanbook_me/package.json
+++ b/components/youcanbook_me/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/youcanbook_me",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream YouCanBook.Me Components",
   "main": "youcanbook_me.app.mjs",
   "keywords": [

--- a/components/youtube_data_api/package.json
+++ b/components/youtube_data_api/package.json
@@ -1,21 +1,21 @@
 {
-    "name": "@pipedream/youtube_data_api",
-    "version": "0.3.3",
-    "description": "Pipedream Youtube Components",
-    "main": "youtube_data_api.app.mjs",
-    "keywords": [
-        "pipedream",
-        "youtube_data_api"
-    ],
-    "homepage": "https://pipedream.com/apps/youtube_data_api",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "@googleapis/youtube": "^4.1.1",
-        "got": "^11.8.3"
-    },
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/youtube_data_api",
+  "version": "0.3.4",
+  "description": "Pipedream Youtube Components",
+  "main": "youtube_data_api.app.mjs",
+  "keywords": [
+    "pipedream",
+    "youtube_data_api"
+  ],
+  "homepage": "https://pipedream.com/apps/youtube_data_api",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "@googleapis/youtube": "^4.1.1",
+    "got": "^11.8.3"
+  },
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/yr/package.json
+++ b/components/yr/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/yr",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Yr Components",
   "main": "dist/app/yr.app.mjs",
   "keywords": [
     "pipedream",
     "yr"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/yr",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/zendesk/package.json
+++ b/components/zendesk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/zendesk",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Pipedream Zendesk Components",
   "main": "zendesk.app.mjs",
   "keywords": [

--- a/components/zenkit/package.json
+++ b/components/zenkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/zenkit",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Zenkit Components",
   "main": "zenkit.app.mjs",
   "keywords": [

--- a/components/zerotier/package.json
+++ b/components/zerotier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/zerotier",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Pipedream Zerotier Components",
   "main": "zerotier.app.js",
   "keywords": [

--- a/components/zoho_creator/package.json
+++ b/components/zoho_creator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/zoho_creator",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Pipedream Zoho_creator Components",
   "main": "zoho_creator.app.mjs",
   "keywords": [

--- a/components/zoho_crm/package.json
+++ b/components/zoho_crm/package.json
@@ -1,21 +1,21 @@
 {
-    "name": "@pipedream/zoho_crm",
-    "version": "0.3.4",
-    "description": "Pipedream Zoho CRM Components",
-    "main": "zoho_crm.app.mjs",
-    "keywords": [
-        "pipedream",
-        "zoho_crm"
-    ],
-    "homepage": "https://pipedream.com/apps/zoho_crm",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "dependencies": {
-        "@pipedream/platform": "^1.1.0",
-        "crypto": "^1.0.1",
-        "lodash.sortby": "^4.7.0"
-    },
-    "publishConfig": {
-        "access": "public"
-    }
+  "name": "@pipedream/zoho_crm",
+  "version": "0.3.5",
+  "description": "Pipedream Zoho CRM Components",
+  "main": "zoho_crm.app.mjs",
+  "keywords": [
+    "pipedream",
+    "zoho_crm"
+  ],
+  "homepage": "https://pipedream.com/apps/zoho_crm",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "dependencies": {
+    "@pipedream/platform": "^1.1.0",
+    "crypto": "^1.0.1",
+    "lodash.sortby": "^4.7.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/components/zoho_mail/package.json
+++ b/components/zoho_mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/zoho_mail",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Pipedream Zoho Mail Components",
   "main": "zoho_mail.app.mjs",
   "keywords": [

--- a/components/zoho_sheet/package.json
+++ b/components/zoho_sheet/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/zoho_sheet",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Zoho Sheet Components",
   "main": "dist/app/zoho_sheet.app.mjs",
   "keywords": [
     "pipedream",
     "zoho_sheet"
   ],
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "homepage": "https://pipedream.com/apps/zoho_sheet",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",

--- a/components/zonka_feedback/package.json
+++ b/components/zonka_feedback/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/zonka_feedback",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Zonka Feedback Components",
   "main": "zonka_feedback.app.js",
   "keywords": [

--- a/components/zoom/package.json
+++ b/components/zoom/package.json
@@ -1,20 +1,20 @@
 {
-    "name": "@pipedream/zoom",
-    "version": "0.3.4",
-    "description": "Pipedream Zoom Components",
-    "main": "zoom.app.js",
-    "keywords": [
-        "pipedream",
-        "zoom"
-    ],
-    "homepage": "https://pipedream.com/apps/zoom",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    },
-    "dependencies": {
-        "@pipedream/platform": "^1.1.0"
-    }
+  "name": "@pipedream/zoom",
+  "version": "0.3.5",
+  "description": "Pipedream Zoom Components",
+  "main": "zoom.app.js",
+  "keywords": [
+    "pipedream",
+    "zoom"
+  ],
+  "homepage": "https://pipedream.com/apps/zoom",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^1.1.0"
+  }
 }

--- a/components/zoom_admin/package.json
+++ b/components/zoom_admin/package.json
@@ -1,20 +1,20 @@
 {
-    "name": "@pipedream/zoom_admin",
-    "version": "0.3.3",
-    "description": "Pipedream Zoom_admin Components",
-    "main": "zoom_admin.app.js",
-    "keywords": [
-        "pipedream",
-        "zoom_admin"
-    ],
-    "homepage": "https://pipedream.com/apps/zoom_admin",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "license": "MIT",
-    "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
-    "publishConfig": {
-        "access": "public"
-    },
-    "dependencies": {
-        "uuid": "^8.3.2"
-    }
+  "name": "@pipedream/zoom_admin",
+  "version": "0.3.4",
+  "description": "Pipedream Zoom_admin Components",
+  "main": "zoom_admin.app.js",
+  "keywords": [
+    "pipedream",
+    "zoom_admin"
+  ],
+  "homepage": "https://pipedream.com/apps/zoom_admin",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "license": "MIT",
+  "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "uuid": "^8.3.2"
+  }
 }


### PR DESCRIPTION
**Context:**

Apps components are published to `@pipedream`'s NPM registry so they can be reused in any code and workflows, e.g. [`@pipedream/rss`](https://www.npmjs.com/package/@pipedream/rss).
Whenever a change is deployed, the user should also modify the app's `package.json` version [as stated in the docs](https://pipedream.com/docs/components/guidelines/#package-json). However, it wasn't clear (_at least to me_) why this was required. And in my experience, most PRs did not contain modification to `package.json` versions.

**Changes:**

This PR modifies the GH Check and ensures that whenever a dependency file is modified, the respective `package.json` version should also be.

**Note:**

Probably a lot of components versions are not updated in the NPM registry.
The script below can be used to bump all minor versions and guarantee they are updated in the NPM registry (save and run the script in `components/script.js`):

```js
let fs = require("fs");

const apps = fs.readdirSync("./");
apps.forEach((appName) => {
  const packagePath = `${appName}/package.json`;
  if (fs.existsSync(packagePath)) {
    let contents = JSON.parse(fs.readFileSync(packagePath));
    let minor = Number.parseInt(contents.version.split(".").splice(-1));
    minor++;
    const version = contents.version.split(".").splice(0, 2);
    version.push(minor.toString());
    contents.version = version.join(".");
    const newPackage = JSON.stringify(contents, null, 2) + "\n";
    fs.writeFileSync(packagePath, newPackage);
  }
});
```

The reason I didn't do it yet is that while this PR is not merged, other PRs might change the versions and cause a conflict here. **But it should be run and the changes committed to this PR right before merging so they are published to NPM**.

Resolves #4103.

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/4168"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

