### PR TITLE
Adding docs for moving projects between workflows

### DIFF
--- a/docs/docs/projects/README.md
+++ b/docs/docs/projects/README.md
@@ -65,6 +65,18 @@ Then at the top right of the project's page, click the **Import** button.
 
 You'll be prompted to select a workflow from your **Workflows** area to import.
 
+### Moving workflows between projects
+
+To move a workflow from a project to another project, first check the workflow and then click **Move** to open a dropdown of projects. Select the project to move this workflow to, and click **Move** once more to complete the move.
+
+![How to move workflows from one project to another in the Pipedream dashboard.](https://res.cloudinary.com/pipedreamin/image/upload/v1695662665/docs/docs/projects/CleanShot_2023-09-25_at_13.23.38_2x_dyrtlv.png)
+
+::: warning Github Sync limitation
+
+At this time it's not possible to move workflows out of GitHub Synchronized Projects.
+
+:::
+
 
 ## Frequently Asked Questions
 


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bb2120e</samp>

This change adds documentation for moving workflows between projects in `docs/docs/projects/README.md`. It explains how to use the dashboard to perform this action and warns about the restriction for GitHub Synchronized Projects.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bb2120e</samp>

> _Move workflows with ease_
> _`projects` feature explained_
> _Autumn leaves the old_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bb2120e</samp>

* Add a subsection on moving workflows between projects to the `Importing workflows into workspaces` section of `docs/docs/projects/README.md` ([link](https://github.com/PipedreamHQ/pipedream/pull/8224/files?diff=unified&w=0#diff-c5d62eae9773461d83a46004db96d84959832c1a5ed5184198efa465d7529b6eL68-R80))
* Include an image and a warning note about the limitation of moving workflows out of GitHub Synchronized Projects ([link](https://github.com/PipedreamHQ/pipedream/pull/8224/files?diff=unified&w=0#diff-c5d62eae9773461d83a46004db96d84959832c1a5ed5184198efa465d7529b6eL68-R80))
