### PR TITLE
fix filter channels prop

### DIFF
--- a/components/discord_bot/actions/add-role/add-role.mjs
+++ b/components/discord_bot/actions/add-role/add-role.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Add Role",
   description: "Assign a role to a user. Remember that your bot requires the `MANAGE_ROLES` permission. [See the docs here](https://discord.com/developers/docs/resources/guild#add-guild-member-role)",
   type: "action",
-  version: "0.0.10",
+  version: "0.0.11",
   props: {
     ...common.props,
     userId: {

--- a/components/discord_bot/actions/change-nickname/change-nickname.mjs
+++ b/components/discord_bot/actions/change-nickname/change-nickname.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Change Nickname",
   description: "Modifies the nickname of the current user in a guild.",
   type: "action",
-  version: "0.0.7",
+  version: "0.0.8",
   props: {
     ...common.props,
     nick: {

--- a/components/discord_bot/actions/create-channel-invite/create-channel-invite.mjs
+++ b/components/discord_bot/actions/create-channel-invite/create-channel-invite.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Create Channel Invite",
   description: "Create a new invite for the channel. [See the docs here](https://discord.com/developers/docs/resources/channel#create-channel-invite)",
   type: "action",
-  version: "0.0.10",
+  version: "0.0.11",
   props: {
     ...common.props,
     maxAge: {

--- a/components/discord_bot/actions/create-guild-channel/create-guild-channel.mjs
+++ b/components/discord_bot/actions/create-guild-channel/create-guild-channel.mjs
@@ -9,7 +9,7 @@ export default {
   name: "Create Guild Channel",
   description: "Create a new channel for the guild. [See the docs here](https://discord.com/developers/docs/resources/guild#create-guild-channel)",
   type: "action",
-  version: "0.0.12",
+  version: "0.0.13",
   props: {
     ...common.props,
     name: {

--- a/components/discord_bot/actions/delete-channel/delete-channel.mjs
+++ b/components/discord_bot/actions/delete-channel/delete-channel.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Delete Channel",
   description: "Delete a Channel.",
   type: "action",
-  version: "0.0.10",
+  version: "0.0.11",
   async run({ $ }) {
     return this.discord.deleteChannel({
       $,

--- a/components/discord_bot/actions/delete-message/delete-message.mjs
+++ b/components/discord_bot/actions/delete-message/delete-message.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Delete message",
   description: "Delete a message. [See the docs here](https://discord.com/developers/docs/resources/channel#delete-message)",
   type: "action",
-  version: "0.0.10",
+  version: "0.0.11",
   props: {
     ...common.props,
     messageId: {

--- a/components/discord_bot/actions/find-channel/find-channel.mjs
+++ b/components/discord_bot/actions/find-channel/find-channel.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Find Channel",
   description: "Find an existing channel by name. [See the docs here](https://discord.com/developers/docs/resources/guild#get-guild-channels)",
   type: "action",
-  version: "0.0.10",
+  version: "0.0.11",
   props: {
     ...common.props,
     channelName: {

--- a/components/discord_bot/actions/find-user/find-user.mjs
+++ b/components/discord_bot/actions/find-user/find-user.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Find User",
   description: "Find an existing user by name. [See the docs here](https://discord.com/developers/docs/resources/guild#search-guild-members)",
   type: "action",
-  version: "0.0.11",
+  version: "0.0.12",
   props: {
     ...common.props,
     query: {

--- a/components/discord_bot/actions/get-message/get-message.mjs
+++ b/components/discord_bot/actions/get-message/get-message.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Get message",
   description: "Return a specific message in a channel. [See the docs here](https://discord.com/developers/docs/resources/channel#get-channel-message)",
   type: "action",
-  version: "0.0.10",
+  version: "0.0.11",
   props: {
     ...common.props,
     messageId: {

--- a/components/discord_bot/actions/list-channel-invites/list-channel-invites.mjs
+++ b/components/discord_bot/actions/list-channel-invites/list-channel-invites.mjs
@@ -9,7 +9,7 @@ export default {
   name: "List Channel Invites",
   description: "Return a list of invitees for the channel. Only usable for guild channels.",
   type: "action",
-  version: "0.0.10",
+  version: "0.0.11",
   props: {
     ...common.props,
     channelId: {

--- a/components/discord_bot/actions/list-channel-messages/list-channel-messages.mjs
+++ b/components/discord_bot/actions/list-channel-messages/list-channel-messages.mjs
@@ -10,7 +10,7 @@ export default {
   name: "List Channel Messages",
   description: "Return the messages for a channel. [See the docs here](https://discord.com/developers/docs/resources/channel#get-channel-messages)",
   type: "action",
-  version: "0.0.11",
+  version: "0.0.12",
   props: {
     ...common.props,
     max: {

--- a/components/discord_bot/actions/list-channels/list-channels.mjs
+++ b/components/discord_bot/actions/list-channels/list-channels.mjs
@@ -6,7 +6,7 @@ export default {
   name: "List Channels",
   description: "Return a list of channels. [See the docs here](https://discord.com/developers/docs/resources/guild#get-guild-channels)",
   type: "action",
-  version: "0.0.10",
+  version: "0.0.11",
   async run({ $ }) {
     return this.discord.getGuildChannels({
       $,

--- a/components/discord_bot/actions/list-guild-members/list-guild-members.mjs
+++ b/components/discord_bot/actions/list-guild-members/list-guild-members.mjs
@@ -11,7 +11,7 @@ export default {
   name: "List Guild Members",
   description: "Return a list of guild members. [See the docs here](https://discord.com/developers/docs/resources/guild#list-guild-members)",
   type: "action",
-  version: "0.0.11",
+  version: "0.0.12",
   props: {
     discord,
     guildId: {

--- a/components/discord_bot/actions/list-users-with-emoji-reactions/list-users-with-emoji-reactions.mjs
+++ b/components/discord_bot/actions/list-users-with-emoji-reactions/list-users-with-emoji-reactions.mjs
@@ -11,7 +11,7 @@ export default {
   name: "List Users that Reacted with Emoji",
   description: "Return a list of users that reacted with a specified emoji.",
   type: "action",
-  version: "0.0.11",
+  version: "0.0.12",
   props: {
     ...common.props,
     messageId: {

--- a/components/discord_bot/actions/modify-channel/modify-channel.mjs
+++ b/components/discord_bot/actions/modify-channel/modify-channel.mjs
@@ -18,7 +18,7 @@ export default {
   name: "Modify Channel",
   description: "Update a channel's settings. [See the docs here](https://discord.com/developers/docs/resources/channel#modify-channel)",
   type: "action",
-  version: "0.0.12",
+  version: "0.0.13",
   props: {
     ...common.props,
     channelId: {

--- a/components/discord_bot/actions/modify-guild-member/modify-guild-member.mjs
+++ b/components/discord_bot/actions/modify-guild-member/modify-guild-member.mjs
@@ -19,7 +19,7 @@ export default {
   name: "Modify Guild Member",
   description: "Update attributes of a guild member. [See the docs here](https://discord.com/developers/docs/resources/guild#modify-guild-member)",
   type: "action",
-  version: "0.0.8",
+  version: "0.0.9",
   props: {
     ...common.props,
     userId: {

--- a/components/discord_bot/actions/post-reaction-with-emoji/post-reaction-with-emoji.mjs
+++ b/components/discord_bot/actions/post-reaction-with-emoji/post-reaction-with-emoji.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Post Reaction with Emoji",
   description: "Post a reaction for a message with an emoji. [See the docs here](https://discord.com/developers/docs/resources/channel#create-reaction)",
   type: "action",
-  version: "0.0.10",
+  version: "0.0.11",
   props: {
     ...common.props,
     messageId: {

--- a/components/discord_bot/actions/remove-user-role/remove-user-role.mjs
+++ b/components/discord_bot/actions/remove-user-role/remove-user-role.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Remove User Role",
   description: "Remove a selected role from the specified user. [See the docs here](https://discord.com/developers/docs/resources/guild#remove-guild-member-role)",
   type: "action",
-  version: "0.0.10",
+  version: "0.0.11",
   props: {
     ...common.props,
     userId: {

--- a/components/discord_bot/actions/rename-channel/rename-channel.mjs
+++ b/components/discord_bot/actions/rename-channel/rename-channel.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Rename Channel",
   description: "Rename a channel to a specified name you choose",
   type: "action",
-  version: "0.0.11",
+  version: "0.0.12",
   props: {
     ...common.props,
     channelId: {

--- a/components/discord_bot/actions/send-message-with-file/send-message-with-file.mjs
+++ b/components/discord_bot/actions/send-message-with-file/send-message-with-file.mjs
@@ -9,7 +9,7 @@ export default {
   key: "discord_bot-send-message-with-file",
   name: "Send Message With File",
   description: "Post a message with an attached file. [See the docs here](https://discord.com/developers/docs/reference#uploading-files)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   props: {
     discord,

--- a/components/discord_bot/actions/send-message/send-message.mjs
+++ b/components/discord_bot/actions/send-message/send-message.mjs
@@ -9,7 +9,7 @@ export default {
   key: "discord_bot-send-message",
   name: "Send message",
   description: "Send message to a user or a channel. [See the docs here](https://discord.com/developers/docs/resources/user#create-dm) and [here](https://discord.com/developers/docs/resources/channel#create-message)",
-  version: "0.0.10",
+  version: "0.0.11",
   type: "action",
   props: {
     discord,

--- a/components/discord_bot/common/utils.mjs
+++ b/components/discord_bot/common/utils.mjs
@@ -46,6 +46,18 @@ export default {
 
       }, []));
     }
+
+    if (!notAllowedChannels.length && !allowedChannels.length) {
+      channelsResp.push(...channels.reduce((reduction, channel) => {
+        return [
+          ...reduction,
+          {
+            label: channel.name,
+            value: channel.id,
+          },
+        ];
+      }, []));
+    }
     return channelsResp;
   },
   getCategoryChannelOptions(channels) {

--- a/components/discord_bot/package.json
+++ b/components/discord_bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/discord_bot",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Pipedream Discord_bot Components",
   "main": "discord_bot.app.js",
   "keywords": [

--- a/components/discord_bot/sources/new-forum-thread-message/new-forum-thread-message.mjs
+++ b/components/discord_bot/sources/new-forum-thread-message/new-forum-thread-message.mjs
@@ -10,7 +10,7 @@ export default {
   name: "New Forum Thread Message",
   description: "Emit new event for each forum thread message posted. Note that your bot must have the `MESSAGE_CONTENT` privilege intent to see the message content, [see the docs here](https://discord.com/developers/docs/topics/gateway#message-content-intent).",
   type: "source",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique", // Dedupe events based on the Discord message ID
   props: {
     ...common.props,

--- a/components/discord_bot/sources/new-guild-member/new-guild-member.mjs
+++ b/components/discord_bot/sources/new-guild-member/new-guild-member.mjs
@@ -8,7 +8,7 @@ export default {
   description: "Emit new event for every member added to a guild. [See docs here](https://discord.com/developers/docs/resources/guild#list-guild-members)",
   type: "source",
   dedupe: "unique",
-  version: "0.1.2",
+  version: "0.1.3",
   props: {
     ...common.props,
     db: "$.service.db",

--- a/components/discord_bot/sources/new-message-in-channel/new-message-in-channel.mjs
+++ b/components/discord_bot/sources/new-message-in-channel/new-message-in-channel.mjs
@@ -11,7 +11,7 @@ export default {
   name: "New Message in Channel",
   description: "Emit new event for each message posted to one or more channels",
   type: "source",
-  version: "0.0.16",
+  version: "0.0.17",
 
   dedupe: "unique", // Dedupe events based on the Discord message ID
   props: {

--- a/components/discord_bot/sources/new-thread-message/new-thread-message.mjs
+++ b/components/discord_bot/sources/new-thread-message/new-thread-message.mjs
@@ -9,7 +9,7 @@ export default {
   name: "New Thread Message",
   description: "Emit new event for each thread message posted.",
   type: "source",
-  version: "0.0.3",
+  version: "0.0.4",
   dedupe: "unique", // Dedupe events based on the Discord message ID
   props: {
     ...common.props,


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c5f216b</samp>

This pull request improves the channel selection logic for the Discord sources by adding a `getChannels` function in `components/discord_bot/common/utils.mjs` that handles empty inclusion and exclusion criteria. It also updates the version number of the `new-message-in-channel` source to reflect this change.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c5f216b</samp>

> _`getChannels` checks_
> _both inclusion and exclusion_
> _all channels or none_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c5f216b</samp>

* Increase the version number of the `new-message-in-channel` source to reflect the addition of the `getChannels` function ([link](https://github.com/PipedreamHQ/pipedream/pull/7850/files?diff=unified&w=0#diff-3a664864f541779254c40ac6e5824f306d54c99333d1bd028d29e7f853fb5bb4L14-R14))
* Add a condition to the `getChannels` function in `utils.mjs` to handle the case when no inclusion or exclusion criteria are specified for the channel options ([link](https://github.com/PipedreamHQ/pipedream/pull/7850/files?diff=unified&w=0#diff-92dc81292e1c8b2b351838d12c52c64d0382b4f8f2c1aa9a83f823556b6b6327R49-R60))
