### PR TITLE
[BUG] Fix openai transcription failed with file format srt

### DIFF
--- a/components/openai/actions/create-transcription/create-transcription.mjs
+++ b/components/openai/actions/create-transcription/create-transcription.mjs
@@ -22,7 +22,7 @@ const pipelineAsync = promisify(stream.pipeline);
 
 export default {
   name: "Create Transcription",
-  version: "0.0.11",
+  version: "0.0.7",
   key: "openai-create-transcription",
   description: "Transcribes audio into the input language. [See docs here](https://platform.openai.com/docs/api-reference/audio/create).",
   type: "action",

--- a/components/openai/package.json
+++ b/components/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/openai",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Pipedream OpenAI Components",
   "main": "app/openai.app.mjs",
   "keywords": [


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d383078</samp>

Refactored the `Create Transcription` action to return more detailed results and updated the `@pipedream/openai` package version. The action now returns the full text and the array of transcriptions for the input files, using promises to simplify the code. The `components/openai/package.json` file was changed to reflect the new package version.

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d383078</samp>

*  Bump up the version of the `Create Transcription` action and the `@pipedream/openai` package to reflect the changes in the code ([link](https://github.com/PipedreamHQ/pipedream/pull/7093/files?diff=unified&w=0#diff-af2de3327bbe4b5ac7ee39f8edaed8cc729f3344072f87db0c0147cc2c4ec2afL25-R25), [link](https://github.com/PipedreamHQ/pipedream/pull/7093/files?diff=unified&w=0#diff-d53db1f6f1c2069172138aaf09b971481bfa0777e04f58f6b56b34c2cd4bc171L3-R3))
* Simplify the `chunkFileAndTranscribe`, `transcribeFiles`, and `transcribe` functions to return promises of arrays or objects instead of wrapping them in unnecessary variables or properties ([link](https://github.com/PipedreamHQ/pipedream/pull/7093/files?diff=unified&w=0#diff-af2de3327bbe4b5ac7ee39f8edaed8cc729f3344072f87db0c0147cc2c4ec2afL120-R125), [link](https://github.com/PipedreamHQ/pipedream/pull/7093/files?diff=unified&w=0#diff-af2de3327bbe4b5ac7ee39f8edaed8cc729f3344072f87db0c0147cc2c4ec2afL158-R155), [link](https://github.com/PipedreamHQ/pipedream/pull/7093/files?diff=unified&w=0#diff-af2de3327bbe4b5ac7ee39f8edaed8cc729f3344072f87db0c0147cc2c4ec2afL166-R163), [link](https://github.com/PipedreamHQ/pipedream/pull/7093/files?diff=unified&w=0#diff-af2de3327bbe4b5ac7ee39f8edaed8cc729f3344072f87db0c0147cc2c4ec2afL173-R171), [link](https://github.com/PipedreamHQ/pipedream/pull/7093/files?diff=unified&w=0#diff-af2de3327bbe4b5ac7ee39f8edaed8cc729f3344072f87db0c0147cc2c4ec2afL182-R185))
* Add a new function `getFullText` to join the texts of the transcriptions array returned by the `transcribe` function ([link](https://github.com/PipedreamHQ/pipedream/pull/7093/files?diff=unified&w=0#diff-af2de3327bbe4b5ac7ee39f8edaed8cc729f3344072f87db0c0147cc2c4ec2afL182-R185))
* Update the `run` function in `create-transcription.mjs` to use the new functions and return both the full transcription and the array of transcriptions to the user ([link](https://github.com/PipedreamHQ/pipedream/pull/7093/files?diff=unified&w=0#diff-af2de3327bbe4b5ac7ee39f8edaed8cc729f3344072f87db0c0147cc2c4ec2afL228-R238))
