### PR TITLE
Adding Sample Test Event for gmail_custom_oauth-new-labeled-email

### DIFF
--- a/components/gmail_custom_oauth/package.json
+++ b/components/gmail_custom_oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/gmail_custom_oauth",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Pipedream Gmail (Consumer) Components",
   "main": "gmail_custom_oauth.app.mjs",
   "keywords": [

--- a/components/gmail_custom_oauth/sources/new-labeled-email/new-labeled-email.mjs
+++ b/components/gmail_custom_oauth/sources/new-labeled-email/new-labeled-email.mjs
@@ -1,4 +1,5 @@
 import { DEFAULT_POLLING_SOURCE_TIMER_INTERVAL } from "@pipedream/platform";
+import sampleEmit from "./test-event.mjs";
 import gmail from "../../gmail_custom_oauth.app.mjs";
 
 export default {
@@ -6,7 +7,7 @@ export default {
   name: "New Labeled Email",
   description: "Emit new event when a new email is labeled.",
   type: "source",
-  version: "0.0.2",
+  version: "0.0.3",
   dedupe: "unique",
   props: {
     gmail,
@@ -89,4 +90,5 @@ export default {
     }
     await this.emitHistories(lastHistoryId);
   },
+  sampleEmit,
 };

--- a/components/gmail_custom_oauth/sources/new-labeled-email/test-event.mjs
+++ b/components/gmail_custom_oauth/sources/new-labeled-email/test-event.mjs
@@ -1,0 +1,26 @@
+export default  {
+  "id": "332932",
+  "messages": [
+   {
+    "id": "1872ede547346f26",
+    "threadId": "1872ede547346f26"
+   }
+  ],
+  "labelsAdded": [
+   {
+    "message": {
+     "id": "1872ede547346f26",
+     "threadId": "1872ede547346f26",
+     "labelIds": [
+      "UNREAD",
+      "Label_1",
+      "CATEGORY_PERSONAL",
+      "INBOX"
+     ]
+    },
+    "labelIds": [
+     "Label_1"
+    ]
+   }
+  ]
+ }


### PR DESCRIPTION
Adding Sample Test Event for gmail_custom_oauth-new-labeled-email

Created via Pipedream