### PR TITLE
Adding docs for graphql

### DIFF
--- a/docs/docs/code/nodejs/http-requests/README.md
+++ b/docs/docs/code/nodejs/http-requests/README.md
@@ -631,3 +631,76 @@ See [the `axios` docs](https://github.com/axios/axios#request-config) for more d
 When you fetch data from an API, the API may return records in "pages". For example, if you're trying to fetch a list of 1,000 records, the API might return those in groups of 100 items.
 
 Different APIs paginate data in different ways. You'll need to consult the docs of your API provider to see how they suggest you paginate through records.
+
+## Send GraphQL request
+
+Make a GraphQL request using the `graphql-request` NPM package:
+
+```javascript
+import { graphql } from  'graphql'
+import { request, gql } from 'graphql-request'
+
+export default defineComponent({
+  async run({ steps, $ }) {
+    const document = gql`
+      query samplePokeAPIquery {
+        generations: pokemon_v2_generation {
+          name
+          pokemon_species: pokemon_v2_pokemonspecies_aggregate {
+            aggregate {
+              count
+            }
+          }
+        }
+      }
+    `
+    return await request('https://beta.pokeapi.co/graphql/v1beta', document)
+  },
+})
+```
+
+:::tip The graphql package is required
+
+The `graphql` package is required for popular GraphQL clients to function, like `graphql-request` and `urql`. 
+
+Even though you will not need to use the `graphql` code itself in your code step, it's required to import it in order for `graphql-request` to function.
+
+:::
+
+### Send an authenticated GraphQL request
+
+Authenticate your connected accounts in Pipedream with GraphQL requests using the `app` prop:
+
+```javascript
+import { graphql } from  'graphql'
+import { GraphQLClient, gql } from 'graphql-request'
+
+export default defineComponent({
+  props: {
+    github: {
+      type: 'app',
+      app: 'github'
+    }
+  },
+  async run({ steps, $ }) {
+    const me = gql`
+      query { 
+        viewer { 
+          login
+        }
+      }
+    `
+
+    const client = new GraphQLClient('https://api.github.com/graphql', {
+      headers: {
+        authorization: `Bearer ${this.github.$auth.oauth_access_token}`,
+      },
+    })
+
+    return await client.request(me)
+  },
+})
+
+```
+
+Alternatively, you can use Environment Variables as well for simple API key based GraphQL APIs.


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3abf774</samp>

This pull request updates the documentation for the Node.js HTTP Requests code component to include a section on how to send and authenticate GraphQL requests using the `graphql-request` package.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3abf774</samp>

> _`README.md` changed_
> _More examples for GraphQL_
> _Autumn of learning_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3abf774</samp>

* Add a section on GraphQL requests to the documentation ([link](https://github.com/PipedreamHQ/pipedream/pull/7287/files?diff=unified&w=0#diff-5727126ad6da8d08adc0937482d6d975b1425b74a128199db49ab1bba0a2f38fR634-R706))
