### PR TITLE
ShipEngine : Updated versions because previous publish didn't work

### DIFF
--- a/components/shipengine/actions/find-tracking-status/find-tracking-status.mjs
+++ b/components/shipengine/actions/find-tracking-status/find-tracking-status.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Find Tracking Status",
   description: "Retrieves package tracking information. [See the docs](https://shipengine.github.io/shipengine-openapi/#operation/get_tracking_log).",
   type: "action",
-  version: "0.0.1",
+  version: "0.0.2",
   props: {
     app,
     carrierCode: {

--- a/components/shipengine/actions/search-labels/search-labels.mjs
+++ b/components/shipengine/actions/search-labels/search-labels.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Search Labels",
   description: "By default, all labels are returned, 25 at a time, starting with the most recently created ones. You can combine multiple filter options to narrow-down the results. [See the docs](https://shipengine.github.io/shipengine-openapi/#operation/list_labels).",
   type: "action",
-  version: "0.0.1",
+  version: "0.0.2",
   props: {
     app,
     labelStatus: {

--- a/components/shipengine/actions/start-tracking-package/start-tracking-package.mjs
+++ b/components/shipengine/actions/start-tracking-package/start-tracking-package.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Start Tracking a Package",
   description: "Allows you to subscribe to tracking updates for a package. [See the docs](https://shipengine.github.io/shipengine-openapi/#operation/start_tracking).",
   type: "action",
-  version: "0.0.1",
+  version: "0.0.2",
   props: {
     app,
     carrierCode: {

--- a/components/shipengine/actions/validate-address/validate-address.mjs
+++ b/components/shipengine/actions/validate-address/validate-address.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Validate An Address",
   description: "Address validation ensures accurate addresses and can lead to reduced shipping costs by preventing address correction surcharges. [See the docs](https://shipengine.github.io/shipengine-openapi/#operation/validate_address).",
   type: "action",
-  version: "0.0.1",
+  version: "0.0.2",
   props: {
     app,
     name: {

--- a/components/shipengine/package.json
+++ b/components/shipengine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/shipengine",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Shipengine Components",
   "main": "shipengine.app.mjs",
   "keywords": [

--- a/components/shipengine/sources/new-tracking-event/new-tracking-event.mjs
+++ b/components/shipengine/sources/new-tracking-event/new-tracking-event.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Tracking Event (Instant)",
   description: "Emit new event when a new event is tracked. [See the docs](https://shipengine.github.io/shipengine-openapi/#operation/create_webhook).",
   type: "source",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/shipengine/sources/shipping-label-created/shipping-label-created.mjs
+++ b/components/shipengine/sources/shipping-label-created/shipping-label-created.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Shipping Label Created",
   description: "Emit new event when a new label is shipped. [See the docs](https://shipengine.github.io/shipengine-openapi/#operation/create_webhook).",
   type: "source",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
   methods: {
     ...common.methods,


### PR DESCRIPTION
due to errors in `pnpm-lock.yaml` file being outdated