### PR TITLE
adding azure openai to premium apps

### DIFF
--- a/docs/docs/apps/README.md
+++ b/docs/docs/apps/README.md
@@ -14,6 +14,7 @@ The vast majority of integrated apps on Pipedream are free to use in your workfl
 
 - [ActiveCampaign](https://pipedream.com/apps/activecampaign)
 - [Asana](https://pipedream.com/apps/asana)
+- [Azure OpenAI Service]([https://pipedream.com/apps/](https://pipedream.com/apps/azure-openai-service))
 - [Close](https://pipedream.com/apps/close)
 - [ERPNext](https://pipedream.com/apps/erpnext)
 - [HubSpot](https://pipedream.com/apps/hubspot)


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 88c5d2a</samp>

Added the Azure OpenAI Service app to the list of premium apps in `docs/docs/apps/README.md`. The app enables users to interact with the Azure OpenAI service from Pipedream workflows.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 88c5d2a</samp>

> _`Azure OpenAI` app_
> _Premium feature for text tasks_
> _Winter of AI_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 88c5d2a</samp>

* Add Azure OpenAI Service app to the list of premium apps ([link](https://github.com/PipedreamHQ/pipedream/pull/7451/files?diff=unified&w=0#diff-4e833c92f7690266d283ff316f5d3b4b6bbc69120b1f0f74b5ed9f3874c242a7R17))
