### PR TITLE
Update README.md

### DIFF
--- a/docs/docs/workflows/domains/README.md
+++ b/docs/docs/workflows/domains/README.md
@@ -74,7 +74,7 @@ Now you'll need to add the wildcard record that points all traffic for your doma
 
 - **Type**: `CNAME`
 - **Name**: `*.eng.example.com`
-- **Value**: `id123.cd.pdrm.net`
+- **Value**: `id123.cd.pdrm.net.`
 - **TTL (seconds)**: 300
 
 Once you've finished adding these DNS records, please **reach out to the Pipedream team**. We'll validate the records and finalize the configuration for your domain.


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dd28dd7</samp>

This pull request fixes a typo in the `docs/docs/workflows/domains/README.md` file that could cause DNS issues for custom domains. It adds a trailing dot to the CNAME record value to make it a fully qualified domain name.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at dd28dd7</samp>

> _`CNAME` record_
> _trailing dot for subdomains_
> _autumn leaves falling_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dd28dd7</samp>

* Fix typo in CNAME record value for custom domains ([link](https://github.com/PipedreamHQ/pipedream/pull/7702/files?diff=unified&w=0#diff-62454da934ab93e0c6b7bfbd3dbc61a5775f8fdb13836cfa36599b8384c6bfa6L77-R77))
