### PR TITLE
Add optional prop to DBT Cloud

### DIFF
--- a/components/dbt/actions/get-run/get-run.mjs
+++ b/components/dbt/actions/get-run/get-run.mjs
@@ -4,7 +4,7 @@ export default {
   key: "dbt-get-run",
   name: "Get Run",
   description: "Retrieve information about a run. [See the documentation](https://docs.getdbt.com/dbt-cloud/api-v2#/operations/Retrieve%20Run)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     dbt,
@@ -46,11 +46,29 @@ export default {
         }),
       ],
     },
+    includeRelated: {
+      type: "string[]",
+      label: "Include Related",
+      description: "List of related fields to pull with the run",
+      options: [
+        "job",
+        "trigger",
+        "environment",
+        "repository",
+        "run_steps",
+      ],
+      optional: true,
+    },
   },
   async run({ $ }) {
     const { data } = await this.dbt.getRun({
       accountId: this.accountId,
       runId: this.runId,
+      params: this.includeRelated
+        ? {
+          include_related: this.includeRelated,
+        }
+        : {},
       $,
     });
 

--- a/components/dbt/actions/trigger-job-run/trigger-job-run.mjs
+++ b/components/dbt/actions/trigger-job-run/trigger-job-run.mjs
@@ -4,7 +4,7 @@ export default {
   key: "dbt-trigger-job-run",
   name: "Trigger Job Run",
   description: "Trigger a specified job to begin running. [See the documentation](https://docs.getdbt.com/dbt-cloud/api-v2#/operations/Trigger%20Job%20Run)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     dbt,
@@ -53,19 +53,6 @@ export default {
       optional: true,
       default: "Triggered via Pipedream",
     },
-    includeRelated: {
-      type: "string[]",
-      label: "Include Related",
-      description: "List of related fields to pull with the run",
-      options: [
-        "job",
-        "trigger",
-        "environment",
-        "repository",
-        "run_steps",
-      ],
-      optional: true,
-    },
     steps: {
       type: "string[]",
       label: "Steps Override",
@@ -81,11 +68,6 @@ export default {
         cause: this.cause,
         steps_override: this.steps || undefined,
       },
-      params: this.includeRelated
-        ? {
-          include_related: this.includeRelated,
-        }
-        : {},
       $,
     });
 

--- a/components/dbt/package.json
+++ b/components/dbt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/dbt",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream dbt Cloud Components",
   "main": "dbt.app.mjs",
   "keywords": [


### PR DESCRIPTION
Related Issue #7980 
Moves the `include_related` prop from "Trigger Job Run" to "Get Run".

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4361185</samp>

Enhanced the `get-run` action and simplified the `trigger-job-run` action for the dbt component. Bumped the package version to `0.1.2`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4361185</samp>

> _To keep up with dbt's actions_
> _We updated the package's fractions_
> _We added `includeRelated`_
> _And removed what was dated_
> _To improve our job runs and run fetchin's_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4361185</samp>

*  Bump dbt package version to `0.1.2` ([link](https://github.com/PipedreamHQ/pipedream/pull/8048/files?diff=unified&w=0#diff-ffd65b605bbaa4bd26ffac7a5dcc6974a77e47340b916c01e2ab896596e0d933L3-R3))
*  Add `includeRelated` prop to `get-run` action to enable fetching related fields ([link](https://github.com/PipedreamHQ/pipedream/pull/8048/files?diff=unified&w=0#diff-5bec14c8eb04e098362bc0c469a6f5e7dbfdb1626fde533676024bf4044a3f40L7-R7), [link](https://github.com/PipedreamHQ/pipedream/pull/8048/files?diff=unified&w=0#diff-5bec14c8eb04e098362bc0c469a6f5e7dbfdb1626fde533676024bf4044a3f40R49-R61), [link](https://github.com/PipedreamHQ/pipedream/pull/8048/files?diff=unified&w=0#diff-5bec14c8eb04e098362bc0c469a6f5e7dbfdb1626fde533676024bf4044a3f40R67-R71))
*  Remove `includeRelated` prop from `trigger-job-run` action as it is not supported by API ([link](https://github.com/PipedreamHQ/pipedream/pull/8048/files?diff=unified&w=0#diff-b2d23e6227f15915ed407ec563711b492f90a8cb1dfdb2d8286f2e4cff5d20bdL7-R7), [link](https://github.com/PipedreamHQ/pipedream/pull/8048/files?diff=unified&w=0#diff-b2d23e6227f15915ed407ec563711b492f90a8cb1dfdb2d8286f2e4cff5d20bdL56-L68), [link](https://github.com/PipedreamHQ/pipedream/pull/8048/files?diff=unified&w=0#diff-b2d23e6227f15915ed407ec563711b492f90a8cb1dfdb2d8286f2e4cff5d20bdL84-L88))
