### PR TITLE
Coda.io "New Row Created" Source fix for large tables

### DIFF
--- a/components/coda/package.json
+++ b/components/coda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/coda",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Coda Components",
   "main": "coda.app.mjs",
   "keywords": [

--- a/components/coda/sources/row-created/row-created.mjs
+++ b/components/coda/sources/row-created/row-created.mjs
@@ -4,9 +4,10 @@ import { DEFAULT_POLLING_SOURCE_TIMER_INTERVAL } from "@pipedream/platform";
 export default {
   key: "coda-row-created",
   name: "New Row Created",
-  description: "Emit new event for every created / updated row in a table. [See the docs here.](https://coda.io/developers/apis/v1#tag/Rows/operation/listRows)",
+  description: "Emit new event for every created / updated row in a table. [See the documentation.](https://coda.io/developers/apis/v1#tag/Rows/operation/listRows)",
   type: "source",
-  version: "0.0.2",
+  version: "0.0.3",
+  dedupe: "unique",
   props: {
     coda,
     db: "$.service.db",
@@ -38,24 +39,33 @@ export default {
       optional: true,
     },
   },
+  hooks: {
+    async deploy() {
+      const rows = await this.fetchRows(25);
+      this.emitEvents(rows.reverse());
+    },
+  },
   methods: {
-    _getEmittedRows() {
-      return this.db.get("emittedRows") || [];
+    _getLastTs() {
+      return this.db.get("lastTs") || 0;
     },
-    _setEmittedRows(rows) {
-      this.db.set("emittedRows", rows);
+    _setLastTs(lastTs) {
+      this.db.set("lastTs", lastTs);
     },
-    _getNextPageToken() {
-      return this.db.get("nextPageToken");
+    getTsKey() {
+      return this.includeUpdates
+        ? "updatedAt"
+        : "createdAt";
     },
-    _setNextPageToken(nextPageToken) {
-      nextPageToken && this.db.set("nextPageToken", nextPageToken);
-    },
-    async fetchRows() {
+    async fetchRows(maxResults) {
       const rows = [];
-      let nextPageToken = this._getNextPageToken();
+      const tsKey = this.getTsKey();
+      const lastTs = this._getLastTs();
+      let maxTs = lastTs;
+      let done = false;
+
       const params = {
-        pageToken: nextPageToken,
+        sortBy: tsKey,
       };
 
       while (true) {
@@ -68,12 +78,26 @@ export default {
           this.tableId,
           params,
         );
-
-        rows.push(...items);
+        for (const item of items) {
+          const ts = Date.parse(item[tsKey]);
+          if (ts > lastTs) {
+            rows.push(item);
+            if (ts > maxTs) {
+              maxTs = ts;
+            }
+            if (rows.length >= maxResults) {
+              done = true;
+              break;
+            }
+          }
+          else {
+            done = true;
+          }
+        }
         params.pageToken = nextPageToken;
-        this._setNextPageToken(nextPageToken);
 
-        if (!nextPageToken) {
+        if (!nextPageToken || done) {
+          this._setLastTs(maxTs);
           return rows;
         }
       }
@@ -83,24 +107,17 @@ export default {
       return `Row index: ${row.index}` + name;
     },
     emitEvents(events) {
-      const emittedRows = this._getEmittedRows();
-
       for (const row of events) {
         const id = this.includeUpdates
           ? `${row.id}-${row.updatedAt}`
           : row.id;
 
-        if (!emittedRows.includes(id)) {
-          emittedRows.unshift(id);
-          this.$emit(row, {
-            id,
-            summary: this.rowSummary(row),
-            ts: row.updatedAt,
-          });
-        }
+        this.$emit(row, {
+          id,
+          summary: this.rowSummary(row),
+          ts: row.updatedAt,
+        });
       }
-
-      this._setEmittedRows(emittedRows);
     },
   },
   async run() {


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7e147b3</samp>

This pull request enhances the `coda-row-created` source component to support deduplication, deploy hooks, and pagination, and updates the `@pipedream/coda` package version accordingly. These changes improve the reliability and performance of the component and enable users to customize its behavior.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7e147b3</samp>

> _Sing, O Muse, of the mighty deeds of the Pipedream team_
> _Who with skill and cunning updated the Coda package_
> _And enhanced the `coda-row-created` source component_
> _To emit events like swift arrows from a Coda table._


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7e147b3</samp>

*  Increment the version of the `@pipedream/coda` package to reflect the new features and bug fixes ([link](https://github.com/PipedreamHQ/pipedream/pull/8454/files?diff=unified&w=0#diff-ce453f8372963a8bc249e590d74882bf1ce107e0e5123a4de2253af2fa26b0ccL3-R3))
  - Use a `dedupe` property to emit only new or updated rows ([link](https://github.com/PipedreamHQ/pipedream/pull/8454/files?diff=unified&w=0#diff-1128a2648a02a91a9cfe26c83e029dfeb17c263a2b9d912af74bfee9a504c539L7-R10))
  - Use a `deploy` hook to fetch and emit the initial rows ([link](https://github.com/PipedreamHQ/pipedream/pull/8454/files?diff=unified&w=0#diff-1128a2648a02a91a9cfe26c83e029dfeb17c263a2b9d912af74bfee9a504c539L41-R68))
  - Use a timestamp-based logic to filter out older rows and limit the number of rows per request ([link](https://github.com/PipedreamHQ/pipedream/pull/8454/files?diff=unified&w=0#diff-1128a2648a02a91a9cfe26c83e029dfeb17c263a2b9d912af74bfee9a504c539L41-R68), [link](https://github.com/PipedreamHQ/pipedream/pull/8454/files?diff=unified&w=0#diff-1128a2648a02a91a9cfe26c83e029dfeb17c263a2b9d912af74bfee9a504c539L71-R100))
  - Simplify the code by removing the `emittedRows` variable and methods ([link](https://github.com/PipedreamHQ/pipedream/pull/8454/files?diff=unified&w=0#diff-1128a2648a02a91a9cfe26c83e029dfeb17c263a2b9d912af74bfee9a504c539L86-L87), [link](https://github.com/PipedreamHQ/pipedream/pull/8454/files?diff=unified&w=0#diff-1128a2648a02a91a9cfe26c83e029dfeb17c263a2b9d912af74bfee9a504c539L93-R120))
