### PR TITLE
feat[asana]: emit new event each time a tag is added to any task

### DIFF
--- a/components/asana/package.json
+++ b/components/asana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/asana",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Pipedream Asana Components",
   "main": "asana.app.mjs",
   "keywords": [

--- a/components/asana/sources/tags-added-to-any-task/tags-added-to-any-task.mjs
+++ b/components/asana/sources/tags-added-to-any-task/tags-added-to-any-task.mjs
@@ -5,7 +5,7 @@ export default {
   ...common,
   key: "asana-tags-added-to-any-task",
   type: "source",
-  name: "Tags Added to Any Task (Instant)",
+  name: "Tags added to any task (Instant)",
   description: "Emit a new event each time a tag is added to any task, optionally filtering by a given set of tags.",
   version: "0.0.1",
   dedupe: "unique",

--- a/components/asana/sources/tags-added-to-any-task/tags-added-to-any-task.mjs
+++ b/components/asana/sources/tags-added-to-any-task/tags-added-to-any-task.mjs
@@ -5,8 +5,8 @@ export default {
   ...common,
   key: "asana-tags-added-to-any-task",
   type: "source",
-  name: "Tags Added To Any Task (Instant)",
-  description: "Emit new event each time a tag is added to any task, optionally filtering by a given set of tags.",
+  name: "Tags Added to Any Task (Instant)",
+  description: "Emit a new event each time a tag is added to any task, optionally filtering by a given set of tags.",
   version: "0.0.1",
   dedupe: "unique",
   props: {

--- a/components/asana/sources/tags-added-to-any-task/tags-added-to-any-task.mjs
+++ b/components/asana/sources/tags-added-to-any-task/tags-added-to-any-task.mjs
@@ -1,0 +1,84 @@
+import common from "../common/common.mjs";
+const { asana } = common.props;
+
+export default {
+  ...common,
+  key: "asana-tags-added-to-any-task",
+  type: "source",
+  name: "Tags Added To Any Task (Instant)",
+  description: "Emit new event each time a tag is added to any task, optionally filtering by a given set of tags.",
+  version: "0.0.1",
+  dedupe: "unique",
+  props: {
+    ...common.props,
+    project: {
+      label: "Project",
+      description: "Gid of a project.",
+      type: "string",
+      propDefinition: [
+        asana,
+        "projects",
+        (c) => ({
+          workspace: c.workspace,
+        }),
+      ],
+    },
+    tags: {
+      optional: true,
+      propDefinition: [
+        asana,
+        "tags",
+        (c) => ({
+          tags: c.tags,
+        }),
+      ],
+    },
+  },
+  methods: {
+    ...common.methods,
+    getWebhookFilter() {
+      return {
+        filters: [
+          {
+            action: "added",
+            resource_type: "task",
+          },
+        ],
+        resource: this.project,
+      };
+    },
+    async emitEvent(event) {
+      const { tags } = this;
+      const { events = [] } = event.body || {};
+
+      const promises = events
+        .filter(({ parent }) => {
+          return tags?.length
+            ? tags.includes(String(parent.gid))
+            : true;
+        })
+        .map(async (event) => ({
+          event,
+          task: await this.asana.getTask(event.resource.gid),
+          tag: await this.asana.getTag(event.parent.gid),
+        }));
+
+      const responses = await Promise.all(promises);
+
+      responses.forEach((response) => {
+        const {
+          event, task, tag,
+        } = response;
+        const ts = Date.parse(event.created_at);
+        this.$emit(
+          response,
+          {
+            id: `${tag.gid}-${ts}`,
+            summary: `${tag.name} added to ${task.name}`,
+            ts,
+          },
+        );
+      });
+    },
+  },
+};


### PR DESCRIPTION
## WHAT

Emit new event each time a tag is added to any task, optionally filtering by a given set of tags.

## WHY

The current "Tag Added to Task" source only emits events when a tag is added to a task that's known ahead of time. This doesn't fit my workflow needs: I need to trigger an event whenever a given tag (or tags) are added to ANY task within a project.
