### PR TITLE
Update create-transcription.mjs

### DIFF
--- a/components/openai/actions/create-transcription/create-transcription.mjs
+++ b/components/openai/actions/create-transcription/create-transcription.mjs
@@ -22,7 +22,7 @@ const pipelineAsync = promisify(stream.pipeline);
 
 export default {
   name: "Create Transcription",
-  version: "0.0.9",
+  version: "0.0.10",
   key: "openai-create-transcription",
   description: "Transcribes audio into the input language. [See docs here](https://platform.openai.com/docs/api-reference/audio/create).",
   type: "action",

--- a/components/openai/actions/create-transcription/create-transcription.mjs
+++ b/components/openai/actions/create-transcription/create-transcription.mjs
@@ -22,6 +22,7 @@ const pipelineAsync = promisify(stream.pipeline);
 
 export default {
   name: "Create Transcription",
+  // incrementing based on new logic
   version: "0.0.10",
   key: "openai-create-transcription",
   description: "Transcribes audio into the input language. [See docs here](https://platform.openai.com/docs/api-reference/audio/create).",


### PR DESCRIPTION
Add additional logic for ensuring chunks are always less than 25MB

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 56d16f8</samp>

Fixed a bug in the `create-transcription` action that caused some audio files to fail transcription due to size limit. Modified the `chunkFile` function to ensure each chunk is less than or equal to 25MB.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 56d16f8</samp>

> _`chunkFile` adjusts_
> _segment time to fit limit_
> _snow melts, bug is gone_


## WHY

Sometimes chunks can exceed the Whisper limit of 25MB. This method ensures that this will not happen.


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 56d16f8</samp>

* Fix bug that caused some audio files to fail transcription due to exceeding the size limit ([link](https://github.com/PipedreamHQ/pipedream/pull/8085/files?diff=unified&w=0#diff-af2de3327bbe4b5ac7ee39f8edaed8cc729f3344072f87db0c0147cc2c4ec2afL127-R171))
