### PR TITLE
Adding Sample Test Event for tally-new-response

### DIFF
--- a/components/tally/sources/new-response/new-response.mjs
+++ b/components/tally/sources/new-response/new-response.mjs
@@ -1,9 +1,10 @@
 import common from "../common/common.mjs";
+import sampleEmit from "./test-event.mjs";
 
 export default {
   ...common,
   name: "New Response",
-  version: "0.0.1",
+  version: "0.0.2",
   key: "tally-new-response",
   description: "Emit new event on each form message. [See docs here](https://tallyso.notion.site/Tally-OAuth-2-reference-d0442c679a464664823628f675f43454)",
   type: "source",
@@ -25,4 +26,5 @@ export default {
       });
     },
   },
+  sampleEmit,
 };


### PR DESCRIPTION
Adding Sample Test Event for tally-new-response

Created via Pipedream