### PR TITLE
[Postgres] Republish components

### DIFF
--- a/components/postgresql/actions/delete-rows/delete-rows.mjs
+++ b/components/postgresql/actions/delete-rows/delete-rows.mjs
@@ -4,7 +4,7 @@ export default {
   name: "Delete Row(s)",
   key: "postgresql-delete-rows",
   description: "Deletes a row or rows from a table. [See Docs](https://node-postgres.com/features/queries)",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "action",
   props: {
     postgresql,

--- a/components/postgresql/actions/execute-custom-query/execute-custom-query.mjs
+++ b/components/postgresql/actions/execute-custom-query/execute-custom-query.mjs
@@ -4,7 +4,7 @@ export default {
   name: "Execute Custom Query",
   key: "postgresql-execute-custom-query",
   description: "Executes a custom query you provide. [See Docs](https://node-postgres.com/features/queries)",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "action",
   props: {
     postgresql,

--- a/components/postgresql/actions/find-row-custom-query/find-row-custom-query.mjs
+++ b/components/postgresql/actions/find-row-custom-query/find-row-custom-query.mjs
@@ -4,7 +4,7 @@ export default {
   name: "Find Row With Custom Query",
   key: "postgresql-find-row-custom-query",
   description: "Finds a row in a table via a custom query. [See Docs](https://node-postgres.com/features/queries)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   props: {
     postgresql,

--- a/components/postgresql/actions/find-row-custom-query/find-row-custom-query.mjs
+++ b/components/postgresql/actions/find-row-custom-query/find-row-custom-query.mjs
@@ -19,7 +19,6 @@ export default {
         postgresql,
         "values",
       ],
-      optional: true,
     },
     rejectUnauthorized: {
       propDefinition: [

--- a/components/postgresql/actions/find-row/find-row.mjs
+++ b/components/postgresql/actions/find-row/find-row.mjs
@@ -4,7 +4,7 @@ export default {
   name: "Find Row",
   key: "postgresql-find-row",
   description: "Finds a row in a table via a lookup column. [See Docs](https://node-postgres.com/features/queries)",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "action",
   props: {
     postgresql,

--- a/components/postgresql/actions/insert-row/insert-row.mjs
+++ b/components/postgresql/actions/insert-row/insert-row.mjs
@@ -4,7 +4,7 @@ export default {
   name: "Insert Row",
   key: "postgresql-insert-row",
   description: "Adds a new row. [See Docs](https://node-postgres.com/features/queries)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   props: {
     postgresql,

--- a/components/postgresql/actions/update-row/update-row.mjs
+++ b/components/postgresql/actions/update-row/update-row.mjs
@@ -4,7 +4,7 @@ export default {
   name: "Update Row",
   key: "postgresql-update-row",
   description: "Updates an existing row. [See Docs](https://node-postgres.com/features/queries)",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "action",
   props: {
     postgresql,

--- a/components/postgresql/package.json
+++ b/components/postgresql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/postgresql",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Pipedream PostgreSQL Components",
   "main": "postgresql.app.mjs",
   "keywords": [

--- a/components/postgresql/postgresql.app.mjs
+++ b/components/postgresql/postgresql.app.mjs
@@ -72,7 +72,7 @@ export default {
     rejectUnauthorized: {
       type: "boolean",
       label: "Reject Unauthorized",
-      description: "If `true`, the server certificate is verified against the list of supplied CAs. If you encounter the error `Connection terminated unexpectedly`, try setting this prop to `false`."
+      description: "If `true`, the server certificate is verified against the list of supplied CAs. If you encounter the error `Connection terminated unexpectedly`, try setting this prop to `false`.",
       default: true,
     },
   },
@@ -235,7 +235,7 @@ export default {
       });
       return this.executeQuery({
         text: format(`
-          INSERT INTO %I.%I (${columns}) 
+          INSERT INTO %I.%I (${columns})
             VALUES (${placeholders})
             RETURNING *
         `, schema, table),

--- a/components/postgresql/postgresql.app.mjs
+++ b/components/postgresql/postgresql.app.mjs
@@ -44,6 +44,7 @@ export default {
       type: "string[]",
       label: "Values",
       description: "List of values represented in your SQL Query above",
+      optional: true,
     },
     value: {
       type: "string",

--- a/components/postgresql/sources/new-column/new-column.mjs
+++ b/components/postgresql/sources/new-column/new-column.mjs
@@ -5,7 +5,7 @@ export default {
   name: "New Column",
   key: "postgresql-new-column",
   description: "Emit new event when a new column is added to a table. [See Docs](https://node-postgres.com/features/queries)",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "source",
   props: {
     ...common.props,

--- a/components/postgresql/sources/new-or-updated-row/new-or-updated-row.mjs
+++ b/components/postgresql/sources/new-or-updated-row/new-or-updated-row.mjs
@@ -5,7 +5,7 @@ export default {
   name: "New or Updated Row",
   key: "postgresql-new-or-updated-row",
   description: "Emit new event when a row is added or modified. [See Docs](https://node-postgres.com/features/queries)",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/postgresql/sources/new-row-custom-query/new-row-custom-query.mjs
+++ b/components/postgresql/sources/new-row-custom-query/new-row-custom-query.mjs
@@ -5,7 +5,7 @@ export default {
   name: "New Row Custom Query",
   key: "postgresql-new-row-custom-query",
   description: "Emit new event when new rows are returned from a custom query that you provide. [See Docs](https://node-postgres.com/features/queries)",
-  version: "0.0.9",
+  version: "0.0.10",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/postgresql/sources/new-row/new-row.mjs
+++ b/components/postgresql/sources/new-row/new-row.mjs
@@ -5,7 +5,7 @@ export default {
   name: "New Row",
   key: "postgresql-new-row",
   description: "Emit new event when a new row is added to a table. [See Docs](https://node-postgres.com/features/queries)",
-  version: "1.0.6",
+  version: "1.0.7",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/postgresql/sources/new-table/new-table.mjs
+++ b/components/postgresql/sources/new-table/new-table.mjs
@@ -5,7 +5,7 @@ export default {
   name: "New Table",
   key: "postgresql-new-table",
   description: "Emit new event when a new table is added to the database. [See Docs](https://node-postgres.com/features/queries)",
-  version: "0.0.9",
+  version: "0.0.10",
   type: "source",
   props: {
     ...common.props,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2113,6 +2113,9 @@ importers:
   components/key_app_demo_1:
     specifiers: {}
 
+  components/kintone:
+    specifiers: {}
+
   components/klaviyo:
     specifiers:
       klaviyo-sdk: ^1.0.1
@@ -4169,6 +4172,9 @@ importers:
     specifiers: {}
 
   components/successeve:
+    specifiers: {}
+
+  components/suitedash:
     specifiers: {}
 
   components/supabase:


### PR DESCRIPTION
Republishing #6379.

Also: making `values` prop optional because simple custom SQL expressions might not have `VALUES`.

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3544b61</samp>

This pull request updates the PostgreSQL app file and the version numbers of the PostgreSQL package and components. These changes fix a syntax error, add new dependencies, and reflect the code and prop modifications made in the PostgreSQL action and source components.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3544b61</samp>

> _The PostgreSQL components got a bump_
> _To fix some bugs and add a new pump_
> _For Kintone and SuiteDash_
> _They added some new stash_
> _And cleaned up the app file from a slump_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3544b61</samp>

*  Incremented the version of the `@pipedream/postgresql` package and its components to reflect the changes made in the code and props ([link](https://github.com/PipedreamHQ/pipedream/pull/6386/files?diff=unified&w=0#diff-895497ca9302c0c7e8dab52e2cc8cf02a7f9bd1afb8295ea7ffc7fa17aafc8a2L7-R7), [link](https://github.com/PipedreamHQ/pipedream/pull/6386/files?diff=unified&w=0#diff-3bfca177bfa44e9d2951f3d3b5f3feec6e3f8413bd75fd2507bb585ef9d4869dL7-R7), [link](https://github.com/PipedreamHQ/pipedream/pull/6386/files?diff=unified&w=0#diff-fb2fa6ed7ac8be7ddf3fabf0dd2e7a6ec594d1d8b37cdacdb6487cebbd83630cL7-R7), [link](https://github.com/PipedreamHQ/pipedream/pull/6386/files?diff=unified&w=0#diff-32de97cf8c59222002f84d4175841b84d0dc4247630359981d0dbc88a866dff8L7-R7), [link](https://github.com/PipedreamHQ/pipedream/pull/6386/files?diff=unified&w=0#diff-aab820151415783719a2718001f917d5ce0a3ce9fe7195e892ed9d32a9c1221cL7-R7), [link](https://github.com/PipedreamHQ/pipedream/pull/6386/files?diff=unified&w=0#diff-33495c1c015f575f14305f12537e2b1ff7830ef3558f1c71d52349a2267d481aL7-R7), [link](https://github.com/PipedreamHQ/pipedream/pull/6386/files?diff=unified&w=0#diff-6f1ecefb9f918dca5e790a97ea235ce0574bb4cd5ad13c82bcfa477725bddf48L3-R3), [link](https://github.com/PipedreamHQ/pipedream/pull/6386/files?diff=unified&w=0#diff-2cedcb59865a6cd78944d81e308ab02870f9587e818c4aec46f2b41639ab2a1dL8-R8), [link](https://github.com/PipedreamHQ/pipedream/pull/6386/files?diff=unified&w=0#diff-55b48e6d069e0c92265f099c98598956f5d942898f39433d368af0c540f62a81L8-R8), [link](https://github.com/PipedreamHQ/pipedream/pull/6386/files?diff=unified&w=0#diff-d87c266067e58a6bc693358365628c9ecd22e18fdabe426b8cd392abe63c7c26L8-R8), [link](https://github.com/PipedreamHQ/pipedream/pull/6386/files?diff=unified&w=0#diff-73de2f18a21fea70d37c58168dbac3548edd9873d7e1f432ddffae5f15dd5409L8-R8), [link](https://github.com/PipedreamHQ/pipedream/pull/6386/files?diff=unified&w=0#diff-c3bf65921c94f49e24a875d478044f9bd52f2eb2f1d3d0c54b5a07599ed71f23L8-R8))
* Fixed a syntax error in the `postgresql.app.mjs` file by adding a missing comma after the `description` prop of the `rejectUnauthorized` prop ([link](https://github.com/PipedreamHQ/pipedream/pull/6386/files?diff=unified&w=0#diff-75b9969de4b6db255cc629b1bfce4cb6dfc2ca8ac6f724b3045d8904be78344eL75-R75))
* Removed a trailing whitespace in the `postgresql.app.mjs` file after the `columns` variable in the `insertRow` method ([link](https://github.com/PipedreamHQ/pipedream/pull/6386/files?diff=unified&w=0#diff-75b9969de4b6db255cc629b1bfce4cb6dfc2ca8ac6f724b3045d8904be78344eL238-R238))
* Added the `kintone` and `suitedash` packages as dependencies for some components in the `pnpm-lock.yaml` file ([link](https://github.com/PipedreamHQ/pipedream/pull/6386/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2116-R2118), [link](https://github.com/PipedreamHQ/pipedream/pull/6386/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4177-R4179))
