### PR TITLE
Fix README Typos

### DIFF
--- a/components/salesforce_rest_api/README.md
+++ b/components/salesforce_rest_api/README.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-You can install the Pipedream Discord app in the [Accounts](https://pipedream.com/accounts) section of your account, or directly in a workflow.
+You can install the Pipedream Salesforce app in the [Accounts](https://pipedream.com/accounts) section of your account, or directly in a workflow.
 
 ### Webhooks
 

--- a/docs/docs/components/api/README.md
+++ b/docs/docs/components/api/README.md
@@ -191,7 +191,7 @@ To see more examples, explore the [curated components in Pipedream's GitHub repo
 
 ##### Advanced Configuration
 
-##### Async Options ([example](https://github.com/PipedreamHQ/pipedream/blob/master/components/github/github.app.js))
+##### Async Options ([example](https://github.com/PipedreamHQ/pipedream/blob/master/components/github/github.app.mjs))
 
 Async options allow users to select prop values that can be programmatically-generated (e.g., based on a real-time API response).
 


### PR DESCRIPTION
Fix some typos I found

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/4358"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

