### PR TITLE
Fix dropbox from_path bug

### DIFF
--- a/components/dropbox/actions/move-file-folder/move-file-folder.mjs
+++ b/components/dropbox/actions/move-file-folder/move-file-folder.mjs
@@ -56,7 +56,7 @@ export default {
     }
 
     const res = await this.dropbox.filesMove({
-      from_path: pathFrom.value,
+      from_path: normalizedPathFrom,
       to_path: normalizedPathTo,
       autorename,
       allow_ownership_transfer: allowOwnershipTransfer,


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e68f9c5</samp>

Fixed a bug in the `move-file-folder` action of the Dropbox component that could cause errors when moving files or folders from the root folder. Changed the `from_path` parameter of the `filesMove` method to use the `normalizedPathFrom` variable instead of the `pathFrom.value` property.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e68f9c5</samp>

> _`from_path` changes_
> _avoid errors in root folder_
> _a slash matters not_


## WHY

Resolves https://github.com/PipedreamHQ/pipedream/issues/6202


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e68f9c5</samp>

*  Normalize the `from_path` and `to_path` parameters for the `filesMove` method by using helper variables ([link](https://github.com/PipedreamHQ/pipedream/pull/6203/files?diff=unified&w=0#diff-af94378fcb356971070c72e77ef9b6b4f85f5b2a25b53186328a5d0c3f505a3fL59-R59), )
