### PR TITLE
Creating async options error messaging for Facebook Groups

### DIFF
--- a/components/facebook_groups/actions/common/errorMessage.mjs
+++ b/components/facebook_groups/actions/common/errorMessage.mjs
@@ -1,0 +1,1 @@
+export const ERROR_MESSAGE = "Please double-check that the Pipedream app has been installed in the group you have selected. Learn more at https://pipedream.com/apps/facebook-groups#getting-started.";

--- a/components/facebook_groups/actions/create-post/create-post.mjs
+++ b/components/facebook_groups/actions/create-post/create-post.mjs
@@ -1,5 +1,6 @@
 import common from "../common/common.mjs";
 import { ConfigurationError } from "@pipedream/platform";
+import { ERROR_MESSAGE } from "../common/errorMessage.mjs";
 
 export default {
   ...common,
@@ -24,23 +25,30 @@ export default {
     },
   },
   async run({ $ }) {
-    if (!this.message && !this.link) {
-      throw new ConfigurationError("Either `link` or `message` must be supplied");
-    }
+    try {
+      if (!this.message && !this.link) {
+        throw new ConfigurationError("Either `link` or `message` must be supplied");
+      }
 
-    const response = await this.facebookGroups.createPost({
-      groupId: this.group,
-      data: {
-        message: this.message,
-        link: this.link,
-      },
-      $,
-    });
+      const response = await this.facebookGroups.createPost({
+        groupId: this.group,
+        data: {
+          message: this.message,
+          link: this.link,
+        },
+        $,
+      });
 
-    if (response) {
+      if (!response) {
+        throw new ConfigurationError("Post creation was unsuccessful");
+      }
+
       $.export("$summary", `Successfully created new post with ID ${response.id}.`);
-    }
 
-    return response;
+      return response;
+    } catch (error) {
+      console.error(error);
+      throw new Error(ERROR_MESSAGE);
+    }
   },
 };

