### PR TITLE
[BUG] Datastore - Get or create record returns No data found for key when the value is 0 #7187

### DIFF
--- a/components/data_stores/actions/get-record-or-create/get-record-or-create.mjs
+++ b/components/data_stores/actions/get-record-or-create/get-record-or-create.mjs
@@ -4,7 +4,7 @@ export default {
   key: "data_stores-get-record-or-create",
   name: "Get record (or create one if not found)",
   description: "Get a single record in your [Pipedream Data Store](https://pipedream.com/data-stores/) or create one if it doesn't exist.",
-  version: "0.0.9",
+  version: "0.0.10",
   type: "action",
   props: {
     app,
@@ -41,7 +41,7 @@ export default {
   async run({ $ }) {
     const record = await this.dataStore.get(this.key);
 
-    if (record) {
+    if (record !== undefined) {
       $.export("$summary", `Found data for the key, \`${this.key}\`.`);
       return record;
     }

--- a/components/data_stores/package.json
+++ b/components/data_stores/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/data_stores",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Pipedream Data Stores Components",
   "main": "data_stores.app.js",
   "keywords": [


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5c0ef44</samp>

Fixed a bug in the `data_stores` package that caused duplicate records with falsy values. Updated the `get-record-or-create` action and the package version accordingly.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5c0ef44</samp>

> _There once was a package called `data_stores`_
> _That helped users manage their data chores_
> _But it had a bug_
> _With falsy values, ugh_
> _So they fixed it and bumped up the version by fours_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5c0ef44</samp>

*  Fix bug in `get-record-or-create` action that caused new records to be created when existing records had falsy values ([link](https://github.com/PipedreamHQ/pipedream/pull/7204/files?diff=unified&w=0#diff-02cf94c842624d76146f076461050e7287ab0b917b84012f11ffd45318c0849aL44-R44))
*  Bump version of `get-record-or-create` action to `0.0.10` ([link](https://github.com/PipedreamHQ/pipedream/pull/7204/files?diff=unified&w=0#diff-02cf94c842624d76146f076461050e7287ab0b917b84012f11ffd45318c0849aL7-R7))
*  Bump version of `@pipedream/data_stores` package to `0.1.3` to reflect action changes ([link](https://github.com/PipedreamHQ/pipedream/pull/7204/files?diff=unified&w=0#diff-73ea22e92ae612c4d1ee82dd1416dccdd6008d493b97a3b89b644d4198e59390L3-R3))
