### PR TITLE
[Actions] #7984 Docusign - Add dynamic inputs for every configured template recipient

### DIFF
--- a/components/docusign/actions/create-signature-request/create-signature-request.mjs
+++ b/components/docusign/actions/create-signature-request/create-signature-request.mjs
@@ -4,7 +4,7 @@ import common from "../common/common.mjs";
 export default {
   ...common,
   key: "docusign-create-signature-request",
-  version: "0.1.1",
+  version: "0.2.0",
   name: "Create Signature Request",
   description: "Creates a signature request from a template [See the docs here](https://developers.docusign.com/docs/esign-rest-api/reference/envelopes/envelopes/create)",
   type: "action",
@@ -43,28 +43,6 @@ export default {
       propDefinition: [
         docusign,
         "emailBlurb",
-      ],
-    },
-    recipientEmail: {
-      propDefinition: [
-        docusign,
-        "recipientEmail",
-      ],
-    },
-    recipientName: {
-      propDefinition: [
-        docusign,
-        "recipientName",
-      ],
-    },
-    role: {
-      propDefinition: [
-        docusign,
-        "role",
-        (c) => ({
-          account: c.account,
-          template: c.template,
-        }),
       ],
     },
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 importers:
 
   .:
@@ -1796,6 +1800,8 @@ importers:
         specifier: ^1.2.0
         version: 1.5.1
 
+  components/giantcampaign: {}
+
   components/giphy:
     dependencies:
       '@pipedream/platform':
@@ -2947,6 +2953,8 @@ importers:
       '@pipedream/platform':
         specifier: ^1.4.1
         version: 1.5.1
+
+  components/melo: {}
 
   components/mem: {}
 
@@ -26741,7 +26749,3 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
(Draft PR as this is just ideation/experimentation - Please check discussion in #7984)

#7984

## WHAT

copilot:summary

copilot:poem


## WHY
Currently the Docusign Create Signature Request and Create Draft actions only support sending to one recipient. This is flawed because a Docusign can have multiple roles(recipients) configured. This PR aims to show an example of what we could do in the short term to support a user in providing the name/email for every configured role in a Docusign template. Please check the discussion of #7984 for more in depth conversation around this.

## HOW

copilot:walkthrough



Example Screenshots:

The text highlighted in yellow is dynamic based on the roles pre-configured in your Docusign template.
![image](https://github.com/PipedreamHQ/pipedream/assets/25756024/b084ce26-9bec-4b6c-9e8c-3432f2675ef0)
Docusign role configuration
![image](https://github.com/PipedreamHQ/pipedream/assets/25756024/aa2711ac-d6e7-4185-94f8-d159733fa8e6)
