### PR TITLE
631 google forms sources

### DIFF
--- a/components/google_forms/package.json
+++ b/components/google_forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_forms",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream Google Forms Components",
   "main": "google_forms.app.mjs",
   "keywords": [

--- a/components/google_forms/package.json
+++ b/components/google_forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_forms",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Google Forms Components",
   "main": "google_forms.app.mjs",
   "keywords": [

--- a/components/google_forms/sources/common/base.mjs
+++ b/components/google_forms/sources/common/base.mjs
@@ -1,0 +1,46 @@
+import googleForms from "../../google_forms.app.mjs";
+import { DEFAULT_POLLING_SOURCE_TIMER_INTERVAL } from "@pipedream/platform";
+
+export default {
+  props: {
+    googleForms,
+    timer: {
+      type: "$.interface.timer",
+      default: {
+        intervalSeconds: DEFAULT_POLLING_SOURCE_TIMER_INTERVAL,
+      },
+    },
+    db: "$.service.db",
+    formId: {
+      propDefinition: [
+        googleForms,
+        "formId",
+      ],
+    },
+  },
+  methods: {
+    generateMeta() {
+      throw new Error("generateMeta not implemented.");
+    },
+    sortResponses(responses) {
+      return responses.sort((a, b) => (
+        new Date(b.lastSubmittedTime) - new Date(a.lastSubmittedTime)
+      ));
+    },
+    setLastSubmittedTime(time) {
+      if (!time) {
+        return;
+      }
+      this.db.set("lastSubmittedTime", time);
+    },
+    getLastSubmittedTime() {
+      return this.db.get("lastSubmittedTime");
+    },
+    emitResponses(responses) {
+      for (const response of responses) {
+        const meta = this.generateMeta(response);
+        this.$emit(response, meta);
+      }
+    },
+  },
+};

--- a/components/google_forms/sources/new-form-answer-update/new-form-answer-update.mjs
+++ b/components/google_forms/sources/new-form-answer-update/new-form-answer-update.mjs
@@ -4,7 +4,7 @@ export default {
   ...base,
   key: "google_forms-new-form-answer-update",
   name: "New Form Answer Update",
-  description: "Emit new event when an answer is sent or updated. [See the documentation](https://developers.google.com/forms/api/reference/rest/v1/forms.responses/list)",
+  description: "Emit a new event when an answer is sent or updated. [See the documentation](https://developers.google.com/forms/api/reference/rest/v1/forms.responses/list)",
   version: "0.0.1",
   dedupe: "last",
   type: "source",

--- a/components/google_forms/sources/new-form-answer-update/new-form-answer-update.mjs
+++ b/components/google_forms/sources/new-form-answer-update/new-form-answer-update.mjs
@@ -1,0 +1,39 @@
+import base from "../common/base.mjs";
+
+export default {
+  ...base,
+  key: "google_forms-new-comment-answer",
+  name: "New Form Answer Update",
+  description: "Emit new event when an answer is sent or updated. [See the documentation](https://developers.google.com/forms/api/reference/rest/v1/forms.responses/list)",
+  version: "0.0.1",
+  dedupe: "last",
+  type: "source",
+  methods: {
+    ...base.methods,
+    generateMeta(response) {
+      console.log(response);
+      return {
+        id: new Date(response.lastSubmittedTime).getTime(),
+        summary: "New Answer Update",
+      };
+    },
+  },
+  async run({ $ }) {
+    const lastSubmittedTime = this.getLastSubmittedTime();
+    const { responses } = await this.googleForms.listFormResponses({
+      formId: this.formId,
+      $,
+      params: {
+        filter: lastSubmittedTime && `timestamp >= ${lastSubmittedTime}`,
+      },
+    });
+    if (!responses || !Array.isArray(responses)) {
+      return;
+    }
+    const responseSorted = this.sortResponses(responses);
+    this.setLastSubmittedTime(
+      responseSorted.length && responseSorted[0].lastSubmittedTime,
+    );
+    this.emitResponses(responseSorted.reverse());
+  },
+};

--- a/components/google_forms/sources/new-form-answer-update/new-form-answer-update.mjs
+++ b/components/google_forms/sources/new-form-answer-update/new-form-answer-update.mjs
@@ -2,7 +2,7 @@ import base from "../common/base.mjs";
 
 export default {
   ...base,
-  key: "google_forms-new-comment-answer",
+  key: "google_forms-new-form-answer-update",
   name: "New Form Answer Update",
   description: "Emit new event when an answer is sent or updated. [See the documentation](https://developers.google.com/forms/api/reference/rest/v1/forms.responses/list)",
   version: "0.0.1",

--- a/components/google_forms/sources/new-form-answer/new-form-answer.mjs
+++ b/components/google_forms/sources/new-form-answer/new-form-answer.mjs
@@ -2,7 +2,7 @@ import base from "../common/base.mjs";
 
 export default {
   ...base,
-  key: "google_forms-new-comment-answer",
+  key: "google_forms-new-form-answer",
   name: "New Form Answer",
   description: "Emit new event when the form is answered. [See the documentation](https://developers.google.com/forms/api/reference/rest/v1/forms.responses/list)",
   version: "0.0.1",

--- a/components/google_forms/sources/new-form-answer/new-form-answer.mjs
+++ b/components/google_forms/sources/new-form-answer/new-form-answer.mjs
@@ -4,7 +4,7 @@ export default {
   ...base,
   key: "google_forms-new-form-answer",
   name: "New Form Answer",
-  description: "Emit new event when the form is answered. [See the documentation](https://developers.google.com/forms/api/reference/rest/v1/forms.responses/list)",
+  description: "Emit a new event when the form is answered. [See the documentation](https://developers.google.com/forms/api/reference/rest/v1/forms.responses/list)",
   version: "0.0.1",
   dedupe: "unique",
   type: "source",

--- a/components/google_forms/sources/new-form-answer/new-form-answer.mjs
+++ b/components/google_forms/sources/new-form-answer/new-form-answer.mjs
@@ -1,0 +1,39 @@
+import base from "../common/base.mjs";
+
+export default {
+  ...base,
+  key: "google_forms-new-comment-answer",
+  name: "New Form Answer",
+  description: "Emit new event when the form is answered. [See the documentation](https://developers.google.com/forms/api/reference/rest/v1/forms.responses/list)",
+  version: "0.0.1",
+  dedupe: "unique",
+  type: "source",
+  methods: {
+    ...base.methods,
+    generateMeta(response) {
+      return {
+        id: response.responseId,
+        summary: "New Answer",
+        ts: new Date(response.createdTime).getTime(),
+      };
+    },
+  },
+  async run({ $ }) {
+    const lastSubmittedTime = this.getLastSubmittedTime();
+    const { responses } = await this.googleForms.listFormResponses({
+      formId: this.formId,
+      $,
+      params: {
+        filter: lastSubmittedTime && `timestamp >= ${lastSubmittedTime}`,
+      },
+    });
+    if (!responses || !Array.isArray(responses)) {
+      return;
+    }
+    const responseSorted = this.sortResponses(responses);
+    this.setLastSubmittedTime(
+      responseSorted.length && responseSorted[0].lastSubmittedTime,
+    );
+    this.emitResponses(responseSorted.reverse());
+  },
+};


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 85419cd</samp>

Added two new sources to the Google Forms components to emit events for new and updated form answers. Created a common base class for the sources to share the logic of fetching and emitting form responses. Bumped the component version to `0.1.1`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 85419cd</samp>

> _Google Forms sources_
> _`base.mjs` for common logic_
> _New events in spring_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 85419cd</samp>

* Create a common base class for Google Forms sources in `base.mjs` ([link](https://github.com/PipedreamHQ/pipedream/pull/6670/files?diff=unified&w=0#diff-454d96c25a710bb0118c1d4edcd66990d36f09f9d5ed6c29fa8bf5f9a54d355eR1-R46))
* Add two new sources to emit events for new or updated form answers, using the base class and customizing the event metadata and filtering logic ([link](https://github.com/PipedreamHQ/pipedream/pull/6670/files?diff=unified&w=0#diff-0688b172125d38a80214fdd6314437234e2d46beae832207fb5d073cba0762afR1-R39), [link](https://github.com/PipedreamHQ/pipedream/pull/6670/files?diff=unified&w=0#diff-c31e2d72cd2986ea63c25c24383a3419f400308f5f221e2f239a21f581acfe87R1-R39))
* Bump the version of the Google Forms components to `0.1.1` in `package.json` ([link](https://github.com/PipedreamHQ/pipedream/pull/6670/files?diff=unified&w=0#diff-af472c86e048e5a05117031ca47a7f473b874f2579d555ddffa6baf99c67ccd2L3-R3))
