### PR TITLE
Bugfix: updating "extract email address" regex

### DIFF
--- a/components/formatting/actions/extract-email-address/extract-email-address.ts
+++ b/components/formatting/actions/extract-email-address/extract-email-address.ts
@@ -7,7 +7,7 @@ export default defineAction({
   description:
     "Find an email address out of a text field. Finds the first email address only.",
   key: "formatting-extract-email-address",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     ...commonExtractText.props,
@@ -20,7 +20,7 @@ export default defineAction({
   methods: {
     ...commonExtractText.methods,
     getRegExp() {
-      return /[\w-.]+@([\w-]+\.)+[\w-]{2,}/;
+      return /[\w.!#$%&'*+-/=?^_`{|}~]+@([\w-]+\.)+[\w-]{2,}/;
     },
     getType() {
       return "email address";

--- a/components/formatting/package.json
+++ b/components/formatting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/formatting",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Pipedream Formatting Components",
   "main": "dist/app/formatting.app.mjs",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1406,6 +1406,9 @@ importers:
     dependencies:
       '@pipedream/platform': 1.5.1
 
+  components/facebook_lead_ads:
+    specifiers: {}
+
   components/facebook_pages:
     specifiers: {}
 


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1836f58</samp>

Updated the `formatting` package to improve email extraction and added the `facebook_lead_ads` component as a dependency.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1836f58</samp>

> _`formatting` is the key to our salvation_
> _We extract the emails of the damned_
> _With a new regex and a version bump_
> _We unleash the power of the `facebook_lead_ads` component_


## WHY

Email addresses allow several special characters that the component was not taking into account in the RegExp used.


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1836f58</samp>

*  Incremented the version of the formatting package to 0.0.5 and installed the facebook_lead_ads component as a dependency ([link](https://github.com/PipedreamHQ/pipedream/pull/6917/files?diff=unified&w=0#diff-846687f3a83f906e5a9e53cc9486c91bb2d51f62c1505b5f1eef38f8379c47dbL3-R3), [link](https://github.com/PipedreamHQ/pipedream/pull/6917/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1409-R1411))
*  Updated the regular expression for email validation in the formatting-extract-email-address component to include more characters allowed in the local part of an email address, based on the RFC 5322 standard ([link](https://github.com/PipedreamHQ/pipedream/pull/6917/files?diff=unified&w=0#diff-087e61381ead1e1b7fbca7cf0db39d9061f92cbd140f61122868add2516ea060L23-R23))
*  Incremented the version of the formatting-extract-email-address component to 0.0.3 to reflect the updated email validation ([link](https://github.com/PipedreamHQ/pipedream/pull/6917/files?diff=unified&w=0#diff-087e61381ead1e1b7fbca7cf0db39d9061f92cbd140f61122868add2516ea060L10-R10))
