### PR TITLE
[BUG] Monday Create Item action

### DIFF
--- a/components/monday/actions/create-item/create-item.mjs
+++ b/components/monday/actions/create-item/create-item.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Create Item",
   description: "Creates an item. [See the docs here](https://api.developer.monday.com/docs/items-queries#create-an-item)",
   type: "action",
-  version: "0.0.5",
+  version: "0.0.6",
   props: {
     monday,
     boardId: {
@@ -63,7 +63,7 @@ export default {
       } else if (column === "date4") {
         description = "Enter date of item in YYYY-MM-DD format. Eg. `2022-09-02`";
       } else {
-        description = `Value for column ${column}`;
+        description = `Value for column ${column}. See the [Column Type Reference](https://developer.monday.com/api-reference/docs/column-types-reference) to learn more about entering column type values.`;
       }
       props[column] = {
         type: "string",
@@ -73,10 +73,30 @@ export default {
     }
     return props;
   },
+  methods: {
+    getEmailValue(value) {
+      let email = value;
+      if (typeof value === "string") {
+        try {
+          email = JSON.parse(value);
+        } catch {
+          email = {
+            text: value,
+            email: value,
+          };
+        }
+      }
+      return email;
+    },
+  },
   async run({ $ }) {
     const columnValues = {};
     if (this.columns?.length > 0) {
       for (const column of this.columns) {
+        if (column === "email") {
+          columnValues[column] = this.getEmailValue(this[column]);
+          continue;
+        }
         columnValues[column] = this[column];
       }
     }

--- a/components/monday/package.json
+++ b/components/monday/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/monday",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Pipedream Monday Components",
   "main": "monday.app.mjs",
   "keywords": [


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6c063b3</samp>

This pull request updates the monday app components with new features and fixes. It adds email column support and better documentation to the `create-item` action, and bumps the `@pipedream/monday` package version.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6c063b3</samp>

> _Oh we're the pipedream crew and we work with monday too_
> _We update our packages and we make our actions new_
> _We heave away and haul away with `create-item` in hand_
> _We support the email column and we document our plan_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6c063b3</samp>

* Incremented the version of the `create-item` action and the `@pipedream/monday` package to reflect the new features and bug fixes ([link](https://github.com/PipedreamHQ/pipedream/pull/7072/files?diff=unified&w=0#diff-40418ca555fa6316697e21e2ff629a1873428a91dddc36f452b93529b32bad9cL9-R9), [link](https://github.com/PipedreamHQ/pipedream/pull/7072/files?diff=unified&w=0#diff-9e2dbcdafce34df582a248f129a06848b8c44dd1390a74234c5506c8b732b1b1L3-R3))
* Added a link to the Column Type Reference documentation in the description of the dynamic props for each column in the `create-item` action, to help users enter valid values for different column types ([link](https://github.com/PipedreamHQ/pipedream/pull/7072/files?diff=unified&w=0#diff-40418ca555fa6316697e21e2ff629a1873428a91dddc36f452b93529b32bad9cL66-R66))
* Added a new method `getEmailValue` in the `create-item` action, which parses and formats the email column type value, and modified the `run` method to use this method and skip the default assignment of the column value ([link](https://github.com/PipedreamHQ/pipedream/pull/7072/files?diff=unified&w=0#diff-40418ca555fa6316697e21e2ff629a1873428a91dddc36f452b93529b32bad9cL76-R99))
