### PR TITLE
Fix discord bot trigger without dedupe

### DIFF
--- a/components/discord_bot/constants.mjs
+++ b/components/discord_bot/constants.mjs
@@ -1,5 +1,6 @@
 const LAST_MESSAGE_IDS = "lastMessageIDs";
 const GUILD_MEMBER_IDS = "guildMemberIDs";
+const LAST_MEMBER_ID = "lastMemberID";
 const DEFAULT_MAX_ITEMS = 60;
 const DEFAULT_PAGE_LIMIT = 20;
 const PAGINATION_KEY = {
@@ -65,6 +66,7 @@ const NOT_ALLOWED_CHANNELS = [
 export default {
   LAST_MESSAGE_IDS,
   GUILD_MEMBER_IDS,
+  LAST_MEMBER_ID,
   PERMISSION_TYPES,
   CHANNEL_TYPES,
   NOT_ALLOWED_CHANNELS,

--- a/components/discord_bot/sources/common.mjs
+++ b/components/discord_bot/sources/common.mjs
@@ -11,12 +11,6 @@ export default {
     _setLastMessageIDs(lastMessageIDs) {
       this.db.set(constants.LAST_MESSAGE_IDS, lastMessageIDs);
     },
-    _getGuildMemberIDs() {
-      return this.db.get(constants.GUILD_MEMBER_IDS) ?? {};
-    },
-    _setGuildMemberIDs(memberIDs) {
-      this.db.set(constants.GUILD_MEMBER_IDS, memberIDs);
-    },
     _getLastMemberID() {
       return this.db.get(constants.LAST_MEMBER_ID);
     },

--- a/components/discord_bot/sources/common.mjs
+++ b/components/discord_bot/sources/common.mjs
@@ -17,5 +17,11 @@ export default {
     _setGuildMemberIDs(memberIDs) {
       this.db.set(constants.GUILD_MEMBER_IDS, memberIDs);
     },
+    _getLastMemberID() {
+      return this.db.get(constants.LAST_MEMBER_ID);
+    },
+    _setLastMemberID(memberID) {
+      this.db.set(constants.LAST_MEMBER_ID, memberID);
+    },
   },
 };

--- a/components/discord_bot/sources/new-guild-member/new-guild-member.mjs
+++ b/components/discord_bot/sources/new-guild-member/new-guild-member.mjs
@@ -8,7 +8,7 @@ export default {
   description: "Emit new event for every member added to a guild. [See docs here](https://discord.com/developers/docs/resources/guild#list-guild-members)",
   type: "source",
   dedupe: "unique",
-  version: "0.0.11",
+  version: "0.1.0",
   props: {
     ...common.props,
     db: "$.service.db",
@@ -19,11 +19,7 @@ export default {
       },
     },
   },
-  methods: {
-    ...common.methods,
-  },
   async run({ $ }) {
-    const guildMembers = this._getGuildMemberIDs();
     const { guildId } = this;
     const params = {
       limit: 100,
@@ -47,22 +43,17 @@ export default {
           joined_at: joinedAt,
         } = member;
 
-        if (!(user.id in guildMembers)) {
-          guildMembers[user.id] = true;
-          params.after = user.id;
+        params.after = user.id;
+        if (user.bot) continue;
 
-          if (user.bot) continue;
-
-          this.$emit(member, {
-            summary: `New member: ${user.username}`,
-            id: user.id,
-            ts: Date.parse(joinedAt),
-          });
-        }
+        this.$emit(member, {
+          summary: `New member: ${user.username}`,
+          id: user.id,
+          ts: Date.parse(joinedAt),
+        });
       }
 
       this._setLastMemberID(params.after);
-      this._setGuildMemberIDs(guildMembers);
     }
   },
 };


### PR DESCRIPTION
**Discord Bot - New Guild Member** trigger did not have deduping in place, and was infinitely looping on requests / emits.

Fixes:
  - properly dedupes emitted events

Improvements:
  - save only `lastMemberID` emitted instead of all member IDs
  - in each new run, begin fetching members using the `lastMemberID`

Bug reported by a customer

## WHAT

copilot:summary

copilot:poem


## WHY

<!-- author to complete -->


## HOW

copilot:walkthrough
