### PR TITLE
Add GH PR Check for TS Compile Phase

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -24,7 +24,7 @@ jobs:
           # since the merge-base (the commit where we branched off)
           # so we can check the git diff against all changed files.
           # By default, the checkout action only returns the last commit,
-          # There's no native way to do this in the checkout action, so 
+          # There's no native way to do this in the checkout action, so
           # we have to fetch the entire history. See
           # https://github.com/actions/checkout/issues/266#issuecomment-638346893
           fetch-depth: 0
@@ -152,6 +152,95 @@ jobs:
       - name: pnpm publish
         run: pnpm publish -r --no-git-checks --dry-run
 
+  verify-typescript-components:
+    name: Verify TypeScript components
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2.4.0
+      - uses: pnpm/action-setup@v2.0.1
+        with:
+          version: 7.0.0
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: |
+          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+      - name: Setup Node Env
+        uses: actions/setup-node@v3.4.1
+        with:
+          node-version: 14
+          registry-url: https://registry.npmjs.org/
+          cache: 'pnpm'
+      - name: Install Dependencies
+        run: pnpm install -r
+      - name: Compile TypeScript
+        id: compile
+        run: npm run build > files.txt
+      - name: Get Changed Files
+        id: files
+        uses: jitterbit/get-changed-files@v1
+        with:
+          format: 'csv'
+      - name: Check For Compiled TypeScript Files
+        run: |
+          IFS=$'\n'
+          # Remove initial tsc output
+          output_files=$(cat files.txt | sed 1,3d)
+          declare -a ERRORS
+          declare -a SKIPPED
+          mapfile -d ',' -t added_modified_renamed_files < <(printf '%s,%s' '${{ steps.files.outputs.added_modified }}' '${{ steps.files.outputs.renamed }}')
+          for added_modified_file in "${added_modified_renamed_files[@]}";
+          do
+            echo "Checking if $added_modified_file is a publishable ts file"
+            if [[ $added_modified_file == components/* ]] && [[ $added_modified_file == *.ts ]] && [[ $added_modified_file != *.app.ts ]] \
+                && [[ $added_modified_file != */common*.ts ]] && [[ $added_modified_file != */common/* ]]
+            then
+              # XXX This is a hacky way to publish only TS components with changes. If a changed
+              # file "path-a/path-b/c.ts" has a corresponding compiled output file
+              # "path-a/dist/path-b/c.mjs", attempt to publish the output `.mjs` file.
+              changed_output_file=""
+              for f in $output_files; # check each output file for a match
+              do
+                # Replaces /dist/path/filename.mjs with /path/filename.ts
+                maybe_source_file=$(echo "$f" | sed 's/\/dist\//\//;s/.mjs/\.ts/')
+                if [[ ${maybe_source_file} == **/${added_modified_file} ]]
+                then
+                  changed_output_file=${f}
+                  break
+                fi
+              done
+              if [[ $changed_output_file == "" ]]
+              then
+                ERROR_MESSAGE="cannot find an output .mjs file with ${added_modified_file}"
+                echo $ERROR_MESSAGE
+                ERRORS+=("*${ERROR_MESSAGE}")
+              fi
+            else
+              echo "$added_modified_file will not be added to the registry"
+              SKIPPED+=("*$added_modified_file")
+            fi
+          done
+          if [[ ${#SKIPPED[@]} -ne 0 ]]; then
+            echo "the following files were skipped:"
+            printf '%s\n' "${SKIPPED[@]}"
+          fi
+          if [[ ${#ERRORS[@]} -ne 0 ]]; then
+            echo "the following files generated errors:"
+            printf '%s\n' "${ERRORS[@]}"
+            echo "Please check if the components above were successfully compiled"
+            echo "More information here: https://pipedream.com/docs/components/typescript/#developing-typescript-components-in-the-pipedreamhq-pipedream-registry"
+            exit 1
+          fi
+          unset IFS
+
   publish-typescript-components-dry-run:
     name: Publish TypeScript components
     runs-on: ubuntu-latest
@@ -219,7 +308,3 @@ jobs:
             fi
           done
           unset IFS
-
- 
-
-


### PR DESCRIPTION
Adds a new GitHub Action check on Pull Requests - **Verify TypeScript components**.
This check verifies if the modified `.ts` components have a corresponding `dist/**/*.mjs` file.

**To test:**
on line 8 of `.github/workflows/pull-request-checks.yaml`, change from
``` yaml
on:
  pull_request:
    branches:
      - master
```
to
``` yaml
on: push
```

Then the check will run in every push on any branch.

**Expected behaviour:**
The check should fail whenever the TS compile phase fails or the corresponding modified typescript components in the branch scope doesn't generate a `.mjs` file.

Resolves #4172.

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/4214"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

