### PR TITLE
Add optional props to DBT Cloud

### DIFF
--- a/components/dbt/actions/trigger-job-run/trigger-job-run.mjs
+++ b/components/dbt/actions/trigger-job-run/trigger-job-run.mjs
@@ -4,7 +4,7 @@ export default {
   key: "dbt-trigger-job-run",
   name: "Trigger Job Run",
   description: "Trigger a specified job to begin running. [See the documentation](https://docs.getdbt.com/dbt-cloud/api-v2#/operations/Trigger%20Job%20Run)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     dbt,
@@ -53,6 +53,25 @@ export default {
       optional: true,
       default: "Triggered via Pipedream",
     },
+    includeRelated: {
+      type: "string[]",
+      label: "Include Related",
+      description: "List of related fields to pull with the run",
+      options: [
+        "job",
+        "trigger",
+        "environment",
+        "repository",
+        "run_steps",
+      ],
+      optional: true,
+    },
+    steps: {
+      type: "string[]",
+      label: "Steps Override",
+      description: "Steps to override the job's default steps",
+      optional: true,
+    },
   },
   async run({ $ }) {
     const { data } = await this.dbt.triggerJobRun({
@@ -60,7 +79,13 @@ export default {
       jobId: this.jobId,
       data: {
         cause: this.cause,
+        steps_override: this.steps || undefined,
       },
+      params: this.includeRelated
+        ? {
+          include_related: this.includeRelated,
+        }
+        : {},
       $,
     });
 

--- a/components/dbt/package.json
+++ b/components/dbt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/dbt",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream dbt Cloud Components",
   "main": "dbt.app.mjs",
   "keywords": [


### PR DESCRIPTION
Note: I haven't tested this because my trial account and Sergio's are both expired.

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f78d893</samp>

Updated the `dbt` package and the `trigger-job-run` action component to support more options for dbt job runs.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f78d893</samp>

> _`dbt` package updated, action component changed_
> _We unleash the power of data transformation_
> _New parameters give us more control and flexibility_
> _We run the jobs with precision and reliability_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f78d893</samp>

*  Bump up the version of the dbt package and the trigger-job-run action component to reflect the new features and parameters added ([link](https://github.com/PipedreamHQ/pipedream/pull/8016/files?diff=unified&w=0#diff-b2d23e6227f15915ed407ec563711b492f90a8cb1dfdb2d8286f2e4cff5d20bdL7-R7), [link](https://github.com/PipedreamHQ/pipedream/pull/8016/files?diff=unified&w=0#diff-ffd65b605bbaa4bd26ffac7a5dcc6974a77e47340b916c01e2ab896596e0d933L3-R3))
* Add two optional parameters to the trigger-job-run action component: `includeRelated` and `steps`, which allow the user to customize the run output and the job steps ([link](https://github.com/PipedreamHQ/pipedream/pull/8016/files?diff=unified&w=0#diff-b2d23e6227f15915ed407ec563711b492f90a8cb1dfdb2d8286f2e4cff5d20bdR56-R74))
* Modify the axios request in the trigger-job-run action component to include the new parameters in the data and params objects, using conditional logic to omit or set undefined values ([link](https://github.com/PipedreamHQ/pipedream/pull/8016/files?diff=unified&w=0#diff-b2d23e6227f15915ed407ec563711b492f90a8cb1dfdb2d8286f2e4cff5d20bdL63-R88))
