### PR TITLE
[ACTION] Add inReplyTo & references to gmail-send-email

### DIFF
--- a/components/gmail/actions/send-email/send-email.mjs
+++ b/components/gmail/actions/send-email/send-email.mjs
@@ -6,7 +6,7 @@ export default {
   key: "gmail-send-email",
   name: "Send Email",
   description: "Send an email from your Google Workspace email account",
-  version: "0.0.7",
+  version: "0.0.12",
   type: "action",
   props: {
     gmail,
@@ -100,7 +100,7 @@ export default {
         opts.references = inReplyTo;
         opts.threadId = repliedMessage.threadId;
       } catch (err) {
-        throw new Error(`\`${this.inReplyTo}\` is not a valid message ID!`);
+        opts.threadId = this.inReplyTo;
       }
     }
 

--- a/components/gmail/actions/send-email/send-email.mjs
+++ b/components/gmail/actions/send-email/send-email.mjs
@@ -6,7 +6,7 @@ export default {
   key: "gmail-send-email",
   name: "Send Email",
   description: "Send an email from your Google Workspace email account",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   props: {
     gmail,

--- a/components/gmail/actions/send-email/send-email.mjs
+++ b/components/gmail/actions/send-email/send-email.mjs
@@ -6,7 +6,7 @@ export default {
   key: "gmail-send-email",
   name: "Send Email",
   description: "Send an email from your Google Workspace email account",
-  version: "0.0.12",
+  version: "0.0.7",
   type: "action",
   props: {
     gmail,

--- a/components/gmail/actions/send-email/send-email.mjs
+++ b/components/gmail/actions/send-email/send-email.mjs
@@ -66,7 +66,7 @@ export default {
     inReplyTo: {
       type: "string",
       label: "In Reply To",
-      description: "Specify the `message-id` this email is replying to. To use this prop with `async options` please use `Gmail (Developer App)` `Send Email` component.",
+      description: "Add that it must be the `message-id` of the first message sent in the thread. To use this prop with `async options` please use `Gmail (Developer App)` `Send Email` component.",
       optional: true,
     },
   },

--- a/components/gmail/actions/send-email/send-email.mjs
+++ b/components/gmail/actions/send-email/send-email.mjs
@@ -66,7 +66,7 @@ export default {
     inReplyTo: {
       type: "string",
       label: "In Reply To",
-      description: "Specify the message-id this email is replying to. To use this prop with async options please use `Gmail(Developer App)` `Send Email` component.",
+      description: "Specify the `message-id` this email is replying to. To use this prop with `async options` please use `Gmail (Developer App)` `Send Email` component.",
       optional: true,
     },
   },

--- a/components/gmail/actions/send-email/send-email.mjs
+++ b/components/gmail/actions/send-email/send-email.mjs
@@ -66,7 +66,7 @@ export default {
     inReplyTo: {
       type: "string",
       label: "In Reply To",
-      description: "Add that it must be the `message-id` of the first message sent in the thread. To use this prop with `async options` please use `Gmail (Developer App)` `Send Email` component.",
+      description: "Specify the `message-id` this email is replying to. Must be from the first message sent in the thread. To use this prop with `async options` please use `Gmail (Developer App)` `Send Email` component.",
       optional: true,
     },
   },

--- a/components/gmail/actions/send-email/send-email.mjs
+++ b/components/gmail/actions/send-email/send-email.mjs
@@ -63,6 +63,18 @@ export default {
       description: "Add any attachments you'd like to include as objects. The `key` should be the **filename** and the `value` should be the **url** for the attachment. The **filename** must contain the file extension (i.e. `.jpeg`, `.txt`) and the **url** is the download link for the file.",
       optional: true,
     },
+    inReplyTo: {
+      type: "string",
+      label: "In Reply To",
+      description: "Specify the message-id this email is replying to.",
+      optional: true,
+    },
+    references: {
+      type: "string",
+      label: "References",
+      description: "Specify the list of message-id in the thread the email is replying to (space-separated string).",
+      optional: true,
+    },
   },
   async run({ $ }) {
     const {
@@ -79,6 +91,8 @@ export default {
       bcc: this.bcc,
       replyTo: this.replyTo,
       subject: this.subject,
+      inReplyTo: this.inReplyTo,
+      references: this.references,
     };
 
     if (this.attachments) {

--- a/components/gmail/gmail.app.mjs
+++ b/components/gmail/gmail.app.mjs
@@ -185,14 +185,22 @@ export default {
         .replace(/:\r\n/g, ":")
         .replace(/:\n/g, ":");
       const rawMessage = this.encodeMessage(messageFixed);
-      const response = await this._client().users.messages.send({
-        userId: constants.USER_ID,
-        requestBody: {
-          threadId: threadId,
-          raw: rawMessage,
-        },
-      });
-      return response.data;
+      try {
+        const response = await this._client().users.messages.send({
+          userId: constants.USER_ID,
+          requestBody: {
+            threadId: threadId,
+            raw: rawMessage,
+          },
+        });
+        return response.data;
+      } catch (err) {
+        if (err.code == 404) {
+          throw new Error("Unable to find email thread. `In Reply To` must be the `message-id` of the first message of the thread.");
+        } else {
+          throw err;
+        }
+      }
     },
     async addLabelToEmail({
       message, label,

--- a/components/gmail/gmail.app.mjs
+++ b/components/gmail/gmail.app.mjs
@@ -41,34 +41,6 @@ export default {
       },
     },
 
-    repliableMessageId: {
-      type: "string",
-      label: "In Reply To",
-      description: "Specify the message-id this email is replying to.",
-      optional: true,
-      async options({ prevContext }) {
-        const {
-          messages,
-          nextPageToken,
-        } = await this.listMessages({
-          pageToken: prevContext?.nextPageToken,
-        });
-
-        const options = await Promise.all(messages.map(async (message) => {
-          return await this.getMessageRepliableId({
-            id: message.id,
-          });
-        }));
-
-        return {
-          options,
-          context: {
-            nextPageToken,
-          },
-        };
-      },
-    },
-
     label: {
       type: "string",
       label: "Label",
@@ -162,10 +134,6 @@ export default {
         id,
       });
       const { value: subject } = message.payload.headers.find(({ name }) => name === "Subject");
-      console.log("message", message);
-      console.log("payload", message.payload);
-      console.log("headers", message.payload.headers);
-      console.log("---------------------------------");
       return subject;
     },
     async getMessages(ids = []) {
@@ -204,7 +172,6 @@ export default {
         .replace(/=+$/, "");
     },
     async sendEmail({ ...opts }) {
-      console.log("opts", opts);
       const {
         threadId,
         ...options

--- a/components/gmail/package.json
+++ b/components/gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/gmail",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Pipedream Gmail Components",
   "main": "gmail.app.mjs",
   "keywords": [

--- a/components/gmail_custom_oauth/actions/send-email/send-email.mjs
+++ b/components/gmail_custom_oauth/actions/send-email/send-email.mjs
@@ -10,5 +10,15 @@ overrideApp(base);
 export default {
   ...base,
   key: "gmail_custom_oauth-send-email",
-  version: "0.0.7",
+  version: "0.0.8",
+  props: {
+    ...base.props,
+    inReplyTo: {
+      propDefinition: [
+        base.props.gmail,
+        "message",
+      ],
+      description: "Specify the message-id this email is replying to.",
+    },
+  },
 };

--- a/components/gmail_custom_oauth/actions/send-email/send-email.mjs
+++ b/components/gmail_custom_oauth/actions/send-email/send-email.mjs
@@ -18,7 +18,9 @@ export default {
         base.props.gmail,
         "message",
       ],
-      description: "Specify the message-id this email is replying to.",
+      label: "In Reply To",
+      description: "Specify the `message-id` this email is replying to.",
+      optional: true,
     },
   },
 };

--- a/components/gmail_custom_oauth/package.json
+++ b/components/gmail_custom_oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/gmail_custom_oauth",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Pipedream Gmail (Consumer) Components",
   "main": "gmail_custom_oauth.app.mjs",
   "keywords": [


### PR DESCRIPTION
The "References" and "In-Reply-To" headers are necessary to keep an email answer in the same thread as the original email. 

Related documentation:
- Gmail API: https://developers.google.com/gmail/api/guides/sending#sending_messages
- RFC 2822 standard: https://www.rfc-editor.org/rfc/rfc2822#appendix-A.2
- Nodemailer Mailcomposer: https://nodemailer.com/extras/mailcomposer/#e-mail-message-fields