### PR TITLE
Added missing await to MongoDB client connect retry

### DIFF
--- a/components/mongodb/mongodb.app.mjs
+++ b/components/mongodb/mongodb.app.mjs
@@ -70,7 +70,7 @@ export default {
         if (err.code === "ENOTFOUND") {
           // Last attempt to connect to the server
           const url = this._getConnectionUrl(false);
-          return MongoClient.connect(url);
+          return await MongoClient.connect(url);
         }
         throw err;
       }


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 89c73d1</samp>

Added `await` to `MongoClient.connect` in `mongodb.app.mjs` to fix SSL/TLS connection bug.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 89c73d1</samp>

> _`await` the promise_
> _connect with SSL/TLS_
> _retry on failure_


## WHY

MongoDB actions were throwing errors on completion that code was still running. This is the only piece of that code that would still create that issue. Corrects async issue as noted: https://pipedream.com/docs/code/nodejs/async/


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 89c73d1</samp>

* Fix connection bug with SSL/TLS by adding `await` to `MongoClient.connect` ([link](https://github.com/PipedreamHQ/pipedream/pull/7089/files?diff=unified&w=0#diff-dee670ffaa1b2a544b406385e2eee9ff41447f6b0a3bf9adbd8435acc8d63824L73-R73))
