### PR TITLE
Ignore Test Files (Linting)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,7 +9,7 @@
     "plugin:jsonc/recommended-with-jsonc",
     "plugin:jest/recommended"
   ],
-  "ignorePatterns": ["scripts", "**/test-event.mjs"],
+  "ignorePatterns": ["scripts", "components/**/test-event.mjs"],
   "overrides": [
     {
       "files": [

--- a/.eslintrc
+++ b/.eslintrc
@@ -9,7 +9,7 @@
     "plugin:jsonc/recommended-with-jsonc",
     "plugin:jest/recommended"
   ],
-  "ignorePatterns": ["scripts"],
+  "ignorePatterns": ["scripts", "**/test-event.mjs"],
   "overrides": [
     {
       "files": [


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 23d66eb</samp>

Ignore `test-event.mjs` file in linting. This file is only used for testing purposes and does not affect the functionality or quality of the components.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 23d66eb</samp>

> _`test-event.mjs`_
> _Linter ignores it for now_
> _A winter silence_


## WHY
Test event files do not pass the current lint

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 23d66eb</samp>

* Ignore `test-event.mjs` file for linting ([link](https://github.com/PipedreamHQ/pipedream/pull/6961/files?diff=unified&w=0#diff-e7e195d3d8fa5b82fa51ed952f3a179d429cbc46c0432ce1f7b357c54c162822L12-R12))
