### PR TITLE
[BUG] SendGrid - Remove Contact from List throws error Unexpected token '?.' #6744

### DIFF
--- a/components/sendgrid/actions/remove-contact-from-list/remove-contact-from-list.mjs
+++ b/components/sendgrid/actions/remove-contact-from-list/remove-contact-from-list.mjs
@@ -5,7 +5,7 @@ export default {
   key: "sendgrid-remove-contact-from-list",
   name: "Remove Contact From List",
   description: "Allows you to remove contacts from a given list. [See the docs here](https://docs.sendgrid.com/api-reference/lists/remove-contacts-from-a-list)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   props: {
     ...common.props,
@@ -45,7 +45,11 @@ export default {
     } = this;
     for (const email of contactEmails) {
       const { result } = await this.sendgrid.searchContacts(`email like '${email}'`);
-      const id = result[0]?.id;
+
+      const id = result && result.length
+        ? result[0].id
+        : null;
+
       if (!contactIds.includes(id)) {
         contactIds.push(id);
       }

--- a/components/sendgrid/package.json
+++ b/components/sendgrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/sendgrid",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "Pipedream Sendgrid Components",
   "main": "sendgrid.app.js",
   "keywords": [


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 987787d</samp>

This pull request fixes a bug in the `remove-contact-from-list` action of the `sendgrid` component and bumps the package version to 0.3.10. The action now handles non-existent contacts gracefully and avoids throwing an error.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 987787d</samp>

> _`remove-contact` fixed_
> _no more errors for missing_
> _autumn leaves the list_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 987787d</samp>

* Increment the version of the action and the package to reflect the bug fix and the new release ([link](https://github.com/PipedreamHQ/pipedream/pull/6746/files?diff=unified&w=0#diff-30f69042f3592944a6ff3a9de135d6d086249afc2992eec245a8f2813e599ae1L8-R8), [link](https://github.com/PipedreamHQ/pipedream/pull/6746/files?diff=unified&w=0#diff-55f3b49bf606b24b7c01417fa70d8612623dbf62340f9bcd068f3891c28d87f7L3-R3))
* Improve the logic for getting the contact id from the search result to handle the empty or undefined cases and avoid accessing a potentially undefined property in `remove-contact-from-list.mjs` ([link](https://github.com/PipedreamHQ/pipedream/pull/6746/files?diff=unified&w=0#diff-30f69042f3592944a6ff3a9de135d6d086249afc2992eec245a8f2813e599ae1L48-R52))
