### PR TITLE
Imgur - Upload Image

### DIFF
--- a/components/imgur/actions/upload-image/upload-image.mjs
+++ b/components/imgur/actions/upload-image/upload-image.mjs
@@ -3,7 +3,7 @@ import imgur from "../../imgur.app.mjs";
 export default {
   name: "Upload Image",
   version: "0.1.0",
-  key: "upload-image",
+  key: "imgur-upload-image",
   description: "Upload an image to Imgur",
   props: {
     imgur,

--- a/components/imgur/actions/upload-image/upload-image.mjs
+++ b/components/imgur/actions/upload-image/upload-image.mjs
@@ -2,7 +2,7 @@ import imgur from "../../imgur.app.mjs";
 
 export default {
   name: "Upload Image",
-  version: "0.0.1",
+  version: "0.1.0",
   key: "upload-image",
   description: "Upload an image to Imgur",
   props: {

--- a/components/imgur/actions/upload-image/upload-image.mjs
+++ b/components/imgur/actions/upload-image/upload-image.mjs
@@ -1,0 +1,27 @@
+import imgur from "../../imgur.app.mjs";
+
+export default {
+  name: "Upload Image",
+  version: "0.0.1",
+  key: "upload-image",
+  description: "Upload an image to Imgur",
+  props: {
+    imgur,
+    image: {
+      type: "string",
+      label: "Image",
+      description: "A base 64 encoded image",
+    },
+  },
+  type: "action",
+  async run({ $ }) {
+    const res = await this.imgur.uploadImage(this.image);
+
+    if (!res.status == 200) {
+      $.export("response", res);
+      return $.flow.exit("Failed to upload.");
+    }
+
+    return res;
+  },
+};

--- a/components/imgur/imgur.app.mjs
+++ b/components/imgur/imgur.app.mjs
@@ -1,3 +1,6 @@
+import { axios } from "@pipedream/platform";
+import FormData from "form-data";
+
 export default {
   type: "app",
   app: "imgur",
@@ -6,6 +9,27 @@ export default {
     // this.$auth contains connected account data
     authKeys() {
       console.log(Object.keys(this.$auth));
+    },
+    /**
+     * Upload a screenshot to Imgur
+     *
+     * @param {String} screenshot
+     * @returns
+     */
+    uploadImage(screenshot) {
+      const formData = new FormData();
+      formData.append("image", screenshot);
+
+      return axios(this, {
+        method: "POST",
+        maxBodyLength: Infinity,
+        url: "https://api.imgur.com/3/image",
+        headers: {
+          "Authorization": `Bearer ${this.$auth.oauth_access_token}`,
+          ...formData.getHeaders(),
+        },
+        data: formData,
+      });
     },
   },
 };

--- a/components/imgur/package.json
+++ b/components/imgur/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "imgur",
+  "version": "1.0.0",
+  "description": "The imgur app file for Pipedream action & trigger integrations.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "imgur",
+    "api"
+  ],
+  "author": "Dylan Pierce <pierce@pipedream.com>",
+  "license": "ISC"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2573,6 +2573,9 @@ importers:
   components/imgbb:
     specifiers: {}
 
+  components/imgur:
+    specifiers: {}
+
   components/implisense_api:
     specifiers: {}
 


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b759f7a</samp>

This pull request adds a new feature to the `imgur` app that enables uploading images from base 64 data. It modifies the `imgur.app.mjs` module and adds a new action component `upload-image.mjs` to handle the input and output.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b759f7a</samp>

> _We are the uploaders of doom_
> _We send our images to the Imgur tomb_
> _With `base 64` and `FormData`_
> _We unleash our metal rage_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b759f7a</samp>

*  Add a new action component to upload an image to Imgur using a base 64 encoded string ([link](https://github.com/PipedreamHQ/pipedream/pull/8418/files?diff=unified&w=0#diff-9c46a1fdba6c337ff82723874a729421dfcfe91b00461650fab67a4666bd2be8R1-R27))
* Enhance the `imgur` app module with new dependencies and a new method ([link](https://github.com/PipedreamHQ/pipedream/pull/8418/files?diff=unified&w=0#diff-c3b4f15e56b869b904d0f0e592a0511602c9d0b1d8da00c9cf00aaf33228e90cR1-R3),[link](https://github.com/PipedreamHQ/pipedream/pull/8418/files?diff=unified&w=0#diff-c3b4f15e56b869b904d0f0e592a0511602c9d0b1d8da00c9cf00aaf33228e90cR13-R33))
  * Import `axios` and `FormData` modules to make the HTTP request and encode the image as multipart/form-data ([link](https://github.com/PipedreamHQ/pipedream/pull/8418/files?diff=unified&w=0#diff-c3b4f15e56b869b904d0f0e592a0511602c9d0b1d8da00c9cf00aaf33228e90cR1-R3))
  * Add a new method that takes a base 64 encoded image as a parameter and uploads it to Imgur using the OAuth access token and the `axios` module ([link](https://github.com/PipedreamHQ/pipedream/pull/8418/files?diff=unified&w=0#diff-c3b4f15e56b869b904d0f0e592a0511602c9d0b1d8da00c9cf00aaf33228e90cR13-R33))
