### PR TITLE
Adding Sample Test Event for telegram_bot_api-new-bot-command-received

### DIFF
--- a/components/telegram_bot_api/package.json
+++ b/components/telegram_bot_api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/telegram_bot_api",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "Pipedream Telegram_bot_api Components",
   "main": "telegram_bot_api.app.mjs",
   "keywords": [

--- a/components/telegram_bot_api/sources/new-bot-command-received/new-bot-command-received.mjs
+++ b/components/telegram_bot_api/sources/new-bot-command-received/new-bot-command-received.mjs
@@ -1,11 +1,13 @@
 import base from "../common/webhooks.mjs";
+import sampleEmit from "./test-event.mjs";
 
 export default {
   ...base,
   key: "telegram_bot_api-new-bot-command-received",
   name: "New Bot Command Received (Instant)",
   description: "Emit new event each time a Telegram Bot command is received.",
-  version: "0.0.3",
+  version: "0.0.4",
+
   type: "source",
   dedupe: "unique",
   props: {
@@ -55,4 +57,5 @@ export default {
       this.$emit(event, this.getMeta(event, message));
     },
   },
+  sampleEmit,
 };

--- a/components/telegram_bot_api/sources/new-bot-command-received/new-bot-command-received.mjs
+++ b/components/telegram_bot_api/sources/new-bot-command-received/new-bot-command-received.mjs
@@ -7,7 +7,6 @@ export default {
   name: "New Bot Command Received (Instant)",
   description: "Emit new event each time a Telegram Bot command is received.",
   version: "0.0.4",
-
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/telegram_bot_api/sources/new-bot-command-received/test-event.mjs
+++ b/components/telegram_bot_api/sources/new-bot-command-received/test-event.mjs
@@ -1,0 +1,30 @@
+export default  {
+  "update_id": 999999999,
+  "message": {
+   "message_id": 99,
+   "from": {
+    "id": 100000000,
+    "is_bot": false,
+    "first_name": "John",
+    "last_name": "Doe",
+    "username": "johndoe",
+    "language_code": "en"
+   },
+   "chat": {
+    "id": 100000000,
+    "first_name": "John",
+    "last_name": "Doe",
+    "username": "johndoe",
+    "type": "private"
+   },
+   "date": 2000000000,
+   "text": "/test",
+   "entities": [
+    {
+     "offset": 0,
+     "length": 5,
+     "type": "bot_command"
+    }
+   ]
+  }
+ }


### PR DESCRIPTION
Adding Sample Test Event for telegram_bot_api-new-bot-command-received

Created via Pipedream