### PR TITLE
Sheets action label typo

### DIFF
--- a/components/google_sheets/actions/update-cell/update-cell.mjs
+++ b/components/google_sheets/actions/update-cell/update-cell.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_sheets-update-cell",
   name: "Update Cell",
   description: "Update a cell in a spreadsheet",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   props: {
     googleSheets,

--- a/components/google_sheets/actions/update-cell/update-cell.mjs
+++ b/components/google_sheets/actions/update-cell/update-cell.mjs
@@ -46,6 +46,7 @@ export default {
         googleSheets,
         "cell",
       ],
+      label: "Cell Value",
       description: "The new cell value",
     },
   },

--- a/components/google_sheets/package.json
+++ b/components/google_sheets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_sheets",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "Pipedream Google_sheets Components",
   "main": "google_sheets.app.mjs",
   "keywords": [


### PR DESCRIPTION
fixed the label (currently shows "**Cell Number**" which is wrong)

<img width="200" alt="image" src="https://user-images.githubusercontent.com/35234925/219509109-9b9e6f60-9329-4f7d-a0b7-59e8b63b7b63.png">

should be merged with #5506 and #5509 for the package.json version