--- a/components/facebook_groups/actions/create-post/create-post.mjs
+++ b/components/facebook_groups/actions/create-post/create-post.mjs
@@ -6,7 +6,7 @@ export default {
   key: "facebook_groups-create-post",
   name: "Create Post",
   description: "Create a new post in a group. [See the documentation](https://developers.facebook.com/docs/graph-api/reference/v17.0/group/feed)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     ...common.props,

--- a/components/facebook_groups/actions/get-post/get-post.mjs
+++ b/components/facebook_groups/actions/get-post/get-post.mjs
@@ -5,7 +5,7 @@ export default {
   key: "facebook_groups-get-post",
   name: "Get Post",
   description: "Retrieves post in a group. [See the documentation](https://developers.facebook.com/docs/graph-api/reference/post/)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     ...common.props,

--- a/components/facebook_groups/actions/get-post/get-post.mjs
+++ b/components/facebook_groups/actions/get-post/get-post.mjs
@@ -1,4 +1,5 @@
 import common from "../common/common.mjs";
+import { ERROR_MESSAGE } from "../common/errorMessage.mjs";
 
 export default {
   ...common,
@@ -20,13 +21,18 @@ export default {
     },
   },
   async run({ $ }) {
-    const response = this.facebookGroups.getPost({
-      postId: this.post,
-      $,
-    });
+    try {
+      const response = await this.facebookGroups.getPost({
+        postId: this.post,
+        $,
+      });
 
-    $.export("$summary", `Successfully retrieved post with ID ${this.post}`);
+      $.export("$summary", `Successfully retrieved post with ID ${this.post}`);
 
-    return response;
+      return response;
+    } catch (error) {
+      console.error(error);
+      throw new Error(ERROR_MESSAGE);
+    }
   },
 };

--- a/components/facebook_groups/actions/list-comments/list-comments.mjs
+++ b/components/facebook_groups/actions/list-comments/list-comments.mjs
@@ -5,7 +5,7 @@ export default {
   key: "facebook_groups-list-comments",
   name: "List Comments",
   description: "Retrieves a list of comments on a group post. [See the documentation](https://developers.facebook.com/docs/graph-api/reference/v17.0/comment)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     ...common.props,

--- a/components/facebook_groups/actions/list-reactions/list-reactions.mjs
+++ b/components/facebook_groups/actions/list-reactions/list-reactions.mjs
@@ -5,7 +5,7 @@ export default {
   key: "facebook_groups-list-reactions",
   name: "List Reactions",
   description: "Retrieves a list of reactions on a group post. [See the documentation](https://developers.facebook.com/docs/graph-api/reference/v17.0/object/reactions)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     ...common.props,

--- a/components/facebook_groups/actions/post-photo/post-photo.mjs
+++ b/components/facebook_groups/actions/post-photo/post-photo.mjs
@@ -5,7 +5,7 @@ export default {
   key: "facebook_groups-post-photo",
   name: "Post Photo",
   description: "Post a photo in a group. [See the documentation](https://developers.facebook.com/docs/graph-api/reference/group/photos)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     ...common.props,

--- a/components/facebook_groups/actions/post-photo/post-photo.mjs
+++ b/components/facebook_groups/actions/post-photo/post-photo.mjs
@@ -1,4 +1,5 @@
 import common from "../common/common.mjs";
+import { ERROR_MESSAGE } from "../common/errorMessage.mjs";
 
 export default {
   ...common,
@@ -16,18 +17,23 @@ export default {
     },
   },
   async run({ $ }) {
-    const response = await this.facebookGroups.postPhoto({
-      groupId: this.group,
-      data: {
-        url: this.url,
-      },
-      $,
-    });
+    try {
+      const response = await this.facebookGroups.postPhoto({
+        groupId: this.group,
+        data: {
+          url: this.url,
+        },
+        $,
+      });
 
-    if (response) {
-      $.export("$summary", `Successfully posted photo with ID ${response.id}.`);
+      if (response) {
+        $.export("$summary", `Successfully posted photo with ID ${response.id}.`);
+      }
+
+      return response;
+    } catch (error) {
+      console.error(error);
+      throw new Error(ERROR_MESSAGE);
     }
-
-    return response;
   },
 };

--- a/components/facebook_groups/facebook_groups.app.mjs
+++ b/components/facebook_groups/facebook_groups.app.mjs
@@ -43,7 +43,7 @@ export default {
           })) || [];
         } catch (error) {
           console.error(error);
-          throw new ConfigurationError("Please doublecheck that the Pipedream app has been installed in the group you have selected above. Learn more [here](https://pipedream.com/apps/facebook-groups).");
+          throw new ConfigurationError("Please double-check that the Pipedream app has been installed in the group you have selected above. Learn more [here](https://pipedream.com/apps/facebook-groups).");
         }
       },
     },

--- a/components/facebook_groups/facebook_groups.app.mjs
+++ b/components/facebook_groups/facebook_groups.app.mjs
@@ -1,4 +1,7 @@
-import { axios } from "@pipedream/platform";
+import {
+  axios,
+  ConfigurationError,
+} from "@pipedream/platform";
 
 export default {
   type: "app",
@@ -27,16 +30,21 @@ export default {
       label: "Post",
       description: "Identifier of a post",
       async options({ groupId }) {
-        const opts = {
-          groupId,
-        };
-        const { data } = await this.listPosts(opts);
-        return data?.map(({
-          id, message,
-        }) => ({
-          label: message || id,
-          value: id,
-        })) || [];
+        try {
+          const opts = {
+            groupId,
+          };
+          const { data } = await this.listPosts(opts);
+          return data?.map(({
+            id, message,
+          }) => ({
+            label: message || id,
+            value: id,
+          })) || [];
+        } catch (error) {
+          console.error(error);
+          throw new ConfigurationError("Please doublecheck that the Pipedream app has been [installed](https://pipedream.com/apps/facebook-groups) in the group you have selected above.");
+        }
       },
     },
     maxResults: {

--- a/components/facebook_groups/facebook_groups.app.mjs
+++ b/components/facebook_groups/facebook_groups.app.mjs
@@ -43,7 +43,7 @@ export default {
           })) || [];
         } catch (error) {
           console.error(error);
-          throw new ConfigurationError("Please doublecheck that the Pipedream app has been installed in the group you have selected above. Learn more [here].(https://pipedream.com/apps/facebook-groups)");
+          throw new ConfigurationError("Please doublecheck that the Pipedream app has been installed in the group you have selected above. Learn more [here](https://pipedream.com/apps/facebook-groups).");
         }
       },
     },

