### PR TITLE
6488 mastodon split long text posted

### DIFF
--- a/components/mastodon/actions/post-multiple-statuses/post-multiple-statuses.mjs
+++ b/components/mastodon/actions/post-multiple-statuses/post-multiple-statuses.mjs
@@ -13,7 +13,7 @@ export default {
     statuses: {
       type: "string[]",
       label: "Statuses",
-      description: "Array of status to be published in sequence, each status must be fewer than 500 characters long.",
+      description: "Array of statuses to be published in sequence; each status must be fewer than 500 characters long.",
     },
     inReplyToId: {
       type: "string",

--- a/components/mastodon/actions/post-multiple-statuses/post-multiple-statuses.mjs
+++ b/components/mastodon/actions/post-multiple-statuses/post-multiple-statuses.mjs
@@ -13,7 +13,7 @@ export default {
     statuses: {
       type: "string[]",
       label: "Statuses",
-      description: "Array of status to be published in sequence, each status must be less than 500 characters long.",
+      description: "Array of status to be published in sequence, each status must be fewer than 500 characters long.",
     },
     inReplyToId: {
       type: "string",
@@ -24,7 +24,7 @@ export default {
     sensitive: {
       type: "boolean",
       label: "Sensitive",
-      description: "Mark the status and attached media as sensitive? Defaults to false.",
+      description: "Mark the status and attached media as sensitive. Defaults to false.",
       optional: true,
       default: false,
     },
@@ -52,7 +52,7 @@ export default {
     validateStatuses(statuses) {
       for (const status of statuses) {
         if (status.length > 500) {
-          throw new ConfigurationError("Each status must be less than 500 characters long.");
+          throw new ConfigurationError("Each status must be fewer than 500 characters long.");
         }
       }
     },
@@ -78,7 +78,7 @@ export default {
         }),
       );
     }
-    $.export("$summary", `Successfully posted ${statuses.length} status(es)`);
+    $.export("$summary", `Successfully posted ${statuses.length} statuses`);
     return results;
   },
 };

--- a/components/mastodon/actions/post-multiple-statuses/post-multiple-statuses.mjs
+++ b/components/mastodon/actions/post-multiple-statuses/post-multiple-statuses.mjs
@@ -24,7 +24,7 @@ export default {
     sensitive: {
       type: "boolean",
       label: "Sensitive",
-      description: "Mark the status and attached media as sensitive. Defaults to false.",
+      description: "Mark the status and attached media as sensitive. The default is false.",
       optional: true,
       default: false,
     },
@@ -78,7 +78,7 @@ export default {
         }),
       );
     }
-    $.export("$summary", `Successfully posted ${statuses.length} statuses`);
+    $.export("$summary", `Successfully posted ${statuses.length} statuses.`);
     return results;
   },
 };

