### PR TITLE
fix(crove_app): allow to pass custom name to generate pdf from templa…

### DIFF
--- a/components/crove_app/actions/complete-document/complete-document.mjs
+++ b/components/crove_app/actions/complete-document/complete-document.mjs
@@ -4,7 +4,7 @@ export default {
   key: "crove_app-complete-document",
   name: "Complete Document",
   description: "Mark the document as completed",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     croveApp,

--- a/components/crove_app/actions/create-document/create-document.mjs
+++ b/components/crove_app/actions/create-document/create-document.mjs
@@ -4,7 +4,7 @@ export default {
   key: "crove_app-create-document",
   name: "Create Document",
   description: "Create a new document.",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     croveApp,

--- a/components/crove_app/actions/create-invitation-link/create-invitation-link.mjs
+++ b/components/crove_app/actions/create-invitation-link/create-invitation-link.mjs
@@ -4,7 +4,7 @@ export default {
   key: "crove_app-create-invitation-link",
   name: "Create Invitation Link",
   description: "Create invitation link to fill or sign the document. ",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     croveApp,

--- a/components/crove_app/actions/generate-pdf-from-document/generate-pdf-from-document.mjs
+++ b/components/crove_app/actions/generate-pdf-from-document/generate-pdf-from-document.mjs
@@ -4,7 +4,7 @@ export default {
   key: "crove_app-generate-pdf-from-document",
   name: "Generate PDF from Document",
   description: "Generate PDF of a document and return PDF URL.",
-  version: "0.0.4",
+  version: "0.0.3",
   type: "action",
   props: {
     croveApp,

--- a/components/crove_app/actions/generate-pdf-from-document/generate-pdf-from-document.mjs
+++ b/components/crove_app/actions/generate-pdf-from-document/generate-pdf-from-document.mjs
@@ -4,7 +4,7 @@ export default {
   key: "crove_app-generate-pdf-from-document",
   name: "Generate PDF from Document",
   description: "Generate PDF of a document and return PDF URL.",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   props: {
     croveApp,

--- a/components/crove_app/actions/generate-template-pdf/generate-template-pdf.mjs
+++ b/components/crove_app/actions/generate-template-pdf/generate-template-pdf.mjs
@@ -4,7 +4,7 @@ export default {
   key: "crove_app-generate-template-pdf",
   name: "Generate Document PDF From Template",
   description: "Generate PDF of a document created from the template",
-  version: "1.0.2",
+  version: "1.0.3",
   type: "action",
   props: {
     croveApp,

--- a/components/crove_app/actions/generate-template-pdf/generate-template-pdf.mjs
+++ b/components/crove_app/actions/generate-template-pdf/generate-template-pdf.mjs
@@ -4,7 +4,7 @@ export default {
   key: "crove_app-generate-template-pdf",
   name: "Generate Document PDF From Template",
   description: "Generate PDF of a document created from the template",
-  version: "1.0.1",
+  version: "1.0.2",
   type: "action",
   props: {
     croveApp,

--- a/components/crove_app/actions/generate-template-pdf/generate-template-pdf.mjs
+++ b/components/crove_app/actions/generate-template-pdf/generate-template-pdf.mjs
@@ -15,6 +15,12 @@ export default {
       ],
       reloadProps: true,
     },
+    name: {
+      type: "string",
+      label: "Document Name",
+      description: "Name of the document.",
+      optional: true,
+    },
     background_mode: {
       type: "boolean",
       label: "Background Mode",
@@ -47,6 +53,7 @@ export default {
 
     return await this.croveApp.generatePdfFromTemplate(
       this.template_id,
+      this.name,
       response,
       this.background_mode,
     );

--- a/components/crove_app/actions/get-document-details/get-document-details.mjs
+++ b/components/crove_app/actions/get-document-details/get-document-details.mjs
@@ -4,7 +4,7 @@ export default {
   key: "crove_app-get-document-details",
   name: "Get Document Details",
   description: "Get details of a document. Example: Name, Current Status, etc.",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     croveApp,

--- a/components/crove_app/actions/send-document/send-document.mjs
+++ b/components/crove_app/actions/send-document/send-document.mjs
@@ -4,7 +4,7 @@ export default {
   key: "crove_app-send-document",
   name: "Send Document",
   description: "Send email invitation link to fill & sign the document.  ",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     croveApp,

--- a/components/crove_app/actions/submit-document/submit-document.mjs
+++ b/components/crove_app/actions/submit-document/submit-document.mjs
@@ -4,7 +4,7 @@ export default {
   key: "crove_app-submit-document",
   name: "Submit Document",
   description: "Submit the document like you do it via Crove form.",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     croveApp,

--- a/components/crove_app/actions/update-document-details/update-document-details.mjs
+++ b/components/crove_app/actions/update-document-details/update-document-details.mjs
@@ -4,7 +4,7 @@ export default {
   key: "crove_app-update-document-details",
   name: "Update Document Details",
   description: "Update details of a document. Example: Name, Current Status, etc.",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     croveApp,

--- a/components/crove_app/actions/update-document/update-document.mjs
+++ b/components/crove_app/actions/update-document/update-document.mjs
@@ -4,7 +4,7 @@ export default {
   key: "crove_app-update-document",
   name: "Update Document",
   description: "Update values of variables of a document.",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     croveApp,

--- a/components/crove_app/crove_app.app.mjs
+++ b/components/crove_app/crove_app.app.mjs
@@ -68,12 +68,13 @@ export default {
       };
       return await this._makeRequest(config);
     },
-    async generatePdfFromTemplate(templateId, response, backgroundMode) {
+    async generatePdfFromTemplate(templateId, name, response, backgroundMode) {
       var config = {
         url: `${this._getBaseUrl()}/helpers/generate-pdf-from-template/`,
         method: "POST",
         data: {
           template_id: templateId,
+          name: name,
           response: response,
           background_mode: backgroundMode,
         },

--- a/components/crove_app/package.json
+++ b/components/crove_app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/crove_app",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Pipedream Crove Components",
   "main": "crove_app.app.js",
   "keywords": [

--- a/components/crove_app/sources/document-completed/document-completed.mjs
+++ b/components/crove_app/sources/document-completed/document-completed.mjs
@@ -5,7 +5,7 @@ export default {
   key: "crove_app-document-completed",
   name: "Document Completed",
   description: "Triggers when a document is completed.",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "source",
   methods: {
     ...common.methods,

--- a/components/crove_app/sources/document-created/document-created.mjs
+++ b/components/crove_app/sources/document-created/document-created.mjs
@@ -5,7 +5,7 @@ export default {
   key: "crove_app-document-created",
   name: "Document Created",
   description: "Triggers when a new document is created.",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "source",
   methods: {
     ...common.methods,

--- a/components/crove_app/sources/document-submitted/document-submitted.mjs
+++ b/components/crove_app/sources/document-submitted/document-submitted.mjs
@@ -5,7 +5,7 @@ export default {
   key: "crove_app-document-submitted",
   name: "Document Submitted",
   description: "Triggers when a document is submitted.",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "source",
   methods: {
     ...common.methods,


### PR DESCRIPTION
## Update the existing generate pdf from template action to pass custom document name.

### Changes with this update
- We are allowing users to pass custom name for the document generated using this action.

documentation for api https://crove.stoplight.io/docs/crove-external-integrations-api/9d66126c64e05-return-a-pdf-of-document-generated-using-a-template-background-mode-supported