--- a/components/facebook_groups/facebook_groups.app.mjs
+++ b/components/facebook_groups/facebook_groups.app.mjs
@@ -43,7 +43,7 @@ export default {
           })) || [];
         } catch (error) {
           console.error(error);
-          throw new ConfigurationError("Please doublecheck that the Pipedream app has been [installed](https://pipedream.com/apps/facebook-groups) in the group you have selected above.");
+          throw new ConfigurationError("Please doublecheck that the Pipedream app has been installed in the group you have selected above. Learn more [here].(https://pipedream.com/apps/facebook-groups)");
         }
       },
     },

--- a/components/facebook_groups/facebook_groups.app.mjs
+++ b/components/facebook_groups/facebook_groups.app.mjs
@@ -10,7 +10,7 @@ export default {
     group: {
       type: "string",
       label: "Group",
-      description: "Identifier of a group",
+      description: "Identifier of a group. The Pipedream app must be installed in the Facebook group in order to make any API calls or receive data.",
       async options() {
         const userId = await this.getUserId();
         const opts = {

--- a/components/facebook_groups/facebook_groups.app.mjs
+++ b/components/facebook_groups/facebook_groups.app.mjs
@@ -43,7 +43,7 @@ export default {
           })) || [];
         } catch (error) {
           console.error(error);
-          throw new ConfigurationError("Please double-check that the Pipedream app has been installed in the group you have selected above. Learn more [here](https://pipedream.com/apps/facebook-groups).");
+          throw new ConfigurationError("Please double-check that the Pipedream app has been installed in the group you have selected above. Learn more [here](https://pipedream.com/apps/facebook-groups#getting-started).");
         }
       },
     },

