### PR TITLE
Minor changes to Google readmes.

### DIFF
--- a/components/gmail_custom_oauth/README.md
+++ b/components/gmail_custom_oauth/README.md
@@ -9,7 +9,7 @@ The Google Developer App in Pipedream can integrate with either a personal Gmail
 
 In order to connect your personal or workspace Gmail account to Pipedream, you'll need to create a custom OAuth app in Google Cloud.
 
-1. Sign in to the [Google Cloud Console](https://cloud.google.com/)
+1. Sign in to the [Google Cloud Console](https://console.cloud.google.com/apis/library)
 2. Select an existing project or create a new one
 
   ![Select an exisiting project or create a a new one in the Google Cloud Console](https://res.cloudinary.com/pipedreamin/image/upload/v1663268100/docs/components/CleanShot_2022-09-15_at_14.54.34_vajyds.png)
@@ -48,7 +48,7 @@ You will need to generate a set of OAuth credentials to connect your new Gmail a
     
     ![Open the Credentials menu in the left hand nav bar](https://res.cloudinary.com/pipedreamin/image/upload/v1663269973/docs/components/CleanShot_2022-09-15_at_15.13.52_yvllxi.png)
 
-2. Click **Create Credentials** at the top and select **“*OAuth client ID**
+2. Click **Create Credentials** at the top and select **OAuth client ID**
    
   ![Click create credentials to start the process](https://res.cloudinary.com/pipedreamin/image/upload/v1663270014/docs/components/CleanShot_2022-09-15_at_15.14.15_hjulis.png)
   

--- a/components/google_fit_developer_app/README.md
+++ b/components/google_fit_developer_app/README.md
@@ -7,7 +7,7 @@ The Google Fit Developer App in Pipedream can integrate with either a personal G
 ## Creating a Google Fit app
 In order to connect your personal or workspace Google Fit account to Pipedream, you'll need to create a custom OAuth app in Google Cloud.
 
-1. Sign in to the [Google Cloud Console](https://cloud.google.com/)
+1. Sign in to the [Google Cloud Console](https://console.cloud.google.com/apis/library)
 2. Select an existing project or create a new one
 
   ![Select an exisiting project or create a a new one in the Google Cloud Console](https://res.cloudinary.com/pipedreamin/image/upload/v1663268100/docs/components/CleanShot_2022-09-15_at_14.54.34_vajyds.png)
@@ -47,7 +47,7 @@ You will need to generate a set of OAuth credentials to connect your new Google 
     
     ![Open the Credentials menu in the left hand nav bar](https://res.cloudinary.com/pipedreamin/image/upload/v1663269973/docs/components/CleanShot_2022-09-15_at_15.13.52_yvllxi.png)
 
-2. Click **Create Credentials** at the top and select **“*OAuth client ID**
+2. Click **Create Credentials** at the top and select **OAuth client ID**
    
   ![Click create credentials to start the process](https://res.cloudinary.com/pipedreamin/image/upload/v1663270014/docs/components/CleanShot_2022-09-15_at_15.14.15_hjulis.png)
   
@@ -58,7 +58,7 @@ You will need to generate a set of OAuth credentials to connect your new Google 
   ![Web application is the type of OAuth credential we're generating](https://res.cloudinary.com/pipedreamin/image/upload/v1663270117/docs/components/CleanShot_2022-09-15_at_15.14.56_hlseq6.png)
 
 4. Name the app “Pipedream”
-5. Click **Add URI** and enter `https://api.pipedream.com/connect/oauth/oa_gA6iex/callback`
+5. Click **Add URI** in the **Authorized Redirect URIs** section, and enter `https://api.pipedream.com/connect/oauth/oa_gA6iex/callback`
 
   ![Add the Pipedream URL to the Callback Redirect URL option](https://res.cloudinary.com/dpenc2lit/image/upload/v1692295499/Screenshot_2023-08-17_at_11.04.54_AM_blco7y.png)
 


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 11d3df7</samp>

This pull request enhances the documentation for two components: `gmail_custom_oauth` and `google_fit_developer_app`. It fixes some errors and provides more clarity for users who want to use these components with Pipedream.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 11d3df7</samp>

> _Sing, O Muse, of the skillful scribes who polished the README files_
> _With keen-eyed care they mended typos, links, and formats awry_
> _Like Hephaestus, who forged the shield of Achilles with art divine_
> _They crafted clear and helpful guides for Gmail and Google Fit_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 11d3df7</samp>

*  Update the Google Cloud Console links to point to the APIs library page for Gmail and Google Fit ([link](https://github.com/PipedreamHQ/pipedream/pull/7642/files?diff=unified&w=0#diff-83c15546e32dd0b99150556ec50a65aaf737847020584230a5698af867c00c39L12-R12), [link](https://github.com/PipedreamHQ/pipedream/pull/7642/files?diff=unified&w=0#diff-aef667c9e472a44fe0592128cd242c4e190952d988c7845f8dcd2598317672f9L10-R10))
*  Remove typos from the text `OAuth client ID` in both `README.md` files ([link](https://github.com/PipedreamHQ/pipedream/pull/7642/files?diff=unified&w=0#diff-83c15546e32dd0b99150556ec50a65aaf737847020584230a5698af867c00c39L51-R51), [link](https://github.com/PipedreamHQ/pipedream/pull/7642/files?diff=unified&w=0#diff-aef667c9e472a44fe0592128cd242c4e190952d988c7845f8dcd2598317672f9L50-R50))
*  Add text to specify the section for adding the redirect URI in the Google Fit `README.md` file ([link](https://github.com/PipedreamHQ/pipedream/pull/7642/files?diff=unified&w=0#diff-aef667c9e472a44fe0592128cd242c4e190952d988c7845f8dcd2598317672f9L61-R61))
