### PR TITLE
6503 bingx trade new order error

### DIFF
--- a/components/bingx/actions/trade-new-order/trade-new-order.mjs
+++ b/components/bingx/actions/trade-new-order/trade-new-order.mjs
@@ -2,7 +2,7 @@ import bingx from "../../bingx.app.mjs";
 
 export default {
   name: "BingX Trade New Order",
-  version: "0.1.1",
+  version: "0.1.2",
   key: "bingx-trade-new-order",
   description: "Place a New Order [reference](https://bingx-api.github.io/docs/swap/trade-api.html#_1-place-a-new-order).",
   props: {
@@ -61,14 +61,6 @@ export default {
     const API_METHOD = "POST";
     const API_PATH = "/api/v1/user/trade";
 
-    if (this.takerProfitPrice) {
-      this.takerProfitPrice = parseFloat(this.takerProfitPrice.replace(",", "."));
-    }
-
-    if (this.stopLossPrice) {
-      this.stopLossPrice = parseFloat(this.stopLossPrice.replace(",", "."));
-    }
-
     const parameters = {
       "symbol": this.symbol,
       "side": this.side,
@@ -76,8 +68,8 @@ export default {
       "entrustVolume": this.bingx.convertToFloat(this.entrustVolume),
       "tradeType": this.tradeType,
       "action": this.action,
-      "takerProfitPrice": this.takerProfitPrice,
-      "stopLossPrice": this.stopLossPrice,
+      "takerProfitPrice": this.bingx.convertToFloat(this.takerProfitPrice?.toString().replace(",", ".")),
+      "stopLossPrice": this.bingx.convertToFloat(this.stopLossPrice?.toString().replace(",", ".")),
     };
     const returnValue = await this.bingx.makeRequest(API_METHOD, API_PATH, parameters);
     $.export("$summary", `New Future Order for ${this.symbol}`);

--- a/components/bingx/package.json
+++ b/components/bingx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/bingx",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream BingX Components",
   "main": "bingx.app.mjs",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -631,6 +631,9 @@ importers:
   components/cascade_strategy:
     specifiers: {}
 
+  components/caspio:
+    specifiers: {}
+
   components/cdc_national_environmental_public_health_tracking:
     specifiers: {}
 
@@ -782,6 +785,9 @@ importers:
       form-data: 4.0.0
 
   components/cloudtalk:
+    specifiers: {}
+
+  components/cloze:
     specifiers: {}
 
   components/clubworx:
@@ -3572,6 +3578,9 @@ importers:
       '@pipedream/platform': 1.5.1
 
   components/resend:
+    specifiers: {}
+
+  components/respond_io:
     specifiers: {}
 
   components/rest_countries_pe:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1923,6 +1923,9 @@ importers:
     dependencies:
       '@pipedream/platform': 1.5.1
 
+  components/hotjar:
+    specifiers: {}
+
   components/hotspotsystem:
     specifiers:
       '@pipedream/platform': ^1.2.1
@@ -3577,6 +3580,9 @@ importers:
     dependencies:
       '@pipedream/platform': 1.5.1
 
+  components/retool:
+    specifiers: {}
+
   components/rev:
     specifiers:
       '@pipedream/platform': ^1.2.1
@@ -4903,6 +4909,12 @@ importers:
     specifiers: {}
 
   components/watchsignals:
+    specifiers: {}
+
+  components/wati:
+    specifiers: {}
+
+  components/wealthbox:
     specifiers: {}
 
   components/weatherbit_io:


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5c67799</samp>

Added four new components to the repository and improved the BingX Trade New Order component to handle price parameters better. Updated the `bingx` package version and the `pnpm-lock.yaml` file accordingly.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5c67799</samp>

> _We're updating our packages, we're fixing our code_
> _We're adding new components to lighten our load_
> _Heave away, me hearties, on the count of three_
> _We're sailing with `BingX` and the latest `pnpm`_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5c67799</samp>

*  Bump up the version of the BingX package and the BingX Trade New Order component to 0.1.2 ([link](https://github.com/PipedreamHQ/pipedream/pull/6525/files?diff=unified&w=0#diff-e3ce12deae82dd360db064c144edcb44b0459f2bc6b57de7e0f4cfa5b35a0937L5-R5), [link](https://github.com/PipedreamHQ/pipedream/pull/6525/files?diff=unified&w=0#diff-37e6e279bc7d94ca0ed853df4c0467bb6a7c0cfcb8f17e156323f8f896cd1ae5L3-R3))
*  Simplify and fix the parsing of the takerProfitPrice and stopLossPrice parameters for the BingX Trade New Order component by using the bingx.convertToFloat helper function ([link](https://github.com/PipedreamHQ/pipedream/pull/6525/files?diff=unified&w=0#diff-e3ce12deae82dd360db064c144edcb44b0459f2bc6b57de7e0f4cfa5b35a0937L64-L71), [link](https://github.com/PipedreamHQ/pipedream/pull/6525/files?diff=unified&w=0#diff-e3ce12deae82dd360db064c144edcb44b0459f2bc6b57de7e0f4cfa5b35a0937L79-R72))
*  Add the Hotjar, Retool, Wati, and Wealthbox components to the `pnpm-lock.yaml` file ([link](https://github.com/PipedreamHQ/pipedream/pull/6525/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1926-R1928), [link](https://github.com/PipedreamHQ/pipedream/pull/6525/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3583-R3585), [link](https://github.com/PipedreamHQ/pipedream/pull/6525/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4914-R4919))