--- a/components/mastodon/actions/post-status/post-status.mjs
+++ b/components/mastodon/actions/post-status/post-status.mjs
@@ -23,7 +23,7 @@ export default {
     sensitive: {
       type: "boolean",
       label: "Sensitive",
-      description: "Mark the status and attached media as sensitive? Defaults to false.",
+      description: "Mark the status and attached media as sensitive. Defaults to false.",
       optional: true,
       default: false,
     },

--- a/components/mastodon/actions/post-status/post-status.mjs
+++ b/components/mastodon/actions/post-status/post-status.mjs
@@ -17,13 +17,13 @@ export default {
     inReplyToId: {
       type: "string",
       label: "In Reply To ID",
-      description: "ID of the status being replied to, if status is a reply.",
+      description: "ID of the status being replied to, if the status is a reply.",
       optional: true,
     },
     sensitive: {
       type: "boolean",
       label: "Sensitive",
-      description: "Mark status and attached media as sensitive? Defaults to false.",
+      description: "Mark the status and attached media as sensitive? Defaults to false.",
       optional: true,
       default: false,
     },
@@ -36,7 +36,7 @@ export default {
     visibility: {
       type: "string",
       label: "Visibility",
-      description: "Sets the visibility of the posted status to `public`, `unlisted`, `private`, or `direct`.",
+      description: "Set the visibility of the posted status to `public`, `unlisted`, `private`, or `direct`.",
       options: VISIBILITY_OPTIONS,
       optional: true,
     },
@@ -49,7 +49,7 @@ export default {
     shouldSplit: {
       type: "boolean",
       label: "Split to multiple messages",
-      description: "If the status content is longer than 500 characters, it will be splitted, respecting words, and posted to subsequent thread.\n\nThis action will return the array of submitted posts.",
+      description: "If the status content is longer than 500 characters, it will be split, respecting words, and posted to the subsequent thread.\n\nThis action will return the array of submitted posts.",
       optional: true,
       default: false,
     },
@@ -105,7 +105,7 @@ export default {
         }),
       );
     }
-    $.export("$summary", `Successfully posted ${chunkedStatus.length} status`);
+    $.export("$summary", `Successfully posted ${chunkedStatus.length} status(es)`);
     return this.shouldSplit ?
       results :
       results[0];

--- a/components/mastodon/actions/post-status/post-status.mjs
+++ b/components/mastodon/actions/post-status/post-status.mjs
@@ -23,7 +23,7 @@ export default {
     sensitive: {
       type: "boolean",
       label: "Sensitive",
-      description: "Mark the status and attached media as sensitive. Defaults to false.",
+      description: "Mark the status and attached media as sensitive. The default is false.",
       optional: true,
       default: false,
     },

--- a/components/mastodon/actions/post-status/post-status.mjs
+++ b/components/mastodon/actions/post-status/post-status.mjs
@@ -4,63 +4,110 @@ import { VISIBILITY_OPTIONS } from "../../common/constants.mjs";
 export default {
   key: "mastodon-post-status",
   name: "Post Status",
-  description: "Publish a status with the given parameters. [See the docs here](https://docs.joinmastodon.org/methods/statuses/#create)",
-  version: "0.0.1",
+  description: "Publish a status with the given parameters. [See the documentation](https://docs.joinmastodon.org/methods/statuses/#create)",
+  version: "0.0.2",
   type: "action",
   props: {
     mastodon,
     status: {
       type: "string",
       label: "Status",
-      description: "The text content of the status",
+      description: "The text content of the status.",
     },
     inReplyToId: {
       type: "string",
       label: "In Reply To ID",
-      description: "ID of the status being replied to, if status is a reply",
+      description: "ID of the status being replied to, if status is a reply.",
       optional: true,
     },
     sensitive: {
       type: "boolean",
       label: "Sensitive",
-      description: "Mark status and attached media as sensitive? Defaults to false",
+      description: "Mark status and attached media as sensitive? Defaults to false.",
       optional: true,
       default: false,
     },
     spoilerText: {
       type: "string",
       label: "Spoiler Text",
-      description: "Text to be shown as a warning or subject before the actual content. Statuses are generally collapsed behind this field",
+      description: "Text to be shown as a warning or subject before the actual content. Statuses are generally collapsed behind this field.",
       optional: true,
     },
     visibility: {
       type: "string",
       label: "Visibility",
-      description: "Sets the visibility of the posted status to `public`, `unlisted`, `private`, or `direct`",
+      description: "Sets the visibility of the posted status to `public`, `unlisted`, `private`, or `direct`.",
       options: VISIBILITY_OPTIONS,
       optional: true,
     },
     scheduledAt: {
       type: "string",
       label: "Scheduled At",
-      description: "ISO 8601 Datetime at which to schedule a status. Must be at least 5 minutes in the future.",
+      description: "ISO 8601 DateTime at which to schedule a status. Must be at least 5 minutes in the future.",
       optional: true,
+    },
+    shouldSplit: {
+      type: "boolean",
+      label: "Split to multiple messages",
+      description: "If the status content is longer than 500 characters, it will be splitted, respecting words, and posted to subsequent thread.\n\nThis action will return the array of submitted posts.",
+      optional: true,
+      default: false,
+    },
+  },
+  methods: {
+    wordWrap: (str, maxLength) => {
+      const words = str.split(" ");
+      const chunks = [];
+      let currentChunk = "";
+
+      for (const word of words) {
+        if (currentChunk.length + word.length <= maxLength) {
+          const prefix = currentChunk.length > 0 ?
+            " " :
+            "";
+          currentChunk += prefix + word;
+        } else {
+          chunks.push(currentChunk);
+          currentChunk = word;
+        }
+      }
+
+      if (currentChunk.length > 0) {
+        chunks.push(currentChunk);
+      }
+
+      return chunks;
     },
   },
   async run({ $ }) {
-    const data = {
-      status: this.status,
-      in_reply_to_id: this.inReplyToId,
-      sensitive: this.sensitive,
-      spoiler_text: this.spoilerText,
-      visibility: this.visibility,
-      scheduled_at: this.scheduledAt,
-    };
-    const status = await this.mastodon.postStatus({
-      $,
-      data,
-    });
-    $.export("$summary", `Successfully posted new status with ID ${status?.id}`);
-    return status;
+    const { status } = this;
+    let chunkedStatus = [
+      status,
+    ];
+    if (this.shouldSplit && status.length > 500) {
+      chunkedStatus = this.wordWrap(status, 500);
+    }
+
+    const results = [];
+    for (const status of chunkedStatus) {
+      const data = {
+        status,
+        in_reply_to_id: this.inReplyToId,
+        sensitive: this.sensitive,
+        spoiler_text: this.spoilerText,
+        visibility: this.visibility,
+        scheduled_at: this.scheduledAt,
+      };
+      results.push(
+        await this.mastodon.postStatus({
+          $,
+          data,
+        }),
+      );
+    }
+    $.export("$summary", `Successfully posted ${chunkedStatus.length} status`);
+    return this.shouldSplit ?
+      results :
+      results[0];
   },
 };

--- a/components/mastodon/package.json
+++ b/components/mastodon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/mastodon",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Mastodon Components",
   "main": "mastodon.app.mjs",
   "keywords": [


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 89aa159</samp>

Added a new feature to the `post-status` action of the `mastodon` component that enables posting long statuses as threads. Updated the action and component versions and descriptions accordingly.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 89aa159</samp>

> _`post-status` grows_
> _Splitting long messages now_
> _Autumn of threads_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 89aa159</samp>

*  Add `shouldSplit` prop to `post-status` action to enable splitting long status into multiple messages and posting them to a thread ([link](https://github.com/PipedreamHQ/pipedream/pull/6750/files?diff=unified&w=0#diff-86f6c1b8ad6a1d2111c84d40a1dcc136d294dad997a8631b23a90f117de1b451L46-R111),[link](https://github.com/PipedreamHQ/pipedream/pull/6750/files?diff=unified&w=0#diff-b349f3d3693ee62def5b72ebc0817e5bb767a62c3f21c232057d099b7736a5beL3-R3))
* Update descriptions of props in `post-status` action to end with periods for consistency ([link](https://github.com/PipedreamHQ/pipedream/pull/6750/files?diff=unified&w=0#diff-86f6c1b8ad6a1d2111c84d40a1dcc136d294dad997a8631b23a90f117de1b451L15-R20),[link](https://github.com/PipedreamHQ/pipedream/pull/6750/files?diff=unified&w=0#diff-86f6c1b8ad6a1d2111c84d40a1dcc136d294dad997a8631b23a90f117de1b451L26-R26),[link](https://github.com/PipedreamHQ/pipedream/pull/6750/files?diff=unified&w=0#diff-86f6c1b8ad6a1d2111c84d40a1dcc136d294dad997a8631b23a90f117de1b451L33-R33),[link](https://github.com/PipedreamHQ/pipedream/pull/6750/files?diff=unified&w=0#diff-86f6c1b8ad6a1d2111c84d40a1dcc136d294dad997a8631b23a90f117de1b451L39-R39))
* Update description of `post-status` action to remove word "here" from link to documentation ([link](https://github.com/PipedreamHQ/pipedream/pull/6750/files?diff=unified&w=0#diff-86f6c1b8ad6a1d2111c84d40a1dcc136d294dad997a8631b23a90f117de1b451L7-R8))
