### PR TITLE
Zoho CRM: New or Updated Module Entry source

### DIFF
--- a/components/zoho_crm/package.json
+++ b/components/zoho_crm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/zoho_crm",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Pipedream Zoho CRM Components",
   "main": "zoho_crm.app.mjs",
   "keywords": [

--- a/components/zoho_crm/sources/common/http-based/common-custom-module.mjs
+++ b/components/zoho_crm/sources/common/http-based/common-custom-module.mjs
@@ -14,6 +14,7 @@ export default {
         const { modules } = await this.zohoCrm.listModules();
         const options = modules
           .filter(this.areEventsSupportedByModule)
+          .filter(({ generated_type: type }) => type !== "custom")
           .map(({
             api_name: type,
             singular_label: name,

--- a/components/zoho_crm/sources/new-module-entry/new-module-entry.mjs
+++ b/components/zoho_crm/sources/new-module-entry/new-module-entry.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoho_crm-new-module-entry",
   name: "New Module Entry (Instant)",
   description: "Emit new events each time a new module/record is created in Zoho CRM",
-  version: "0.0.13",
+  version: "0.0.14",
   type: "source",
   methods: {
     ...common.methods,

--- a/components/zoho_crm/sources/new-or-updated-module-entry/new-or-updated-module-entry.mjs
+++ b/components/zoho_crm/sources/new-or-updated-module-entry/new-or-updated-module-entry.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoho_crm-new-or-updated-module-entry",
   name: "New or Updated Module Entry (Instant)",
   description: "Emits an event each time a module/record is created or edited in Zoho CRM",
-  version: "0.0.12",
+  version: "0.0.13",
   type: "source",
   methods: {
     ...common.methods,

--- a/components/zoho_crm/sources/updated-module-entry/updated-module-entry.mjs
+++ b/components/zoho_crm/sources/updated-module-entry/updated-module-entry.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoho_crm-updated-module-entry",
   name: "Updated Module Entry (Instant)",
   description: "Emits an event each time a new module/record is updated in Zoho CRM",
-  version: "0.0.12",
+  version: "0.0.13",
   type: "source",
   methods: {
     ...common.methods,


### PR DESCRIPTION
Removed custom module options for `moduleInfo` prop as Zoho CRM doesn't support webhooks for custom modules. [docs](https://help.zoho.com/portal/en/kb/crm/automate-business-processes/actions/articles/webhooks-workflow#List_of_Fields_in_Webhook)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a617f7a</samp>

This pull request updates the `@pipedream/zoho_crm` package and the Zoho CRM source components to handle custom modules with complex custom fields. It also increments the versions of the affected files to reflect the new functionality and bug fixes.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a617f7a</samp>

> _`common-custom-module`_
> _Filters out complex fields now_
> _Winter bug fixes_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a617f7a</samp>

*  Incremented the version of the `@pipedream/zoho_crm` package to reflect the new features and bug fixes ([link](https://github.com/PipedreamHQ/pipedream/pull/8391/files?diff=unified&w=0#diff-1d685fed98935d0dea874fa169247a80e3e81279ff3390bc8c3c53cb88c8b1b7L3-R3))
*  Added a filter to exclude fields with the `generated_type` of `custom` when fetching the metadata of custom modules, to avoid errors with complex data types ([link](https://github.com/PipedreamHQ/pipedream/pull/8391/files?diff=unified&w=0#diff-a6d0f603939d264dd6e3429a4e78a5630fe4489d396d844d737353fd8fd20aa0R17))
*  Incremented the versions of the `new-module-entry`, `new-or-updated-module-entry`, and `updated-module-entry` source components, to reflect the changes in the `common-custom-module` class that affect the module selection and field mapping logic ([link](https://github.com/PipedreamHQ/pipedream/pull/8391/files?diff=unified&w=0#diff-6a1bf9a8060e77d4185a29af720474dffb9e87509895ebdb00036920d913414bL9-R9), [link](https://github.com/PipedreamHQ/pipedream/pull/8391/files?diff=unified&w=0#diff-8899da8d0d981e46d5dc5098658bd5aa5028a3add022b1c2d9d1111280493502L9-R9), [link](https://github.com/PipedreamHQ/pipedream/pull/8391/files?diff=unified&w=0#diff-585118cb12859a331ad2378aba67083d11ea65c4b5f8966790ffeee4dd1d4edfL9-R9))
