### PR TITLE
fixing typo in attachments example

### DIFF
--- a/docs/docs/workflows/settings/README.md
+++ b/docs/docs/workflows/settings/README.md
@@ -69,10 +69,14 @@ For example, if you upload a file named `test.csv`, Pipedream will expose the _f
 ```javascript
 import fs from "fs";
 
-const fileData = fs
-  .readFileSync(steps.trigger.context.attachments["test.csv"])
-  .toString();
-console.log(fileData);
+export default defineComponent({
+  async run({ steps, $ }) {
+    const fileData = fs
+      .readFileSync(steps.trigger.context.attachments["test.csv"])
+      .toString();
+    console.log(fileData);
+  },
+})
 ```
 
 <div>


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d60ec01</samp>

Updated the code snippet in the `Attachments` section of the `docs/docs/workflows/settings/README.md` file to use the new `defineComponent` syntax and fix the indentation. This change aligns the documentation with the latest platform features and improves the readability of the code.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d60ec01</samp>

> _`defineComponent`_
> _New syntax for workflows now_
> _Autumn of code steps_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d60ec01</samp>

*  Update code snippet for attachments component ([link](https://github.com/PipedreamHQ/pipedream/pull/6536/files?diff=unified&w=0#diff-d483fcc47a053088e0728ae584b54dd21609caf55d8e39f35339aa270f7fed17L72-R79))
