### PR TITLE
some new webhooks for dear

### DIFF
--- a/components/dear/sources/available-stock-level-change/available-stock-level-change.mjs
+++ b/components/dear/sources/available-stock-level-change/available-stock-level-change.mjs
@@ -1,0 +1,32 @@
+import constants from "../../common/constants.mjs";
+import base from "../common/webhooks.mjs";
+
+export default {
+  ...base,
+  name: "Available Stock Level Change",
+  key: "dear-available-stock-level-change",
+  type: "source",
+  description: "Emit new event when available stock level is changed.",
+  version: "0.0.1",
+  dedupe: "unique",
+  methods: {
+    ...base.methods,
+    getWebhookType() {
+      return constants.WEBHOOK_TYPE.STOCK_AVAILABLE_STOCK_LEVEL_CHANGE;
+    },
+    getMetadata(payload) {
+      const {
+        amznTraceId,
+        ...summary
+      } = payload;
+
+      const compositeId = `${payload[0].ID}-${amznTraceId}`;
+
+      return {
+        id: compositeId,
+        summary: JSON.stringify(summary),
+        ts: Date.now(),
+      };
+    },
+  },
+};

--- a/components/dear/sources/available-stock-level-change/available-stock-level-change.mjs
+++ b/components/dear/sources/available-stock-level-change/available-stock-level-change.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Available Stock Level Change",
   key: "dear-available-stock-level-change",
   type: "source",
