### PR TITLE
Update README.md

### DIFF
--- a/docs/docs/components/quickstart/nodejs/sources/README.md
+++ b/docs/docs/components/quickstart/nodejs/sources/README.md
@@ -580,7 +580,7 @@ response.data.forEach((issue) => {
 Here is the updated code.
 
 ```javascript
-import axios from "@pipedream/platform";
+import { axios } from "@pipedream/platform";
 
 export default {
   name: "Source Demo",
@@ -629,7 +629,7 @@ timer: {
 Here's the updated code.
 
 ```javascript
-import axios from "@pipedream/platform";
+import { axios } from "@pipedream/platform";
 
 export default {
   name: "Source Demo",


### PR DESCRIPTION
fixes missing braces on axios import statements in code snippets. 

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at deeba0d</samp>

Fixed import syntax for axios in Node.js sources quickstart document. This improves the accuracy and consistency of the code examples in `docs/docs/components/quickstart/nodejs/sources/README.md`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at deeba0d</samp>

> _`axios` import_
> _fixed in Node.js snippets_
> _autumn of errors_


## WHY

Running the code as-is throws an error because axios is imported incorrectly

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at deeba0d</samp>

*  Update import statements for axios to use named export (`[link](https://github.com/PipedreamHQ/pipedream/pull/8207/files?diff=unified&w=0#diff-455e0189bbedff767ba4ee8e8977bee9d7d46c4fbac795fe11601783a71d40abL583-R583)`, `[link](https://github.com/PipedreamHQ/pipedream/pull/8207/files?diff=unified&w=0#diff-455e0189bbedff767ba4ee8e8977bee9d7d46c4fbac795fe11601783a71d40abL632-R632)`)
