### PR TITLE
Add orgid to publish workflow

### DIFF
--- a/.github/workflows/publish-components.yaml
+++ b/.github/workflows/publish-components.yaml
@@ -78,7 +78,7 @@ jobs:
                 KEY=`echo $PD_OUTPUT | jq -r ".key"`
                 echo "published ${KEY}"
                 echo "${KEY} will be added to the registry"
-          curl "https://api.pipedream.com/graphql" -H "Content-Type: application/json" -H "Authorization: Bearer ${PD_API_KEY}" --data-binary $'{"query":"mutation setComponentRegistry($key: String!, $registry: Boolean!, $gitPath: String, $orgId: String){\\n  setComponentRegistry(key: $key, registry: $registry, gitPath: $gitPath, orgId: $orgId){\\n    savedComponent{\\n      id\\n      key\\n      gitPath\\n    }\\n  }\\n}","variables":{"key":"'${KEY}'","registry":'true',"gitPath":"'${added_modified_file}'","orgId":"'${PD_ORG_ID}'"}}'
+                curl "https://api.pipedream.com/graphql" -H "Content-Type: application/json" -H "Authorization: Bearer ${PD_API_KEY}" --data-binary $'{"query":"mutation setComponentRegistry($key: String!, $registry: Boolean!, $gitPath: String, $orgId: String){\\n  setComponentRegistry(key: $key, registry: $registry, gitPath: $gitPath, orgId: $orgId){\\n    savedComponent{\\n      id\\n      key\\n      gitPath\\n    }\\n  }\\n}","variables":{"key":"'${KEY}'","registry":'true',"gitPath":"'${added_modified_file}'","orgId":"'${PD_ORG_ID}'"}}'
                 [[ "$PREV_VERSION" == "null" ]] && PUBLISHED+="*${added_modified_file}" || PUBLISHED+="*${added_modified_file}~$PREV_VERSION"
               else
                 ERROR=`echo $PD_OUTPUT | jq -r ".error"`

--- a/.github/workflows/publish-components.yaml
+++ b/.github/workflows/publish-components.yaml
@@ -37,6 +37,7 @@ jobs:
       - name: Install pd cli
         env:
           PD_API_KEY: ${{ secrets.PD_API_KEY }}
+          PD_ORG_ID: ${{ secrets.PD_ORG_ID }}
         run: |
           curl -O https://cli.pipedream.com/linux/amd64/latest/pd.zip
           unzip pd.zip
@@ -52,6 +53,7 @@ jobs:
         id: publish
         env:
           PD_API_KEY: ${{ secrets.PD_API_KEY }}
+          PD_ORG_ID: ${{ secrets.PD_ORG_ID }}
           ENDPOINT: ${{ secrets.ENDPOINT }}
         shell: bash {0} # don't fast fail
         run: |
@@ -139,6 +141,7 @@ jobs:
       - name: Install pd cli
         env:
           PD_API_KEY: ${{ secrets.PD_API_KEY }}
+          PD_ORG_ID: ${{ secrets.PD_ORG_ID }}
         run: |
           curl -O https://cli.pipedream.com/linux/amd64/latest/pd.zip
           unzip pd.zip
@@ -155,8 +158,9 @@ jobs:
           format: 'csv'
       - name: Publish TypeScript components (dry run)
         env:
-            PD_API_KEY: ${{ secrets.PD_API_KEY }}
-            ENDPOINT: ${{ secrets.ENDPOINT }}
+          PD_API_KEY: ${{ secrets.PD_API_KEY }}
+          PD_ORG_ID: ${{ secrets.PD_ORG_ID }}
+          ENDPOINT: ${{ secrets.ENDPOINT }}
         shell: bash {0} # don't fast fail
         run: |
           IFS=$'\n'
@@ -213,7 +217,7 @@ jobs:
                   KEY=`echo $PD_OUTPUT | jq -r ".key"`
                   echo "published ${KEY}"
                   echo "${KEY} will be added to the registry"
-                  curl "https://api.pipedream.com/graphql" -H "Content-Type: application/json" -H "Authorization: Bearer ${PD_API_KEY}" --data-binary $'{"query":"mutation setComponentRegistry($key: String!, $registry: Boolean!, $gitPath: String, $orgId: String){\\n  setComponentRegistry(key: $key, registry: $registry, gitPath: $gitPath, orgId: $orgId){\\n    savedComponent{\\n      id\\n      key\\n      gitPath\\n    }\\n  }\\n}","variables":{"key":"'${KEY}'","registry":'true',"gitPath":"'${added_modified_file}'","orgId":"'${PD_ORG_ID}'"}}'
+                  curl "https://api.pipedream.com/graphql" -H "Content-Type: application/json" -H "Authorization: Bearer ${PD_API_KEY}" --data-binary $'{"query":"mutation setComponentRegistry($key: String!, $registry: Boolean!, $gitPath: String, $orgId: String){\\n  setComponentRegistry(key: $key, registry: $registry, gitPath: $gitPath, orgId: $orgId){\\n    savedComponent{\\n      id\\n      key\\n      gitPath\\n    }\\n  }\\n}","variables":{"key":"'${KEY}'","registry":'true',"gitPath":"'${changed_output_file}'","orgId":"'${PD_ORG_ID}'"}}'
                   [[ "$PREV_VERSION" == "null" ]] && PUBLISHED+="*${changed_output_file}" || PUBLISHED+="*${changed_output_file}~$PREV_VERSION"
                 else
                   ERROR=`echo $PD_OUTPUT | jq -r ".error"`

