### PR TITLE
Adding puppeeter support

### DIFF
--- a/components/puppeteer/app/puppeteer.app.ts
+++ b/components/puppeteer/app/puppeteer.app.ts
@@ -1,13 +1,60 @@
 import { defineApp } from "@pipedream/types";
+import puppeteer from "puppeteer-core@19.8.0"
+import chromium from "@sparticuz/chromium@112"
 
 export default defineApp({
   type: "app",
   app: "puppeteer",
   propDefinitions: {},
   methods: {
-    // this.$auth contains connected account data
-    authKeys() {
-      console.log(Object.keys(this.$auth));
+    /**
+     * Launch a new Puppeteer Headless Browser
+     * 
+     * After launching the browser, you can start new pages and perform browser actions
+     * 
+     * @param opts = {}
+     * @returns browser
+     */
+    async launch(opts = {}) {
+      const browser = await puppeteer.launch({
+        executablePath: await chromium.executablePath(),
+        headless: chromium.headless,
+        ignoreHTTPSErrors: true,
+        defaultViewport: chromium.defaultViewport,
+        args: [...chromium.args, "--hide-scrollbars", "--disable-web-security"],
+        ...opts
+      });
+
+      return browser
     },
+    /**
+     * New Page
+     * 
+     * Creates a new web brower page.
+     * 
+     * This returns both the page and the browser instance so the browser instance can be closed.
+     * 
+     * @returns { page, browser }
+     */
+    async newPage() {
+      const browser = this._launch();
+      const page = await browser.newPage();
+
+      return {
+        page, browser
+      }
+    },
+    /**
+     * Goto URL
+     * 
+     * Shorthand method to go directly to a page
+     * 
+     * @returns { page, browser }
+     */
+    async goto() {
+      const { page, browser } = this.newPage();
+
+      return { page, browser }
+    }
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4019,6 +4019,8 @@ importers:
 
   components/platform_ly: {}
 
+  components/playwright: {}
+
   components/plecto: {}
 
   components/plisio: {}
@@ -4180,6 +4182,8 @@ importers:
       '@pipedream/platform':
         specifier: ^1.2.1
         version: 1.5.1
+
+  components/puppeteer: {}
 
   components/pushcut:
     dependencies:


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f2805e3</samp>

This pull request introduces two new components, `playwright` and `puppeteer`, that allow users to create and control headless browsers in AWS Lambda. It also updates the `pnpm-lock.yaml` file to include the dependencies for these components.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f2805e3</samp>

> _Oh we're the crew of the Lambda ship, and we sail the web so fast_
> _We use `puppeteer` and `playwright` to make our browsers last_
> _We launch and create and navigate, with chromium at the core_
> _And we heave away on the count of three, for the headless browser score_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f2805e3</samp>

*  Add puppeteer component to provide headless browser functionality using puppeteer-core and chromium packages ([link](https://github.com/PipedreamHQ/pipedream/pull/8214/files?diff=unified&w=0#diff-d20ebf7c2286333acde4d88b53172e69b6ac42d6aab077dd403cf14fd0b3c044R2-R3), [link](https://github.com/PipedreamHQ/pipedream/pull/8214/files?diff=unified&w=0#diff-d20ebf7c2286333acde4d88b53172e69b6ac42d6aab077dd403cf14fd0b3c044L8-R60), [link](https://github.com/PipedreamHQ/pipedream/pull/8214/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4186-R4187))
* Add playwright component to provide headless browser functionality using playwright library ([link](https://github.com/PipedreamHQ/pipedream/pull/8214/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4022-R4023))
