### PR TITLE
[Quickbooks] Create sales receipt action

### DIFF
--- a/components/quickbooks/actions/create-sales-receipt/create-sales-receipt.mjs
+++ b/components/quickbooks/actions/create-sales-receipt/create-sales-receipt.mjs
@@ -1,0 +1,73 @@
+import quickbooks from "../../quickbooks.app.mjs";
+import { ConfigurationError } from "@pipedream/platform";
+
+export default {
+  key: "quickbooks-create-sales-receipt",
+  name: "Create Sales Receipt",
+  description: "Creates a sales receipt. [See docs here](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/salesreceipt#create-a-salesreceipt)",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    quickbooks,
+    lineItems: {
+      propDefinition: [
+        quickbooks,
+        "lineItems",
+      ],
+    },
+    currencyRefValue: {
+      propDefinition: [
+        quickbooks,
+        "currencyRefValue",
+      ],
+      optional: true,
+    },
+    currencyRefName: {
+      propDefinition: [
+        quickbooks,
+        "currencyRefName",
+      ],
+      optional: true,
+    },
+  },
+  methods: {
+    async createSalesReceipt({
+      $, data,
+    }) {
+      return this.quickbooks._makeRequest(`company/${this.quickbooks._companyId()}/salesreceipt`, {
+        method: "post",
+        data,
+      }, $);
+    },
+  },
+  async run({ $ }) {
+    try {
+      if (typeof (this.lineItems) === "string") {
+        this.lineItems = JSON.parse(this.lineItems);
+      } else {
+        this.lineItems = this.lineItems.map((lineItem) => typeof lineItem === "string"
+          ? JSON.parse(lineItem)
+          : lineItem);
+      }
+    } catch (error) {
+      throw new ConfigurationError(`We got an error trying to parse the LineItems. Error: ${error}`);
+    }
+
+    const response = await this.createSalesReceipt({
+      $,
+      data: {
+        Line: this.lineItems,
+        CurrencyRef: this.currencyRefValue && {
+          value: this.currencyRefValue,
+          name: this.currencyRefName,
+        },
+      },
+    });
+
+    if (response) {
+      $.export("summary", `Successfully created sales receipt with id ${response.SalesReceipt.Id}`);
+    }
+
+    return response;
+  },
+};

--- a/components/quickbooks/actions/create-sales-receipt/create-sales-receipt.mjs
+++ b/components/quickbooks/actions/create-sales-receipt/create-sales-receipt.mjs
@@ -4,7 +4,7 @@ import { ConfigurationError } from "@pipedream/platform";
 export default {
   key: "quickbooks-create-sales-receipt",
   name: "Create Sales Receipt",
-  description: "Creates a sales receipt. [See docs here](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/salesreceipt#create-a-salesreceipt)",
+  description: "Creates a sales receipt. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/salesreceipt#create-a-salesreceipt)",
   version: "0.0.1",
   type: "action",
   props: {

--- a/components/quickbooks/actions/create-sales-receipt/create-sales-receipt.mjs
+++ b/components/quickbooks/actions/create-sales-receipt/create-sales-receipt.mjs
@@ -50,7 +50,7 @@ export default {
           : lineItem);
       }
     } catch (error) {
-      throw new ConfigurationError(`We got an error trying to parse the LineItems. Error: ${error}`);
+      throw new ConfigurationError(`An error occurred while trying to parse the LineItems. Error: ${error}`);
     }
 
     const response = await this.createSalesReceipt({

--- a/components/quickbooks/package.json
+++ b/components/quickbooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/quickbooks",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Pipedream Quickbooks Components",
   "main": "quickbooks.app.mjs",
   "keywords": [


### PR DESCRIPTION
Resolves #6031.

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 152195b</samp>

This pull request adds a new action component for creating sales receipts in Quickbooks using the `@pipedream/quickbooks` package. It also updates the package version in `components/quickbooks/package.json`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 152195b</samp>

> _`createSalesReceipt`_
> _New action for Quickbooks_
> _Autumn leaves fall fast_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 152195b</samp>

*  Add a new action component for creating sales receipts in Quickbooks ([link](https://github.com/PipedreamHQ/pipedream/pull/6235/files?diff=unified&w=0#diff-8559f357b02064c2f33699808848be08bc017602c615db52c3514811b267eae1R1-R73))
* Update the version of the `@pipedream/quickbooks` package ([link](https://github.com/PipedreamHQ/pipedream/pull/6235/files?diff=unified&w=0#diff-25c667d24bdd09e573fbea6632373b801df5fca34f2536587619294cef69d430L3-R3))
