### PR TITLE
Update README for cli docs (creating profile for workspace)

### DIFF
--- a/docs/docs/cli/reference/README.md
+++ b/docs/docs/cli/reference/README.md
@@ -314,7 +314,7 @@ If you're working with resources in an [workspace](/workspaces/), you'll need to
 
 ```
 [profile_name]
-api_key = <API Key from workspace settings>
+api_key = <API Key from user settings>
 org_id = <Workspace ID from workspace settings>
 ```
 


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d2e27d3</samp>

Updated the CLI reference documentation to use the user API key for creating a profile for a workspace. This change matches the current Pipedream UI and CLI behavior.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d2e27d3</samp>

> _`API key` moved_
> _From workspace to user settings_
> _Autumn of changes_


## WHY

Previous wording was unclear about where to get API Key from

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d2e27d3</samp>

* Update the code snippet for creating a profile for a workspace to use the user API key instead of the workspace API key ([link](https://github.com/PipedreamHQ/pipedream/pull/6821/files?diff=unified&w=0#diff-ae84ceeefe9263c82c06fe12d9f754a22c1d863bbd34cfb4af75ac09c2ab6465L317-R317))
