### PR TITLE
[ACTION] Update Threads API endpoint and docs link

### DIFF
--- a/components/threads/actions/delete-thread/delete-thread.mjs
+++ b/components/threads/actions/delete-thread/delete-thread.mjs
@@ -3,8 +3,8 @@ import threads from "../../threads.app.mjs";
 export default {
   key: "threads-delete-thread",
   name: "Delete a Thread",
-  description: "Delete a thread",
-  version: "0.1.3",
+  description: "Delete a thread. [See the Documentation](https://github.com/ThreadsHQ/api-documentation#delete-thread)",
+  version: "0.1.4",
   type: "action",
   props: {
     threads,

--- a/components/threads/actions/post-chat-message/post-chat-message.mjs
+++ b/components/threads/actions/post-chat-message/post-chat-message.mjs
@@ -3,8 +3,8 @@ import threads from "../../threads.app.mjs";
 export default {
   key: "threads-post-chat-message",
   name: "Post a Chat Message",
-  description: "Post a message to a chat. First, make sure you add your Bot user to the chat.",
-  version: "0.0.4",
+  description: "Post a message to a chat. First, make sure you add your Bot user to the chat. [See the Documentation](https://github.com/ThreadsHQ/api-documentation#post-chat-message)",
+  version: "0.0.5",
   type: "action",
   props: {
     threads,

--- a/components/threads/actions/post-thread/post-thread.mjs
+++ b/components/threads/actions/post-thread/post-thread.mjs
@@ -3,8 +3,8 @@ import threads from "../../threads.app.mjs";
 export default {
   key: "threads-post-thread",
   name: "Post a Thread",
-  description: "Post a new thread to a specific channel",
-  version: "0.2.0",
+  description: "Post a new thread to a specific channel. [See the Documentation](https://github.com/ThreadsHQ/api-documentation#post-thread).",
+  version: "0.2.1",
   type: "action",
   props: {
     threads,

--- a/components/threads/package.json
+++ b/components/threads/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/threads",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Pipedream Threads Components",
   "main": "threads.app.mjs",
   "keywords": [

--- a/components/threads/threads.app.mjs
+++ b/components/threads/threads.app.mjs
@@ -1,5 +1,3 @@
-// See API docs here:
-// https://gist.github.com/gauravmk/c9263120b9309c24d6f14df6668e5326
 import { axios } from "@pipedream/platform";
 
 export default {
@@ -32,24 +30,25 @@ export default {
     blocks: {
       label: "Blocks",
       type: "string[]",
-      description: "Add one or more blocks to your thread. You can use [Markdown](https://www.markdownguide.org/basic-syntax/) to format text. Try `# This is a block`",
+      description:
+        "Add one or more blocks to a thread. You can use [Markdown](https://www.markdownguide.org/basic-syntax/) to format text. Try `# This is a block`",
     },
     threadID: {
       type: "string",
       label: "Thread ID",
       description:
-        "To find your thread ID, open the relevant thread in your browser and copy the ID: `https://trythreads.com/{thread_id}`",
+        "To find your thread ID, open the relevant thread in your browser and copy the ID: `https://threads.com/{thread_id}`",
     },
     chatID: {
       type: "string",
       label: "Chat ID",
       description:
-        "To find the chat ID, open the Threads chat in your browser and copy the ID: `https://trythreads.com/messages/{your_chat_id}`",
+        "To find your chat ID, open the Threads chat in your browser and copy the ID: `https://threads.com/messages/{your_chat_id}`",
     },
   },
   methods: {
     _apiUrl() {
-      return "https://trythreads.com/api/public";
+      return "https://threads.com/api/public";
     },
     _apiKey() {
       return this.$auth.api_key;


### PR DESCRIPTION
## WHAT

This PR updates the endpoint from trythreads.com to threads.com, as our current pipelines are 403ing.

## WHY

According to Threads themselves, the API endpoint has moved.

<img width="460" alt="Screenshot 2023-05-19 at 3 43 24 PM" src="https://github.com/PipedreamHQ/pipedream/assets/7211830/6b719b43-b4fb-4738-ad21-b8f9a67d34c6">

## HOW

A small change to the endpoint string.
