### PR TITLE
Fix microsoft outlook 'end' field description

### DIFF
--- a/components/microsoft_outlook/actions/create-calendar-event/create-calendar-event.mjs
+++ b/components/microsoft_outlook/actions/create-calendar-event/create-calendar-event.mjs
@@ -3,7 +3,7 @@ import microsoftOutlook from "../../microsoft_outlook.app.mjs";
 export default {
   type: "action",
   key: "microsoft_outlook-create-calendar-event",
-  version: "0.0.2",
+  version: "0.0.3",
   name: "Create Calendar Event",
   description: "Create an event in the user's default calendar, [See the docs](https://docs.microsoft.com/en-us/graph/api/user-post-events)",
   props: {

--- a/components/microsoft_outlook/actions/create-contact/create-contact.mjs
+++ b/components/microsoft_outlook/actions/create-contact/create-contact.mjs
@@ -3,7 +3,7 @@ import microsoftOutlook from "../../microsoft_outlook.app.mjs";
 export default {
   type: "action",
   key: "microsoft_outlook-create-contact",
-  version: "0.0.2",
+  version: "0.0.3",
   name: "Create Contact",
   description: "Add a contact to the root Contacts folder, [See the docs](https://docs.microsoft.com/en-us/graph/api/user-post-contacts)",
   props: {

--- a/components/microsoft_outlook/actions/create-draft-email/create-draft-email.mjs
+++ b/components/microsoft_outlook/actions/create-draft-email/create-draft-email.mjs
@@ -3,7 +3,7 @@ import microsoftOutlook from "../../microsoft_outlook.app.mjs";
 export default {
   type: "action",
   key: "microsoft_outlook-create-draft-email",
-  version: "0.0.2",
+  version: "0.0.3",
   name: "Create Draft Email",
   description: "Create a draft email, [See the docs](https://docs.microsoft.com/en-us/graph/api/user-post-messages)",
   props: {

--- a/components/microsoft_outlook/actions/find-contacts/find-contacts.mjs
+++ b/components/microsoft_outlook/actions/find-contacts/find-contacts.mjs
@@ -3,7 +3,7 @@ import microsoftOutlook from "../../microsoft_outlook.app.mjs";
 export default {
   type: "action",
   key: "microsoft_outlook-find-contacts",
-  version: "0.0.2",
+  version: "0.0.3",
   name: "Find Contacts",
   description: "Finds contacts with given search string",
   props: {

--- a/components/microsoft_outlook/actions/list-contacts/list-contacts.mjs
+++ b/components/microsoft_outlook/actions/list-contacts/list-contacts.mjs
@@ -3,7 +3,7 @@ import microsoftOutlook from "../../microsoft_outlook.app.mjs";
 export default {
   type: "action",
   key: "microsoft_outlook-list-contacts",
-  version: "0.0.2",
+  version: "0.0.3",
   name: "List Contacts",
   description: "Get a contact collection from the default contacts folder, [See the docs](https://docs.microsoft.com/en-us/graph/api/user-list-contacts)",
   props: {

--- a/components/microsoft_outlook/actions/send-email/send-email.mjs
+++ b/components/microsoft_outlook/actions/send-email/send-email.mjs
@@ -3,7 +3,7 @@ import microsoftOutlook from "../../microsoft_outlook.app.mjs";
 export default {
   type: "action",
   key: "microsoft_outlook-send-email",
-  version: "0.0.3",
+  version: "0.0.4",
   name: "Send Email",
   description: "Send an email to one or multiple recipients, [See the docs](https://docs.microsoft.com/en-us/graph/api/user-sendmail)",
   props: {

--- a/components/microsoft_outlook/actions/update-contact/update-contact.mjs
+++ b/components/microsoft_outlook/actions/update-contact/update-contact.mjs
@@ -3,7 +3,7 @@ import microsoftOutlook from "../../microsoft_outlook.app.mjs";
 export default {
   type: "action",
   key: "microsoft_outlook-update-contact",
-  version: "0.0.2",
+  version: "0.0.3",
   name: "Update Contact",
   description: "Add a contact to the root Contacts folder, [See the docs](https://docs.microsoft.com/en-us/graph/api/user-post-contacts)",
   props: {

--- a/components/microsoft_outlook/microsoft_outlook.app.mjs
+++ b/components/microsoft_outlook/microsoft_outlook.app.mjs
@@ -69,7 +69,7 @@ export default {
     },
     end: {
       label: "End",
-      description: "Start date-time (yyyy-MM-ddThh:mm:ss) e.g. '2022-04-15T13:30:00'",
+      description: "End date-time (yyyy-MM-ddThh:mm:ss) e.g. '2022-04-15T13:30:00'",
       type: "string",
     },
     givenName: {

--- a/components/microsoft_outlook/package.json
+++ b/components/microsoft_outlook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/microsoft_outlook",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Pipedream Microsoft Outlook Components",
   "main": "microsoft_outlook.app.mjs",
   "keywords": [

--- a/components/microsoft_outlook/sources/new-calendar-event/new-calendar-event.mjs
+++ b/components/microsoft_outlook/sources/new-calendar-event/new-calendar-event.mjs
@@ -5,7 +5,7 @@ export default {
   key: "microsoft_outlook-new-calendar-event",
   name: "New Calendar Event (Instant)",
   description: "Emit new event when a new Calendar event is created",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "source",
   hooks: {
     ...common.hooks,

--- a/components/microsoft_outlook/sources/new-contact/new-contact.mjs
+++ b/components/microsoft_outlook/sources/new-contact/new-contact.mjs
@@ -5,7 +5,7 @@ export default {
   key: "microsoft_outlook-new-contact",
   name: "New Contact Event (Instant)",
   description: "Emit new event when a new Contact is created",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "source",
   hooks: {
     ...common.hooks,

--- a/components/microsoft_outlook/sources/new-email/new-email.mjs
+++ b/components/microsoft_outlook/sources/new-email/new-email.mjs
@@ -5,7 +5,7 @@ export default {
   key: "microsoft_outlook-new-email",
   name: "New Email Event (Instant)",
   description: "Emit new event when an email received",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "source",
   hooks: {
     ...common.hooks,

--- a/components/microsoft_outlook/sources/updated-calendar-event/updated-calendar-event.mjs
+++ b/components/microsoft_outlook/sources/updated-calendar-event/updated-calendar-event.mjs
@@ -5,7 +5,7 @@ export default {
   key: "microsoft_outlook-updated-calendar-event",
   name: "New Calendar Event Update (Instant)",
   description: "Emit new event when a Calendar event is updated",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "source",
   hooks: {
     ...common.hooks,


### PR DESCRIPTION
The description of the field "end" was wrong, probably a copy/paste mistake.

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/4609"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

