### PR TITLE
[FIX] Exclude files with name 'test-event.mjs' from processing in scripts/findDuplicateKeys.js

### DIFF
--- a/scripts/findDuplicateKeys.js
+++ b/scripts/findDuplicateKeys.js
@@ -13,8 +13,9 @@ function included(dirent) {
   if (dirent.isDirectory()) {
     return !excludeDirs.includes(dirent.name);
   }
-  return includedExtensions.includes(path.extname(dirent.name)) &&
-    !excludedExtensions.find((ext) => dirent.name.endsWith(ext));
+  return includedExtensions.includes(path.extname(dirent.name))
+    && !excludedExtensions.find((ext) => dirent.name.endsWith(ext))
+    && !dirent.name.includes("test-event.mjs");
 }
 
 async function* getFiles(dir) {


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a0bea98</samp>

Modified a script to exclude test files from duplicate key detection. This improved the quality and consistency of the event sources in `scripts/findDuplicateKeys.js`.


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a0bea98</samp>

*  Exclude test-event files from duplicate key detection ([link](https://github.com/PipedreamHQ/pipedream/pull/8438/files?diff=unified&w=0#diff-d5643419840885d8c4e0ffc0e04509e5c808aaf5b929f93cf4829251ee8e77bcL16-R18))
