### PR TITLE
RSS - store ids in db to filter against

### DIFF
--- a/components/rss/package.json
+++ b/components/rss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/rss",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Pipedream RSS Components",
   "main": "dist/app/rss.app.mjs",
   "types": "dist/app/rss.app.d.ts",

--- a/components/rss/sources/common/common.ts
+++ b/components/rss/sources/common/common.ts
@@ -3,6 +3,7 @@ import rss from "../../app/rss.app";
 export default {
   props: {
     rss,
+    db: "$.service.db",
     timer: {
       propDefinition: [
         rss,
@@ -11,6 +12,12 @@ export default {
     },
   },
   methods: {
+    getPreviousIds() {
+      return this.db.get("previousIds") || {};
+    },
+    setPreviousIds(previousIds) {
+      this.db.set("previousIds", previousIds);
+    },
     generateMeta: function (item) {
       return {
         id: this.rss.itemKey(item),

--- a/components/rss/sources/new-item-from-multiple-feeds/new-item-from-multiple-feeds.ts
+++ b/components/rss/sources/new-item-from-multiple-feeds/new-item-from-multiple-feeds.ts
@@ -8,7 +8,7 @@ export default defineSource({
   name: "New Item From Multiple RSS Feeds",
   type: "source",
   description: "Emit new items from multiple RSS feeds",
-  version: "1.2.2",
+  version: "1.2.3",
   props: {
     ...rssCommon.props,
     urls: {
@@ -37,6 +37,8 @@ export default defineSource({
     },
   },
   async run() {
+    const previousIds = this.getPreviousIds();
+
     const items = [];
     for (const url of this.urls) {
       const feedItems = (await this.rss.fetchAndParseFeed(url))?.slice(0, this.max);
@@ -45,7 +47,12 @@ export default defineSource({
     }
     this.rss.sortItems(items).forEach((item: any) => {
       const meta = this.generateMeta(item);
-      this.$emit(item, meta);
+      if (!previousIds[meta.id]) {
+        this.$emit(item, meta);
+        previousIds[meta.id] = true;
+      }
     });
+
+    this.setPreviousIds(previousIds);
   },
 });

--- a/components/rss/sources/new-item-in-feed/new-item-in-feed.ts
+++ b/components/rss/sources/new-item-in-feed/new-item-in-feed.ts
@@ -7,7 +7,7 @@ export default defineSource({
   key: "rss-new-item-in-feed",
   name: "New Item in Feed",
   description: "Emit new items from an RSS feed",
-  version: "1.2.2",
+  version: "1.2.3",
   type: "source",
   dedupe: "unique",
   props: {
@@ -43,6 +43,8 @@ export default defineSource({
     },
   },
   async run() {
+    const previousIds = this.getPreviousIds();
+
     const items = await this.rss.fetchAndParseFeed(this.url);
     for (const item of items.reverse()) {
       if (this.publishedAfterThan) {
@@ -53,7 +55,12 @@ export default defineSource({
         }
       }
       const meta = this.generateMeta(item);
-      this.$emit(item, meta);
+      if (!previousIds[meta.id]) {
+        this.$emit(item, meta);
+        previousIds[meta.id] = true;
+      }
     }
+
+    this.setPreviousIds(previousIds);
   },
 });


### PR DESCRIPTION
Updates actions "New Item in Feed" and "New Item From Multiple RSS Feeds" to store ids in the database and filter out any incoming events that have already been processed.
