### PR TITLE
Add timeout option to OpenAI component and chat action

### DIFF
--- a/components/openai/actions/chat/chat.mjs
+++ b/components/openai/actions/chat/chat.mjs
@@ -35,7 +35,7 @@ export default {
     },
     timeoutSeconds: {
       label: "API Timeout (in seconds)",
-      type: "number",
+      type: "integer",
       description: "The maximum time (in seconds) to wait for the API to return a response.",
       optional: true,
     },
@@ -46,7 +46,7 @@ export default {
     const response = await this.openai.createChatCompletion({
       $,
       args,
-      timeout: this.timeoutSeconds * 1000,
+      timeout: this.timeoutSeconds ? this.timeoutSeconds * 1000 : undefined,
     });
 
     if (response) {

--- a/components/openai/actions/chat/chat.mjs
+++ b/components/openai/actions/chat/chat.mjs
@@ -33,6 +33,12 @@ export default {
       description: "_Advanced_. Because [the models have no memory of past chat requests](https://platform.openai.com/docs/guides/chat/introduction), all relevant information must be supplied via the conversation. You can provide [an array of messages](https://platform.openai.com/docs/guides/chat/introduction) from prior conversations here. If this param is set, the action ignores the values passed to **System Instructions** and **Assistant Response**, appends the new **User Message** to the end of this array, and sends it to the API.",
       optional: true,
     },
+    timeout: {
+      label: "API Timeout (in seconds)",
+      type: "number",
+      description: "The maximum time (in seconds) to wait for the API to return a response.",
+      optional: true,
+    },
     ...common.props,
   },
   async run({ $ }) {
@@ -40,6 +46,7 @@ export default {
     const response = await this.openai.createChatCompletion({
       $,
       args,
+      timeout: args.timeout,
     });
 
     if (response) {

--- a/components/openai/actions/chat/chat.mjs
+++ b/components/openai/actions/chat/chat.mjs
@@ -46,7 +46,7 @@ export default {
     const response = await this.openai.createChatCompletion({
       $,
       args,
-      timeout: args.timeoutSeconds * 1000,
+      timeout: this.timeoutSeconds * 1000,
     });
 
     if (response) {

--- a/components/openai/actions/chat/chat.mjs
+++ b/components/openai/actions/chat/chat.mjs
@@ -33,7 +33,7 @@ export default {
       description: "_Advanced_. Because [the models have no memory of past chat requests](https://platform.openai.com/docs/guides/chat/introduction), all relevant information must be supplied via the conversation. You can provide [an array of messages](https://platform.openai.com/docs/guides/chat/introduction) from prior conversations here. If this param is set, the action ignores the values passed to **System Instructions** and **Assistant Response**, appends the new **User Message** to the end of this array, and sends it to the API.",
       optional: true,
     },
-    timeout: {
+    timeoutSeconds: {
       label: "API Timeout (in seconds)",
       type: "number",
       description: "The maximum time (in seconds) to wait for the API to return a response.",
@@ -46,7 +46,7 @@ export default {
     const response = await this.openai.createChatCompletion({
       $,
       args,
-      timeout: args.timeout,
+      timeout: args.timeoutSeconds * 1000,
     });
 
     if (response) {

--- a/components/openai/app/openai.app.mjs
+++ b/components/openai/app/openai.app.mjs
@@ -96,13 +96,14 @@ export default {
       });
     },
     async _makeCompletion({
-      $, path, args,
+      $, path, args, timeout,
     }) {
       const data = await this._makeRequest({
         $,
         path,
         method: "POST",
         data: args,
+        timeout
       });
 
       // For completions, return the text of the first choice at the top-level
@@ -125,45 +126,49 @@ export default {
       };
     },
     async createCompletion({
-      $, args,
+      $, args, timeout,
     }) {
       return this._makeCompletion({
         $,
         path: "/completions",
         args,
+        timeout,
       });
     },
     async createChatCompletion({
-      $, args,
+      $, args, timeout,
     }) {
       return this._makeCompletion({
         $,
         path: "/chat/completions",
         args,
+        timeout,
       });
     },
     async createImage({
-      $, args,
+      $, args, timeout,
     }) {
       return this._makeRequest({
         $,
         path: "/images/generations",
         data: args,
         method: "POST",
+        timeout,
       });
     },
     async createEmbeddings({
-      $, args,
+      $, args, timeout,
     }) {
       return this._makeRequest({
         $,
         path: "/embeddings",
         data: args,
         method: "POST",
+        timeout,
       });
     },
     async createTranscription({
-      $, form,
+      $, form, timeout,
     }) {
       return this._makeRequest({
         $,
@@ -174,6 +179,7 @@ export default {
           "Content-Type": `multipart/form-data; boundary=${form._boundary}`,
         },
         data: form,
+        timeout,
       });
     },
   },

--- a/components/openai/app/openai.app.mjs
+++ b/components/openai/app/openai.app.mjs
@@ -126,13 +126,12 @@ export default {
       };
     },
     async createCompletion({
-      $, args, timeout,
+      $, args,
     }) {
       return this._makeCompletion({
         $,
         path: "/completions",
         args,
-        timeout,
       });
     },
     async createChatCompletion({
@@ -146,29 +145,27 @@ export default {
       });
     },
     async createImage({
-      $, args, timeout,
+      $, args,
     }) {
       return this._makeRequest({
         $,
         path: "/images/generations",
         data: args,
         method: "POST",
-        timeout,
       });
     },
     async createEmbeddings({
-      $, args, timeout,
+      $, args,
     }) {
       return this._makeRequest({
         $,
         path: "/embeddings",
         data: args,
         method: "POST",
-        timeout,
       });
     },
     async createTranscription({
-      $, form, timeout,
+      $, form,
     }) {
       return this._makeRequest({
         $,
@@ -179,7 +176,6 @@ export default {
           "Content-Type": `multipart/form-data; boundary=${form._boundary}`,
         },
         data: form,
-        timeout,
       });
     },
   },


### PR DESCRIPTION
## WHAT
Added a custom timeout option to the OpenAI component.

## WHY
To resolve issue #7253 where timeouts occur for long chat histories.

## HOW
Allowing users to set a custom timeout duration in seconds for the chat action in OpenAI component.

---

**Note:** The `axios@0.21.2` documentation indicates that there should be no timeout by default. However, a 30-second timeout is consistently reproduced when running the OpenAI chat step with the 'gpt-4' model and ~1.2K tokens (https://github.com/PipedreamHQ/pipedream/issues/7253). So I'm not sure if This PR will resolve the issue.