### PR TITLE
Colin/dj 893 prevent publish test event file

### DIFF
--- a/.github/workflows/publish-components.yaml
+++ b/.github/workflows/publish-components.yaml
@@ -67,7 +67,7 @@ jobs:
           # starts with components, ends with .*js (e.g. .js and .mjs) and not app.js,
           # doesn't end with /common*.*js, and doesn't follow */common/
           if [[ $added_modified_file == components/* ]] && [[ $added_modified_file == *.*js ]] && [[ $added_modified_file != *.app.*js ]] \
-              && [[ $added_modified_file != */common*.*js ]] && [[ $added_modified_file != */common/* ]]
+              && [[ $added_modified_file != */common*.*js ]] && [[ $added_modified_file != */common/* ]] && [[ $added_modified_file != components/*/test-event.mjs ]]
             then
               echo "retrieving previous version for ${added_modified_file}"
               KEY=`echo $added_modified_file | tr '/' ' ' | awk '{ print $2 "-" $4 }'`

--- a/.github/workflows/publish-components.yaml
+++ b/.github/workflows/publish-components.yaml
@@ -67,7 +67,7 @@ jobs:
           # starts with components, ends with .*js (e.g. .js and .mjs) and not app.js,
           # doesn't end with /common*.*js, and doesn't follow */common/
           if [[ $added_modified_file == components/* ]] && [[ $added_modified_file == *.*js ]] && [[ $added_modified_file != *.app.*js ]] \
-              && [[ $added_modified_file != */common*.*js ]] && [[ $added_modified_file != */common/* ]] && [[ $added_modified_file != components/*/test-event.mjs ]]
+              && [[ $added_modified_file != */common*.*js ]] && [[ $added_modified_file != */common/* ]] && [[ $added_modified_file != */test-event.mjs ]]
             then
               echo "retrieving previous version for ${added_modified_file}"
               KEY=`echo $added_modified_file | tr '/' ' ' | awk '{ print $2 "-" $4 }'`


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ab60bd6</samp>

Updated the publish-components workflow to exclude test events from component metadata. This prevents test events from being displayed in the Pipedream UI when users select a component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ab60bd6</samp>

> _`test-event.mjs`_
> _Skipped by new condition_
> _No more false metadata_


## WHY

Update regex

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ab60bd6</samp>

*  Exclude test events from component metadata by updating the condition for retrieving the previous version of a component file ([link](https://github.com/PipedreamHQ/pipedream/pull/7016/files?diff=unified&w=0#diff-030ed26869c98dd8baf020e1616dab36ab1616258d74f35f655214382a973d77L70-R70))
