### PR TITLE
Slack: fix deploy New Reaction Added without channels

### DIFF
--- a/components/slack/package.json
+++ b/components/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/slack",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Pipedream Slack Components",
   "main": "slack.app.mjs",
   "keywords": [

--- a/components/slack/sources/new-reaction-added/new-reaction-added.mjs
+++ b/components/slack/sources/new-reaction-added/new-reaction-added.mjs
@@ -4,7 +4,7 @@ export default {
   ...common,
   key: "slack-new-reaction-added",
   name: "New Reaction Added (Instant)",
-  version: "1.1.1",
+  version: "1.1.2",
   description: "Emit new event when a member has added an emoji reaction to an item",
   type: "source",
   dedupe: "unique",
@@ -25,7 +25,7 @@ export default {
       type: "$.interface.apphook",
       appProp: "slack",
       async eventNames() {
-        if (this.conversations.length) {
+        if (this.conversations?.length) {
           const conversations = [];
           for (const conversation of this.conversations) {
             conversations.push(`reaction_added:${conversation}`);


### PR DESCRIPTION
Check if the **Channels** prop value is defined before iterating over it.

**Context**

When I try to create a Slack **New Reaction Added** source without selecting one or more channels, I get the error:
```
TypeError:
Cannot read properties of undefined (reading 'deployComponent')
```

The conversations (Channels) `string[]` prop is undefined when a channel hasn't been selected in the pipedream.com UI.

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/4318"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

