### PR TITLE
[GH Actions Check] Enable multiple apps for a component

### DIFF
--- a/scripts/checkComponentAppProp.js
+++ b/scripts/checkComponentAppProp.js
@@ -14,8 +14,12 @@ function checkComponentKey(component, nameslug) {
     console.error(`[!] ${key} - missing app prop`);
     err = true;
   } else if (props.length > 1) {
-    console.error(`[!] ${key} - more than one app prop not expected`);
-    err = true;
+    if (props.map((prop) => prop.app)
+      .filter((prop) => prop === nameslug)
+      .length === 0) {
+        console.error(`[!] ${key} - missing app prop for ${nameslug}`);
+        err = true;
+    }
   } else {
     const appProp = props.reduce((prop) => prop);
     const appName = appProp.app;

--- a/scripts/checkComponentAppProp.js
+++ b/scripts/checkComponentAppProp.js
@@ -4,30 +4,13 @@ const {
   iterateComponentFiles,
 } = require("./findBadKeys.js");
 
-function checkComponentKey(component, nameslug) {
-  const key = component.key;
+function checkComponentHasAppProp(component, appNameSlug) {
+  const matching = Object.values(component.props)
+    .filter((prop) => prop.type === "app" && prop.app === appNameSlug);
 
-  const props = Object.values(component.props)
-    .filter((prop) => prop.type === "app");
-
-  if (props.length === 0) {
-    console.error(`[!] ${key} - missing app prop`);
+  if (!matching.length) {
+    console.error(`[!] ${component.key} - missing app prop for ${appNameSlug}`);
     err = true;
-  } else if (props.length > 1) {
-    if (props.map((prop) => prop.app)
-      .filter((prop) => prop === nameslug)
-      .length === 0) {
-        console.error(`[!] ${key} - missing app prop for ${nameslug}`);
-        err = true;
-    }
-  } else {
-    const appProp = props.reduce((prop) => prop);
-    const appName = appProp.app;
-
-    if (appName !== nameslug) {
-      console.error(`[!] ${key} - importing wrong app: ${appName}`);
-      err = true;
-    }
   }
 }
 
@@ -35,9 +18,9 @@ async function main() {
   const iterator = iterateComponentFiles();
   for (const file of iterator) {
     const p = path.join(rootDir, file);
-    const nameslug = file.split("/")[1];
+    const appNameSlug = file.split("/")[1];
     const { default: component } = await import(p)
-    checkComponentKey(component, nameslug);
+    checkComponentHasAppProp(component, appNameSlug);
   }
 
   if (err) {


### PR DESCRIPTION
Should be ok using multiple apps in a component, but should check for corresponding nameslug app.

Example: `deployhq-deploy-failed` should contain at least `deployhq` app; can contain other apps.

Noticed this because I'm currently working on a **Google Calendar** component that also needs **Pipedream** app auth.