### PR TITLE
Adding workspaces / credits FAQ for phase 5

### DIFF
--- a/docs/docs/workspaces-and-credits-faq/README.md
+++ b/docs/docs/workspaces-and-credits-faq/README.md
@@ -1,0 +1,47 @@
+# Workspaces, credits, and other new features for Pipedream orgs
+
+We're excited to announce a new set of foundational changes and features! In short — orgs are now [workspaces](/workspaces), invocations are now [credits](/pricing/#credits), and you have access to a new features: [free source invocations](/pricing/#source-credit-usage), unlimited team members, and more.
+
+[[toc]]
+
+## Orgs are now workspaces
+
+We've renamed organizations to [workspaces](/workspaces), which is more consistent with the language other products use. Anywhere you used to see references to “organizations”, you'll now see “workspaces”.
+
+## Invocations are now credits
+
+Pipedream previously charged for invocations (number of workflow executions), but not on compute time (how long your executions run). We've combined these into a single metric: [credits](/pricing/#credits). All paid workspaces now have a default credit limit of 50,000 credits per month, an increase of 30,000 credits a month from the Team plan.
+
+## Source invocations are now free
+
+Previously, workflows often cost two invocations: one to run your source, and another for the workflow. Now, [most source executions are free](/pricing/#source-credit-usage), and you'll only be charged credits for workflow executions.
+
+## The Team plan is now the Advanced plan
+
+As a part of this rollout, we've released new paid plans, and are automatically upgrading your org to the Advanced Plan. We're grateful to have you as an early customer, and **we're honoring your old price for the next 12 months. You should see no impact to your monthly bill with this change**. If you do, please reach out to `support@pipedream.com`. In 12 months, your workspace will move to the standard Advanced plan pricing: currently $149 / month for 50,000 credits, $0.0004 per extra credit.
+
+### What's on the Advanced plan?
+
+You have access to everything on the Team plan, including:
+
+- 50,000 invocations per month, 30,000 more than the Team plan
+- Support for annual plans at 33% off the monthly price — you can change to an annual plan after we convert your org to a workspace
+- 5 team members by default, $50 / user / month for extra users ($30 for annual plans)
+- [Auto-retry](/workflows/settings/#error-reruns) on workflow errors
+- Slack error notifications
+
+A <a href="https://pipedreamhq.typeform.com/to/XtJ8R9Hq">GitHub integration</a>, folders to organize workflows, and other features are coming soon.
+
+### Why the plan / pricing changes?
+
+Overall, we try to price our products far below the value we are providing, and try to do right by the existing customers who helped us get to where we are.
+
+We developed our old pricing when we first launched organizations, and had limited functionality. Today, we offer:
+
+- Better collaboration in workspaces
+- Thousands of integrated apps, triggers, and actions
+- Support for Node.js, Python, Go, and Bash
+- Data stores, concurrency and execution controls, and automatic retry for failed executions.
+- We'll be launching a GitHub integration, extended event history, warm workers, looping and branching, and much more this year.
+
+Our goal is to build a product that our customers feel is wildly underpriced for ther value we are providing, and we are working every day to make that happen. If there are areas in which our product isn’t delivering, please reach out anytime at `support@pipedream.com`.

--- a/docs/docs/workspaces-and-credits-faq/README.md
+++ b/docs/docs/workspaces-and-credits-faq/README.md
@@ -44,4 +44,4 @@ We developed our old pricing when we first launched organizations, and had limit
 - Data stores, concurrency and execution controls, and automatic retry for failed executions.
 - We'll be launching a GitHub integration, extended event history, warm workers, looping and branching, and much more this year.
 
-Our goal is to build a product that our customers feel is wildly underpriced for ther value we are providing, and we are working every day to make that happen. If there are areas in which our product isn’t delivering, please reach out anytime at `support@pipedream.com`.
+Our goal is to build a product that our customers feel is wildly underpriced for the value we are providing, and we are working every day to make that happen. If there are areas in which our product isn’t delivering, please reach out anytime at `support@pipedream.com`.

--- a/docs/docs/workspaces-and-credits-faq/README.md
+++ b/docs/docs/workspaces-and-credits-faq/README.md
@@ -1,4 +1,4 @@
-# Workspaces, credits, and other new features for Pipedream orgs
+# Workspaces, Credits, and Other New Features for Pipedream Orgs
 
 We're excited to announce a new set of foundational changes and features! In short — orgs are now [workspaces](/workspaces), invocations are now [credits](/pricing/#credits), and you have access to a new features: [free source invocations](/pricing/#source-credit-usage), unlimited team members, and more.
 

--- a/docs/docs/workspaces-and-credits-faq/README.md
+++ b/docs/docs/workspaces-and-credits-faq/README.md
@@ -6,7 +6,7 @@ We're excited to announce a new set of foundational changes and features! In sho
 
 ## Orgs are now workspaces
 
-We've renamed organizations to [workspaces](/workspaces), which is more consistent with the language other products use. Anywhere you used to see references to “organizations”, you'll now see “workspaces”.
+We've renamed organizations to [workspaces](/workspaces), which is more consistent with the language other products use. Anywhere you used to see references to "organizations", you'll now see "workspaces".
 
 ## Invocations are now credits
 

--- a/docs/docs/workspaces-and-credits-faq/README.md
+++ b/docs/docs/workspaces-and-credits-faq/README.md
@@ -1,6 +1,6 @@
 # Workspaces, Credits, and Other New Features for Pipedream Orgs
 
-We're excited to announce a new set of foundational changes and features! In short — orgs are now [workspaces](/workspaces), invocations are now [credits](/pricing/#credits), and you have access to a new features: [free source invocations](/pricing/#source-credit-usage), unlimited team members, and more.
+We're excited to announce a new set of foundational changes and features! In short — orgs are now [workspaces](/workspaces), invocations are now [credits](/pricing/#credits), and you have access to new features: [free source invocations](/pricing/#source-credit-usage), unlimited team members, and more.
 
 [[toc]]
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4032,6 +4032,9 @@ importers:
       he: 1.2.0
       lodash: 4.17.21
 
+  components/stannp:
+    specifiers: {}
+
   components/status_hero:
     specifiers:
       '@pipedream/platform': ^0.10.0


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c3815f3</samp>

This pull request adds a new document to the `docs` folder explaining the Pipedream workspaces, credits, and plans, and updates the `pnpm-lock.yaml` file to allow the stannp component to use any version of the stannp package. The purpose is to inform customers and improve the stannp component functionality.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c3815f3</samp>

> _`docs` folder grows_
> _New features and plans explained_
> _Spring of Pipedream_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c3815f3</samp>

*  Add a new document explaining workspaces, credits, and plans ([link](https://github.com/PipedreamHQ/pipedream/pull/6169/files?diff=unified&w=0#diff-0cc9ff78c2da62e7630dabe72557343af961cf1763f0b0db20fe7d3ef0a2b338R1-R47))
*  Update the dependency lock for the stannp component ([link](https://github.com/PipedreamHQ/pipedream/pull/6169/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4035-R4037))
