### PR TITLE
English Style Guide prompt

### DIFF
--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/prompts",
-  "version": "0.0.17",
+  "version": "0.1.0",
   "description": "Pipedream LLM prompts",
   "type": "module",
   "exports": "./dist/index.js",

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -654,11 +654,16 @@ Below, I'm passing data as a CSV of the following format:
 
 ## Output format
 
-You MUST output your results as a CSV of the following format:
+You MUST ONLY output your results as a CSV of the following format:
 
 - \`key\`: A string, a composite key of the following format: \`<file path>:<line number>\` found in the \`key\` field of the input CSV text provided.
 - \`corrected_code_or_text\`: A string, the corrected found at the \`key\` location, with all English corrected according to the rules of the style guide.
 - \`reason\`: A string, the rule you applied to the English found at the \`key\` location. Explain why you made the change you did. If multiple rules / issues are found, list them all.
 
 You MUST only include lines in the output where you've corrected English. If you don't correct any English on a line, you MUST NOT include the line in the output.
+
+Do not include any other English text before or after the CSV. ONLY return the CSV.
+
+## Input Data:
+
 `

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -662,7 +662,7 @@ You must only output your results as a CSV of the following format:
 
 You MUST only include lines in the output where you've corrected English. If you don't correct any English on a line, you MUST NOT include the line in the output.
 
-Do not include any other English text before or after the CSV. ONLY return the CSV.
+Do not include any other English text before or after the CSV. Only return the CSV.
 
 ## Input Data:
 

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -654,7 +654,7 @@ Below, I'm passing data as a CSV of the following format:
 
 ## Output format
 
-You MUST ONLY output your results as a CSV of the following format:
+You must only output your results as a CSV of the following format:
 
 - \`key\`: A string, a composite key of the following format: \`<file path>:<line number>\` found in the \`key\` field of the input CSV text provided.
 - \`corrected_code_or_text\`: A string, the corrected found at the \`key\` location, with all English corrected according to the rules of the style guide.

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -643,7 +643,7 @@ You might see English in places like the following (this is not an exhaustive li
 - HTML attributes, like img alt tags
 - etc.
 
-Please apply the rules of the style guide to ANY English you find.
+Apply the rules of the style guides to any English you find.
 
 ## Input format
 

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -624,3 +624,45 @@ Only return Node.js code. DO NOT include any English text before or after the No
 
 `;
 };
+
+export const englishStyleGuidePrompt = `# English Style Guide
+
+## Instructions
+
+Your goal is to apply all of the following rules to any English you detect in the provided code.
+
+You might see English in places like the following (this is not an exhaustive list):
+
+- Code comments
+- Code strings
+- Any string you find in the code (e.g. the values of properties, variables, etc.)
+- Markdown (headings, text, lists, etc.)
+- HTML attributes, like img alt tags
+- etc.
+
+Please apply the rules to ANY English you find. You can ignore any code (Node.js, Python, etc).
+
+## Style Guide
+
+Apply the following rules to any English you find:
+
+1. Prefer the most common hyphenation of a word. For example, \`non-English\` is more common than \`nonEnglish\`.
+2. Prefer common contractions over the full word. For example, \`it's\` is more common than \`it is\`.
+
+## Input format
+
+Below, I'm passing data as a CSV of the following format:
+
+- \`key\`: A string, a composite key of the following format: \`<file path>:<line number>\`
+- \`code\`: A string, the code found at the \`key\` location
+
+## Output format
+
+You MUST output your results as a CSV of the following format:
+
+- \`key\`: A string, a composite key of the following format: \`<file path>:<line number>\` found in the \`key\` field of the input CSV text provided.
+- \`rule\`: A string, the rule you applied to the English found at the \`key\` location. Reference the rule from the style guide above. If multiple rules are found, output a list of reasons, delimited by periods.
+- \`corrected_code_or_text\`: A string, the corrected found at the \`key\` location, with all English corrected according to the rules of the style guide.
+
+You MUST only include lines in the output where you've corrected English. If you don't correct any English, you MUST NOT include the line in the output.
+`

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -631,7 +631,7 @@ export const englishStyleGuidePrompt = `# English Style Guide
 
 Your goal is to apply the following style guides to any English you find in the code:
 
-1. Google Developer Documentation Style Guide (https://developers.google.com/style)
+1. Google's Developer docs style guide (https://developers.google.com/style)
 2. Dreyer's English
 
 You might see English in places like the following (this is not an exhaustive list):

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -629,7 +629,7 @@ export const englishStyleGuidePrompt = `# English Style Guide
 
 ## Instructions
 
