### PR TITLE
[BUG] Default Values in Text Fields are not Getting Updated - Supportivekoala | Create Image

### DIFF
--- a/components/supportivekoala/actions/create-image/create-image.mjs
+++ b/components/supportivekoala/actions/create-image/create-image.mjs
@@ -5,7 +5,7 @@ export default {
   key: "supportivekoala-create-image",
   name: "Create an Image",
   description: "Creates an image based on a template. [See the docs here](https://developers.supportivekoala.com/#create_image)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     app,
@@ -31,7 +31,7 @@ export default {
       constants.ALLOWED_FIELD_TYPES.includes(child.type) && !child.locked);
     const props = fields?.reduce((props, field) => ({
       ...props,
-      [field.name]: {
+      [field.name + "templateId:" + this.templateId]: {
         type: "string",
         label: field.name,
         default: field.text || field.src,
@@ -57,10 +57,11 @@ export default {
     } = this;
 
     const params = Object.entries(fields).map((field) => {
-      const [
+      let [
         name,
         value,
       ] = field;
+      name = name.split("templateId")[0];
       return {
         name,
         value,

--- a/components/supportivekoala/package.json
+++ b/components/supportivekoala/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/supportivekoala",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Pipedream Supportivekoala Components",
-  "main": "supportivekoala.app.js",
+  "main": "supportivekoala.app.mjs",
   "keywords": [
     "pipedream",
     "supportivekoala"


### PR DESCRIPTION
Resolves #3905

Default values for additional props were not being updated if the prop names matched the previous prop names. I added the templateId to the end of the additional prop names so that they will always be refreshed. The templateId is then removed from the name when creating params to pass into `createImage()`.

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/4636"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

