### PR TITLE
Updating Salesforce Readme to add clarifying language on API Access.

### DIFF
--- a/components/salesforce_rest_api/README.md
+++ b/components/salesforce_rest_api/README.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-You can install the Pipedream Salesforce app in the [Accounts](https://pipedream.com/accounts) section of your account, or directly in a workflow.
+You can connect your Salesforce account in the [Accounts](https://pipedream.com/accounts) section of your account, or directly in a workflow.
 
 ## API Access
 

--- a/components/salesforce_rest_api/README.md
+++ b/components/salesforce_rest_api/README.md
@@ -2,6 +2,23 @@
 
 You can install the Pipedream Salesforce app in the [Accounts](https://pipedream.com/accounts) section of your account, or directly in a workflow.
 
+## API Access
+
+Please note that only certain [editions](https://help.salesforce.com/s/articleView?id=000385436&type=1) of Salesforce are granted API Access: 
+
+**Editions with API Access**
+- Enterprise Edition
+- Unlimited Edition
+- Developer Edition
+- Performance Edition
+ 
+**Editions without API Access**
+- Group Edition
+- Essentials Edition
+- Professional Edition (can be purchased as an add-on) 
+
+If you are on a Salesforce edition with API Access, you will need to enable it at the user-profile level under **Administrative Permissions** -> **"API-Enabled"**
+
 ### Webhooks
 
 If you happen to stumble on the error: `UNKNOWN_EXCEPTION: admin operation already in progress` when creating an **Instant** trigger, you can follow the steps below to use the Salesforce Flow Builder to be able to use webhooks with Pipedream. This is a known error in Salesforce.


### PR DESCRIPTION
## WHAT

Updating Salesforce Readme to add clarifying language on API Access. 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4ba65bf</samp>

This pull request updates the `README.md` file of the `salesforce_rest_api` component to include a new section on API access requirements. The new section helps users to check and enable API access for their Salesforce edition and user profile.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4ba65bf</samp>

> _`README.md` changed_
> _Salesforce API access_
> _Explained for users_


## WHY

Several user inquiries have come up in the past day which relate to the user being able to authenticate but hitting 403 errors with actions.

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4ba65bf</samp>

* Add a section to the component's README file explaining Salesforce API access requirements ([link](https://github.com/PipedreamHQ/pipedream/pull/6715/files?diff=unified&w=0#diff-85dcf148c03d92a3529202035fd636ef9fed8a339f0c73819cde1a20216bb2a0R5-R21))
