### PR TITLE
Vestaboard Create Message Update - allow characters prop to be string or array

### DIFF
--- a/components/vestaboard/actions/create-message/create-message.mjs
+++ b/components/vestaboard/actions/create-message/create-message.mjs
@@ -5,7 +5,7 @@ export default {
   key: "vestaboard-create-message",
   name: "Create Message",
   description: "Creates a new message for a subscription. [See the docs](https://swagger.vestaboard.com/docs/vestaboard/b3A6MTYwMTA4OTc-post-v2-0-subscriptions-with-id-message)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     vestaboard,
@@ -29,16 +29,28 @@ export default {
     },
   },
   async run({ $ }) {
-    if (!this.text && !this.characters) {
+    const {
+      subscriptionId,
+      text,
+      characters,
+    } = this;
+
+    if (!text && !characters) {
       throw new ConfigurationError("Either `text` or `characters` must be entered");
     }
 
+    const data = {};
+    if (text) {
+      data.text = text;
+    } else {
+      data.characters = Array.isArray(characters)
+        ? characters
+        : JSON.parse(characters);
+    }
+
     const response = await this.vestaboard.createMessage({
-      subscriptionId: this.subscriptionId,
-      data: {
-        text: this.text,
-        characters: this.characters,
-      },
+      subscriptionId,
+      data,
       $,
     });
 

--- a/components/vestaboard/package.json
+++ b/components/vestaboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/vestaboard",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Vestaboard Components",
   "main": "vestaboard.app.mjs",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2029,6 +2029,9 @@ importers:
     dependencies:
       '@pipedream/platform': 0.10.0
 
+  components/imagga:
+    specifiers: {}
+
   components/imap:
     specifiers:
       '@pipedream/platform': ^1.2.0


### PR DESCRIPTION
Updates the Vestaboard Create Message Action to allow the `characters` prop to be entered as either a string or an array.

Related issue https://github.com/PipedreamHQ/pipedream/issues/6596