### PR TITLE
Gmail send-email attachments

### DIFF
--- a/components/gmail/actions/send-email/send-email.mjs
+++ b/components/gmail/actions/send-email/send-email.mjs
@@ -73,7 +73,7 @@ export default {
     mimeType: {
       type: "string",
       label: "Mime Type",
-      description: "Mime Type of attachments",
+      description: "Mime Type of attachments. Setting the mime-type will override using the filename extension to determine attachment's content type.",
       optional: true,
       options() {
         return Object.values(mime._types);

--- a/components/gmail/actions/send-email/send-email.mjs
+++ b/components/gmail/actions/send-email/send-email.mjs
@@ -1,12 +1,13 @@
 /* eslint-disable pipedream/props-description */
 import gmail from "../../gmail.app.mjs";
 import constants from "../../common/constants.mjs";
+import mime from "mime";
 
 export default {
   key: "gmail-send-email",
   name: "Send Email",
   description: "Send an email from your Google Workspace email account",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   props: {
     gmail,
@@ -69,6 +70,15 @@ export default {
       description: "Specify the `message-id` this email is replying to. Must be from the first message sent in the thread. To use this prop with `async options` please use `Gmail (Developer App)` `Send Email` component.",
       optional: true,
     },
+    mimeType: {
+      type: "string",
+      label: "Mime Type",
+      description: "Mime Type of attachments",
+      optional: true,
+      options() {
+        return Object.values(mime._types);
+      },
+    },
   },
   async run({ $ }) {
     const {
@@ -109,10 +119,16 @@ export default {
         .map(([
           filename,
           path,
-        ]) => ({
-          filename,
-          path,
-        }));
+        ]) => {
+          const attachment = {
+            filename,
+            path,
+          };
+          if (this.mimeType) {
+            attachment.contentType = this.mimeType;
+          }
+          return attachment;
+        });
     }
 
     if (this.bodyType === constants.BODY_TYPES.HTML) {

--- a/components/gmail/package.json
+++ b/components/gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/gmail",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Pipedream Gmail Components",
   "main": "gmail.app.mjs",
   "keywords": [
@@ -17,6 +17,7 @@
     "@googleapis/gmail": "^0.3.4",
     "@pipedream/platform": "^1.1.1",
     "html-to-text": "^8.2.1",
+    "mime": "^3.0.0",
     "nodemailer": "^6.7.8"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1183,11 +1183,13 @@ importers:
       '@googleapis/gmail': ^0.3.4
       '@pipedream/platform': ^1.1.1
       html-to-text: ^8.2.1
+      mime: ^3.0.0
       nodemailer: ^6.7.8
     dependencies:
       '@googleapis/gmail': 0.3.4
       '@pipedream/platform': 1.1.1
       html-to-text: 8.2.1
+      mime: 3.0.0
       nodemailer: 6.7.8
 
   components/gmail_custom_oauth:
@@ -1461,6 +1463,9 @@ importers:
     dependencies:
       '@pipedream/platform': 1.2.0
       bottleneck: 2.19.5
+
+  components/hubspot_developer_app:
+    specifiers: {}
 
   components/humanitix:
     specifiers: {}
@@ -2288,6 +2293,9 @@ importers:
     dependencies:
       '@pipedream/platform': 1.2.0
       graphql-request: 5.0.0_graphql@16.5.0
+
+  components/pirate_weather:
+    specifiers: {}
 
   components/planning_center:
     specifiers: {}
@@ -18623,6 +18631,7 @@ packages:
   /mime/1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
     engines: {node: '>=4'}
+    hasBin: true
     dev: false
 
   /mime/2.6.0:


### PR DESCRIPTION
Resolves #5133 

To address the issue of not being able to parse attachments without filename extensions, I added a `mimeType` prop that will overwrite using the file extension to determine the attachment's content type.

@andrewjschuang I think the issue you were seeing with the file-examples.com files was because the links they provide are not actually direct links to the file. So what happens is that it tries to send the HTML page as a .docx file. If you use https://file-examples.com/storage/fea8fc38fd63bc5c39cf20b/2017/02/file-sample_100kB.docx as the URL instead of https://file-examples.com/wp-content/uploads/2017/02/file-sample_100kB.docx it should parse successfully.

<img width="1285" alt="Screen Shot 2023-01-11 at 10 39 35 AM" src="https://user-images.githubusercontent.com/10889229/211864820-b8a7f8ab-ce59-4fe0-a362-0726de3f1556.png">
