### PR TITLE
Remove key check for test-event.mjs

### DIFF
--- a/scripts/findBadKeys.js
+++ b/scripts/findBadKeys.js
@@ -48,6 +48,10 @@ function* iterateComponentFiles() {
 const checkPathVsKey = () => {
   const iterator = iterateComponentFiles();
   for (const file of iterator) {
+    if (file.split("/").pop() === "test-event.mjs") {
+      continue
+    }
+
     const p = path.join(rootDir, file);
     const componentKey = getComponentKey(p);
     if (!componentKey) {
@@ -142,6 +146,7 @@ for (const name of dirs) {
 }
 
 checkPathVsKey();
+// console.log("hello")
 
 if (err) {
   const core = require('@actions/core');

--- a/scripts/findBadKeys.js
+++ b/scripts/findBadKeys.js
@@ -18,8 +18,8 @@ const isCommonFile = ( subname ) => {
   return regex.test(subname);
 };
 
-isTestEventFile = ( subname ) =>
-  subname.split("/").pop() === "test-event.mjs"
+const isTestEventFile = ( subname ) =>
+  subname.split("/").pop() === "test-event.mjs";
 
 const getComponentKey = ( p )  => {
   const data = fs.readFileSync(p, "utf8");

--- a/scripts/findBadKeys.js
+++ b/scripts/findBadKeys.js
@@ -18,6 +18,9 @@ const isCommonFile = ( subname ) => {
   return regex.test(subname);
 };
 
+isTestEventFile = ( subname ) =>
+  subname.split("/").pop() === "test-event.mjs"
+
 const getComponentKey = ( p )  => {
   const data = fs.readFileSync(p, "utf8");
   const md = data.match(/['"]?key['"]?: ['"]([^'"]+)/);
@@ -39,7 +42,7 @@ function* iterateComponentFiles() {
     const p = path.join(rootDir, file);
     if (!file.startsWith("components/"))
       continue;
-    if (isAppFile(p) || isCommonFile(p) || !isSourceFile(p))
+    if (isAppFile(p) || isCommonFile(p) || !isSourceFile(p) || isTestEventFile(p))
       continue;
     yield file;
   }
@@ -48,9 +51,6 @@ function* iterateComponentFiles() {
 const checkPathVsKey = () => {
   const iterator = iterateComponentFiles();
   for (const file of iterator) {
-    if (file.split("/").pop() === "test-event.mjs") {
-      continue
-    }
 
     const p = path.join(rootDir, file);
     const componentKey = getComponentKey(p);

--- a/scripts/findBadKeys.js
+++ b/scripts/findBadKeys.js
@@ -51,7 +51,6 @@ function* iterateComponentFiles() {
 const checkPathVsKey = () => {
   const iterator = iterateComponentFiles();
   for (const file of iterator) {
-
     const p = path.join(rootDir, file);
     const componentKey = getComponentKey(p);
     if (!componentKey) {

--- a/scripts/findBadKeys.js
+++ b/scripts/findBadKeys.js
@@ -146,7 +146,6 @@ for (const name of dirs) {
 }
 
 checkPathVsKey();
-// console.log("hello")
 
 if (err) {
   const core = require('@actions/core');


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9a10a9d</samp>

This pull request improves the `findBadKeys.js` script by fixing a false positive and removing unnecessary output.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9a10a9d</samp>

> _`findBadKeys.js` is the tool of our wrath_
> _We purge the code of all the filth and trash_
> _We ignore the test file, it's a useless lie_
> _We remove the debug log, we don't need to spy_


## WHY

Test event fails `keys` check currently

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9a10a9d</samp>

* Skip checking test-event.mjs file for keys, since it is used for testing and does not contain real keys ([link](https://github.com/PipedreamHQ/pipedream/pull/6967/files?diff=unified&w=0#diff-6a9bbea02b37f1347105af56b9d4fc21258d6e46b1d4065574699865e08a9fbbR51-R54))
* Remove console.log statement from findBadKeys.js, as it is not needed and reduces readability and performance ([link](https://github.com/PipedreamHQ/pipedream/pull/6967/files?diff=unified&w=0#diff-6a9bbea02b37f1347105af56b9d4fc21258d6e46b1d4065574699865e08a9fbbR149))
