### PR TITLE
Adjusting findBadKeys to not match mixed quotes

### DIFF
--- a/scripts/findBadKeys.js
+++ b/scripts/findBadKeys.js
@@ -5,6 +5,11 @@ const path = require("path");
 const rootDir = path.resolve(__dirname, "..");
 const componentsDir = path.join(rootDir, "components");
 
+const REGEXP_COMPONENT_KEY = {
+  regExp: /(?:(?:['"]key['"])|(?:key)): ['"]([^'"]+)/,
+  captureGroup: 1
+};
+
 let err = false;
 
 const isAppFile = ( subname ) =>
@@ -23,9 +28,9 @@ const isTestEventFile = ( subname ) =>
 
 const getComponentKey = ( p )  => {
   const data = fs.readFileSync(p, "utf8");
-  const md = data.match(/['"]?key['"]?: ['"]([^'"]+)/);
-  if (md && md.length > 1)
-    return md[1];
+  const md = data.match(REGEXP_COMPONENT_KEY.regExp);
+  if (md && md.length > REGEXP_COMPONENT_KEY.captureGroup)
+    return md[REGEXP_COMPONENT_KEY.captureGroup];
   return false;
 };
 
@@ -86,10 +91,10 @@ function checkKeys(p, nameSlug) {
     }
     if (name.endsWith(".mjs") || name.endsWith(".js") || name.endsWith(".ts") || name.endsWith(".mts")) {
       const data = fs.readFileSync(pp, "utf8");
-      const md = data.match(/['"]?key['"]?: ['"]([^'"]+)/);
+      const md = data.match(REGEXP_COMPONENT_KEY.regExp);
       if (md) {
-        const key = md[1];
-        if (!key.startsWith(`${nameSlug}-`)) {
+        const key = md[REGEXP_COMPONENT_KEY.captureGroup];
+        if (!key?.startsWith(`${nameSlug}-`)) {
           err = true;
           console.error(`[?] ${pp} [key: ${key}] [nameSlug: ${nameSlug}]`);
         }


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f89407a</samp>

Refactor `findBadKeys.js` script to use constant object for regex and capture group. This simplifies the code and makes it easier to modify and reuse.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f89407a</samp>

> _`findBadKeys` in the dark, searching for the broken parts_
> _No more chaos in the code, `regex` and `group` are the mode_
> _Refactor the script, make it strong, avoid the errors that don't belong_
> _We are the masters of the source, we control the component force_


## WHY

Fixes matching mixed quotes (`key"`, `"key`) when it should only match a JS property (`key` or `"key"`)
Issue reported in #7284 


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f89407a</samp>

*  Refactor the regular expression for extracting the component key from a source file into a constant object `REGEXP_COMPONENT_KEY` to avoid duplication and improve maintainability ([link](https://github.com/PipedreamHQ/pipedream/pull/7290/files?diff=unified&w=0#diff-6a9bbea02b37f1347105af56b9d4fc21258d6e46b1d4065574699865e08a9fbbR8-R12),[link](https://github.com/PipedreamHQ/pipedream/pull/7290/files?diff=unified&w=0#diff-6a9bbea02b37f1347105af56b9d4fc21258d6e46b1d4065574699865e08a9fbbL26-R33),[link](https://github.com/PipedreamHQ/pipedream/pull/7290/files?diff=unified&w=0#diff-6a9bbea02b37f1347105af56b9d4fc21258d6e46b1d4065574699865e08a9fbbL89-R97))
*  Add optional chaining operator to the `key` variable in the `checkKeys` function to handle null or undefined match results and prevent errors ([link](https://github.com/PipedreamHQ/pipedream/pull/7290/files?diff=unified&w=0#diff-6a9bbea02b37f1347105af56b9d4fc21258d6e46b1d4065574699865e08a9fbbL89-R97))
