### PR TITLE
[BUG] SendGrid - BCC handling not optimal #7375

### DIFF
--- a/components/sendgrid/actions/send-email-single-recipient/send-email-single-recipient.mjs
+++ b/components/sendgrid/actions/send-email-single-recipient/send-email-single-recipient.mjs
@@ -6,7 +6,7 @@ export default {
   key: "sendgrid-send-email-single-recipient",
   name: "Send Email Single Recipient",
   description: "This action sends a personalized e-mail to the specified recipient. [See the docs here](https://docs.sendgrid.com/api-reference/mail-send/mail-send)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   props: {
     ...common.props,
@@ -255,10 +255,18 @@ export default {
       personalizations[0].to[0].name = this.toName;
     }
     if (this.cc) {
-      personalizations[0].cc = this.getArrayObject(this.cc);
+      const ccArray = this.getArrayObject(this.cc);
+
+      if (ccArray?.length) {
+        personalizations[0].cc = ccArray;
+      }
     }
     if (this.bcc) {
-      personalizations[0].bcc = this.getArrayObject(this.bcc);
+      const bccArray = this.getArrayObject(this.bcc);
+
+      if (bccArray?.length) {
+        personalizations[0].bcc = bccArray;
+      }
     }
     if (this.personalizationHeaders) {
       personalizations[0].headers = this.convertEmptyStringToUndefined(this.personalizationHeaders);

--- a/components/sendgrid/package.json
+++ b/components/sendgrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/sendgrid",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "Pipedream Sendgrid Components",
   "main": "sendgrid.app.js",
   "keywords": [


### PR DESCRIPTION
@vunguyenhung I can't reproduce this bug, so any problem with the tests send me a message. Thanks!

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8b5e31e</samp>

This pull request improves the `send-email-single-recipient` action of the `sendgrid` component by allowing cc and bcc fields and updates the component version in `package.json`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8b5e31e</samp>

> _Oh, we're the crew of the `SendGrid` ship_
> _And we sail the internet sea_
> _We've updated our action to send an email_
> _With a better `cc` and `bcc`_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8b5e31e</samp>

*  Increment package version to 0.3.10 to reflect action changes ([link](https://github.com/PipedreamHQ/pipedream/pull/7380/files?diff=unified&w=0#diff-55f3b49bf606b24b7c01417fa70d8612623dbf62340f9bcd068f3891c28d87f7L3-R3))
*  Increment action version to 0.0.6 to reflect new functionality and bug fixes ([link](https://github.com/PipedreamHQ/pipedream/pull/7380/files?diff=unified&w=0#diff-8edbea0b8aaf219645609aec78f325c63a82e70d0c6fc19f8b341e85956f1093L9-R9))
*  Improve logic for adding cc and bcc fields to personalizations object in `send-email-single-recipient.mjs` to prevent empty fields and API errors ([link](https://github.com/PipedreamHQ/pipedream/pull/7380/files?diff=unified&w=0#diff-8edbea0b8aaf219645609aec78f325c63a82e70d0c6fc19f8b341e85956f1093L258-R269))
