### PR TITLE
Spotify Get Album's Tracks

### DIFF
--- a/components/spotify/actions/get-album-tracks/get-album-tracks.mjs
+++ b/components/spotify/actions/get-album-tracks/get-album-tracks.mjs
@@ -1,0 +1,63 @@
+import { axios } from "@pipedream/platform";
+import spotify from "../../spotify.app.mjs";
+import { ITEM_TYPES } from "../../consts.mjs";
+const DEFAULT_LIMIT = 20;
+
+export default {
+  name: "Get Album Tracks",
+  description: "Get all tracks in an album. [See the docs here](https://developer.spotify.com/documentation/web-api/reference/get-an-albums-tracks)",
+  key: "spotify-get-album-tracks",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    spotify,
+    albumId: {
+      type: "string",
+      label: "Album ID",
+      description: "Type to search for any album on Spotify or enter a custom expression to specify an album's [Spotify ID](https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids) (for example, `43ZHCT0cAZBISjO8DG9PnE`).",
+      useQuery: true,
+      async options({
+        query,
+        page,
+      }) {
+        const limit = DEFAULT_LIMIT;
+        const albums = await this.spotify.getItems(
+          ITEM_TYPES.ALBUM,
+          query,
+          limit,
+          limit * page,
+        );
+        return {
+          options: albums.map((album) => ({
+            label: album.name,
+            value: album.id,
+          })),
+        };
+      },
+    },
+  },
+  async run({ $ }) {
+    const params = {
+      limit: DEFAULT_LIMIT,
+      offset: 0,
+    };
+    const tracks = [];
+    let total = 0;
+
+    do {
+      const { items } = await axios($, this.spotify._getAxiosParams({
+        path: `/albums/${this.albumId}/tracks`,
+        params,
+      }));
+      tracks.push(...items);
+      total = items.length;
+      params.offset += params.limit;
+    } while (total === params.limit);
+
+    $.export("$summary", `Successfully retrieved ${tracks.length} track${tracks.length === 1
+      ? ""
+      : "s"}.`);
+
+    return tracks;
+  },
+};

--- a/components/spotify/package.json
+++ b/components/spotify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/spotify",
-  "version": "0.5.0",
+  "version": "0.7.0",
   "description": "Pipedream Spotify Components",
   "main": "spotify.app.js",
   "keywords": [


### PR DESCRIPTION
Resolves #7193 
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0e5b7a1</samp>

Added a new Spotify action component to get album tracks using the Spotify API. Bumped the Spotify app version and updated the pnpm-lock.yaml file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0e5b7a1</samp>

> _Spotify app grows_
> _`getAlbumTracks` action_
> _Autumn of music_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0e5b7a1</samp>

*  Add new action component to get album tracks from Spotify API (`components/spotify/actions/get-album-tracks/get-album-tracks.mjs`, [link](https://github.com/PipedreamHQ/pipedream/pull/7386/files?diff=unified&w=0#diff-e5b8f533cb3342a0115dbd401310e2161708b16512551ace3c50b68a6bc24b40R1-R63))
*  Bump Spotify app version number to 0.7.0 (`components/spotify/package.json`, [link](https://github.com/PipedreamHQ/pipedream/pull/7386/files?diff=unified&w=0#diff-408877985c192bb8d947207ab5b0558447911abd1d98fd13cf387330bb6b61d2L3-R3))
*  Update pnpm-lock.yaml file with latest dependencies (`pnpm-lock.yaml`, [link](https://github.com/PipedreamHQ/pipedream/pull/7386/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1900-R1902))
