### PR TITLE
Fix adding labels to tasks in Todoist API migration

### DIFF
--- a/components/todoist/actions/create-filter/create-filter.mjs
+++ b/components/todoist/actions/create-filter/create-filter.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-create-filter",
   name: "Create Filter",
   description: "Creates a filter. [See the docs here](https://developer.todoist.com/sync/v9/#add-a-filter)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/create-label/create-label.mjs
+++ b/components/todoist/actions/create-label/create-label.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-create-label",
   name: "Create Label",
   description: "Creates a label. [See the docs here](https://developer.todoist.com/rest/v2/#create-a-new-personal-label)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/create-project-comment/create-project-comment.mjs
+++ b/components/todoist/actions/create-project-comment/create-project-comment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-create-project-comment",
   name: "Create Project Comment",
   description: "Adds a comment to a project. [See the docs here](https://developer.todoist.com/rest/v2/#create-a-new-comment)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/create-project/create-project.mjs
+++ b/components/todoist/actions/create-project/create-project.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-create-project",
   name: "Create Project",
   description: "Creates a project. [See the docs here](https://developer.todoist.com/rest/v2/#create-a-new-project)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/create-section/create-section.mjs
+++ b/components/todoist/actions/create-section/create-section.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-create-section",
   name: "Create Section",
   description: "Creates a section. [See the docs here](https://developer.todoist.com/rest/v2/#create-a-new-section)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/create-task-comment/create-task-comment.mjs
+++ b/components/todoist/actions/create-task-comment/create-task-comment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-create-task-comment",
   name: "Create Task Comment",
   description: "Adds a comment to a task. [See the docs here](https://developer.todoist.com/rest/v2/#create-a-new-comment)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/create-task/create-task.mjs
