### PR TITLE
Notion duplicate-page action improvements

### DIFF
--- a/components/notion/actions/append-block/append-block.mjs
+++ b/components/notion/actions/append-block/append-block.mjs
@@ -6,7 +6,7 @@ export default {
   key: "notion-append-block",
   name: "Append Block to Parent",
   description: "Creates and appends blocks to the specified parent. [See the docs](https://developers.notion.com/reference/patch-block-children)",
-  version: "0.2.4",
+  version: "0.2.5",
   type: "action",
   props: {
     notion,

--- a/components/notion/actions/common/base-page-builder.mjs
+++ b/components/notion/actions/common/base-page-builder.mjs
@@ -161,6 +161,60 @@ export default {
     createBlocks(pageContent) {
       return markdownToBlocks(pageContent);
     },
+    isSupportedVideoType(url) {
+      const supportedTypes = [
+        ".mkv",
+        ".flv",
+        ".gifv",
+        ".avi",
+        ".mov",
+        ".qt",
+        ".wmv",
+        ".asf",
+        ".amv",
+        ".mp4",
+        ".m4v",
+        ".mpeg",
+        ".mpv",
+        ".mpg",
+        ".f4v",
+      ];
+      const extension = url.split(".").pop();
+      return supportedTypes.includes(extension);
+    },
+    // creating a new file object is not currently supported by the API
+    // https://developers.notion.com/reference/file-object
+    isFile(block) {
+      return (block?.type === "file");
+    },
+    // returns false if the child block is a video of an unsupported type,
+    // an image file, or a column-list with less than 2 children
+    notValid(child, c) {
+      return (
+        (child.type === "video" && !this.isSupportedVideoType(child.video?.external?.url))
+        || (child.type === "image" && this.isFile(child.image))
+        || (child.type === "column_list" && c.length < 2));
+    },
+    childPageToLink(block) {
+      return {
+        object: "block",
+        type: "link_to_page",
+        link_to_page: {
+          type: "page_id",
+          page_id: block.id,
+        },
+      };
+    },
+    childDatabaseToLink(block) {
+      return {
+        object: "block",
+        type: "link_to_page",
+        link_to_page: {
+          type: "database_id",
+          database_id: block.id,
+        },
+      };
+    },
     /**
      * Formats the children of an existing block for creating/appending
      * to a new page/block
@@ -174,63 +228,32 @@ export default {
       (await Promise.all(children.map((child) => this.formatChildBlocks(child))))
         .forEach((c, i) => {
           const child = children[i];
-          children[i] = {
-            object: "block",
-            type: child.type,
-            [child.type]: child[child.type],
-          };
-          if (c.length > 0) {
-            children[i][child.type].children = c;
+          if (child.type === "child_page") {
+            // convert child pages to links
+            children[i] = this.childPageToLink(child);
+          } else if (child.type === "child_database") {
+            // convert child databases to links
+            children[i] = this.childDatabaseToLink(child);
+          } else {
+            if (this.notValid(child, c)) {
+              children[i] = undefined;
+            } else {
+              children[i] = {
+                object: "block",
+                type: child.type,
+                [child.type]: child[child.type],
+              };
+
+              if (c.length > 0) {
+                children[i][child.type].children = c;
+              } else if (Object.keys(children[i][child.type]).length === 0) {
+                // block has no children and no content
+                children[i] = undefined;
+              }
+            }
           }
         });
-      return children;
-    },
-    createChild(block, children) {
-      let child = {
-        object: "block",
-      };
-      if (block.type === "child_page") {
-        child = {
-          ...child,
-          type: "link_to_page",
-          link_to_page: {
-            type: "page_id",
-            page_id: block.id,
-          },
-        };
-      } else if (block.type === "child_database") {
-        child = {
-          ...child,
-          type: "link_to_page",
-          link_to_page: {
-            type: "database_id",
-            database_id: block.id,
-          },
-        };
-      } else {
-        child = {
-          ...child,
-          type: block.type,
-          [block.type]: block[block.type],
-        };
-        if (children?.length > 0) {
-          child[block.type].children = children;
-        }
-      }
-      return child;
-    },
-    async getFormattedBlocks(children) {
-      const blocks = [];
-      for (const block of children) {
-        if (!(Object.keys(block[block.type])?.length > 0)) {
-          continue;
-        }
-
-        const formattedChildBlocks = await this.formatChildBlocks(block);
-        const child = this.createChild(block, formattedChildBlocks);
-        blocks.push(child);
-      }
-      return blocks;
+      return children.filter((child) => child !== undefined);
     },
   },
 };

--- a/components/notion/actions/common/base-page-builder.mjs
+++ b/components/notion/actions/common/base-page-builder.mjs
@@ -162,6 +162,9 @@ export default {
       return markdownToBlocks(pageContent);
     },
     isSupportedVideoType(url) {
+      if (!url) {
+        return false;
+      }
       const supportedTypes = [
         ".mkv",
         ".flv",

--- a/components/notion/actions/create-page-from-database/create-page-from-database.mjs
+++ b/components/notion/actions/create-page-from-database/create-page-from-database.mjs
@@ -7,7 +7,7 @@ export default {
   key: "notion-create-page-from-database",
   name: "Create Page from Database",
   description: "Creates a page from a database. [See the docs](https://developers.notion.com/reference/post-page)",
-  version: "0.1.3",
+  version: "0.1.4",
   type: "action",
   props: {
     notion,

--- a/components/notion/actions/create-page/create-page.mjs
+++ b/components/notion/actions/create-page/create-page.mjs
@@ -7,7 +7,7 @@ export default {
   key: "notion-create-page",
   name: "Create Page",
   description: "Creates a page from a parent page. The only valid property is *title*. [See the docs](https://developers.notion.com/reference/post-page)",
-  version: "0.2.3",
+  version: "0.2.4",
   type: "action",
   props: {
     notion,

--- a/components/notion/actions/duplicate-page/duplicate-page.mjs
+++ b/components/notion/actions/duplicate-page/duplicate-page.mjs
@@ -7,8 +7,7 @@ export default {
   key: "notion-duplicate-page",
   name: "Duplicate Page",
   description: "Creates a new page copied from an existing page block. [See the docs](https://developers.notion.com/reference/post-page)",
-  //version: "0.0.1",
-  version: "0.0.63",
+  version: "0.0.2",
   type: "action",
   props: {
     notion,

--- a/components/notion/actions/duplicate-page/duplicate-page.mjs
+++ b/components/notion/actions/duplicate-page/duplicate-page.mjs
@@ -7,7 +7,8 @@ export default {
   key: "notion-duplicate-page",
   name: "Duplicate Page",
   description: "Creates a new page copied from an existing page block. [See the docs](https://developers.notion.com/reference/post-page)",
-  version: "0.0.1",
+  //version: "0.0.1",
+  version: "0.0.63",
   type: "action",
   props: {
     notion,
@@ -36,9 +37,8 @@ export default {
   },
   async run({ $ }) {
     const block = await this.notion.retrieveBlock(this.pageId);
-
-    const blockChildren = await this.notion.retrieveBlockChildren(block);
-    const children = await this.getFormattedBlocks(blockChildren);
+    block.children = await this.notion.retrieveBlockChildren(block);
+    const formattedChildren = await this.formatChildBlocks(block);
 
     const pageBlock = await this.notion.retrievePage(this.pageId);
     const {
@@ -55,9 +55,13 @@ export default {
       properties: {
         title: utils.buildTextProperty(title),
       },
-      cover,
-      icon,
-      children,
+      cover: this.isFile(cover)
+        ? null
+        : cover,
+      icon: this.isFile(icon)
+        ? null
+        : icon,
+      children: formattedChildren,
     };
 
     const results = await this.notion.createPage(page);

--- a/components/notion/actions/update-page/update-page.mjs
+++ b/components/notion/actions/update-page/update-page.mjs
@@ -7,7 +7,7 @@ export default {
   key: "notion-update-page",
   name: "Update Page",
   description: "Updates page property values for the specified page. Properties that are not set will remain unchanged. To append page content, use the *append block* action. [See the docs](https://developers.notion.com/reference/patch-page)",
-  version: "0.2.4",
+  version: "0.2.5",
   type: "action",
   props: {
     notion,

--- a/components/notion/package.json
+++ b/components/notion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/notion",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Pipedream Notion Components",
   "main": "notion.app.mjs",
   "keywords": [


### PR DESCRIPTION
Updated `duplicate-page` action to filter out the following unsupported blocks:

- unsupported video types
- file objects for images, icons, and covers
- column-lists with less than 2 valid children

<a href="https://gitpod.io/#https://github.com/PipedreamHQ/pipedream/pull/4770"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

