### PR TITLE
New check added to scripts/finBadKeys.js

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -116,8 +116,13 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_JAVASCRIPT_ES: true
           VALIDATE_JSON: true
+      - name: Get Changed Files
+        id: changed_files
+        uses: jitterbit/get-changed-files@v1
+        with:
+          format: 'csv'
       - name: Check component keys
-        run: node scripts/findBadKeys.js
+        run: node scripts/findBadKeys.js ${{ steps.changed_files.outputs.added_modified }} ${{ steps.changed_files.outputs.renamed }}
       - name: Check for duplicate component keys
         run: node scripts/findDuplicateKeys.js
 

--- a/scripts/findBadKeys.js
+++ b/scripts/findBadKeys.js
@@ -27,7 +27,6 @@ const getComponentKey = ( p )  => {
 };
 
 const checkPathVsKey = () => {
-
   let changedFiles = [];
   if (process.argv[2])
     changedFiles = process.argv[2].split(",");
@@ -38,6 +37,8 @@ const checkPathVsKey = () => {
     ];
   for (const file of changedFiles) {
     const p = path.join(rootDir, file);
+    if (file.startsWith("components/"))
+      continue;
     if (isAppFile(p) || isCommonFile(p) || !isSourceFile(p))
       continue;
     const componentKey = getComponentKey(p);

--- a/scripts/findBadKeys.js
+++ b/scripts/findBadKeys.js
@@ -37,7 +37,7 @@ const checkPathVsKey = () => {
     ];
   for (const file of changedFiles) {
     const p = path.join(rootDir, file);
-    if (file.startsWith("components/"))
+    if (!file.startsWith("components/"))
       continue;
     if (isAppFile(p) || isCommonFile(p) || !isSourceFile(p))
       continue;

--- a/scripts/findBadKeys.js
+++ b/scripts/findBadKeys.js
@@ -44,12 +44,12 @@ const checkPathVsKey = () => {
     const componentKey = getComponentKey(p);
     if (!componentKey) {
       err = true;
-      console.error(`[!] ${file} has no component key! Either its file name should start with 'common' or it should be in a folder named 'common'`);
+      console.error(`[!] ${file} has no component key! Either its file name should start with 'common' or it should be in a folder named 'common'! See the docs: https://pipedream.com/docs/components/guidelines/#folder-structure`);
     } else {
       const uriParts = file.split("/");
       if (uriParts.length < 2) {
         err = true;
-        console.error(`[!] ${file} components should be in folders named as the same with their file names!`);
+        console.error(`[!] ${file} components should be in folders named as the same with their file names! See the docs: https://pipedream.com/docs/components/guidelines/#folder-structure`);
       } else {
         const folderName = uriParts[uriParts.length - 2];
         const fileName = uriParts[uriParts.length - 1].split(".")[0];
@@ -58,7 +58,7 @@ const checkPathVsKey = () => {
           .join("-");
         if (folderName != fileName || fileName != keyName) {
           err = true;
-          console.error(`[!] ${file} component folder name, component file name without extension and component key without slug should be the same!`);
+          console.error(`[!] ${file} component folder name, component file name without extension and component key without slug should be the same! See the docs: https://pipedream.com/docs/components/guidelines/#folder-structure`);
         }
       }
     }
@@ -107,7 +107,7 @@ for (const name of dirs) {
       const data = fs.readFileSync(appPath, "utf8");
       const md = data.match(/['"]?app['"]?: ['"]([^'"]+)/);
       nameSlug = md[1];
-    } 
+    }
     // Some app files are kept in the app dir
     if (subname === "app") {
       const appDir = path.join(p, subname);

--- a/scripts/findBadKeys.js
+++ b/scripts/findBadKeys.js
@@ -27,10 +27,15 @@ const getComponentKey = ( p )  => {
 };
 
 const checkPathVsKey = () => {
-  const changedFiles = [
-    ...process.argv[2].split(","),
-    ...process.argv[3].split(","),
-  ];
+
+  let changedFiles = [];
+  if (process.argv[2])
+    changedFiles = process.argv[2].split(",");
+  if (process.argv[3])
+    changedFiles = [
+      ...changedFiles,
+      ...process.argv[3].split(","),
+    ];
   for (const file of changedFiles) {
     const p = path.join(rootDir, file);
     if (isAppFile(p) || isCommonFile(p) || !isSourceFile(p))


### PR DESCRIPTION
New component key check is implemented to catch the following;
* Detecting common files are not named as `common*` or not in a common folder.
* Detect component keys are not compatible with component names.
* Detect component file names are not compatible with their folder names.

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/4487"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

