### PR TITLE
FixZerotierNodeStatusLogic

### DIFF
--- a/components/zerotier/package.json
+++ b/components/zerotier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/zerotier",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Pipedream Zerotier Components",
   "main": "zerotier.app.js",
   "keywords": [

--- a/components/zerotier/sources/common/common.mjs
+++ b/components/zerotier/sources/common/common.mjs
@@ -58,7 +58,9 @@ export default {
 
       this._setNodePrevLastSeen(nodeId, lastSeen);
 
-      if (online != previousStatus) {
+      if (previousStatus == null)
+        this._setNodeStatus(nodeId, online);
+      else if (online != previousStatus) {
         this._setNodeStatus(nodeId, online);
 
         if (online === rightStatus) {

--- a/components/zerotier/sources/common/common.mjs
+++ b/components/zerotier/sources/common/common.mjs
@@ -22,10 +22,16 @@ export default {
   },
   methods: {
     _getNodeStatus(nodeId) {
-      return this.db.get(nodeId);
+      return this.db.get(nodeId + "status");
+    },
+    _getNodePrevLastSeen(nodeId) {
+      return this.db.get(nodeId + "lastSeen");
     },
     _setNodeStatus(nodeId, status) {
-      return this.db.set(nodeId, status);
+      return this.db.set(nodeId + "status", status);
+    },
+    _setNodePrevLastSeen(nodeId, lastSeen) {
+      return this.db.set(nodeId + "lastSeen", lastSeen);
     },
   },
   async run() {
@@ -42,11 +48,15 @@ export default {
         networkId,
       } = node;
       const previousStatus = this._getNodeStatus(nodeId);
+      const previousLastSeen = this._getNodePrevLastSeen(nodeId);
       const rightStatus = this.getRightStatus();
 
-      const online = previousStatus || lastSeen === 0
-        ? lastSeen - 180000 > previousStatus
+      //Will not work for poll periods around 3 minutes or less
+      const online = previousLastSeen || lastSeen === 0
+        ? (lastSeen - 180000 > previousLastSeen)
         : true;
+
+      this._setNodePrevLastSeen(nodeId, lastSeen);
 
       if (online != previousStatus) {
         this._setNodeStatus(nodeId, online);

--- a/components/zerotier/sources/common/common.mjs
+++ b/components/zerotier/sources/common/common.mjs
@@ -22,16 +22,10 @@ export default {
   },
   methods: {
     _getNodeStatus(nodeId) {
-      return this.db.get(nodeId + "status");
-    },
-    _getNodePrevLastSeen(nodeId) {
-      return this.db.get(nodeId + "lastSeen");
+      return this.db.get(nodeId);
     },
     _setNodeStatus(nodeId, status) {
-      return this.db.set(nodeId + "status", status);
-    },
-    _setNodePrevLastSeen(nodeId, lastSeen) {
-      return this.db.set(nodeId + "lastSeen", lastSeen);
+      return this.db.set(nodeId, status);
     },
   },
   async run() {
@@ -48,15 +42,9 @@ export default {
         networkId,
       } = node;
       const previousStatus = this._getNodeStatus(nodeId);
-      const previousLastSeen = this._getNodePrevLastSeen(nodeId);
       const rightStatus = this.getRightStatus();
 
-      //Will not work for poll periods around 3 minutes or less
-      const online = previousLastSeen || lastSeen === 0
-        ? (lastSeen - 180000 > previousLastSeen)
-        : true;
-
-      this._setNodePrevLastSeen(nodeId, lastSeen);
+      const online = !(lastSeen === 0) && ((clock - lastSeen) < 180000);   //lastSeen === 0 means Zerotier reset api to 0 and indicates device has never connected since
 
       if (previousStatus == null)
         this._setNodeStatus(nodeId, online);

--- a/components/zerotier/sources/new-node-join/new-node-join.mjs
+++ b/components/zerotier/sources/new-node-join/new-node-join.mjs
@@ -7,7 +7,7 @@ export default {
   description: "Emit new event when a node joins a network. [See docs here](https://docs.zerotier.com/central/v1/#operation/getNetworkMemberList)",
   type: "source",
   dedupe: "unique",
-  version: "0.0.6",
+  version: "0.0.7",
   async run() {
     const nodes = await this.zerotier.getNetworkNodes({
       networkId: this.networkId,

--- a/components/zerotier/sources/new-node-left/new-node-left.mjs
+++ b/components/zerotier/sources/new-node-left/new-node-left.mjs
@@ -7,7 +7,7 @@ export default {
   description: "Emit new event when a node left a network. [See docs here](https://docs.zerotier.com/central/v1/#operation/getNetworkMemberList)",
   type: "source",
   dedupe: "unique",
-  version: "0.0.6",
+  version: "0.0.7",
   methods: {
     _setNodes(nodes) {
       return this.db.set("nodes", nodes);

--- a/components/zerotier/sources/new-node-offline/new-node-offline.mjs
+++ b/components/zerotier/sources/new-node-offline/new-node-offline.mjs
@@ -7,7 +7,7 @@ export default {
   description: "Emit new event for each offline node. [See docs here](https://docs.zerotier.com/central/v1/#operation/getNetworkMemberList)",
   type: "source",
   dedupe: "unique",
-  version: "0.0.7",
+  version: "0.0.8",
   methods: {
     ...common.methods,
     getRightStatus() {

--- a/components/zerotier/sources/new-node-online/new-node-online.mjs
+++ b/components/zerotier/sources/new-node-online/new-node-online.mjs
@@ -7,7 +7,7 @@ export default {
   description: "Emit new event for each online node. [See docs here](https://docs.zerotier.com/central/v1/#operation/getNetworkMemberList)",
   type: "source",
   dedupe: "unique",
-  version: "0.0.7",
+  version: "0.0.8",
   methods: {
     ...common.methods,
     getRightStatus() {


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 71cfe85</samp>

Fix `zerotier` source bug with node status. Use node last seen timestamp from database instead of API response.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 71cfe85</samp>

> _Sing, O Muse, of the valiant coder who fixed the `zerotier` bug_
> _That plagued the network of many a peer, and made their status vague_
> _He wisely stored the last seen time of each node in the `db`_
> _And thus he showed their true online or offline state with accuracy_


## WHY

Existing logic doesnt work, status is stored as boolean but compared as if it was milliseconds since epoch


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 71cfe85</samp>

* Fix online/offline status of nodes by storing and using last seen timestamp ([link](https://github.com/PipedreamHQ/pipedream/pull/7295/files?diff=unified&w=0#diff-fae016a9ac10811352dc439cc2f5fa04046d6f71321fecf2fc13ce49d4e1edc9L25-R35), [link](https://github.com/PipedreamHQ/pipedream/pull/7295/files?diff=unified&w=0#diff-fae016a9ac10811352dc439cc2f5fa04046d6f71321fecf2fc13ce49d4e1edc9L45-R60))
