### PR TITLE
AWS - Update to New SNS Messages Source

### DIFF
--- a/components/aws/package.json
+++ b/components/aws/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/aws",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Pipedream Aws Components",
-  "main": "aws.app.js",
+  "main": "aws.app.mjs",
   "keywords": [
     "pipedream",
     "aws"

--- a/components/aws/sources/common/sns.mjs
+++ b/components/aws/sources/common/sns.mjs
@@ -14,20 +14,21 @@ export default {
     region: common.props.region,
   },
   hooks: {
-    async activate() {
-      const topicName = this.getTopicName();
-      const topicArn = await this._createTopic(topicName);
+    async deploy() {
+      let topicArn = this.topicArn;
+      if (!this.topicArn) {
+        const topicName = this.getTopicName();
+        topicArn = await this._createTopic(topicName);
+      }
       this._setTopicArn(topicArn);
-
+    },
+    async activate() {
+      const topicArn = this.getTopicArn();
       await this._subscribeToTopic(topicArn);
     },
     async deactivate() {
       const subscriptionArn = this._getSubscriptionArn();
       await this._unsubscribeFromTopic(subscriptionArn);
-
-      const topicArn = this.getTopicArn();
-      await this._deleteTopic(topicArn);
-      this._setTopicArn(null);
     },
   },
   methods: {

--- a/components/aws/sources/new-emails-sent-to-ses-catch-all-domain/new-emails-sent-to-ses-catch-all-domain.mjs
+++ b/components/aws/sources/new-emails-sent-to-ses-catch-all-domain/new-emails-sent-to-ses-catch-all-domain.mjs
@@ -16,7 +16,7 @@ export default {
     These events can trigger a Pipedream workflow and can be consumed via SSE or REST API.
   `),
   type: "source",
-  version: "1.2.0",
+  version: "1.2.1",
   props: {
     ...base.props,
     domain: {

--- a/components/aws/sources/new-scheduled-tasks/new-scheduled-tasks.mjs
+++ b/components/aws/sources/new-scheduled-tasks/new-scheduled-tasks.mjs
@@ -10,7 +10,7 @@ export default {
     to an SNS topic at a specific timestamp. The SNS topic delivers
     the message to this Pipedream source, and the source emits it as a new event.
   `),
-  version: "0.4.0",
+  version: "0.4.1",
   type: "source",
   dedupe: "unique", // Dedupe on SNS message ID
   methods: {

--- a/components/aws/sources/new-sns-messages/new-sns-messages.mjs
+++ b/components/aws/sources/new-sns-messages/new-sns-messages.mjs
@@ -1,5 +1,7 @@
 import base from "../common/sns.mjs";
 import { toSingleLineString } from "../../common/utils.mjs";
+import commonSNS from "../../common/common-sns.mjs";
+import { ConfigurationError } from "@pipedream/platform";
 
 export default {
   ...base,
@@ -9,11 +11,15 @@ export default {
     Creates an SNS topic in your AWS account.
     Messages published to this topic are emitted from the Pipedream source.
   `),
-  version: "0.4.0",
+  version: "0.4.1",
   type: "source",
   dedupe: "unique", // Dedupe on SNS message ID
   props: {
     ...base.props,
+    topicArn: {
+      ...commonSNS.props.topic,
+      optional: true,
+    },
     topic: {
       label: "SNS Topic Name",
       description: toSingleLineString(`
@@ -22,6 +28,7 @@ export default {
         name](https://docs.aws.amazon.com/sns/latest/api/API_CreateTopic.html).
       `),
       type: "string",
+      optional: true,
     },
   },
   methods: {
@@ -29,5 +36,19 @@ export default {
     getTopicName() {
       return this.convertNameToValidSNSTopicName(this.topic);
     },
+  },
+  async run(event) {
+    if (!this.topicArn && !this.topic) {
+      throw new ConfigurationError("Must specify either an existing topic or a new topic name");
+    }
+
+    if (this._isSubscriptionConfirmationEvent(event)) {
+      const { body } = event;
+      const subscriptionArn = await this._confirmSubscription(body);
+      this._setSubscriptionArn(subscriptionArn);
+      return;
+    }
+
+    await this.processEvent(event);
   },
 };

--- a/components/aws/sources/s3-deleted-file/s3-deleted-file.mjs
+++ b/components/aws/sources/s3-deleted-file/s3-deleted-file.mjs
@@ -6,7 +6,7 @@ export default {
   key: "aws-s3-deleted-file",
   name: "New Deleted S3 File",
   description: "Emit new event when a file is deleted from a S3 bucket",
-  version: "0.1.0",
+  version: "0.1.1",
   dedupe: "unique",
   props: {
     ...base.props,

--- a/components/aws/sources/s3-new-event/s3-new-event.mjs
+++ b/components/aws/sources/s3-new-event/s3-new-event.mjs
@@ -6,7 +6,7 @@ export default {
   key: "aws-s3-new-event",
   name: "New S3 Event",
   description: "Emit new S3 events for a given bucket",
-  version: "0.1.0",
+  version: "0.1.1",
   dedupe: "unique",
   props: {
     ...base.props,

--- a/components/aws/sources/s3-new-file/s3-new-file.mjs
+++ b/components/aws/sources/s3-new-file/s3-new-file.mjs
@@ -6,7 +6,7 @@ export default {
   key: "aws-s3-new-file",
   name: "New S3 File",
   description: "Emit new event when a file is added to an S3 bucket",
-  version: "0.1.0",
+  version: "0.1.1",
   dedupe: "unique",
   methods: {
     ...base.methods,

--- a/components/aws/sources/s3-restored-file/s3-restored-file.mjs
+++ b/components/aws/sources/s3-restored-file/s3-restored-file.mjs
@@ -6,7 +6,7 @@ export default {
   key: "aws-s3-restored-file",
   name: "New Restored S3 File",
   description: "Emit new event when an file is restored into a S3 bucket",
-  version: "0.1.0",
+  version: "0.1.1",
   dedupe: "unique",
   props: {
     ...base.props,


### PR DESCRIPTION
AWS Source New SNS Messages will no longer delete the SNS topic in the `deactivate` hook. It will create the topic in the `deploy` hook and subscribe/unsubscribe to it in the `activate` & `deactivate` hooks. 

Additionally, the user now has the option of entering a preexisting SNS topic to use instead of creating a new one.

Resolves #5764 