### PR TITLE
[Sources] ProWorkFlow: Company Created

### DIFF
--- a/components/proworkflow/package.json
+++ b/components/proworkflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/proworkflow",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Proworkflow Components",
   "main": "proworkflow.app.mjs",
   "keywords": [

--- a/components/proworkflow/sources/new-company-created/new-company-created.mjs
+++ b/components/proworkflow/sources/new-company-created/new-company-created.mjs
@@ -10,7 +10,6 @@ export default {
   type: "source",
   version: "0.0.1",
   dedupe: "unique",
-  type: "source",
   methods: {
     ...common.methods,
     getEventName() {

--- a/components/proworkflow/sources/new-company-created/new-company-created.mjs
+++ b/components/proworkflow/sources/new-company-created/new-company-created.mjs
@@ -1,0 +1,51 @@
+import common from "../common/webhook.mjs";
+import constants from "../../common/constants.mjs";
+
+export default {
+  ...common,
+  name: "New Company Created",
+  key: "proworkflow-new-company-created",
+  description:
+    "Emit new event when a new comapny is created. [See the docs](https://api.proworkflow.net/?documentation#introductionoverview).",
+  type: "source",
+  version: "0.0.1",
+  dedupe: "unique",
+  type: "source",
+  methods: {
+    ...common.methods,
+    getEventName() {
+      return constants.EVENT_NAME.NEWCOMPANY;
+    },
+    generateMeta(event) {
+      return {
+        id: event.id,
+        summary: `New Company: ${event.company.id}`,
+        ts: Date.parse(event.company.lastmodified),
+      };
+    },
+  },
+};
+
+// export default {
+//   ...common,
+//   key: "proworkflow-new-project-created",
+//   name: "New Project Created",
+//   description:
+//     "Emit new event when a new project is created. [See the docs](https://api.proworkflow.net/?documentation#gettingstartedgetfields).",
+//   type: "source",
+//   version: "0.0.1",
+//   dedupe: "unique",
+//   methods: {
+//     ...common.methods,
+//     getEventName() {
+//       return constants.EVENT_NAME.NEWPROJECT;
+//     },
+//     generateMeta(event) {
+//       return {
+//         id: event.id,
+//         summary: `New Project: ${event.project.id}`,
+//         ts: Date.parse(event.project.lastmodified),
+//       };
+//     },
+//   },
+// };

--- a/components/proworkflow/sources/new-company-created/new-company-created.mjs
+++ b/components/proworkflow/sources/new-company-created/new-company-created.mjs
@@ -25,27 +25,3 @@ export default {
     },
   },
 };
-
-// export default {
-//   ...common,
-//   key: "proworkflow-new-project-created",
-//   name: "New Project Created",
-//   description:
-//     "Emit new event when a new project is created. [See the docs](https://api.proworkflow.net/?documentation#gettingstartedgetfields).",
-//   type: "source",
-//   version: "0.0.1",
-//   dedupe: "unique",
-//   methods: {
-//     ...common.methods,
-//     getEventName() {
-//       return constants.EVENT_NAME.NEWPROJECT;
-//     },
-//     generateMeta(event) {
-//       return {
-//         id: event.id,
-//         summary: `New Project: ${event.project.id}`,
-//         ts: Date.parse(event.project.lastmodified),
-//       };
-//     },
-//   },
-// };


### PR DESCRIPTION
closes (#5935)

Implemented Sources - 
ProWorkFlow source when a new company is created.

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c75408d</samp>

Added a new source component `new-company-created` for Pipedream that emits an event when a new company is created in ProWorkflow. Commented out the previous code for a similar component `new-project-created`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c75408d</samp>

> _New source component_
> _`emit` when company made_
> _Autumn of projects_



## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c75408d</samp>

*  Add a new source component for Pipedream that emits an event when a new company is created in ProWorkflow ([link](https://github.com/PipedreamHQ/pipedream/pull/5963/files?diff=unified&w=0#diff-13bfb55dbce72cf654862da26273f71784634870c68eadfa8ab2f9c71c661989R1-R51))
