### PR TITLE
[AWS S3] Bump action version

### DIFF
--- a/components/aws/actions/s3-stream-file/s3-stream-file.mjs
+++ b/components/aws/actions/s3-stream-file/s3-stream-file.mjs
@@ -10,7 +10,7 @@ export default {
     Accepts a file URL, and streams the file to the provided S3 bucket/key.
     [See the docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/upload-objects.html)
   `),
-  version: "0.4.0",
+  version: "0.4.1",
   type: "action",
   props: {
     aws: common.props.aws,

--- a/components/aws/package.json
+++ b/components/aws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/aws",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Pipedream Aws Components",
   "main": "aws.app.js",
   "keywords": [


### PR DESCRIPTION
Updating to AWS S3 Client version [3.292.0](https://www.npmjs.com/package/@aws-sdk/client-s3/v/3.292.0).

[Context](https://pipedream-users.slack.com/archives/CPTJYRY5A/p1678882802368399).