### PR TITLE
[BugFix] Zoom Admin - List Webinar Participants

### DIFF
--- a/components/zoom_admin/actions/list-webinar-participants/list-webinar-participants.mjs
+++ b/components/zoom_admin/actions/list-webinar-participants/list-webinar-participants.mjs
@@ -4,7 +4,7 @@ export default {
   name: "List Webinar Participants",
   description: "Use this API to list all the participants who attended a webinar hosted in the past. [See the documentation](https://developers.zoom.us/docs/api/rest/reference/zoom-api/methods/#operation/listWebinarParticipants)",
   key: "zoom_admin-list-webinar-participants",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     zoomAdmin,
@@ -28,7 +28,7 @@ export default {
     },
   },
   async run ({ $ }) {
-    const res = await this.app.zoomAdmin.listWebinarParticipants(
+    const res = await this.zoomAdmin.listWebinarParticipants(
       this.webinar,
       this.pageSize,
       this.nextPageToken,

--- a/components/zoom_admin/package.json
+++ b/components/zoom_admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/zoom_admin",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Pipedream Zoom_admin Components",
   "main": "zoom_admin.app.js",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -359,6 +359,9 @@ importers:
       '@pipedream/platform': 1.5.1
       mailparser-mit: 1.0.0
 
+  components/axonaut:
+    specifiers: {}
+
   components/azure_devops:
     specifiers:
       '@pipedream/platform': ^1.2.1
@@ -423,6 +426,9 @@ importers:
       '@pipedream/platform': 1.5.1
       '@pipedream/types': 0.1.6
 
+  components/better_uptime:
+    specifiers: {}
+
   components/big_cartel:
     specifiers:
       '@pipedream/platform': ^1.1.0
@@ -442,6 +448,9 @@ importers:
       '@pipedream/platform': 1.5.1
 
   components/bill:
+    specifiers: {}
+
+  components/billsby:
     specifiers: {}
 
   components/bingx:
@@ -485,6 +494,9 @@ importers:
     dependencies:
       '@pipedream/platform': 0.10.0
       path: 0.12.7
+
+  components/braintree:
+    specifiers: {}
 
   components/brandmentions:
     specifiers: {}
@@ -837,6 +849,9 @@ importers:
     specifiers: {}
 
   components/congress_gov:
+    specifiers: {}
+
+  components/convertapi:
     specifiers: {}
 
   components/convertkit:
@@ -1935,6 +1950,9 @@ importers:
   components/hygraph:
     specifiers: {}
 
+  components/icontact:
+    specifiers: {}
+
   components/idealpostcodes:
     specifiers: {}
 
@@ -2476,6 +2494,9 @@ importers:
       '@pipedream/platform': ^1.2.0
     dependencies:
       '@pipedream/platform': 1.5.1
+
+  components/messagebird:
+    specifiers: {}
 
   components/metabase:
     specifiers: {}
@@ -3305,6 +3326,9 @@ importers:
       '@pipedream/platform': 1.5.1
 
   components/qstash:
+    specifiers: {}
+
+  components/quaderno:
     specifiers: {}
 
   components/qualaroo:
@@ -4140,6 +4164,9 @@ importers:
     dependencies:
       '@pipedream/platform': 1.5.1
 
+  components/stealthseminar:
+    specifiers: {}
+
   components/stormboard:
     specifiers: {}
 
@@ -4721,6 +4748,9 @@ importers:
       verifalia: 3.2.2
 
   components/verifybee:
+    specifiers: {}
+
+  components/vestaboard:
     specifiers: {}
 
   components/virustotal:


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f195809</samp>

Added new components for various integrations and improved an existing one. The new components enable users to work with different services and APIs, such as `airtable`, `google_sheets`, and `stripe`. The improved component, `zoom_admin-list-webinar-participants`, now supports a prop for the Zoom Admin API, which simplifies its configuration and usage.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f195809</samp>

> _Zoom admin prop change_
> _New components with lock file_
> _Winter of updates_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f195809</samp>

*  Bumped the version of the `zoom_admin-list-webinar-participants` action to reflect code changes ([link](https://github.com/PipedreamHQ/pipedream/pull/6422/files?diff=unified&w=0#diff-19593164b1231167fac441fafce752ae59c391834696de93d618ff4e7eedb353L7-R7))
*  Simplified the access to the `zoomAdmin` prop in the `zoom_admin-list-webinar-participants` action ([link](https://github.com/PipedreamHQ/pipedream/pull/6422/files?diff=unified&w=0#diff-19593164b1231167fac441fafce752ae59c391834696de93d618ff4e7eedb353L31-R31))
*  Added new components for `axonaut`, `better_uptime`, `billsby`, `braintree`, `convertapi`, `icontact`, `messagebird`, `quaderno`, `stealthseminar`, and `vestaboard` with their respective dependencies locked in the `pnpm-lock.yaml` file ([link](https://github.com/PipedreamHQ/pipedream/pull/6422/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR362-R364), [link](https://github.com/PipedreamHQ/pipedream/pull/6422/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR429-R431), [link](https://github.com/PipedreamHQ/pipedream/pull/6422/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR453-R455), [link](https://github.com/PipedreamHQ/pipedream/pull/6422/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR498-R500), [link](https://github.com/PipedreamHQ/pipedream/pull/6422/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR854-R856), [link](https://github.com/PipedreamHQ/pipedream/pull/6422/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1953-R1955), [link](https://github.com/PipedreamHQ/pipedream/pull/6422/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2498-R2500), [link](https://github.com/PipedreamHQ/pipedream/pull/6422/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3331-R3333), [link](https://github.com/PipedreamHQ/pipedream/pull/6422/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4167-R4169), [link](https://github.com/PipedreamHQ/pipedream/pull/6422/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4753-R4755))
