### PR TITLE
remove old screenshot from workflow settings attachments

### DIFF
--- a/docs/docs/workflows/settings/README.md
+++ b/docs/docs/workflows/settings/README.md
@@ -83,10 +83,6 @@ const fileData = fs
 console.log(fileData);
 ```
 
-<div>
-<img alt="File attachment data" src="./images/attachment-file-data.png">
-</div>
-
 ### Limits
 
 Each attachment is limited to `25MB` in size. The total size of all attachments within a single workflow cannot exceed `200MB`.


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3ffcac9</samp>

Removed an unnecessary image from the workflow documentation. This change simplifies the `Attachments` section of the `docs/docs/workflows/settings/README.md` file and makes it easier to read and understand.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3ffcac9</samp>

> _`Attachments` image_
> _Cut from `Settings` doc file_
> _Redundant in spring_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3ffcac9</samp>

* Remove redundant image of file attachment data from `Attachments` section of workflow `Settings` documentation ([link](https://github.com/PipedreamHQ/pipedream/pull/6653/files?diff=unified&w=0#diff-d483fcc47a053088e0728ae584b54dd21609caf55d8e39f35339aa270f7fed17L86-L89))
