### PR TITLE
Edit: Notion - supports sorting for database query

### DIFF
--- a/components/notion/actions/query-database/query-database.mjs
+++ b/components/notion/actions/query-database/query-database.mjs
@@ -20,12 +20,19 @@ export default {
       description: "The filter to query. [See how filters work here](https://developers.notion.com/reference/post-database-query-filter). E.g. { \"property\": \"Email\", \"rich_text\": { \"contains\": \"gmail.com\" } }",
       type: "string",
     },
+    sorts: {
+      label: "Sorts",
+      description: "The array of sorting option objects. [See how sort work here](https://developers.notion.com/reference/post-database-query-sort). E.g. [ { \"property\": \"Food group\", \"direction\": \"descending\" }, { \"property\": \"Name\", \"direction\": \"ascending\" } ]",
+      type: "string",
+      optional: true,
+    },
   },
   async run({ $ }) {
-    const { filter } = this;
+    const { filter, sorts } = this;
 
     const response = await this.notion.queryDatabase(this.databaseId, {
       filter: utils.parseStringToJSON(filter),
+      sorts: utils.parseStringToJSON(sorts),
     });
 
     $.export("$summary", "Retrieved database query result");

--- a/components/notion/actions/query-database/query-database.mjs
+++ b/components/notion/actions/query-database/query-database.mjs
@@ -32,7 +32,7 @@ export default {
 
     const response = await this.notion.queryDatabase(this.databaseId, {
       filter: utils.parseStringToJSON(filter),
-      sorts: utils.parseStringToJSON(sorts),
+      sorts: utils.parseStringToJSON(sorts, undefined),
     });
 
     $.export("$summary", "Retrieved database query result");


### PR DESCRIPTION
This PR ables user to sort the result from query_database notion action.
- Adds builder input for sort object(array of objects)
- Edits action to include sort object on querying the notion database

About sort object - Official Notion API docs
- https://developers.notion.com/reference/post-database-query (Please see javascript example)

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/4372"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

