### PR TITLE
Adding playwright & puppeteer readmes

### DIFF
--- a/components/playwright/README.md
+++ b/components/playwright/README.md
@@ -4,7 +4,8 @@
 
 Using Playwright you can perform tasks including:
 
-* Screenshots and PDFs: Capture web page visuals.
+* Capture Screenshots: Convert webpages into images.
+* Processing PDFs: parse and scan PDFs.
 * Web Scraping: Extract data from websites.
 * UI/UX Testing: Verify user interface and experience.
 * Integration with Test Frameworks: Combine with testing frameworks.
@@ -22,7 +23,7 @@ Simply import this package, launch a browser and navigate using a Playwright Pag
 
 To get started, import the `@pipedream/browsers` package into your Node.js code step. Pipedream will automatically install this specialized package that bundles the dependencies needed to run `playwright` in your code step.
 
-This package exports a `playwright` module that features these methods:
+This package exports a `playwright` module that exposes these methods:
 
 * `browser(opts?)` - method to instantiate a new browser (returns a [Playwright Browser instance](https://playwright.dev/docs/browsers))
 * `launch(opts?)` - an alias to browser()
@@ -50,6 +51,8 @@ export default defineComponent({
 The same `@pipedream/browsers` package can be used in [actions](https://pipedream.com/docs/components/quickstart/nodejs/actions/) as well as [sources](https://pipedream.com/docs/components/quickstart/nodejs/sources/).
 
 The steps are the same as usage in Node.js code. Open a browser, create a page, and close the browser at the end of the code step.
+
+*Please note*: At this time Source's memory are not configurable and are fixed to 256 mb. This is below the recommened 2 gbs for usage in workflows.
 
 # Troubleshooting
 

--- a/components/playwright/README.md
+++ b/components/playwright/README.md
@@ -1,6 +1,6 @@
 # Overview
 
-[Playwright](https://pptr.dev/) is a Node.js library which provides a high-level API to control Chrome/Chromium over the DevTools Protocol. Playwright runs in headless mode on Chromium on Pipedream.
+[Playwright](https://playwright.dev/) is a Node.js library which provides a high-level API to control Chrome/Chromium over the DevTools Protocol. Playwright runs in headless mode on Chromium on Pipedream.
 
 Using Playwright you can perform tasks including:
 

--- a/components/playwright/README.md
+++ b/components/playwright/README.md
@@ -1,0 +1,62 @@
+# Overview
+
+[Playwright](https://pptr.dev/) is a Node.js library which provides a high-level API to control Chrome/Chromium over the DevTools Protocol. Playwright runs in headless mode on Chromium on Pipedream.
+
+Using Playwright you can perform tasks including:
+
+* Screenshots and PDFs: Capture web page visuals.
+* Web Scraping: Extract data from websites.
+* UI/UX Testing: Verify user interface and experience.
+* Integration with Test Frameworks: Combine with testing frameworks.
+* Task Automation: Automate web-related tasks like form filling.
+* Functional Testing: Automate user interactions to test web application functionality.
+* Regression Testing: Ensure new code changes don't introduce bugs.
+
+# Getting Started
+
+No authentication is required to use Playwright in your Pipedream workflows. Pipedream publishes [a specific NPM package](https://www.npmjs.com/package/@pipedream/browsers) that is compatible with the Pipedream Execution Environment. This package includes the headless Chromium binary needed to run a browser headlessly within your Pipedream workflows.
+
+Simply import this package, launch a browser and navigate using a Playwright Page instance.
+
+## Usage in Node.js Code Steps
+
+To get started, import the `@pipedream/browsers` package into your Node.js code step. Pipedream will automatically install this specialized package that bundles the dependencies needed to run `playwright` in your code step.
+
+This package exports a `playwright` module that features these methods:
+
+* `browser(opts?)` - method to instantiate a new browser (returns a [Playwright Browser instance](https://playwright.dev/docs/browsers))
+* `launch(opts?)` - an alias to browser()
+* `newPage()` - creates a new [Playwright Page](https://playwright.dev/docs/pages) instance and returns both the page & browser
+
+> Note: After awaiting the browser instance, make sure to close the browser at the end of your Node.js code step.
+
+```javascript
+import { playwright } from '@pipedream/browsers';
+
+export default defineComponent({
+  async run({steps, $}) {
+    const browser = await playwright.browser();
+    
+    console.log(browser)
+    // get page, perform actions, etc.
+
+    await browser.close();
+  },
+})
+```
+
+## Usage in Sources or Actions
+
+The same `@pipedream/browsers` package can be used in [actions](https://pipedream.com/docs/components/quickstart/nodejs/actions/) as well as [sources](https://pipedream.com/docs/components/quickstart/nodejs/sources/).
+
+The steps are the same as usage in Node.js code. Open a browser, create a page, and close the browser at the end of the code step.
+
+# Troubleshooting
+
+## Workflow exited before step finished execution
+
+Remember to close the browser instance _before_ the step finishes. Otherwise, the browser will keep the step "open" and not transfer control to the next step.
+
+## Out of memory errors or slow starts
+
+For best results, we recommend increasing the amount of memory available to your workflow to 2 gigabytes. You can adjust the available memory in the [workflow settings](https://pipedream.com/docs/workflows/settings/#memory).

--- a/components/puppeteer/README.md
+++ b/components/puppeteer/README.md
@@ -1,0 +1,62 @@
+# Overview
+
+[Puppeteer](https://pptr.dev/) is a Node.js library which provides a high-level API to control Chrome/Chromium over the DevTools Protocol. Puppeteer runs in headless mode on Chromium on Pipedream.
+
+Using Puppeteer you can perform tasks including:
+
+* Screenshots and PDFs: Capture web page visuals.
+* Web Scraping: Extract data from websites.
+* UI/UX Testing: Verify user interface and experience.
+* Integration with Test Frameworks: Combine with testing frameworks.
+* Task Automation: Automate web-related tasks like form filling.
+* Functional Testing: Automate user interactions to test web application functionality.
+* Regression Testing: Ensure new code changes don't introduce bugs.
+
+# Getting Started
+
+No authentication is required to use Puppeteer in your Pipedream workflows. Pipedream publishes [a specific NPM package](https://www.npmjs.com/package/@pipedream/browsers) that is compatible with the Pipedream Execution Environment. This package includes the headless Chromium binary needed to run a browser headlessly within your Pipedream workflows.
+
+Simply import this package, launch a browser and navigate using a Puppeteer Page instance.
+
+## Usage in Node.js Code Steps
+
+To get started, import the `@pipedream/browsers` package into your Node.js code step. Pipedream will automatically install this specialized package that bundles the dependencies needed to run `puppeteer` in your code step.
+
+This package exports a `puppeteer` module that features these methods:
+
+* `browser(opts?)` - method to instantiate a new browser (returns a [Puppeteer Browser instance](https://pptr.dev/api/puppeteer.browser))
+* `launch(opts?)` - an alias to browser()
+* `newPage()` - creates a new [Puppeteer Page](https://pptr.dev/api/puppeteer.page) instance and returns both the page & browser
+
+> Note: After awaiting the browser instance, make sure to close the browser at the end of your Node.js code step.
+
+```javascript
+import { puppeteer } from '@pipedream/browsers';
+
+export default defineComponent({
+  async run({steps, $}) {
+    const browser = await puppeteer.browser();
+    
+    console.log(browser)
+    // get page, perform actions, etc.
+
+    await browser.close();
+  },
+})
+```
+
+## Usage in Sources or Actions
+
+The same `@pipedream/browsers` package can be used in [actions](https://pipedream.com/docs/components/quickstart/nodejs/actions/) as well as [sources](https://pipedream.com/docs/components/quickstart/nodejs/sources/).
+
+The steps are the same as usage in Node.js code. Open a browser, create a page, and close the browser at the end of the code step.
+
+# Troubleshooting
+
+## Workflow exited before step finished execution
+
+Remember to close the browser instance _before_ the step finishes. Otherwise, the browser will keep the step "open" and not transfer control to the next step.
+
+## Out of memory errors or slow starts
+
+For best results, we recommend increasing the amount of memory available to your workflow to 2 gigabytes. You can adjust the available memory in the [workflow settings](https://pipedream.com/docs/workflows/settings/#memory).

--- a/components/puppeteer/README.md
+++ b/components/puppeteer/README.md
@@ -4,7 +4,8 @@
 
 Using Puppeteer you can perform tasks including:
 
-* Screenshots and PDFs: Capture web page visuals.
+* Capture Screenshots: Convert webpages into images.
+* Processing PDFs: parse and scan PDFs.
 * Web Scraping: Extract data from websites.
 * UI/UX Testing: Verify user interface and experience.
 * Integration with Test Frameworks: Combine with testing frameworks.
@@ -22,7 +23,7 @@ Simply import this package, launch a browser and navigate using a Puppeteer Page
 
 To get started, import the `@pipedream/browsers` package into your Node.js code step. Pipedream will automatically install this specialized package that bundles the dependencies needed to run `puppeteer` in your code step.
 
-This package exports a `puppeteer` module that features these methods:
+This package exports a `puppeteer` module that exposes these methods:
 
 * `browser(opts?)` - method to instantiate a new browser (returns a [Puppeteer Browser instance](https://pptr.dev/api/puppeteer.browser))
 * `launch(opts?)` - an alias to browser()
@@ -50,6 +51,8 @@ export default defineComponent({
 The same `@pipedream/browsers` package can be used in [actions](https://pipedream.com/docs/components/quickstart/nodejs/actions/) as well as [sources](https://pipedream.com/docs/components/quickstart/nodejs/sources/).
 
 The steps are the same as usage in Node.js code. Open a browser, create a page, and close the browser at the end of the code step.
+
+*Please note*: At this time Source's memory are not configurable and are fixed to 256 mb. This is below the recommened 2 gbs for usage in workflows.
 
 # Troubleshooting
 

--- a/docs/docs/.vuepress/configs/sidebarConfig.js
+++ b/docs/docs/.vuepress/configs/sidebarConfig.js
@@ -66,7 +66,8 @@ const docsNav = [
           "/code/nodejs/rerun/",
           "/environment-variables/",
           "/code/nodejs/async/",
-          "/code/nodejs/sharing-code/"
+          "/code/nodejs/sharing-code/",
+          "/code/nodejs/browser-automation/"
         ],
       },
       {

--- a/docs/docs/code/nodejs/browser-automation/README.md
+++ b/docs/docs/code/nodejs/browser-automation/README.md
@@ -56,6 +56,8 @@ Puppeteer can take a full screenshot of a webpage rendered with Chromium. For fu
 :::: tabs :options="{ useUrlFragment: false }"
 
 ::: tab "Save screenshot to /tmp"
+
+Save a screenshot within the local `/tmp` directory:
 ```javascript
 import { puppeteer } from '@pipedreamhq/platform';
 
@@ -73,6 +75,8 @@ export default defineComponent({
 :::
 
 ::: tab "Return screenshot as a base64 encoded string"
+
+Save the screenshot as a base 64 encoded string:
 
 ```javascript
 import { puppeteer } from '@pipedream/browsers';
@@ -100,6 +104,9 @@ Puppeteer can render a PDF of a webpage. For full options [see the Puppeteer Scr
 :::: tabs :options="{ useUrlFragment: false }"
 
 ::: tab "Save PDF to /tmp"
+
+Save the PDF locally to `/tmp`:
+
 ```javascript
 import { puppeteer } from '@pipedreamhq/platform';
 
@@ -116,7 +123,9 @@ export default defineComponent({
 ```
 :::
 
-::: tab "Return screenshot as a base64 encoded string"
+::: tab "Return the PDF as a base64 encoded string"
+
+Save the PDF as a base 64 encoded string:
 
 ```javascript
 import { puppeteer } from '@pipedream/browsers';
@@ -145,6 +154,9 @@ Puppeteer can scrape individual elements or return all content of a webpage.
 :::: tabs :options="{ useUrlFragment: false }"
 
 ::: tab "Extract the h1 tag from a webpage"
+
+Extract individual elements with a CSS selector:
+
 ```javascript
 import { puppeteer } from '@pipedream/browsers';
 
@@ -163,6 +175,8 @@ export default defineComponent({
 :::
 
 ::: tab "Retrieve all HTML content from a webpage"
+
+Extract all HTML content form a webpage:
 
 ```javascript
 import { puppeteer } from '@pipedream/browsers';
@@ -190,6 +204,9 @@ Puppeteer can also programmatically click and type on a webpage.
 :::: tabs :options="{ useUrlFragment: false }"
 
 ::: tab "With Page.type"
+
+`Page.type` accepts a CSS selector and a string to type into the field.
+
 ```javascript
 import { puppeteer } from '@pipedream/browsers';
 
@@ -211,6 +228,9 @@ export default defineComponent({
 :::
 
 ::: tab "With Page.click and Page.keyboard.type"
+
+`Page.click` will click on the element to focus on it, then `Page.keyboard.type` emulates keyboard keystrokes.
+
 ```javascript
 import { puppeteer } from '@pipedream/browsers';
 
@@ -265,7 +285,7 @@ export default defineComponent({
     $.export('content', content);
 
     // The browser context and browser needs to be closed, otherwise the step will hang
-    await page.context().close();
+    await page.context().clos);
     await browser.close();
   },
 })
@@ -291,6 +311,9 @@ Playwright can take a full screenshot of a webpage rendered with Chromium. For f
 :::: tabs :options="{ useUrlFragment: false }"
 
 ::: tab "Save screenshot to /tmp"
+
+Save a screenshot within the local `/tmp` directory:
+
 ```javascript
 import { playwright } from '@pipedreamhq/platform';
 
@@ -310,6 +333,8 @@ export default defineComponent({
 :::
 
 ::: tab "Return screenshot as a base64 encoded string"
+
+Save the screenshot as a base 64 encoded string:
 
 ```javascript
 import { playwright } from '@pipedream/browsers';
@@ -342,6 +367,9 @@ Playwright can render a PDF of a webpage. For full options [see the Playwright S
 :::: tabs :options="{ useUrlFragment: false }"
 
 ::: tab "Save PDF to /tmp"
+
+Save a PDF locally to `/tmp`:
+
 ```javascript
 import { playwright } from '@pipedreamhq/platform';
 
@@ -361,6 +389,8 @@ export default defineComponent({
 :::
 
 ::: tab "Return screenshot as a base64 encoded string"
+
+Save the screenshot as a base 64 encoded string:
 
 ```javascript
 import { playwright } from '@pipedream/browsers';
@@ -393,6 +423,9 @@ Playwright can scrape individual elements or return all content of a webpage.
 :::: tabs :options="{ useUrlFragment: false }"
 
 ::: tab "Extract the h1 tag from a webpage"
+
+Extract individual HTML elements using a CSS Selector:
+
 ```javascript
 import { playwright } from '@pipedream/browsers';
 
@@ -414,6 +447,8 @@ export default defineComponent({
 :::
 
 ::: tab "Retrieve all HTML content from a webpage"
+
+Extract all HTML content from a webpage with `Page.content`:
 
 ```javascript
 import { playwright } from '@pipedream/browsers';
@@ -444,6 +479,9 @@ Playwright can also programmatically click and type on a webpage.
 :::: tabs :options="{ useUrlFragment: false }"
 
 ::: tab "With Page.type"
+
+`Page.type` accepts a CSS selector and a string to type into the selected element.
+
 ```javascript
 import { playwright } from '@pipedream/browsers';
 
@@ -466,6 +504,9 @@ export default defineComponent({
 :::
 
 ::: tab "With Page.click and Page.keyboard.type"
+
+`Page.click` will click on the element to focus on it, then `Page.keyboard.type` emulates keyboard keystrokes.
+
 ```javascript
 import { playwright } from '@pipedream/browsers';
 

--- a/docs/docs/code/nodejs/browser-automation/README.md
+++ b/docs/docs/code/nodejs/browser-automation/README.md
@@ -1,0 +1,523 @@
+# Browser Automation with Node.js
+
+<VideoPlayer src="https://www.youtube.com/embed/RXlCDTQc8xI" title="Browser automation with Node.js in Pipedream" />
+
+You can leverage headless browser automations within Pipedream workflows for web scraping, generating screenshots, or programmatically interacting with websites - even those that make heavy usage of frontend Javascript.
+
+Pipedream manages a [specialized package](https://www.npmjs.com/package/@pipedream/browsers) that includes Puppeteer and Playwright bundled with a specialized Chromium instance that's compatible with Pipedream's Node.js Execution Environment.
+
+All that's required is importing the [`@pipedream/browsers`](https://www.npmjs.com/package/@pipedream/browsers) package into your Node.js code step and launch a browser. Pipedream will start Chromium and launch a Puppeteer or Playwright Browser instance for you.
+
+[[toc]]
+
+## Usage
+
+The `@pipedream/browsers` package exports two modules: `puppeteer` & `playwright`. Both modules share the same interface:
+
+* `browser(opts?)` - method to instantiate a new browser (returns a browser instance)
+* `launch(opts?)` - an alias to browser()
+* `newPage()` - creates a new page instance and returns both the page & browser
+
+### Puppeteer
+
+First import the `puppeteer` module from `@pipedream/browsers` and use `browser()` or `launch()` method to instantiate a browser.
+
+Then using this browser you can open new [Pages](https://pptr.dev/api/puppeteer.page), which have individual controls to open URLs:
+
+```javascript
+ import { puppeteer } from '@pipedream/browsers';
+
+export default defineComponent({
+  async run({steps, $}) {
+    const browser = await puppeteer.browser();
+    
+    // Interact with the web page programmatically
+    // See Puppeeter's Page documentation for available methods:
+    // https://pptr.dev/api/puppeteer.page
+    const page = await browser.newPage();
+
+    await page.goto('https://pipedream.com/');
+    const title = await page.title();
+    const content = await page.content();
+
+    $.export('title', title);
+    $.export('content', content);
+
+    // The browser needs to be closed, otherwise the step will hang
+    await browser.close();
+  },
+})
+```
+
+#### Screenshot a webpage
+
+Puppeteer can take a full screenshot of a webpage rendered with Chromium. For full options [see the Puppeteer Screenshot method documentation.](https://pptr.dev/api/puppeteer.page.screenshot)
+
+:::: tabs :options="{ useUrlFragment: false }"
+
+::: tab "Save screenshot to /tmp"
+```javascript
+import { puppeteer } from '@pipedreamhq/platform';
+
+export default defineComponent({
+  async run({ $ }) {
+    const browser = await puppeteer.launch();
+    const page = await browser.newPage();
+    await page.goto('https://pipedream.com');
+    await page.screenshot({ path: '/tmp/screenshot.png' });
+    await browser.close();
+  },
+});
+
+```
+:::
+
+::: tab "Return screenshot as a base64 encoded string"
+
+```javascript
+import { puppeteer } from '@pipedream/browsers';
+
+export default defineComponent({
+  async run({ $ }) {
+    const browser = await puppeteer.browser();
+    const page = await browser.newPage();
+    await page.goto('https://pipedream.com/');
+    const screenshot = await page.screenshot({ encoding: 'base64' });
+    await browser.close();
+    return screenshot;
+  },
+});
+```
+
+:::
+
+::::
+
+#### Generate a PDF of a webpage
+
+Puppeteer can render a PDF of a webpage. For full options [see the Puppeteer Screenshot method documentation.](https://pptr.dev/api/puppeteer.page.pdf)
+
+:::: tabs :options="{ useUrlFragment: false }"
+
+::: tab "Save PDF to /tmp"
+```javascript
+import { puppeteer } from '@pipedreamhq/platform';
+
+export default defineComponent({
+  async run({ $ }) {
+    const browser = await puppeteer.launch();
+    const page = await browser.newPage();
+    await page.goto('https://pipedream.com');
+    await page.pdf({ path: '/tmp/screenshot.pdf' });
+    await browser.close();
+  },
+});
+
+```
+:::
+
+::: tab "Return screenshot as a base64 encoded string"
+
+```javascript
+import { puppeteer } from '@pipedream/browsers';
+
+export default defineComponent({
+  async run({ $ }) {
+    const browser = await puppeteer.browser();
+    const page = await browser.newPage();
+    await page.goto('https://pipedream.com');
+    const pdfBuffer = await page.pdf();
+    const pdfBase64 = pdfBuffer.toString('base64');
+    await browser.close();
+    return pdfBase64;
+  },
+});
+```
+
+:::
+
+::::
+
+#### Scrape content from a webpage
+
+Puppeteer can scrape individual elements or return all content of a webpage.
+
+:::: tabs :options="{ useUrlFragment: false }"
+
+::: tab "Extract the h1 tag from a webpage"
+```javascript
+import { puppeteer } from '@pipedream/browsers';
+
+export default defineComponent({
+  async run({ $ }) {
+    const browser = await puppeteer.browser();
+    const page = await browser.newPage();
+    await page.goto('https://pipedream.com');
+    const h1Content = await page.$eval('h1', el => el.textContent);
+    await browser.close();
+    return h1Content;
+  },
+});
+
+```
+:::
+
+::: tab "Retrieve all HTML content from a webpage"
+
+```javascript
+import { puppeteer } from '@pipedream/browsers';
+
+export default defineComponent({
+  async run({ $ }) {
+    const browser = await puppeteer.browser();
+    const page = await browser.newPage();
+    await page.goto('https://pipedream.com');
+    const content = await page.content();
+    await browser.close();
+    return content;
+  },
+});
+```
+
+:::
+
+::::
+
+#### Submit a form
+
+Puppeteer can also programmatically click and type on a webpage.
+
+:::: tabs :options="{ useUrlFragment: false }"
+
+::: tab "With Page.type"
+```javascript
+import { puppeteer } from '@pipedream/browsers';
+
+export default defineComponent({
+  async run({ steps, $ }) {
+    const browser = await puppeteer.browser();
+    const page = await browser.newPage();
+
+    await page.goto('https://example.com/contact');
+    await page.type('input[name=email]', 'pierce@pipedream.com');
+    await page.type('input[name=name]', 'Dylan Pierce');
+    await page.type('textarea[name=message]', "Hello, from a Pipedream workflow.");
+    await page.click('input[type=submit]');
+
+    await browser.close();
+  },
+});
+```
+:::
+
+::: tab "With Page.click and Page.keyboard.type"
+```javascript
+import { puppeteer } from '@pipedream/browsers';
+
+export default defineComponent({
+  async run({ steps, $ }) {
+    const browser = await puppeteer.browser();
+    const page = await browser.newPage();
+
+    await page.goto('https://example.com/contact');
+    await page.click('input[name=email]')
+    await page.keyboard.type('pierce@pipedream.com');
+    await page.click('input[name=name]')
+    await page.keyboard.type('Dylan Pierce');
+    await page.click('textarea[name=message]')
+    await page.keyboard.type("Hello, from a Pipedream workflow.");
+    await page.click('input[type=submit]');
+
+    await browser.close();
+  },
+});
+```
+:::
+
+::::
+
+
+
+
+### Playwright
+
+First import the `playwright` module from `@pipedream/browsers` and use `browser()` or `launch()` method to instantiate a browser.
+
+Then using this browser you can open new [Pages](https://playwright.dev/docs/api/class-page), which have individual controls to open URLs, click elements, generate screenshots and type and more:
+
+```javascript
+import { playwright } from '@pipedream/browsers';
+
+export default defineComponent({
+  async run({steps, $}) {
+    const browser = await playwright.browser();
+    
+    // Interact with the web page programmatically
+    // See Playwright's Page documentation for available methods:
+    // https://playwright.dev/docs/api/class-page
+    const page = await browser.newPage();
+
+    await page.goto('https://pipedream.com/');
+    const title = await page.title();
+    const content = await page.content();
+
+    $.export('title', title);
+    $.export('content', content);
+
+    // The browser context and browser needs to be closed, otherwise the step will hang
+    await page.context().close();
+    await browser.close();
+  },
+})
+```
+
+::: tip Don't forget to close the Browser Context
+
+Playwright differs from Puppeteer slightly in that you have to close the page's BrowserContext before closing the Browser itself.
+
+```javascript
+// Close the context & browser before returning results
+// Otherwise the step will hang
+await page.context().close();
+await browser.close();
+```
+
+:::
+
+#### Screenshot a webpage
+
+Playwright can take a full screenshot of a webpage rendered with Chromium. For full options [see the Playwright Screenshot method documentation.](https://playwright.dev/docs/api/class-page#page-screenshot)
+
+:::: tabs :options="{ useUrlFragment: false }"
+
+::: tab "Save screenshot to /tmp"
+```javascript
+import { playwright } from '@pipedreamhq/platform';
+
+export default defineComponent({
+  async run({ $ }) {
+    const browser = await playwright.launch();
+    const page = await browser.newPage();
+    await page.goto('https://pipedream.com');
+    await page.screenshot({ path: '/tmp/screenshot.png' });
+
+    await page.context().close();
+    await browser.close();
+  },
+});
+
+```
+:::
+
+::: tab "Return screenshot as a base64 encoded string"
+
+```javascript
+import { playwright } from '@pipedream/browsers';
+
+export default defineComponent({
+  async run({ $ }) {
+    const browser = await playwright.launch();
+    const page = await browser.newPage();
+    await page.goto('https://pipedream.com/');
+
+    const screenshotBuffer = await page.screenshot();
+    const screenshotBase64 = screenshotBuffer.toString('base64');
+
+    await page.context().close();
+    await browser.close();
+
+    return screenshotBase64;
+  },
+});
+```
+
+:::
+
+::::
+
+#### Generate a PDF of a webpage
+
+Playwright can render a PDF of a webpage. For full options [see the Playwright Screenshot method documentation.](https://playwright.dev/docs/api/class-page#page-pdf)
+
+:::: tabs :options="{ useUrlFragment: false }"
+
+::: tab "Save PDF to /tmp"
+```javascript
+import { playwright } from '@pipedreamhq/platform';
+
+export default defineComponent({
+  async run({ $ }) {
+    const browser = await playwright.launch();
+    const page = await browser.newPage();
+    await page.goto('https://pipedream.com');
+    await page.pdf({ path: '/tmp/screenshot.pdf' });
+
+    await page.context().close();
+    await browser.close();
+  },
+});
+
+```
+:::
+
+::: tab "Return screenshot as a base64 encoded string"
+
+```javascript
+import { playwright } from '@pipedream/browsers';
+
+export default defineComponent({
+  async run({ $ }) {
+    const browser = await playwright.launch();
+    const page = await browser.newPage();
+    await page.goto('https://pipedream.com/');
+
+    const screenshotBuffer = await page.pdf();
+    const screenshotBase64 = screenshotBuffer.toString('base64');
+
+    await page.context().close();
+    await browser.close();
+
+    return screenshotBase64;
+  },
+});
+```
+
+:::
+
+::::
+
+#### Scrape content from a webpage
+
+Playwright can scrape individual elements or return all content of a webpage.
+
+:::: tabs :options="{ useUrlFragment: false }"
+
+::: tab "Extract the h1 tag from a webpage"
+```javascript
+import { playwright } from '@pipedream/browsers';
+
+export default defineComponent({
+  async run({ $ }) {
+    const browser = await playwright.browser();
+    const page = await browser.newPage();
+    await page.goto('https://pipedream.com');
+    const h1Content = await page.$eval('h1', el => el.textContent);
+
+    await page.context().close();
+    await browser.close();
+
+    return h1Content;
+  },
+});
+
+```
+:::
+
+::: tab "Retrieve all HTML content from a webpage"
+
+```javascript
+import { playwright } from '@pipedream/browsers';
+
+export default defineComponent({
+  async run({ $ }) {
+    const browser = await playwright.browser();
+    const page = await browser.newPage();
+    await page.goto('https://pipedream.com');
+    const content = await page.content();
+
+    await page.context().close();
+    await browser.close();
+
+    return content;
+  },
+});
+```
+
+:::
+
+::::
+
+#### Submit a form
+
+Playwright can also programmatically click and type on a webpage.
+
+:::: tabs :options="{ useUrlFragment: false }"
+
+::: tab "With Page.type"
+```javascript
+import { playwright } from '@pipedream/browsers';
+
+export default defineComponent({
+  async run({ steps, $ }) {
+    const browser = await playwright.browser();
+    const page = await browser.newPage();
+
+    await page.goto('https://example.com/contact');
+    await page.type('input[name=email]', 'pierce@pipedream.com');
+    await page.type('input[name=name]', 'Dylan Pierce');
+    await page.type('textarea[name=message]', "Hello, from a Pipedream workflow.");
+    await page.click('input[type=submit]');
+
+    await page.context().close();
+    await browser.close();
+  },
+});
+```
+:::
+
+::: tab "With Page.click and Page.keyboard.type"
+```javascript
+import { playwright } from '@pipedream/browsers';
+
+export default defineComponent({
+  async run({ steps, $ }) {
+    const browser = await playwright.browser();
+    const page = await browser.newPage();
+
+    await page.goto('https://example.com/contact');
+    await page.click('input[name=email]')
+    await page.keyboard.type('pierce@pipedream.com');
+    await page.click('input[name=name]')
+    await page.keyboard.type('Dylan Pierce');
+    await page.click('textarea[name=message]')
+    await page.keyboard.type("Hello, from a Pipedream workflow.");
+    await page.click('input[type=submit]');
+
+    await page.context().browser();
+    await browser.close();
+  },
+});
+```
+:::
+
+::::
+
+
+
+## Frequently Asked Questions
+
+### Can I use this package in sources or actions?
+
+Yes, the same `@pipedream/browsers` package can be used in [actions](https://pipedream.com/docs/components/quickstart/nodejs/actions/) as well as [sources](https://pipedream.com/docs/components/quickstart/nodejs/sources/).
+
+The steps are the same as usage in Node.js code. Open a browser, create a page, and close the browser at the end of the code step.
+
+:::warning Memory limits
+
+At this time it's not possible to configure the allocated memory to a Source. You may experience a higher rate of Out of Memory errors on Sources that use Puppeteer or Playwright due to the high usage of memory required by Chromium.
+
+:::
+
+### Workflow exited before step finished execution
+
+Remember to close the browser instance _before_ the step finishes. Otherwise, the browser will keep the step "open" and not transfer control to the next step.
+
+### Out of memory errors or slow starts
+
+For best results, we recommend increasing the amount of memory available to your workflow to 2 gigabytes. You can adjust the available memory in the [workflow settings](https://pipedream.com/docs/workflows/settings/#memory).
+
+### Which browser are these packages using?
+
+The `@pipedream/browsers` package includes a specific version of Chromium that is compatible with Pipedream Node.js execution environments that run your code.
+
+For details on the specific versions of Chromium, puppeeter and playwright bundled in this package, visit the package's [README](https://github.com/PipedreamHQ/pipedream/tree/master/packages/browsers).

--- a/packages/browsers/README.md
+++ b/packages/browsers/README.md
@@ -43,10 +43,15 @@ import { playwright } from '@pipedream/browsers';
 export default defineComponent({
   async run({steps, $}) {
     const browser = await puppeteer.browser();
-    
-    console.log(browser)
-    // get page, perform actions, etc.
+    const page = await browser.newPage();
 
+    page.goto('https://pipedream.com');
+    const title = await page.title()
+
+
+    // Puppeteer requires you to close page context's before closing the browser itself
+    // otherwise, the code step's execution will hang
+    await page.context().close();
     await browser.close();
   },
 })

--- a/packages/browsers/package.json
+++ b/packages/browsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/browsers",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "For using puppeeter or playwright in Pipedream Node.js Code Steps. Includes the prebuilt binaries and specific versions for compatiblity with Pipedream.",
   "main": "index.mjs",
   "scripts": {


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 147214b</samp>

This pull request adds new README files for the `playwright` and `puppeteer` components, which are Node.js libraries for controlling browsers. The README files explain how to use these components in Pipedream workflows, sources, and actions, and provide some troubleshooting tips. The goal is to help users learn about and use these components more easily.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 147214b</samp>

> _`Playwright`, `Puppeteer`_
> _Node libraries for browsers_
> _READMEs in spring_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 147214b</samp>

*  Add README files for Playwright and Puppeteer components ([link](https://github.com/PipedreamHQ/pipedream/pull/8436/files?diff=unified&w=0#diff-db07ab667cdea7fbb48698d7d695d55dd2dcc699e988882c9a1b84cd86989fd4R1-R62), [link](https://github.com/PipedreamHQ/pipedream/pull/8436/files?diff=unified&w=0#diff-11d661086719d071c42ca809209161a17df9620d48b797c47263b6a7e33d3fb7R1-R62))
