### PR TITLE
Converting string props takerProfitPrice and stopLossPrice to float

### DIFF
--- a/components/bingx/actions/trade-new-order/trade-new-order.mjs
+++ b/components/bingx/actions/trade-new-order/trade-new-order.mjs
@@ -2,7 +2,7 @@ import bingx from "../../bingx.app.mjs";
 
 export default {
   name: "BingX Trade New Order",
-  version: "0.1.0",
+  version: "0.1.1",
   key: "bingx-trade-new-order",
   description: "Place a New Order [reference](https://bingx-api.github.io/docs/swap/trade-api.html#_1-place-a-new-order).",
   props: {
@@ -60,6 +60,15 @@ export default {
   async run({ $ }) {
     const API_METHOD = "POST";
     const API_PATH = "/api/v1/user/trade";
+
+    if (this.takerProfitPrice) {
+      this.takerProfitPrice = parseFloat(this.takerProfitPrice.replace(",", "."));
+    }
+
+    if (this.stopLossPrice) {
+      this.stopLossPrice = parseFloat(this.stopLossPrice.replace(",", "."));
+    }
+
     const parameters = {
       "symbol": this.symbol,
       "side": this.side,

--- a/components/bingx/package.json
+++ b/components/bingx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/bingx",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream BingX Components",
   "main": "bingx.app.mjs",
   "keywords": [


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1d9dc10</samp>

Fixed decimal number handling and bugs in `bingx/actions/trade-new-order/trade-new-order.mjs` and bumped the version of `bingx/package.json` to 0.1.1.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1d9dc10</samp>

> _`BingX` is the package of doom_
> _It brings confusion and despair_
> _But we updated the version and the component_
> _To handle decimals and fix the bugs in there_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1d9dc10</samp>

*  Update the version of the BingX package and the BingX Trade New Order component to 0.1.1 ([link](https://github.com/PipedreamHQ/pipedream/pull/6403/files?diff=unified&w=0#diff-e3ce12deae82dd360db064c144edcb44b0459f2bc6b57de7e0f4cfa5b35a0937L5-R5), [link](https://github.com/PipedreamHQ/pipedream/pull/6403/files?diff=unified&w=0#diff-37e6e279bc7d94ca0ed853df4c0467bb6a7c0cfcb8f17e156323f8f896cd1ae5L3-R3))
*  Fix the parsing of the takerProfitPrice and stopLossPrice parameters in the `trade-new-order.mjs` file to use floats with dots as separators ([link](https://github.com/PipedreamHQ/pipedream/pull/6403/files?diff=unified&w=0#diff-e3ce12deae82dd360db064c144edcb44b0459f2bc6b57de7e0f4cfa5b35a0937R63-R71))
