### PR TITLE
Ghost Admin API with Featured Image

### DIFF
--- a/components/ghost_org_admin_api/actions/create-post/create-post.mjs
+++ b/components/ghost_org_admin_api/actions/create-post/create-post.mjs
@@ -17,6 +17,7 @@ export default {
       type: "string",
       label: "Featured Image",
       description: "URL of the featured image",
+      optional: true,
     },
     html: {
       type: "string",

--- a/components/ghost_org_admin_api/actions/create-post/create-post.mjs
+++ b/components/ghost_org_admin_api/actions/create-post/create-post.mjs
@@ -59,7 +59,7 @@ export default {
         posts: [
           {
             title,
-            featured_image: featuredImage,
+            feature_image: featuredImage,
             html,
             status,
             tags,

--- a/components/ghost_org_admin_api/actions/create-post/create-post.mjs
+++ b/components/ghost_org_admin_api/actions/create-post/create-post.mjs
@@ -59,7 +59,7 @@ export default {
         posts: [
           {
             title,
-            image,
+            featured_image,
             html,
             status,
             tags,

--- a/components/ghost_org_admin_api/actions/create-post/create-post.mjs
+++ b/components/ghost_org_admin_api/actions/create-post/create-post.mjs
@@ -13,7 +13,7 @@ export default {
       label: "Title",
       description: "Title of the post",
     },
-    featured_image: {
+    featuredImage: {
       type: "string",
       label: "Featured Image",
       description: "URL of the featured image",
@@ -44,7 +44,7 @@ export default {
   async run({ $ }) {
     const {
       title,
-      featured_image,
+      featuredImage,
       html,
       status,
       tags,

--- a/components/ghost_org_admin_api/actions/create-post/create-post.mjs
+++ b/components/ghost_org_admin_api/actions/create-post/create-post.mjs
@@ -5,13 +5,18 @@ export default {
   name: "Create post",
   description: "Create a post. [See the docs here](https://ghost.org/docs/admin-api/#creating-a-post).",
   type: "action",
-  version: "0.0.2",
+  version: "0.0.3",
   props: {
     ghostAdminApi,
     title: {
       type: "string",
       label: "Title",
       description: "Title of the post",
+    },
+    featured_image: {
+      type: "string",
+      label: "Featured Image",
+      description: "URL of the featured image",
     },
     html: {
       type: "string",
@@ -39,6 +44,7 @@ export default {
   async run({ $ }) {
     const {
       title,
+      featured_image,
       html,
       status,
       tags,
@@ -53,6 +59,7 @@ export default {
         posts: [
           {
             title,
+            image,
             html,
             status,
             tags,

--- a/components/ghost_org_admin_api/actions/create-post/create-post.mjs
+++ b/components/ghost_org_admin_api/actions/create-post/create-post.mjs
@@ -59,7 +59,7 @@ export default {
         posts: [
           {
             title,
-            featured_image,
+            featured_image: featuredImage,
             html,
             status,
             tags,

--- a/components/ghost_org_admin_api/package.json
+++ b/components/ghost_org_admin_api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/ghost_org_admin_api",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Pipedream Ghost_org_admin_api Components",
   "main": "ghost_org_admin_api.app.mjs",
   "keywords": [


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4866031</samp>

Added a feature to create posts with images in `ghost_org_admin_api`. The new prop `featured_image` accepts a URL and sends it to the API.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4866031</samp>

> _Oh, we're the crew of the Ghost Admin ship_
> _And we sail the web with skill and wit_
> _We've added a prop to the create-post action_
> _To let you set a featured image for your attraction_


## WHY

<!-- author to complete -->
Added key:value for:

```
"feature_image": "https://static.ghost.org/v3.0.0/images/welcome-to-ghost.png"
```
as noted in Ghost Docs: https://ghost.org/docs/admin-api/#the-post-object


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4866031</samp>

*  Increment the version of the create-post action to reflect the new feature of adding a featured image to a post ([link](https://github.com/PipedreamHQ/pipedream/pull/7031/files?diff=unified&w=0#diff-7c850f36120470e56b1614303cc99ec0bc8a784ab7b04a37b646b6ca1c17ac79L8-R8))
*  Add a new prop `featured_image` to the create-post action, which allows the user to specify a URL of an image to be used as the featured image of the post ([link](https://github.com/PipedreamHQ/pipedream/pull/7031/files?diff=unified&w=0#diff-7c850f36120470e56b1614303cc99ec0bc8a784ab7b04a37b646b6ca1c17ac79R16-R20))
*  Destructure the `featured_image` prop from the props object and add it to the payload object that is passed to the `ghostAdminApi.posts.add` method, which creates the post with the given data ([link](https://github.com/PipedreamHQ/pipedream/pull/7031/files?diff=unified&w=0#diff-7c850f36120470e56b1614303cc99ec0bc8a784ab7b04a37b646b6ca1c17ac79R47), [link](https://github.com/PipedreamHQ/pipedream/pull/7031/files?diff=unified&w=0#diff-7c850f36120470e56b1614303cc99ec0bc8a784ab7b04a37b646b6ca1c17ac79R62))
