### PR TITLE
7980 fix dbt get run

### DIFF
--- a/components/dbt/actions/get-run/get-run.mjs
+++ b/components/dbt/actions/get-run/get-run.mjs
@@ -4,7 +4,7 @@ export default {
   key: "dbt-get-run",
   name: "Get Run",
   description: "Retrieve information about a run. [See the documentation](https://docs.getdbt.com/dbt-cloud/api-v2#/operations/Retrieve%20Run)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     dbt,

--- a/components/dbt/actions/get-run/get-run.mjs
+++ b/components/dbt/actions/get-run/get-run.mjs
@@ -65,10 +65,12 @@ export default {
       accountId: this.accountId,
       runId: this.runId,
       params: this.includeRelated
-        ? {
-          include_related: this.includeRelated,
+        ?
+        {
+          include_related: JSON.stringify(this.includeRelated),
         }
-        : {},
+        :
+        {},
       $,
     });
 

--- a/components/dbt/package.json
+++ b/components/dbt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/dbt",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Pipedream dbt Cloud Components",
   "main": "dbt.app.mjs",
   "keywords": [


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8cf5349</samp>

Fix bug and bump version of dbt get-run action. Use `JSON.stringify` for `include_related` parameter in `components/dbt/actions/get-run/get-run.mjs`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8cf5349</samp>

> _There once was a bug in dbt_
> _That caused the get-run action to fail_
> _The fix was quite simple_
> _Just `JSON.stringify` a little_
> _And then bump the version and sail_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8cf5349</samp>

*  Fix bug in `get-run` action where related objects were not fetched properly ([link](https://github.com/PipedreamHQ/pipedream/pull/8072/files?diff=unified&w=0#diff-5bec14c8eb04e098362bc0c469a6f5e7dbfdb1626fde533676024bf4044a3f40L68-R73))
*  Bump version of `get-run` action to 0.0.3 ([link](https://github.com/PipedreamHQ/pipedream/pull/8072/files?diff=unified&w=0#diff-5bec14c8eb04e098362bc0c469a6f5e7dbfdb1626fde533676024bf4044a3f40L7-R7))
