### PR TITLE
[Google Sheets] Fix add_single_row action

### DIFF
--- a/components/google_sheets/actions/add-single-row/add-single-row.mjs
+++ b/components/google_sheets/actions/add-single-row/add-single-row.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_sheets-add-single-row",
   name: "Add Single Row",
   description: "Add a single row of data to Google Sheets",
-  version: "2.0.8",
+  version: "2.0.9",
   type: "action",
   props: {
     googleSheets,

--- a/components/google_sheets/package.json
+++ b/components/google_sheets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_sheets",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Pipedream Google_sheets Components",
   "main": "google_sheets.app.mjs",
   "keywords": [


### PR DESCRIPTION
Just bumping the version because the action works when I publish it locally.

![image](https://user-images.githubusercontent.com/15385076/203594657-6f66de95-2ae0-4214-ad47-e3a9b089f82a.png)

Resolves #4809.