### PR TITLE
fix search folder on dropbox

### DIFF
--- a/components/dropbox/actions/create-a-text-file/create-a-text-file.mjs
+++ b/components/dropbox/actions/create-a-text-file/create-a-text-file.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Create a Text File",
   description: "Creates a brand new text file from plain text content you specify. [See docs here](https://dropbox.github.io/dropbox-sdk-js/Dropbox.html#filesUpload__anchor)",
   key: "dropbox-create-a-text-file",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   props: {
     dropbox,

--- a/components/dropbox/actions/create-folder/create-folder.mjs
+++ b/components/dropbox/actions/create-folder/create-folder.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Create folder",
   description: "Create a folder. [See docs here](https://dropbox.github.io/dropbox-sdk-js/Dropbox.html#filesCreateFolderV2__anchor)",
   key: "dropbox-create-folder",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   props: {
     dropbox,

--- a/components/dropbox/actions/create-or-append-to-a-text-file/create-or-append-to-a-text-file.mjs
+++ b/components/dropbox/actions/create-or-append-to-a-text-file/create-or-append-to-a-text-file.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Create or Append to a Text File",
   description: "Adds a new line to an existing text file, or creates a file if it doesn't exist. [See docs here](https://dropbox.github.io/dropbox-sdk-js/Dropbox.html#filesUpload__anchor)",
   key: "dropbox-create-or-append-to-a-text-file",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   props: {
     dropbox,

--- a/components/dropbox/actions/create-update-share-link/create-update-share-link.mjs
+++ b/components/dropbox/actions/create-update-share-link/create-update-share-link.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Create/Update a Share Link",
   description: "Creates or updates a public share link to the file or folder (It allows to share the file or folder with anyone). [See docs here](https://dropbox.github.io/dropbox-sdk-js/Dropbox.html#sharingCreateSharedLinkWithSettings__anchor)",
   key: "dropbox-create-update-share-link",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   props: {
     dropbox,

--- a/components/dropbox/actions/delete-file-folder/delete-file-folder.mjs
+++ b/components/dropbox/actions/delete-file-folder/delete-file-folder.mjs
@@ -4,7 +4,7 @@ export default {
   name: "Delete a File/Folder",
   description: "Permanently removes a file/folder from the server. [See docs here](https://dropbox.github.io/dropbox-sdk-js/Dropbox.html#filesDeleteV2__anchor)",
   key: "dropbox-delete-file-folder",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   props: {
     dropbox,

--- a/components/dropbox/actions/download-file-to-tmp/download-file-to-tmp.mjs
+++ b/components/dropbox/actions/download-file-to-tmp/download-file-to-tmp.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Download File to TMP",
   description: "Download a specific file to the temporary directory. [See the documentation](https://dropbox.github.io/dropbox-sdk-js/Dropbox.html#filesDownload__anchor).",
   key: "dropbox-download-file-to-tmp",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     dropbox,

--- a/components/dropbox/actions/list-file-folders-in-a-folder/list-file-folders-in-a-folder.mjs
+++ b/components/dropbox/actions/list-file-folders-in-a-folder/list-file-folders-in-a-folder.mjs
@@ -4,7 +4,7 @@ export default {
   name: "List All Files/Subfolders in a Folder",
   description: "Retrieves a list of files or subfolders in a specified folder [See the docs here](https://dropbox.github.io/dropbox-sdk-js/Dropbox.html#filesListFolder__anchor)",
   key: "dropbox-list-file-folders-in-a-folder",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   props: {
     dropbox,

--- a/components/dropbox/actions/list-file-revisions/list-file-revisions.mjs
+++ b/components/dropbox/actions/list-file-revisions/list-file-revisions.mjs
@@ -5,7 +5,7 @@ export default {
   name: "List File Revisions",
   description: "Retrieves a list of file revisions needed to recover previous content. [See docs here](https://dropbox.github.io/dropbox-sdk-js/Dropbox.html#filesListRevisions__anchor)",
   key: "dropbox-list-file-revisions",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   props: {
     dropbox,

--- a/components/dropbox/actions/move-file-folder/move-file-folder.mjs
+++ b/components/dropbox/actions/move-file-folder/move-file-folder.mjs
@@ -4,7 +4,7 @@ export default {
   name: "Move a File/Folder",
   description: "Moves a file or folder to a different location in the user's Dropbox [See the docs here](https://dropbox.github.io/dropbox-sdk-js/Dropbox.html#filesMoveV2__anchor)",
   key: "dropbox-move-file-folder",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   props: {
     dropbox,

--- a/components/dropbox/actions/rename-file-folder/rename-file-folder.mjs
+++ b/components/dropbox/actions/rename-file-folder/rename-file-folder.mjs
@@ -4,7 +4,7 @@ export default {
   name: "Rename a File/Folder",
   description: "Renames a file or folder in the user's Dropbox [See the docs here](https://dropbox.github.io/dropbox-sdk-js/Dropbox.html#filesMoveV2__anchor)",
   key: "dropbox-rename-file-folder",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   props: {
     dropbox,

--- a/components/dropbox/actions/restore-a-file/restore-a-file.mjs
+++ b/components/dropbox/actions/restore-a-file/restore-a-file.mjs
@@ -4,7 +4,7 @@ export default {
   name: "Restore a File",
   description: "Restores a previous file version. [See docs here](https://dropbox.github.io/dropbox-sdk-js/Dropbox.html#filesRestore__anchor)",
   key: "dropbox-restore-a-file",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   props: {
     dropbox,

--- a/components/dropbox/actions/search-files-folders/search-files-folders.mjs
+++ b/components/dropbox/actions/search-files-folders/search-files-folders.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Search files and folders",
   description: "Searches for files and folders by name. [See the docs here](https://dropbox.github.io/dropbox-sdk-js/Dropbox.html#filesSearchV2__anchor)",
   key: "dropbox-search-files-folders",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   props: {
     dropbox,

--- a/components/dropbox/actions/upload-file/upload-file.mjs
+++ b/components/dropbox/actions/upload-file/upload-file.mjs
@@ -9,7 +9,7 @@ export default {
   name: "Upload a File",
   description: "Uploads a file to a selected folder. [See docs here](https://dropbox.github.io/dropbox-sdk-js/Dropbox.html#filesUpload__anchor)",
   key: "dropbox-upload-file",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   props: {
     dropbox,

--- a/components/dropbox/dropbox.app.mjs
+++ b/components/dropbox/dropbox.app.mjs
@@ -179,6 +179,10 @@ export default {
           ? ""
           : path;
 
+        if (path.length > 0 && !path.startsWith("/")) {
+          path = "/" + path;
+        }
+
         const dpx = await this.sdk();
         if (path === "") {
           res = await dpx.filesListFolder({

--- a/components/dropbox/dropbox.app.mjs
+++ b/components/dropbox/dropbox.app.mjs
@@ -14,7 +14,7 @@ export default {
     pathFolder: {
       type: "string",
       label: "Path",
-      description: "The folder path. (Please use a valid path to filter the values)",
+      description: "The folder path. (Please use a valid path to filter the values and type at least 2 characters after the latest '/' to perform the search.)",
       useQuery: true,
       withLabel: true,
       async options({
@@ -192,10 +192,17 @@ export default {
             type: item[".tag"],
           }));
         } else {
+          let subpath = "";
+          let query = path;
+          if ((path.match(/\//g) || []).length > 1) {
+            const splitPath = path.split("/");
+            query = splitPath.pop();
+            subpath = splitPath.join("/");
+          }
           res = await this.searchFilesFolders({
-            query: path,
+            query,
             options: {
-              path: "",
+              path: subpath,
             },
           });
 

--- a/components/dropbox/package.json
+++ b/components/dropbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/dropbox",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "description": "Pipedream Dropbox Components",
   "main": "dropbox.app.mjs",
   "keywords": [

--- a/components/dropbox/sources/all-updates/all-updates.mjs
+++ b/components/dropbox/sources/all-updates/all-updates.mjs
@@ -6,7 +6,7 @@ export default {
   type: "source",
   key: "dropbox-all-updates",
   name: "New or Modified File or Folder",
-  version: "0.0.12",
+  version: "0.0.13",
   description: "Emit new event when a file or folder is added or modified. Make sure the number of files/folders in the watched folder does not exceed 4000.",
   props: {
     ...common.props,

--- a/components/dropbox/sources/new-file/new-file.mjs
+++ b/components/dropbox/sources/new-file/new-file.mjs
@@ -7,7 +7,7 @@ export default {
   type: "source",
   key: "dropbox-new-file",
   name: "New File",
-  version: "0.0.13",
+  version: "0.0.14",
   description: "Emit new event when a new file is added to your account or a specific folder. Make sure the number of files/folders in the watched folder does not exceed 4000.",
   props: {
     ...common.props,

--- a/components/dropbox/sources/new-folder/new-folder.mjs
+++ b/components/dropbox/sources/new-folder/new-folder.mjs
@@ -6,7 +6,7 @@ export default {
   type: "source",
   key: "dropbox-new-folder",
   name: "New Folder",
-  version: "0.0.12",
+  version: "0.0.13",
   description: "Emit new event when a new folder is created. Make sure the number of files/folders in the watched folder does not exceed 4000.",
   hooks: {
     async activate() {


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 614bea8</samp>

Enhanced the `path` prop of the Dropbox component to support subfolder search and updated the documentation. Fixed a bug in `components/dropbox/dropbox.app.mjs`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 614bea8</samp>

> _Sing, O Muse, of the skillful coder who refined_
> _the Dropbox component, that wondrous tool of cloud_
> _that stores and shares the files of many a mortal mind_
> _and lets them search the `path` prop, clear and loud._


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 614bea8</samp>

*  Clarify the expected input format and minimum query length for the `path` prop of the `search` and `search:watch` sources ([link](https://github.com/PipedreamHQ/pipedream/pull/7097/files?diff=unified&w=0#diff-f2860da6c13af22f05f1d78a9b85cc8e4fc7b26d265bd4401c6084e02da51523L17-R17))
*  Enable the search to work on subfolders by splitting the `path` prop into a `subpath` and a `query` when it contains more than one slash ([link](https://github.com/PipedreamHQ/pipedream/pull/7097/files?diff=unified&w=0#diff-f2860da6c13af22f05f1d78a9b85cc8e4fc7b26d265bd4401c6084e02da51523L195-R205))
