### PR TITLE
Add support for Llama2, Palm, Cohere, Replicate Models - using litellm 

### DIFF
--- a/packages/component_code_gen/code_gen/transform_code.py
+++ b/packages/component_code_gen/code_gen/transform_code.py
@@ -1,13 +1,13 @@
 from dotenv import load_dotenv
 load_dotenv()
 
-import openai
+import litellm
 from config.config import config
 from litellm import completion
 
 
 def transform(code, templates):
-    openai.api_key = config['openai']['api_key']
+    litellm.api_key = config['openai']['api_key']
     response = completion(
         model="gpt-4",
         messages=[

--- a/packages/component_code_gen/code_gen/transform_code.py
+++ b/packages/component_code_gen/code_gen/transform_code.py
@@ -3,11 +3,12 @@ load_dotenv()
 
 import openai
 from config.config import config
+from litellm import completion
 
 
 def transform(code, templates):
     openai.api_key = config['openai']['api_key']
-    response = openai.ChatCompletion.create(
+    response = completion(
         model="gpt-4",
         messages=[
             {"role": "system", "content": templates.system_instructions},

--- a/packages/component_code_gen/helpers/langchain_helpers.py
+++ b/packages/component_code_gen/helpers/langchain_helpers.py
@@ -9,6 +9,7 @@ from langchain.chat_models import ChatOpenAI
 from langchain.agents.agent_toolkits.json.toolkit import JsonToolkit
 from langchain.tools.json.tool import JsonSpec
 from litellm import completion
+import litellm
 
 
 class OpenAPIExplorerTool:
@@ -68,7 +69,7 @@ def ask_agent(user_prompt, docs, templates):
 
 
 def no_docs(app, prompt, templates):
-    openai.api_key = config['openai']['api_key']
+    litellm.api_key = config['openai']['api_key']
     result = completion(
         model="gpt-4",
         messages=[

--- a/packages/component_code_gen/helpers/langchain_helpers.py
+++ b/packages/component_code_gen/helpers/langchain_helpers.py
@@ -8,6 +8,7 @@ from langchain.agents import ZeroShotAgent, AgentExecutor
 from langchain.chat_models import ChatOpenAI
 from langchain.agents.agent_toolkits.json.toolkit import JsonToolkit
 from langchain.tools.json.tool import JsonSpec
+from litellm import completion
 
 
 class OpenAPIExplorerTool:
@@ -68,7 +69,7 @@ def ask_agent(user_prompt, docs, templates):
 
 def no_docs(app, prompt, templates):
     openai.api_key = config['openai']['api_key']
-    result = openai.ChatCompletion.create(
+    result = completion(
         model="gpt-4",
         messages=[
             {"role": "system", "content": format_template(templates.no_docs_system_instructions)},


### PR DESCRIPTION
## WHAT
This PR adds support for models from all the above mentioned providers using https://github.com/BerriAI/litellm/

Here's a sample of how it's used:

```
from litellm import completion, acompletion

## set ENV variables
# ENV variables can be set in .env file, too. Example in .env.example
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# llama2 call
model_name = "replicate/llama-2-70b-chat:2c1608e18606fad2812020dc541930f2d0495ce32eee50074220b87300bc16e1"
response = completion(model_name, messages)

# cohere call
response = completion("command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2564da1</samp>

The pull request updates the `component_code_gen` package to use the `litellm` library for code generation tasks. This library is a wrapper around the OpenAI API that simplifies and enhances the code documentation and transformation features.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2564da1</samp>

> _To transform code with more ease_
> _We switched to the `litellm` library_
> _It wraps the OpenAI API_
> _And makes code generation snappy_
> _We hope you like this change, pretty please_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2564da1</samp>

*  Replace `openai` library with `litellm` library for code generation tasks ([link](https://github.com/PipedreamHQ/pipedream/pull/7577/files?diff=unified&w=0#diff-27675f9b63c3bc04dc6debb87feda8639f849a79cf11f8a55b31a3ae33c204a0L6-R11), [link](https://github.com/PipedreamHQ/pipedream/pull/7577/files?diff=unified&w=0#diff-53a92d1cb5d0f3bd57b82e0c495cc9c1966d4a5493ab88134930f6dbd93e0059R11), [link](https://github.com/PipedreamHQ/pipedream/pull/7577/files?diff=unified&w=0#diff-53a92d1cb5d0f3bd57b82e0c495cc9c1966d4a5493ab88134930f6dbd93e0059L71-R72))
