### PR TITLE
Don't break and log warning if empty URLs list

### DIFF
--- a/packages/component_code_gen/code_gen/generate_for_github_issue.py
+++ b/packages/component_code_gen/code_gen/generate_for_github_issue.py
@@ -41,7 +41,7 @@ def generate_app_file_prompt(requirements, app_file_content):
 {app_file_content}"""
 
     return f"""Generate an app file that provides propDefinitions and methods that solve the following requirements:
-    
+
 {requirements}"""
 
 
@@ -94,7 +94,7 @@ def generate(issue_number, output_dir, verbose=False, tries=3):
         for component_key in markdown[app][h2_header]:
             component_data = markdown[app][h2_header][component_key]
             instructions = f"""### Requirements
-            
+
 {component_data['prompt']}
 
 ### Use methods and propDefinitions from this app file
@@ -106,7 +106,9 @@ Use the methods and propDefinitions in this app file to solve the requirements:
 You can call methods from the app file using `this.{app}.<method name>`. Think about it: you've already defined props and methods in the app file, so you should use these to promote code reuse.
 
 """
-            urls = component_data["urls"]
+            urls = component_data.get("urls", [])
+            if not urls:
+                logger.warn(f"No API docs URLs found for {component_key}")
 
             if "source" in h2_header:
                 component_type = "webhook_source" if "webhook" in h2_header else "polling_source"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5567,6 +5567,9 @@ importers:
   components/tapfiliate:
     specifiers: {}
 
+  components/tave:
+    specifiers: {}
+
   components/taxjar:
     specifiers: {}
 


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fa27911</samp>

This pull request enhances the code generator for GitHub issue components and adds support for the Tave app component. It also updates the `pnpm-lock.yaml` file with the latest dependency information.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fa27911</samp>

> _`Tave` app component_
> _Added to code generator_
> _Winter of refactor_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fa27911</samp>

* Remove extra blank lines in prompt and instructions strings for Markdown consistency ([link](https://github.com/PipedreamHQ/pipedream/pull/8357/files?diff=unified&w=0#diff-69bedac25cab56c4653721b18b35683ac9f1958fcf91f090470a07db747ee17bL44-R44), [link](https://github.com/PipedreamHQ/pipedream/pull/8357/files?diff=unified&w=0#diff-69bedac25cab56c4653721b18b35683ac9f1958fcf91f090470a07db747ee17bL97-R97))
* Add error handling and logging for missing API docs URLs in `generate` function ([link](https://github.com/PipedreamHQ/pipedream/pull/8357/files?diff=unified&w=0#diff-69bedac25cab56c4653721b18b35683ac9f1958fcf91f090470a07db747ee17bL109-R111))
* Update `pnpm-lock.yaml` file with new entry for `components/tave` package ([link](https://github.com/PipedreamHQ/pipedream/pull/8357/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5570-R5572))
