### PR TITLE
Adding Sample Test Event for airtable_oauth-new-or-modified-records

### DIFF
--- a/components/airtable_oauth/sources/new-or-modified-records/new-or-modified-records.mjs
+++ b/components/airtable_oauth/sources/new-or-modified-records/new-or-modified-records.mjs
@@ -1,4 +1,5 @@
 import base from "../common/common.mjs";
+import sampleEmit from "./test-event.mjs";
 import common from "../../../airtable/sources/new-or-modified-records/common.mjs";
 
 export default {
@@ -7,7 +8,7 @@ export default {
   name: "New or Modified Records",
   key: "airtable_oauth-new-or-modified-records",
   description: "Emit new event for each new or modified record in a table",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   props: {
     ...base.props,
@@ -22,4 +23,5 @@ export default {
       description: "The table ID to watch for changes.",
     },
   },
+  sampleEmit,
 };


### PR DESCRIPTION
Adding Sample Test Event for airtable_oauth-new-or-modified-records

Created via Pipedream