### PR TITLE
[Pipedream Platform Axios] Add more info to the axios error

### DIFF
--- a/platform/dist/axios.js
+++ b/platform/dist/axios.js
@@ -104,6 +104,7 @@ async function default_1(step, config, signConfig) {
     }
     catch (err) {
         if (err.response) {
+            convertAxiosError(err);
             stepExport(step, err.response, "debug");
         }
         throw err;
@@ -120,4 +121,10 @@ function stepExport(step, message, key) {
         step[key] = message;
     }
     console.log(`export: ${key} - ${JSON.stringify(message, null, 2)}`);
+}
+function convertAxiosError(err) {
+    delete err.response.request;
+    err.name = `${err.name} - ${err.message}`;
+    err.message = JSON.stringify(err.response.data);
+    return err;
 }

--- a/platform/lib/axios.ts
+++ b/platform/lib/axios.ts
@@ -107,6 +107,7 @@ export default async function (step: any, config: AxiosRequestConfig, signConfig
     return data;
   } catch (err) {
     if (err.response) {
+      convertAxiosError(err);
       stepExport(step, err.response, "debug");
     }
     throw err;
@@ -125,4 +126,11 @@ function stepExport(step: any, message: any, key: string) {
   }
 
   console.log(`export: ${key} - ${JSON.stringify(message, null, 2)}`);
+}
+
+function convertAxiosError(err) {
+  delete err.response.request;
+  err.name = `${err.name} - ${err.message}`;
+  err.message = JSON.stringify(err.response.data);
+  return err;
 }

--- a/platform/package-lock.json
+++ b/platform/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pipedream/platform",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pipedream/platform",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.2",

--- a/platform/package.json
+++ b/platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/platform",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Pipedream platform globals (typing and runtime type checking)",
   "homepage": "https://pipedream.com",
   "main": "dist/index.js",


### PR DESCRIPTION
Workaround in `@pipedream/platform axios` that changes from:

![image](https://user-images.githubusercontent.com/15385076/213758761-8bd8fa22-c5fe-4cb1-9ff8-939370638d95.png)
to:
![image](https://user-images.githubusercontent.com/15385076/213758394-b049b872-ccaa-43f1-bb3f-3f8e646620d6.png)

Resolves #5218.