### PR TITLE
Fixing incorrect link in documentation regarding API Keys.

### DIFF
--- a/docs/docs/api/auth/README.md
+++ b/docs/docs/api/auth/README.md
@@ -6,7 +6,7 @@
 
 When you sign up for Pipedream, an API key is automatically generated for your account. You can use this key to authorize requests to the API. 
 
-You'll find this API key in your [Account Settings](https://pipedream.com/settings/account) (**Settings** -> **Account**).
+You'll find this API key in your [User Settings](https://pipedream.com/user) (**My Account** -> **API Key**).
 
 ## Authorizing API requests
 


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b4b0046</samp>

Updated the documentation for accessing the API key in `docs/docs/api/auth/README.md`. The change reflects the new user interface of Pipedream and improves the user experience.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b4b0046</samp>

> _`API key` moved_
> _Pipedream has new interface_
> _Update the link now_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b4b0046</samp>

* Updated the link and the navigation path to the API key in the documentation ([link](https://github.com/PipedreamHQ/pipedream/pull/6965/files?diff=unified&w=0#diff-605941d067c72e8efa2d302440bd16581efeff71090d9b87d6f279460ba3a5e1L9-R9))
