### PR TITLE
Action - Clickup

### DIFF
--- a/components/clickup/actions/update-task/update-task.mjs
+++ b/components/clickup/actions/update-task/update-task.mjs
@@ -108,11 +108,11 @@ export default {
         : undefined,
     };
 
-    if (isNaN(data.due_date)) {
+    if (data.due_date && isNaN(data.due_date)) {
       throw new ConfigurationError("Due date is not a valid date");
     }
 
-    if (isNaN(data.start_date)) {
+    if (data.start_date && isNaN(data.start_date)) {
       throw new ConfigurationError("Start date is not a valid date");
     }
 

--- a/components/clickup/actions/update-task/update-task.mjs
+++ b/components/clickup/actions/update-task/update-task.mjs
@@ -1,11 +1,12 @@
 import common from "../common/task-props.mjs";
 import constants from "../common/constants.mjs";
+import { ConfigurationError } from "@pipedream/platform";
 
 export default {
   key: "clickup-update-task",
   name: "Update Task",
   description: "Update a task. See the docs [here](https://clickup.com/api) in **Tasks / Update Task** section.",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   props: {
     ...common.props,
@@ -61,6 +62,18 @@ export default {
       ],
       optional: true,
     },
+    dueDate: {
+      label: "Due Date",
+      type: "string",
+      description: "The due date of task, please use `YYYY-MM-DD` format",
+      optional: true,
+    },
+    startDate: {
+      label: "Start Date",
+      type: "string",
+      description: "The start date of task, please use `YYYY-MM-DD` format",
+      optional: true,
+    },
   },
   async run({ $ }) {
     const {
@@ -87,7 +100,21 @@ export default {
       },
       status,
       parent,
+      due_date: this.dueDate
+        ? new Date(this.dueDate).getTime()
+        : undefined,
+      start_date: this.startDate
+        ? new Date(this.startDate).getTime()
+        : undefined,
     };
+
+    if (isNaN(data.due_date)) {
+      throw new ConfigurationError("Due date is not a valid date");
+    }
+
+    if (isNaN(data.start_date)) {
+      throw new ConfigurationError("Start date is not a valid date");
+    }
 
     if (priority) data[priority] = constants.PRIORITIES[priority];
 

--- a/components/clickup/package.json
+++ b/components/clickup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/clickup",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Pipedream Clickup Components",
   "main": "clickup.app.mjs",
   "keywords": [


### PR DESCRIPTION
Closes #8065 

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c702ab3</samp>

Enhanced the `Update Task` action for Clickup to allow setting and validating due dates and start dates. Bumped up the `@pipedream/clickup` package version.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c702ab3</samp>

> _We're updating tasks on Clickup, me hearties_
> _We're setting dates and checking them twice_
> _We're using `ConfigurationError` for the baddies_
> _We're bumping up the package version, that's nice_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c702ab3</samp>

*  Add `dueDate` and `startDate` props to `Update Task` action to enable users to set task dates ([link](https://github.com/PipedreamHQ/pipedream/pull/8078/files?diff=unified&w=0#diff-2d64786858d4b8d6f349403695b3e6baa49d8a26718da5f6ef0f75ddb21c212fR65-R76), [link](https://github.com/PipedreamHQ/pipedream/pull/8078/files?diff=unified&w=0#diff-2d64786858d4b8d6f349403695b3e6baa49d8a26718da5f6ef0f75ddb21c212fL90-R118))
*  Validate date inputs and throw `ConfigurationError` if invalid ([link](https://github.com/PipedreamHQ/pipedream/pull/8078/files?diff=unified&w=0#diff-2d64786858d4b8d6f349403695b3e6baa49d8a26718da5f6ef0f75ddb21c212fR3), [link](https://github.com/PipedreamHQ/pipedream/pull/8078/files?diff=unified&w=0#diff-2d64786858d4b8d6f349403695b3e6baa49d8a26718da5f6ef0f75ddb21c212fL90-R118))
*  Increment version of `Update Task` action and `@pipedream/clickup` package to reflect new features and bug fixes ([link](https://github.com/PipedreamHQ/pipedream/pull/8078/files?diff=unified&w=0#diff-2d64786858d4b8d6f349403695b3e6baa49d8a26718da5f6ef0f75ddb21c212fL8-R9), [link](https://github.com/PipedreamHQ/pipedream/pull/8078/files?diff=unified&w=0#diff-b3fc14bb19c32fe8fcb02592e33be43dcdc992702ad0f2354020ac966e610bf6L3-R3))
