### PR TITLE
Readwise: Support List Document

### DIFF
--- a/components/readwise/actions/get-highlight-details/get-highlight-details.mjs
+++ b/components/readwise/actions/get-highlight-details/get-highlight-details.mjs
@@ -4,7 +4,7 @@ export default {
   key: "readwise-get-highlight-details",
   name: "Get Highlight Details",
   description: "Get Highlight´s Details [See the docs here](https://readwise.io/api_deets)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     readwise,

--- a/components/readwise/actions/list-highlights/list-highlights.mjs
+++ b/components/readwise/actions/list-highlights/list-highlights.mjs
@@ -4,7 +4,7 @@ export default {
   key: "readwise-list-highlights",
   name: "List Highlights",
   description: "A list of highlights with a pagination metadata. The rate limit of this endpoint is restricted to 20 requests per minute. Each request returns 1000 items. [See the docs here](https://readwise.io/api_deets)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     readwise,

--- a/components/readwise/package.json
+++ b/components/readwise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/readwise",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Pipedream Readwise Components",
   "main": "dist/app/readwise.app.mjs",
   "keywords": [

--- a/components/readwise/package.json
+++ b/components/readwise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/readwise",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "description": "Pipedream Readwise Components",
   "main": "dist/app/readwise.app.mjs",
   "keywords": [

--- a/components/readwise/readwise.app.mjs
+++ b/components/readwise/readwise.app.mjs
@@ -55,7 +55,7 @@ export default {
   },
   methods: {
     _getBaseUrl() {
-      return "https://readwise.io/api/v2";
+      return "https://readwise.io/api";
     },
     _getHeaders() {
       return {
@@ -78,7 +78,7 @@ export default {
     }) {
       return this._makeRequest({
         $,
-        path: "books",
+        path: "v2/books",
         params,
       });
     },
@@ -87,7 +87,16 @@ export default {
     }) {
       return this._makeRequest({
         $,
-        path: "highlights",
+        path: "v2/highlights",
+        params,
+      });
+    },
+    async listDocuments({
+      $, params,
+    }) {
+      return this._makeRequest({
+        $,
+        path: "v3/list",
         params,
       });
     },
@@ -96,7 +105,7 @@ export default {
     }) {
       return this._makeRequest({
         $,
-        path: `highlights/${highlightId}`,
+        path: `v2/highlights/${highlightId}`,
       });
     },
     async *paginate({

--- a/components/readwise/sources/new-documents/new-documents.mjs
+++ b/components/readwise/sources/new-documents/new-documents.mjs
@@ -41,7 +41,7 @@ export default {
       const { results: events } = await this.readwise.listDocuments({
         params,
       });
-      for (const event of events) {
+      for (const event of events.splice(0, 100)) {
         this.emitEvent(event);
       }
     },

--- a/components/readwise/sources/new-documents/new-documents.mjs
+++ b/components/readwise/sources/new-documents/new-documents.mjs
@@ -43,6 +43,7 @@ export default {
       const { results: events } = await this.readwise.listDocuments({
         params,
       });
+      events.reverse();
       for (const event of events.slice(0, 100)) {
         this.emitEvent(event);
       }

--- a/components/readwise/sources/new-documents/new-documents.mjs
+++ b/components/readwise/sources/new-documents/new-documents.mjs
@@ -41,7 +41,7 @@ export default {
       const { results: events } = await this.readwise.listDocuments({
         params,
       });
-      for (const event of events.splice(0, 100)) {
+      for (const event of events.slice(0, 100)) {
         this.emitEvent(event);
       }
     },

--- a/components/readwise/sources/new-documents/new-documents.mjs
+++ b/components/readwise/sources/new-documents/new-documents.mjs
@@ -4,7 +4,7 @@ import { DEFAULT_POLLING_SOURCE_TIMER_INTERVAL } from "@pipedream/platform";
 export default {
   key: "readwise-new-documents",
   name: "New Documents",
-  description: "Emit new document",
+  description: "Emit new document [See the documentation](https://readwise.io/reader_api)",
   version: "0.0.1",
   type: "source",
   dedupe: "unique",

--- a/components/readwise/sources/new-documents/new-documents.mjs
+++ b/components/readwise/sources/new-documents/new-documents.mjs
@@ -12,7 +12,7 @@ export default {
     readwise,
     timer: {
       label: "Polling interval",
-      description: "Pipedream will poll the Readwise API on this schedule",
+      description: "Pipedream polls the Readwise API on this schedule",
       type: "$.interface.timer",
       default: {
         intervalSeconds: DEFAULT_POLLING_SOURCE_TIMER_INTERVAL,

--- a/components/readwise/sources/new-documents/new-documents.mjs
+++ b/components/readwise/sources/new-documents/new-documents.mjs
@@ -4,7 +4,7 @@ import { DEFAULT_POLLING_SOURCE_TIMER_INTERVAL } from "@pipedream/platform";
 export default {
   key: "readwise-new-documents",
   name: "New Documents",
-  description: "Emit new Document",
+  description: "Emit new document",
   version: "0.0.1",
   type: "source",
   dedupe: "unique",

--- a/components/readwise/sources/new-documents/new-documents.mjs
+++ b/components/readwise/sources/new-documents/new-documents.mjs
@@ -43,7 +43,6 @@ export default {
       const { results: events } = await this.readwise.listDocuments({
         params,
       });
-      events.reverse();
       for (const event of events.slice(0, 100)) {
         this.emitEvent(event);
       }

--- a/components/readwise/sources/new-documents/new-documents.mjs
+++ b/components/readwise/sources/new-documents/new-documents.mjs
@@ -57,7 +57,7 @@ export default {
       this.$emit(event, {
         id: event.id,
         summary: `New Document: ${event.id}`,
-        ts: Date.now(),
+        ts: new Date(event.created_at),
       });
     },
   },

--- a/components/readwise/sources/new-documents/new-documents.mjs
+++ b/components/readwise/sources/new-documents/new-documents.mjs
@@ -21,13 +21,15 @@ export default {
     location: {
       type: "string",
       label: "Location",
-      description: "(Optional) The document's location, can be one of: new, later, shortlist, archive, feed",
+      description: "(Optional) The document's location, see https://readwise.io/reader_api",
+      options: ["new", "later", "shortlist", "archive", "feed"],
       optional: true,
     },
     category: {
       type: "string",
       label: "Category",
-      description: "(Optional) The document's category, can be one of: article, email, rss, highlight, note, pdf, epub, tweet, video",
+      description: "(Optional) The document's category, see https://readwise.io/reader_api",
+      options: ["article", "email", "rss", "highlight", "note", "pdf", "epub", "tweet", "video"],
       optional: true,
     },
   },

--- a/components/readwise/sources/new-documents/new-documents.mjs
+++ b/components/readwise/sources/new-documents/new-documents.mjs
@@ -55,6 +55,7 @@ export default {
       this.$emit(event, {
         id: event.id,
         summary: `New Document: ${event.id}`,
+        ts: Date.now(),
       });
     },
   },

--- a/components/readwise/sources/new-documents/new-documents.mjs
+++ b/components/readwise/sources/new-documents/new-documents.mjs
@@ -27,7 +27,7 @@ export default {
     category: {
       type: "string",
       label: "Category",
-      description: "(Optional) The document's category, could be one of: article, email, rss, highlight, note, pdf, epub, tweet, video",
+      description: "(Optional) The document's category, can be one of: article, email, rss, highlight, note, pdf, epub, tweet, video",
       optional: true,
     },
   },

--- a/components/readwise/sources/new-documents/new-documents.mjs
+++ b/components/readwise/sources/new-documents/new-documents.mjs
@@ -33,7 +33,7 @@ export default {
   },
   hooks: {
     async activate() {
-      await this.processDocuments();
+      await this.processEvent();
     },
   },
   methods: {

--- a/components/readwise/sources/new-documents/new-documents.mjs
+++ b/components/readwise/sources/new-documents/new-documents.mjs
@@ -21,7 +21,7 @@ export default {
     location: {
       type: "string",
       label: "Location",
-      description: "(Optional) The document's location, could be one of: new, later, shortlist, archive, feed",
+      description: "(Optional) The document's location, can be one of: new, later, shortlist, archive, feed",
       optional: true,
     },
     category: {

--- a/components/readwise/sources/new-documents/new-documents.mjs
+++ b/components/readwise/sources/new-documents/new-documents.mjs
@@ -21,7 +21,7 @@ export default {
     location: {
       type: "string",
       label: "Location",
-      description: "(Optional) The document's location, see https://readwise.io/reader_api",
+      description: "(Optional) The document's location. [See the documentation](https://readwise.io/reader_api).",
       options: ["new", "later", "shortlist", "archive", "feed"],
       optional: true,
     },

--- a/components/readwise/sources/new-documents/new-documents.mjs
+++ b/components/readwise/sources/new-documents/new-documents.mjs
@@ -28,7 +28,7 @@ export default {
     category: {
       type: "string",
       label: "Category",
-      description: "(Optional) The document's category, see https://readwise.io/reader_api",
+      description: "(Optional) The document's category. [See the documentation](https://readwise.io/reader_api).",
       options: ["article", "email", "rss", "highlight", "note", "pdf", "epub", "tweet", "video"],
       optional: true,
     },

--- a/components/readwise/sources/new-highlights/new-highlights.mjs
+++ b/components/readwise/sources/new-highlights/new-highlights.mjs
@@ -5,7 +5,7 @@ export default {
   key: "readwise-new-highlights",
   name: "New Highlights",
   description: "Emit new Highlight",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "source",
   dedupe: "unique",
   props: {


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2c7aeab</samp>

This pull request adds a new source component `new-documents` that emits new documents from the Readwise API based on user-defined filters. It also updates the `readwise` app component to use the latest API endpoints and parameters. The changes enable users to access and integrate more data from Readwise in their workflows.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2c7aeab</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A new source component, `new-documents`, that spies_
> _On the Readwise API, and with `timer` and `listDocuments` calls_
> _Fetches and emits the latest writings from the halls_


## WHY

I try to add https://readwise.io/reader_api Document List as a source in this PR.

But there's some point:

1. Because of the change of `readwise.app.mjs`, I can't find a way to test. I just "test" with my eyes.
2. I can't find any document about the `async *paginate` in `readwise.app.mjs`. I don't know if it's something do not use or something app's internal use. I just treat it as a legacy issue from history so I only request the first page and assume it (which returns 100 records) is enough.
3. I don't store the recently updated time as the "new highlights" module does. Because I find the document says "Use built-in deduping strategies whenever possible (unique, greatest, last) vs developing custom deduping code."



## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2c7aeab</samp>

*  Add a new source component `new-documents` that emits new documents from Readwise based on location and category filters ([link](https://github.com/PipedreamHQ/pipedream/pull/6366/files?diff=unified&w=0#diff-a3a436c36f1955b7850cd4374e778d31f158efbfe772d217bd1ecc46598ecd27R1-R64))
*  Update the `readwise` app module to use the latest versions of the Readwise API endpoints for books and highlights, and add a new method `listDocuments` that uses the new `v3/list` endpoint ([link](https://github.com/PipedreamHQ/pipedream/pull/6366/files?diff=unified&w=0#diff-6efb8907bf7711c6d5934d61b3b3f6a6482e887617f2d889d6013d31afad6b09L58-R58), [link](https://github.com/PipedreamHQ/pipedream/pull/6366/files?diff=unified&w=0#diff-6efb8907bf7711c6d5934d61b3b3f6a6482e887617f2d889d6013d31afad6b09L81-R81), [link](https://github.com/PipedreamHQ/pipedream/pull/6366/files?diff=unified&w=0#diff-6efb8907bf7711c6d5934d61b3b3f6a6482e887617f2d889d6013d31afad6b09L90-R102), [link](https://github.com/PipedreamHQ/pipedream/pull/6366/files?diff=unified&w=0#diff-6efb8907bf7711c6d5934d61b3b3f6a6482e887617f2d889d6013d31afad6b09L99-R108))
*  Update the `new-documents` component to use the `listDocuments` method, implement the `activate` hook, and define the `processDocuments` and `emitEvent` methods ([link](https://github.com/PipedreamHQ/pipedream/pull/6366/files?diff=unified&w=0#diff-a3a436c36f1955b7850cd4374e778d31f158efbfe772d217bd1ecc46598ecd27R1-R64))
*  Update the `new-documents` component to use the `timer` prop and the `run` function to schedule and execute the document fetching and emitting logic ([link](https://github.com/PipedreamHQ/pipedream/pull/6366/files?diff=unified&w=0#diff-a3a436c36f1955b7850cd4374e778d31f158efbfe772d217bd1ecc46598ecd27R1-R64))
