### PR TITLE
[AWS] add upload file action variants

### DIFF
--- a/components/aws/actions/s3-upload-file-tmp/s3-upload-file-tmp.mjs
+++ b/components/aws/actions/s3-upload-file-tmp/s3-upload-file-tmp.mjs
@@ -1,32 +1,36 @@
 import common from "../../common/common-s3.mjs";
+import fs from "fs";
 import { toSingleLineString } from "../../common/utils.mjs";
 
 export default {
   ...common,
-  key: "aws-s3-upload-file",
-  name: "S3 - Upload File - Base64",
+  key: "aws-s3-upload-file-tmp",
+  name: "S3 - Upload File - /tmp",
   description: toSingleLineString(`
-    Accepts a base64-encoded string and a filename, then uploads as a file to S3.
+    Accepts a file path starting from /tmp, then uploads as a file to S3.
     [See the docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/upload-objects.html)
   `),
-  version: "0.2.1",
+  version: "0.0.1",
   type: "action",
   props: {
     aws: common.props.aws,
     region: common.props.region,
     bucket: common.props.bucket,
     filename: common.props.key,
-    data: {
+    path: {
       type: "string",
-      label: "Base64-encoded Data",
-      description: "A string of base64-encoded data, or a variable reference to that string",
+      label: "File Path",
+      description: "A path starting from `/tmp`, i.e. `/tmp/some_text_file.txt`",
     },
   },
   async run({ $ }) {
+    const file = fs.readFileSync(this.path, {
+      encoding: "base64",
+    });
     const response = await this.uploadFile({
       Bucket: this.bucket,
       Key: this.filename,
-      Body: Buffer.from(this.data, "base64"),
+      Body: Buffer.from(file, "base64"),
     });
     $.export("$summary", `Uploaded file ${this.filename} to S3`);
     return response;

--- a/components/aws/actions/s3-upload-file-url/s3-upload-file-url.mjs
+++ b/components/aws/actions/s3-upload-file-url/s3-upload-file-url.mjs
@@ -1,0 +1,39 @@
+import base from "@pipedream/helper_functions/actions/download-file-to-tmp/download-file-to-tmp.mjs";
+import common from "../../common/common-s3.mjs";
+import { toSingleLineString } from "../../common/utils.mjs";
+
+// override base props label and description
+base.props.url = common.props.fileUrl;
+base.props.filename = common.props.key;
+
+export default {
+  ...common,
+  key: "aws-s3-upload-file-url",
+  name: "S3 - Upload File - URL",
+  description: toSingleLineString(`
+    Accepts a download link and a filename, downloads it, then uploads to S3.
+    [See the docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/upload-objects.html)
+  `),
+  version: "0.0.1",
+  type: "action",
+  props: {
+    aws: common.props.aws,
+    region: common.props.region,
+    bucket: common.props.bucket,
+    ...base.props,
+  },
+  async run({ $ }) {
+    const filedata = await base.run.bind(this)({
+      $,
+    });
+    const filename = filedata[0];
+    const content = filedata[3];
+    const response = await this.uploadFile({
+      Bucket: this.bucket,
+      Key: filename,
+      Body: content,
+    });
+    $.export("$summary", `Uploaded file ${filename} to S3`);
+    return response;
+  },
+};

--- a/components/aws/package.json
+++ b/components/aws/package.json
@@ -24,7 +24,7 @@
     "@aws-sdk/client-sqs": "^3.58.0",
     "@aws-sdk/client-ssm": "^3.58.0",
     "@aws-sdk/client-sts": "^3.58.0",
-    "@pipedream/helper_functions": "^0.3.6",
+    "@pipedream/helper_functions": "^0.3.5",
     "mailparser-mit": "^1.0.0"
   },
   "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",

--- a/components/aws/package.json
+++ b/components/aws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/aws",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Pipedream Aws Components",
   "main": "aws.app.js",
   "keywords": [
@@ -24,6 +24,7 @@
     "@aws-sdk/client-sqs": "^3.58.0",
     "@aws-sdk/client-ssm": "^3.58.0",
     "@aws-sdk/client-sts": "^3.58.0",
+    "@pipedream/helper_functions": "^0.3.6",
     "mailparser-mit": "^1.0.0"
   },
   "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",

--- a/components/aws/package.json
+++ b/components/aws/package.json
@@ -24,7 +24,7 @@
     "@aws-sdk/client-sqs": "^3.58.0",
     "@aws-sdk/client-ssm": "^3.58.0",
     "@aws-sdk/client-sts": "^3.58.0",
-    "@pipedream/helper_functions": "^0.3.5",
+    "@pipedream/helper_functions": "^0.3.6",
     "mailparser-mit": "^1.0.0"
   },
   "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",

--- a/components/helper_functions/package.json
+++ b/components/helper_functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/helper_functions",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Pipedream Helper_functions Components",
   "main": "helper_functions.app.mjs",
   "keywords": [
@@ -15,6 +15,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@pipedream/platform": "^0.10.0"
+    "@pipedream/platform": "^1.1.1",
+    "streamifier": "^0.1.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,7 +212,7 @@ importers:
       '@aws-sdk/client-sqs': ^3.58.0
       '@aws-sdk/client-ssm': ^3.58.0
       '@aws-sdk/client-sts': ^3.58.0
-      '@pipedream/helper_functions': ^0.3.5
+      '@pipedream/helper_functions': ^0.3.6
       mailparser-mit: ^1.0.0
     dependencies:
       '@aws-sdk/client-cloudwatch-logs': 3.131.0
@@ -228,7 +228,7 @@ importers:
       '@aws-sdk/client-sqs': 3.131.0
       '@aws-sdk/client-ssm': 3.131.0
       '@aws-sdk/client-sts': 3.131.0
-      '@pipedream/helper_functions': 0.3.5
+      '@pipedream/helper_functions': 0.3.6
       mailparser-mit: 1.0.0
 
   components/bandwidth:
@@ -5262,22 +5262,22 @@ packages:
       kuler: 2.0.0
     dev: false
 
-  /@definitelytyped/header-parser/0.0.127:
-    resolution: {integrity: sha512-4BvTT/EXZPqkmpw/mhg7inbaLI16Sq1E7K6QeWoTGU60mf8sfB7me7Kta+/EYZptZzyyt/xR6I7MnptWuDCoPw==}
+  /@definitelytyped/header-parser/0.0.129:
+    resolution: {integrity: sha512-4LcBmghSDBU+NukAd0nLosWyrurWyjF8WeMJXk3wUUBBUbTvjU3F7i4r6eS5TCdoEWPCoKOBBymbj5HW8NFGpA==}
     dependencies:
-      '@definitelytyped/typescript-versions': 0.0.127
+      '@definitelytyped/typescript-versions': 0.0.129
       '@types/parsimmon': 1.10.6
       parsimmon: 1.18.1
     dev: true
 
-  /@definitelytyped/typescript-versions/0.0.127:
-    resolution: {integrity: sha512-q/vGlB0sVOKeEj4L661MmYPmBBzfZltG/unjsFGBaglu1zz9BIuhSW3NYPeiPrtq8OyrwtR6slet22b2SH/xyw==}
+  /@definitelytyped/typescript-versions/0.0.129:
+    resolution: {integrity: sha512-tJvjfd1FT3ow/ggYfXUWVD+N0WP7dcDGoN9/pTlC8Xxc890Yja4B42bYCnZCuE5H2LDXlPCnugNydl1OsD3suw==}
     dev: true
 
-  /@definitelytyped/utils/0.0.127:
-    resolution: {integrity: sha512-EBpYDuYt8T9i63k/jBjWgF7Gr6YebKUiKaNH5kWkIfvGAC1NfyruhxBT40pFTcKICt02/w4Bws/AcjEEekWyww==}
+  /@definitelytyped/utils/0.0.129:
+    resolution: {integrity: sha512-qmLW4fYzl24XS5a3CPCnzFmQ0l+07NIZR111RYXvAgqQuGpPjr7ce+gZwywpACprRAHPVHtxW1B5UxII8Zh3rQ==}
     dependencies:
-      '@definitelytyped/typescript-versions': 0.0.127
+      '@definitelytyped/typescript-versions': 0.0.129
       '@qiwi/npm-registry-client': 8.9.1
       '@types/node': 14.18.22
       charm: 1.0.2
@@ -6457,12 +6457,13 @@ packages:
     engines: {node: '>=10.13.0'}
     dev: false
 
-  /@pipedream/helper_functions/0.3.5:
-    resolution: {integrity: sha512-VulkmPPQ88yGiF6tqwpwGbVWdU0+7l2QLo99ZJzeVaCwMQvWDVRbt+LhFSpCIEBb6HE6MqY98iPFduTSL0D9Dg==}
+  /@pipedream/helper_functions/0.3.6:
+    resolution: {integrity: sha512-R/44qZ9+ueTwY21MQFRAfYHUnDL7o5WTfDYRZvvfxyPQ1E3Cu8sm4x7NFOu9gZTIJ1kB5jdaYKZ4BitddrAzHA==}
     dependencies:
-      '@pipedream/platform': 0.10.0
+      '@pipedream/platform': 1.1.1
+      streamifier: 0.1.1
     transitivePeerDependencies:
-      - supports-color
+      - debug
     dev: false
 
   /@pipedream/helpers/1.3.12:
@@ -10821,7 +10822,7 @@ packages:
     peerDependencies:
       typescript: '*'
     dependencies:
-      '@definitelytyped/header-parser': 0.0.127
+      '@definitelytyped/header-parser': 0.0.129
       command-exists: 1.2.9
       rimraf: 3.0.2
       semver: 6.3.0
@@ -10837,9 +10838,9 @@ packages:
     peerDependencies:
       typescript: '>= 3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.7.0-dev || >= 3.8.0-dev || >= 3.9.0-dev || >= 4.0.0-dev'
     dependencies:
-      '@definitelytyped/header-parser': 0.0.127
-      '@definitelytyped/typescript-versions': 0.0.127
-      '@definitelytyped/utils': 0.0.127
+      '@definitelytyped/header-parser': 0.0.129
+      '@definitelytyped/typescript-versions': 0.0.129
+      '@definitelytyped/utils': 0.0.129
       dts-critic: 3.3.11_typescript@4.7.4
       fs-extra: 6.0.1
       json-stable-stringify: 1.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -918,9 +918,11 @@ importers:
 
   components/helper_functions:
     specifiers:
-      '@pipedream/platform': ^0.10.0
+      '@pipedream/platform': ^1.1.1
+      streamifier: ^0.1.1
     dependencies:
-      '@pipedream/platform': 0.10.0
+      '@pipedream/platform': 1.1.1
+      streamifier: 0.1.1
 
   components/helpwise:
     specifiers: {}
@@ -18334,6 +18336,11 @@ packages:
 
   /stream-shift/1.0.1:
     resolution: {integrity: sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==}
+    dev: false
+
+  /streamifier/0.1.1:
+    resolution: {integrity: sha512-zDgl+muIlWzXNsXeyUfOk9dChMjlpkq0DRsxujtYPgyJ676yQ8jEm6zzaaWHFDg5BNcLuif0eD2MTyJdZqXpdg==}
+    engines: {node: '>=0.10'}
     dev: false
 
   /strict-uri-encode/2.0.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,6 +212,7 @@ importers:
       '@aws-sdk/client-sqs': ^3.58.0
       '@aws-sdk/client-ssm': ^3.58.0
       '@aws-sdk/client-sts': ^3.58.0
+      '@pipedream/helper_functions': ^0.3.5
       mailparser-mit: ^1.0.0
     dependencies:
       '@aws-sdk/client-cloudwatch-logs': 3.131.0
@@ -227,6 +228,7 @@ importers:
       '@aws-sdk/client-sqs': 3.131.0
       '@aws-sdk/client-ssm': 3.131.0
       '@aws-sdk/client-sts': 3.131.0
+      '@pipedream/helper_functions': 0.3.5
       mailparser-mit: 1.0.0
 
   components/bandwidth:
@@ -6453,6 +6455,14 @@ packages:
   /@panva/asn1.js/1.0.0:
     resolution: {integrity: sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw==}
     engines: {node: '>=10.13.0'}
+    dev: false
+
+  /@pipedream/helper_functions/0.3.5:
+    resolution: {integrity: sha512-VulkmPPQ88yGiF6tqwpwGbVWdU0+7l2QLo99ZJzeVaCwMQvWDVRbt+LhFSpCIEBb6HE6MqY98iPFduTSL0D9Dg==}
+    dependencies:
+      '@pipedream/platform': 0.10.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@pipedream/helpers/1.3.12:


### PR DESCRIPTION
Depends on #4215 - please review and test this PR first.

- [x] Pending update and merge of `@pipedream/helper_functions@0.3.6` version - #4215.

Adds variants for Upload File action:
  - Upload File - Base64
  - Upload File - URL
  - Upload File - /tmp

Resolves #4094.

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/4216"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

