### PR TITLE
fixing prop

### DIFF
--- a/components/google_calendar/package.json
+++ b/components/google_calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_calendar",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "description": "Pipedream Google_calendar Components",
   "main": "google_calendar.app.mjs",
   "keywords": [

--- a/components/google_calendar/sources/new-or-updated-event-instant/new-or-updated-event-instant.mjs
+++ b/components/google_calendar/sources/new-or-updated-event-instant/new-or-updated-event-instant.mjs
@@ -7,7 +7,7 @@ export default {
   type: "source",
   name: "New or Updated Event (Instant)",
   description: "Emit new calendar events when an event is created or updated (does not emit cancelled events)",
-  version: "0.1.6",
+  version: "0.1.7",
   dedupe: "unique",
   props: {
     googleCalendar,
@@ -18,13 +18,16 @@ export default {
         "calendarId",
       ],
       type: "string[]",
+      default: [
+        "primary",
+      ],
       label: "Calendars",
-      description: "Select one or more calendars to watch",
+      description: "Select one or more calendars to watch (defaults to the primary calendar)",
     },
     newOnly: {
-      label: "New events only?",
+      label: "Emit only for new events",
       type: "boolean",
-      description: "Emit new events only, and not updates to existing events",
+      description: "Emit new events only, and not updates to existing events (defaults to `false`)",
       optional: true,
       default: false,
     },


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8a0a130</samp>

Updated the `new-or-updated-event-instant` component of the Google Calendar source to improve usability and documentation. Bumped the `version` field in the `package.json` file accordingly.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8a0a130</samp>

> _Sing, O Muse, of the skillful developers who_
> _Updated the `package.json` with a new version,_
> _Adding a minor digit to the sacred code_
> _That governs the Google Calendar component._


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8a0a130</samp>

*  Increment the version of the Google Calendar component and the new-or-updated-event-instant source to reflect the changes made ([link](https://github.com/PipedreamHQ/pipedream/pull/7105/files?diff=unified&w=0#diff-7006d6160329e26d480fbcd5257f5cbfb872c6e84c2af626698f31125dc0d4afL3-R3), [link](https://github.com/PipedreamHQ/pipedream/pull/7105/files?diff=unified&w=0#diff-e7f661e669c0dc863e0bdee9f9bd19ddfe3c8bff047d2667a14f3a4d870820b2L10-R10))
*  Add default values and improve descriptions for the `calendars` and `newOnly` props in the `new-or-updated-event-instant.mjs` file to enhance the user experience and provide more guidance ([link](https://github.com/PipedreamHQ/pipedream/pull/7105/files?diff=unified&w=0#diff-e7f661e669c0dc863e0bdee9f9bd19ddfe3c8bff047d2667a14f3a4d870820b2L21-R30))
