### PR TITLE
ignore test-event files

### DIFF
--- a/scripts/findBadKeys.js
+++ b/scripts/findBadKeys.js
@@ -12,21 +12,21 @@ const REGEXP_COMPONENT_KEY = {
 
 let err = false;
 
-const isAppFile = ( subname ) =>
+const isAppFile = (subname) =>
   subname.endsWith(".app.mjs") || subname.endsWith(".app.js") || subname.endsWith(".app.mts") || subname.endsWith(".app.ts");
 
-const isSourceFile = ( subname ) =>
+const isSourceFile = (subname) =>
   subname.endsWith(".mjs") || subname.endsWith(".js") || subname.endsWith(".mts") || subname.endsWith(".ts");
 
-const isCommonFile = ( subname ) => {
+const isCommonFile = (subname) => {
   const regex = /\/common.*(\/|\.js|\.mjs|\.ts|\.mts|)/g;
   return regex.test(subname);
 };
 
-const isTestEventFile = ( subname ) =>
+const isTestEventFile = (subname) =>
   subname.split("/").pop() === "test-event.mjs";
 
-const getComponentKey = ( p )  => {
+const getComponentKey = (p) => {
   const data = fs.readFileSync(p, "utf8");
   const md = data.match(REGEXP_COMPONENT_KEY.regExp);
   if (md && md.length > REGEXP_COMPONENT_KEY.captureGroup)
@@ -90,6 +90,10 @@ function checkKeys(p, nameSlug) {
       continue;
     }
     if (name.endsWith(".mjs") || name.endsWith(".js") || name.endsWith(".ts") || name.endsWith(".mts")) {
+      // ignore test-event files
+      if (isTestEventFile(name)) {
+        continue;
+      }
       const data = fs.readFileSync(pp, "utf8");
       const md = data.match(REGEXP_COMPONENT_KEY.regExp);
       if (md) {


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a030103</samp>

Improved the `findBadKeys.js` script to make it more readable and efficient. The script now ignores test-event files that are not relevant for component key validation.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a030103</samp>

> _`findBadKeys` in the dark, searching for the flaws_
> _Reformatting the code, enforcing the laws_
> _Skipping the test-events, they don't matter now_
> _We are the validators, we'll make the components bow_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a030103</samp>

* Skip checking component keys for test-event files to avoid unnecessary errors and warnings ([link](https://github.com/PipedreamHQ/pipedream/pull/7569/files?diff=unified&w=0#diff-6a9bbea02b37f1347105af56b9d4fc21258d6e46b1d4065574699865e08a9fbbR93-R96))
* Reformat code to remove extra spaces between parentheses and parameters of arrow functions for consistency and readability ([link](https://github.com/PipedreamHQ/pipedream/pull/7569/files?diff=unified&w=0#diff-6a9bbea02b37f1347105af56b9d4fc21258d6e46b1d4065574699865e08a9fbbL15-R29))