+++ b/components/todoist/actions/create-task/create-task.mjs
@@ -132,7 +132,7 @@ export default {
       section_id: section,
       parent_id: parent,
       order,
-      label_ids: labels,
+      labels,
       priority,
       due_string: dueString,
       due_date: dueDate,

--- a/components/todoist/actions/create-task/create-task.mjs
+++ b/components/todoist/actions/create-task/create-task.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-create-task",
   name: "Create Task",
   description: "Creates a task. [See the docs here](https://developer.todoist.com/rest/v2/#create-a-new-task)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/create-task/create-task.mjs
+++ b/components/todoist/actions/create-task/create-task.mjs
@@ -63,11 +63,8 @@ export default {
     labels: {
       propDefinition: [
         todoist,
-        "label",
+        "labelString",
       ],
-      type: "string[]",
-      description: "Labels associated with the task",
-      optional: true,
     },
     priority: {
       propDefinition: [

--- a/components/todoist/actions/delete-comment/delete-comment.mjs
+++ b/components/todoist/actions/delete-comment/delete-comment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-delete-comment",
   name: "Delete Comment",
   description: "Deletes a comment. [See the docs here](https://developer.todoist.com/rest/v2/#delete-a-comment)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/delete-filter/delete-filter.mjs
+++ b/components/todoist/actions/delete-filter/delete-filter.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-delete-filter",
   name: "Delete Filter",
   description: "Deletes a filter. [See the docs here](https://developer.todoist.com/sync/v9/#delete-a-filter)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/delete-label/delete-label.mjs
+++ b/components/todoist/actions/delete-label/delete-label.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-delete-label",
   name: "Delete Label",
   description: "Deletes a label. [See the docs here](https://developer.todoist.com/rest/v2/#delete-a-personal-label)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/delete-project/delete-project.mjs
+++ b/components/todoist/actions/delete-project/delete-project.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-delete-project",
   name: "Delete Project",
   description: "Deletes a project. [See the docs here](https://developer.todoist.com/rest/v2/#delete-a-project)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/delete-section/delete-section.mjs
+++ b/components/todoist/actions/delete-section/delete-section.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-delete-section",
   name: "Delete Section",
   description: "Deletes a section. [See the docs here](https://developer.todoist.com/rest/v2/#delete-a-section)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/delete-task/delete-task.mjs
+++ b/components/todoist/actions/delete-task/delete-task.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-delete-task",
   name: "Delete Task",
   description: "Deletes a task. [See the docs here](https://developer.todoist.com/rest/v2/#delete-a-task)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/export-tasks/export-tasks.mjs
+++ b/components/todoist/actions/export-tasks/export-tasks.mjs
@@ -7,7 +7,7 @@ export default {
   key: "todoist-export-tasks",
   name: "Export Tasks",
   description: "Export project task names as comma separated file. Returns path to new file. [See Docs](https://developer.todoist.com/rest/v2/#get-active-tasks)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/find-project/find-project.mjs
+++ b/components/todoist/actions/find-project/find-project.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-find-project",
   name: "Find Project",
   description: "Finds a project (by name/title). [See Docs](https://developer.todoist.com/rest/v2/#get-all-projects) Optionally, create one if none are found. [See Docs](https://developer.todoist.com/rest/v2/#create-a-new-project)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/find-task/find-task.mjs
+++ b/components/todoist/actions/find-task/find-task.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-find-task",
   name: "Find Task",
   description: "Finds a task by name. [See Docs](https://developer.todoist.com/rest/v2/#get-active-tasks) Optionally, create one if none are found. [See Docs](https://developer.todoist.com/rest/v2/#create-a-new-task)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/find-user/find-user.mjs
+++ b/components/todoist/actions/find-user/find-user.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-find-user",
   name: "Find User",
   description: "Searches by email for a user who is connected/shared with your account. [See the docs here](https://developer.todoist.com/sync/v9/#read-resources)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/get-label/get-label.mjs
+++ b/components/todoist/actions/get-label/get-label.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-get-label",
   name: "Get Label",
   description: "Returns info about a label. [See the docs here](https://developer.todoist.com/rest/v2/#get-a-personal-label)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/get-project-comment/get-project-comment.mjs
+++ b/components/todoist/actions/get-project-comment/get-project-comment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-get-project-comment",
   name: "Get Project Comment",
   description: "Returns info about a project comment. [See the docs here](https://developer.todoist.com/rest/v2/#get-a-comment)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/get-project/get-project.mjs
+++ b/components/todoist/actions/get-project/get-project.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-get-project",
   name: "Get Project",
   description: "Returns info about a project. [See the docs here](https://developer.todoist.com/rest/v2/#get-a-project)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/get-section/get-section.mjs
+++ b/components/todoist/actions/get-section/get-section.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-get-section",
   name: "Get Section",
   description: "Returns info about a section. [See the docs here](https://developer.todoist.com/rest/v2/#get-a-single-section)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/get-task-comment/get-task-comment.mjs
+++ b/components/todoist/actions/get-task-comment/get-task-comment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-get-task-comment",
   name: "Get Task Comment",
   description: "Returns info about a task comment. [See the docs here](https://developer.todoist.com/rest/v2/#get-a-comment)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/get-task/get-task.mjs
+++ b/components/todoist/actions/get-task/get-task.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-get-task",
   name: "Get Task",
   description: "Returns info about a task. [See the docs here](https://developer.todoist.com/rest/v2/#get-an-active-task)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/import-tasks/import-tasks.mjs
+++ b/components/todoist/actions/import-tasks/import-tasks.mjs
@@ -6,7 +6,7 @@ export default {
   key: "todoist-import-tasks",
   name: "Import Tasks",
   description: "Import tasks into a selected project. [See Docs](https://developer.todoist.com/sync/v9/#add-an-item)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/invite-user-to-project/invite-user-to-project.mjs
+++ b/components/todoist/actions/invite-user-to-project/invite-user-to-project.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-invite-user-to-project",
   name: "Invite User To Project",
   description: "Sends email to a person, inviting them to use one of your projects. [See the docs here](https://developer.todoist.com/sync/v9/#share-a-project)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/list-filters/list-filters.mjs
+++ b/components/todoist/actions/list-filters/list-filters.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-list-filters",
   name: "List Filters",
   description: "Returns a list of all filters. [See the docs here](https://developer.todoist.com/sync/v9/#read-resources)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/list-labels/list-labels.mjs
+++ b/components/todoist/actions/list-labels/list-labels.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-list-labels",
   name: "List Labels",
   description: "Returns a list of all labels. [See the docs here](https://developer.todoist.com/rest/v2/#get-all-personal-labels)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/list-project-comments/list-project-comments.mjs
+++ b/components/todoist/actions/list-project-comments/list-project-comments.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-list-project-comments",
   name: "List Project Comments",
   description: "Returns a list of comments for a project. [See the docs here](https://developer.todoist.com/rest/v2/#get-all-comments)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/list-projects/list-projects.mjs
+++ b/components/todoist/actions/list-projects/list-projects.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-list-projects",
   name: "List Projects",
   description: "Returns a list of all projects. [See the docs here](https://developer.todoist.com/rest/v2/#get-all-projects)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/list-sections/list-sections.mjs
+++ b/components/todoist/actions/list-sections/list-sections.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-list-sections",
   name: "List Sections",
   description: "Returns a list of all sections. [See the docs here](https://developer.todoist.com/rest/v2/#get-all-sections)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/list-task-comments/list-task-comments.mjs
+++ b/components/todoist/actions/list-task-comments/list-task-comments.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-list-task-comments",
   name: "List Task Comments",
   description: "Returns a list of comments for a task. [See the docs here](https://developer.todoist.com/rest/v2/#get-all-comments)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/list-uncompleted-tasks/list-uncompleted-tasks.mjs
+++ b/components/todoist/actions/list-uncompleted-tasks/list-uncompleted-tasks.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-list-uncompleted-tasks",
   name: "List Uncompleted Tasks",
   description: "Returns a list of uncompleted tasks by project, section, and/or label. [See the docs here](https://developer.todoist.com/rest/v2/#get-active-tasks)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/mark-task-completed/mark-task-completed.mjs
+++ b/components/todoist/actions/mark-task-completed/mark-task-completed.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-mark-task-completed",
   name: "Mark Task as Completed",
   description: "Marks a task as being completed. [See the docs here](https://developer.todoist.com/rest/v2/#close-a-task)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/move-task-to-section/move-task-to-section.mjs
+++ b/components/todoist/actions/move-task-to-section/move-task-to-section.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-move-task-to-section",
   name: "Move Task To Section",
   description: "Move a Task to a different section within the same project. [See the docs here](https://developer.todoist.com/sync/v9/#move-an-item)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/uncomplete-task/uncomplete-task.mjs
+++ b/components/todoist/actions/uncomplete-task/uncomplete-task.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-uncomplete-task",
   name: "Uncomplete Task",
   description: "Uncompletes a task. [See the docs here](https://developer.todoist.com/rest/v2/#reopen-a-task)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/update-comment/update-comment.mjs
+++ b/components/todoist/actions/update-comment/update-comment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-update-comment",
   name: "Update Comment",
   description: "Updates a comment. [See the docs here](https://developer.todoist.com/rest/v2/#update-a-comment)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/update-filter/update-filter.mjs
+++ b/components/todoist/actions/update-filter/update-filter.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-update-filter",
   name: "Update Filter",
   description: "Updates a filter. [See the docs here](https://developer.todoist.com/sync/v9/#update-a-filter)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/update-label/update-label.mjs
+++ b/components/todoist/actions/update-label/update-label.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-update-label",
   name: "Update Label",
   description: "Updates a label. [See the docs here](https://developer.todoist.com/rest/v2/#update-a-personal-label)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/update-project/update-project.mjs
+++ b/components/todoist/actions/update-project/update-project.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-update-project",
   name: "Update Project",
   description: "Updates a project. [See the docs here](https://developer.todoist.com/rest/v2/#update-a-project)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/update-section/update-section.mjs
+++ b/components/todoist/actions/update-section/update-section.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-update-section",
   name: "Update Section",
   description: "Updates a section. [See the docs here](https://developer.todoist.com/rest/v2/#update-a-section)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/update-task/update-task.mjs
+++ b/components/todoist/actions/update-task/update-task.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-update-task",
   name: "Update Task",
   description: "Updates a task. [See the docs here](https://developer.todoist.com/rest/v2/#update-a-task)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     todoist,

--- a/components/todoist/actions/update-task/update-task.mjs
+++ b/components/todoist/actions/update-task/update-task.mjs
@@ -41,11 +41,8 @@ export default {
     labels: {
       propDefinition: [
         todoist,
-        "label",
+        "labelString",
       ],
-      type: "string[]",
-      description: "Labels associated with the task",
-      optional: true,
     },
     priority: {
       propDefinition: [

--- a/components/todoist/actions/update-task/update-task.mjs
+++ b/components/todoist/actions/update-task/update-task.mjs
@@ -104,7 +104,7 @@ export default {
       taskId: task,
       content,
       description,
-      label_ids: labels,
+      labels,
       priority,
       due_string: dueString,
       due_date: dueDate,

--- a/components/todoist/package.json
+++ b/components/todoist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/todoist",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Pipedream Todoist Components",
   "main": "todoist.app.mjs",
   "keywords": [

--- a/components/todoist/sources/completed-task/completed-task.mjs
+++ b/components/todoist/sources/completed-task/completed-task.mjs
@@ -5,7 +5,7 @@ export default {
   key: "todoist-completed-task",
   name: "New Completed Task",
   description: "Emit new event for each completed task. [See the docs here](https://developer.todoist.com/sync/v8/#read-resources)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/todoist/sources/incomplete-task/incomplete-task.mjs
+++ b/components/todoist/sources/incomplete-task/incomplete-task.mjs
@@ -5,7 +5,7 @@ export default {
   key: "todoist-incomplete-task",
   name: "New Incomplete Task",
   description: "Emit new event for each new incomplete task. [See the docs here](https://developer.todoist.com/sync/v8/#read-resources)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/todoist/sources/new-or-modified-project/new-or-modified-project.mjs
+++ b/components/todoist/sources/new-or-modified-project/new-or-modified-project.mjs
@@ -5,6 +5,6 @@ export default {
   key: "todoist-new-or-modified-project",
   name: "New or Modified Project",
   description: "Emit new event for each new or modified project. [See the docs here](https://developer.todoist.com/sync/v8/#read-resources)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
 };

--- a/components/todoist/sources/new-or-modified-task/new-or-modified-task.mjs
+++ b/components/todoist/sources/new-or-modified-task/new-or-modified-task.mjs
@@ -5,6 +5,6 @@ export default {
   key: "todoist-new-or-modified-task",
   name: "New or Modified Task",
   description: "Emit new event for each new or modified task. [See the docs here](https://developer.todoist.com/sync/v8/#read-resources)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
 };

--- a/components/todoist/sources/new-project/new-project.mjs
+++ b/components/todoist/sources/new-project/new-project.mjs
@@ -5,7 +5,7 @@ export default {
   key: "todoist-new-project",
   name: "New Project",
   description: "Emit new event for each new project. [See the docs here](https://developer.todoist.com/sync/v8/#read-resources)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   dedupe: "greatest",
 };

--- a/components/todoist/sources/new-section/new-section.mjs
+++ b/components/todoist/sources/new-section/new-section.mjs
@@ -5,7 +5,7 @@ export default {
   key: "todoist-new-section",
   name: "New Section",
   description: "Emit new event for each new section added. [See the docs here](https://developer.todoist.com/sync/v8/#read-resources)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   dedupe: "greatest",
   methods: {

--- a/components/todoist/sources/new-task/new-task.mjs
+++ b/components/todoist/sources/new-task/new-task.mjs
@@ -5,7 +5,7 @@ export default {
   key: "todoist-new-task",
   name: "New Task",
   description: "Emit new event for each new task. [See the docs here](https://developer.todoist.com/sync/v8/#read-resources)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   dedupe: "greatest",
 };

--- a/components/todoist/sources/sync-resources/sync-resources.mjs
+++ b/components/todoist/sources/sync-resources/sync-resources.mjs
@@ -5,7 +5,7 @@ export default {
   key: "todoist-sync-resources",
   name: "New Sync Resources",
   description: "Emit new updates for your selected resources. [See the docs here](https://developer.todoist.com/sync/v8/#read-resources)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   props: {
     ...common.props,

--- a/components/todoist/todoist.app.mjs
+++ b/components/todoist/todoist.app.mjs
@@ -70,6 +70,15 @@ export default {
         }));
       },
     },
+    labelString: {
+      type: "string[]",
+      label: "Labels",
+      description: "Select labels to add to the task.",
+      optional: true,
+      async options() {
+        return (await this.getLabels({})).map((label) => label.name);
+      },
+    },
     task: {
       type: "string",
       label: "Task",


### PR DESCRIPTION
Todoist changed the payload to add labels when creating or updating a task. In the _v1_, it was `label_ids`, while in the _v2_ it's only `labels`. This was not addressed when moving Todoist from `v1` to _v2_. This small pull request fixes those issues.