### PR TITLE
add pandadoc send document action

### DIFF
--- a/components/pandadoc/actions/create-document-attachment/create-document-attachment.mjs
+++ b/components/pandadoc/actions/create-document-attachment/create-document-attachment.mjs
@@ -9,7 +9,7 @@ export default {
   name: "Create Document Attachment",
   description: "Adds an attachment to a document. [See the docs here](https://developers.pandadoc.com/reference/create-document-attachment)",
   type: "action",
-  version: "0.0.3",
+  version: "0.0.4",
   props: {
     app,
     documentId: {

--- a/components/pandadoc/actions/create-document-from-file/create-document-from-file.mjs
+++ b/components/pandadoc/actions/create-document-from-file/create-document-from-file.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Create Document From File",
   description: "Create a document from a file or public file URL. [See the docs here](https://developers.pandadoc.com/reference/create-document-from-pdf)",
   type: "action",
-  version: "0.0.4",
+  version: "0.0.5",
   props: {
     app,
     name: {

--- a/components/pandadoc/actions/create-document-from-template/create-document-from-template.mjs
+++ b/components/pandadoc/actions/create-document-from-template/create-document-from-template.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Create Document From Template",
   description: "Create Document from PandaDoc Template. [See the docs here](https://developers.pandadoc.com/reference/create-document-from-pandadoc-template)",
   type: "action",
-  version: "0.0.3",
+  version: "0.0.4",
   props: {
     app,
     name: {

--- a/components/pandadoc/actions/create-folder/create-folder.mjs
+++ b/components/pandadoc/actions/create-folder/create-folder.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Create Folder",
   description: "Create a new folder to store your documents. [See the docs here](https://developers.pandadoc.com/reference/create-documents-folder)",
   type: "action",
-  version: "0.0.2",
+  version: "0.0.3",
   props: {
     app,
     name: {

--- a/components/pandadoc/actions/create-or-update-contact/create-or-update-contact.mjs
+++ b/components/pandadoc/actions/create-or-update-contact/create-or-update-contact.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Create or Update Contact",
   description: "This method adds or updates a contact using the email as index. [See the docs here](https://developers.pandadoc.com/reference/create-contact)",
   type: "action",
-  version: "0.0.3",
+  version: "0.0.4",
   props: {
     app,
     email: {

--- a/components/pandadoc/actions/document-details/document-details.mjs
+++ b/components/pandadoc/actions/document-details/document-details.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Document Details",
   description: "Return detailed data about a document. [See the docs here](https://developers.pandadoc.com/reference/document-details)",
   type: "action",
-  version: "0.0.3",
+  version: "0.0.4",
   props: {
     app,
     id: {

--- a/components/pandadoc/actions/list-contacts/list-contacts.mjs
+++ b/components/pandadoc/actions/list-contacts/list-contacts.mjs
@@ -5,7 +5,7 @@ export default {
   name: "List Contacts",
   description: "This method lists all contacts within an account. [See the docs here](https://developers.pandadoc.com/reference/list-contacts)",
   type: "action",
-  version: "0.0.3",
+  version: "0.0.4",
   props: {
     app,
   },

--- a/components/pandadoc/actions/list-document-attachments/list-document-attachments.mjs
+++ b/components/pandadoc/actions/list-document-attachments/list-document-attachments.mjs
@@ -5,7 +5,7 @@ export default {
   name: "List Document Attachment",
   description: "Returns a list of attachments associated with a specified document. [See the docs here](https://developers.pandadoc.com/reference/list-attachment)",
   type: "action",
-  version: "0.0.3",
+  version: "0.0.4",
   props: {
     app,
     documentId: {

--- a/components/pandadoc/actions/list-documents/list-documents.mjs
+++ b/components/pandadoc/actions/list-documents/list-documents.mjs
@@ -6,7 +6,7 @@ export default {
   name: "List Documents",
   description: "List documents optionally filter by a search query or tags. [See the docs here](https://developers.pandadoc.com/reference/list-documents)",
   type: "action",
-  version: "0.0.3",
+  version: "0.0.4",
   props: {
     app,
     query: {

--- a/components/pandadoc/actions/list-folders/list-folders.mjs
+++ b/components/pandadoc/actions/list-folders/list-folders.mjs
@@ -5,7 +5,7 @@ export default {
   name: "List Folders",
   description: "List folders which contain Documents [See the docs here](https://developers.pandadoc.com/reference/list-documents-folders)",
   type: "action",
-  version: "0.0.2",
+  version: "0.0.3",
   props: {
     app,
     parentFolderId: {

--- a/components/pandadoc/actions/send-document/send-document.mjs
+++ b/components/pandadoc/actions/send-document/send-document.mjs
@@ -4,7 +4,7 @@ import { axios } from "@pipedream/platform";
 export default defineComponent({
   key: "pandadoc-send-document",
   name: "Send Document",
-  description: "Move a document to sent status and send an optional email. [See the docs here](https://developers.pandadoc.com/reference/send-document)",
+  description: "Move a document to sent status and send an optional email. [See the documentation](https://developers.pandadoc.com/reference/send-document)",
   type: "action",
   version: "0.0.1",
   props: {

--- a/components/pandadoc/actions/send-document/send-document.mjs
+++ b/components/pandadoc/actions/send-document/send-document.mjs
@@ -1,0 +1,86 @@
+import app from "../../pandadoc.app.mjs";
+import { axios } from "@pipedream/platform";
+
+export default defineComponent({
+  key: "pandadoc-send-document",
+  name: "Send Document",
+  description: "Move a document to sent status and send an optional email. [See the docs here](https://developers.pandadoc.com/reference/send-document)",
+  type: "action",
+  version: "0.0.1",
+  props: {
+    app,
+    documentId: {
+      propDefinition: [
+        app,
+        "documentId",
+      ],
+    },
+    subject: {
+      type: "string",
+      label: "Subject",
+      description: "Value that will be used as the email subject.",
+      optional: true,
+    },
+    message: {
+      type: "string",
+      label: "Message",
+      description:
+        "A message which will be sent by email with a link to a document to sign.",
+      optional: true,
+    },
+    silent: {
+      type: "boolean",
+      label: "Silent",
+      description:
+        "Disables sent, viewed, comment and completed email notifications for document recipients and the document sender.",
+      optional: true,
+      default: false,
+    },
+    sender: {
+      type: "object",
+      label: "Sender",
+      description: "Set a sender of the document.",
+      optional: true,
+    },
+    forwarding_allowed: {
+      type: "boolean",
+      label: "Forwarding Allowed",
+      description:
+        "Your recipient will be able/not able to forward the document to another email address.",
+      optional: true,
+      default: false,
+    },
+    forwarding_with_reassigning_allowed: {
+      type: "boolean",
+      label: "Forwarding With Reassigning Allowed",
+      description:
+        "Your recipient will be able/not able to forward the right to fill out all fields (including signature) assigned to them to another email address.",
+      optional: true,
+      default: false,
+    },
+  },
+  async run({ steps, $ }) {
+    const documentId = this.documentId;
+
+    const data = {
+      subject: this.subject,
+      message: this.message,
+      silent: this.silent,
+      sender: this.sender,
+      forwarding_settings: {
+        forwarding_allowed: this.forwarding_allowed,
+        forwarding_with_reassigning_allowed:
+          this.forwarding_with_reassigning_allowed,
+      },
+    };
+
+    const response = await this.app.sendDocument({
+      $,
+      documentId,
+      data,
+    });
+
+    $.export("$summary", `Successfully sent "${response.name}" document with ID: ${response.id} to ${response.recipients.length} recipient(s)`);
+    return response;
+  },
+});

--- a/components/pandadoc/actions/send-document/send-document.mjs
+++ b/components/pandadoc/actions/send-document/send-document.mjs
@@ -32,7 +32,7 @@ export default defineComponent({
       type: "boolean",
       label: "Silent",
       description:
-        "Disables sent, viewed, comment and completed email notifications for document recipients and the document sender.",
+        `Disables sent, viewed, comment and completed email notifications for document recipients and the document sender. By default, notifications emails are sent for specific actions. If set as true, it won't affect "Approve document" email notification sent to the Approver.`,
       optional: true,
       default: false,
     },

--- a/components/pandadoc/actions/send-document/send-document.mjs
+++ b/components/pandadoc/actions/send-document/send-document.mjs
@@ -59,7 +59,7 @@ export default defineComponent({
       default: false,
     },
   },
-  async run({ steps, $ }) {
+  async run({ $ }) {
     const documentId = this.documentId;
 
     const data = {

--- a/components/pandadoc/actions/send-document/send-document.mjs
+++ b/components/pandadoc/actions/send-document/send-document.mjs
@@ -1,5 +1,4 @@
 import app from "../../pandadoc.app.mjs";
-import { axios } from "@pipedream/platform";
 
 export default defineComponent({
   key: "pandadoc-send-document",
@@ -36,10 +35,10 @@ export default defineComponent({
       optional: true,
       default: false,
     },
-    sender: {
-      type: "object",
-      label: "Sender",
-      description: "Set a sender of the document.",
+    senderEmail: {
+      type: "string",
+      label: "Sender Email",
+      description: "Set a sender (email) for the document. Must be an email which is a member on your account.",
       optional: true,
     },
     forwarding_allowed: {
@@ -66,13 +65,18 @@ export default defineComponent({
       subject: this.subject,
       message: this.message,
       silent: this.silent,
-      sender: this.sender,
       forwarding_settings: {
         forwarding_allowed: this.forwarding_allowed,
         forwarding_with_reassigning_allowed:
           this.forwarding_with_reassigning_allowed,
       },
     };
+
+    if (this.senderEmail) {
+      data.sender = {
+        email: this.senderEmail,
+      };
+    }
 
     const response = await this.app.sendDocument({
       $,

--- a/components/pandadoc/package.json
+++ b/components/pandadoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/pandadoc",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream PandaDoc Components",
   "main": "pandadoc.app.mjs",
   "keywords": [

--- a/components/pandadoc/pandadoc.app.mjs
+++ b/components/pandadoc/pandadoc.app.mjs
@@ -181,5 +181,12 @@ export default {
         method: "DELETE",
       });
     },
+    sendDocument(args = {}) {
+      return this.makeRequest({
+        path: `/documents/${args.documentId}/send`,
+        method: "POST",
+        ...args,
+      });
+    },
   },
 };

--- a/components/pandadoc/sources/document-creation-failed/document-creation-failed.mjs
+++ b/components/pandadoc/sources/document-creation-failed/document-creation-failed.mjs
@@ -8,7 +8,7 @@ export default {
   description:
     `Emit new event when a document failed to be created [See docs here](${DOCS_LINK})`,
   key: "pandadoc-document-creation-failed",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   methods: {
     ...common.methods,

--- a/components/pandadoc/sources/document-deleted/document-deleted.mjs
+++ b/components/pandadoc/sources/document-deleted/document-deleted.mjs
@@ -8,7 +8,7 @@ export default {
   description:
     `Emit new event when a document is deleted [See docs here](${DOCS_LINK})`,
   key: "pandadoc-document-deleted",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   methods: {
     ...common.methods,

--- a/components/pandadoc/sources/document-state-changed/document-state-changed.mjs
+++ b/components/pandadoc/sources/document-state-changed/document-state-changed.mjs
@@ -8,7 +8,7 @@ export default {
   description:
     `Emit new event when a document's state is changed [See docs here](${DOCS_LINK})`,
   key: "pandadoc-document-state-changed",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   methods: {
     ...common.methods,

--- a/components/pandadoc/sources/document-updated/document-updated.mjs
+++ b/components/pandadoc/sources/document-updated/document-updated.mjs
@@ -8,7 +8,7 @@ export default {
   description:
     `Emit new event when a document is updated [See docs here](${DOCS_LINK})`,
   key: "pandadoc-document-updated",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   methods: {
     ...common.methods,

--- a/components/pandadoc/sources/recipient-completed/recipient-completed.mjs
+++ b/components/pandadoc/sources/recipient-completed/recipient-completed.mjs
@@ -8,7 +8,7 @@ export default {
   description:
     `Emit new event when a recipient completes a document [See docs here](${DOCS_LINK})`,
   key: "pandadoc-recipient-completed",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   methods: {
     ...common.methods,


### PR DESCRIPTION
resolves #6922

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 596a0a2</samp>

This pull request adds a new action component to the PandaDoc app that enables users to send documents via email. It also updates the app package version and the app module with the necessary logic and API calls for the new functionality. The affected files are `components/pandadoc/actions/send-document/send-document.mjs`, `components/pandadoc/package.json`, and `components/pandadoc/pandadoc.app.mjs`.

## WHY

#6922 

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 596a0a2</samp>

*  Add a new action component to send a document via email ([link](https://github.com/PipedreamHQ/pipedream/pull/6939/files?diff=unified&w=0#diff-6e8f4cbc7cacd75282446d5370f4d60b1c7d5f0e0e3ffef7064c107f5ff93cc3R1-R86))
* Update app package version to 0.2.1 ([link](https://github.com/PipedreamHQ/pipedream/pull/6939/files?diff=unified&w=0#diff-3d775c398b2ef6382327e8c78d5584393d3e8b93be1de20b410ed98299af2debL3-R3))
* Implement `sendDocument` method in app module ([link](https://github.com/PipedreamHQ/pipedream/pull/6939/files?diff=unified&w=0#diff-74f4072e665d9faba2515b3e77fb8b8076788b4128dedbf4b47b77ca267e1d1dR184-R190))
