### PR TITLE
[Supabase] Fix deployment action

### DIFF
--- a/components/supabase/actions/select-row/select-row.mjs
+++ b/components/supabase/actions/select-row/select-row.mjs
@@ -5,7 +5,7 @@ export default {
   key: "supabase-select-row",
   name: "Select Row",
   type: "action",
-  version: "0.0.3",
+  version: "0.0.4",
   description: "Selects row(s) in a database. [See the docs here](https://supabase.com/docs/reference/javascript/select)",
   props: {
     supabase,
@@ -47,7 +47,7 @@ export default {
     sortOrder: {
       propDefinition: [
         supabase,
-        "orderBy",
+        "sortOrder",
       ],
     },
     max: {

--- a/components/supabase/package.json
+++ b/components/supabase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/supabase",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Supabase Components",
   "main": "supabase.app.mjs",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -863,6 +863,9 @@ importers:
   components/congress_gov:
     specifiers: {}
 
+  components/constant_contact:
+    specifiers: {}
+
   components/convertapi:
     specifiers: {}
 
@@ -1757,6 +1760,9 @@ importers:
       '@pipedream/platform': 1.5.1
 
   components/google_maps_platform:
+    specifiers: {}
+
+  components/google_palm_api:
     specifiers: {}
 
   components/google_photos:
@@ -3572,6 +3578,9 @@ importers:
     dependencies:
       '@pipedream/platform': 1.5.1
 
+  components/replicate:
+    specifiers: {}
+
   components/reply_io:
     specifiers:
       '@pipedream/platform': ^1.2.1
@@ -3805,6 +3814,9 @@ importers:
     specifiers: {}
 
   components/selectpdf:
+    specifiers: {}
+
+  components/sellercloud:
     specifiers: {}
 
   components/sellix:


### PR DESCRIPTION
Republish `select-row` action in #6546

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 39cb784</samp>

This pull request adds four new components and updates the supabase component to use the latest app definition and API parameters. It also updates the `pnpm-lock.yaml` and `package.json` files accordingly.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 39cb784</samp>

> _Oh we're the pipedream crew and we've got work to do_
> _We update and we add components to our repo_
> _We heave away on the `supabase` package too_
> _And we sing as we code with the wind in our sails_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 39cb784</samp>

*  Update the Select Row action of the supabase component to use the sortOrder prop instead of the orderBy prop ([link](https://github.com/PipedreamHQ/pipedream/pull/6578/files?diff=unified&w=0#diff-a3a99b5e91cf4f5da0a5afc5937c42711db4e1aa81d8e17f1931825e04462d9eL8-R8),[link](https://github.com/PipedreamHQ/pipedream/pull/6578/files?diff=unified&w=0#diff-a3a99b5e91cf4f5da0a5afc5937c42711db4e1aa81d8e17f1931825e04462d9eL50-R50))
* Bump up the version of the supabase component and the supabase package to reflect the changes in the app and the actions ([link](https://github.com/PipedreamHQ/pipedream/pull/6578/files?diff=unified&w=0#diff-a3a99b5e91cf4f5da0a5afc5937c42711db4e1aa81d8e17f1931825e04462d9eL8-R8),[link](https://github.com/PipedreamHQ/pipedream/pull/6578/files?diff=unified&w=0#diff-f6ed22bb0bfd1bfb25c81e814d657944b8f92f355f6edea3c7b01c18f5bb4b87L3-R3))
* Add new components to the `pnpm-lock.yaml` file to track their dependencies and versions: constant_contact, google_palm_api, replicate, and sellercloud ([link](https://github.com/PipedreamHQ/pipedream/pull/6578/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR866-R868),[link](https://github.com/PipedreamHQ/pipedream/pull/6578/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1765-R1767),[link](https://github.com/PipedreamHQ/pipedream/pull/6578/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3581-R3583),[link](https://github.com/PipedreamHQ/pipedream/pull/6578/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3819-R3821))
