### PR TITLE
[Drata] Add deviceId async options

### DIFF
--- a/components/drata/actions/create-asset/create-asset.mjs
+++ b/components/drata/actions/create-asset/create-asset.mjs
@@ -6,7 +6,7 @@ export default {
   key: "drata-create-asset",
   name: "Create Asset",
   description: `Create an asset. [See the documentation](${docsLink}).`,
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     drata,

--- a/components/drata/actions/create-control/create-control.mjs
+++ b/components/drata/actions/create-control/create-control.mjs
@@ -6,7 +6,7 @@ export default {
   key: "drata-create-control",
   name: "Create Control",
   description: `Create a new Control. [See the documentation](${docsLink}).`,
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     drata,

--- a/components/drata/actions/create-vendor/create-vendor.mjs
+++ b/components/drata/actions/create-vendor/create-vendor.mjs
@@ -6,7 +6,7 @@ export default {
   key: "drata-create-vendor",
   name: "Create Vendor",
   description: `Create a new Vendor. [See the documentation](${docsLink}).`,
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     drata,

--- a/components/drata/actions/find-controls/find-controls.mjs
+++ b/components/drata/actions/find-controls/find-controls.mjs
@@ -7,7 +7,7 @@ export default {
   key: "drata-find-controls",
   name: "Find Controls",
   description: `Find Controls. [See the documentation](${docsLink}).`,
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     drata,

--- a/components/drata/actions/find-personnel/find-personnel.mjs
+++ b/components/drata/actions/find-personnel/find-personnel.mjs
@@ -7,7 +7,7 @@ export default {
   key: "drata-find-personnel",
   name: "Find Personnel",
   description: `Find Personnel. [See the documentation](${docsLink}).`,
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     drata,

--- a/components/drata/actions/find-vendors/find-vendors.mjs
+++ b/components/drata/actions/find-vendors/find-vendors.mjs
@@ -7,7 +7,7 @@ export default {
   key: "drata-find-vendors",
   name: "Find Vendors",
   description: `Find Vendors. [See the documentation](${docsLink}).`,
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     drata,

--- a/components/drata/actions/update-vendor/update-vendor.mjs
+++ b/components/drata/actions/update-vendor/update-vendor.mjs
@@ -6,7 +6,7 @@ export default {
   key: "drata-update-vendor",
   name: "Update Vendor",
   description: `Update a Vendor. [See the documentation](${docsLink}).`,
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     drata,

--- a/components/drata/actions/upload-background-check/upload-background-check.mjs
+++ b/components/drata/actions/upload-background-check/upload-background-check.mjs
@@ -6,7 +6,7 @@ export default {
   key: "drata-upload-background-check",
   name: "Upload Background Check",
   description: `Upload background check for a personnel. [See the documentation](${docsLink}).`,
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     drata,

--- a/components/drata/actions/upload-device-compliance-document/upload-device-compliance-document.mjs
+++ b/components/drata/actions/upload-device-compliance-document/upload-device-compliance-document.mjs
@@ -7,14 +7,15 @@ export default {
   key: "drata-upload-device-compliance-document",
   name: "Upload Device Compliance Document",
   description: `Upload a device compliance document. [See the documentation](${docsLink}).`,
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     drata,
     deviceId: {
-      type: "integer",
-      label: "Device ID",
-      description: "The ID of the device.",
+      propDefinition: [
+        drata,
+        "deviceId",
+      ],
     },
     documentType: {
       type: "string",

--- a/components/drata/actions/upload-user-compliance-document/upload-user-compliance-document.mjs
+++ b/components/drata/actions/upload-user-compliance-document/upload-user-compliance-document.mjs
@@ -7,7 +7,7 @@ export default {
   key: "drata-upload-user-compliance-document",
   name: "Upload User Compliance Document",
   description: `Upload a user compliance document. [See the documentation](${docsLink}).`,
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     drata,

--- a/components/drata/drata.app.mjs
+++ b/components/drata/drata.app.mjs
@@ -73,6 +73,15 @@ export default {
         }));
       },
     },
+    deviceId: {
+      type: "string",
+      label: "Device ID",
+      description: "The ID of the device.",
+      async options() {
+        const devices = await this.listDevices();
+        return devices.map((device) => `${device.id}`);
+      },
+    },
   },
   methods: {
     ...utils.methods,
@@ -203,6 +212,15 @@ export default {
         path: `/workspaces/${workspaceId}/controls`,
         method: "POST",
       });
+    },
+    async listDevices() {
+      const response = await this.listPersonnel({
+        paginate: true,
+      });
+      return response.data
+        .map((personnel) => personnel.devices)
+        .flat()
+        .sort((a, b) => a.id - b.id);
     },
     async listMonitors({
       paginate = false, ...opts

--- a/components/drata/drata.app.mjs
+++ b/components/drata/drata.app.mjs
@@ -79,7 +79,13 @@ export default {
       description: "The ID of the device.",
       async options() {
         const devices = await this.listDevices();
-        return devices.map((device) => `${device.id}`);
+        return devices.map((device) => {
+          const deviceId = `${device.id}`;
+          return {
+            label: device.model || deviceId,
+            value: deviceId,
+          };
+        });
       },
     },
   },

--- a/components/drata/package.json
+++ b/components/drata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/drata",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Pipedream Drata Components",
   "main": "drata.app.mjs",
   "keywords": [

--- a/components/drata/sources/failed-monitor/failed-monitor.mjs
+++ b/components/drata/sources/failed-monitor/failed-monitor.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Failed Monitor",
   description: `Emit a new event whenever a monitor fails. [See the documentation](${docsLink}).`,
   type: "source",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
   props: {
     drata,

--- a/components/drata/sources/new-asset-added/new-asset-added.mjs
+++ b/components/drata/sources/new-asset-added/new-asset-added.mjs
@@ -9,7 +9,7 @@ export default {
   name: "New Asset Added",
   description: `Emit a new event for every new asset. [See the documentation](${docsLink}).`,
   type: "source",
-  version: "0.0.2",
+  version: "0.0.3",
   dedupe: "unique",
   props: {
     drata,

--- a/components/drata/sources/new-control-added/new-control-added.mjs
+++ b/components/drata/sources/new-control-added/new-control-added.mjs
@@ -9,7 +9,7 @@ export default {
   name: "New Control Added",
   description: `Emit a new event for every new control. [See the documentation](${docsLink}).`,
   type: "source",
-  version: "0.0.2",
+  version: "0.0.3",
   dedupe: "unique",
   props: {
     drata,

--- a/components/drata/sources/new-evidence-added/new-evidence-added.mjs
+++ b/components/drata/sources/new-evidence-added/new-evidence-added.mjs
@@ -9,7 +9,7 @@ export default {
   name: "New Evidence for Control Added",
   description: `Emit a new event for every new evidence for a control. [See the documentation](${docsLink}).`,
   type: "source",
-  version: "0.0.2",
+  version: "0.0.3",
   dedupe: "unique",
   props: {
     drata,

--- a/components/drata/sources/new-personnel-added/new-personnel-added.mjs
+++ b/components/drata/sources/new-personnel-added/new-personnel-added.mjs
@@ -9,7 +9,7 @@ export default {
   name: "New Personnel Added",
   description: `Emit a new event for every new personnel. [See the documentation](${docsLink}).`,
   type: "source",
-  version: "0.0.2",
+  version: "0.0.3",
   dedupe: "unique",
   props: {
     drata,

--- a/components/drata/sources/new-vendor-added/new-vendor-added.mjs
+++ b/components/drata/sources/new-vendor-added/new-vendor-added.mjs
@@ -9,7 +9,7 @@ export default {
   name: "New Vendor Added",
   description: `Emit a new event for every new vendor. [See the documentation](${docsLink}).`,
   type: "source",
-  version: "0.0.2",
+  version: "0.0.3",
   dedupe: "unique",
   props: {
     drata,

--- a/components/drata/sources/terminated-employee/terminated-employee.mjs
+++ b/components/drata/sources/terminated-employee/terminated-employee.mjs
@@ -9,7 +9,7 @@ export default {
   name: "Employee Terminated",
   description: `Emit a new event when an employee is terminated. [See the documentation](${docsLink}).`,
   type: "source",
-  version: "0.0.2",
+  version: "0.0.3",
   dedupe: "unique",
   props: {
     drata,

--- a/components/drata/sources/vendor-updated/vendor-updated.mjs
+++ b/components/drata/sources/vendor-updated/vendor-updated.mjs
@@ -9,7 +9,7 @@ export default {
   name: "Vendor Updated",
   description: `Emit a new event when a vendor is updated. [See the documentation](${docsLink}).`,
   type: "source",
-  version: "0.0.2",
+  version: "0.0.3",
   props: {
     drata,
     db: "$.service.db",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -882,9 +882,6 @@ importers:
     dependencies:
       '@pipedream/platform': 1.5.1
 
-  components/danny_test_app:
-    specifiers: {}
-
   components/darwinbox:
     specifiers: {}
 
@@ -24830,7 +24827,7 @@ packages:
   /wide-align/1.1.5:
     resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
     dependencies:
-      string-width: 1.0.2
+      string-width: 4.2.3
     dev: true
     optional: true
 


### PR DESCRIPTION
Adds `async options()` for `deviceId` prop.

Info from Drata is that to list devices we need to first list the personnel and then extract the devices included in the personnel object.
From the sandbox environment, there was no device property besides the `id` that could help identify it better. Looking at the API Reference, `model` seems to be a good candidate.
And for some reason, I kept getting an error when trying to make it an `integer prop`, so I had to make a `string`.

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9abf9d2</samp>

This pull request adds a new feature to the `drata` component that allows selecting and uploading compliance documents for a specific device. It also removes an unused component and updates a dependency in the `pnpm-lock.yaml` file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9abf9d2</samp>

> _To upload a document with ease_
> _We updated the `deviceId` prop, please_
> _We used a `propDefinition`_
> _From the `drata` app's collection_
> _And bumped up the action and package versions by degrees_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9abf9d2</samp>

*  Add `deviceId` prop definition to `drata` app and use it in `upload-device-compliance-document` action ([link](https://github.com/PipedreamHQ/pipedream/pull/6111/files?diff=unified&w=0#diff-60b002040098c47c885a597dacd638b9ee7ca5bc763e353ae519b547e798da02L10-R18), [link](https://github.com/PipedreamHQ/pipedream/pull/6111/files?diff=unified&w=0#diff-a07058fe354e5714b5b288324099660f299a6c49cb5ec445a7251a3072c43db2R76-R90))
*  Add `listDevices` method to `drata` app to fetch and sort device options for `deviceId` prop ([link](https://github.com/PipedreamHQ/pipedream/pull/6111/files?diff=unified&w=0#diff-a07058fe354e5714b5b288324099660f299a6c49cb5ec445a7251a3072c43db2R222-R230))
*  Increment `drata` package version to reflect app and action changes ([link](https://github.com/PipedreamHQ/pipedream/pull/6111/files?diff=unified&w=0#diff-f308bcfbd8557663c1c9360bb4d8bc09ad1946ad1dfe5c5bc638abe738126f45L3-R3))
*  Remove unused `danny_test_app` component from `pnpm-lock.yaml` file ([link](https://github.com/PipedreamHQ/pipedream/pull/6111/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL885-L887))
*  Update `string-width` dependency version in `pnpm-lock.yaml` file ([link](https://github.com/PipedreamHQ/pipedream/pull/6111/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL24833-R24830))
