### PR TITLE
updating claude models

### DIFF
--- a/components/anthropic/actions/chat/chat.mjs
+++ b/components/anthropic/actions/chat/chat.mjs
@@ -11,7 +11,7 @@ export default {
     anthropic,
     model: {
       label: "Model",
-      description: "Select the model to use for your query. Defaults to the `claude-v1` model, which is recommended by Anthropic, and always uses their latest stable version.",
+      description: "Select the model to use for your query. Defaults to the latest stable `claude-2` model, which Anthropic describes as having \"superior performance on tasks that require complex reasoning\".",
       type: "string",
       options: constants.COMPLETION_MODELS,
       default: constants.COMPLETION_MODELS[0],

--- a/components/anthropic/actions/chat/chat.mjs
+++ b/components/anthropic/actions/chat/chat.mjs
@@ -3,7 +3,7 @@ import constants from "../common/constants.mjs";
 
 export default {
   name: "Chat",
-  version: "0.0.2",
+  version: "0.0.3",
   key: "anthropic-chat",
   description: "The Chat API. [See docs here](https://console.anthropic.com/docs/api/reference#-v1-complete)",
   type: "action",

--- a/components/anthropic/actions/common/constants.mjs
+++ b/components/anthropic/actions/common/constants.mjs
@@ -1,10 +1,6 @@
 export default {
   COMPLETION_MODELS: [
-    "claude-v1",
-    "claude-v1.0",
-    "claude-v1.2",
-    "claude-v1.3",
-    "claude-instant-v1",
-    "claude-instant-v1.0",
+    "claude-2",
+    "claude-instant-1",
   ],
 };

--- a/components/anthropic/package.json
+++ b/components/anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/anthropic",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Pipedream Anthropic (Claude) Components",
   "main": "app/anthropic.app.mjs",
   "keywords": [


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2cc3f88</samp>

Updated the Chat component and the Anthropic package to use the latest and fastest completion models from Anthropic. Changed the constants file and the version numbers in `chat.mjs` and `package.json`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2cc3f88</samp>

> _Chat component grows_
> _`claude-2` and `instant-1`_
> _Autumn of progress_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2cc3f88</samp>

*  Update the Chat component to use the latest and fastest completion models from Anthropic ([link](https://github.com/PipedreamHQ/pipedream/pull/7221/files?diff=unified&w=0#diff-60ea2e1410fb82bfe29b6a66e013a1699796b414b7008f89d248259761579042L6-R6), [link](https://github.com/PipedreamHQ/pipedream/pull/7221/files?diff=unified&w=0#diff-44707ab9a9634e2fc8eea075359243478651844c51f9720e3157e311a578975aL3-R4))
*  Bump up the version of the Anthropic package to reflect the changes in the Chat component and the completion models ([link](https://github.com/PipedreamHQ/pipedream/pull/7221/files?diff=unified&w=0#diff-07c4844396863fc377e9cdcfab3b43082714d0a0295db89c3e8108fe208b61a8L3-R3))
*  Update the `package.json` file with the new version of the Anthropic package ([link](https://github.com/PipedreamHQ/pipedream/pull/7221/files?diff=unified&w=0#diff-07c4844396863fc377e9cdcfab3b43082714d0a0295db89c3e8108fe208b61a8L3-R3))
