### PR TITLE
feat: add reply_broadcast parameter to Slack's reply-to-a-message

### DIFF
--- a/components/slack/actions/reply-to-a-message/reply-to-a-message.mjs
+++ b/components/slack/actions/reply-to-a-message/reply-to-a-message.mjs
@@ -6,7 +6,7 @@ export default {
   key: "slack-reply-to-a-message",
   name: "Reply to a Message Thread",
   description: "Send a message as a threaded reply. See [postMessage](https://api.slack.com/methods/chat.postMessage) or [scheduleMessage](https://api.slack.com/methods/chat.scheduleMessage) docs here",
-  version: "0.1.13",
+  version: "0.1.14",
   type: "action",
   props: {
     ...common.props,
@@ -16,6 +16,12 @@ export default {
         "thread_ts",
       ],
       optional: false,
+    },
+    reply_broadcast: {
+      propDefinition: [
+        slack,
+        "reply_broadcast",
+      ],
     },
     conversation: {
       propDefinition: [

--- a/components/slack/package.json
+++ b/components/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/slack",
-  "version": "0.4.21",
+  "version": "0.4.22",
   "description": "Pipedream Slack Components",
   "main": "slack.app.mjs",
   "keywords": [


### PR DESCRIPTION
"Reply broadcast" was already exposed for various components, but not `reply-to-a-message`, where it's quite important.

Should close #5903 