-  description: "Emit new event when available stock level is changed.",
+  description: "Emit a new event when the available stock level changes.",
   version: "0.0.1",
   dedupe: "unique",
   methods: {

--- a/components/dear/sources/customer-updated/customer-updated.mjs
+++ b/components/dear/sources/customer-updated/customer-updated.mjs
@@ -1,0 +1,32 @@
+import constants from "../../common/constants.mjs";
+import base from "../common/webhooks.mjs";
+
+export default {
+  ...base,
+  name: "Customer Updated",
+  key: "dear-customer-updated",
+  type: "source",
+  description: "Emit new event when a customer is updated.",
+  version: "0.0.1",
+  dedupe: "unique",
+  methods: {
+    ...base.methods,
+    getWebhookType() {
+      return constants.WEBHOOK_TYPE.CUSTOMER_UPDATED;
+    },
+    getMetadata(payload) {
+      const {
+        amznTraceId,
+        ...summary
+      } = payload;
+
+      const compositeId = `${payload.CustomerDetailsList[0].Customer.ID}-${amznTraceId}`;
+
+      return {
+        id: compositeId,
+        summary: JSON.stringify(summary),
+        ts: Date.now(),
+      };
+    },
+  },
+};

--- a/components/dear/sources/customer-updated/customer-updated.mjs
+++ b/components/dear/sources/customer-updated/customer-updated.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Customer Updated",
   key: "dear-customer-updated",
   type: "source",
-  description: "Emit new event when a customer is updated.",
+  description: "Emit a new event when a customer is updated.",
   version: "0.0.1",
   dedupe: "unique",
   methods: {

--- a/components/dear/sources/sale-shipment-tracking-number-changed/sale-shipment-tracking-number-changed.mjs
+++ b/components/dear/sources/sale-shipment-tracking-number-changed/sale-shipment-tracking-number-changed.mjs
@@ -1,0 +1,32 @@
+import constants from "../../common/constants.mjs";
+import base from "../common/webhooks.mjs";
+
+export default {
+  ...base,
+  name: "Shipment Tracking Number Change",
+  key: "dear-sale-shipment-tracking-number-change",
+  type: "source",
+  description: "Emit new event when a shipment tracking number changes.",
+  version: "0.0.1",
+  dedupe: "unique",
+  methods: {
+    ...base.methods,
+    getWebhookType() {
+      return constants.WEBHOOK_TYPE.SALE_SHIPMENT_TRACKING_NUMBER_CHANGED;
+    },
+    getMetadata(payload) {
+      const {
+        amznTraceId,
+        ...summary
+      } = payload;
+
+      const compositeId = `${payload.SaleID}-${amznTraceId}`;
+
+      return {
+        id: compositeId,
+        summary: JSON.stringify(summary),
+        ts: Date.now(),
+      };
+    },
+  },
+};

--- a/components/dear/sources/sale-shipment-tracking-number-changed/sale-shipment-tracking-number-changed.mjs
+++ b/components/dear/sources/sale-shipment-tracking-number-changed/sale-shipment-tracking-number-changed.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Shipment Tracking Number Change",
   key: "dear-sale-shipment-tracking-number-change",
   type: "source",
-  description: "Emit new event when a shipment tracking number changes.",
+  description: "Emit a new event when a shipment tracking number changes.",
   version: "0.0.1",
   dedupe: "unique",
   methods: {

--- a/components/dear/sources/supplier-updated/supplier-updated.mjs
+++ b/components/dear/sources/supplier-updated/supplier-updated.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Supplier Updated",
   key: "dear-supplier-updated",
   type: "source",
-  description: "Emit new event when a supplier is updated.",
+  description: "Emit a new event when a supplier is updated.",
   version: "0.0.1",
   dedupe: "unique",
   methods: {

--- a/components/dear/sources/supplier-updated/supplier-updated.mjs
+++ b/components/dear/sources/supplier-updated/supplier-updated.mjs
@@ -1,0 +1,32 @@
+import constants from "../../common/constants.mjs";
+import base from "../common/webhooks.mjs";
+
+export default {
+  ...base,
+  name: "Supplier Updated",
+  key: "dear-supplier-updated",
+  type: "source",
+  description: "Emit new event when a supplier is updated.",
+  version: "0.0.1",
+  dedupe: "unique",
+  methods: {
+    ...base.methods,
+    getWebhookType() {
+      return constants.WEBHOOK_TYPE.SUPPLIER_UPDATED;
+    },
+    getMetadata(payload) {
+      const {
+        amznTraceId,
+        ...summary
+      } = payload;
+
+      const compositeId = `${payload.SupplierDetailsList[0].Supplier.ID}-${amznTraceId}`;
+
+      return {
+        id: compositeId,
+        summary: JSON.stringify(summary),
+        ts: Date.now(),
+      };
+    },
+  },
+};


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at eed2e8f</samp>

This pull request adds four new source components for the DEAR Inventory app that emit events based on different webhook types. The components use a common base component for webhooks and specify the relevant metadata and version. The new components are `available-stock-level-change`, `customer-updated`, `sale-shipment-tracking-number-changed`, and `supplier-updated`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at eed2e8f</samp>

> _`DEAR Inventory`_
> _Webhook sources multiply_
> _Autumn harvest time_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at eed2e8f</samp>

*  Add four new source components for the DEAR Inventory app that emit events based on different webhook types ([link](https://github.com/PipedreamHQ/pipedream/pull/6001/files?diff=unified&w=0#diff-a2d0f66b76b39b55eaa89dab760e0e9f6fca5f4ec988361c8a814161c3d7d14fR1-R32), [link](https://github.com/PipedreamHQ/pipedream/pull/6001/files?diff=unified&w=0#diff-bad7247ca747f662d633816fd34e84dd8f167cc43a9913c658bf7c18fda6cc9fR1-R32), [link](https://github.com/PipedreamHQ/pipedream/pull/6001/files?diff=unified&w=0#diff-2e969812d1707f438ce5dc82054017b677783ccf8fc3370d099521446ba5e72cR1-R32), [link](https://github.com/PipedreamHQ/pipedream/pull/6001/files?diff=unified&w=0#diff-f6dd5022400c5cffb4b0470856e3876ee442dc1d4ff9c3206aeb3380ef2a683fR1-R32))
