### PR TITLE
Adding Sample Test Event for google_sheets-new-row-added-shared-drive

### DIFF
--- a/components/google_sheets/sources/new-row-added-shared-drive/new-row-added-shared-drive.mjs
+++ b/components/google_sheets/sources/new-row-added-shared-drive/new-row-added-shared-drive.mjs
@@ -1,4 +1,5 @@
 import httpBase from "../common/http-based/drive.mjs";
+import sampleEmit from "./test-event.mjs";
 import newRowAdded from "../common/new-row-added.mjs";
 
 export default {
@@ -7,7 +8,7 @@ export default {
   key: "google_sheets-new-row-added-shared-drive",
   name: "New Row Added (Shared Drive, Instant)",
   description: "Emit new events each time a row or rows are added to the bottom of a spreadsheet in a shared drive",
-  version: "0.1.1",
+  version: "0.1.2",
   dedupe: "unique",
   type: "source",
   props: {
@@ -18,4 +19,5 @@ export default {
     ...httpBase.methods,
     ...newRowAdded.methods,
   },
+  sampleEmit,
 };


### PR DESCRIPTION
Adding Sample Test Event for google_sheets-new-row-added-shared-drive

Created via Pipedream