### PR TITLE
Update README.md

### DIFF
--- a/docs/docs/user-settings/README.md
+++ b/docs/docs/user-settings/README.md
@@ -48,6 +48,11 @@ Each recovery code is a one-time-use code, so make sure to generate new recovery
 
 :::
 
+::: warning 2FA is not currently supported with Single Sign On
+Pipedream recommends enabling 2FA with your identity provider.
+
+:::
+
 ### Pipedream API Key
 
 Pipedream provides a [REST API](/api/) for interacting with Pipedream programmatically. You'll find your API key here, which you use to [authorize requests to the API](/api/auth/).


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f93e520</samp>

This pull request updates the user settings documentation to warn users that 2FA is not compatible with SSO on Pipedream. It advises users to use 2FA with their identity provider instead.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f93e520</samp>

> _`2FA` and `SSO`_
> _cannot work together here_
> _warning in the docs_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f93e520</samp>

* Add a warning box about 2FA and SSO limitations to the user settings documentation page ([link](https://github.com/PipedreamHQ/pipedream/pull/8097/files?diff=unified&w=0#diff-b6d835088ba58bf16344311bb0780c819358aef0eca5dff4e9ebebe37a1465feR51-R55))
