### PR TITLE
Update links from /limits to /docs/limits

### DIFF
--- a/docs/docs/code/bash/README.md
+++ b/docs/docs/code/bash/README.md
@@ -146,5 +146,5 @@ ls /tmp
 ```
 
 :::warning
-The `/tmp` directory does not have unlimited storage. Please refer to the [disk limits](/limits/#disk) for details.
+The `/tmp` directory does not have unlimited storage. Please refer to the [disk limits](/docs/limits/#disk) for details.
 :::

--- a/docs/docs/code/bash/working-with-files/README.md
+++ b/docs/docs/code/bash/working-with-files/README.md
@@ -23,4 +23,4 @@ ls /tmp
 
 The `/tmp` directory can store up to {{$site.themeConfig.TMP_SIZE_LIMIT}} of storage. Also the storage may be wiped or may not exist between workflow executions.
 
-To avoid errors, assume that the `/tmp` directory is empty between workflow runs. Please refer to the [disk limits](/limits/#disk) for details.
+To avoid errors, assume that the `/tmp` directory is empty between workflow runs. Please refer to the [disk limits](/docs/limits/#disk) for details.

--- a/docs/docs/code/go/working-with-files/README.md
+++ b/docs/docs/code/go/working-with-files/README.md
@@ -84,4 +84,4 @@ func main() {
 
 The `/tmp` directory can store up to {{$site.themeConfig.TMP_SIZE_LIMIT}} of storage. Also the storage may be wiped or may not exist between workflow executions.
 
-To avoid errors, assume that the `/tmp` directory is empty between workflow runs. Please refer to the [disk limits](/limits/#disk) for details.
+To avoid errors, assume that the `/tmp` directory is empty between workflow runs. Please refer to the [disk limits](/docs/limits/#disk) for details.

--- a/docs/docs/code/nodejs/README.md
+++ b/docs/docs/code/nodejs/README.md
@@ -435,7 +435,7 @@ See the [Environment Variables](/environment-variables/) docs for more informati
 
 ## Limitations of code steps
 
-Code steps operate within the [general constraints on workflows](/limits/#workflows). As long as you stay within those limits and abide by our [acceptable use policy](/limits/#acceptable-use), you can add any number of code steps in a workflow to do virtually anything you'd be able to do in Node.js.
+Code steps operate within the [general constraints on workflows](/docs/limits/#workflows). As long as you stay within those limits and abide by our [acceptable use policy](/docs/limits/#acceptable-use), you can add any number of code steps in a workflow to do virtually anything you'd be able to do in Node.js.
 
 If you're trying to run code that doesn't work or you have questions about any limits on code steps, [please reach out](https://pipedream.com/support/).
 

--- a/docs/docs/code/nodejs/http-requests/README.md
+++ b/docs/docs/code/nodejs/http-requests/README.md
@@ -530,7 +530,7 @@ By default, [HTTP requests made from Pipedream can come from a large range of IP
 
 Sometimes you need to upload a downloaded file directly to another service, without processing the downloaded file. You could [download the file](#download-a-file-to-the-tmp-directory) and then [upload it](#upload-a-file-from-the-tmp-directory) to the other URL, but these intermediate steps are unnecessary: you can just stream the download to the other service directly, without saving the file to disk.
 
-This method is especially effective for large files that exceed the [limits of the `/tmp` directory](/limits/#disk).
+This method is especially effective for large files that exceed the [limits of the `/tmp` directory](/docs/limits/#disk).
 
 [Copy this workflow](https://pipedream.com/@dylburger/stream-download-to-upload-p_5VCLoa1/edit) or paste this code into a [new Node.js code step](/code/nodejs/):
 

--- a/docs/docs/code/nodejs/working-with-files/README.md
+++ b/docs/docs/code/nodejs/working-with-files/README.md
@@ -90,4 +90,4 @@ export default defineComponent({
 
 [This workflow](https://pipedream.com/@dylan/upload-email-attachments-to-s3-p_V9CGAQ/edit) is triggered by incoming emails. When copied, you'll get a workflow-specific email address you can send any email to. This workflow takes any attachments included with inbound emails, saves them to `/tmp`, and uploads them to Amazon S3.
 
-You should also be aware of the [inbound payload limits](/limits/#email-triggers) associated with the email trigger.
+You should also be aware of the [inbound payload limits](/docs/limits/#email-triggers) associated with the email trigger.

--- a/docs/docs/code/python/README.md
+++ b/docs/docs/code/python/README.md
@@ -372,5 +372,5 @@ print(os.listdir('/tmp'))
 ```
 
 :::warning
