### PR TITLE
Fix mispelling in readwise app

### DIFF
--- a/components/readwise/actions/get-highlight-details/get-highlight-details.mjs
+++ b/components/readwise/actions/get-highlight-details/get-highlight-details.mjs
@@ -4,7 +4,7 @@ export default {
   key: "readwise-get-highlight-details",
   name: "Get Highlight Details",
   description: "Get Highlight´s Details [See the docs here](https://readwise.io/api_deets)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     readwise,

--- a/components/readwise/actions/list-highlights/list-highlights.mjs
+++ b/components/readwise/actions/list-highlights/list-highlights.mjs
@@ -4,7 +4,7 @@ export default {
   key: "readwise-list-highlights",
   name: "List Highlights",
   description: "A list of highlights with a pagination metadata. The rate limit of this endpoint is restricted to 20 requests per minute. Each request returns 1000 items. [See the docs here](https://readwise.io/api_deets)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     readwise,

--- a/components/readwise/package.json
+++ b/components/readwise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/readwise",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Pipedream Readwise Components",
   "main": "dist/app/readwise.app.mjs",
   "keywords": [

--- a/components/readwise/readwise.app.mjs
+++ b/components/readwise/readwise.app.mjs
@@ -59,7 +59,7 @@ export default {
     },
     _getHeaders() {
       return {
-        "Authorization": `Token ${this.$auth.accesss_token}`,
+        "Authorization": `Token ${this.$auth.access_token}`,
       };
     },
     async _makeRequest({

--- a/components/readwise/sources/new-highlights/new-highlights.mjs
+++ b/components/readwise/sources/new-highlights/new-highlights.mjs
@@ -5,7 +5,7 @@ export default {
   key: "readwise-new-highlights",
   name: "New Highlights",
   description: "Emit new Highlight",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "source",
   dedupe: "unique",
   props: {


### PR DESCRIPTION
accesss_token -> access_token

One question I have is where is the piece of code that actually saves `accesss_token` into the $auth object? I can't seem to find it therefore update it. 

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 088281b</samp>

Fixed a typo in the Readwise app component that prevented authentication with the Readwise API. Updated the `components/readwise/readwise.app.mjs` file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 088281b</samp>

> _`_getHeaders` fixed_
> _access_token spelled right now_
> _autumn leaves fall fast_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 088281b</samp>

* Fix spelling of `access_token` in authorization header for Readwise API requests ([link](https://github.com/PipedreamHQ/pipedream/pull/6046/files?diff=unified&w=0#diff-6efb8907bf7711c6d5934d61b3b3f6a6482e887617f2d889d6013d31afad6b09L62-R62))
