### PR TITLE
PandaDoc: Send Document - wait for 'Draft' Status

### DIFF
--- a/components/pandadoc/actions/send-document/send-document.mjs
+++ b/components/pandadoc/actions/send-document/send-document.mjs
@@ -5,7 +5,7 @@ export default defineComponent({
   name: "Send Document",
   description: "Move a document to sent status and send an optional email. [See the documentation](https://developers.pandadoc.com/reference/send-document)",
   type: "action",
-  version: "0.0.2",
+  version: "0.0.3",
   props: {
     app,
     documentId: {
@@ -60,6 +60,24 @@ export default defineComponent({
   },
   async run({ $ }) {
     const documentId = this.documentId;
+
+    let documentStatus = "";
+
+    while (documentStatus !== "document.draft") {
+      try {
+        const response = await this.app.getDocument({
+          id: documentId,
+        });
+        docStatus = response.status;
+        if (docStatus == "document.draft") break;
+        console.log(
+          `Document status is '${documentStatus}' and not 'document.draft'. Waiting 1s and trying again...`
+        );
+        await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait for 1 second
+      } catch (error) {
+        console.error("Error fetching document details:", error);
+      }
+    }
 
     const data = {
       subject: this.subject,

--- a/components/pandadoc/package.json
+++ b/components/pandadoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/pandadoc",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Pipedream PandaDoc Components",
   "main": "pandadoc.app.mjs",
   "keywords": [


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f11b704</samp>

Added a feature to the `send-document` action of the `pandadoc` component that waits for the document to be in draft status before sending it. Updated the component and action versions accordingly.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f11b704</samp>

> _Sing, O Muse, of the skillful coder who updated the pandadoc package_
> _And added a feature to the send-document action, wise and sagacious_
> _He made sure the document was in draft, like a cautious warrior in battle_
> _And he changed the action version, like a shepherd marking his cattle_


## WHY

Per the [PandaDoc API documentation](https://developers.pandadoc.com/reference/send-document)
> **Document state**
> You can only send a document in the document.draft status.
>
> After creating a new document, it usually retains a document.uploaded status for 3-5 seconds while the document syncs across PandaDoc servers. When the document is available for further API calls, it moves to the document.draft state. Use [Document Status](https://developers.pandadoc.com/reference/document-status) or [Webhooks](https://developers.pandadoc.com/reference/on-document-status-change) to check document status.

This PR just adds a check to wait until the document status is 'draft' before sending the document.


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f11b704</samp>

*  Bump up the version of the `pandadoc` package to `0.2.3` to reflect the new feature of the `send-document` action ([link](https://github.com/PipedreamHQ/pipedream/pull/8144/files?diff=unified&w=0#diff-3d775c398b2ef6382327e8c78d5584393d3e8b93be1de20b410ed98299af2debL3-R3))
*  Update the version of the `send-document` action to `0.0.3` and add code to wait for the document to be in draft status before sending it ([link](https://github.com/PipedreamHQ/pipedream/pull/8144/files?diff=unified&w=0#diff-6e8f4cbc7cacd75282446d5370f4d60b1c7d5f0e0e3ffef7064c107f5ff93cc3L8-R8), [link](https://github.com/PipedreamHQ/pipedream/pull/8144/files?diff=unified&w=0#diff-6e8f4cbc7cacd75282446d5370f4d60b1c7d5f0e0e3ffef7064c107f5ff93cc3R64-R81))
