### PR TITLE
[Action] Google Tag Manager - Updates a GTM Variable #5050

### DIFF
--- a/components/google_tag_manager/actions/create-tag/create-tag.mjs
+++ b/components/google_tag_manager/actions/create-tag/create-tag.mjs
@@ -2,7 +2,7 @@ import app from "../../google_tag_manager.app.mjs";
 
 export default {
   name: "Create Tag",
-  version: "0.0.1",
+  version: "0.0.2",
   key: "google_tag_manager-create-tag",
   description: "Create a tag in a workspace. [See the documentation](https://developers.google.com/tag-platform/tag-manager/api/v2/reference/accounts/containers/workspaces/tags/create)",
   type: "action",
@@ -107,7 +107,7 @@ export default {
     });
 
     if (response) {
-      $.export("$summary", `Successfully create tag with ID ${response.tagId}`);
+      $.export("$summary", `Successfully created tag with ID ${response.tagId}`);
     }
 
     return response;

--- a/components/google_tag_manager/actions/get-tag/get-tag.mjs
+++ b/components/google_tag_manager/actions/get-tag/get-tag.mjs
@@ -2,7 +2,7 @@ import app from "../../google_tag_manager.app.mjs";
 
 export default {
   name: "Get Tag",
-  version: "0.0.1",
+  version: "0.0.2",
   key: "google_tag_manager-get-tag",
   description: "Get a specific tag of a workspace. [See the documentation](https://developers.google.com/tag-platform/tag-manager/api/v2/reference/accounts/containers/workspaces/tags/get)",
   type: "action",

--- a/components/google_tag_manager/actions/get-tags/get-tags.mjs
+++ b/components/google_tag_manager/actions/get-tags/get-tags.mjs
@@ -2,7 +2,7 @@ import app from "../../google_tag_manager.app.mjs";
 
 export default {
   name: "Get Tags",
-  version: "0.0.1",
+  version: "0.0.2",
   key: "google_tag_manager-get-tags",
   description: "Get all tags of an workspace. [See the documentation](https://developers.google.com/tag-platform/tag-manager/api/v2/reference/accounts/containers/workspaces/tags/list)",
   type: "action",

--- a/components/google_tag_manager/actions/update-variable/update-variable.mjs
+++ b/components/google_tag_manager/actions/update-variable/update-variable.mjs
@@ -2,9 +2,9 @@ import app from "../../google_tag_manager.app.mjs";
 
 export default {
   name: "Update Tag",
-  version: "0.0.2",
-  key: "google_tag_manager-update-tag",
-  description: "Update a tag in a workspace. [See the documentation](https://developers.google.com/tag-platform/tag-manager/api/v2/reference/accounts/containers/workspaces/tags/update)",
+  version: "0.0.1",
+  key: "google_tag_manager-update-variable",
+  description: "Update a variable in a workspace. [See the documentation](https://developers.google.com/tag-platform/tag-manager/api/v2/reference/accounts/containers/workspaces/variables/update)",
   type: "action",
   props: {
     app,
@@ -36,11 +36,11 @@ export default {
         }),
       ],
     },
-    tagId: {
+    variableId: {
       optional: false,
       propDefinition: [
         app,
-        "tagId",
+        "variableId",
         (c) => ({
           accountId: c.accountId,
           containerId: c.containerId,
@@ -53,75 +53,60 @@ export default {
         app,
         "name",
       ],
-      optional: true,
+      description: "The name of the variable",
+      optional: false,
     },
     type: {
       propDefinition: [
         app,
         "type",
       ],
-    },
-    liveOnly: {
-      propDefinition: [
-        app,
-        "liveOnly",
-      ],
-    },
-    notes: {
-      propDefinition: [
-        app,
-        "notes",
-      ],
+      description: "The type of the variable. E.g. `jsm`",
+      optional: false,
     },
     parameter: {
       propDefinition: [
         app,
         "parameter",
       ],
+      description: "The list of parameters for the variable",
+      optional: false,
     },
-    consentSettings: {
-      propDefinition: [
-        app,
-        "consentSettings",
-      ],
-    },
-    monitoringMetadata: {
-      propDefinition: [
-        app,
-        "monitoringMetadata",
-      ],
+    formatValue: {
+      label: "Format Value",
+      type: "string",
+      description: "The formatValue object for the variable",
+      optional: true,
     },
   },
   async run({ $ }) {
     const parameter = typeof this.parameter === "string"
       ? JSON.parse(this.parameter)
       : this.parameter;
-    const consentSettings = typeof this.consentSettings === "string"
-      ? JSON.parse(this.consentSettings)
-      : this.consentSettings;
-    const monitoringMetadata = typeof this.monitoringMetadata === "string"
-      ? JSON.parse(this.monitoringMetadata)
-      : this.monitoringMetadata;
 
-    const response = await this.app.updateTag({
+    const formatValue = typeof this.formatValue === "string"
+      ? JSON.parse(this.formatValue)
+      : this.formatValue;
+
+    const response = await this.app.updateVariable({
       $,
       accountId: this.accountId,
       containerId: this.containerId,
       workspaceId: this.workspaceId,
-      tagId: this.tagId,
+      variableId: this.variableId,
       data: {
         name: this.name,
         type: this.type,
-        liveOnly: this.liveOnly,
-        notes: this.notes,
         parameter,
-        consentSettings,
-        monitoringMetadata,
+        formatValue,
+        vendorTemplate: {
+          key: {},
+        },
       },
     });
 
     if (response) {
-      $.export("$summary", `Successfully updated tag with ID ${response.tagId}`);
+      $.export("$summary", `Successfully updated variable with ID ${response.variableId}`);
     }
 
     return response;

--- a/components/google_tag_manager/google_tag_manager.app.mjs
+++ b/components/google_tag_manager/google_tag_manager.app.mjs
@@ -27,9 +27,9 @@ export default {
           accountId,
         });
 
-        return containers.map((account) => ({
-          label: account.name,
-          value: account.containerId,
+        return containers.map((container) => ({
+          label: container.name,
+          value: container.containerId,
         }));
       },
     },
@@ -45,9 +45,9 @@ export default {
           containerId,
         });
 
-        return workspaces.map((account) => ({
-          label: account.name,
-          value: account.workspaceId,
+        return workspaces.map((workspace) => ({
+          label: workspace.name,
+          value: workspace.workspaceId,
         }));
       },
     },
@@ -64,9 +64,30 @@ export default {
           workspaceId,
         });
 
-        return tags.map((account) => ({
-          label: account.name,
-          value: account.tagId,
+        return tags.map((tag) => ({
+          label: tag.name,
+          value: tag.tagId,
+        }));
+      },
+    },
+    variableId: {
+      label: "Variable ID",
+      description: "The variable ID",
+      type: "string",
+      async options({
+        accountId, containerId, workspaceId,
+      }) {
+        const { variable: variables } = await this.getVariables({
+          accountId,
+          containerId,
+          workspaceId,
+        });
+
+        if (!variables) return [];
+
+        return variables.map((variable) => ({
+          label: variable.name,
+          value: variable.variableId,
         }));
       },
     },
@@ -191,6 +212,23 @@ export default {
     }) {
       return this._makeRequest({
         path: `/accounts/${accountId}/containers/${containerId}/workspaces/${workspaceId}/tags/${tagId}`,
+        method: "put",
+        ...args,
+      });
+    },
+    async getVariables({
+      accountId, containerId, workspaceId, ...args
+    }) {
+      return this._makeRequest({
+        path: `/accounts/${accountId}/containers/${containerId}/workspaces/${workspaceId}/variables`,
+        ...args,
+      });
+    },
+    async updateVariable({
+      accountId, containerId, workspaceId, variableId, ...args
+    }) {
+      return this._makeRequest({
+        path: `/accounts/${accountId}/containers/${containerId}/workspaces/${workspaceId}/variables/${variableId}`,
         method: "put",
         ...args,
       });

--- a/components/google_tag_manager/package.json
+++ b/components/google_tag_manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_tag_manager",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "Pipedream Google Tag Manager Components",
   "keywords": [
     "pipedream",


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 808bf9c</samp>

This pull request updates and adds actions for the `google_tag_manager` component. It fixes some typos and summary messages, increments the version numbers of the actions and the component, and introduces a new action to update a variable using the API. The pull request also improves the variable names and prop options for the `google_tag_manager` app.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 808bf9c</samp>

> _Oh we're the crew of the `google_tag_manager` app_
> _We update our actions with a snap_
> _We add new features to the component_
> _And we keep our versions consistent_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 808bf9c</samp>

*  Added `update-variable` action to allow updating a variable in a workspace ([link](https://github.com/PipedreamHQ/pipedream/pull/7374/files?diff=unified&w=0#diff-b01fb53c410a3d9891638186e0c23b67c6dd17a24e7d957efa4ff2c69bcea4eaR1-R114), [link](https://github.com/PipedreamHQ/pipedream/pull/7374/files?diff=unified&w=0#diff-c32ef95d71b8854bc90d0c8a02354371d2ba6fdff4aa66f8cc7d57d070df7cdeL67-R93), [link](https://github.com/PipedreamHQ/pipedream/pull/7374/files?diff=unified&w=0#diff-c32ef95d71b8854bc90d0c8a02354371d2ba6fdff4aa66f8cc7d57d070df7cdeR219-R235))
*  Fixed summary messages of `create-tag` and `update-tag` actions to use past tense verbs ([link](https://github.com/PipedreamHQ/pipedream/pull/7374/files?diff=unified&w=0#diff-880ab6cd72f1408a09bcd83ac16a63d11be317f0cc0bc697de15a9e325f8cec5L110-R110), [link](https://github.com/PipedreamHQ/pipedream/pull/7374/files?diff=unified&w=0#diff-fb008470a72036620c521df700f24e5034106b263954a36067ade22b1a1f49cbL124-R124))
*  Updated versions of actions and component to reflect changes and keep consistency ([link](https://github.com/PipedreamHQ/pipedream/pull/7374/files?diff=unified&w=0#diff-880ab6cd72f1408a09bcd83ac16a63d11be317f0cc0bc697de15a9e325f8cec5L5-R5), [link](https://github.com/PipedreamHQ/pipedream/pull/7374/files?diff=unified&w=0#diff-454597e2c43da43590e0641ad85e2a8b928350d23250d86c18633632405f2017L5-R5), [link](https://github.com/PipedreamHQ/pipedream/pull/7374/files?diff=unified&w=0#diff-7dedef36c86616ef9a93c52d97d3ed4fbe90c0f056d4fbc5342d6afa82ba60b9L5-R5), [link](https://github.com/PipedreamHQ/pipedream/pull/7374/files?diff=unified&w=0#diff-fb008470a72036620c521df700f24e5034106b263954a36067ade22b1a1f49cbL5-R5), [link](https://github.com/PipedreamHQ/pipedream/pull/7374/files?diff=unified&w=0#diff-a0c0ed9221b3c6ef2ee153221491bbc3fe5bbf2e077776f7f43b5a46f3f64534L3-R3))
*  Changed variable names in `containerId`, `workspaceId`, and `tagId` props to match API response and avoid confusion ([link](https://github.com/PipedreamHQ/pipedream/pull/7374/files?diff=unified&w=0#diff-c32ef95d71b8854bc90d0c8a02354371d2ba6fdff4aa66f8cc7d57d070df7cdeL30-R32), [link](https://github.com/PipedreamHQ/pipedream/pull/7374/files?diff=unified&w=0#diff-c32ef95d71b8854bc90d0c8a02354371d2ba6fdff4aa66f8cc7d57d070df7cdeL48-R50), [link](https://github.com/PipedreamHQ/pipedream/pull/7374/files?diff=unified&w=0#diff-c32ef95d71b8854bc90d0c8a02354371d2ba6fdff4aa66f8cc7d57d070df7cdeL67-R93))
