### PR TITLE
[GitHub Actions] Fail step if any error in publishing

### DIFF
--- a/.github/workflows/publish-components.yaml
+++ b/.github/workflows/publish-components.yaml
@@ -99,6 +99,9 @@ jobs:
           fi
           # curl with form
           curl -X POST -d "type=javascript" --data-urlencode event@$GITHUB_EVENT_PATH -d "github=$(printenv | grep "GITHUB_*")" -d "skipped=${SKIPPED}" -d "errors=${ERRORS}" -d "unpublished=${UNPUBLISHED}" -d "published=${PUBLISHED}" $ENDPOINT
+          if [ ${#ERRORS[@]} -ne 0 ]; then
+            exit 1
+          fi
       - name: Remove pd cli config
         run: |
           rm $HOME/.config/pipedream/config
@@ -231,6 +234,9 @@ jobs:
           fi
           # curl with form
           curl -X POST -d "type=typescript" --data-urlencode event@$GITHUB_EVENT_PATH -d "github=$(printenv | grep "GITHUB_*")" -d "skipped=${SKIPPED}" -d "errors=${ERRORS}" -d "unpublished=${UNPUBLISHED}" -d "published=${PUBLISHED}" $ENDPOINT
+          if [ ${#ERRORS[@]} -ne 0 ]; then
+            exit 1
+          fi
           unset IFS
       - name: Remove pd cli config
         run: |


### PR DESCRIPTION
Currently, the action step doesn't fail when there is an error when attempting to publish a component to the Pipedream registry. This PR enables the developer to be better notified of possible errors so they can fix them ASAP.