### PR TITLE
[Supabase] Fix trigger historical events object structure

### DIFF
--- a/components/supabase/package.json
+++ b/components/supabase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/supabase",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream Supabase Components",
   "main": "supabase.app.mjs",
   "keywords": [

--- a/components/supabase/sources/new-webhook-event/new-webhook-event.mjs
+++ b/components/supabase/sources/new-webhook-event/new-webhook-event.mjs
@@ -5,7 +5,7 @@ export default {
   key: "supabase-new-webhook-event",
   name: "New Webhook Event (Instant)",
   description: "Emit new event for every `insert`, `update`, or `delete` operation in a table. This source requires user configuration using the Supabase website. More information in the README. [Also see documentation here](https://supabase.com/docs/guides/database/webhooks#creating-a-webhook)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   props: {
     ...base.props,
@@ -22,7 +22,9 @@ export default {
         .range(0, constants.HISTORICAL_EVENT_LIMIT);
       const { data } = await query;
       for (const row of data) {
-        this.$emit(row, {
+        this.$emit({
+          record: row,
+        }, {
           summary: "Historical row in table",
         });
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2029,6 +2029,9 @@ importers:
     dependencies:
       '@pipedream/platform': 0.10.0
 
+  components/imagga:
+    specifiers: {}
+
   components/imap:
     specifiers:
       '@pipedream/platform': ^1.2.0


### PR DESCRIPTION
- Make the historical event object have the same structure as a webhook object

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6cf5b72</samp>

Updated the `new-webhook-event` source component for Supabase to emit row data and support historical data. Also fixed the `pnpm-lock.yaml` file to include the Imagga components.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6cf5b72</samp>

> _`Supabase` is the fire, burning the old ways down_
> _`Imagga` is the eye, seeing the hidden truth_
> _`Webhook` is the blade, cutting through the noise_
> _We are the source, we are the force, we are the code_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6cf5b72</samp>

*  Incremented the version of the `@pipedream/supabase` package and the `new-webhook-event` source component to reflect the updates made to the event payload and the historical data query ([link](https://github.com/PipedreamHQ/pipedream/pull/6611/files?diff=unified&w=0#diff-f6ed22bb0bfd1bfb25c81e814d657944b8f92f355f6edea3c7b01c18f5bb4b87L3-R3), [link](https://github.com/PipedreamHQ/pipedream/pull/6611/files?diff=unified&w=0#diff-84da0e60472ebe33479f4a5adde9e812297821021fe665cde3e25a2c8960b06fL8-R8))
*  Added a `record` property to the event payload emitted by the `new-webhook-event` source component to include the row data from the Supabase table, making the payload more consistent with the other Supabase source components and allowing users to access the row data more easily ([link](https://github.com/PipedreamHQ/pipedream/pull/6611/files?diff=unified&w=0#diff-84da0e60472ebe33479f4a5adde9e812297821021fe665cde3e25a2c8960b06fL25-R27))
*  Locked the dependencies of the Imagga source components in the `pnpm-lock.yaml` file to ensure that they use the same versions of the packages that they depend on ([link](https://github.com/PipedreamHQ/pipedream/pull/6611/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2032-R2034))
