### PR TITLE
6780 mastodon multiple statuses posted as thread

### DIFF
--- a/components/mastodon/actions/post-multiple-statuses/post-multiple-statuses.mjs
+++ b/components/mastodon/actions/post-multiple-statuses/post-multiple-statuses.mjs
@@ -5,8 +5,8 @@ import { ConfigurationError } from "@pipedream/platform";
 export default {
   key: "mastodon-post-multiple-statuses",
   name: "Post Multiple Statuses",
-  description: "Publish multiple statuses with the given parameters. [See the documentation](https://docs.joinmastodon.org/methods/statuses/#create)",
-  version: "0.0.1",
+  description: "Publish multiple statuses with the given parameters, the subsequent statuses will be posted as a reply of of the first status. [See the documentation](https://docs.joinmastodon.org/methods/statuses/#create)",
+  version: "0.0.2",
   type: "action",
   props: {
     mastodon,
@@ -59,13 +59,14 @@ export default {
   },
   async run({ $ }) {
     const { statuses } = this;
+    let { inReplyToId } = this;
     this.validateStatuses(statuses);
 
     const results = [];
     for (const status of statuses) {
       const data = {
         status,
-        in_reply_to_id: this.inReplyToId,
+        in_reply_to_id: inReplyToId,
         sensitive: this.sensitive,
         spoiler_text: this.spoilerText,
         visibility: this.visibility,
@@ -77,6 +78,9 @@ export default {
           data,
         }),
       );
+      if (!inReplyToId) {
+        inReplyToId = results[0].id;
+      }
     }
     $.export("$summary", `Successfully posted ${statuses.length} statuses.`);
     return results;

--- a/components/mastodon/actions/post-status/post-status.mjs
+++ b/components/mastodon/actions/post-status/post-status.mjs
@@ -5,7 +5,7 @@ export default {
   key: "mastodon-post-status",
   name: "Post Status",
   description: "Publish a status with the given parameters. [See the documentation](https://docs.joinmastodon.org/methods/statuses/#create)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     mastodon,
@@ -49,7 +49,7 @@ export default {
     shouldSplit: {
       type: "boolean",
       label: "Split to multiple messages",
-      description: "If the status content is longer than 500 characters, it will be split, respecting words, and posted to the subsequent thread.\n\nThis action will return the array of submitted posts.",
+      description: "If the status content is longer than 500 characters, it will be split, respecting words, and posted as a reply of of the first status.\n\nThis action will return the array of submitted posts.",
       optional: true,
       default: false,
     },
@@ -81,6 +81,7 @@ export default {
   },
   async run({ $ }) {
     const { status } = this;
+    let { inReplyToId } = this;
     let chunkedStatus = [
       status,
     ];
@@ -92,7 +93,7 @@ export default {
     for (const status of chunkedStatus) {
       const data = {
         status,
-        in_reply_to_id: this.inReplyToId,
+        in_reply_to_id: inReplyToId,
         sensitive: this.sensitive,
         spoiler_text: this.spoilerText,
         visibility: this.visibility,
@@ -104,6 +105,9 @@ export default {
           data,
         }),
       );
+      if (!inReplyToId) {
+        inReplyToId = results[0].id;
+      }
     }
     $.export("$summary", `Successfully posted ${chunkedStatus.length} status(es)`);
     return this.shouldSplit ?

--- a/components/mastodon/package.json
+++ b/components/mastodon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/mastodon",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream Mastodon Components",
   "main": "mastodon.app.mjs",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3213,6 +3213,9 @@ importers:
   components/phone_com:
     specifiers: {}
 
+  components/phoneburner:
+    specifiers: {}
+
   components/phrase:
     specifiers:
       '@pipedream/platform': ^1.1.0


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 23f5cc2</samp>

This pull request enhances the `mastodon-post-status` and `mastodon-post-multiple-statuses` actions to support posting threads of statuses on Mastodon. It also updates the `@pipedream/mastodon` package version and adds a new entry for the `phoneburner` package in the `pnpm-lock.yaml` file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 23f5cc2</samp>

> _Sing, O Muse, of the skillful coder who changed the mastodon package_
> _And added phoneburner as a new dependency in the lock file_
> _He made the action of posting statuses more versatile and elegant_
> _And linked them as a thread, like the golden chain of Hephaestus_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 23f5cc2</samp>

*  Increment the version of the `@pipedream/mastodon` package and the `mastodon-post-status` and `mastodon-post-multiple-statuses` actions to reflect the changes made to the action logic and description ([link](https://github.com/PipedreamHQ/pipedream/pull/6781/files?diff=unified&w=0#diff-a1a28102a8b34a2edf1bb02a22dd524b8b27f2802d80e8fa0bd4f1e2e5b6413eL8-R9), [link](https://github.com/PipedreamHQ/pipedream/pull/6781/files?diff=unified&w=0#diff-86f6c1b8ad6a1d2111c84d40a1dcc136d294dad997a8631b23a90f117de1b451L8-R8), [link](https://github.com/PipedreamHQ/pipedream/pull/6781/files?diff=unified&w=0#diff-b349f3d3693ee62def5b72ebc0817e5bb767a62c3f21c232057d099b7736a5beL3-R3))
*  Declare a local variable `inReplyToId` to store the value of the `inReplyToId` prop of the actions and use it instead of the prop value directly in the `in_reply_to_id` field of the data object ([link](https://github.com/PipedreamHQ/pipedream/pull/6781/files?diff=unified&w=0#diff-a1a28102a8b34a2edf1bb02a22dd524b8b27f2802d80e8fa0bd4f1e2e5b6413eR62), [link](https://github.com/PipedreamHQ/pipedream/pull/6781/files?diff=unified&w=0#diff-a1a28102a8b34a2edf1bb02a22dd524b8b27f2802d80e8fa0bd4f1e2e5b6413eL68-R69), [link](https://github.com/PipedreamHQ/pipedream/pull/6781/files?diff=unified&w=0#diff-86f6c1b8ad6a1d2111c84d40a1dcc136d294dad997a8631b23a90f117de1b451R84), [link](https://github.com/PipedreamHQ/pipedream/pull/6781/files?diff=unified&w=0#diff-86f6c1b8ad6a1d2111c84d40a1dcc136d294dad997a8631b23a90f117de1b451L95-R96))
*  Add a conditional statement to assign the `inReplyToId` variable to the id of the first posted status if it was not provided as a prop, ensuring that the subsequent statuses will be posted as a reply of the first status ([link](https://github.com/PipedreamHQ/pipedream/pull/6781/files?diff=unified&w=0#diff-a1a28102a8b34a2edf1bb02a22dd524b8b27f2802d80e8fa0bd4f1e2e5b6413eR81-R83), [link](https://github.com/PipedreamHQ/pipedream/pull/6781/files?diff=unified&w=0#diff-86f6c1b8ad6a1d2111c84d40a1dcc136d294dad997a8631b23a90f117de1b451R108-R110))
*  Update the description of the `splitToMultipleMessages` prop of the `mastodon-post-status` action to match the description of the `mastodon-post-multiple-statuses` action, since they share the same logic for splitting and posting statuses ([link](https://github.com/PipedreamHQ/pipedream/pull/6781/files?diff=unified&w=0#diff-86f6c1b8ad6a1d2111c84d40a1dcc136d294dad997a8631b23a90f117de1b451L52-R52))
*  Add a new entry for the `components/phoneburner` package to the `pnpm-lock.yaml` file, likely a result of running `pnpm install` after adding the `phoneburner` package as a dependency in another component ([link](https://github.com/PipedreamHQ/pipedream/pull/6781/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3216-R3218))