-Your goal is to apply two style guides to any English you find in the code:
+Your goal is to apply the following style guides to any English you find in the code:
 
 1. Google's Developer docs style guide (https://developers.google.com/style)
 2. Dreyer's English

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -629,7 +629,10 @@ export const englishStyleGuidePrompt = `# English Style Guide
 
 ## Instructions
 
-Your goal is to apply all of the following rules to any English you detect in the provided code.
+Your goal is to apply two style guides to any English you find in the code:
+
+1. Google's Developer docs style guide (https://developers.google.com/style)
+2. Dreyer's English
 
 You might see English in places like the following (this is not an exhaustive list):
 
@@ -640,14 +643,7 @@ You might see English in places like the following (this is not an exhaustive li
 - HTML attributes, like img alt tags
 - etc.
 
-Please apply the rules to ANY English you find. You can ignore any code (Node.js, Python, etc).
-
-## Style Guide
-
-Apply the following rules to any English you find:
-
-1. Prefer the most common hyphenation of a word. For example, \`non-English\` is more common than \`nonEnglish\`.
-2. Prefer common contractions over the full word. For example, \`it's\` is more common than \`it is\`.
+Please apply the rules of the style guide to ANY English you find.
 
 ## Input format
 
@@ -661,8 +657,8 @@ Below, I'm passing data as a CSV of the following format:
 You MUST output your results as a CSV of the following format:
 
 - \`key\`: A string, a composite key of the following format: \`<file path>:<line number>\` found in the \`key\` field of the input CSV text provided.
-- \`rule\`: A string, the rule you applied to the English found at the \`key\` location. Reference the rule from the style guide above. If multiple rules are found, output a list of reasons, delimited by periods.
 - \`corrected_code_or_text\`: A string, the corrected found at the \`key\` location, with all English corrected according to the rules of the style guide.
+- \`reason\`: A string, the rule you applied to the English found at the \`key\` location. Explain why you made the change you did. If multiple rules / issues are found, list them all.
 
-You MUST only include lines in the output where you've corrected English. If you don't correct any English, you MUST NOT include the line in the output.
+You MUST only include lines in the output where you've corrected English. If you don't correct any English on a line, you MUST NOT include the line in the output.
 `

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -658,7 +658,7 @@ You must only output your results as a CSV of the following format:
 
 - \`key\`: A string, a composite key of the following format: \`<file path>:<line number>\` found in the \`key\` field of the input CSV text provided.
 - \`corrected_code_or_text\`: A string, the corrected found at the \`key\` location, with all English corrected according to the rules of the style guide.
-- \`reason\`: A string, the rule you applied to the English found at the \`key\` location. Explain why you made the change you did. If multiple rules / issues are found, list them all.
+- `reason`: A string, the rule(s) you applied to the English found at the `key` location. Explain why you made the change(s). If multiple rules or issues are found, list them all.
 
 You MUST only include lines in the output where you've corrected English. If you don't correct any English on a line, you MUST NOT include the line in the output.
 

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -631,7 +631,7 @@ export const englishStyleGuidePrompt = `# English Style Guide
 
 Your goal is to apply the following style guides to any English you find in the code:
 
-1. Google's Developer docs style guide (https://developers.google.com/style)
+1. Google Developer Documentation Style Guide (https://developers.google.com/style)
 2. Dreyer's English
 
 You might see English in places like the following (this is not an exhaustive list):


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fda7d48</samp>

The `@pipedream/prompts` package was updated to version `0.1.0` and a new prompt for English style guide correction was added. This prompt helps the LLM platform to generate and evaluate code corrections.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fda7d48</samp>

> _`prompts` package grows_
> _English style guide added_
> _autumn of learning_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fda7d48</samp>

*  Update the version of the `@pipedream/prompts` package to `0.1.0` ([link](https://github.com/PipedreamHQ/pipedream/pull/5973/files?diff=unified&w=0#diff-0ae3e7c81e64b3f61788001c9e6eb85149d68b0098ad142debe86f496572edbcL3-R3))
*  Add a new prompt for English style guide correction to the `packages/prompts/src/index.ts` file ([link](https://github.com/PipedreamHQ/pipedream/pull/5973/files?diff=unified&w=0#diff-73ca05c9ec7ff43e3e44685ca68cf2bf19ad847b233571458de26ed57ad22e46R627-R668))
