### PR TITLE
Platform axios fix

### DIFF
--- a/platform/dist/axios.js
+++ b/platform/dist/axios.js
@@ -71,7 +71,7 @@ function transformConfigForOauth(config) {
         requestData.data = querystring.parse(config.data);
     }
     config.paramsSerializer = oauth1ParamsSerializer;
-    return config;
+    return requestData;
 }
 exports.transformConfigForOauth = transformConfigForOauth;
 async function getOauthSignature(config, signConfig) {

--- a/platform/lib/axios.ts
+++ b/platform/lib/axios.ts
@@ -74,7 +74,7 @@ export function transformConfigForOauth(config: AxiosRequestConfig) {
     (requestData as any).data = querystring.parse(config.data);
   }
   config.paramsSerializer = oauth1ParamsSerializer;
-  return config;
+  return requestData;
 }
 
 async function getOauthSignature(config: AxiosRequestConfig, signConfig: any) {

--- a/platform/package.json
+++ b/platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/platform",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Pipedream platform globals (typing and runtime type checking)",
   "homepage": "https://pipedream.com",
   "main": "dist/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -518,9 +518,6 @@ importers:
   components/budgets_ai:
     specifiers: {}
 
-  components/budgets_ai:
-    specifiers: {}
-
   components/bugsnag:
     specifiers: {}
 
@@ -1180,6 +1177,9 @@ importers:
     dependencies:
       '@pipedream/platform': 1.4.1
 
+  components/eodhd_apis:
+    specifiers: {}
+
   components/esendex:
     specifiers: {}
 
@@ -1369,9 +1369,6 @@ importers:
       '@pipedream/platform': ^1.2.0
     dependencies:
       '@pipedream/platform': 1.4.1
-
-  components/formstack_documents:
-    specifiers: {}
 
   components/formstack_documents:
     specifiers: {}
@@ -1814,9 +1811,6 @@ importers:
       '@pipedream/platform': ^1.4.1
     dependencies:
       '@pipedream/platform': 1.4.1
-
-  components/holded:
-    specifiers: {}
 
   components/hotspotsystem:
     specifiers:
@@ -2278,6 +2272,9 @@ importers:
   components/mailrefine:
     specifiers: {}
 
+  components/mailwizz:
+    specifiers: {}
+
   components/maintainx:
     specifiers:
       '@pipedream/platform': ^1.4.1
@@ -2505,6 +2502,9 @@ importers:
       '@pipedream/types': 0.1.5
 
   components/nano_nets:
+    specifiers: {}
+
+  components/nasdaq_data_link_time_series_and_table_data_:
     specifiers: {}
 
   components/nectar_crm:
@@ -3533,6 +3533,9 @@ importers:
     dependencies:
       '@pipedream/platform': 0.10.0
 
+  components/selectpdf:
+    specifiers: {}
+
   components/sellix:
     specifiers: {}
 
@@ -4409,7 +4412,7 @@ importers:
       '@pipedream/types': ^0.1.4
       oauth-1.0a: ^2.2.6
     dependencies:
-      '@pipedream/platform': 1.4.1
+      '@pipedream/platform': 1.5.0
       '@pipedream/types': 0.1.5
       oauth-1.0a: 2.2.6
 
@@ -8740,7 +8743,7 @@ packages:
     engines: {node: ^8.13.0 || >=10.10.0}
     dependencies:
       '@grpc/proto-loader': 0.7.6
-      '@types/node': 18.15.11
+      '@types/node': 17.0.45
     dev: false
     optional: true
 
@@ -8749,7 +8752,7 @@ packages:
     engines: {node: ^8.13.0 || >=10.10.0}
     dependencies:
       '@grpc/proto-loader': 0.7.6
-      '@types/node': 18.15.11
+      '@types/node': 17.0.45
     dev: false
 
   /@grpc/proto-loader/0.6.13:
@@ -8835,7 +8838,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.5.0
-      '@types/node': 18.15.11
+      '@types/node': 17.0.45
       chalk: 4.1.2
       jest-message-util: 29.5.0
       jest-util: 29.5.0
@@ -8945,7 +8948,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 29.5.0
       '@jest/types': 29.5.0
-      '@types/node': 18.15.11
+      '@types/node': 17.0.45
       jest-mock: 29.5.0
     dev: true
 
@@ -8984,7 +8987,7 @@ packages:
     dependencies:
       '@jest/types': 29.5.0
       '@sinonjs/fake-timers': 10.0.2
-      '@types/node': 18.15.11
+      '@types/node': 17.0.45
       jest-message-util: 29.5.0
       jest-mock: 29.5.0
       jest-util: 29.5.0
@@ -9064,7 +9067,7 @@ packages:
       '@jest/transform': 29.5.0
       '@jest/types': 29.5.0
       '@jridgewell/trace-mapping': 0.3.18
-      '@types/node': 18.15.11
+      '@types/node': 17.0.45
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
@@ -9646,6 +9649,17 @@ packages:
 
   /@pipedream/platform/1.4.1:
     resolution: {integrity: sha512-gAVCA011u8CK/ZEDb1IpLWyE+lVt4R0YI1Ql6trOdZ5roBgaxy3nf0NK7BC+HDiDjNLZ6dFZ5qWSGFqnFiWrqw==}
+    dependencies:
+      axios: 0.21.4
+      fp-ts: 2.13.1
+      io-ts: 2.2.20_fp-ts@2.13.1
+      querystring: 0.2.1
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
+  /@pipedream/platform/1.5.0:
+    resolution: {integrity: sha512-GyIf+atrN9WNrjwImjsc+rd3y/Yhw5pCcMHlmRVuX7q+GW6m/SgcWSXQDU29En2btgG3mk2BzdRhxecimqAmFQ==}
     dependencies:
       axios: 0.21.4
       fp-ts: 2.13.1
@@ -11457,7 +11471,7 @@ packages:
   /@types/express-serve-static-core/4.17.33:
     resolution: {integrity: sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==}
     dependencies:
-      '@types/node': 18.15.11
+      '@types/node': 17.0.45
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
     dev: false
@@ -11482,20 +11496,20 @@ packages:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 18.15.11
+      '@types/node': 17.0.45
     dev: false
 
   /@types/glob/8.1.0:
     resolution: {integrity: sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 18.15.11
+      '@types/node': 17.0.45
     dev: false
 
   /@types/graceful-fs/4.1.6:
     resolution: {integrity: sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==}
     dependencies:
-      '@types/node': 18.15.11
+      '@types/node': 17.0.45
     dev: true
 
   /@types/hast/2.3.4:
@@ -11543,7 +11557,7 @@ packages:
   /@types/jsonwebtoken/8.5.9:
     resolution: {integrity: sha512-272FMnFGzAVMGtu9tkr29hRL6bZj4Zs1KZNeHLnKqAvp06tAIcarTMwOh8/8bz4FmKRcMxZhZNeUAQsNLoiPhg==}
     dependencies:
-      '@types/node': 18.15.11
+      '@types/node': 17.0.45
     dev: false
 
   /@types/keyv/3.1.4:
@@ -11668,7 +11682,7 @@ packages:
     resolution: {integrity: sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==}
     dependencies:
       '@types/glob': 8.1.0
-      '@types/node': 18.15.11
+      '@types/node': 17.0.45
     dev: false
 
   /@types/sax/1.2.4:
@@ -11685,7 +11699,7 @@ packages:
     resolution: {integrity: sha512-NUo5XNiAdULrJENtJXZZ3fHtfMolzZwczzBbnAeBbqBwG+LaG6YaJtuwzwGSQZ2wsCrxjEhNNjAkKigy3n8teQ==}
     dependencies:
       '@types/mime': 3.0.1
-      '@types/node': 18.15.11
+      '@types/node': 17.0.45
     dev: false
 
   /@types/source-map/0.5.7:
@@ -11706,7 +11720,7 @@ packages:
   /@types/tunnel/0.0.3:
     resolution: {integrity: sha512-sOUTGn6h1SfQ+gbgqC364jLFBw2lnFqkgF3q0WovEHRLMrVD1sd5aufqi/aJObLekJO+Aq5z646U4Oxy6shXMA==}
     dependencies:
-      '@types/node': 18.15.11
+      '@types/node': 17.0.45
     dev: false
 
   /@types/unist/2.0.6:
@@ -11723,7 +11737,7 @@ packages:
   /@types/websocket/1.0.5:
     resolution: {integrity: sha512-NbsqiNX9CnEfC1Z0Vf4mE1SgAJ07JnRYcNex7AJ9zAVzmiGHmjKFEk7O4TJIsgv2B1sLEb6owKFZrACwdYngsQ==}
     dependencies:
-      '@types/node': 18.15.11
+      '@types/node': 17.0.45
     dev: false
 
   /@types/whatwg-url/8.2.2:
@@ -12867,7 +12881,7 @@ packages:
     resolution: {integrity: sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==}
     dependencies:
       base64-js: 1.5.1
-      ieee754: 1.1.13
+      ieee754: 1.2.1
       isarray: 1.0.0
     dev: false
 
@@ -17210,7 +17224,7 @@ packages:
       '@jest/expect': 29.5.0
       '@jest/test-result': 29.5.0
       '@jest/types': 29.5.0
-      '@types/node': 18.15.11
+      '@types/node': 17.0.45
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -17498,7 +17512,7 @@ packages:
       '@jest/environment': 29.5.0
       '@jest/fake-timers': 29.5.0
       '@jest/types': 29.5.0
-      '@types/node': 18.15.11
+      '@types/node': 17.0.45
       jest-mock: 29.5.0
       jest-util: 29.5.0
     dev: true
@@ -17539,7 +17553,7 @@ packages:
     dependencies:
       '@jest/types': 29.5.0
       '@types/graceful-fs': 4.1.6
-      '@types/node': 18.15.11
+      '@types/node': 17.0.45
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -17656,7 +17670,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.5.0
-      '@types/node': 18.15.11
+      '@types/node': 17.0.45
       jest-util: 29.5.0
     dev: true
 
@@ -17787,7 +17801,7 @@ packages:
       '@jest/test-result': 29.5.0
       '@jest/transform': 29.5.0
       '@jest/types': 29.5.0
-      '@types/node': 18.15.11
+      '@types/node': 17.0.45
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -17848,7 +17862,7 @@ packages:
       '@jest/test-result': 29.5.0
       '@jest/transform': 29.5.0
       '@jest/types': 29.5.0
-      '@types/node': 18.15.11
+      '@types/node': 17.0.45
       chalk: 4.1.2
       cjs-module-lexer: 1.2.2
       collect-v8-coverage: 1.0.1
@@ -17953,7 +17967,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.5.0
-      '@types/node': 18.15.11
+      '@types/node': 17.0.45
       chalk: 4.1.2
       ci-info: 3.8.0
       graceful-fs: 4.2.11
@@ -18003,7 +18017,7 @@ packages:
     dependencies:
       '@jest/test-result': 29.5.0
       '@jest/types': 29.5.0
-      '@types/node': 18.15.11
+      '@types/node': 17.0.45
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -18024,7 +18038,7 @@ packages:
     resolution: {integrity: sha512-NcrQnevGoSp4b5kg+akIpthoAFHxPBcb5P6mYPY0fUNT+sSvmtu6jlkEle3anczUKIKEbMxFimk9oTP/tpIPgA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@types/node': 18.15.11
+      '@types/node': 17.0.45
       jest-util: 29.5.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -21203,7 +21217,7 @@ packages:
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
       '@types/long': 4.0.2
-      '@types/node': 18.15.11
+      '@types/node': 17.0.45
       long: 4.0.0
     dev: false
     optional: true
@@ -21223,7 +21237,7 @@ packages:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 18.15.11
+      '@types/node': 17.0.45
       long: 5.2.3
     dev: false
 
@@ -24801,7 +24815,7 @@ packages:
   /wide-align/1.1.5:
     resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
     dependencies:
-      string-width: 1.0.2
+      string-width: 4.2.3
     dev: true
     optional: true
 


### PR DESCRIPTION
## WHAT

copilot:summary

copilot:poem


## WHY

We're currently only able to validate updates to the platform package in production. A recent update #6034 needs a small follow-up fix: the method returned the variable `config` (the original object) instead of the variable `requestData` (the transformed object, which is what it should return to keep the original flow unchanged).


## HOW

copilot:walkthrough
