### PR TITLE
Microsoft Teams Errors coming from API while in workflow builder

### DIFF
--- a/components/microsoft_teams/actions/create-channel/create-channel.mjs
+++ b/components/microsoft_teams/actions/create-channel/create-channel.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Create Channel",
   description: "Create a new channel in Microsoft Teams. [See the docs here](https://docs.microsoft.com/en-us/graph/api/channel-post?view=graph-rest-1.0&tabs=http)",
   type: "action",
-  version: "0.0.4",
+  version: "0.0.5",
   props: {
     microsoftTeams,
     teamId: {

--- a/components/microsoft_teams/actions/list-channels/list-channels.mjs
+++ b/components/microsoft_teams/actions/list-channels/list-channels.mjs
@@ -5,7 +5,7 @@ export default {
   name: "List Channels",
   description: "Lists all channels in a Microsoft Team. [See the docs here](https://docs.microsoft.com/en-us/graph/api/channel-list?view=graph-rest-1.0&tabs=http)",
   type: "action",
-  version: "0.0.4",
+  version: "0.0.5",
   props: {
     microsoftTeams,
     teamId: {

--- a/components/microsoft_teams/actions/list-shifts/list-shifts.mjs
+++ b/components/microsoft_teams/actions/list-shifts/list-shifts.mjs
@@ -5,7 +5,7 @@ export default {
   name: "List Shifts",
   description: "Get the list of shift instances for a team. [See the documentation](https://learn.microsoft.com/en-us/graph/api/schedule-list-shifts?view=graph-rest-1.0&tabs=http)",
   type: "action",
-  version: "0.0.1",
+  version: "0.0.2",
   props: {
     microsoftTeams,
     teamId: {

--- a/components/microsoft_teams/actions/send-channel-message/send-channel-message.mjs
+++ b/components/microsoft_teams/actions/send-channel-message/send-channel-message.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Send Channel Message",
   description: "Send a message to a team&#39;s channel. [See the docs here](https://docs.microsoft.com/en-us/graph/api/channel-post-messages?view=graph-rest-1.0&tabs=http)",
   type: "action",
-  version: "0.0.4",
+  version: "0.0.5",
   props: {
     microsoftTeams,
     teamId: {

--- a/components/microsoft_teams/actions/send-chat-message/send-chat-message.mjs
+++ b/components/microsoft_teams/actions/send-chat-message/send-chat-message.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Send Chat Message",
   description: "Send a message to a team&#39;s chat. [See the docs here](https://docs.microsoft.com/en-us/graph/api/chat-post-messages?view=graph-rest-1.0&tabs=http)",
   type: "action",
-  version: "0.0.4",
+  version: "0.0.5",
   props: {
     microsoftTeams,
     chatId: {

--- a/components/microsoft_teams/common/constants.mjs
+++ b/components/microsoft_teams/common/constants.mjs
@@ -1,7 +1,5 @@
 const DEFAULT_METHOD = "get";
-const ORDER_BY_CREATED_DESC = "orderby=createdDateTime%20desc";
 
 export default {
   DEFAULT_METHOD,
-  ORDER_BY_CREATED_DESC,
 };

--- a/components/microsoft_teams/microsoft_teams.app.mjs
+++ b/components/microsoft_teams/microsoft_teams.app.mjs
@@ -96,13 +96,6 @@ export default {
       label: "Message",
       description: "Message to be sent",
     },
-    max: {
-      type: "integer",
-      label: "Max",
-      description: "Maximum number of items to return",
-      optional: true,
-      default: 20,
-    },
   },
   methods: {
     _accessToken() {
@@ -154,12 +147,12 @@ export default {
     },
     async listChannels({ teamId }) {
       return this.makeRequest({
-        path: `/teams/${teamId}/channels?${constants.ORDER_BY_CREATED_DESC}`,
+        path: `/teams/${teamId}/channels`,
       });
     },
     async listChats() {
       return this.makeRequest({
-        path: `/chats?$expand=members&${constants.ORDER_BY_CREATED_DESC}`,
+        path: "/chats?$expand=members",
       });
     },
     async createChannel({
@@ -214,7 +207,7 @@ export default {
       teamId, channelId,
     }) {
       return this.makeRequest({
-        path: `/teams/${teamId}/channels/${channelId}/messages/delta?${constants.ORDER_BY_CREATED_DESC}`,
+        path: `/teams/${teamId}/channels/${channelId}/messages/delta`,
       });
     },
     async listTeamMembers({ teamId }) {
@@ -224,7 +217,7 @@ export default {
     },
     async listChatMessages({ chatId }) {
       return this.makeRequest({
-        path: `/chats/${chatId}/messages?${constants.ORDER_BY_CREATED_DESC}`,
+        path: `/chats/${chatId}/messages`,
       });
     },
     async listShifts({ teamId }) {

--- a/components/microsoft_teams/package.json
+++ b/components/microsoft_teams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/microsoft_teams",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Microsoft Teams Components",
   "main": "microsoft_teams.app.mjs",
   "keywords": [

--- a/components/microsoft_teams/sources/common/base.mjs
+++ b/components/microsoft_teams/sources/common/base.mjs
@@ -27,7 +27,7 @@ export default {
       }
       return Date.parse(resource.createdDateTime) > lastCreated;
     },
-    async getNewPaginatedResources(fn, params, max, lastCreated) {
+    async getNewPaginatedResources(fn, params, lastCreated) {
       const resources = [];
       const paginator = this.paginate(fn, params);
 
@@ -35,9 +35,6 @@ export default {
         const isNewResource = this.isNew(resource, lastCreated);
         if (isNewResource) {
           resources.push(resource);
-        }
-        if (!isNewResource || resources.length >= max) {
-          break;
         }
       }
       return resources;

--- a/components/microsoft_teams/sources/new-channel-message/new-channel-message.mjs
+++ b/components/microsoft_teams/sources/new-channel-message/new-channel-message.mjs
@@ -5,7 +5,7 @@ export default {
   key: "microsoft_teams-new-channel-message",
   name: "New Channel Message",
   description: "Emit new event when a new message is posted in a channel",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   dedupe: "unique",
   props: {
@@ -25,12 +25,6 @@ export default {
         }),
       ],
     },
-    max: {
-      propDefinition: [
-        base.props.microsoftTeams,
-        "max",
-      ],
-    },
   },
   methods: {
     ...base.methods,
@@ -41,7 +35,6 @@ export default {
           teamId: this.team,
           channelId: this.channel,
         },
-        this.max,
         lastCreated,
       );
     },

--- a/components/microsoft_teams/sources/new-channel/new-channel.mjs
+++ b/components/microsoft_teams/sources/new-channel/new-channel.mjs
@@ -5,7 +5,7 @@ export default {
   key: "microsoft_teams-new-channel",
   name: "New Channel",
   description: "Emit new event when a new channel is created within a team",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   dedupe: "unique",
   props: {
@@ -14,12 +14,6 @@ export default {
       propDefinition: [
         base.props.microsoftTeams,
         "team",
-      ],
-    },
-    max: {
-      propDefinition: [
-        base.props.microsoftTeams,
-        "max",
       ],
     },
   },
@@ -31,7 +25,6 @@ export default {
         {
           teamId: this.team,
         },
-        this.max,
         lastCreated,
       );
     },

--- a/components/microsoft_teams/sources/new-chat-message/new-chat-message.mjs
+++ b/components/microsoft_teams/sources/new-chat-message/new-chat-message.mjs
@@ -5,7 +5,7 @@ export default {
   key: "microsoft_teams-new-chat-message",
   name: "New Chat Message",
   description: "Emit new event when a new message is received in a chat",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   dedupe: "unique",
   props: {
@@ -14,12 +14,6 @@ export default {
       propDefinition: [
         base.props.microsoftTeams,
         "chat",
-      ],
-    },
-    max: {
-      propDefinition: [
-        base.props.microsoftTeams,
-        "max",
       ],
     },
   },
@@ -31,7 +25,6 @@ export default {
         {
           chatId: this.chat,
         },
-        this.max,
         lastCreated,
       );
     },

--- a/components/microsoft_teams/sources/new-chat/new-chat.mjs
+++ b/components/microsoft_teams/sources/new-chat/new-chat.mjs
@@ -5,25 +5,15 @@ export default {
   key: "microsoft_teams-new-chat",
   name: "New Chat",
   description: "Emit new event when a new chat is created",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   dedupe: "unique",
-  props: {
-    ...base.props,
-    max: {
-      propDefinition: [
-        base.props.microsoftTeams,
-        "max",
-      ],
-    },
-  },
   methods: {
     ...base.methods,
     async getResources(lastCreated) {
       return this.getNewPaginatedResources(
         this.microsoftTeams.listChats,
         {},
-        this.max,
         lastCreated,
       );
     },

--- a/components/microsoft_teams/sources/new-team-member/new-team-member.mjs
+++ b/components/microsoft_teams/sources/new-team-member/new-team-member.mjs
@@ -5,7 +5,7 @@ export default {
   key: "microsoft_teams-new-team-member",
   name: "New Team Member",
   description: "Emit new event when a new member is added to a team",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/microsoft_teams/sources/new-team/new-team.mjs
+++ b/components/microsoft_teams/sources/new-team/new-team.mjs
@@ -5,25 +5,15 @@ export default {
   key: "microsoft_teams-new-team",
   name: "New Team",
   description: "Emit new event when a new team is joined by the authenticated user",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   dedupe: "unique",
-  props: {
-    ...base.props,
-    max: {
-      propDefinition: [
-        base.props.microsoftTeams,
-        "max",
-      ],
-    },
-  },
   methods: {
     ...base.methods,
     async getResources(lastCreated) {
       return this.getNewPaginatedResources(
         this.microsoftTeams.listTeams,
         {},
-        this.max,
         lastCreated,
       );
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5325,6 +5325,8 @@ importers:
         specifier: ^1.2.0
         version: 1.5.1
 
+  components/webinarkit: {}
+
   components/webscraper_io:
     dependencies:
       '@pipedream/platform':


### PR DESCRIPTION
Resolves #7388 
The client can no longer apply query settings `$count`, `$orderby`, `$select`, `$top`, `$expand`, `$filter` by default.
https://learn.microsoft.com/en-us/odata/webapi/modelbound-attribute 
Removed the `orderby` query. Sources are updated to paginate through all resources to ensure new items are not missed.

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c41ada7</samp>

This pull request simplifies the pagination logic for the microsoft_teams sources and removes redundant parameters and constants. It also updates the versions of the sources, actions, and package to reflect minor changes in functionality or behavior. Additionally, it adds the webinarkit component as a dependency of the microsoft_teams package.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c41ada7</samp>

> _We're breaking the chains of redundant code_
> _We're simplifying the logic of pagination_
> _We're updating the versions of our actions and sources_
> _We're rocking the world with microsoft_teams_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c41ada7</samp>

*  Bumped the version of the microsoft_teams package and its actions and sources to reflect minor changes in functionality or behavior ([link](https://github.com/PipedreamHQ/pipedream/pull/7590/files?diff=unified&w=0#diff-20335ef3f220fe167e193cac7985b4e707cc5baedc6802e90264099f1123c6d1L8-R8), [link](https://github.com/PipedreamHQ/pipedream/pull/7590/files?diff=unified&w=0#diff-20cfc8edb8ba813a3455daee99f98bb857ca57696101a433c1d766bef3f6810dL8-R8), [link](https://github.com/PipedreamHQ/pipedream/pull/7590/files?diff=unified&w=0#diff-3f26edf53edccbd0fb742ed1032fae12bf78b5a52b0fc79c9e38f500974490eaL8-R8), [link](https://github.com/PipedreamHQ/pipedream/pull/7590/files?diff=unified&w=0#diff-53c5579e531fa13b1d59c29ff346ba37952c5244dd0cab926527408355ebc4b0L8-R8), [link](https://github.com/PipedreamHQ/pipedream/pull/7590/files?diff=unified&w=0#diff-148409ea9e630e3138d19050ef104298ec5a08d8ce2b137aa500e7f9e6f631b8L8-R8), [link](https://github.com/PipedreamHQ/pipedream/pull/7590/files?diff=unified&w=0#diff-ab182a49aaab0cea2a58264c349c6439b8f838b9268d84deb72452d3c91f13f3L3-R3), [link](https://github.com/PipedreamHQ/pipedream/pull/7590/files?diff=unified&w=0#diff-0d3fb4adf21210cdeee08706552f2ebe5d0bf46b205b0004d4888bfc67892b40L8-R8), [link](https://github.com/PipedreamHQ/pipedream/pull/7590/files?diff=unified&w=0#diff-8be45a561743c6616f23fad6502baca596f810a87924c220e2154963ea272520L8-R8), [link](https://github.com/PipedreamHQ/pipedream/pull/7590/files?diff=unified&w=0#diff-05ad854cd593faa5ca17dda7fc362f38671b0964259087fd17a81f1b4a5196f0L8-R8), [link](https://github.com/PipedreamHQ/pipedream/pull/7590/files?diff=unified&w=0#diff-906b3b7cdd11610089725a08335144455ea78400e16adc4a2508b245eb0522ceL8-R10), [link](https://github.com/PipedreamHQ/pipedream/pull/7590/files?diff=unified&w=0#diff-893dcc47c7a533d734e5b0b1f922c3bc8b699c7d11c1a5ddc173a87787d82916L8-R8), [link](https://github.com/PipedreamHQ/pipedream/pull/7590/files?diff=unified&w=0#diff-9174e79880c6da08b58ff412acef57283e158908b7cfbfb0063e6fb49849cebfL8-R10))
* Removed the max prop and parameter from the actions, sources, and app methods that used to limit the number of items returned by the API requests, as this logic was moved to the base source class and the API does not use the max value ([link](https://github.com/PipedreamHQ/pipedream/pull/7590/files?diff=unified&w=0#diff-340fd3b3d79c473ce390d17b136cf79241039a5b423b98f1bde04a814b39411fL99-L105), [link](https://github.com/PipedreamHQ/pipedream/pull/7590/files?diff=unified&w=0#diff-0d3fb4adf21210cdeee08706552f2ebe5d0bf46b205b0004d4888bfc67892b40L28-L33), [link](https://github.com/PipedreamHQ/pipedream/pull/7590/files?diff=unified&w=0#diff-0d3fb4adf21210cdeee08706552f2ebe5d0bf46b205b0004d4888bfc67892b40L44), [link](https://github.com/PipedreamHQ/pipedream/pull/7590/files?diff=unified&w=0#diff-8be45a561743c6616f23fad6502baca596f810a87924c220e2154963ea272520L19-L24), [link](https://github.com/PipedreamHQ/pipedream/pull/7590/files?diff=unified&w=0#diff-8be45a561743c6616f23fad6502baca596f810a87924c220e2154963ea272520L34), [link](https://github.com/PipedreamHQ/pipedream/pull/7590/files?diff=unified&w=0#diff-05ad854cd593faa5ca17dda7fc362f38671b0964259087fd17a81f1b4a5196f0L19-L24), [link](https://github.com/PipedreamHQ/pipedream/pull/7590/files?diff=unified&w=0#diff-05ad854cd593faa5ca17dda7fc362f38671b0964259087fd17a81f1b4a5196f0L34), [link](https://github.com/PipedreamHQ/pipedream/pull/7590/files?diff=unified&w=0#diff-906b3b7cdd11610089725a08335144455ea78400e16adc4a2508b245eb0522ceL26), [link](https://github.com/PipedreamHQ/pipedream/pull/7590/files?diff=unified&w=0#diff-9174e79880c6da08b58ff412acef57283e158908b7cfbfb0063e6fb49849cebfL26), [link](https://github.com/PipedreamHQ/pipedream/pull/7590/files?diff=unified&w=0#diff-a711df7e55646d3605c362955ef9246537f651a4ec850bd651a3826915b10bf4L30-R30), [link](https://github.com/PipedreamHQ/pipedream/pull/7590/files?diff=unified&w=0#diff-a711df7e55646d3605c362955ef9246537f651a4ec850bd651a3826915b10bf4L39-L41))
* Removed the ORDER_BY_CREATED_DESC constant from the common/constants.mjs file and the app methods that used to append it to the API requests, as the API responses are already sorted by creation date in descending order by default ([link](https://github.com/PipedreamHQ/pipedream/pull/7590/files?diff=unified&w=0#diff-9d3907db3a26986160253e60e038f65739d220388946baeef9a5cc30411a463eL2-R4), [link](https://github.com/PipedreamHQ/pipedream/pull/7590/files?diff=unified&w=0#diff-340fd3b3d79c473ce390d17b136cf79241039a5b423b98f1bde04a814b39411fL157-R155), [link](https://github.com/PipedreamHQ/pipedream/pull/7590/files?diff=unified&w=0#diff-340fd3b3d79c473ce390d17b136cf79241039a5b423b98f1bde04a814b39411fL217-R210), [link](https://github.com/PipedreamHQ/pipedream/pull/7590/files?diff=unified&w=0#diff-340fd3b3d79c473ce390d17b136cf79241039a5b423b98f1bde04a814b39411fL227-R220))
* Added the webinarkit component as a dependency of the microsoft_teams package in the pnpm-lock.yaml file ([link](https://github.com/PipedreamHQ/pipedream/pull/7590/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5328-R5329))
