### PR TITLE
GitHub source bugfix

### DIFF
--- a/components/github/package.json
+++ b/components/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/github",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "description": "Pipedream Github Components",
   "main": "github.app.mjs",
   "keywords": [

--- a/components/github/sources/new-card-in-column/new-card-in-column.mjs
+++ b/components/github/sources/new-card-in-column/new-card-in-column.mjs
@@ -6,7 +6,7 @@ export default {
   key: "github-new-card-in-column",
   name: "New Card in Column (Classic Projects)",
   description: "Emit new event when a (classic) project card is created or moved to a specific column. For Projects V2 use `New Issue with Status` trigger. [More information here](https://docs.github.com/en/issues/organizing-your-work-with-project-boards/tracking-work-with-project-boards/adding-issues-and-pull-requests-to-a-project-board)",
-  version: "0.1.9",
+  version: "0.1.10",
   type: "source",
   props: {
     ...common.props,
@@ -93,6 +93,6 @@ export default {
       return;
     }
 
-    this.processCard(card);
+    await this.processCard(card);
   },
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5612,6 +5612,12 @@ importers:
     dependencies:
       '@pipedream/platform': 1.5.1
 
+  components/zoho_analytics:
+    specifiers: {}
+
+  components/zoho_catalyst:
+    specifiers: {}
+
   components/zoho_cliq:
     specifiers: {}
 
@@ -5665,6 +5671,9 @@ importers:
     specifiers: {}
 
   components/zoho_sheet:
+    specifiers: {}
+
+  components/zoho_sign:
     specifiers: {}
 
   components/zonka_feedback:


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2eb30bb</samp>

Added new components for Zoho services and improved the `new-card-in-column` component for GitHub. The `@pipedream/github` package and the `pnpm-lock.yaml` file were updated accordingly.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2eb30bb</samp>

> _A pull request for Pipedream_
> _Made some components more supreme_
> _With async and await_
> _And Zoho to integrate_
> _And a package version update scheme_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2eb30bb</samp>

*  Incremented version of `@pipedream/github` package and `new-card-in-column` source component to reflect changes in `run` method ([link](https://github.com/PipedreamHQ/pipedream/pull/7401/files?diff=unified&w=0#diff-9392f0832806d96b3c68e6b780a8020d17efaec7cfeeb2803895eafc81e460ecL3-R3), [link](https://github.com/PipedreamHQ/pipedream/pull/7401/files?diff=unified&w=0#diff-cdff6ff38779c323a537b73bc9ca29bbea467e2b0c3c92b14038fe43a3e8bf07L9-R9))
*  Added `await` to `run` method of `new-card-in-column` source component to ensure proper async handling of `processCard` method ([link](https://github.com/PipedreamHQ/pipedream/pull/7401/files?diff=unified&w=0#diff-cdff6ff38779c323a537b73bc9ca29bbea467e2b0c3c92b14038fe43a3e8bf07L96-R96))
*  Updated `pnpm-lock.yaml` file to include specifiers for new `zoho_analytics`, `zoho_catalyst`, and `zoho_sign` components ([link](https://github.com/PipedreamHQ/pipedream/pull/7401/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5615-R5620), [link](https://github.com/PipedreamHQ/pipedream/pull/7401/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5676-R5678))
