### PR TITLE
Add support for appending an array of blocks to Notion Append Block action

### DIFF
--- a/components/notion/actions/append-block/append-block.mjs
+++ b/components/notion/actions/append-block/append-block.mjs
@@ -5,8 +5,8 @@ export default {
   ...base,
   key: "notion-append-block",
   name: "Append Block to Parent",
-  description: "Creates and appends new blocks to the specified parent. [See the docs](https://developers.notion.com/reference/patch-block-children)",
-  version: "0.2.2",
+  description: "Creates and appends blocks to the specified parent. [See the docs](https://developers.notion.com/reference/patch-block-children)",
+  version: "0.2.3",
   type: "action",
   props: {
     notion,
@@ -18,16 +18,46 @@ export default {
       label: "Parent Block ID",
       description: "The identifier for the parent block",
     },
-    pageContent: {
-      type: "string",
-      label: "Page Content",
-      description: "Content of the page. You can use Markdown syntax [See docs](https://www.notion.so/help/writing-and-editing-basics#markdown-&-shortcuts)",
+    blockIds: {
+      propDefinition: [
+        notion,
+        "pageId",
+      ],
+      type: "string[]",
+      label: "Block IDs",
+      description: "Contents of selected blocks will be appended",
+      optional: true,
+    },
+    pageContents: {
+      type: "string[]",
+      label: "Page Contents",
+      description: "Content of new blocks to append. You can use Markdown syntax [See docs](https://www.notion.so/help/writing-and-editing-basics#markdown-&-shortcuts)",
+      optional: true,
     },
   },
   async run({ $ }) {
-    const blocks = this.createBlocks(this.pageContent);
-    const response = await this.notion.appendBlock(this.pageId, blocks);
-    $.export("$summary", "Appended block(s) successfully");
-    return response;
+    const blocks = [];
+    if (this.blockIds?.length > 0) {
+      for (const id of this.blockIds) {
+        const block = await this.notion.retrieveBlock(id);
+        const children = await this.notion.retrieveBlockChildren(block);
+        blocks.push(...children
+          .filter((child) => Object.keys(child[child.type]).length > 0 && child.type !== "child_page")
+          .map((child) => ({
+            object: "block",
+            type: child.type,
+            [child.type]: child[child.type],
+          })));
+      }
+    }
+    if (this.pageContents?.length > 0) {
+      for (const content of this.pageContents) {
+        const block = this.createBlocks(content);
+        blocks.push(...block);
+      }
+    }
+    const { results } = await this.notion.appendBlock(this.pageId, blocks);
+    $.export("$summary", `Appended ${results.length} block(s) successfully`);
+    return results;
   },
 };

--- a/components/notion/package.json
+++ b/components/notion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/notion",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Pipedream Notion Components",
   "main": "notion.app.mjs",
   "keywords": [


### PR DESCRIPTION
Resolves #4711 

Updated the Append Block action to allow for selecting existing blocks **AND/OR** entering markup to create new blocks to append.