### PR TITLE
Mario doc hax

### DIFF
--- a/docs/docs/.vuepress/configs/envVars.js
+++ b/docs/docs/.vuepress/configs/envVars.js
@@ -7,6 +7,8 @@ module.exports = {
   MEMORY_ABSOLUTE_LIMIT: "10GB",
   EMAIL_PAYLOAD_SIZE_LIMIT: "30MB",
 
+  MAX_WORKFLOW_EXECUTION_LIMIT: "750",
+
   base_credits_price: {
     memory: 256,
     seconds: 30,

--- a/docs/docs/.vuepress/configs/sidebarConfig.js
+++ b/docs/docs/.vuepress/configs/sidebarConfig.js
@@ -12,7 +12,7 @@ const docsNav = [
       "/workflows/steps/using-props/",
       "/workflows/events/",
       "/workflows/events/inspect/",
-      "/workflows/built-in-functions/",
+      "/workflows/flow-control/",
       "/workflows/errors/",
       "/workflows/concurrency-and-throttling/",
       "/workflows/settings/",
@@ -70,6 +70,7 @@ const docsNav = [
       "/environment-variables/",
     ],
   },
+  "/http/",
   {
     title: 'Integrations',
     type: "group", 

--- a/docs/docs/code/nodejs/delay/README.md
+++ b/docs/docs/code/nodejs/delay/README.md
@@ -40,7 +40,7 @@ export default defineComponent({
 
 ::: tip Paused workflow state
 
-When `$.flow.delay` is executed in a Node.js step, the workflow itself will enter in a **Paused** state.
+When `$.flow.delay` is executed in a Node.js step, the workflow itself will enter a **Paused** state.
 
 While the workflow is paused, it will not incur any credits towards compute time. You can also [view all paused workflows in the Event History](/event-history/#filtering-by-status).
 

--- a/docs/docs/code/nodejs/delay/README.md
+++ b/docs/docs/code/nodejs/delay/README.md
@@ -38,6 +38,22 @@ export default defineComponent({
 });
 ```
 
+::: tip Paused workflow state
+
+When `$.flow.delay` is executed in a Node.js step, the workflow itself will enter in a **Paused** state.
+
+While the workflow is paused, it will not incur any credits towards compute time. You can also [view all paused workflows in the Event History](/event-history/#filtering-by-status).
+
+:::
+
+### Credit usage
+
+The length of time a workflow is delayed from `$.flow.delay` does _not_ impact your credit usage. For example, delaying a 256 megabyte workflow for five minutes will **not** incur ten credits.
+
+However, using `$.flow.delay` in a workflow will incur two credits.
+
+One credit is used to initially start the workflow, then the second credit is used when the workflow resumes after its pause period has ended.
+
 ## `cancel_url` and `resume_url`
 
 Both the built-in **Delay** actions and `$.flow.delay` return a `cancel_url` and `resume_url` that lets you cancel or resume paused executions.
@@ -94,3 +110,29 @@ export default defineComponent({
 You cannot run `$.respond` after running `$.flow.delay`. Pipedream ends the original execution of the workflow when `$.flow.delay` is called and issues the following response to the client to indicate this state:
 
 > $.respond() not called for this invocation
+
+If you need to set a delay on an HTTP request triggered workflow, consider using using [`setTimeout`](#settimeout) instead.
+
+## `setTimeout`
+
+Alternatively, you can use `setTimeout` instead of using `$.flow.delay` to delay individual workflow steps.
+
+However, there are some drawbacks to using `setTimeout` instead of `$.flow.delay`. `setTimeout` will count towards your workflows compute time, for example:
+
+```javascript
+export default defineComponent({
+  async run({ steps, $ }) {
+    // delay this step for 30 seconds
+    const delay = 30000;
+
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        resolve('timer ended')
+      }, delay)
+    })
+  }
+});
+
+```
+
+The Node.js step above will hold the workflow's execution for this step for 30 seconds; however, 30 seconds will also _contribute_ to your credit usage. Also consider that workflows have a hard limit of {{$site.themeConfig.MAX_WORKFLOW_EXECUTION_LIMIT}} seconds.

--- a/docs/docs/code/nodejs/delay/README.md
+++ b/docs/docs/code/nodejs/delay/README.md
@@ -7,9 +7,9 @@ thumbnail: https://res.cloudinary.com/pipedreamin/image/upload/v1646841376/docs/
 
 <VideoPlayer title="Delaying Workflow Steps" url="https://www.youtube.com/embed/IBORwBnIZ-k" startAt="148" />
 
-Use `$.flow.delay` to [delay a step in a workflow](/workflows/built-in-functions/#delay).
+Use `$.flow.delay` to [delay a step in a workflow](/workflows/flow-control/#delay).
 
-These docs show you how write Node.js code to handle delays. If you don't need to write code, see [our built-in delay actions](/workflows/built-in-functions/#delay-actions).
+These docs show you how write Node.js code to handle delays. If you don't need to write code, see [our built-in delay actions](/workflows/flow-control/#delay-actions).
 
 [[toc]]
 

--- a/docs/docs/code/nodejs/delay/README.md
+++ b/docs/docs/code/nodejs/delay/README.md
@@ -9,7 +9,7 @@ thumbnail: https://res.cloudinary.com/pipedreamin/image/upload/v1646841376/docs/
 
 Use `$.flow.delay` to [delay a step in a workflow](/workflows/flow-control/#delay).
 
-These docs show you how write Node.js code to handle delays. If you don't need to write code, see [our built-in delay actions](/workflows/flow-control/#delay-actions).
+These docs show you how to write Node.js code to handle delays. If you don't need to write code, see [our built-in delay actions](/workflows/flow-control/#delay-actions).
 
 [[toc]]
 

--- a/docs/docs/code/nodejs/delay/README.md
+++ b/docs/docs/code/nodejs/delay/README.md
@@ -117,7 +117,7 @@ If you need to set a delay on an HTTP request triggered workflow, consider using
 
 Alternatively, you can use `setTimeout` instead of using `$.flow.delay` to delay individual workflow steps.
 
-However, there are some drawbacks to using `setTimeout` instead of `$.flow.delay`. `setTimeout` will count towards your workflows compute time, for example:
+However, there are some drawbacks to using `setTimeout` instead of `$.flow.delay`. `setTimeout` will count towards your workflow's compute time, for example:
 
 ```javascript
 export default defineComponent({

--- a/docs/docs/code/nodejs/delay/README.md
+++ b/docs/docs/code/nodejs/delay/README.md
@@ -111,7 +111,7 @@ You cannot run `$.respond` after running `$.flow.delay`. Pipedream ends the orig
 
 > $.respond() not called for this invocation
 
-If you need to set a delay on an HTTP request triggered workflow, consider using using [`setTimeout`](#settimeout) instead.
+If you need to set a delay on an HTTP request triggered workflow, consider using [`setTimeout`](#settimeout) instead.
 
 ## `setTimeout`
 

--- a/docs/docs/code/nodejs/rerun/README.md
+++ b/docs/docs/code/nodejs/rerun/README.md
@@ -112,7 +112,7 @@ export default defineComponent({
       const MAX_RETRIES = 3
       const DELAY = 1000 * 30
 
-      // Retry the request again every 30 seconds, for up to 3 times
+      // Retry the request every 30 seconds, for up to 3 times
       $.flow.rerun(DELAY, null, MAX_RETRIES)
     }
   },

--- a/docs/docs/code/nodejs/rerun/README.md
+++ b/docs/docs/code/nodejs/rerun/README.md
@@ -79,6 +79,47 @@ export default defineComponent({
 
 Use `$.flow.rerun` when you want to run a specific step of a workflow multiple times. This is useful when you need to start a job in an external API and poll for its completion, or have the service call back to the step and let you process the HTTP request within the step.
 
+### Retrying a failed API request
+
+`$.flow.rerun` can be used to conditionally retry a failed API request due to a service outage or rate limit reached. Place the `$.flow.rerun` call within a `catch` block to only retry the API request if an error is thrown:
+
+```javascript
+import { axios } from "@pipedream/platform"
+
+export default defineComponent({
+  props: {
+    openai: {
+      type: "app",
+      app: "openai"
+    }
+  },
+  async run({steps, $}) {
+    try {
+      return await axios($, {
+        url: `https://api.openai.com/v1/completions`,
+        method: 'post',
+        headers: {
+          Authorization: `Bearer ${this.openai.$auth.api_key}`,
+        },
+        data: {
+          "model": "text-davinci-003",
+          "prompt": "Say this is a test",
+          "max_tokens": 7,
+          "temperature": 0
+        }
+      })
+    } catch(error) {
+      const MAX_RETRIES = 3
+      const DELAY = 1000 * 30
+
+      // Retry the request again every 30 seconds, for up to 3 times
+      $.flow.rerun(DELAY, null, MAX_RETRIES)
+    }
+  },
+})
+```
+
+
 ### Polling for the status of an external job
 
 Sometimes you need to poll for the status of an external job until it completes. `$.flow.rerun` lets you rerun a specific step multiple times:
@@ -128,7 +169,7 @@ $.flow.rerun(
 
 ### Accept an HTTP callback from an external service
 
-When you trigger a job in an external service, and that service can send back data in an HTTP callback to Pipedream, you can process that data within the same step using `$.flow.retry`:
+When you trigger a job in an external service, and that service can send back data in an HTTP callback to Pipedream, you can process that data within the same step using `$.flow.rerun`:
 
 ```javascript
 import axios from 'axios'

--- a/docs/docs/code/nodejs/rerun/README.md
+++ b/docs/docs/code/nodejs/rerun/README.md
@@ -79,7 +79,7 @@ export default defineComponent({
 
 Use `$.flow.rerun` when you want to run a specific step of a workflow multiple times. This is useful when you need to start a job in an external API and poll for its completion, or have the service call back to the step and let you process the HTTP request within the step.
 
-### Retrying a failed API request
+### Retrying a Failed API Request
 
 `$.flow.rerun` can be used to conditionally retry a failed API request due to a service outage or rate limit reached. Place the `$.flow.rerun` call within a `catch` block to only retry the API request if an error is thrown:
 

--- a/docs/docs/code/python/using-data-stores/README.md
+++ b/docs/docs/code/python/using-data-stores/README.md
@@ -3,6 +3,8 @@ short_description: Store and read data with data stores.
 thumbnail: https://res.cloudinary.com/pipedreamin/image/upload/v1646763735/docs/icons/icons8-database-96_iv1oup.png
 ---
 
+# Using Data Stores
+
 :::warning
 
 This feature is in **beta**. There might be changes while we prepare it for a full release.

--- a/docs/docs/event-history/README.md
+++ b/docs/docs/event-history/README.md
@@ -107,7 +107,7 @@ You'll need to replay an event to execute the workflow with the latest changes.
 
 ::: tip Beta access
 
-During the beta, Paid accounts will have access to view the past 7 days of events across all of their workflows. This limit will increase as this trial continues.
+During the beta, paid accounts will have access to view the past 7 days of events across all of their workflows. This limit will increase as this trial continues.
 
 :::
 

--- a/docs/docs/event-history/README.md
+++ b/docs/docs/event-history/README.md
@@ -107,7 +107,7 @@ You'll need to replay an event to execute the workflow with the latest changes.
 
 ::: tip Beta access
 
-During the beta, Paid accounts will have access to view the past 100 events across all of their workflows. This limit will increase as this trial continues.
+During the beta, Paid accounts will have access to view the past 7 days of events across all of their workflows. This limit will increase as this trial continues.
 
 :::
 

--- a/docs/docs/http/README.md
+++ b/docs/docs/http/README.md
@@ -26,7 +26,7 @@ All pre-built actions are published from the [Pipedream Component Registry](/app
 
 ## HTTP Request Action
 
-The HTTP request action is the next most convienent option. Use a Postman-like interface to configure an HTTP request - including the headers, body, and even connecting an account. 
+The HTTP request action is the next most convenient option. Use a Postman-like interface to configure an HTTP request - including the headers, body, and even connecting an account.
 
 ![Finding the HTTP request builder action](https://res.cloudinary.com/pipedreamin/image/upload/v1684420462/docs/docs/http/CleanShot_2023-05-18_at_10.33.50_vigdf7.png)
 

--- a/docs/docs/http/README.md
+++ b/docs/docs/http/README.md
@@ -20,7 +20,7 @@ Now with a few clicks and some text you've integrated Slack into a Pipedream wor
 
 ::: tip Pre-built actions are open source
 
-All pre-built actions are published from the [Pipedream Component Registry](/apps/contributing/), so you can read and modify their source code. You can even publish your own from [Node.js code steps privately to your own workspace](/nodejs/sharing-code/).
+All pre-built actions are published from the [Pipedream Component Registry](/apps/contributing/), so you can read and modify their source code. You can even publish your own from [Node.js code steps privately to your own workspace](/code/nodejs/sharing-code/).
 
 :::
 
@@ -154,7 +154,7 @@ export default defineComponent({
 
 ::: tip Subscribing to all errors
 
-[You can use a subscription](/docs/api/rest/#subscriptions) to subscribe a workflow to all errors through the `$errors` channel, instead of handling each error individually.
+[You can use a subscription](/api/rest/#subscriptions) to subscribe a workflow to all errors through the `$errors` channel, instead of handling each error individually.
 
 :::
 

--- a/docs/docs/http/README.md
+++ b/docs/docs/http/README.md
@@ -4,7 +4,7 @@ Integrate and automate any API using Pipedream workflows. Use app specific pre-b
 
 ## Pre-built actions
 
-Pre-built actions are the most convienent option for integrating your workflow with an API. Pre-built actions can use your connected accounts to perform API requests, and are configured through props.
+Pre-built actions are the most convenient option for integrating your workflow with an API. Pre-built actions can use your connected accounts to perform API requests, and are configured through props.
 
 Pre-built actions are the fastest way to get started building workflows, but they may not fit your use case if a prop is missing or is handling data in a way that doesn't fit your needs.
 

--- a/docs/docs/http/README.md
+++ b/docs/docs/http/README.md
@@ -51,7 +51,7 @@ Finally modify the body of the request to specify the `channel` and `message` fo
 HTTP Request actions can be used to quickly scaffold API requests, but are not as flexible as code for a few reasons:
 
 * Conditionally sending requests - The HTTP request action will always request, to send requests conditionally you'll need to use code.
-* Workflow execution halts - if a HTTP request fails the entire workflow cancels
+* Workflow execution halts - if an HTTP request fails, the entire workflow cancels
 * Automatically retrying - `$.flow.retry` isn't available in the HTTP Request action to retry automatically if the request fails
 * Error handling - It's not possible to set up a secondary action if an HTTP request fails.
 

--- a/docs/docs/http/README.md
+++ b/docs/docs/http/README.md
@@ -1,0 +1,165 @@
+# HTTP
+
+Integrate and automate any API using Pipedream workflows. Use app specific pre-built actions, or an HTTP request action for a no code interface. If you need more control over error handling, then use your same connected accounts with code in Node.js or Python.
+
+## Pre-built actions
+
+Pre-built actions are the most convienent option for integrating your workflow with an API. Pre-built actions can use your connected accounts to perform API requests, and are configured through props.
+
+Pre-built actions are the fastest way to get started building workflows, but they may not fit your use case if a prop is missing or is handling data in a way that doesn't fit your needs.
+
+For example, to send a message using Slack just search for Slack and use the **Send Message to a Public Channel** action:
+
+![Finding the Slack - Send Message to a Public Channel action](https://res.cloudinary.com/pipedreamin/image/upload/v1684263132/docs/docs/CleanShot_2023-05-16_at_14.36.58_et1kg2.png)
+
+Then connect your Slack account, select a channel and write your message:
+
+![Configuring a Slack - Send Message to a Public Channel action](https://res.cloudinary.com/pipedreamin/image/upload/v1684263134/docs/docs/CleanShot_2023-05-16_at_14.37.29_qngd26.png)
+
+Now with a few clicks and some text you've integrated Slack into a Pipedream workflow.
+
+::: tip Pre-built actions are open source
+
+All pre-built actions are published from the [Pipedream Component Registry](/apps/contributing/), so you can read and modify their source code. You can even publish your own from [Node.js code steps privately to your own workspace](/nodejs/sharing-code/).
+
+:::
+
+## HTTP Request Action
+
+The HTTP request action is the next most convienent option. Use a Postman-like interface to configure an HTTP request - including the headers, body, and even connecting an account. 
+
+![Finding the HTTP request builder action](https://res.cloudinary.com/pipedreamin/image/upload/v1684420462/docs/docs/http/CleanShot_2023-05-18_at_10.33.50_vigdf7.png)
+
+Once you connect your account to the step, it will automatically configure the authorization headers to match.
+
+![Selecting a connected account for a HTTP request step](https://res.cloudinary.com/pipedreamin/image/upload/v1684259987/docs/docs/event%20histories/CleanShot_2023-05-16_at_13.50.53_fv3caw.png)
+
+Then you can choose **Slack** as the service to connect the HTTP request with:
+
+![Connecting the HTTP Request step to Slack](https://res.cloudinary.com/pipedreamin/image/upload/v1684420551/docs/docs/http/CleanShot_2023-05-18_at_10.35.41_dxyipl.png)
+
+The HTTP request action will automatically be configured with the Slack connection, you'll just need to select your account to finish the authentication.
+
+Then it's simply updating the URL to send a message which is [`https://slack.com/api/chat.postMessage`](https://api.slack.com/methods/chat.postMessage):
+
+![Defining the Slack API endpoint URL and connecting an account](https://res.cloudinary.com/pipedreamin/image/upload/v1684263130/docs/docs/CleanShot_2023-05-16_at_14.35.05_mame6o.png)
+
+Finally modify the body of the request to specify the `channel` and `message` for the request:
+
+![Configuring the Slack body for sending the request](https://res.cloudinary.com/pipedreamin/image/upload/v1684263128/docs/docs/CleanShot_2023-05-16_at_14.34.56_kpk2vp.png)
+
+HTTP Request actions can be used to quickly scaffold API requests, but are not as flexible as code for a few reasons:
+
+* Conditionally sending requests - The HTTP request action will always request, to send requests conditionally you'll need to use code.
+* Workflow execution halts - if a HTTP request fails the entire workflow cancels
+* Automatically retrying - `$.flow.retry` isn't available in the HTTP Request action to retry automatically if the request fails
+* Error handling - It's not possible to set up a secondary action if an HTTP request fails.
+
+## HTTP Requests in code
+
+When you need more control, use code. You can use your connected accounts with Node.js or Python code steps.
+
+This gives you the flexibility to catch errors, use retries, or send multiple API requests in a single step.
+
+First, connect your account to the code step:
+
+* [Connecting any account to a Node.js step](/code/nodejs/auth/#accessing-connected-account-data-with-this-appname-auth)
+* [Connecting any account to a Python step](/code/python/auth/)
+
+### Conditionally sending an API Request
+
+You may only want to send a Slack message on a certain condition, in this example we'll only send a Slack message if the HTTP request triggering the workflow passes a special variable: `steps.trigger.event.body.send_message`
+
+```javascript
+import { axios } from "@pipedream/platform"
+
+export default defineComponent({
+  props: {
+    slack: {
+      type: "app",
+      app: "slack",
+    }
+  },
+  async run({steps, $}) {
+    // only send the Slack message if the HTTP request has a `send_message` property in the body
+    if(steps.trigger.body.send_message) {
+      return await axios($, {
+        headers: {
+          Authorization: `Bearer ${this.slack.$auth.oauth_access_token}`,
+        },
+
+        url: `https://slack.com/api/chat.postMessage`,
+
+        method: 'post',
+        data: {
+          channel: 'C123456',
+          text: 'Hi from a Pipedream Node.js code step'
+        }
+      })
+    }
+  },
+})
+
+```
+
+### Error Handling
+
+The other advantage of using code is handling error messages using `try...catch` blocks. In this example, we'll only send a Slack message if another API request fails:
+
+```javascript
+import { axios } from "@pipedream/platform"
+
+export default defineComponent({
+  props: {
+    openai: {
+      type: "app",
+      app: "openai"
+    },
+    slack: {
+      type: "app",
+      app: "slack",
+    }
+  },
+  async run({steps, $}) {
+    try {
+      return await axios($, {
+        url: `https://api.openai.com/v1/completions`,
+        method: 'post',
+        headers: {
+          Authorization: `Bearer ${this.openai.$auth.api_key}`,
+        },
+        data: {
+          "model": "text-davinci-003",
+          "prompt": "Say this is a test",
+          "max_tokens": 7,
+          "temperature": 0
+        }
+      })
+    } catch(error) {
+      return await axios($, {
+        url: `https://slack.com/api/chat.postMessage`,
+        method: 'post',
+        headers: {
+          Authorization: `Bearer ${this.slack.$auth.oauth_access_token}`,
+        },
+        data: {
+          channel: 'C123456',
+          text: `OpenAI returned an error: ${error}`
+        }
+      })
+    }
+  },
+})
+```
+
+::: tip Subscribing to all errors
+
+[You can use a subscription](/docs/api/rest/#subscriptions) to subscribe a workflow to all errors through the `$errors` channel, instead of handling each error individually.
+
+:::
+
+### Automatically retrying an HTTP request
+
+You can leverage `$.flow.rerun` within a `try...catch` block in order to retry a failed API request.
+
+[See the example in the `$.flow.rerun` docs](/code/nodejs/rerun/#pause-resume-and-rerun-a-workflow) for Node.js.

--- a/docs/docs/workflows/flow-control/README.md
+++ b/docs/docs/workflows/flow-control/README.md
@@ -2,9 +2,9 @@
 short_description: Use Pipedream built-in functions to filter, delay, and perform other common operations.
 ---
 
-# Built-In Functions
+# Flow control 
 
-Use Pipedream built-in functions to filter, delay, and perform other common operations.
+Use Pipedream built-in functions to filter, delay, and perform other common flow control operations.
 
 [[toc]]
 
@@ -76,4 +76,3 @@ For example, to only process orders with a `status = ready`
 ### Continue Workflow on Condition
 
 With this action, only when values that _pass_ a set condition will the workflow continue to execute steps after this filter.
-

--- a/docs/docs/workflows/flow-control/README.md
+++ b/docs/docs/workflows/flow-control/README.md
@@ -2,7 +2,7 @@
 short_description: Use Pipedream built-in functions to filter, delay, and perform other common operations.
 ---
 
-# Flow control 
+# Flow Control
 
 Use Pipedream built-in functions to filter, delay, and perform other common flow control operations.
 

--- a/docs/docs/workflows/steps/README.md
+++ b/docs/docs/workflows/steps/README.md
@@ -20,7 +20,7 @@ Every workflow begins with a single [**trigger**](/workflows/steps/triggers/) st
 
 ### Code, Actions
 
-[**Actions**](/components#actions) and [**code**](/code/) steps drive the logic of your workflow. Anytime your workflow runs, Pipedream will execute each step of your workflow in order. Actions are prebuilt code steps that let you connect to hundreds of APIs without writing code. When you need more control than the default actions provide, code steps let you write any custom Node.js code.
+[**Actions**](https://pipedream.com/docs/components#actions) and [**code**](/code/) steps drive the logic of your workflow. Anytime your workflow runs, Pipedream will execute each step of your workflow in order. Actions are prebuilt code steps that let you connect to hundreds of APIs without writing code. When you need more control than the default actions provide, code steps let you write any custom Node.js code.
 
 Code and action steps cannot precede triggers, since they'll have no data to operate on.
 

--- a/docs/docs/workflows/steps/README.md
+++ b/docs/docs/workflows/steps/README.md
@@ -20,7 +20,7 @@ Every workflow begins with a single [**trigger**](/workflows/steps/triggers/) st
 
 ### Code, Actions
 
-[**Actions**](https://pipedream.com/docs/components#actions) and [**code**](/code/) steps drive the logic of your workflow. Anytime your workflow runs, Pipedream will execute each step of your workflow in order. Actions are prebuilt code steps that let you connect to hundreds of APIs without writing code. When you need more control than the default actions provide, code steps let you write any custom Node.js code.
+[**Actions**](https://pipedream.com/docs/components#actions) and [**code**](/code/) steps drive the logic of your workflow. Anytime your workflow runs, Pipedream executes each step of your workflow in order. Actions are prebuilt code steps that let you connect to hundreds of APIs without writing code. When you need more control than the default actions provide, code steps let you write any custom Node.js code.
 
 Code and action steps cannot precede triggers, since they'll have no data to operate on.
 


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c5452cb</samp>

This pull request improves the Node.js documentation on delays, adds a new environment variable for the maximum workflow execution limit, and updates the event history limit for paid accounts.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c5452cb</samp>

> _To limit the workflow duration_
> _We added a new env var equation_
> _`MAX_WORKFLOW_EXECUTION_LIMIT`_
> _Is the name of it_
> _And it applies to the whole documentation_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c5452cb</samp>

*  Add new environment variable `MAX_WORKFLOW_EXECUTION_LIMIT` to store maximum workflow duration ([link](https://github.com/PipedreamHQ/pipedream/pull/6514/files?diff=unified&w=0#diff-25db0506fc0deea8a6b3bae8c0573595e10b67353a1cbe1fc75390b22d78b16cR10-R11))
*  Explain how `$.flow.delay` affects workflow status and credit usage in Node.js steps ([link](https://github.com/PipedreamHQ/pipedream/pull/6514/files?diff=unified&w=0#diff-fcf8b1554dccdee2e939e37045be52a977892fa4a6e61f6a4da115ec159dff92R41-R56))
*  Advise users to use `setTimeout` instead of `$.flow.delay` for HTTP request triggered workflows ([link](https://github.com/PipedreamHQ/pipedream/pull/6514/files?diff=unified&w=0#diff-fcf8b1554dccdee2e939e37045be52a977892fa4a6e61f6a4da115ec159dff92R113-R138))
*  Update beta access limit for paid accounts in `Event History` page ([link](https://github.com/PipedreamHQ/pipedream/pull/6514/files?diff=unified&w=0#diff-3a56f0ca10dbde89b2ba2556e7ee63c7fc2f8639462e292882e57e21df9ea4baL110-R110))
