### PR TITLE
Update Baserow to set default custom fields for base api url

### DIFF
--- a/components/baserow/actions/create-row/create-row.ts
+++ b/components/baserow/actions/create-row/create-row.ts
@@ -11,7 +11,7 @@ export default defineAction({
   name: "Create Row",
   description: `Create a row [See docs here](${DOCS_LINK})`,
   key: "baserow-create-row",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     ...common.props,

--- a/components/baserow/actions/delete-row/delete-row.ts
+++ b/components/baserow/actions/delete-row/delete-row.ts
@@ -10,7 +10,7 @@ export default defineAction({
   description:
     `Delete a row [See docs here](${DOCS_LINK})`,
   key: "baserow-delete-row",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     ...common.props,

--- a/components/baserow/actions/get-row/get-row.ts
+++ b/components/baserow/actions/get-row/get-row.ts
@@ -12,7 +12,7 @@ export default defineAction({
   description:
     `Get a single row [See docs here](${DOCS_LINK})`,
   key: "baserow-get-row",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     ...common.props,

--- a/components/baserow/actions/list-rows/list-rows.ts
+++ b/components/baserow/actions/list-rows/list-rows.ts
@@ -11,7 +11,7 @@ export default defineAction({
   description:
     `List a table's rows [See docs here](${DOCS_LINK})`,
   key: "baserow-list-rows",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   async run({ $ }) {
     const { tableId } = this;

--- a/components/baserow/actions/update-row/update-row.ts
+++ b/components/baserow/actions/update-row/update-row.ts
@@ -11,7 +11,7 @@ export default defineAction({
   name: "Update Row",
   description: `Update a row [See docs here](${DOCS_LINK})`,
   key: "baserow-update-row",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     ...common.props,

--- a/components/baserow/app/baserow.app.ts
+++ b/components/baserow/app/baserow.app.ts
@@ -15,7 +15,7 @@ export default defineApp({
       return this.$auth.token;
     },
     _baseUrl() {
-      return "https://api.baserow.io/api";
+      return this.$auth.base_api_url ?? "https://api.baserow.io/api";
     },
     async _httpRequest({
       $ = this,

--- a/components/baserow/package.json
+++ b/components/baserow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/baserow",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Pipedream Baserow Components",
   "main": "dist/app/baserow.app.mjs",
   "keywords": [

--- a/components/baserow/package.json
+++ b/components/baserow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/baserow",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Pipedream Baserow Components",
   "main": "dist/app/baserow.app.mjs",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -810,6 +810,8 @@ importers:
         specifier: ^8.3.2
         version: 8.3.2
 
+  components/civicrm: {}
+
   components/clearbit:
     dependencies:
       '@pipedream/platform':
@@ -1477,6 +1479,8 @@ importers:
       crypto:
         specifier: ^1.0.1
         version: 1.0.1
+
+  components/ewebinar: {}
 
   components/exact:
     dependencies:
@@ -2587,6 +2591,8 @@ importers:
         version: 1.5.1
 
   components/knowbe4: {}
+
+  components/knowfirst: {}
 
   components/kontent_ai: {}
 
@@ -4399,6 +4405,8 @@ importers:
         specifier: ^1.4.1
         version: 1.5.1
 
+  components/scraptio: {}
+
   components/screendesk: {}
 
   components/screenshotone: {}
@@ -4899,6 +4907,8 @@ importers:
         version: 4.17.21
 
   components/stannp: {}
+
+  components/starton: {}
 
   components/status_hero:
     dependencies:


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 698864e</samp>

Added new components for external platform integration and improved Baserow API base URL handling. The new components are `civicrm`, `ewebinar`, `knowfirst`, `scraptio`, and `starton`. The `baserow.app.ts` file was updated to use the `$auth` object for the base URL if available.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 698864e</samp>

> _To make the `baserow.app.ts` more flexible_
> _The `_baseUrl` method got a new trick_
> _It can use the `$auth` object_
> _To set the base URL correct_
> _Or default to `"https://api.baserow.io/api"`_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 698864e</samp>

*  Modify `_baseUrl` method to use `base_api_url` from `$auth` or default value ([link](https://github.com/PipedreamHQ/pipedream/pull/7954/files?diff=unified&w=0#diff-070850d5b8960060fdedf3969a0ed2880795067e7448e0a71efd18d53f5d69ccL18-R18))
*  Install new components as dependencies using `pnpm` ([link](https://github.com/PipedreamHQ/pipedream/pull/7954/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR813-R814), [link](https://github.com/PipedreamHQ/pipedream/pull/7954/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1483-R1484), [link](https://github.com/PipedreamHQ/pipedream/pull/7954/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2595-R2596), [link](https://github.com/PipedreamHQ/pipedream/pull/7954/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4408-R4409), [link](https://github.com/PipedreamHQ/pipedream/pull/7954/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4911-R4912))
