### PR TITLE
Onedrive stream when downloading

### DIFF
--- a/components/microsoft_onedrive/actions/download-file/download-file.mjs
+++ b/components/microsoft_onedrive/actions/download-file/download-file.mjs
@@ -1,4 +1,6 @@
 import fs from "fs";
+import stream from "stream";
+import util from "util";
 import onedrive from "../../microsoft_onedrive.app.mjs";
 import httpRequest from "../../common/httpRequest.mjs";
 import { ConfigurationError } from "@pipedream/platform";
@@ -7,7 +9,7 @@ export default {
   name: "Download File",
   description: "Download a file stored in OneDrive. [See the documentation](https://learn.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_get_content?view=odsp-graph-online)",
   key: "microsoft_onedrive-download-file",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     onedrive,
@@ -64,14 +66,14 @@ export default {
     const response = await this.httpRequest({
       $,
       url,
-      responseType: "arraybuffer",
+      responseType: "stream",
     });
 
     const fileName = newFileName.split("/").pop();
     const tmpFilePath = `/tmp/${fileName}`;
-    const buffer = Buffer.from(response, "base64");
 
-    fs.writeFileSync(tmpFilePath, buffer);
+    const pipeline = util.promisify(stream.pipeline);
+    await pipeline(response, fs.createWriteStream(tmpFilePath));
 
     $.export("$summary", `Returned file contents and saved to \`${tmpFilePath}\`.`);
     return tmpFilePath;

--- a/components/microsoft_onedrive/package.json
+++ b/components/microsoft_onedrive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/microsoft_onedrive",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Pipedream Microsoft OneDrive components",
   "main": "microsoft_onedrive.app.js",
   "homepage": "https://pipedream.com/apps/microsoft-onedrive",


### PR DESCRIPTION
Command to create large file then upload to OneDrive:
`dd if=/dev/urandom of=temp_1.5GB_file bs=1M count=1500`

Resolves https://github.com/PipedreamHQ/pipedream/issues/7657.

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 149b120</samp>

This pull request adds two new components for `devrev` and `microsofttodo` and improves the `microsoft_onedrive-download-file` action by using streams instead of buffers. It also updates the package versions and the lock file accordingly.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 149b120</samp>

> _To download files from OneDrive_
> _We use streams instead of `Buffer` to thrive_
> _We also added some components_
> _For `devrev` and `microsofttodo` events_
> _And bumped the package version to `1.1.3` to jive_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 149b120</samp>

*  Bump `@pipedream/microsoft_onedrive` package version to `1.1.3` ([link](https://github.com/PipedreamHQ/pipedream/pull/7717/files?diff=unified&w=0#diff-7018b5abfaa202418d01a1e96367e1c9ed5a788d57f30fdfe8ae66324c0656beL3-R3))
*  Change download action logic to use streams instead of buffers ([link](https://github.com/PipedreamHQ/pipedream/pull/7717/files?diff=unified&w=0#diff-7cd55a28aa3245f830af07785ebbb014a17d001e492178b39d7d20158bf08ff5R2-R3),[link](https://github.com/PipedreamHQ/pipedream/pull/7717/files?diff=unified&w=0#diff-7cd55a28aa3245f830af07785ebbb014a17d001e492178b39d7d20158bf08ff5L10-R12),[link](https://github.com/PipedreamHQ/pipedream/pull/7717/files?diff=unified&w=0#diff-7cd55a28aa3245f830af07785ebbb014a17d001e492178b39d7d20158bf08ff5L67-R76))
   * Import `stream` and `util` modules in `download-file.mjs` ([link](https://github.com/PipedreamHQ/pipedream/pull/7717/files?diff=unified&w=0#diff-7cd55a28aa3245f830af07785ebbb014a17d001e492178b39d7d20158bf08ff5R2-R3))
   * Update action version to `0.0.3` in `download-file.mjs` ([link](https://github.com/PipedreamHQ/pipedream/pull/7717/files?diff=unified&w=0#diff-7cd55a28aa3245f830af07785ebbb014a17d001e492178b39d7d20158bf08ff5L10-R12))
   * Use `responseType: "stream"` and `stream.pipeline` to stream file to temporary file in `download-file.mjs` ([link](https://github.com/PipedreamHQ/pipedream/pull/7717/files?diff=unified&w=0#diff-7cd55a28aa3245f830af07785ebbb014a17d001e492178b39d7d20158bf08ff5L67-R76))
*  Add new component dependencies to `pnpm-lock.yaml` ([link](https://github.com/PipedreamHQ/pipedream/pull/7717/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1158-R1159),[link](https://github.com/PipedreamHQ/pipedream/pull/7717/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2901-R2902))
   * Add `components/devrev` package as a dependency of `components` package ([link](https://github.com/PipedreamHQ/pipedream/pull/7717/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1158-R1159))
   * Add `components/microsofttodo` package as a dependency of `components` package ([link](https://github.com/PipedreamHQ/pipedream/pull/7717/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2901-R2902))
