### PR TITLE
Jotform - Update for encrypted forms

### DIFF
--- a/components/jotform/actions/get-form-submissions/get-form-submissions.mjs
+++ b/components/jotform/actions/get-form-submissions/get-form-submissions.mjs
@@ -1,5 +1,4 @@
 import common from "../common.mjs";
-import jotform from "../../jotform.app.mjs";
 
 export default {
   ...common,
@@ -12,19 +11,19 @@ export default {
     ...common.props,
     formId: {
       propDefinition: [
-        jotform,
+        common.props.jotform,
         "formId",
       ],
     },
     max: {
       propDefinition: [
-        jotform,
+        common.props.jotform,
         "max",
       ],
     },
     encrypted: {
       propDefinition: [
-        jotform,
+        common.props.jotform,
         "encrypted",
       ],
       reloadProps: true,
@@ -33,7 +32,7 @@ export default {
   async additionalProps() {
     const props = {};
     if (this.encrypted) {
-      props.privateKey = jotform.propDefinitions.privateKey;
+      props.privateKey = common.props.jotform.propDefinitions.privateKey;
     }
     return props;
   },

--- a/components/jotform/actions/get-form-submissions/get-form-submissions.mjs
+++ b/components/jotform/actions/get-form-submissions/get-form-submissions.mjs
@@ -1,27 +1,41 @@
 import common from "../common.mjs";
+import jotform from "../../jotform.app.mjs";
 
 export default {
   ...common,
   key: "jotform-get-form-submissions",
   name: "Get Form Submissions",
   description: "Gets a list of form responses [See the docs here](https://api.jotform.com/docs/#form-id-submissions)",
-  version: "0.0.2",
+  version: "0.1.0",
   type: "action",
   props: {
     ...common.props,
     formId: {
       propDefinition: [
-        common.props.jotform,
+        jotform,
         "formId",
       ],
     },
     max: {
       propDefinition: [
-        common.props.jotform,
+        jotform,
         "max",
       ],
     },
-    http: "$.interface.http",
+    encrypted: {
+      propDefinition: [
+        jotform,
+        "encrypted",
+      ],
+      reloadProps: true,
+    },
+  },
+  async additionalProps() {
+    const props = {};
+    if (this.encrypted) {
+      props.privateKey = jotform.propDefinitions.privateKey;
+    }
+    return props;
   },
   async run({ $ }) {
     const params = {
@@ -31,10 +45,15 @@ export default {
     };
     const submissions = await this.paginate(this.jotform.getFormSubmissions.bind(this), params);
     const results = [];
-    for await (const submission of submissions) {
+    for await (let submission of submissions) {
+      if (this.encrypted) {
+        submission = this.jotform.decryptSubmission(submission, this.privateKey);
+      }
       results.push(submission);
     }
-    $.export("$summary", "Successfully retrieved list of form submissions");
+    $.export("$summary", `Successfully retrieved ${results.length} form submission${results.length === 1
+      ? "s"
+      : ""}`);
     return results;
   },
 };

--- a/components/jotform/actions/get-monthly-user-usage/get-monthly-user-usage.mjs
+++ b/components/jotform/actions/get-monthly-user-usage/get-monthly-user-usage.mjs
@@ -5,7 +5,7 @@ export default {
   key: "jotform-get-monthly-user-usage",
   name: "Get Monthly User Usage",
   description: "Gets number of form submissions received this month. Also, get number of SSL form submissions, payment form submissions and upload space used by user [See the docs here](https://api.jotform.com/docs/#user-usage)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     ...common.props,

--- a/components/jotform/actions/get-user-submissions/get-user-submissions.mjs
+++ b/components/jotform/actions/get-user-submissions/get-user-submissions.mjs
@@ -1,21 +1,35 @@
 import common from "../common.mjs";
+import jotform from "../../jotform.app.mjs";
 
 export default {
   ...common,
   key: "jotform-get-user-submissions",
   name: "Get User Submissions",
   description: "Gets a list of all submissions for all forms on the account [See the docs here](https://api.jotform.com/docs/#user-submissions)",
-  version: "0.0.2",
+  version: "0.1.0",
   type: "action",
   props: {
     ...common.props,
     max: {
       propDefinition: [
-        common.props.jotform,
+        jotform,
         "max",
       ],
     },
-    http: "$.interface.http",
+    encrypted: {
+      propDefinition: [
+        jotform,
+        "encrypted",
+      ],
+      reloadProps: true,
+    },
+  },
+  async additionalProps() {
+    const props = {};
+    if (this.encrypted) {
+      props.privateKey = jotform.propDefinitions.privateKey;
+    }
+    return props;
   },
   async run({ $ }) {
     const params = {
@@ -24,10 +38,15 @@ export default {
     };
     const submissions = await this.paginate(this.jotform.getUserSubmissions.bind(this), params);
     const results = [];
-    for await (const submission of submissions) {
+    for await (let submission of submissions) {
+      if (this.encrypted) {
+        submission = this.jotform.decryptSubmission(submission, this.privateKey);
+      }
       results.push(submission);
     }
-    $.export("$summary", "Successfully retrieved all form submissions");
+    $.export("$summary", `Successfully retrieved ${results.length} form submission${results.length === 1
+      ? "s"
+      : ""}`);
     return results;
   },
 };

--- a/components/jotform/actions/get-user-submissions/get-user-submissions.mjs
+++ b/components/jotform/actions/get-user-submissions/get-user-submissions.mjs
@@ -1,5 +1,4 @@
 import common from "../common.mjs";
-import jotform from "../../jotform.app.mjs";
 
 export default {
   ...common,
@@ -12,13 +11,13 @@ export default {
     ...common.props,
     max: {
       propDefinition: [
-        jotform,
+        common.props.jotform,
         "max",
       ],
     },
     encrypted: {
       propDefinition: [
-        jotform,
+        common.props.jotform,
         "encrypted",
       ],
       reloadProps: true,
@@ -27,7 +26,7 @@ export default {
   async additionalProps() {
     const props = {};
     if (this.encrypted) {
-      props.privateKey = jotform.propDefinitions.privateKey;
+      props.privateKey = common.props.jotform.propDefinitions.privateKey;
     }
     return props;
   },

--- a/components/jotform/common/constants.mjs
+++ b/components/jotform/common/constants.mjs
@@ -1,0 +1,7 @@
+const KEY_HEADER = "-----BEGIN RSA PRIVATE KEY-----";
+const KEY_FOOTER = "-----END RSA PRIVATE KEY-----";
+
+export default {
+  KEY_HEADER,
+  KEY_FOOTER,
+};

--- a/components/jotform/jotform.app.mjs
+++ b/components/jotform/jotform.app.mjs
@@ -1,5 +1,6 @@
 import { axios } from "@pipedream/platform";
 import querystring from "query-string";
+import crypto from "crypto";
 
 export default {
   type: "app",
@@ -71,6 +72,18 @@ export default {
       label: "Max Items",
       description: "Maximum number of items to return",
       default: 20,
+    },
+    encrypted: {
+      type: "boolean",
+      label: "Encrypted",
+      description: "Are the form responses encrypted? Set to `true` to decrypt responses.",
+      optional: true,
+    },
+    privateKey: {
+      type: "string",
+      label: "Private Key",
+      description: "The private key provided/created when setting the form as encrypted. Starts with `-----BEGIN RSA PRIVATE KEY-----` and ends with `-----END RSA PRIVATE KEY-----`",
+      secret: true,
     },
   },
   methods: {
@@ -185,6 +198,40 @@ export default {
       return this._makeRequest({
         endpoint: `form/${encodeURIComponent(formId)}/webhooks`,
       });
+    },
+    decryptSubmission(submission, privateKey) {
+      const { answers } = submission;
+      if (!answers) {
+        return submission;
+      }
+
+      if (!privateKey.includes("-----BEGIN RSA PRIVATE KEY-----\n")) {
+        privateKey = privateKey.replace("-----BEGIN RSA PRIVATE KEY-----", "-----BEGIN RSA PRIVATE KEY-----\n");
+      }
+      if (!privateKey.includes("\n-----END RSA PRIVATE KEY-----")) {
+        privateKey = privateKey.replace("-----END RSA PRIVATE KEY-----", "\n-----END RSA PRIVATE KEY-----");
+      }
+
+      for (const answer of Object.keys(answers)) {
+        if (!answers[answer]["answer"]) {
+          continue;
+        }
+        for (const question of Object.keys(answers[answer]["answer"])) {
+          const q = answers[answer]["answer"][question];
+          try {
+            const decrypted = crypto.privateDecrypt({
+              key: privateKey,
+              passphrase: "",
+              padding: crypto.constants.RSA_PKCS1_PADDING,
+            }, Buffer.from(q, "base64"));
+            answers[answer]["answer"][question] = decrypted.toString("utf8");
+          } catch (e) {
+            // not a base64 string
+            continue;
+          }
+        }
+      }
+      return submission;
     },
   },
 };

--- a/components/jotform/jotform.app.mjs
+++ b/components/jotform/jotform.app.mjs
@@ -1,6 +1,7 @@
 import { axios } from "@pipedream/platform";
 import querystring from "query-string";
 import crypto from "crypto";
+import constants from "./common/constants.mjs";
 
 export default {
   type: "app",
@@ -205,11 +206,11 @@ export default {
         return submission;
       }
 
-      if (!privateKey.includes("-----BEGIN RSA PRIVATE KEY-----\n")) {
-        privateKey = privateKey.replace("-----BEGIN RSA PRIVATE KEY-----", "-----BEGIN RSA PRIVATE KEY-----\n");
+      if (!privateKey.includes(`${constants.KEY_HEADER}\n`)) {
+        privateKey = privateKey.replace(constants.KEY_HEADER, `${constants.KEY_HEADER}\n`);
       }
-      if (!privateKey.includes("\n-----END RSA PRIVATE KEY-----")) {
-        privateKey = privateKey.replace("-----END RSA PRIVATE KEY-----", "\n-----END RSA PRIVATE KEY-----");
+      if (!privateKey.includes(`\n${constants.KEY_FOOTER}`)) {
+        privateKey = privateKey.replace(constants.KEY_FOOTER, `\n${constants.KEY_FOOTER}`);
       }
 
       for (const answer of Object.keys(answers)) {

--- a/components/jotform/package.json
+++ b/components/jotform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/jotform",
-  "version": "0.3.7",
+  "version": "0.4.7",
   "description": "Pipedream Jotform Components",
   "main": "jotform.app.mjs",
   "keywords": [
@@ -11,6 +11,7 @@
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "dependencies": {
     "@pipedream/platform": "^1.5.1",
+    "crypto": "^1.0.1",
     "query-string": "^8.1.0"
   },
   "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",

--- a/components/jotform/sources/new-submission/new-submission.mjs
+++ b/components/jotform/sources/new-submission/new-submission.mjs
@@ -4,19 +4,33 @@ export default {
   key: "jotform-new-submission",
   name: "New Submission (Instant)",
   description: "Emit new event when a form is submitted",
-  version: "0.0.7",
+  version: "0.1.0",
   type: "source",
+  dedupe: "unique",
   props: {
     jotform,
+    http: "$.interface.http",
     formId: {
       propDefinition: [
         jotform,
         "formId",
       ],
     },
-    http: "$.interface.http",
+    encrypted: {
+      propDefinition: [
+        jotform,
+        "encrypted",
+      ],
+      reloadProps: true,
+    },
   },
-  dedupe: "unique",
+  async additionalProps() {
+    const props = {};
+    if (this.encrypted) {
+      props.privateKey = jotform.propDefinitions.privateKey;
+    }
+    return props;
+  },
   hooks: {
     async deploy() {
       const { content: form } = await this.jotform.getForm(this.formId);
@@ -27,7 +41,10 @@ export default {
           orderby: "created_at",
         },
       });
-      for (const submission of submissions.reverse()) {
+      for (let submission of submissions.reverse()) {
+        if (this.encrypted) {
+          submission = this.jotform.decryptSubmission(submission, this.privateKey);
+        }
         const meta = {
           id: submission.id,
           summary: form.title,
@@ -51,9 +68,13 @@ export default {
   },
   async run(event) {
     const { body } = event;
-    const { content: submission } = await this.jotform.getFormSubmission({
+    let { content: submission } = await this.jotform.getFormSubmission({
       submissionId: body.submissionID,
     });
+
+    if (this.encrypted) {
+      submission = this.jotform.decryptSubmission(submission, this.privateKey);
+    }
 
     this.$emit(submission, {
       summary: body.formTitle || JSON.stringify(body),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1946,6 +1946,9 @@ importers:
     dependencies:
       '@pipedream/platform': 1.5.1
 
+  components/hootsuite:
+    specifiers: {}
+
   components/hotjar:
     specifiers: {}
 
@@ -4789,6 +4792,9 @@ importers:
     dependencies:
       '@pipedream/platform': 0.10.0
 
+  components/unbounce:
+    specifiers: {}
+
   components/unisender:
     specifiers:
       '@pipedream/platform': ^0.10.0
@@ -5058,6 +5064,9 @@ importers:
       '@pipedream/platform': 1.5.1
 
   components/wix:
+    specifiers: {}
+
+  components/wix_api_key:
     specifiers: {}
 
   components/woocommerce:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2149,9 +2149,11 @@ importers:
   components/jotform:
     specifiers:
       '@pipedream/platform': ^1.5.1
+      crypto: ^1.0.1
       query-string: ^8.1.0
     dependencies:
       '@pipedream/platform': 1.5.1
+      crypto: 1.0.1
       query-string: 8.1.0
 
   components/jp_funda:
@@ -8490,22 +8492,22 @@ packages:
       kuler: 2.0.0
     dev: false
 
-  /@definitelytyped/header-parser/0.0.160:
-    resolution: {integrity: sha512-VhWtup4T3LxRnWZxhLz710h56WsVXatUakOMPzALO3qgy9xKT19nP8ufUxrP9IJfOINZx6LRkQDgbbTHt+vlrA==}
+  /@definitelytyped/header-parser/0.0.162:
+    resolution: {integrity: sha512-OdllVVEFQ7ePyLM6PxTVL5Sa+EHkf1EuWqFCE+2jbDh5Mh356tiy8mgvhJ3ZtvxViCxJQ9Ew3wtzdELcg0qWqg==}
     dependencies:
-      '@definitelytyped/typescript-versions': 0.0.160
+      '@definitelytyped/typescript-versions': 0.0.162
       '@types/parsimmon': 1.10.6
       parsimmon: 1.18.1
     dev: true
 
-  /@definitelytyped/typescript-versions/0.0.160:
-    resolution: {integrity: sha512-Uk10J/JzjdrwzftCI56CSVdCuIq2apAveL/bluu1F76QUoBT7WUWrVCh/GB9tVcUq8fKjdUMF8IIXugijlezJA==}
+  /@definitelytyped/typescript-versions/0.0.162:
+    resolution: {integrity: sha512-o9cXltHGl/AqL0kjHqSgc04voBDozfIv/va29DVUTTOcNtJtoMlnMVmpWLo4lmOMuPAlTm9w+O0tBT+jqVhWzw==}
     dev: true
 
-  /@definitelytyped/utils/0.0.160:
-    resolution: {integrity: sha512-qhjoWxqnuUOPfX5Omm2aip57GlNP5MuWuE7vvqGFWe3U+ep+2207wnf6CNbh8PjuNDQGS68rPks2uQdPbXfL4Q==}
+  /@definitelytyped/utils/0.0.162:
+    resolution: {integrity: sha512-UM4RmI87WwqaNiC/XwsuyFNim9wOOMKHrHuoTH88/Q4nrFrSYrXZvy7Css+29wLJY1qhpLYrf1pux/zLetIHHw==}
     dependencies:
-      '@definitelytyped/typescript-versions': 0.0.160
+      '@definitelytyped/typescript-versions': 0.0.162
       '@qiwi/npm-registry-client': 8.9.1
       '@types/node': 14.18.42
       charm: 1.0.2
@@ -14694,7 +14696,7 @@ packages:
     peerDependencies:
       typescript: '*'
     dependencies:
-      '@definitelytyped/header-parser': 0.0.160
+      '@definitelytyped/header-parser': 0.0.162
       command-exists: 1.2.9
       rimraf: 3.0.2
       semver: 6.3.0
@@ -14710,9 +14712,9 @@ packages:
     peerDependencies:
       typescript: '>= 3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.7.0-dev || >= 3.8.0-dev || >= 3.9.0-dev || >= 4.0.0-dev'
     dependencies:
-      '@definitelytyped/header-parser': 0.0.160
-      '@definitelytyped/typescript-versions': 0.0.160
-      '@definitelytyped/utils': 0.0.160
+      '@definitelytyped/header-parser': 0.0.162
+      '@definitelytyped/typescript-versions': 0.0.162
+      '@definitelytyped/utils': 0.0.162
       dts-critic: 3.3.11_typescript@4.9.5
       fs-extra: 6.0.1
       json-stable-stringify: 1.0.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2029,6 +2029,9 @@ importers:
     dependencies:
       '@pipedream/platform': 0.10.0
 
+  components/imagga:
+    specifiers: {}
+
   components/imap:
     specifiers:
       '@pipedream/platform': ^1.2.0


### PR DESCRIPTION
Resolves #6221 

Adds props `encryped` and `privateKey`. If `encrypted` is set to `true`, form submission results will be decrypted using the user's `privateKey`.

Affected source:

- New Submission (Instant)

Affected actions:

- Get Form Submissions
- Get User Submissions