### PR TITLE
Update pricing README.md

### DIFF
--- a/docs/docs/pricing/README.md
+++ b/docs/docs/pricing/README.md
@@ -104,7 +104,7 @@ Execution time used to develop a workflow in the builder does not count towards 
 
 #### Source Credit Usage
 
-When an [event source](/sources) triggers a workflow, the first credit per source execution is included for free. This means that the first {{ $site.themeConfig.base_credits_price.seconds }} of compute doesn't incur credits. This includes [Free Tier](/pricing/#free-tier) accounts.
+When an [event source](/sources) triggers a workflow, the first credit per source execution is included for free. This means that the first {{ $site.themeConfig.base_credits_price.seconds }} seconds of compute doesn't incur credits. This includes [Free Tier](/pricing/#free-tier) accounts.
 
 When a source is configured as a workflow trigger, the core value is in the workflow. We don't want to charge you two credits (one to run the source, one to run the workflow) when the workflow contains the core logic. Sources that trigger workflows are called "dependent" sources.
 


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3664c6a</samp>

Fixed a typo in the pricing documentation by adding the word "seconds" to indicate the unit of time for the free credit per source execution. This change affects the file `docs/docs/pricing/README.md`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3664c6a</samp>

> _`seconds` added_
> _clarify free credit time_
> _autumn of docs_


## WHY

<!-- author to complete -->
Include word that was left out: "seconds" after number of seconds.

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3664c6a</samp>

*  Clarify the unit of time for the free credit per source execution in the pricing documentation ([link](https://github.com/PipedreamHQ/pipedream/pull/7095/files?diff=unified&w=0#diff-2193227971a8af8a512647a42d2f62a0e47de3a9dd43290bcb2c47125b87d26aL107-R107))
