### PR TITLE
Prevent publish test-event file

### DIFF
--- a/.github/workflows/publish-components.yaml
+++ b/.github/workflows/publish-components.yaml
@@ -67,7 +67,7 @@ jobs:
           # starts with components, ends with .*js (e.g. .js and .mjs) and not app.js,
           # doesn't end with /common*.*js, and doesn't follow */common/
           if [[ $added_modified_file == components/* ]] && [[ $added_modified_file == *.*js ]] && [[ $added_modified_file != *.app.*js ]] \
-              && [[ $added_modified_file != */common*.*js ]] && [[ $added_modified_file != */common/* ]]
+              && [[ $added_modified_file != */common*.*js ]] && [[ $added_modified_file != */common/* ]] && [[ $added_modified_file != components/*/test-event.mjs ]]
             then
               echo "retrieving previous version for ${added_modified_file}"
               KEY=`echo $added_modified_file | tr '/' ' ' | awk '{ print $2 "-" $4 }'`


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3ac7fb2</samp>

Updated the workflow for publishing components to ignore `test-event.mjs` files. This prevents false positives in detecting component version changes.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3ac7fb2</samp>

> _`test-event.mjs`_
> _skipped in version check - why?_
> _only for testing_


## WHY

Currently attempting to publish test-event file, which causes errors

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3ac7fb2</samp>

*  Exclude test-event files from component versioning ([link](https://github.com/PipedreamHQ/pipedream/pull/7007/files?diff=unified&w=0#diff-030ed26869c98dd8baf020e1616dab36ab1616258d74f35f655214382a973d77L70-R70))
