### PR TITLE
feat[asana]: ability to emit events only for some fields

### DIFF
--- a/components/asana/asana.app.mjs
+++ b/components/asana/asana.app.mjs
@@ -134,10 +134,7 @@ export default {
         }
         const task = await this.getTask(tasks[0].gid);
 
-        return Object.keys(task).map((key) => ({
-          label: key,
-          value: key,
-        }));
+        return Object.keys(task);
       },
     },
   },

--- a/components/asana/asana.app.mjs
+++ b/components/asana/asana.app.mjs
@@ -117,6 +117,29 @@ export default {
         });
       },
     },
+    taskFields: {
+      label: "Task Fields",
+      description: "List of task fields that will emit events when updated. This field uses the field code.",
+      type: "string[]",
+      async options({ project }) {
+        const tasks = await this.getTasks({
+          params: {
+            project,
+            limit: 1,
+          },
+        });
+
+        if (!tasks || tasks.length === 0) {
+          return [];
+        }
+        const task = await this.getTask(tasks[0].gid);
+
+        return Object.keys(task).map((key) => ({
+          label: key,
+          value: key,
+        }));
+      },
+    },
   },
   methods: {
     /**

--- a/components/asana/sources/task-field-updated-in-project/task-field-updated-in-project.mjs
+++ b/components/asana/sources/task-field-updated-in-project/task-field-updated-in-project.mjs
@@ -7,7 +7,7 @@ export default {
   type: "source",
   name: "Task Field Updated In Project (Instant)",
   description: "Emit a new event whenever a given task field is updated.",
-  version: "1.0.0",
+  version: "0.0.1",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/asana/sources/task-field-updated-in-project/task-field-updated-in-project.mjs
+++ b/components/asana/sources/task-field-updated-in-project/task-field-updated-in-project.mjs
@@ -1,0 +1,74 @@
+import common from "../common/common.mjs";
+const { asana } = common.props;
+
+export default {
+  ...common,
+  key: "asana-task-field-updated-in-project",
+  type: "source",
+  name: "Task Field Updated In Project (Instant)",
+  description: "Emit a new event whenever a given task field is updated.",
+  version: "1.0.0",
+  dedupe: "unique",
+  props: {
+    ...common.props,
+    project: {
+      label: "Project",
+      description: "Gid of a project.",
+      type: "string",
+      propDefinition: [
+        asana,
+        "projects",
+        (c) => ({
+          workspace: c.workspace,
+        }),
+      ],
+    },
+    taskFields: {
+      propDefinition: [
+        asana,
+        "taskFields",
+        (c) => ({
+          project: c.project,
+        }),
+      ],
+    },
+  },
+  methods: {
+    ...common.methods,
+    getWebhookFilter() {
+      console.log("Using filters: " + this.taskFields);
+      return {
+        filters: [
+          {
+            action: "changed",
+            resource_type: "task",
+            fields: this.taskFields,
+          },
+        ],
+        resource: this.project,
+      };
+    },
+    async emitEvent(event) {
+      const { events = [] } = event.body || {};
+
+      const promises = events
+        .map(async (event) => ({
+          event,
+          task: await this.asana.getTask(event.resource.gid),
+        }));
+
+      const responses = await Promise.all(promises);
+
+      responses.forEach(({
+        event, task,
+      }) => {
+        const ts = Date.parse(event.created_at);
+        this.$emit(task, {
+          id: `${task.gid}-${ts}`,
+          summary: task.name,
+          ts,
+        });
+      });
+    },
+  },
+};

--- a/components/asana/sources/task-field-updated-in-project/task-field-updated-in-project.mjs
+++ b/components/asana/sources/task-field-updated-in-project/task-field-updated-in-project.mjs
@@ -36,7 +36,6 @@ export default {
   methods: {
     ...common.methods,
     getWebhookFilter() {
-      console.log("Using filters: " + this.taskFields);
       return {
         filters: [
           {


### PR DESCRIPTION
NOTES: only standard fields are supported right now (no custom fields). Standard fields are retrieved from the first task available in the project.