### PR TITLE
Script adjustment to ignore test event files

### DIFF
--- a/scripts/findBadKeys.js
+++ b/scripts/findBadKeys.js
@@ -23,8 +23,7 @@ const isCommonFile = (subname) => {
   return regex.test(subname);
 };
 
-const isTestEventFile = (subname) =>
-  subname.split("/").pop() === "test-event.mjs";
+const isTestEventFile = (subname) => subname.includes("test-event.mjs");
 
 const getComponentKey = (p) => {
   const data = fs.readFileSync(p, "utf8");


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 354c790</samp>

Refactor code for finding bad component keys in `scripts/findBadKeys.js`. Simplify `isTestEventFile` function with `includes` method.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 354c790</samp>

> _`isTestEventFile`_
> _Simplified with `includes`_
> _Code is like spring breeze_


## WHY

Test event files are not being properly ignored by the `findBadKeys` script.


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 354c790</samp>

*  Simplify `isTestEventFile` function to use `includes` method ([link](https://github.com/PipedreamHQ/pipedream/pull/8366/files?diff=unified&w=0#diff-6a9bbea02b37f1347105af56b9d4fc21258d6e46b1d4065574699865e08a9fbbL26-R26))