--- a/.github/workflows/publish-components.yaml
+++ b/.github/workflows/publish-components.yaml
@@ -42,6 +42,7 @@ jobs:
           unzip pd.zip
           mkdir -p $HOME/.config/pipedream
           echo "api_key = $PD_API_KEY" > $HOME/.config/pipedream/config
+          echo "org_id = $PD_ORG_ID" >> $HOME/.config/pipedream/config
       - name: Get Changed Files
         id: files
         uses: jitterbit/get-changed-files@v1
@@ -77,7 +78,7 @@ jobs:
                 KEY=`echo $PD_OUTPUT | jq -r ".key"`
                 echo "published ${KEY}"
                 echo "${KEY} will be added to the registry"
-                curl "https://api.pipedream.com/graphql" -H "Content-Type: application/json" -H "Authorization: Bearer ${PD_API_KEY}" --data-binary $'{"query":"mutation setComponentRegistry($key: String!, $registry: Boolean!, $gitPath: String){\\n  setComponentRegistry(key: $key, registry: $registry, gitPath: $gitPath){\\n    savedComponent{\\n      id\\n      key\\n      gitPath\\n    }\\n  }\\n}","variables":{"key":"'${KEY}'","registry":'true',"gitPath":"'${added_modified_file}'"}}'
+          curl "https://api.pipedream.com/graphql" -H "Content-Type: application/json" -H "Authorization: Bearer ${PD_API_KEY}" --data-binary $'{"query":"mutation setComponentRegistry($key: String!, $registry: Boolean!, $gitPath: String, $orgId: String){\\n  setComponentRegistry(key: $key, registry: $registry, gitPath: $gitPath, orgId: $orgId){\\n    savedComponent{\\n      id\\n      key\\n      gitPath\\n    }\\n  }\\n}","variables":{"key":"'${KEY}'","registry":'true',"gitPath":"'${added_modified_file}'","orgId":"'${PD_ORG_ID}'"}}'
                 [[ "$PREV_VERSION" == "null" ]] && PUBLISHED+="*${added_modified_file}" || PUBLISHED+="*${added_modified_file}~$PREV_VERSION"
               else
                 ERROR=`echo $PD_OUTPUT | jq -r ".error"`
@@ -143,6 +144,7 @@ jobs:
           unzip pd.zip
           mkdir -p $HOME/.config/pipedream
           echo "api_key = $PD_API_KEY" > $HOME/.config/pipedream/config
+          echo "org_id = $PD_ORG_ID" >> $HOME/.config/pipedream/config
       - name: Compile TypeScript
         id: compile
         run: npm run build > files.txt
@@ -211,7 +213,7 @@ jobs:
                   KEY=`echo $PD_OUTPUT | jq -r ".key"`
                   echo "published ${KEY}"
                   echo "${KEY} will be added to the registry"
-                  curl "https://api.pipedream.com/graphql" -H "Content-Type: application/json" -H "Authorization: Bearer ${PD_API_KEY}" --data-binary $'{"query":"mutation setComponentRegistry($key: String!, $registry: Boolean!, $gitPath: String){\\n  setComponentRegistry(key: $key, registry: $registry, gitPath: $gitPath){\\n    savedComponent{\\n      id\\n      key\\n      gitPath\\n    }\\n  }\\n}","variables":{"key":"'${KEY}'","registry":'true',"gitPath":"'${changed_output_file}'"}}'
+                  curl "https://api.pipedream.com/graphql" -H "Content-Type: application/json" -H "Authorization: Bearer ${PD_API_KEY}" --data-binary $'{"query":"mutation setComponentRegistry($key: String!, $registry: Boolean!, $gitPath: String, $orgId: String){\\n  setComponentRegistry(key: $key, registry: $registry, gitPath: $gitPath, orgId: $orgId){\\n    savedComponent{\\n      id\\n      key\\n      gitPath\\n    }\\n  }\\n}","variables":{"key":"'${KEY}'","registry":'true',"gitPath":"'${added_modified_file}'","orgId":"'${PD_ORG_ID}'"}}'
                   [[ "$PREV_VERSION" == "null" ]] && PUBLISHED+="*${changed_output_file}" || PUBLISHED+="*${changed_output_file}~$PREV_VERSION"
                 else
                   ERROR=`echo $PD_OUTPUT | jq -r ".error"`


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 54912f5</samp>

This pull request enables publishing components to a custom organization by using the `orgId` variable in the `.github/workflows/publish-components.yaml` file and the GraphQL API. It supports both git and local sources for components.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 54912f5</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A way to publish components to the chosen orgs_
> _By passing `orgId` to the pipedream config file_
> _And to the GraphQL mutation that sends the code._


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 54912f5</samp>

*  Append `org_id` to pipedream config file to identify component owner ([link](https://github.com/PipedreamHQ/pipedream/pull/6774/files?diff=unified&w=0#diff-030ed26869c98dd8baf020e1616dab36ab1616258d74f35f655214382a973d77R45), [link](https://github.com/PipedreamHQ/pipedream/pull/6774/files?diff=unified&w=0#diff-030ed26869c98dd8baf020e1616dab36ab1616258d74f35f655214382a973d77R147))
*  Modify GraphQL mutation to set component registry flag with `orgId` variable ([link](https://github.com/PipedreamHQ/pipedream/pull/6774/files?diff=unified&w=0#diff-030ed26869c98dd8baf020e1616dab36ab1616258d74f35f655214382a973d77L80-R81), [link](https://github.com/PipedreamHQ/pipedream/pull/6774/files?diff=unified&w=0#diff-030ed26869c98dd8baf020e1616dab36ab1616258d74f35f655214382a973d77L214-R216))
