### PR TITLE
Adding Sample Test Event for gmail_custom_oauth-new-email-received

### DIFF
--- a/components/gmail_custom_oauth/sources/new-email-received/new-email-received.mjs
+++ b/components/gmail_custom_oauth/sources/new-email-received/new-email-received.mjs
@@ -1,11 +1,12 @@
 import common from "../common/polling.mjs";
+import sampleEmit from "./test-event.mjs";
 
 export default {
   ...common,
   key: "gmail_custom_oauth-new-email-received",
   name: "New Email Received",
   description: "Emit new event when an email is received. This source is capped at 100 max new messages per run.",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "source",
   dedupe: "unique",
   methods: {
@@ -63,4 +64,5 @@ export default {
       this.emitEvents(messages);
     },
   },
+  sampleEmit,
 };


### PR DESCRIPTION
Adding Sample Test Event for gmail_custom_oauth-new-email-received

Created via Pipedream