### PR TITLE
Salesforce: fix loading Object Type options in Updated Field on Record

### DIFF
--- a/components/salesforce_rest_api/package.json
+++ b/components/salesforce_rest_api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/salesforce_rest_api",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Pipedream Salesforce (REST API) Components",
   "main": "salesforce_rest_api.app.mjs",
   "keywords": [

--- a/components/salesforce_rest_api/sources/common.mjs
+++ b/components/salesforce_rest_api/sources/common.mjs
@@ -13,6 +13,7 @@ export default {
       },
     },
     objectType: {
+      type: "string",
       label: "Object Type",
       description: "The type of object for which to monitor events",
       propDefinition: [

--- a/components/salesforce_rest_api/sources/new-object/new-object.mjs
+++ b/components/salesforce_rest_api/sources/new-object/new-object.mjs
@@ -8,7 +8,7 @@ export default {
   name: "New Object (of Selectable Type)",
   key: "salesforce_rest_api-new-object",
   description: "Emit new event (at regular intervals) when an object of arbitrary type (selected as an input parameter by the user) is created. See [the docs](https://sforce.co/3yPSJZy) for more information.",
-  version: "0.1.2",
+  version: "0.1.3",
   methods: {
     ...common.methods,
     isItemRelevant(item, startTimestamp, endTimestamp) {

--- a/components/salesforce_rest_api/sources/object-deleted/object-deleted.mjs
+++ b/components/salesforce_rest_api/sources/object-deleted/object-deleted.mjs
@@ -8,7 +8,7 @@ export default {
   name: "New Deleted Object (of Selectable Type)",
   key: "salesforce_rest_api-object-deleted",
   description: "Emit new event (at regular intervals) when an object of arbitrary type (selected as an input parameter by the user) is deleted. [See the docs](https://sforce.co/3msDDEE) for more information.",
-  version: "0.1.2",
+  version: "0.1.3",
   methods: {
     ...common.methods,
     generateMeta(item) {

--- a/components/salesforce_rest_api/sources/object-updated/object-updated.mjs
+++ b/components/salesforce_rest_api/sources/object-updated/object-updated.mjs
@@ -8,7 +8,7 @@ export default {
   name: "New Updated Object (of Selectable Type)",
   key: "salesforce_rest_api-object-updated",
   description: "Emit new event (at regular intervals) when an object of arbitrary type (selected as an input parameter by the user) is updated. [See the docs](https://sforce.co/3yPSJZy) for more information.",
-  version: "0.1.2",
+  version: "0.1.3",
   methods: {
     ...common.methods,
     generateMeta(item) {

--- a/components/salesforce_rest_api/sources/updated-field-on-record/updated-field-on-record.mjs
+++ b/components/salesforce_rest_api/sources/updated-field-on-record/updated-field-on-record.mjs
@@ -15,11 +15,11 @@ export default {
   name: "New Updated Field on Record (of Selectable Type)",
   key: "salesforce_rest_api-updated-field-on-record",
   description: "Emit new event (at regular intervals) when a field of your choosing is updated on any record of a specified Salesforce object. Field history tracking must be enabled for the chosen field. See the docs on [field history tracking](https://sforce.co/3mtj0rF) and [history objects](https://sforce.co/3Fn4lWB) for more information.",
-  version: "0.1.2",
+  version: "0.1.3",
   props: {
     ...common.props,
     objectType: {
-      ...common.props.objectType,
+      type: common.props.objectType.type,
       label: common.props.objectType.label,
       description: common.props.objectType.description,
       async options(context) {


### PR DESCRIPTION
Remove inheriting propDefinition from common objectType prop, which doesn't support overriding async options.

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/4342"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

