### PR TITLE
AI Code Gen - path fixes

### DIFF
--- a/packages/component_code_gen/code_gen/generate.py
+++ b/packages/component_code_gen/code_gen/generate.py
@@ -38,7 +38,7 @@ def main(component_type, app, instructions, tries=3, urls=[], custom_path=None, 
 
 def parse_common_files(app, component_type, custom_path=None):
     file_list = []
-    app_path = custom_path or f'../../components/{app}'
+    app_path = custom_path or os.path.join('..', '..', 'components', app)
 
     if "source" in component_type:
         component_type = "source"
@@ -46,9 +46,9 @@ def parse_common_files(app, component_type, custom_path=None):
     for root, _, files in os.walk(app_path):
         for filename in files:
             filepath = os.path.join(root, filename)
-            if "dist/" in filepath or "node_modules/" in filepath:
+            if "dist" in filepath or "node_modules" in filepath:
                 continue
-            if "actions/" in filepath or "sources/" in filepath:
+            if "actions" in filepath or "sources" in filepath:
                 if component_type == "app":
                     continue
                 elif component_type in filepath and "common" in filepath:
@@ -60,7 +60,7 @@ def parse_common_files(app, component_type, custom_path=None):
     parsed_common_files = ""
     for common_file in file_list:
         with open(common_file, 'r') as f:
-            common_file = common_file.split(f"{app}/")[1]
+            common_file = common_file.split(f"{app}{os.sep}")[1]
             parsed_common_files += f'### ../../{common_file}\n\n{f.read()}\n'
     return parsed_common_files
 


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8732c46</samp>

Improved code generation script for components by using `os.path` functions and fixing a file filtering bug.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8732c46</samp>

> _There once was a script for code generation_
> _That had some issues with path concatenation_
> _It used `os.path` and `os.sep`_
> _To avoid any mishap_
> _And fixed a bug with file filtration_


## WHY

Aiming to resolve incompatibilities between operating systems (such as path separators `/` on Mac, `\\` on Windows)


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8732c46</samp>

*  Use `os.path.join` and `os.sep` to construct and split file paths in a portable way ([link](https://github.com/PipedreamHQ/pipedream/pull/8242/files?diff=unified&w=0#diff-57c6ea428b4134afc63a249ce4461df96eb6f49a0e7083c5badc9be262291a87L41-R41), [link](https://github.com/PipedreamHQ/pipedream/pull/8242/files?diff=unified&w=0#diff-57c6ea428b4134afc63a249ce4461df96eb6f49a0e7083c5badc9be262291a87L63-R63))
*  Fix bug where `in/` substring in file name would cause incorrect exclusion from code generation ([link](https://github.com/PipedreamHQ/pipedream/pull/8242/files?diff=unified&w=0#diff-57c6ea428b4134afc63a249ce4461df96eb6f49a0e7083c5badc9be262291a87L49-R51))
