### PR TITLE
[Snowflake] New Sources - Part 4 (FInal)

### DIFF
--- a/components/snowflake/package.json
+++ b/components/snowflake/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/snowflake",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Pipedream Snowflake Components",
   "main": "snowflake.app.mjs",
   "keywords": [

--- a/components/snowflake/sources/common-update.mjs
+++ b/components/snowflake/sources/common-update.mjs
@@ -1,0 +1,109 @@
+import snowflake from "../snowflake.app.mjs";
+import { DEFAULT_POLLING_SOURCE_TIMER_INTERVAL } from "@pipedream/platform";
+import { v4 as uuid } from "uuid";
+
+export default {
+  dedupe: "unique",
+  props: {
+    snowflake,
+    db: "$.service.db",
+    timer: {
+      description: "Watch for changes on this schedule",
+      type: "$.interface.timer",
+      default: {
+        intervalSeconds: DEFAULT_POLLING_SOURCE_TIMER_INTERVAL,
+      },
+    },
+  },
+  methods: {
+    async getDbValues() {
+      return this.db.get("dbValues") ?? {};
+    },
+    async setDbValues(values) {
+      return this.db.set("dbValues", values);
+    },
+    async fetchData() {
+      return this.snowflake.getRows({
+        sqlText: this.getSqlText(),
+      });
+    },
+    async updateDbValues() {
+      const db = await this.getDbValues();
+      const rows = await this.fetchData();
+      for await (const item of rows) {
+        const key = item[this.lookUpKey()];
+        db[key] = item;
+      }
+      await this.setDbValues(db);
+    },
+    async checkForDifferentData(db, rows) {
+      for await (const item of rows) {
+        const currentLookUpKey = item[this.lookUpKey()];
+        const isNewItem = !db[currentLookUpKey];
+        if (isNewItem) {
+          this.emitNewEvent(item);
+        } else {
+          const changedKeys = this.getChangedKeys(db[currentLookUpKey], item);
+          if (changedKeys.length > 0) {
+            this.emitUpdatedEvent(item, db[currentLookUpKey], changedKeys);
+          }
+        }
+      }
+    },
+
+    getChangedKeys(dbObject, queryObject) {
+      const changedKeys = [];
+      for (const key in dbObject) {
+        if (queryObject[key] instanceof Date) {
+          if (new Date(dbObject[key]).getTime() != queryObject[key].getTime()) {
+            changedKeys.push(key);
+          }
+          continue;
+        }
+        if (dbObject[key] != queryObject[key]) {
+          changedKeys.push(key);
+        }
+      }
+      return changedKeys;
+    },
+    emit(isNew, newData, oldData, changedKeys) {
+      const event = {
+        newData,
+        oldData,
+        changedKeys,
+      };
+
+      const createOrUpdatedString = isNew
+        ? "created"
+        : "updated";
+      this.$emit(event, {
+        summary: `${newData[this.lookUpKey()]} was ${createOrUpdatedString}`,
+        id: uuid(),
+        ts: Date.now(),
+      });
+    },
+    emitNewEvent(newData) {
+      this.emit(true, newData);
+    },
+    emitUpdatedEvent(newData, oldData, changedKeys) {
+      this.emit(false, newData, oldData, changedKeys);
+    },
+    lookUpKey() {
+      throw new Error("lookUpKey must be implemented");
+    },
+    getSqlText() {
+      throw new Error("getSqlText must be implemented");
+    },
+  },
+  hooks: {
+    async deploy() {
+      await this.updateDbValues();
+    },
+  },
+  async run() {
+    const db = await this.getDbValues();
+    const rows = await this.fetchData();
+    await this.checkForDifferentData(db, rows);
+    await this.updateDbValues();
+  },
+};

--- a/components/snowflake/sources/common-update.mjs
+++ b/components/snowflake/sources/common-update.mjs
@@ -1,5 +1,8 @@
 import snowflake from "../snowflake.app.mjs";
-import { DEFAULT_POLLING_SOURCE_TIMER_INTERVAL } from "@pipedream/platform";
+import {
+  ConfigurationError,
+  DEFAULT_POLLING_SOURCE_TIMER_INTERVAL,
+} from "@pipedream/platform";
 import { v4 as uuid } from "uuid";
 
 export default {
@@ -16,10 +19,10 @@ export default {
     },
   },
   methods: {
-    async getDbValues() {
+    getDbValues() {
       return this.db.get("dbValues") ?? {};
     },
-    async setDbValues(values) {
+    setDbValues(values) {
       return this.db.set("dbValues", values);
     },
     async fetchData() {
@@ -28,13 +31,13 @@ export default {
       });
     },
     async updateDbValues() {
-      const db = await this.getDbValues();
+      const db = this.getDbValues();
       const rows = await this.fetchData();
       for await (const item of rows) {
         const key = item[this.getLookUpKey()];
         db[key] = item;
       }
-      await this.setDbValues(db);
+      this.setDbValues(db);
     },
     async checkForDifferentData(db, rows) {
       for await (const item of rows) {
@@ -89,10 +92,10 @@ export default {
       this.emit(false, newData, oldData, changedKeys);
     },
     getLookUpKey() {
-      throw new Error("getLookUpKey must be implemented");
+      throw new ConfigurationError("getLookUpKey must be implemented");
     },
     getSqlText() {
-      throw new Error("getSqlText must be implemented");
+      throw new ConfigurationError("getSqlText must be implemented");
     },
   },
   hooks: {
@@ -101,7 +104,7 @@ export default {
     },
   },
   async run() {
-    const db = await this.getDbValues();
+    const db = this.getDbValues();
     const rows = await this.fetchData();
     await this.checkForDifferentData(db, rows);
     await this.updateDbValues();

--- a/components/snowflake/sources/common-update.mjs
+++ b/components/snowflake/sources/common-update.mjs
@@ -31,14 +31,14 @@ export default {
       const db = await this.getDbValues();
       const rows = await this.fetchData();
       for await (const item of rows) {
-        const key = item[this.lookUpKey()];
+        const key = item[this.getLookUpKey()];
         db[key] = item;
       }
       await this.setDbValues(db);
     },
     async checkForDifferentData(db, rows) {
       for await (const item of rows) {
-        const currentLookUpKey = item[this.lookUpKey()];
+        const currentLookUpKey = item[this.getLookUpKey()];
         const isNewItem = !db[currentLookUpKey];
         if (isNewItem) {
           this.emitNewEvent(item);
@@ -77,7 +77,7 @@ export default {
         ? "created"
         : "updated";
       this.$emit(event, {
-        summary: `${newData[this.lookUpKey()]} was ${createOrUpdatedString}`,
+        summary: `${newData[this.getLookUpKey()]} was ${createOrUpdatedString}`,
         id: uuid(),
         ts: Date.now(),
       });
@@ -88,8 +88,8 @@ export default {
     emitUpdatedEvent(newData, oldData, changedKeys) {
       this.emit(false, newData, oldData, changedKeys);
     },
-    lookUpKey() {
-      throw new Error("lookUpKey must be implemented");
+    getLookUpKey() {
+      throw new Error("getLookUpKey must be implemented");
     },
     getSqlText() {
       throw new Error("getSqlText must be implemented");

--- a/components/snowflake/sources/updated-role/updated-role.mjs
+++ b/components/snowflake/sources/updated-role/updated-role.mjs
@@ -1,0 +1,19 @@
+import common from "../common-update.mjs";
+
+export default {
+  ...common,
+  type: "source",
+  key: "snowflake-updated-role",
+  name: "New Update Role",
+  description: "Emit new event when a role is updated",
+  version: "0.0.1",
+  methods: {
+    ...common.methods,
+    lookUpKey() {
+      return "name";
+    },
+    getSqlText() {
+      return "show roles";
+    },
+  },
+};

--- a/components/snowflake/sources/updated-role/updated-role.mjs
+++ b/components/snowflake/sources/updated-role/updated-role.mjs
@@ -9,7 +9,7 @@ export default {
   version: "0.0.1",
   methods: {
     ...common.methods,
-    lookUpKey() {
+    getLookUpKey() {
       return "name";
     },
     getSqlText() {

--- a/components/snowflake/sources/updated-user/updated-user.mjs
+++ b/components/snowflake/sources/updated-user/updated-user.mjs
@@ -1,142 +1,19 @@
-/**
- * On Start: Fetch data from snowflake and store in DB
- * {
- *  1: {id: 1, name: "foo", description: "bar"},
- *  2: {id: 2, name: "baz", description: "qux"},
- * }
- * After that, for each time that the event is fired, check if data changed
- *
- * Example payload:
- * {
- *  1: {id: 1, name: "foo", description: "bar2"},
- *  3: {id: 3, name: "quux", description: "quuz"},
- * }
- *
- * 1: Check if something was deleted running previous data against current data
- * if key in previous data is not in current data
- * (emit delete event)
- *
- * 2: Check if something was added running current data against previous data
- * if key in current data is not in previous data
- * (emit create event)
- *
- * 3: Check if something was updated running current data against previous data
- * check field by field for each key and check if something changed
- *
- * 4: Update DB with current data
- */
-
-import snowflake from "../../snowflake.app.mjs";
-import { DEFAULT_POLLING_SOURCE_TIMER_INTERVAL } from "@pipedream/platform";
-import { v4 as uuid } from "uuid";
+import common from "../common-update.mjs";
 
 export default {
+  ...common,
   type: "source",
   key: "snowflake-updated-user",
   name: "New Update User",
   description: "Emit new event when a user is updated",
   version: "0.0.1",
-  dedupe: "unique",
-  props: {
-    snowflake,
-    db: "$.service.db",
-    timer: {
-      description: "Watch for changes on this schedule",
-      type: "$.interface.timer",
-      default: {
-        intervalSeconds: DEFAULT_POLLING_SOURCE_TIMER_INTERVAL,
-      },
-    },
-  },
   methods: {
-    async getDbValues() {
-      return this.db.get("dbValues") ?? {};
-    },
-    async setDbValues(values) {
-      return this.db.set("dbValues", values);
-    },
-    async fetchData() {
-      return this.snowflake.getRows({
-        sqlText: this.getSqlText(),
-      });
-    },
-    async updateDbValues() {
-      const db = await this.getDbValues();
-      const rows = await this.fetchData();
-      for await (const item of rows) {
-        const key = item[this.lookUpKey()];
-        db[key] = item;
-      }
-      await this.setDbValues(db);
-    },
-    async checkForDifferentData(db, rows) {
-      for await (const item of rows) {
-        const currentLookUpKey = item[this.lookUpKey()];
-        const isNewItem = !db[currentLookUpKey];
-        if (isNewItem) {
-          this.emitNewEvent(item);
-        } else {
-          const changedKeys = this.getChangedKeys(db[currentLookUpKey], item);
-          if (changedKeys.length > 0) {
-            this.emitUpdatedEvent(item, db[currentLookUpKey], changedKeys);
-          }
-        }
-      }
-    },
-
-    getChangedKeys(dbObject, queryObject) {
-      const changedKeys = [];
-      for (const key in dbObject) {
-        if (queryObject[key] instanceof Date) {
-          if (new Date(dbObject[key]).getTime() != queryObject[key].getTime()) {
-            changedKeys.push(key);
-          }
-          continue;
-        }
-        if (dbObject[key] != queryObject[key]) {
-          changedKeys.push(key);
-        }
-      }
-      return changedKeys;
-    },
-    emit(isNew, newData, oldData, changedKeys) {
-      const event = {
-        newData,
-        oldData,
-        changedKeys,
-      };
-
-      const createOrUpdatedString = isNew
-        ? "created"
-        : "updated";
-      this.$emit(event, {
-        summary: `${newData[this.lookUpKey()]} was ${createOrUpdatedString}`,
-        id: uuid(),
-        ts: Date.now(),
-      });
-    },
-    emitNewEvent(newData) {
-      this.emit(true, newData);
-    },
-    emitUpdatedEvent(newData, oldData, changedKeys) {
-      this.emit(false, newData, oldData, changedKeys);
-    },
+    ...common.methods,
     lookUpKey() {
       return "name";
     },
     getSqlText() {
       return "show users";
     },
-  },
-  hooks: {
-    async deploy() {
-      await this.updateDbValues();
-    },
-  },
-  async run() {
-    const db = await this.getDbValues();
-    const rows = await this.fetchData();
-    await this.checkForDifferentData(db, rows);
-    await this.updateDbValues();
   },
 };

--- a/components/snowflake/sources/updated-user/updated-user.mjs
+++ b/components/snowflake/sources/updated-user/updated-user.mjs
@@ -9,7 +9,7 @@ export default {
   version: "0.0.1",
   methods: {
     ...common.methods,
-    lookUpKey() {
+    getLookUpKey() {
       return "name";
     },
     getSqlText() {

--- a/components/snowflake/sources/updated-user/updated-user.mjs
+++ b/components/snowflake/sources/updated-user/updated-user.mjs
@@ -1,0 +1,142 @@
+/**
+ * On Start: Fetch data from snowflake and store in DB
+ * {
+ *  1: {id: 1, name: "foo", description: "bar"},
+ *  2: {id: 2, name: "baz", description: "qux"},
+ * }
+ * After that, for each time that the event is fired, check if data changed
+ *
+ * Example payload:
+ * {
+ *  1: {id: 1, name: "foo", description: "bar2"},
+ *  3: {id: 3, name: "quux", description: "quuz"},
+ * }
+ *
+ * 1: Check if something was deleted running previous data against current data
+ * if key in previous data is not in current data
+ * (emit delete event)
+ *
+ * 2: Check if something was added running current data against previous data
+ * if key in current data is not in previous data
+ * (emit create event)
+ *
+ * 3: Check if something was updated running current data against previous data
+ * check field by field for each key and check if something changed
+ *
+ * 4: Update DB with current data
+ */
+
+import snowflake from "../../snowflake.app.mjs";
+import { DEFAULT_POLLING_SOURCE_TIMER_INTERVAL } from "@pipedream/platform";
+import { v4 as uuid } from "uuid";
+
+export default {
+  type: "source",
+  key: "snowflake-updated-user",
+  name: "New Update User",
+  description: "Emit new event when a user is updated",
+  version: "0.0.1",
+  dedupe: "unique",
+  props: {
+    snowflake,
+    db: "$.service.db",
+    timer: {
+      description: "Watch for changes on this schedule",
+      type: "$.interface.timer",
+      default: {
+        intervalSeconds: DEFAULT_POLLING_SOURCE_TIMER_INTERVAL,
+      },
+    },
+  },
+  methods: {
+    async getDbValues() {
+      return this.db.get("dbValues") ?? {};
+    },
+    async setDbValues(values) {
+      return this.db.set("dbValues", values);
+    },
+    async fetchData() {
+      return this.snowflake.getRows({
+        sqlText: this.getSqlText(),
+      });
+    },
+    async updateDbValues() {
+      const db = await this.getDbValues();
+      const rows = await this.fetchData();
+      for await (const item of rows) {
+        const key = item[this.lookUpKey()];
+        db[key] = item;
+      }
+      await this.setDbValues(db);
+    },
+    async checkForDifferentData(db, rows) {
+      for await (const item of rows) {
+        const currentLookUpKey = item[this.lookUpKey()];
+        const isNewItem = !db[currentLookUpKey];
+        if (isNewItem) {
+          this.emitNewEvent(item);
+        } else {
+          const changedKeys = this.getChangedKeys(db[currentLookUpKey], item);
+          if (changedKeys.length > 0) {
+            this.emitUpdatedEvent(item, db[currentLookUpKey], changedKeys);
+          }
+        }
+      }
+    },
+
+    getChangedKeys(dbObject, queryObject) {
+      const changedKeys = [];
+      for (const key in dbObject) {
+        if (queryObject[key] instanceof Date) {
+          if (new Date(dbObject[key]).getTime() != queryObject[key].getTime()) {
+            changedKeys.push(key);
+          }
+          continue;
+        }
+        if (dbObject[key] != queryObject[key]) {
+          changedKeys.push(key);
+        }
+      }
+      return changedKeys;
+    },
+    emit(isNew, newData, oldData, changedKeys) {
+      const event = {
+        newData,
+        oldData,
+        changedKeys,
+      };
+
+      const createOrUpdatedString = isNew
+        ? "created"
+        : "updated";
+      this.$emit(event, {
+        summary: `${newData[this.lookUpKey()]} was ${createOrUpdatedString}`,
+        id: uuid(),
+        ts: Date.now(),
+      });
+    },
+    emitNewEvent(newData) {
+      this.emit(true, newData);
+    },
+    emitUpdatedEvent(newData, oldData, changedKeys) {
+      this.emit(false, newData, oldData, changedKeys);
+    },
+    lookUpKey() {
+      return "name";
+    },
+    getSqlText() {
+      return "show users";
+    },
+  },
+  hooks: {
+    async deploy() {
+      await this.updateDbValues();
+    },
+  },
+  async run() {
+    const db = await this.getDbValues();
+    const rows = await this.fetchData();
+    await this.checkForDifferentData(db, rows);
+    await this.updateDbValues();
+  },
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2029,6 +2029,9 @@ importers:
     dependencies:
       '@pipedream/platform': 0.10.0
 
+  components/imagga:
+    specifiers: {}
+
   components/imap:
     specifiers:
       '@pipedream/platform': ^1.2.0


### PR DESCRIPTION
Closes #5226 
Part 4 of #5226 

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b7030fc</samp>

This pull request adds two new Snowflake sources that emit events when roles or users are updated in the service. The sources use a common base class that handles the connection, query, and event logic. The pull request also updates the `pnpm-lock.yaml` file to reflect the new sources.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b7030fc</samp>

> _Snowflake sources grow_
> _`common-update` module_
> _Winter of changes_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b7030fc</samp>

*  Add a common base class for Snowflake sources that emit events when data is updated in a table or view ([link](https://github.com/PipedreamHQ/pipedream/pull/6595/files?diff=unified&w=0#diff-9859d9020d06b16a6a3af2a902938b952094c817671f4bd0f38bf7acb5cab82aR1-R109))
* Add two new sources that inherit from the common base class and emit events when a role or a user is updated in Snowflake ([link](https://github.com/PipedreamHQ/pipedream/pull/6595/files?diff=unified&w=0#diff-559283093fb2a6f03b9c20c814f5bc829bb1befd31bbb1ab26fedcd7bf8bdfd3R1-R19), [link](https://github.com/PipedreamHQ/pipedream/pull/6595/files?diff=unified&w=0#diff-31c2cdf4b1399af94fc85e08b735d52725b015d1e5aa2ddb9d99edda4bceaf15R1-R19))
* Add a new entry to the `pnpm-lock.yaml` file to indicate no dependencies for the `components/imagga` directory ([link](https://github.com/PipedreamHQ/pipedream/pull/6595/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2032-R2034))
