### PR TITLE
Return string instead of buffer

### DIFF
--- a/components/puppeteer/actions/screenshot-page/screenshot-page.mjs
+++ b/components/puppeteer/actions/screenshot-page/screenshot-page.mjs
@@ -7,7 +7,7 @@ export default {
   key: "puppeteer-screenshot-page",
   name: "Screenshot a Page",
   description: "Captures a screenshot of a page using Puppeteer. [See the documentation](https://pptr.dev/api/puppeteer.page.screenshot)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   props: {
     puppeteer,
@@ -164,9 +164,9 @@ export default {
 
     return filePath
       ? {
-        screenshot,
+        screenshot: screenshot.toString("base64"),
         filePath,
       }
-      : screenshot;
+      : screenshot.toString("base64");
   },
 };

--- a/components/puppeteer/package.json
+++ b/components/puppeteer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/puppeteer",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Pipedream Puppeteer Components",
   "main": "puppeteer.app.mjs",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -445,6 +445,9 @@ importers:
     dependencies:
       '@pipedream/platform': 1.5.1
 
+  components/azure_sql:
+    specifiers: {}
+
   components/badger_maps:
     specifiers:
       '@pipedream/platform': ^1.2.1
@@ -788,6 +791,9 @@ importers:
     dependencies:
       '@pipedream/platform': 0.10.0
 
+  components/chatbotic:
+    specifiers: {}
+
   components/chatfuel_dashboard_api_:
     specifiers: {}
 
@@ -845,6 +851,9 @@ importers:
       '@pipedream/platform': ^1.5.1
     dependencies:
       '@pipedream/platform': 1.5.1
+
+  components/clevertap:
+    specifiers: {}
 
   components/clickfunnels:
     specifiers: {}
@@ -2648,6 +2657,9 @@ importers:
       '@pipedream/platform': ^1.2.0
     dependencies:
       '@pipedream/platform': 1.5.1
+
+  components/jeffreyai:
+    specifiers: {}
 
   components/jellyreach:
     specifiers: {}
@@ -5333,6 +5345,9 @@ importers:
       '@pipedream/platform': 1.5.1
       moment: 2.29.4
 
+  components/spydra:
+    specifiers: {}
+
   components/square:
     specifiers:
       '@pipedream/platform': ^1.2.1
@@ -6106,6 +6121,9 @@ importers:
       '@pipedream/platform': ^1.5.1
     dependencies:
       '@pipedream/platform': 1.5.1
+
+  components/vies_api:
+    specifiers: {}
 
   components/viral_loops:
     specifiers:


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 38a6845</samp>

This pull request adds a new feature to the `screenshot-page` action that returns the screenshot as a base64-encoded string, and updates the `pnpm-lock.yaml` file to include several new components for external services.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 38a6845</samp>

> _`screenshot-page` adds_
> _base64-encoded image_
> _old `filePath` stays_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 38a6845</samp>

*  Incremented version of screenshot-page action and added feature to return screenshot as base64-encoded string ([link](https://github.com/PipedreamHQ/pipedream/pull/8365/files?diff=unified&w=0#diff-7c651bdabaca3622a521ba2fc19123bd7ddef4eeba614a5b98e6e07c11deb94aL10-R10),[link](https://github.com/PipedreamHQ/pipedream/pull/8365/files?diff=unified&w=0#diff-7c651bdabaca3622a521ba2fc19123bd7ddef4eeba614a5b98e6e07c11deb94aL167-R170))
*  Added new components and their dependencies to pnpm-lock.yaml file: azure_sql, chatbotic, clevertap, jeffreyai, spydra, and vies_api ([link](https://github.com/PipedreamHQ/pipedream/pull/8365/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR448-R450),[link](https://github.com/PipedreamHQ/pipedream/pull/8365/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR794-R796),[link](https://github.com/PipedreamHQ/pipedream/pull/8365/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR855-R857),[link](https://github.com/PipedreamHQ/pipedream/pull/8365/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2661-R2663),[link](https://github.com/PipedreamHQ/pipedream/pull/8365/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5348-R5350),[link](https://github.com/PipedreamHQ/pipedream/pull/8365/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR6125-R6127))
