### PR TITLE
Wise: fix Profile prop names on business accounts

### DIFF
--- a/components/wise/actions/create-transfer/create-transfer.mjs
+++ b/components/wise/actions/create-transfer/create-transfer.mjs
@@ -2,7 +2,7 @@ import wise from "../../wise.app.mjs";
 
 export default {
   name: "Create Transfer",
-  version: "0.0.2",
+  version: "0.0.3",
   key: "wise-create-transfer",
   description: "Creates a transfer. [See docs here](https://api-docs.wise.com/api-reference/transfer#create)",
   type: "action",

--- a/components/wise/actions/fund-transfer/fund-transfer.mjs
+++ b/components/wise/actions/fund-transfer/fund-transfer.mjs
@@ -2,7 +2,7 @@ import wise from "../../wise.app.mjs";
 
 export default {
   name: "Fund Transfer",
-  version: "0.0.1",
+  version: "0.0.2",
   key: "wise-fund-transfer",
   description: "Funds a transfer. [See docs here](https://api-docs.transferwise.com/api-reference/transfer#fund)",
   type: "action",

--- a/components/wise/actions/get-balance/get-balance.mjs
+++ b/components/wise/actions/get-balance/get-balance.mjs
@@ -2,7 +2,7 @@ import wise from "../../wise.app.mjs";
 
 export default {
   name: "Get Balance",
-  version: "0.0.1",
+  version: "0.0.2",
   key: "wise-get-balance",
   description: "Get a balance. [See docs here](https://api-docs.wise.com/api-reference/balance#get)",
   type: "action",

--- a/components/wise/actions/get-exchange-rates/get-exchange-rates.mjs
+++ b/components/wise/actions/get-exchange-rates/get-exchange-rates.mjs
@@ -2,7 +2,7 @@ import wise from "../../wise.app.mjs";
 
 export default {
   name: "Get Exchange Rates",
-  version: "0.0.2",
+  version: "0.0.3",
   key: "wise-get-exchange-rates",
   description: "Get an exchange rates. [See docs here](https://api-docs.wise.com/api-reference/rate#get)",
   type: "action",

--- a/components/wise/actions/get-transfer/get-transfer.mjs
+++ b/components/wise/actions/get-transfer/get-transfer.mjs
@@ -2,7 +2,7 @@ import wise from "../../wise.app.mjs";
 
 export default {
   name: "Get Transfer",
-  version: "0.0.2",
+  version: "0.0.3",
   key: "wise-get-transfer",
   description: "Get a transfer. [See docs here](https://api-docs.wise.com/api-reference/transfer#get-by-id)",
   type: "action",

--- a/components/wise/package.json
+++ b/components/wise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/wise",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Pipedream Wise Components",
   "main": "wise.app.mjs",
   "keywords": [

--- a/components/wise/sources/new-transfer-completed/new-transfer-completed.mjs
+++ b/components/wise/sources/new-transfer-completed/new-transfer-completed.mjs
@@ -3,7 +3,7 @@ import common from "../common/common.mjs";
 export default {
   ...common,
   name: "New Transfer Completed (Instant)",
-  version: "0.0.2",
+  version: "0.0.3",
   key: "wise-new-transfer-completed",
   description: "Emit new event for a transfer completed.",
   type: "source",

--- a/components/wise/sources/new-transfer-created/new-transfer-created.mjs
+++ b/components/wise/sources/new-transfer-created/new-transfer-created.mjs
@@ -3,7 +3,7 @@ import common from "../common/common.mjs";
 export default {
   ...common,
   name: "New Transfer Created (Instant)",
-  version: "0.0.2",
+  version: "0.0.3",
   key: "wise-new-transfer-created",
   description: "Emit new event for a transfer created.",
   type: "source",

--- a/components/wise/sources/new-transfer-state-changed/new-transfer-state-changed.mjs
+++ b/components/wise/sources/new-transfer-state-changed/new-transfer-state-changed.mjs
@@ -3,7 +3,7 @@ import common from "../common/common.mjs";
 export default {
   ...common,
   name: "New Transfer State Changed (Instant)",
-  version: "0.0.2",
+  version: "0.0.3",
   key: "wise-new-transfer-state-changed",
   description: "Emit new event for a transfer created.",
   type: "source",

--- a/components/wise/wise.app.mjs
+++ b/components/wise/wise.app.mjs
@@ -42,7 +42,7 @@ export default {
         const profiles = await this.getProfiles();
 
         return profiles.map((profile) => ({
-          label: profile.details.firstName + " " + profile.details.lastName,
+          label: profile.type == 'personal' ? `${profile.details.firstName} ${profile.details.lastName}` : `${profile.details.name}`,
           value: profile.id,
         }));
       },


### PR DESCRIPTION
currently it displays business accounts profiles as `undefined undefined`

![image](https://user-images.githubusercontent.com/35234925/225150560-c6d0e7bd-30df-4b02-a47f-b5a91a3150f8.png)

Personal accounts are structured like this
<img width="212" alt="image" src="https://user-images.githubusercontent.com/35234925/225152350-c94add54-dd1b-484a-b112-afa37d053d71.png">

Business accounts are structured like this
<img width="204" alt="image" src="https://user-images.githubusercontent.com/35234925/225152551-c6d565ae-ca54-4a61-9437-98c1864950c6.png">

