### PR TITLE
[FEATURE] Add DimensionFilter to Google Analytics: Run Report in G4A action #6724

### DIFF
--- a/components/google_analytics/actions/run-report-in-ga4/run-report-in-ga4.mjs
+++ b/components/google_analytics/actions/run-report-in-ga4/run-report-in-ga4.mjs
@@ -36,7 +36,7 @@ export default {
     },
     dimensionFilter: {
       type: "object",
-      label: "Dimension Filter",
+      label: "Dimension filter",
       description: "Dimension filter let you ask for only specific dimension values in the report. Read more about dimension filters [here](https://developers.google.com/analytics/devguides/reporting/data/v1/basics#dimension_filters)",
       optional: true,
     },

--- a/components/google_analytics/actions/run-report-in-ga4/run-report-in-ga4.mjs
+++ b/components/google_analytics/actions/run-report-in-ga4/run-report-in-ga4.mjs
@@ -2,7 +2,7 @@ import analytics from "../../google_analytics.app.mjs";
 
 export default {
   key: "google_analytics-run-report-in-ga4",
-  version: "0.0.1",
+  version: "0.0.2",
   name: "Run Report in GA4",
   description: "Returns a customized report of your Google Analytics event data. Reports contain statistics derived from data collected by the Google Analytics tracking code. [See the documentation here](https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/properties/runReport)",
   type: "action",
@@ -34,10 +34,20 @@ export default {
       description: "Dimension attributes for your data. Explore the available dimensions [here](https://developers.google.com/analytics/devguides/reporting/data/v1/api-schema#dimensions)",
       optional: true,
     },
+    dimensionFilter: {
+      type: "object",
+      label: "Dimension Filter",
+      description: "Dimension filter let you ask for only specific dimension values in the report. Read more about dimension filters [here](https://developers.google.com/analytics/devguides/reporting/data/v1/basics#dimension_filters)",
+      optional: true,
+    },
   },
   async run({ $ }) {
     const metrics = this.metrics || [];
     const dimensions = this.dimensions || [];
+
+    const dimensionFilter = typeof this.dimensionFilter === "string"
+      ? JSON.parse(this.dimensionFilter)
+      : this.dimensionFilter;
 
     const data = {
       dateRanges: [
@@ -52,6 +62,7 @@ export default {
       metrics: metrics.map((metric) => ({
         name: metric,
       })),
+      dimensionFilter: dimensionFilter,
     };
     const report = await this.analytics.queryReportsGA4({
       property: this.property,

--- a/components/google_analytics/actions/run-report-in-ga4/run-report-in-ga4.mjs
+++ b/components/google_analytics/actions/run-report-in-ga4/run-report-in-ga4.mjs
@@ -37,7 +37,7 @@ export default {
     dimensionFilter: {
       type: "object",
       label: "Dimension filter",
-      description: "Dimension filter let you ask for only specific dimension values in the report. Read more about dimension filters [here](https://developers.google.com/analytics/devguides/reporting/data/v1/basics#dimension_filters)",
+      description: "Dimension filters let you ask for only specific dimension values in the report. Read more about dimension filters [here](https://developers.google.com/analytics/devguides/reporting/data/v1/basics#dimension_filters)",
       optional: true,
     },
   },

--- a/components/google_analytics/package.json
+++ b/components/google_analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_analytics",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Pipedream Google_analytics Components",
   "main": "google_analytics.app.mjs",
   "keywords": [


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d73298d</samp>

Added a new feature to the `run-report-in-ga4` action in the `google_analytics` component that enables filtering dimension values in Google Analytics 4 reports. Bumped the component version to 0.0.5.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d73298d</samp>

> _To run a report in GA4_
> _We added a feature that's new_
> _You can filter dimension_
> _With a simple intention_
> _Just use the `dimensionFilter` parameter too_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d73298d</samp>

*  Bump package and action versions to reflect new feature of dimension filter ([link](https://github.com/PipedreamHQ/pipedream/pull/6726/files?diff=unified&w=0#diff-ac24de360fe22190d0f885f8132f320bdf6bbeb495af6c088b7dbbb35a34e987L5-R5), [link](https://github.com/PipedreamHQ/pipedream/pull/6726/files?diff=unified&w=0#diff-5b2938bff84821f0f845af341d2a000f0d19da82776f65c7c6fa829dcfe76addL3-R3))
*  Add optional `dimensionFilter` parameter to `run-report-in-ga4` action, which accepts an object or a JSON string that follows the Google Analytics Data API specification ([link](https://github.com/PipedreamHQ/pipedream/pull/6726/files?diff=unified&w=0#diff-ac24de360fe22190d0f885f8132f320bdf6bbeb495af6c088b7dbbb35a34e987R37-R42))
*  Parse `dimensionFilter` parameter as JSON object if it is a string, or use it as is otherwise ([link](https://github.com/PipedreamHQ/pipedream/pull/6726/files?diff=unified&w=0#diff-ac24de360fe22190d0f885f8132f320bdf6bbeb495af6c088b7dbbb35a34e987R48-R51))
*  Include `dimensionFilter` variable in the `requestBody` object of the API call to the Google Analytics Data API in `run-report-in-ga4` action ([link](https://github.com/PipedreamHQ/pipedream/pull/6726/files?diff=unified&w=0#diff-ac24de360fe22190d0f885f8132f320bdf6bbeb495af6c088b7dbbb35a34e987R65))
