### PR TITLE
Updating Action Development documentation.

### DIFF
--- a/docs/docs/components/quickstart/nodejs/actions/README.md
+++ b/docs/docs/components/quickstart/nodejs/actions/README.md
@@ -387,7 +387,7 @@ export default {
       auth: this.github.$auth.oauth_access_token
     })
     
-    return (await octokit.repos.get({
+    return (await octokit.rest.repos.get({
       owner: `pipedreamhq`,
       repo: `pipedream`,
     })).data
@@ -417,7 +417,7 @@ export default {
       auth: this.github.$auth.oauth_access_token
     })
     
-    const { data } = await octokit.repos.get({
+    const { data } = await octokit.rest.repos.get({
       owner: `pipedreamhq`,
       repo: `pipedream`,
     })
@@ -452,7 +452,7 @@ export default {
       auth: this.github.$auth.oauth_access_token
     })
     
-    const { data } = await octokit.repos.get({
+    const { data } = await octokit.rest.repos.get({
       owner: `pipedreamhq`,
       repo: `pipedream`,
     })


### PR DESCRIPTION
Due to change in Octokit package, octokit.repos.get throws the error:

```
TypeError
Cannot read property 'get' of undefined

DETAILS
    at Object.run (file:///tmp/__pdg__/dist/code/2bb34f7267fc1562b45f218e9c9786674068fe36fbc4ec9cf98a009756c3e4f8/component.mjs:20:35)
    at global.executeComponent (/var/task/launch_worker.js:139:53)
    at MessagePort.messageHandler (/var/task/launch_worker.js:598:28)
```

This updates the documentation for [Quickstart Action Development ](https://pipedream.com/docs/components/quickstart/nodejs/actions/#use-managed-auth)from octokit.repos.get to octokit.rest.repos.get.

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3e01164</samp>

This pull request fixes the Node.js actions quickstart guide to use the correct octokit syntax and avoid deprecation warnings. It changes the `octokit` method calls in `docs/docs/components/quickstart/nodejs/actions/README.md` to use the `rest` namespace.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3e01164</samp>

> _`octokit.rest` now_
> _replaces old method calls_
> _autumn of code_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3e01164</samp>

* Use the `rest` namespace for octokit method calls to avoid deprecation warnings and ensure compatibility ([link](https://github.com/PipedreamHQ/pipedream/pull/6227/files?diff=unified&w=0#diff-2a4999c8768508fdd06a969718586610245a57b4c4f5be2dac0bbff996fd3fa2L390-R390), [link](https://github.com/PipedreamHQ/pipedream/pull/6227/files?diff=unified&w=0#diff-2a4999c8768508fdd06a969718586610245a57b4c4f5be2dac0bbff996fd3fa2L420-R420), [link](https://github.com/PipedreamHQ/pipedream/pull/6227/files?diff=unified&w=0#diff-2a4999c8768508fdd06a969718586610245a57b4c4f5be2dac0bbff996fd3fa2L455-R455)) in `docs/docs/components/quickstart/nodejs/actions/README.md`
