### PR TITLE
sftp - improving upload file action

### DIFF
--- a/components/sftp/package.json
+++ b/components/sftp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/sftp",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Pipedream SFTP Components",
   "main": "sftp.app.mjs",
   "keywords": [

--- a/components/sftp/sftp.app.mjs
+++ b/components/sftp/sftp.app.mjs
@@ -1,9 +1,24 @@
 import Client from "ssh2-sftp-client";
+import fs from "fs";
 
 export default {
   type: "app",
   app: "sftp",
-  propDefinitions: {},
+  propDefinitions: {
+    file: {
+      type: "string",
+      label: "File",
+      description: "Local file on `/tmp` folder to upload to the remote server.",
+      optional: true,
+      options() {
+        return fs.readdirSync("/tmp", {
+          withFileTypes: true,
+        })
+          .filter((file) => !file.isDirectory())
+          .map((file) => file.name);
+      },
+    },
+  },
   methods: {
     async connect() {
       const {
@@ -21,6 +36,15 @@ export default {
       const sftp = new Client();
       await sftp.connect(config);
       return sftp;
+    },
+    async put({
+      buffer,
+      remotePath,
+    }) {
+      const sftp = await this.connect();
+      const response = await sftp.put(buffer, remotePath);
+      await sftp.end();
+      return response;
     },
   },
 };

--- a/components/sftp/sources/watch-remote-directory/watch-remote-directory.mjs
+++ b/components/sftp/sources/watch-remote-directory/watch-remote-directory.mjs
@@ -5,7 +5,7 @@ export default {
   key: "sftp-watch-remote-directory",
   name: "New Remote Directory Watcher",
   description: "Emit new events when files get created, changed or deleted from a remote directory. [See the docs](https://github.com/theophilusx/ssh2-sftp-client#orgfac43d1)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "source",
   dedupe: "unique",
   props: {


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at df7a858</samp>

Added a new feature to the `sftp` app that enables uploading local files to a remote SFTP server. Refactored the `upload-file` action to use the new feature and support different file formats. Updated the `package.json` file to reflect the new app version and dependencies.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at df7a858</samp>

> _Upload files or strings_
> _With `sftp` app and action_
> _Autumn leaves fall fast_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at df7a858</samp>

* Refactor `upload-file` action to use `sftp.app.mjs` module and support uploading files or strings ([link](https://github.com/PipedreamHQ/pipedream/pull/7608/files?diff=unified&w=0#diff-7af9b67de2990d655c0f65cd63e11b495c78e9725f3f0a570352f84b21197d17L1-R46))
* Update `package.json` to use new version of `sftp` app with `put` method and `file` prop ([link](https://github.com/PipedreamHQ/pipedream/pull/7608/files?diff=unified&w=0#diff-f8a92d1870d201256aa45637513601302d94d9bc7ddced23958de0239b1cab66L3-R3))
* Add `file` prop to `sftp.app.mjs` module to allow selecting local files from `/tmp` folder ([link](https://github.com/PipedreamHQ/pipedream/pull/7608/files?diff=unified&w=0#diff-e72bed3f87793f92dc9537c00f8632d25e61f377edf3597935c07181777b190dL2-R21))
* Add `put` method to `sftp.app.mjs` module to upload buffers to remote server and return response ([link](https://github.com/PipedreamHQ/pipedream/pull/7608/files?diff=unified&w=0#diff-e72bed3f87793f92dc9537c00f8632d25e61f377edf3597935c07181777b190dR40-R48))
