### PR TITLE
Fix onedrive deltalink trigger

### DIFF
--- a/components/microsoft_onedrive/package.json
+++ b/components/microsoft_onedrive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/microsoft_onedrive",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Pipedream Microsoft OneDrive components",
   "main": "microsoft_onedrive.app.js",
   "homepage": "https://pipedream.com/apps/microsoft-onedrive",

--- a/components/microsoft_onedrive/sources/new-file-in-folder/new-file-in-folder.mjs
+++ b/components/microsoft_onedrive/sources/new-file-in-folder/new-file-in-folder.mjs
@@ -8,7 +8,7 @@ export default {
   key: "microsoft_onedrive-new-file-in-folder",
   name: "New File in Folder (Instant)",
   description: "Emit an event when a new file is added to a specific directory tree in a OneDrive drive",
-  version: "0.0.3",
+  version: "0.0.4",
   dedupe: "unique",
   props: {
     ...base.props,

--- a/components/microsoft_onedrive/sources/new-file-of-types-in-folder/new-file-of-types-in-folder.mjs
+++ b/components/microsoft_onedrive/sources/new-file-of-types-in-folder/new-file-of-types-in-folder.mjs
@@ -7,7 +7,7 @@ export default {
   key: "microsoft_onedrive-new-file-of-types-in-folder",
   name: "New File of Types in Folder (Instant)",
   description: "Emit an event when a new file of a specific type is created under a directory tree in a OneDrive drive",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
   props: {
     ...base.props,

--- a/components/microsoft_onedrive/sources/new-file/new-file.mjs
+++ b/components/microsoft_onedrive/sources/new-file/new-file.mjs
@@ -7,7 +7,7 @@ export default {
   key: "microsoft_onedrive-new-file",
   name: "New File (Instant)",
   description: "Emit new event when a new file is added to a specific drive in OneDrive",
-  version: "0.0.3",
+  version: "0.0.4",
   dedupe: "unique",
   methods: {
     ...base.methods,

--- a/components/microsoft_onedrive/sources/new-folder-in-folder/new-folder-in-folder.mjs
+++ b/components/microsoft_onedrive/sources/new-folder-in-folder/new-folder-in-folder.mjs
@@ -7,7 +7,7 @@ export default {
   key: "microsoft_onedrive-new-folder-in-folder",
   name: "New Folder in Folder (Instant)",
   description: "Emit an event when a new folder is created under a directory tree in a OneDrive drive",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
   props: {
     ...base.props,

--- a/components/microsoft_onedrive/sources/new-folder/new-folder.mjs
+++ b/components/microsoft_onedrive/sources/new-folder/new-folder.mjs
@@ -6,7 +6,7 @@ export default {
   key: "microsoft_onedrive-new-folder",
   name: "New Folder (Instant)",
   description: "Emit new event when a new folder is created in a OneDrive drive",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
   methods: {
     ...base.methods,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,8 @@ importers:
         specifier: ^4.7.2
         version: 4.9.5
 
+  components/_twocaptcha: {}
+
   components/a123formbuilder:
     dependencies:
       '@pipedream/platform':
@@ -746,6 +748,8 @@ importers:
   components/cdc_national_environmental_public_health_tracking: {}
 
   components/cdr_platform: {}
+
+  components/celonis_ems: {}
 
   components/census_bureau: {}
 
@@ -1607,6 +1611,8 @@ importers:
       '@pipedream/platform':
         specifier: ^1.3.0
         version: 1.5.1
+
+  components/fidel_api: {}
 
   components/figma:
     dependencies:
@@ -3252,6 +3258,8 @@ importers:
         specifier: ^1.5.1
         version: 1.5.1
 
+  components/mx_technologies: {}
+
   components/mx_toolbox: {}
 
   components/mysql:
@@ -3684,6 +3692,8 @@ importers:
         specifier: ^1.3.0
         version: 1.5.1
 
+  components/passslot: {}
+
   components/patreon:
     dependencies:
       axios:
@@ -3747,6 +3757,8 @@ importers:
       '@pipedream/platform':
         specifier: ^0.10.0
         version: 0.10.0
+
+  components/pdfless: {}
 
   components/pdfmonkey: {}
 
@@ -3958,6 +3970,10 @@ importers:
       dtslint:
         specifier: ^4.2.1
         version: 4.2.1(typescript@4.9.5)
+
+  components/postgrid: {}
+
+  components/postgrid_verify: {}
 
   components/posthog: {}
 
@@ -5002,6 +5018,8 @@ importers:
         specifier: ^1.4.0
         version: 1.5.1
 
+  components/spreadsheet_com: {}
+
   components/square:
     dependencies:
       '@pipedream/platform':
@@ -5344,6 +5362,8 @@ importers:
         version: 2.30.0
 
   components/thankster: {}
+
+  components/the_odds_api: {}
 
   components/threads:
     dependencies:


### PR DESCRIPTION
Resolves #7655.

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0a5b0cd</samp>

Improved the reliability and functionality of the Microsoft OneDrive sources by adding error handling and subscription renewal logic to the `base.mjs` module. Updated the versions of the `@pipedream/microsoft_onedrive` package and the individual components that depend on it. Added new dependencies to the `pnpm-lock.yaml` file for other components.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0a5b0cd</samp>

> _Oh we're the pipers of the code, we make the sources run_
> _We update the versions and the packages one by one_
> _We handle all the errors and renew the delta link_
> _And we heave away together on the count of three, me hearties, heave!_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0a5b0cd</samp>

*  Incremented the version of the `@pipedream/microsoft_onedrive` package to reflect the changes in the OneDrive components ([link](https://github.com/PipedreamHQ/pipedream/pull/8063/files?diff=unified&w=0#diff-7018b5abfaa202418d01a1e96367e1c9ed5a788d57f30fdfe8ae66324c0656beL3-R3))
*  Added methods to handle the sequential errors count in the database and renew the webhook subscription if the delta link fails too many times ([link](https://github.com/PipedreamHQ/pipedream/pull/8063/files?diff=unified&w=0#diff-7288bffa748f5ea81a5e153639e2b3cf8d8ffbf69aeb9dcd9f55fc79c3938000R110-R115))
*  Added error handling to the `processEvent` method to catch the possible error thrown by the `itemsStream.next()` call and increment the errors count ([link](https://github.com/PipedreamHQ/pipedream/pull/8063/files?diff=unified&w=0#diff-7288bffa748f5ea81a5e153639e2b3cf8d8ffbf69aeb9dcd9f55fc79c3938000L130-R155))
*  Incremented the versions of the `new-file-in-folder`, `new-file-of-types-in-folder`, `new-file`, `new-folder-in-folder`, and `new-folder` components to reflect the changes in the `base.mjs` module ([link](https://github.com/PipedreamHQ/pipedream/pull/8063/files?diff=unified&w=0#diff-3642a41b25b339d49a5e89631037c8e3eb019167edc5810ffd834aae5c4b3609L11-R11), [link](https://github.com/PipedreamHQ/pipedream/pull/8063/files?diff=unified&w=0#diff-5c741d547563d30b7a194b94ee0e18a79b987148e104d8837379f822784ad178L10-R10), [link](https://github.com/PipedreamHQ/pipedream/pull/8063/files?diff=unified&w=0#diff-9c13795ebb2aaf85fc6345671182927bbb1cde93defd6ae2325f0598fa2e280bL10-R10), [link](https://github.com/PipedreamHQ/pipedream/pull/8063/files?diff=unified&w=0#diff-e3275526751d6ec9e9ed90c7f7b183c7c80286348da6c3670cffbe1ca3810da2L10-R10), [link](https://github.com/PipedreamHQ/pipedream/pull/8063/files?diff=unified&w=0#diff-4768e9080dce6eb4f64b6e1707a557e104999c80be78e2fc0d114825a3a1a2f3L9-R9))
*  Added new packages to the `pnpm-lock.yaml` file as dependencies of some components that use various external APIs ([link](https://github.com/PipedreamHQ/pipedream/pull/8063/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR100-R101), [link](https://github.com/PipedreamHQ/pipedream/pull/8063/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR752-R753), [link](https://github.com/PipedreamHQ/pipedream/pull/8063/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1615-R1616), [link](https://github.com/PipedreamHQ/pipedream/pull/8063/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3261-R3262), [link](https://github.com/PipedreamHQ/pipedream/pull/8063/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3695-R3696), [link](https://github.com/PipedreamHQ/pipedream/pull/8063/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3761-R3762), [link](https://github.com/PipedreamHQ/pipedream/pull/8063/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3974-R3977), [link](https://github.com/PipedreamHQ/pipedream/pull/8063/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5021-R5022), [link](https://github.com/PipedreamHQ/pipedream/pull/8063/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5366-R5367))
