### PR TITLE
Wise Payment Completed Triggers not receiving events

### DIFF
--- a/components/wise/package.json
+++ b/components/wise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/wise",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Pipedream Wise Components",
   "main": "wise.app.mjs",
   "keywords": [

--- a/components/wise/sources/common/common.mjs
+++ b/components/wise/sources/common/common.mjs
@@ -4,7 +4,10 @@ export default {
   props: {
     wise,
     db: "$.service.db",
-    http: "$.interface.http",
+    http: {
+      type: "$.interface.http",
+      customResponse: true,
+    },
     profileId: {
       propDefinition: [
         wise,
@@ -52,6 +55,9 @@ export default {
     },
   },
   async run(event) {
+    this.http.respond({
+      status: 200,
+    });
     this.emitEvent(event.body);
   },
 };

--- a/components/wise/sources/new-transfer-completed/new-transfer-completed.mjs
+++ b/components/wise/sources/new-transfer-completed/new-transfer-completed.mjs
@@ -3,7 +3,7 @@ import common from "../common/common.mjs";
 export default {
   ...common,
   name: "New Transfer Completed (Instant)",
-  version: "0.0.4",
+  version: "0.0.5",
   key: "wise-new-transfer-completed",
   description: "Emit new event for a transfer completed.",
   type: "source",

--- a/components/wise/sources/new-transfer-created/new-transfer-created.mjs
+++ b/components/wise/sources/new-transfer-created/new-transfer-created.mjs
@@ -3,7 +3,7 @@ import common from "../common/common.mjs";
 export default {
   ...common,
   name: "New Transfer Created (Instant)",
-  version: "0.0.4",
+  version: "0.0.5",
   key: "wise-new-transfer-created",
   description: "Emit new event for a transfer created.",
   type: "source",

--- a/components/wise/sources/new-transfer-state-changed/new-transfer-state-changed.mjs
+++ b/components/wise/sources/new-transfer-state-changed/new-transfer-state-changed.mjs
@@ -3,7 +3,7 @@ import common from "../common/common.mjs";
 export default {
   ...common,
   name: "New Transfer State Changed (Instant)",
-  version: "0.0.4",
+  version: "0.0.5",
   key: "wise-new-transfer-state-changed",
   description: "Emit new event for a transfer created.",
   type: "source",


### PR DESCRIPTION
According to the [documentation](https://docs.wise.com/api-docs/features/webhooks-notifications), Wise webhooks should return a `200 response`. Note: I haven't fully tested this, as I'm not sure how to do so without creating a monetary transaction.

## WHAT

copilot:summary

copilot:poem


## WHY

<!-- author to complete -->


## HOW

copilot:walkthrough
