### PR TITLE
Adding tip about workspace CLI usage

### DIFF
--- a/docs/docs/cli/login/README.md
+++ b/docs/docs/cli/login/README.md
@@ -23,6 +23,14 @@ Once you're done, go back to your shell and you should see confirmation that you
 Logged in as dylburger (dylan@pipedream.com)
 ```
 
+::: warning
+
+If you are a member of a [workspace](/docs/workspaces/) then you'll also need to configure the `pd` CLI with your workspace ID.
+
+[Follow this guide](/cli/reference/#creating-a-profile-for-a-workspace) to learn how to find your workspace ID and associate it with a `pd` profile.
+
+:::
+
 ## Signing up for Pipedream via the CLI
 
 If you haven't signed up for a Pipedream account, you can create an account using the CLI:


### PR DESCRIPTION
Adds a small warning about PD accounts with workspaces when logging into the PD CLI.

We've already updated the CLI profile reference documentation to replace organization IDs with workspace IDs.

However the default `pd login` behavior is currently not compatible with workspaces by default, so adding a tip about this:

https://linear.app/pipedream/issue/DRE-212/[docs]-update-cli-docs-to-include-organization-id-argument