### PR TITLE
RSS - Bug fix for source New Item From Multiple Feeds

### DIFF
--- a/components/rss/actions/merge-rss-feeds/merge-rss-feeds.ts
+++ b/components/rss/actions/merge-rss-feeds/merge-rss-feeds.ts
@@ -3,9 +3,9 @@ import { defineAction } from "@pipedream/types";
 
 export default defineAction({
   name: "Merge RSS Feeds",
-  description: "Retrieve multiple RSS feeds and return a merged array of items sorted by date [See docs](https://www.rssboard.org/rss-specification)",
+  description: "Retrieve multiple RSS feeds and return a merged array of items sorted by date [See documentation](https://www.rssboard.org/rss-specification)",
   key: "rss-merge-rss-feeds",
-  version: "1.2.2",
+  version: "1.2.3",
   type: "action",
   props: {
     rss,

--- a/components/rss/app/rss.app.ts
+++ b/components/rss/app/rss.app.ts
@@ -49,7 +49,9 @@ export default defineApp({
       const itemId = id ?? guid ?? link ?? title;
       if (itemId) {
         // reduce itemId length for deduping
-        return itemId.length > 64 ? itemId.slice(-64) : itemId;
+        return itemId.length > 64
+          ? itemId.slice(-64)
+          : itemId;
       }
       return hash(item);
     },
@@ -88,7 +90,6 @@ export default defineApp({
         feedparser.on("readable", function (this: FeedParser) {
           let item: any = this.read();
           while (item) {
-            console.log(`Item: ${JSON.stringify(item, null, 2)}`);
             for (const k in item) {
               if (item[`rss:${k}`]) {
                 delete item[`rss:${k}`];

--- a/components/rss/package.json
+++ b/components/rss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/rss",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Pipedream RSS Components",
   "main": "dist/app/rss.app.mjs",
   "types": "dist/app/rss.app.d.ts",

--- a/components/rss/sources/new-item-from-multiple-feeds/new-item-from-multiple-feeds.ts
+++ b/components/rss/sources/new-item-from-multiple-feeds/new-item-from-multiple-feeds.ts
@@ -8,7 +8,7 @@ export default defineSource({
   name: "New Item From Multiple RSS Feeds",
   type: "source",
   description: "Emit new items from multiple RSS feeds",
-  version: "1.2.2",
+  version: "1.2.3",
   props: {
     ...rssCommon.props,
     urls: {

--- a/components/rss/sources/new-item-in-feed/new-item-in-feed.ts
+++ b/components/rss/sources/new-item-in-feed/new-item-in-feed.ts
@@ -7,7 +7,7 @@ export default defineSource({
   key: "rss-new-item-in-feed",
   name: "New Item in Feed",
   description: "Emit new items from an RSS feed",
-  version: "1.2.2",
+  version: "1.2.3",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/rss/sources/random-item-in-multiple-feeds/random-item-in-multiple-feeds.ts
+++ b/components/rss/sources/random-item-in-multiple-feeds/random-item-in-multiple-feeds.ts
@@ -8,7 +8,7 @@ export default defineSource({
   name: "Random item from multiple RSS feeds",
   type: "source",
   description: "Emit a random item from multiple RSS feeds",
-  version: "0.2.2",
+  version: "0.2.3",
   props: {
     ...rssCommon.props,
     urls: {


### PR DESCRIPTION
When deploying the source and waiting for initial events, the New Item From Multiple Feeds is timing out and failing to deploy. When I remove the line 
``console.log(`Item: ${JSON.stringify(item, null, 2)}`);``
from rss.app.ts, the process is significantly faster, and I'm able to deploy with multiple (I tested up to 4) RSS feeds.
