### PR TITLE
Fix CLI broken link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Develop components without leaving your browser with the Pipedream Gitpod worksp
 3. Open a new Gitpod Workspace with your fork: `https://gitpod.io/#https://github.com/<your-github-username>/pipedream`
 4. Run `pd init app` to scaffold a new app, or make changes to an exisiting one in the `components` directory
 
-This workspace will automatically configure the Pipedream CLI client with your API key. This allows you to interact with the [advanced Pipedream CLI tool](https://pipedream.com/docs/cli) and develop components on the fly.
+This workspace will automatically configure the Pipedream CLI client with your API key. This allows you to interact with the [advanced Pipedream CLI tool](https://pipedream.com/docs/cli/reference/) and develop components on the fly.
 
 ## The Pull Request process
 


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ee2c4d4</samp>

This pull request fixes a broken link in the `CONTRIBUTING.md` file that guides developers on how to use the Pipedream CLI.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ee2c4d4</samp>

> _`Pipedream` CLI docs_
> _Link fixed for better guidance_
> _Autumn of errors_


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ee2c4d4</samp>

* Update the link to the Pipedream CLI reference in the contributing guide ([link](https://github.com/PipedreamHQ/pipedream/pull/6686/files?diff=unified&w=0#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L60-R60))
