### PR TITLE
Release event history docs

### DIFF
--- a/docs/docs/event-history/README.md
+++ b/docs/docs/event-history/README.md
@@ -4,7 +4,11 @@ Monitor all workflow events and their stack traces in one centralized view under
 
 Within the **Event History**, you'll be able to filter your events by workflow, execution status, within a specific time range.
 
-This includes events in progress for real-time visibility into the health of your workflows.
+::: tip This feature is in beta
+
+Event histories are currently in **beta** with a limited number of events to start.
+
+:::
 
 [[toc]]
 
@@ -26,13 +30,15 @@ If you're not seeing the events or workflow you're expecting, try [switching wor
 
 ### Filtering by status
 
-The **Status** filter controls which events are shown by their status. For example selecting the **Executing** status, you'll be shown all events that are currently being processed by your workflows.
+The **Status** filter controls which events are shown by their status. For example selecting the **Success** status, you'll be shown all events that were successfully executed by workflows.
 
-![Only showing workflow events that are currently being executed](https://res.cloudinary.com/pipedreamin/image/upload/v1683748216/docs/docs/event%20histories/CleanShot_2023-05-10_at_15.50.05_2x_yroowb.png)
+![Only showing workflow events by current execution status](https://res.cloudinary.com/pipedreamin/image/upload/v1689875438/docs/docs/event%20histories/CleanShot_2023-07-20_at_13.49.43_2x_e0mggw.png)
 
 #### All paused workflow executions
 
 Workflows that are paused from `$.flow.delay` or `$.flow.suspend` will be shown when this filter is activated.
+
+![Only showing workflows that are currently paused](https://res.cloudinary.com/pipedreamin/image/upload/v1689875506/docs/docs/event%20histories/CleanShot_2023-07-20_at_13.51.11_2x_kn2dpw.png)
 
 ::: warning
 
@@ -48,7 +54,7 @@ This will only display the failed workflow executions in the selected time perio
 
 This view in particular is helpful for identifying trends of errors, or workflows with persistent problems.
 
-![Viewing all failed workflow executions by the filter in the Event History](https://res.cloudinary.com/pipedreamin/image/upload/v1683747364/docs/docs/event%20histories/CleanShot_2023-05-10_at_15.35.34_2x_pbooqv.png)
+![Viewing all failed workflow executions by the filter in the Event History](https://res.cloudinary.com/pipedreamin/image/upload/v1689875455/docs/docs/event%20histories/CleanShot_2023-07-20_at_13.49.49_2x_fdl2ui.png)
 
 
 ### Within a time frame

--- a/docs/docs/event-history/README.md
+++ b/docs/docs/event-history/README.md
@@ -16,7 +16,7 @@ Event histories are currently in **beta** with a limited number of events to sta
 
 The filters at the top of the screen allow you to search all events processed by your workflows:
 
-![Filtering all events in a workspace by its status, when it was executed or by workflow ID](https://res.cloudinary.com/pipedreamin/image/upload/v1683747287/docs/docs/event%20histories/CleanShot_2023-05-10_at_15.34.00_2x_voaos3.png)
+![Filtering all events in a workspace by its status, when it was executed or by workflow ID](https://res.cloudinary.com/pipedreamin/image/upload/v1689875830/docs/docs/event%20histories/image_44_g2sabg.png)
 
 You can filter by the event's **Status**, **time of initiation** or by the **Workflow name**.
 

--- a/docs/docs/event-history/README.md
+++ b/docs/docs/event-history/README.md
@@ -6,12 +6,6 @@ Within the **Event History**, you'll be able to filter your events by workflow, 
 
 This includes events in progress for real-time visibility into the health of your workflows.
 
-::: tip This feature is in beta
-
-Event histories are currently in **beta** with a limited number of events to start.
-
-:::
-
 [[toc]]
 
 ## Filtering Events

--- a/docs/docs/event-history/README.md
+++ b/docs/docs/event-history/README.md
@@ -14,9 +14,7 @@ Event histories are currently in **beta** with a limited number of events to sta
 
 ## Filtering Events
 
-The filters at the top of the screen allow you to search all events processed by your workflows:
-
-![Filtering all events in a workspace by its status, when it was executed or by workflow ID](https://res.cloudinary.com/pipedreamin/image/upload/v1689875830/docs/docs/event%20histories/image_44_g2sabg.png)
+The filters at the top of the screen allow you to search all events processed by your workflows.
 
 You can filter by the event's **Status**, **time of initiation** or by the **Workflow name**.
 
@@ -32,7 +30,17 @@ If you're not seeing the events or workflow you're expecting, try [switching wor
 
 The **Status** filter controls which events are shown by their status. For example selecting the **Success** status, you'll be shown all events that were successfully executed by workflows.
 
-![Only showing workflow events by current execution status](https://res.cloudinary.com/pipedreamin/image/upload/v1689875438/docs/docs/event%20histories/CleanShot_2023-07-20_at_13.49.43_2x_e0mggw.png)
+![Only showing workflow events by current execution status](https://res.cloudinary.com/pipedreamin/image/upload/v1689875830/docs/docs/event%20histories/image_44_g2sabg.png)
+
+#### All failed workflow executions
+
+You can view all failed workflow executions by applying the **Error** status filter.
+
+This will only display the failed workflow executions in the selected time period.
+
+This view in particular is helpful for identifying trends of errors, or workflows with persistent problems.
+
+![Viewing all failed workflow executions by the filter in the Event History](https://res.cloudinary.com/pipedreamin/image/upload/v1689876111/docs/docs/event%20histories/CleanShot_2023-07-20_at_14.01.43_2x_nksdxd.png)
 
 #### All paused workflow executions
 
@@ -45,17 +53,6 @@ Workflows that are paused from `$.flow.delay` or `$.flow.suspend` will be shown 
 If you're using `setTimeout` or `sleep` in Node.js or Python steps, the event will not be considered **Paused**. Using those language native execution holding controls leaves your workflow in a **Executing** state.
 
 :::
-
-#### All failed workflow executions
-
-You can view all failed workflow executions by applying the **Error** status filter.
-
-This will only display the failed workflow executions in the selected time period.
-
-This view in particular is helpful for identifying trends of errors, or workflows with persistent problems.
-
-![Viewing all failed workflow executions by the filter in the Event History](https://res.cloudinary.com/pipedreamin/image/upload/v1689875455/docs/docs/event%20histories/CleanShot_2023-07-20_at_13.49.49_2x_fdl2ui.png)
-
 
 ### Within a time frame
 

--- a/docs/docs/event-history/README.md
+++ b/docs/docs/event-history/README.md
@@ -105,12 +105,6 @@ You'll need to replay an event to execute the workflow with the latest changes.
 
 ## Limits
 
-::: tip Beta access
-
-During the beta, all accounts have access to view the past 7 days of events across all of their workflows. This limit increases as this trial continues.
-
-:::
-
 The number of events recorded and available for viewing in the Event History depends on your plan. [Please see the pricing page](https://pipedream.com/pricing) for more details.
 
 ## Frequently asked questions

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2899,6 +2899,9 @@ importers:
     dependencies:
       '@pipedream/platform': 1.5.1
 
+  components/motion:
+    specifiers: {}
+
   components/mozilla_observatory:
     specifiers: {}
 


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bf197c7</samp>

Removed beta access tip from `Limits` section of event history docs. Updated docs to match current feature status and account plan limits.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bf197c7</samp>

> _`event history`_
> _no longer in beta mode_
> _limits change with plan_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bf197c7</samp>

* Removed the beta access tip from the event history limits section ([link](https://github.com/PipedreamHQ/pipedream/pull/7300/files?diff=unified&w=0#diff-3a56f0ca10dbde89b2ba2556e7ee63c7fc2f8639462e292882e57e21df9ea4baL108-L113))
