### PR TITLE
Auth docs patch

### DIFF
--- a/docs/docs/connected-accounts/README.md
+++ b/docs/docs/connected-accounts/README.md
@@ -111,12 +111,6 @@ Prior to this change, all connected accounts were accessible to all workspace me
 
 :::
 
-::: warning Private Accounts are not supported in the legacy workflow builder
-
-In order to use a connected account in the legacy (v1) workflow builder, the account must be shared with the entire workspace.
-
-:::
-
 
 ### Managing access
 - Find the account on the Accounts page and click the 3 dots on the far right of the row
@@ -193,6 +187,12 @@ How workspace members can use connected accounts that are **shared**:
 |  Delete  |  :white_check_mark: |  :x: |
 
 ### Frequently Asked Questions
+
+::: warning Why isn't my connected account showing up in the legacy workflow builder?
+
+In order to use a connected account in the legacy (v1) workflow builder, the account must be shared with the entire workspace. Private accounts are accessible in the latest version of the workflow builder.
+
+:::
 
 #### What is the "Owner" column?
 The owner column on the Accounts page indicates who in the workspace originally connected the account (that is the only person who has permissions to manage access).

--- a/docs/docs/connected-accounts/README.md
+++ b/docs/docs/connected-accounts/README.md
@@ -105,9 +105,15 @@ If you encounter errors in a step that appear to be related to credentials or au
 ## Access Control
 
 **New connected accounts are private by default** and can only be used by the person who added it.
-::: warning Accounts connected before August 2023
+::: tip Accounts connected before August 2023
 
 Prior to this change, all connected accounts were accessible to all workspace members. You can now manage access to new and existing connected accounts.
+
+:::
+
+::: warning Private Accounts are not supported in the legacy workflow builder
+
+In order to use a connected account in the legacy (v1) workflow builder, the account must be shared with the entire workspace.
 
 :::
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3986,6 +3986,8 @@ importers:
         specifier: ^1.4.1
         version: 1.5.1
 
+  components/retently: {}
+
   components/retool: {}
 
   components/rev:


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e4139de</samp>

Improved the documentation for connected accounts and added a warning for legacy users. Edited the `README.md` file in the `./docs/docs/connected-accounts/` directory.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e4139de</samp>

> _The docs for connected accounts_
> _Were revised with some skill and nuance_
> _They added a box_
> _For legacy flocks_
> _Who still use the old workflow plants_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e4139de</samp>

* Changed the warning box to a tip box in `docs/docs/connected-accounts/README.md` to improve the user experience and clarity of the documentation ([link](https://github.com/PipedreamHQ/pipedream/pull/7705/files?diff=unified&w=0#diff-3f512da52536955e2c9a904f66732e8c1b7cc1f24823564901d815e7825fc0afL108-R108))
* Added a new warning box in `docs/docs/connected-accounts/README.md` to provide guidance and troubleshooting for users who are using the legacy workflow builder and cannot see their private connected accounts ([link](https://github.com/PipedreamHQ/pipedream/pull/7705/files?diff=unified&w=0#diff-3f512da52536955e2c9a904f66732e8c1b7cc1f24823564901d815e7825fc0afR191-R196))
