### PR TITLE
Google classroom update versions

### DIFF
--- a/components/google_classroom/actions/get-assignment/get-assignment.mjs
+++ b/components/google_classroom/actions/get-assignment/get-assignment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_classroom-get-assignment",
   name: "Get Assignment",
   description: "Retrieve information about an assignment. [See the docs here](https://developers.google.com/classroom/reference/rest/v1/courses.courseWork/get)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     googleClassroom,

--- a/components/google_classroom/package.json
+++ b/components/google_classroom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_classroom",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Google_classroom Components",
   "main": "google_classroom.app.mjs",
   "keywords": [

--- a/components/google_classroom/sources/assignment-done/assignment-done.mjs
+++ b/components/google_classroom/sources/assignment-done/assignment-done.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_classroom-assignment-done",
   name: "Assignment Done",
   description: "Emit new event when an assignment in a course is marked as done.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/google_classroom/sources/new-assignment/new-assignment.mjs
+++ b/components/google_classroom/sources/new-assignment/new-assignment.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_classroom-new-assignment",
   name: "New Assignment",
   description: "Emit new event when an assignment is added to a course.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_classroom/sources/new-due-date/new-due-date.mjs
+++ b/components/google_classroom/sources/new-due-date/new-due-date.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_classroom-new-due-date",
   name: "New Due Date",
   description: "Emit new event when an assignment's due date is created or updated'.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2845,14 +2845,6 @@ importers:
   components/teamdeck:
     specifiers: {}
 
-  components/teamgate:
-    specifiers:
-      '@pipedream/platform': ^0.10.0
-      moment: ^2.29.4
-    dependencies:
-      '@pipedream/platform': 0.10.0
-      moment: 2.29.4
-
   components/teamwork:
     specifiers:
       '@pipedream/platform': ^1.1.1


### PR DESCRIPTION
Updating Google Classroom component versions due to [previous PR](https://github.com/PipedreamHQ/pipedream/pull/4916) failing to publish.