### PR TITLE
Broken link fix on the documentation

### DIFF
--- a/docs/docs/README.md
+++ b/docs/docs/README.md
@@ -10,7 +10,7 @@ Pipedream is the fastest way to automate any process that connects APIs. Build a
 The Pipedream platform includes:
 
 - A [serverless runtime](/code/) and [workflow service](/workflows/)
-- Open source [triggers](/workflows/steps/triggers/) and [actions](/components#actions) for [hundreds of integrated apps](https://pipedream.com/explore/)
+- Open source [triggers](/workflows/steps/triggers/) and [actions](/workflows/steps/actions/) for [hundreds of integrated apps](https://pipedream.com/explore/)
 - One-click [OAuth and key-based authentication](/connected-accounts/) for more than 1000 APIs (use tokens directly in code or with pre-built actions)
 
 Watch a demo or review our [quickstart guide](/quickstart/):


### PR DESCRIPTION
The "actions" URL is broken here: https://pipedream.com/docs/

It redirects to: https://pipedream.com/components#actions. Which has no content.

But the "triggers" URL goes to: https://pipedream.com/docs/workflows/steps/triggers/

This URL should be valid for "actions": https://pipedream.com/docs/workflows/steps/actions/ 

The entire Component page is missing content, maybe there is more of this bug? https://pipedream.com/components