-The `/tmp` directory does not have unlimited storage. Please refer to the [disk limits](/limits/#disk) for details.
+The `/tmp` directory does not have unlimited storage. Please refer to the [disk limits](/docs/limits/#disk) for details.
 :::

--- a/docs/docs/code/python/working-with-files/README.md
+++ b/docs/docs/code/python/working-with-files/README.md
@@ -54,4 +54,4 @@ print(os.listdir('/tmp'))
 
 The `/tmp` directory can store up to {{$site.themeConfig.TMP_SIZE_LIMIT}} of storage. Also the storage may be wiped or may not exist between workflow executions.
 
-To avoid errors, assume that the `/tmp` directory is empty between workflow runs. Please refer to the [disk limits](/limits/#disk) for details.
+To avoid errors, assume that the `/tmp` directory is empty between workflow runs. Please refer to the [disk limits](/docs/limits/#disk) for details.

--- a/docs/docs/components/api/README.md
+++ b/docs/docs/components/api/README.md
@@ -626,7 +626,7 @@ props: {
 
 When a user configures a prop with a value, it can hold at most `{{$site.themeConfig.CONFIGURED_PROPS_SIZE_LIMIT}}` data. Consider this when accepting large input in these fields (such as a base64 string).
 
-The `{{$site.themeConfig.CONFIGURED_PROPS_SIZE_LIMIT}}` limit applies only to static values entered as raw text. In workflows, users can pass expressions (referencing data in a prior step). In that case the prop value is simply the text of the expression, for example <ClientOnly><code v-pre>{{steps.nodejs.$return_value}}</code></ClientOnly>, well below the limit. The value of these expressions is evaluated at runtime, and are subject to [different limits](/limits/).
+The `{{$site.themeConfig.CONFIGURED_PROPS_SIZE_LIMIT}}` limit applies only to static values entered as raw text. In workflows, users can pass expressions (referencing data in a prior step). In that case the prop value is simply the text of the expression, for example <ClientOnly><code v-pre>{{steps.nodejs.$return_value}}</code></ClientOnly>, well below the limit. The value of these expressions is evaluated at runtime, and are subject to [different limits](/docs/limits/).
 
 ### Methods
 

--- a/docs/docs/pricing/README.md
+++ b/docs/docs/pricing/README.md
@@ -17,7 +17,7 @@ To support these goals, **Pipedream offers a generous free tier**. You can run s
 
 Free Tiers have access to all pre-built actions and triggers, and all of the workflow building capabilites as other paid tiers. 
 
-But Free account have a [daily limit of free credits](/limits#daily-credits-limit) that cannot be exceed. Standard [Pipedream platform limits](/limits/) apply to Free Accounts as well.
+But Free account have a [daily limit of free credits](/docs/limits#daily-credits-limit) that cannot be exceed. Standard [Pipedream platform limits](/docs/limits/) apply to Free Accounts as well.
 
 **To lift the daily credit limit and increase the number of workflows and connected accounts [upgrade to a paid tier](https://pipedream.com/pricing)**.
 
@@ -27,7 +27,7 @@ Free Tier accounts can connect up to 3 different service accounts like Twitter, 
 
 ### Free Tier Workflow Limitations
 
-Free Tier accounts have a [daily credit limit](/limits#daily-credits-limit) and have the lowest amount of active workflows available.
+Free Tier accounts have a [daily credit limit](/docs/limits#daily-credits-limit) and have the lowest amount of active workflows available.
 
 Upgrading to a [paid tier](https://pipedream.com/pricing) will increase the number of available active workflows and connected accounts.
 
@@ -178,7 +178,7 @@ When you sign up for a paid plan, you pay a platform fee at the start of each [b
 
 ### Additional Credits
 
-Any credits you run over your [included credit](/limits/#daily-credits-limit) are called **additional credits**. This usage is added to the invoice for your next [billing period](#billing-period), according to the [invoicing cycle described here](#when-am-i-invoiced-billed-for-paid-plans).
+Any credits you run over your [included credit](/docs/limits/#daily-credits-limit) are called **additional credits**. This usage is added to the invoice for your next [billing period](#billing-period), according to the [invoicing cycle described here](#when-am-i-invoiced-billed-for-paid-plans).
 
 ### Data Store Keys
 
@@ -196,7 +196,7 @@ Pipedream charges credits proportional to the memory configuration. If you run y
 
 ### Are there any limits on paid tiers?
 
-**You can run any number of credits for any amount of compute time** on any paid tier. [Other platform limits](/limits/) apply.
+**You can run any number of credits for any amount of compute time** on any paid tier. [Other platform limits](/docs//limits/) apply.
 
 ### When am I invoiced / billed for paid plans?
 

--- a/docs/docs/privacy-and-security/README.md
+++ b/docs/docs/privacy-and-security/README.md
@@ -157,7 +157,7 @@ Pipedream provides annual security training to all employees. Developers go thro
 
 Pipedream retains data only for as long as necessary to provide the core service. Pipedream stores your workflow code, data in data stores, and other data indefinitely, until you choose to delete it.
 
-Event data and the logs associated with workflow executions are stored according to [the retention rules on your account](/limits/#event-execution-history).
+Event data and the logs associated with workflow executions are stored according to [the retention rules on your account](/docs/limits/#event-execution-history).
 
 Pipedream deletes most internal application logs and logs tied to subprocessors within 30 days. We retain a subset of logs for longer periods where required for security investigations.
 

--- a/docs/docs/privacy-and-security/best-practices/README.md
+++ b/docs/docs/privacy-and-security/best-practices/README.md
@@ -49,7 +49,7 @@ The same follows for [npm](https://www.npmjs.com/) packages. Before you use a ne
 
 ## Limit what you log and return from steps
 
-[Pipedream retains a limited history of event data](/limits/#event-execution-history) and associated logs for event sources and workflows. But if you cannot log specific data in Pipedream for privacy / security reasons, or if you want to limit risk, remember that **Pipedream only stores data returned from or logged in steps**. Specifically, Pipedream will only store:
+[Pipedream retains a limited history of event data](/docs/limits/#event-execution-history) and associated logs for event sources and workflows. But if you cannot log specific data in Pipedream for privacy / security reasons, or if you want to limit risk, remember that **Pipedream only stores data returned from or logged in steps**. Specifically, Pipedream will only store:
 
 - The event data emitted from event sources, and any `console` logs / errors
 - The event data that triggers your workflow, any `console` logs / errors, [step exports](/workflows/steps/#step-exports), and any data included in error stack traces.

--- a/docs/docs/sources/README.md
+++ b/docs/docs/sources/README.md
@@ -93,7 +93,7 @@ You can chat about source development with the Pipedream team in the `#contribut
 
 ## Limits
 
-Event sources are subject to the [same limits as Pipedream workflows](/limits/), except:
+Event sources are subject to the [same limits as Pipedream workflows](/docs/limits/), except:
 
 - Sources have a default timeout of 5 min.
 - Memory is fixed at 256MB.

--- a/docs/docs/troubleshooting/README.md
+++ b/docs/docs/troubleshooting/README.md
@@ -77,17 +77,17 @@ See the reference on [running asynchronous code on Pipedream](/code/nodejs/async
 
 ## Pipedream Internal Errors
 
-Pipedream sets [limits](/limits/) on runtime, memory, and other execution-related properties. If you exceed these limits, you'll receive one of the errors below. [See the limits doc](/limits/) for details on specific limits.
+Pipedream sets [limits](/docs/limits/) on runtime, memory, and other execution-related properties. If you exceed these limits, you'll receive one of the errors below. [See the limits doc](/docs/limits/) for details on specific limits.
 
 ### Quota Exceeded
 
-On the Free tier, Pipedream imposes a limit on the [daily credits](/limits/#daily-credits-limit) across all workflows and sources. If you hit this limit, you'll see a **Quota Exceeded** error.
+On the Free tier, Pipedream imposes a limit on the [daily credits](/docs/limits/#daily-credits-limit) across all workflows and sources. If you hit this limit, you'll see a **Quota Exceeded** error.
 
 Paid plans have no credit limit. [Upgrade here](https://pipedream.com/pricing).
 
 ### Timeout
 
-Event sources and workflows have a [default time limit on a given execution](/limits/#time-per-execution). If your code exceeds that limit, you may encounter a **Timeout** error.
+Event sources and workflows have a [default time limit on a given execution](/docs/limits/#time-per-execution). If your code exceeds that limit, you may encounter a **Timeout** error.
 
 To address timeouts, you'll either need to:
 
@@ -96,7 +96,7 @@ To address timeouts, you'll either need to:
 
 ### Out of Memory
 
-Pipedream [limits the default memory](/limits/#memory) available to workflows and event sources. If you exceed this memory, you'll see an **Out of Memory** error. **You can raise the memory of your workflow [in your workflow's Settings](/workflows/settings/#memory)**.
+Pipedream [limits the default memory](/docs/limits/#memory) available to workflows and event sources. If you exceed this memory, you'll see an **Out of Memory** error. **You can raise the memory of your workflow [in your workflow's Settings](/workflows/settings/#memory)**.
 
 This can happen for two main reasons:
 
@@ -105,7 +105,7 @@ This can happen for two main reasons:
 
 ### Rate Limit Exceeded
 
-Pipedream limits the number of events that can be processed by a given interface (e.g. HTTP endpoints) during a given interval. This limit is most commonly reached for HTTP interfaces - see the [QPS limits documentation](/limits/#qps-queries-per-second) for more information on that limit.
+Pipedream limits the number of events that can be processed by a given interface (e.g. HTTP endpoints) during a given interval. This limit is most commonly reached for HTTP interfaces - see the [QPS limits documentation](/docs/limits/#qps-queries-per-second) for more information on that limit.
 
 **This limit can be raised for HTTP endpoints**. [Reach out to our team](https://pipedream.com/support/) to request an increase.
 
@@ -113,7 +113,7 @@ Pipedream limits the number of events that can be processed by a given interface
 
 By default, Pipedream limits the size of incoming HTTP payloads. If you exceed this limit, you'll see a **Request Entity Too Large** error.
 
-Pipedream supports two different ways to bypass this limit. Both of these interfaces support uploading data up to `5TB`, though you may encounter other [platform limits](/limits/).
+Pipedream supports two different ways to bypass this limit. Both of these interfaces support uploading data up to `5TB`, though you may encounter other [platform limits](/docs/limits/).
 
 - You can send large HTTP payloads by passing the `pipedream_upload_body=1` query string or an `x-pd-upload-body: 1` HTTP header in your HTTP request. [Read more here](/workflows/steps/triggers/#sending-large-payloads).
 - You can upload multiple large files, like images and videos, using the [large file upload interface](/workflows/steps/triggers/#large-file-support).

--- a/docs/docs/user-settings/README.md
+++ b/docs/docs/user-settings/README.md
@@ -40,7 +40,7 @@ Environment variables allow you to securely store secrets or other config values
 
 ## Billing and Usage
 
-You'll find information on your usage data (for specific [Pipedream limits](/limits/)) in your [Billing Settings](https://pipedream.com/settings/billing). You can also upgrade to [paid plans](https://pipedream.com/pricing) from this page.
+You'll find information on your usage data (for specific [Pipedream limits](/docs/limits/)) in your [Billing Settings](https://pipedream.com/settings/billing). You can also upgrade to [paid plans](https://pipedream.com/pricing) from this page.
 
 ### Subscription
 
@@ -86,6 +86,6 @@ In an example scenario, with cap set at 20 credits and long running workflow tha
 
 ### Limits
 
-For users on the [Free tier](/pricing/#free-tier), this section displays your usage towards your [credits quota](/limits/#daily-credits-limit) for the current UTC day.
+For users on the [Free tier](/pricing/#free-tier), this section displays your usage towards your [credits quota](/docs/limits/#daily-credits-limit) for the current UTC day.
 
 <Footer />

--- a/docs/docs/workflows/events/inspect/README.md
+++ b/docs/docs/workflows/events/inspect/README.md
@@ -44,6 +44,6 @@ Any `console.log()` statements or other output of code steps is attached to the 
 
 ## Limits
 
-Pipedream retains a limited history of events for a given workflow. See the [limits docs](/limits/#event-execution-history) for more information.
+Pipedream retains a limited history of events for a given workflow. See the [limits docs](/docs/limits/#event-execution-history) for more information.
 
 <Footer />

--- a/docs/docs/workflows/settings/README.md
+++ b/docs/docs/workflows/settings/README.md
@@ -46,9 +46,9 @@ If the step fails on all 8 retries, it throws the final error, and you should re
 
 ### Execution Timeout Limit
 
-Workflows have a default [execution limit](/limits/#time-per-execution), which defines the time the workflow can run for a single execution until it's timed out.
+Workflows have a default [execution limit](/docs/limits/#time-per-execution), which defines the time the workflow can run for a single execution until it's timed out.
 
-If your workflow times out, and needs to run for longer than the [default limit](/limits/#time-per-execution), you can change that limit here.
+If your workflow times out, and needs to run for longer than the [default limit](/docs/limits/#time-per-execution), you can change that limit here.
 
 ### Memory
 

--- a/docs/docs/workflows/steps/triggers/README.md
+++ b/docs/docs/workflows/steps/triggers/README.md
@@ -126,7 +126,7 @@ Pipedream will automatically lowercase header keys for consistency.
 
 #### Limits
 
-You can send any content, up to the [HTTP payload size limit](/limits/#http-request-body-size), as a part of the form request. The content of uploaded images or other binary files does not contribute to this limit — the contents of the file will be uploaded at a Pipedream URL you have access to within your source or workflow. See the section on [Large File Support](#large-file-support) for more detail.
+You can send any content, up to the [HTTP payload size limit](/docs/limits/#http-request-body-size), as a part of the form request. The content of uploaded images or other binary files does not contribute to this limit — the contents of the file will be uploaded at a Pipedream URL you have access to within your source or workflow. See the section on [Large File Support](#large-file-support) for more detail.
 
 ### Sending large payloads
 
@@ -186,7 +186,7 @@ Your raw payload is saved to a Pipedream-owned [Amazon S3 bucket](https://aws.am
 
 #### Limits
 
-**You can upload payloads up to 5TB in size**. However, payloads that large may trigger [other Pipedream limits](/limits/). Please [reach out](https://pipedream.com/support/) with any specific questions or issues.
+**You can upload payloads up to 5TB in size**. However, payloads that large may trigger [other Pipedream limits](/docs/limits/). Please [reach out](https://pipedream.com/support/) with any specific questions or issues.
 
 ### Large File Support
 
@@ -247,7 +247,7 @@ await pipeline(
 
 Since large files are uploaded using a `Content-Type` of `multipart/form-data`, the limits that apply to [form data](#how-pipedream-handles-multipart-form-data) also apply here.
 
-The content of the file itself does not contribute to the HTTP payload limit imposed for forms. **You can upload files up to 5TB in size**. However, files that large may trigger [other Pipedream limits](/limits/). Please [reach out](https://pipedream.com/support/) with any specific questions or issues.
+The content of the file itself does not contribute to the HTTP payload limit imposed for forms. **You can upload files up to 5TB in size**. However, files that large may trigger [other Pipedream limits](/docs/limits/). Please [reach out](https://pipedream.com/support/) with any specific questions or issues.
 
 ### Cross-Origin HTTP Requests
 
@@ -311,7 +311,7 @@ The value of the `body` property can be either a string, object, a [Buffer](http
 In the case where you return a Readable stream:
 
 - You must `await` the `$.respond` function (`await $.respond({ ... }`)
-- The stream must close and be finished reading within your [workflow execution timeout](/limits/#time-per-execution).
+- The stream must close and be finished reading within your [workflow execution timeout](/docs/limits/#time-per-execution).
 - You cannot return a Readable and use the [`immediate: true`](#returning-a-response-immediately) property of `$.respond`.
 
 You can **Copy** [this example workflow](https://pipedream.com/@dylburger/issue-an-http-response-from-a-workflow-p_ljCRdv/edit) and make an HTTP request to its endpoint URL to experiment with this.
@@ -411,7 +411,7 @@ We'll also issue a 404 response on workflows with an HTTP trigger that have been
 
 #### Too Many Requests
 
-If you send too many requests to your HTTP source within a small period of time, we may issue a `429 Too Many Requests` response. [Review our limits](/limits/) to understand the conditions where you might be throttled.
+If you send too many requests to your HTTP source within a small period of time, we may issue a `429 Too Many Requests` response. [Review our limits](/docs/limits/) to understand the conditions where you might be throttled.
 
 You can also [reach out](https://pipedream.com/support/) to inquire about raising this rate limit.
 
@@ -559,7 +559,7 @@ Your email is saved to a Pipedream-owned [Amazon S3 bucket](https://aws.amazon.c
 
 ### Email attachments
 
-You can attach any files to your email, up to [the total email size limit](/limits/#email-triggers).
+You can attach any files to your email, up to [the total email size limit](/docs/limits/#email-triggers).
 
 Attachments are stored in `steps.trigger.event.attachments`, which provides an array of attachment objects. Each attachment in that array exposes key properties:
 


### PR DESCRIPTION
## WHAT

Fix documentation links from /limits to /docs/limits

## WHY

Because I kept clicking the wrong link in the Pricing page on the website.


## HOW

Mass change of /limits to /docs/limits