--- a/components/facebook_groups/package.json
+++ b/components/facebook_groups/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/facebook_groups",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream Facebook Groups Components",
   "main": "facebook_groups.app.mjs",
   "keywords": [

--- a/components/facebook_groups/package.json
+++ b/components/facebook_groups/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/facebook_groups",
-  "version": "0.1.2",
+  "version": "0.1.1",
   "description": "Pipedream Facebook Groups Components",
   "main": "facebook_groups.app.mjs",
   "keywords": [

--- a/components/facebook_groups/package.json
+++ b/components/facebook_groups/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/facebook_groups",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Facebook Groups Components",
   "main": "facebook_groups.app.mjs",
   "keywords": [

--- a/components/facebook_groups/sources/new-comment-created/new-comment-created.mjs
+++ b/components/facebook_groups/sources/new-comment-created/new-comment-created.mjs
@@ -5,7 +5,7 @@ export default {
   key: "facebook_groups-new-comment-created",
   name: "New Comment Created",
   description: "Emit new event when a new comment is created on a group post",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/facebook_groups/sources/new-post-created/new-post-created.mjs
+++ b/components/facebook_groups/sources/new-post-created/new-post-created.mjs
@@ -5,7 +5,7 @@ export default {
   key: "facebook_groups-new-post-created",
   name: "New Post Created",
   description: "Emit new event when a new post is created in a group",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/twitter/actions/list-favorites/list-favorites.ts
+++ b/components/twitter/actions/list-favorites/list-favorites.ts
@@ -1,75 +1,54 @@
-import app from "../../app/twitter.app";
-import { ACTION_ERROR_MESSAGE } from "../../common/errorMessage";
-import { defineAction } from "@pipedream/types";
-import {
-  getMultiItemSummary,
-  getUserId,
-  getTweetFields,
-} from "../../common/methods";
-import { GetUserLikedTweetParams } from "../../common/types/requestParams";
-import {
-  PaginatedResponseObject,
-  Tweet,
-} from "../../common/types/responseSchemas";
+import common from "../common/common.mjs";
+import { ERROR_MESSAGE } from "../../common/errorMessage";
+import { ConfigurationError } from "@pipedream/platform";
 
-export const DOCS_LINK =
-  "https://developer.twitter.com/en/docs/twitter-api/tweets/likes/api-reference/get-users-id-liked_tweets";
-const MIN_RESULTS = 10;
-const DEFAULT_RESULTS = 100;
-export const MAX_RESULTS_PER_PAGE = 100;
-
-export default defineAction({
-  key: "twitter-list-favorites",
-  name: "List Liked Tweets",
-  description: `Return the most recent tweets liked by you or the specified user. [See the documentation](${DOCS_LINK})`,
-  version: "2.0.3",
+export default {
+  ...common,
+  key: "facebook_groups-create-post",
+  name: "Create Post",
+  description: "Create a new post in a group. [See the documentation](https://developers.facebook.com/docs/graph-api/reference/v17.0/group/feed)",
+  version: "0.0.3",
   type: "action",
   props: {
-    app,
-    userNameOrId: {
-      propDefinition: [
-        app,
-        "userNameOrId",
-      ],
+    ...common.props,
+    message: {
+      type: "string",
+      label: "Message",
+      description: "The main body of the post, otherwise called the status message. Either `link` or `message` must be supplied.",
+      optional: true,
     },
-    maxResults: {
-      propDefinition: [
-        app,
-        "maxResults",
-      ],
-      min: MIN_RESULTS,
-      description: `Maximum amount of items to return. Each request can return up to ${MAX_RESULTS_PER_PAGE} items.`,
-      default: DEFAULT_RESULTS,
+    link: {
+      type: "string",
+      label: "Link",
+      description: "The URL of a link to attach to the post. Either link or message must be supplied.",
+      optional: true,
     },
   },
-  methods: {
-    getMultiItemSummary,
-    getUserId,
-    getTweetFields,
-  },
-  async run({ $ }): Promise<PaginatedResponseObject<Tweet>> {
+  async run({ $ }) {
     try {
-      const userId = await this.getUserId();
+      if (!this.message && !this.link) {
+        throw new ConfigurationError("Either `link` or `message` must be supplied");
+      }
 
-      const params: GetUserLikedTweetParams = {
+      const response = await this.facebookGroups.createPost({
+        groupId: this.group,
+        data: {
+          message: this.message,
+          link: this.link,
+        },
         $,
-        maxPerPage: MAX_RESULTS_PER_PAGE,
-        maxResults: this.maxResults,
-        params: this.getTweetFields(),
-        userId,
-      };
+      });
 
-      const response = await this.app.getUserLikedTweets(params);
+      if (!response) {
+        throw new ConfigurationError("Post creation was unsuccessful");
+      }
 
-      $.export(
-        "$summary",
-        this.getMultiItemSummary("liked tweet", response.data?.length),
-      );
+      $.export("$summary", `Successfully created new post with ID ${response.id}.`);
 
       return response;
     } catch (err) {
       $.export("error", err);
-      throw new Error(ACTION_ERROR_MESSAGE);
+      throw new Error(ERROR_MESSAGE);
     }
   },
-});
+};

--- a/components/twitter/actions/list-favorites/list-favorites.ts
+++ b/components/twitter/actions/list-favorites/list-favorites.ts
@@ -72,4 +72,4 @@ export default defineAction({
       throw new Error(ACTION_ERROR_MESSAGE);
     }
   },
-}); 
+});

--- a/components/twitter/actions/list-favorites/list-favorites.ts
+++ b/components/twitter/actions/list-favorites/list-favorites.ts
@@ -72,4 +72,4 @@ export default defineAction({
       throw new Error(ACTION_ERROR_MESSAGE);
     }
   },
-});
+}); 


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d38e31b</samp>

Improved error handling for Facebook Groups source. The source now checks if the selected group has the Pipedream app installed and shows a helpful message if not.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d38e31b</samp>

> _Oh we are the coders of the Pipedream app_
> _And we work on the `postId` prop_
> _We handle the errors when the group is wrong_
> _And we tell the user how to get along_


## WHY

<img width="989" alt="Screenshot 2023-06-21 at 12 16 43 PM" src="https://github.com/PipedreamHQ/pipedream/assets/42158621/ec366055-cf70-4f7a-8916-fa210c383f1a">



## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d38e31b</samp>

* Import and throw `ConfigurationError` for groups without Pipedream app ([link](https://github.com/PipedreamHQ/pipedream/pull/6972/files?diff=unified&w=0#diff-8e811b19be1470e1e31109e1a0191d72054a0c1e1466d194ee24e7be45bb58ddL1-R4), [link](https://github.com/PipedreamHQ/pipedream/pull/6972/files?diff=unified&w=0#diff-8e811b19be1470e1e31109e1a0191d72054a0c1e1466d194ee24e7be45bb58ddL30-R47))
