### PR TITLE
[HubSpot] Add Rate Limiting to Requests

### DIFF
--- a/components/hubspot/common/utils.mjs
+++ b/components/hubspot/common/utils.mjs
@@ -1,9 +1,0 @@
-function monthAgo() {
-  const monthAgo = new Date();
-  monthAgo.setMonth(monthAgo.getMonth() - 1);
-  return monthAgo;
-}
-
-export {
-  monthAgo,
-};

--- a/components/hubspot/package.json
+++ b/components/hubspot/package.json
@@ -11,7 +11,8 @@
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "license": "MIT",
   "dependencies": {
-    "@pipedream/platform": "^0.10.0"
+    "@pipedream/platform": "^0.10.0",
+    "bottleneck": "^2.19.5"
   },
   "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",
   "publishConfig": {

--- a/components/hubspot/package.json
+++ b/components/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/hubspot",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Pipedream Hubspot Components",
   "main": "hubspot.app.mjs",
   "keywords": [

--- a/components/hubspot/sources/common.mjs
+++ b/components/hubspot/sources/common.mjs
@@ -1,5 +1,6 @@
 import { monthAgo } from "../common/utils.mjs";
 import hubspot from "../hubspot.app.mjs";
+import Bottleneck from "bottleneck";
 
 export default {
   props: {
@@ -21,6 +22,14 @@ export default {
     },
   },
   methods: {
+    _limiter() {
+      return new Bottleneck({
+        minTime: 250, // max 4 requests per second
+      });
+    },
+    async _requestWithLimiter(limiter, resourceFn, params) {
+      return limiter.schedule(async () => await resourceFn(params));
+    },
     _getAfter() {
       return this.db.get("after") || Date.parse(monthAgo());
     },
@@ -35,8 +44,9 @@ export default {
     },
     async paginate(params, resourceFn, resultType = null, after = null) {
       let results = null;
+      const limiter = this._limiter();
       while (!results || params.after) {
-        results = await resourceFn(params);
+        results = await this._requestWithLimiter(limiter, resourceFn, params);
         if (results.paging) {
           params.after = results.paging.next.after;
         } else {
@@ -65,9 +75,10 @@ export default {
       let hasMore = true;
       let results, items;
       let count = 0;
+      const limiter = this._limiter();
       while (hasMore && (!limitRequest || count < limitRequest)) {
         count++;
-        results = await resourceFn(params);
+        results = await this._requestWithLimiter(limiter, resourceFn, params);
         hasMore = results.hasMore;
         if (hasMore) {
           params.offset = results.offset;

--- a/components/hubspot/sources/common.mjs
+++ b/components/hubspot/sources/common.mjs
@@ -1,4 +1,3 @@
-import { monthAgo } from "../common/utils.mjs";
 import hubspot from "../hubspot.app.mjs";
 import Bottleneck from "bottleneck";
 
@@ -31,7 +30,7 @@ export default {
       return limiter.schedule(async () => await resourceFn(params));
     },
     _getAfter() {
-      return this.db.get("after") || Date.parse(monthAgo());
+      return this.db.get("after") || new Date();
     },
     _setAfter(after) {
       this.db.set("after", after);

--- a/components/hubspot/sources/company-updated/company-updated.mjs
+++ b/components/hubspot/sources/company-updated/company-updated.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-company-updated",
   name: "Company Updated",
   description: "Emit new event each time a company is updated.",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
   type: "source",
   hooks: {},

--- a/components/hubspot/sources/contact-updated/contact-updated.mjs
+++ b/components/hubspot/sources/contact-updated/contact-updated.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-contact-updated",
   name: "Contact Updated",
   description: "Emit new event each time a contact is updated.",
-  version: "0.0.4",
+  version: "0.0.5",
   dedupe: "unique",
   type: "source",
   methods: {

--- a/components/hubspot/sources/deal-updated/deal-updated.mjs
+++ b/components/hubspot/sources/deal-updated/deal-updated.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-deal-updated",
   name: "Deal Updated",
   description: "Emit new event each time a deal is updated.",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "source",
   dedupe: "unique",
   hooks: {},

--- a/components/hubspot/sources/deal-updated/deal-updated.mjs
+++ b/components/hubspot/sources/deal-updated/deal-updated.mjs
@@ -7,6 +7,7 @@ export default {
   description: "Emit new event each time a deal is updated.",
   version: "0.0.4",
   type: "source",
+  dedupe: "unique",
   hooks: {},
   methods: {
     ...common.methods,

--- a/components/hubspot/sources/delete-blog-article/delete-blog-article.mjs
+++ b/components/hubspot/sources/delete-blog-article/delete-blog-article.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-delete-blog-article",
   name: "Deleted Blog Posts",
   description: "Emit new event for each deleted blog post.",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
   type: "source",
   hooks: {

--- a/components/hubspot/sources/line-item-updated/line-item-updated.mjs
+++ b/components/hubspot/sources/line-item-updated/line-item-updated.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-line-item-updated",
   name: "Line Item Updated",
   description: "Emit new event each time a line item is updated.",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
   type: "source",
   hooks: {},

--- a/components/hubspot/sources/new-blog-article/new-blog-article.mjs
+++ b/components/hubspot/sources/new-blog-article/new-blog-article.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-new-blog-article",
   name: "New Blog Posts",
   description: "Emit new event for each new blog post.",
-  version: "0.0.4",
+  version: "0.0.5",
   dedupe: "unique",
   type: "source",
   hooks: {},

--- a/components/hubspot/sources/new-company/new-company.mjs
+++ b/components/hubspot/sources/new-company/new-company.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-new-company",
   name: "New Companies",
   description: "Emit new event for each new company added.",
-  version: "0.0.4",
+  version: "0.0.5",
   dedupe: "unique",
   type: "source",
   hooks: {},

--- a/components/hubspot/sources/new-contact-in-list/new-contact-in-list.mjs
+++ b/components/hubspot/sources/new-contact-in-list/new-contact-in-list.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-new-contact-in-list",
   name: "New Contact in List",
   description: "Emit new event for each new contact in a list.",
-  version: "0.0.4",
+  version: "0.0.5",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-contact/new-contact.mjs
+++ b/components/hubspot/sources/new-contact/new-contact.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-new-contact",
   name: "New Contacts",
   description: "Emit new event for each new contact added.",
-  version: "0.0.4",
+  version: "0.0.5",
   dedupe: "unique",
   type: "source",
   methods: {

--- a/components/hubspot/sources/new-deal-in-stage/new-deal-in-stage.mjs
+++ b/components/hubspot/sources/new-deal-in-stage/new-deal-in-stage.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-new-deal-in-stage",
   name: "New Deal In Stage",
   description: "Emit new event for each new deal in a stage.",
-  version: "0.0.4",
+  version: "0.0.5",
   dedupe: "unique",
   type: "source",
   hooks: {},

--- a/components/hubspot/sources/new-deal/new-deal.mjs
+++ b/components/hubspot/sources/new-deal/new-deal.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-new-deal",
   name: "New Deals",
   description: "Emit new event for each new deal created.",
-  version: "0.0.4",
+  version: "0.0.5",
   dedupe: "unique",
   type: "source",
   hooks: {},

--- a/components/hubspot/sources/new-email-event/new-email-event.mjs
+++ b/components/hubspot/sources/new-email-event/new-email-event.mjs
@@ -1,5 +1,4 @@
 import common from "../common.mjs";
-import { monthAgo } from "../../common/utils.mjs";
 
 export default {
   ...common,
@@ -27,7 +26,7 @@ export default {
       };
     },
     getParams() {
-      const startTimestamp = Date.parse(monthAgo());
+      const startTimestamp = new Date();
       return {
         limit: 100,
         startTimestamp,

--- a/components/hubspot/sources/new-email-event/new-email-event.mjs
+++ b/components/hubspot/sources/new-email-event/new-email-event.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-new-email-event",
   name: "New Email Event",
   description: "Emit new event for each new Hubspot email event.",
-  version: "0.0.4",
+  version: "0.0.5",
   dedupe: "unique",
   type: "source",
   hooks: {},

--- a/components/hubspot/sources/new-email-subscriptions-timeline/new-email-subscriptions-timeline.mjs
+++ b/components/hubspot/sources/new-email-subscriptions-timeline/new-email-subscriptions-timeline.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-new-email-subscriptions-timeline",
   name: "New Email Subscriptions Timeline",
   description: "Emit new event when new email timeline subscription added for the portal.",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
   type: "source",
   hooks: {},

--- a/components/hubspot/sources/new-email-subscriptions-timeline/new-email-subscriptions-timeline.mjs
+++ b/components/hubspot/sources/new-email-subscriptions-timeline/new-email-subscriptions-timeline.mjs
@@ -1,5 +1,4 @@
 import common from "../common.mjs";
-import { monthAgo } from "../../common/utils.mjs";
 
 export default {
   ...common,
@@ -27,7 +26,7 @@ export default {
       return timeline.timestamp > createdAfter;
     },
     getParams() {
-      const startTimestamp = Date.parse(monthAgo());
+      const startTimestamp = new Date();
       return {
         startTimestamp,
       };

--- a/components/hubspot/sources/new-engagement/new-engagement.mjs
+++ b/components/hubspot/sources/new-engagement/new-engagement.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-new-engagement",
   name: "New Engagement",
   description: "Emit new event for each new engagement created. This action returns a maximum of 5000 records at a time, make sure you set a correct time range so you don't miss any events",
-  version: "0.0.5",
+  version: "0.0.6",
   dedupe: "unique",
   type: "source",
   hooks: {},

--- a/components/hubspot/sources/new-event/new-event.mjs
+++ b/components/hubspot/sources/new-event/new-event.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-new-event",
   name: "New Events",
   description: "Emit new event for each new Hubspot event.",
-  version: "0.0.4",
+  version: "0.0.5",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-form-submission/new-form-submission.mjs
+++ b/components/hubspot/sources/new-form-submission/new-form-submission.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-new-form-submission",
   name: "New Form Submission",
   description: "Emit new event for each new submission of a form.",
-  version: "0.0.4",
+  version: "0.0.5",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-line-item/new-line-item.mjs
+++ b/components/hubspot/sources/new-line-item/new-line-item.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-new-line-item",
   name: "New Line Item",
   description: "Emit new event for each new line item added.",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
   type: "source",
   hooks: {},

--- a/components/hubspot/sources/new-or-updated-crm-object/new-or-updated-crm-object.mjs
+++ b/components/hubspot/sources/new-or-updated-crm-object/new-or-updated-crm-object.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-new-or-updated-crm-object",
   name: "New or Updated CRM Object",
   description: "Emit new event each time a CRM Object of the specified object type is updated.",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-product/new-product.mjs
+++ b/components/hubspot/sources/new-product/new-product.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-new-product",
   name: "New Products",
   description: "Emit new event for each new product created.",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
   type: "source",
   hooks: {},

--- a/components/hubspot/sources/new-social-media-message/new-social-media-message.mjs
+++ b/components/hubspot/sources/new-social-media-message/new-social-media-message.mjs
@@ -4,9 +4,9 @@ export default {
   ...common,
   key: "hubspot-social-media-message",
   name: "New Social Media Message",
-  description: `Emit new event when a message is posted from HubSpot to the specified 
+  description: `Emit new event when a message is posted from HubSpot to the specified
     social media channel`,
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/hubspot/sources/new-task/new-task.mjs
+++ b/components/hubspot/sources/new-task/new-task.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-new-task",
   name: "New Calendar Task",
   description: "Emit new event for each new task added.",
-  version: "0.0.4",
+  version: "0.0.5",
   dedupe: "unique",
   type: "source",
   hooks: {},

--- a/components/hubspot/sources/new-ticket/new-ticket.mjs
+++ b/components/hubspot/sources/new-ticket/new-ticket.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-new-ticket",
   name: "New Tickets",
   description: "Emit new event for each new ticket created.",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
   type: "source",
   hooks: {},

--- a/components/hubspot/sources/product-updated/product-updated.mjs
+++ b/components/hubspot/sources/product-updated/product-updated.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-product-updated",
   name: "Product Updated",
   description: "Emit new event each time a product is updated.",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
   type: "source",
   hooks: {},

--- a/components/hubspot/sources/updated-blog-article/updated-blog-article.mjs
+++ b/components/hubspot/sources/updated-blog-article/updated-blog-article.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-update-blog-article",
   name: "Updated Blog Posts",
   description: "Emit new event for each updated blog post.",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
   type: "source",
   hooks: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -954,8 +954,10 @@ importers:
   components/hubspot:
     specifiers:
       '@pipedream/platform': ^0.10.0
+      bottleneck: ^2.19.5
     dependencies:
       '@pipedream/platform': 0.10.0
+      bottleneck: 2.19.5
 
   components/ifttt:
     specifiers:
@@ -1086,6 +1088,9 @@ importers:
       '@lob/lob-typescript-sdk': ^1.0.0
     dependencies:
       '@lob/lob-typescript-sdk': 1.0.0
+
+  components/lodgify:
+    specifiers: {}
 
   components/looker:
     specifiers: {}
@@ -1574,6 +1579,9 @@ importers:
       '@types/object-hash': 2.2.1
 
   components/sailpoint:
+    specifiers: {}
+
+  components/sailpoint_personal_token:
     specifiers: {}
 
   components/sales_simplify:
@@ -5272,22 +5280,22 @@ packages:
       kuler: 2.0.0
     dev: false
 
-  /@definitelytyped/header-parser/0.0.127:
-    resolution: {integrity: sha512-4BvTT/EXZPqkmpw/mhg7inbaLI16Sq1E7K6QeWoTGU60mf8sfB7me7Kta+/EYZptZzyyt/xR6I7MnptWuDCoPw==}
+  /@definitelytyped/header-parser/0.0.129:
+    resolution: {integrity: sha512-4LcBmghSDBU+NukAd0nLosWyrurWyjF8WeMJXk3wUUBBUbTvjU3F7i4r6eS5TCdoEWPCoKOBBymbj5HW8NFGpA==}
     dependencies:
-      '@definitelytyped/typescript-versions': 0.0.127
+      '@definitelytyped/typescript-versions': 0.0.129
       '@types/parsimmon': 1.10.6
       parsimmon: 1.18.1
     dev: true
 
-  /@definitelytyped/typescript-versions/0.0.127:
-    resolution: {integrity: sha512-q/vGlB0sVOKeEj4L661MmYPmBBzfZltG/unjsFGBaglu1zz9BIuhSW3NYPeiPrtq8OyrwtR6slet22b2SH/xyw==}
+  /@definitelytyped/typescript-versions/0.0.129:
+    resolution: {integrity: sha512-tJvjfd1FT3ow/ggYfXUWVD+N0WP7dcDGoN9/pTlC8Xxc890Yja4B42bYCnZCuE5H2LDXlPCnugNydl1OsD3suw==}
     dev: true
 
-  /@definitelytyped/utils/0.0.127:
-    resolution: {integrity: sha512-EBpYDuYt8T9i63k/jBjWgF7Gr6YebKUiKaNH5kWkIfvGAC1NfyruhxBT40pFTcKICt02/w4Bws/AcjEEekWyww==}
+  /@definitelytyped/utils/0.0.129:
+    resolution: {integrity: sha512-qmLW4fYzl24XS5a3CPCnzFmQ0l+07NIZR111RYXvAgqQuGpPjr7ce+gZwywpACprRAHPVHtxW1B5UxII8Zh3rQ==}
     dependencies:
-      '@definitelytyped/typescript-versions': 0.0.127
+      '@definitelytyped/typescript-versions': 0.0.129
       '@qiwi/npm-registry-client': 8.9.1
       '@types/node': 14.18.22
       charm: 1.0.2
@@ -10823,7 +10831,7 @@ packages:
     peerDependencies:
       typescript: '*'
     dependencies:
-      '@definitelytyped/header-parser': 0.0.127
+      '@definitelytyped/header-parser': 0.0.129
       command-exists: 1.2.9
       rimraf: 3.0.2
       semver: 6.3.0
@@ -10839,9 +10847,9 @@ packages:
     peerDependencies:
       typescript: '>= 3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.7.0-dev || >= 3.8.0-dev || >= 3.9.0-dev || >= 4.0.0-dev'
     dependencies:
-      '@definitelytyped/header-parser': 0.0.127
-      '@definitelytyped/typescript-versions': 0.0.127
-      '@definitelytyped/utils': 0.0.127
+      '@definitelytyped/header-parser': 0.0.129
+      '@definitelytyped/typescript-versions': 0.0.129
+      '@definitelytyped/utils': 0.0.129
       dts-critic: 3.3.11_typescript@4.7.4
       fs-extra: 6.0.1
       json-stable-stringify: 1.0.1


### PR DESCRIPTION
Considering 1000+ deals in HubSpot:

- Add rate limiting (4 requests/sec) when paginating through multiple pages
- Only emit new events from first run

Resolves #4208.
Resolves #4209.

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/4232"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

