### PR TITLE
[BUG] DM Received Slack Trigger emits on every DM *sent* as well as received #5560

### DIFF
--- a/components/slack/package.json
+++ b/components/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/slack",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "description": "Pipedream Slack Components",
   "main": "slack.app.mjs",
   "keywords": [

--- a/components/slack/sources/new-direct-message/new-direct-message.mjs
+++ b/components/slack/sources/new-direct-message/new-direct-message.mjs
@@ -4,7 +4,7 @@ export default {
   ...common,
   key: "slack-new-direct-message",
   name: "New Direct Message (Instant)",
-  version: "1.0.6",
+  version: "1.0.7",
   description: "Emit new event when a message was posted in a direct message channel",
   type: "source",
   dedupe: "unique",

--- a/components/slack/sources/new-direct-message/new-direct-message.mjs
+++ b/components/slack/sources/new-direct-message/new-direct-message.mjs
@@ -20,12 +20,6 @@ export default {
         ];
       },
     },
-    ignoreMyself: {
-      propDefinition: [
-        common.props.slack,
-        "ignoreMyself",
-      ],
-    },
     ignoreBot: {
       propDefinition: [
         common.props.slack,
@@ -39,7 +33,7 @@ export default {
       return "New direct message received";
     },
     processEvent(event) {
-      if (this.ignoreMyself && event.user == this.slack.mySlackId()) {
+      if (event.user == this.slack.mySlackId()) {
         return;
       }
       if ((this.ignoreBot) && (event.subtype == "bot_message" || event.bot_id)) {


### PR DESCRIPTION
Is working as expect on tests, so I think the problem is with the version in production.
I just will increase the version to publish again to production.

Cc: @dannyroosevelt 