### PR TITLE
Auth docs patch

### DIFF
--- a/docs/docs/connected-accounts/README.md
+++ b/docs/docs/connected-accounts/README.md
@@ -111,13 +111,6 @@ Prior to this change, all connected accounts were accessible to all workspace me
 
 :::
 
-::: warning Private Accounts are not supported in the legacy workflow builder
-
-In order to use a connected account in the legacy (v1) workflow builder, the account must be shared with the entire workspace.
-
-:::
-
-
 ### Managing access
 - Find the account on the Accounts page and click the 3 dots on the far right of the row
 - Select "Manage Access"

--- a/docs/docs/connected-accounts/README.md
+++ b/docs/docs/connected-accounts/README.md
@@ -111,12 +111,6 @@ Prior to this change, all connected accounts were accessible to all workspace me
 
 :::
 
-::: warning Private Accounts are not supported in the legacy workflow builder
-
-In order to use a connected account in the legacy (v1) workflow builder, the account must be shared with the entire workspace.
-
-:::
-
 
 ### Managing access
 - Find the account on the Accounts page and click the 3 dots on the far right of the row
@@ -193,6 +187,12 @@ How workspace members can use connected accounts that are **shared**:
 |  Delete  |  :white_check_mark: |  :x: |
 
 ### Frequently Asked Questions
+
+::: warning Why isn't my connected account showing up in the legacy workflow builder?
+
+In order to use a connected account in the legacy (v1) workflow builder, the account must be shared with the entire workspace. Private accounts are accessible in the latest version of the workflow builder.
+
+:::
 
 #### What is the "Owner" column?
 The owner column on the Accounts page indicates who in the workspace originally connected the account (that is the only person who has permissions to manage access).

--- a/docs/docs/connected-accounts/README.md
+++ b/docs/docs/connected-accounts/README.md
@@ -105,9 +105,15 @@ If you encounter errors in a step that appear to be related to credentials or au
 ## Access Control
 
 **New connected accounts are private by default** and can only be used by the person who added it.
-::: warning Accounts connected before August 2023
+::: tip Accounts connected before August 2023
 
 Prior to this change, all connected accounts were accessible to all workspace members. You can now manage access to new and existing connected accounts.
+
+:::
+
+::: warning Private Accounts are not supported in the legacy workflow builder
+
+In order to use a connected account in the legacy (v1) workflow builder, the account must be shared with the entire workspace.
 
 :::
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3986,6 +3986,8 @@ importers:
         specifier: ^1.4.1
         version: 1.5.1
 
+  components/retently: {}
+
   components/retool: {}
 
   components/rev:


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b5b2550</samp>

This pull request improves the documentation on connected accounts and adds a new component for Retently integration. It updates `docs/docs/connected-accounts/README.md` and `pnpm-lock.yaml` files.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b5b2550</samp>

> _To connect with Retently, we need_
> _A new package that we can proceed_
> _To import and to use_
> _In our workflow and views_
> _So `components/retently` we'll heed_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b5b2550</samp>

* Add a dependency on the `components/retently` package to integrate with the Retently API ([link](https://github.com/PipedreamHQ/pipedream/pull/7707/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3989-R3990))
* Remove the warning about private accounts not being supported in the legacy workflow builder from `docs/docs/connected-accounts/README.md`, since this information is now in the FAQ section ([link](https://github.com/PipedreamHQ/pipedream/pull/7707/files?diff=unified&w=0#diff-3f512da52536955e2c9a904f66732e8c1b7cc1f24823564901d815e7825fc0afL114-L120))
* Add a warning to the FAQ section in `docs/docs/connected-accounts/README.md` explaining why connected accounts may not show up in the legacy workflow builder, and directing users to the latest version of the workflow builder where private accounts are supported ([link](https://github.com/PipedreamHQ/pipedream/pull/7707/files?diff=unified&w=0#diff-3f512da52536955e2c9a904f66732e8c1b7cc1f24823564901d815e7825fc0afR190-R195))
