### PR TITLE
123formbuilder triggers fix deduping

### DIFF
--- a/components/a123formbuilder/package.json
+++ b/components/a123formbuilder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/a123formbuilder",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream 123FormBuilder Components",
   "main": "a123formbuilder.app.mjs",
   "keywords": [

--- a/components/a123formbuilder/sources/common/base.mjs
+++ b/components/a123formbuilder/sources/common/base.mjs
@@ -13,11 +13,39 @@ export default {
     },
   },
   methods: {
+    listingFn() {
+      throw new Error("listingFn not implemented");
+    },
     getPage() {
       return this.db.get("page") || 1;
     },
     setPage(page) {
       this.db.set("page", page);
     },
+    getEmittedIds() {
+      return new Set(this.db.get("emittedIds") || []);
+    },
+    setEmittedIds(ids) {
+      this.db.set("emittedIds", Array.from(ids));
+    },
+  },
+  async run() {
+    const page = this.getPage();
+    const emittedIds = this.getEmittedIds();
+    const response = await this.listingFn()({
+      ...this.listingParams(),
+      paginate: true,
+      params: {
+        page,
+      },
+    });
+    this.setPage(this.a123formbuilder.getCurrentPage(response));
+    response.data.forEach((form) => {
+      if (!emittedIds.has(form.id)) {
+        this.$emit(form, this.getMeta(form));
+        emittedIds.add(form.id);
+      }
+    });
+    this.setEmittedIds(emittedIds);
   },
 };

--- a/components/a123formbuilder/sources/common/base.mjs
+++ b/components/a123formbuilder/sources/common/base.mjs
@@ -33,7 +33,7 @@ export default {
     const page = this.getPage();
     const emittedIds = this.getEmittedIds();
     const response = await this.listingFn()({
-      ...this.listingParams(),
+      ...this.listingFnParams(),
       paginate: true,
       params: {
         page,

--- a/components/a123formbuilder/sources/form-created/form-created.mjs
+++ b/components/a123formbuilder/sources/form-created/form-created.mjs
@@ -20,7 +20,7 @@ export default {
     listingFn() {
       return this.a123formbuilder.getForms;
     },
-    listingParams() {
+    listingFnParams() {
       return {};
     },
   },

--- a/components/a123formbuilder/sources/form-created/form-created.mjs
+++ b/components/a123formbuilder/sources/form-created/form-created.mjs
@@ -17,18 +17,11 @@ export default {
         ts: new Date(),
       };
     },
-  },
-  async run() {
-    const page = this.getPage();
-    const response = await this.a123formbuilder.getForms({
-      paginate: true,
-      params: {
-        page,
-      },
-    });
-    this.setPage(this.a123formbuilder.getCurrentPage(response));
-    response.data.forEach((form) => {
-      this.$emit(form, this.getMeta(form));
-    });
+    listingFn() {
+      return this.a123formbuilder.getForms;
+    },
+    listingParams() {
+      return {};
+    },
   },
 };

--- a/components/a123formbuilder/sources/form-created/form-created.mjs
+++ b/components/a123formbuilder/sources/form-created/form-created.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Form Created",
   description: "Emit new event for every created form",
   type: "source",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
   methods: {
     ...base.methods,

--- a/components/a123formbuilder/sources/form-response-submitted/form-response-submitted.mjs
+++ b/components/a123formbuilder/sources/form-response-submitted/form-response-submitted.mjs
@@ -29,7 +29,7 @@ export default {
     listingFn() {
       return this.a123formbuilder.getFormResponses;
     },
-    listingParams() {
+    listingFnParams() {
       return {
         form: this.form,
       };

--- a/components/a123formbuilder/sources/form-response-submitted/form-response-submitted.mjs
+++ b/components/a123formbuilder/sources/form-response-submitted/form-response-submitted.mjs
@@ -26,19 +26,13 @@ export default {
         ts: new Date(formResponse.date),
       };
     },
-  },
-  async run() {
-    const page = this.getPage();
-    const response = await this.a123formbuilder.getFormResponses({
-      paginate: true,
-      form: this.form,
-      params: {
-        page,
-      },
-    });
-    this.setPage(this.a123formbuilder.getCurrentPage(response));
-    response.data.forEach((form) => {
-      this.$emit(form, this.getMeta(form));
-    });
+    listingFn() {
+      return this.a123formbuilder.getFormResponses;
+    },
+    listingParams() {
+      return {
+        form: this.form,
+      };
+    },
   },
 };

--- a/components/a123formbuilder/sources/form-response-submitted/form-response-submitted.mjs
+++ b/components/a123formbuilder/sources/form-response-submitted/form-response-submitted.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Form Response Submitted",
   description: "Emit new event for every submitted form response",
   type: "source",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
   props: {
     ...base.props,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -937,6 +937,9 @@ importers:
   components/datumbox:
     specifiers: {}
 
+  components/dayschedule:
+    specifiers: {}
+
   components/dear:
     specifiers:
       '@pipedream/platform': ^1.2.0
@@ -2730,12 +2733,6 @@ importers:
 
   components/oksign:
     specifiers: {}
-
-  components/omniconvert:
-    specifiers:
-      '@pipedream/platform': ^1.3.0
-    dependencies:
-      '@pipedream/platform': 1.5.1
 
   components/omnisend:
     specifiers: {}


### PR DESCRIPTION
Adds deduping via `db` because each page of response may contain >100 objects (`dedupe unique` maximum retention).

Resolves #6198.

## WHAT

copilot:summary

copilot:poem


## WHY

<!-- author to complete -->


## HOW

copilot:walkthrough
