### PR TITLE
Discord: show "Sent via Pipedream" text below message embeds

### DIFF
--- a/components/discord/package.json
+++ b/components/discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/discord",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Pipedream Discord Components",
   "main": "discord.app.mjs",
   "keywords": [


### PR DESCRIPTION
Moves the "Sent via Pipedream" text from the message text content to an embed when the message has other embeds

Before:
<img width="350" alt="sent-via-pipedream-before" src="https://user-images.githubusercontent.com/19861096/197643212-4e098162-36e2-4d17-a052-6f0b5ee2c78b.png">

After:
<img width="350" alt="sent-via-pipedream-after" src="https://user-images.githubusercontent.com/19861096/197643222-f34b6e7f-3b72-4a9e-bfb8-67e0e9dc727d.png">

Related: https://github.com/PipedreamHQ/pipedream/pull/4476

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/4575"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

