### PR TITLE
1400 apps in docs

### DIFF
--- a/docs/docs/.vuepress/configs/envVars.js
+++ b/docs/docs/.vuepress/configs/envVars.js
@@ -35,7 +35,7 @@ module.exports = {
   TMP_SIZE_LIMIT: "2GB",
   DELAY_MIN_MAX_TIME:
     "You can pause your workflow for as little as one millisecond, or as long as one year",
-  PUBLIC_APPS: "1,300",
+  PUBLIC_APPS: "1,400",
   WARM_WORKERS_INTERVAL: "10 minutes",
   WARM_WORKERS_CREDITS_PER_INTERVAL: 5,
 };


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 89d958f</samp>

Updated the `PUBLIC_APPS` variable in `envVars.js` to show the correct number of public apps on Pipedream. This variable is used in various places in the website and documentation.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 89d958f</samp>

> _`PUBLIC_APPS` grows_
> _reflecting more integrations_
> _autumn harvest time_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 89d958f</samp>

* Updated the `PUBLIC_APPS` variable to show the correct number of public apps ([link](https://github.com/PipedreamHQ/pipedream/pull/7843/files?diff=unified&w=0#diff-25db0506fc0deea8a6b3bae8c0573595e10b67353a1cbe1fc75390b22d78b16cL38-R38))
