### PR TITLE
[BUG] Gorgias - New ticket source failed with the account having more than 5000 tickets #7133

### DIFF
--- a/components/gorgias_oauth/package.json
+++ b/components/gorgias_oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/gorgias_oauth",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Pipedream Gorgias OAuth Components",
   "main": "gorgias_oauth.app.mjs",
   "keywords": [

--- a/components/gorgias_oauth/sources/common/constants.mjs
+++ b/components/gorgias_oauth/sources/common/constants.mjs
@@ -1,3 +1,3 @@
 export default {
-  HISTORICAL_EVENTS_LIMIT: 40, // 40 is the maximum allowed burst by the API
+  HISTORICAL_EVENTS_LIMIT: 10, // 40 is the maximum allowed burst by the API
 };

--- a/components/gorgias_oauth/sources/ticket-created/ticket-created.mjs
+++ b/components/gorgias_oauth/sources/ticket-created/ticket-created.mjs
@@ -6,7 +6,7 @@ export default {
   key: "gorgias_oauth-ticket-created",
   name: "New Ticket",
   description: "Emit new event when a ticket is created. [See the docs](https://developers.gorgias.com/reference/the-event-object)",
-  version: "0.1.2",
+  version: "0.1.3",
   type: "source",
   methods: {
     ...base.methods,

--- a/components/gorgias_oauth/sources/ticket-message-created/ticket-message-created.mjs
+++ b/components/gorgias_oauth/sources/ticket-message-created/ticket-message-created.mjs
@@ -6,7 +6,7 @@ export default {
   key: "gorgias_oauth-ticket-message-created",
   name: "New Ticket Message",
   description: "Emit new event when a ticket message is created. [See the docs](https://developers.gorgias.com/reference/the-event-object)",
-  version: "0.1.2",
+  version: "0.1.3",
   type: "source",
   methods: {
     ...base.methods,

--- a/components/gorgias_oauth/sources/ticket-updated/ticket-updated.mjs
+++ b/components/gorgias_oauth/sources/ticket-updated/ticket-updated.mjs
@@ -6,7 +6,7 @@ export default {
   key: "gorgias_oauth-ticket-updated",
   name: "New Updated Ticket",
   description: "Emit new event when a ticket is updated. [See the docs](https://developers.gorgias.com/reference/the-event-object)",
-  version: "0.1.2",
+  version: "0.1.3",
   type: "source",
   methods: {
     ...base.methods,


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d3331b7</samp>

Updated the `@pipedream/gorgias_oauth` package and the source components that use the Gorgias API to reduce the number of historical events fetched per page. This change aims to avoid hitting the rate limit of the API when initializing the sources.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d3331b7</samp>

> _`Gorgias_oauth`_
> _Updated for rate limit woes_
> _Winter of events_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d3331b7</samp>

*  Increment the version of the `@pipedream/gorgias_oauth` package to `0.3.8` ([link](https://github.com/PipedreamHQ/pipedream/pull/7153/files?diff=unified&w=0#diff-7621500a17285f37e38013ab25e2d09d503a2df2f32f126606a3341f40b702e7L3-R3))
*  Reduce the `HISTORICAL_EVENTS_LIMIT` constant to `10` to avoid rate limit errors when fetching historical events from the Gorgias API ([link](https://github.com/PipedreamHQ/pipedream/pull/7153/files?diff=unified&w=0#diff-a2c43eb936a6c1919839b509101ec0d627c44057f6f223c64c307bb9b33dbfbaL2-R2))
*  Increment the version of the source components `New Ticket`, `New Ticket Message`, and `New Updated Ticket` to `0.1.3` to reflect the change in the constant ([link](https://github.com/PipedreamHQ/pipedream/pull/7153/files?diff=unified&w=0#diff-512dc8b4ea22923025d0a3ac956d3ec8a8e9121ab323ccd9679f67c17ec57f35L9-R9), [link](https://github.com/PipedreamHQ/pipedream/pull/7153/files?diff=unified&w=0#diff-2e819de72c450738b16f8a8766b173f684bc947a604096aca2d1ee8cd2132483L9-R9), [link](https://github.com/PipedreamHQ/pipedream/pull/7153/files?diff=unified&w=0#diff-cd5e478b9742b0d0f314e68359cada072cdb3931d49671c419ceffa3d9a7531bL9-R9))
