### PR TITLE
Custom domains docs

### DIFF
--- a/docs/docs/.vuepress/configs/envVars.js
+++ b/docs/docs/.vuepress/configs/envVars.js
@@ -2,6 +2,7 @@ module.exports = {
   PIPEDREAM_BASE_URL: "https://pipedream.com",
   API_BASE_URL: "https://api.pipedream.com/v1",
   SQL_API_BASE_URL: "https://rt.pipedream.com/sql",
+  ENDPOINT_BASE_URL: "*.m.pipedream.net",
   PAYLOAD_SIZE_LIMIT: "512KB",
   MEMORY_LIMIT: "256MB",
   MEMORY_ABSOLUTE_LIMIT: "10GB",

--- a/docs/docs/.vuepress/configs/sidebarConfig.js
+++ b/docs/docs/.vuepress/configs/sidebarConfig.js
@@ -17,6 +17,7 @@ const docsNav = [
       "/workflows/concurrency-and-throttling/",
       "/workflows/settings/",
       "/workflows/vpc/",
+      "/workflows/domains/",
       "/workflows/sharing/",
       "/migrate-from-v1/",
     ],

--- a/docs/docs/privacy-and-security/README.md
+++ b/docs/docs/privacy-and-security/README.md
@@ -103,7 +103,7 @@ By default, outbound traffic shares the same network as other AWS services deplo
 
 When you use the Pipedream web application at [https://pipedream.com](https://pipedream.com), traffic between your client and Pipedream services is encrypted in transit. When you create an HTTP interface in Pipedream, the Pipedream UI defaults to displaying the HTTPS endpoint, which we recommend you use when sending HTTP traffic to Pipedream so that your data is encrypted in transit.
 
-All Pipedream-managed certificates used to protect user data in transit are created using [AWS Certificate Manager](https://aws.amazon.com/certificate-manager/). This eliminates the need for our employees to manage certificate private keys: these keys are managed and secured by Amazon.
+All Pipedream-managed certificates, including those we create for [custom domains](/workflows/domains/), are created using [AWS Certificate Manager](https://aws.amazon.com/certificate-manager/). This eliminates the need for our employees to manage certificate private keys: these keys are managed and secured by Amazon. Certificate renewal is also handled by Amazon.
 
 ## Encryption of data at rest
 

--- a/docs/docs/workflows/domains/README.md
+++ b/docs/docs/workflows/domains/README.md
@@ -6,31 +6,33 @@ Custom domains are now available in beta on the [Business plan](https://pipedrea
 
 :::
 
-By default, all new [Pipedream HTTP endpoints](/workflows/steps/triggers/#http) are hosted on the `{{$site.themeConfig.ENDPOINT_BASE_URL}}` domain. But you can configure any domain you want: instead of `https://endpoint.m.pipedream.net`, the endpoint would be available on `https://endpoint.yourdomain.com`.
+By default, all new [Pipedream HTTP endpoints](/workflows/steps/triggers/#http) are hosted on the `{{$site.themeConfig.ENDPOINT_BASE_URL}}` domain. But you can configure any domain you want: instead of `https://endpoint.m.pipedream.net`, the endpoint would be available on `https://endpoint.example.com`.
 
 ## Configuring a new custom domain
 
 ### 1. Choose your domain
 
-You can configure any domain you own to work with Pipedream HTTP endpoints. For example, you can host Pipedream HTTP endpoints on a dedicated subdomain on your core domain, like `*.pipedream.yourdomain.com` or `*.marketing.yourdomain.com`. This can be any domain or subdomain you own.
+You can configure any domain you own to work with Pipedream HTTP endpoints. For example, you can host Pipedream HTTP endpoints on a dedicated subdomain on your core domain, like `*.eng.example.com` or `*.marketing.example.com`. This can be any domain or subdomain you own.
 
 In this example, endpoints would look like:
 
 ```
-endpoint.pipedream.yourdomain.com
-endpoint1.pipedream.yourdomain.com
+[endpoint_id].eng.example.com
+[endpoint_id_1].eng.example.com
 ...
 ```
 
-If you own a domain that you want to _completely_ redirect to Pipedream, you can also configure `*.yourdomain.com` to point to Pipedream. In this example, endpoints would look like:
+where `[endpoint_id]` is a uniquely-generated hostname specific to your Pipedream HTTP endpoint.
+
+If you own a domain that you want to _completely_ redirect to Pipedream, you can also configure `*.example.com` to point to Pipedream. In this example, endpoints would look like:
 
 ```
-endpoint.yourdomain.com
-endpoint1.yourdomain.com
+[endpoint_id].example.com
+[endpoint_id_1].example.com
 ...
 ```
 
-Since all traffic on `*.yourdomain.com` points to Pipedream, we can assign hosts on the root domain. This also means that **you cannot use other hosts like www.yourdomain.com** without conflicting with Pipedream endpoints. Choose this option only if you're serving all traffic from `yourdomain.com` from Pipedream.
+Since all traffic on `*.example.com` points to Pipedream, we can assign hosts on the root domain. This also means that **you cannot use other hosts like www.example.com** without conflicting with Pipedream endpoints. Choose this option only if you're serving all traffic from `example.com` from Pipedream.
 
 Before you move on, make sure you have access to manage DNS records for your domain. If you don't, please coordinate with the team at your company that manages DNS records, and feel free to [reach out to our Support team](https://pipedream.com/support) with any questions.
 
@@ -53,17 +55,17 @@ Once we configure your domain, we'll ask you to create two DNS CNAME records:
 
 Pipedream uses [AWS Certificate Manager](https://aws.amazon.com/certificate-manager/) to create the TLS certificate for your domain. To validate the certificate, you need to add a specific DNS recorded provided by Certificate Manager. Pipedream will provide the name and value.
 
-For example, if you requested `*.pipedream.yourdomain.com` as your custom domain, Pipedream will provide the details of the record, like in this example:
+For example, if you requested `*.eng.example.com` as your custom domain, Pipedream will provide the details of the record, like in this example:
 
 - **Type**: `CNAME`
-- **Name**: `_2kf9s72kjfskjflsdf989234nsd0b.pipedream.yourdomain.com`
+- **Name**: `_2kf9s72kjfskjflsdf989234nsd0b.eng.example.com`
 - **Value**: `_7ghslkjsdfnc82374kshflasfhlf.vvykbvdtpk.acm-validations.aws.`
 - **TTL (seconds)**: 300
 
 Consult the docs for your DNS service for more information on adding CNAME records. Here's an example configuration using AWS's Route53 service:
 
 <div>
-<img src="https://res.cloudinary.com/pipedreamin/image/upload/v1692654841/docs/Screenshot_2023-08-21_at_2.52.16_PM_fsdvft.png" />
+<img src="https://res.cloudinary.com/pipedreamin/image/upload/v1692720441/docs/Screenshot_2023-08-21_at_2.52.16_PM_gtj3xl.png" />
 </div>
 
 #### Add the DNS CNAME wildcard record
@@ -71,7 +73,7 @@ Consult the docs for your DNS service for more information on adding CNAME recor
 Now you'll need to add the wildcard record that points all traffic for your domain to Pipedream. Pipedream will also provide the details of this record, like in this example:
 
 - **Type**: `CNAME`
-- **Name**: `*.pipedream.yourdomain.com`
+- **Name**: `*.eng.example.com`
 - **Value**: `id123.cd.pdrm.net`
 - **TTL (seconds)**: 300
 
@@ -81,16 +83,16 @@ Once you've finished adding these DNS records, please **reach out to the Pipedre
 
 Any traffic to existing `{{$site.themeConfig.ENDPOINT_BASE_URL}}` endpoints will continue to work uninterrupted.
 
-To confirm traffic to your new domain works, take any Pipedream endpoint URL and replace the `{{$site.themeConfig.ENDPOINT_BASE_URL}}` with your custom domain. For example, if you configured a custom domain of `pipedream.yourdomain.com` and have an existing endpoint at
+To confirm traffic to your new domain works, take any Pipedream endpoint URL and replace the `{{$site.themeConfig.ENDPOINT_BASE_URL}}` with your custom domain. For example, if you configured a custom domain of `pipedream.example.com` and have an existing endpoint at
 
 ```
-https://endpoint.m.pipedream.net
+https://[endpoint_id].m.pipedream.net
 ```
 
 Try making a test request to
 
 ```
-https://endpoint.pipedream.yourdomain.com
+https://[endpoint_id].eng.example.com
 ```
 
 ## Security
@@ -101,4 +103,4 @@ See our [TLS/SSL security docs](/privacy-and-security/#encryption-of-data-in-tra
 
 ### Requests to custom domains are allowed only for your endpoints
 
-Custom domains are mapped directly to customer endpoints. This means no other customer can send requests to their endpoints on _your_ custom domain. Requests to `yourdomain.com` are restricted specifically to HTTP endpoints in your Pipedream workspace.
+Custom domains are mapped directly to customer endpoints. This means no other customer can send requests to their endpoints on _your_ custom domain. Requests to `example.com` are restricted specifically to HTTP endpoints in your Pipedream workspace.

--- a/docs/docs/workflows/domains/README.md
+++ b/docs/docs/workflows/domains/README.md
@@ -12,7 +12,7 @@ By default, all new [Pipedream HTTP endpoints](/workflows/steps/triggers/#http) 
 
 ### 1. Choose your domain
 
-You can configure any domain you own to work with Pipedream HTTP endpoints. For example, many of our customers host Pipedream HTTP endpoints on a dedicated subdomain on their core domain, like `*.pipedream.yourdomain.com` or `*.marketing.yourdomain.com`. This can be any domain or subdomain you own.
+You can configure any domain you own to work with Pipedream HTTP endpoints. For example, you can host Pipedream HTTP endpoints on a dedicated subdomain on your core domain, like `*.pipedream.yourdomain.com` or `*.marketing.yourdomain.com`. This can be any domain or subdomain you own.
 
 In this example, endpoints would look like:
 
@@ -30,7 +30,7 @@ endpoint1.yourdomain.com
 ...
 ```
 
-Since all traffic on `*.yourdomain.com` points to Pipedream, we can assign hosts on the root domain. This also means that **you cannot host other hosts like www.yourdomain.com** without conflicting with Pipedream endpoints. Choose this option only if you're serving all traffic from `yourdomain.com` from Pipedream.
+Since all traffic on `*.yourdomain.com` points to Pipedream, we can assign hosts on the root domain. This also means that **you cannot use other hosts like www.yourdomain.com** without conflicting with Pipedream endpoints. Choose this option only if you're serving all traffic from `yourdomain.com` from Pipedream.
 
 Before you move on, make sure you have access to manage DNS records for your domain. If you don't, please coordinate with the team at your company that manages DNS records, and feel free to [reach out to our Support team](https://pipedream.com/support) with any questions.
 
@@ -75,6 +75,30 @@ Now you'll need to add the wildcard record that points all traffic for your doma
 - **Value**: `id123.cd.pdrm.net`
 - **TTL (seconds)**: 300
 
-## How Pipedream manages the SSL/TLS certs for your domain
+Once you've finished adding these DNS records, please **reach out to the Pipedream team**. We'll validate the records and finalize the configuration for your domain.
+
+### 4. Send a test request to your custom domain
+
+Any traffic to existing `{{$site.themeConfig.ENDPOINT_BASE_URL}}` endpoints will continue to work uninterrupted.
+
+To confirm traffic to your new domain works, take any Pipedream endpoint URL and replace the `{{$site.themeConfig.ENDPOINT_BASE_URL}}` with your custom domain. For example, if you configured a custom domain of `pipedream.yourdomain.com` and have an existing endpoint at
+
+```
+endpoint.m.pipedream.net
+```
+
+Try making a test request to
+
+```
+endpoint.pipedream.yourdomain.com
+```
+
+## Security
+
+### How Pipedream manages the TLS/SSL certificate
 
 See our [TLS/SSL security docs](/privacy-and-security/#encryption-of-data-in-transit-tls-ssl-certificates) for more detail on how we create and manage the certificates for custom domains.
+
+### Requests to custom domains are allowed only for your endpoints
+
+Custom domains are mapped directly to customer endpoints. This means no other customer can send requests to their endpoints on _your_ custom domain. Requests to `yourdomain.com` are restricted specifically to HTTP endpoints in your Pipedream workspace.

--- a/docs/docs/workflows/domains/README.md
+++ b/docs/docs/workflows/domains/README.md
@@ -84,13 +84,13 @@ Any traffic to existing `{{$site.themeConfig.ENDPOINT_BASE_URL}}` endpoints will
 To confirm traffic to your new domain works, take any Pipedream endpoint URL and replace the `{{$site.themeConfig.ENDPOINT_BASE_URL}}` with your custom domain. For example, if you configured a custom domain of `pipedream.yourdomain.com` and have an existing endpoint at
 
 ```
-endpoint.m.pipedream.net
+https://endpoint.m.pipedream.net
 ```
 
 Try making a test request to
 
 ```
-endpoint.pipedream.yourdomain.com
+https://endpoint.pipedream.yourdomain.com
 ```
 
 ## Security

--- a/docs/docs/workflows/domains/README.md
+++ b/docs/docs/workflows/domains/README.md
@@ -1,0 +1,80 @@
+# Custom Domains
+
+:::tip Beta feature
+
+Custom domains are now available in beta on the [Business plan](https://pipedream.com/pricing).
+
+:::
+
+By default, all new [Pipedream HTTP endpoints](/workflows/steps/triggers/#http) are hosted on the `{{$site.themeConfig.ENDPOINT_BASE_URL}}` domain. But you can configure any domain you want: instead of `https://endpoint.m.pipedream.net`, the endpoint would be available on `https://endpoint.yourdomain.com`.
+
+## Configuring a new custom domain
+
+### 1. Choose your domain
+
+You can configure any domain you own to work with Pipedream HTTP endpoints. For example, many of our customers host Pipedream HTTP endpoints on a dedicated subdomain on their core domain, like `*.pipedream.yourdomain.com` or `*.marketing.yourdomain.com`. This can be any domain or subdomain you own.
+
+In this example, endpoints would look like:
+
+```
+endpoint.pipedream.yourdomain.com
+endpoint1.pipedream.yourdomain.com
+...
+```
+
+If you own a domain that you want to _completely_ redirect to Pipedream, you can also configure `*.yourdomain.com` to point to Pipedream. In this example, endpoints would look like:
+
+```
+endpoint.yourdomain.com
+endpoint1.yourdomain.com
+...
+```
+
+Since all traffic on `*.yourdomain.com` points to Pipedream, we can assign hosts on the root domain. This also means that **you cannot host other hosts like www.yourdomain.com** without conflicting with Pipedream endpoints. Choose this option only if you're serving all traffic from `yourdomain.com` from Pipedream.
+
+Before you move on, make sure you have access to manage DNS records for your domain. If you don't, please coordinate with the team at your company that manages DNS records, and feel free to [reach out to our Support team](https://pipedream.com/support) with any questions.
+
+#### A note on domain wildcards
+
+Note that the records referenced above use the wildcard (`*`) for the host portion of the domain. When you configure DNS records in [step 3](#_3-add-your-dns-records), this allows you to point all traffic for a specific domain to Pipedream and create any number of Pipedream HTTP endpoints that will work with your domain.
+
+### 2. Reach out to Pipedream Support
+
+Once you've chosen your domain, [reach out to Pipedream Support](https://pipedream.com/support) and let us know what domain you'd like to configure for your workspace. We'll configure a TLS/SSL certificate for that domain, and give you two DNS CNAME records to add for that domain in [step 3](#_3-add-your-dns-records).
+
+### 3. Add your DNS records
+
+Once we configure your domain, we'll ask you to create two DNS CNAME records:
+
+- [One record to prove ownership of your domain](#add-the-cname-validation-record) (a `CNAME` record)
+- [Another record to point traffic on your domain to Pipedream](#add-the-dns-cname-wildcard-record) (a `CNAME` record)
+
+#### Add the CNAME validation record
+
+Pipedream uses [AWS Certificate Manager](https://aws.amazon.com/certificate-manager/) to create the TLS certificate for your domain. To validate the certificate, you need to add a specific DNS recorded provided by Certificate Manager. Pipedream will provide the name and value.
+
+For example, if you requested `*.pipedream.yourdomain.com` as your custom domain, Pipedream will provide the details of the record, like in this example:
+
+- **Type**: `CNAME`
+- **Name**: `_2kf9s72kjfskjflsdf989234nsd0b.pipedream.yourdomain.com`
+- **Value**: `_7ghslkjsdfnc82374kshflasfhlf.vvykbvdtpk.acm-validations.aws.`
+- **TTL (seconds)**: 300
+
+Consult the docs for your DNS service for more information on adding CNAME records. Here's an example configuration using AWS's Route53 service:
+
+<div>
+<img src="https://res.cloudinary.com/pipedreamin/image/upload/v1692654841/docs/Screenshot_2023-08-21_at_2.52.16_PM_fsdvft.png" />
+</div>
+
+#### Add the DNS CNAME wildcard record
+
+Now you'll need to add the wildcard record that points all traffic for your domain to Pipedream. Pipedream will also provide the details of this record, like in this example:
+
+- **Type**: `CNAME`
+- **Name**: `*.pipedream.yourdomain.com`
+- **Value**: `id123.cd.pdrm.net`
+- **TTL (seconds)**: 300
+
+## How Pipedream manages the SSL/TLS certs for your domain
+
+See our [TLS/SSL security docs](/privacy-and-security/#encryption-of-data-in-transit-tls-ssl-certificates) for more detail on how we create and manage the certificates for custom domains.

--- a/docs/docs/workflows/steps/triggers/README.md
+++ b/docs/docs/workflows/steps/triggers/README.md
@@ -77,6 +77,12 @@ Pipedream creates a URL endpoint specific to your workflow:
 
 You can send any HTTP requests to this endpoint, from anywhere on the web. You can configure the endpoint as the destination URL for a webhook or send HTTP traffic from your application - we'll accept any [valid HTTP request](#valid-requests).
 
+::: tip Custom domains
+
+Pipedream also supports [custom domains](/workflows/domains). This lets you host endpoints on `https://endpoint.yourdomain.com` instead of the default `{{$site.themeConfig.ENDPOINT_BASE_URL}}` domain.
+
+:::
+
 ### Accessing HTTP request data
 
 You can access properties of the HTTP request, like the method, payload, headers, and more, in [the `event` object](/workflows/events/#event-format), accessible in any [code](/code/) or [action](/components#actions) step.
@@ -92,6 +98,10 @@ You can send data to any path on this host, with any query string parameters. Yo
 You can send data of any [Media Type](https://www.iana.org/assignments/media-types/media-types.xhtml) in the body of your request.
 
 The primary limit we impose is on the size of the request body: we'll issue a `413 Payload Too Large` status when the body [exceeds our specified limit](#request-entity-too-large).
+
+### Custom domains
+
+To configure endpoints on your own domain, e.g. `endpoint.yourdomain.com` instead of the default `{{$site.themeConfig.ENDPOINT_BASE_URL}}` domain, see the [custom domains](/workflows/domains) docs.
 
 ### How Pipedream handles JSON payloads
 

--- a/docs/docs/workflows/vpc/README.md
+++ b/docs/docs/workflows/vpc/README.md
@@ -1,10 +1,10 @@
 # Virtual Private Clouds
 
-<VideoPlayer url="https://www.youtube.com/embed/E_dfTCCccPE" title="Virtual Price Clouds" />
+<VideoPlayer url="https://www.youtube.com/embed/E_dfTCCccPE" title="Virtual Private Clouds" />
 
 :::tip Beta feature
 
-Virtual Private Clouds (VPCs) are now available in beta on the Business tier.
+Virtual Private Clouds (VPCs) are now available in beta on the [Business plan](https://pipedream.com/pricing).
 
 :::
 


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b369cf9</samp>

This pull request adds and updates documentation for the custom domains feature, which allows users to configure a custom domain for Pipedream HTTP endpoints. It also introduces a new environment variable `ENDPOINT_BASE_URL` to the Vuepress config file, and updates the sections on encryption and virtual private clouds.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 152ff0c</samp>

> _Oh we're the docs team of Pipedream_
> _We write and update with skill and speed_
> _We add new features like `custom domains`_
> _And make the endpoints easy to maintain_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b369cf9</samp>

*  Add `ENDPOINT_BASE_URL` environment variable to Vuepress config file to store default domain for Pipedream HTTP endpoints ([link](https://github.com/PipedreamHQ/pipedream/pull/7681/files?diff=unified&w=0#diff-25db0506fc0deea8a6b3bae8c0573595e10b67353a1cbe1fc75390b22d78b16cR5))
*  Document custom domains feature for Pipedream HTTP endpoints in a new file `docs/docs/workflows/domains/README.md`, explaining how to configure, secure, and test custom domains ([link](https://github.com/PipedreamHQ/pipedream/pull/7681/files?diff=unified&w=0#diff-62454da934ab93e0c6b7bfbd3dbc61a5775f8fdb13836cfa36599b8384c6bfa6R1-R104))
*  Update sections on HTTP triggers and encryption of data in transit in `docs/docs/workflows/steps/triggers/README.md` and `docs/docs/privacy-and-security/README.md`, respectively, to mention and link to custom domains docs and provide more details on how to use and manage certificates for custom domains ([link](https://github.com/PipedreamHQ/pipedream/pull/7681/files?diff=unified&w=0#diff-c153df7562f2ec0c61763203a535cdbe73f0126ffffa29581816cd597bb89415R80-R85), [link](https://github.com/PipedreamHQ/pipedream/pull/7681/files?diff=unified&w=0#diff-c153df7562f2ec0c61763203a535cdbe73f0126ffffa29581816cd597bb89415R102-R105), [link](https://github.com/PipedreamHQ/pipedream/pull/7681/files?diff=unified&w=0#diff-90e4052323139c5554eaf322978b2c4a0b279e1509dccb383a1937c134ad4d61L106-R106))
*  Add link to business plan pricing page in `docs/docs/workflows/vpc/README.md` to inform users of plan requirements for virtual private clouds feature ([link](https://github.com/PipedreamHQ/pipedream/pull/7681/files?diff=unified&w=0#diff-955f33168acba3832f788f44a53e5ce8317ea4b01d9c5832ac44adc9da93c04dL3-R7))
