### PR TITLE
Google Drive - allow replace file if exists

### DIFF
--- a/components/google_drive/actions/upload-file/upload-file.mjs
+++ b/components/google_drive/actions/upload-file/upload-file.mjs
@@ -10,7 +10,7 @@ export default {
   key: "google_drive-upload-file",
   name: "Upload File",
   description: "Copy an existing file to Google Drive. [See the docs](https://developers.google.com/drive/api/v3/manage-uploads) for more information",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
   props: {
     googleDrive,
@@ -69,6 +69,27 @@ export default {
       default: GOOGLE_DRIVE_UPLOAD_TYPE_MULTIPART,
       optional: true,
     },
+    replaceFile: {
+      type: "boolean",
+      label: "Replace File",
+      description: "Whether should replace file case it exists, default: `false`",
+      optional: true,
+      default: false,
+    },
+  },
+  methods: {
+    async getFileIdForReplace(filename, parentId) {
+      if (this.replaceFile) {
+        const { files } = await this.googleDrive.listFilesInPage(null, {
+          q: `name = '${filename}' and '${parentId || "root"}' in parents and trashed = false`,
+          fields: "files/id,files/name,files/parents",
+        });
+        if (files.length) {
+          return files[0].id;
+        }
+      }
+      return null;
+    },
   },
   async run({ $ }) {
     const {
@@ -83,21 +104,40 @@ export default {
       throw new Error("One of File URL and File Path is required.");
     }
     const driveId = this.googleDrive.getDriveId(this.drive);
+
+    const filename = name || path.basename(fileUrl || filePath);
+    const fileId = await this.getFileIdForReplace(filename, parentId);
+
     const file = await getFileStream({
       $,
       fileUrl,
       filePath,
     });
     console.log(`Upload type: ${uploadType}.`);
-    const resp = await this.googleDrive.createFile(omitEmptyStringValues({
-      file,
-      mimeType,
-      name: name || path.basename(fileUrl || filePath),
-      parentId,
-      driveId,
-      uploadType,
-    }));
-    $.export("$summary", `Successfully uploaded a new file, "${resp.name}"`);
-    return resp;
+
+    let result = null;
+    if (fileId) {
+      await this.googleDrive.updateFileMedia(fileId, file, omitEmptyStringValues({
+        mimeType,
+        uploadType,
+      }));
+      result = await this.googleDrive.updateFile(fileId, omitEmptyStringValues({
+        name: filename,
+        mimeType,
+        uploadType,
+      }));
+      $.export("$summary", `Successfully updated file, "${result.name}"`);
+    } else {
+      result = await this.googleDrive.createFile(omitEmptyStringValues({
+        file,
+        mimeType,
+        name: filename,
+        parentId,
+        driveId,
+        uploadType,
+      }));
+      $.export("$summary", `Successfully uploaded a new file, "${result.name}"`);
+    }
+    return result;
   },
 };

--- a/components/google_drive/package.json
+++ b/components/google_drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_drive",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "description": "Pipedream Google_drive Components",
   "main": "google_drive.app.mjs",
   "keywords": [


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 90d2c7a</samp>

Added a `replace` option to the `upload-file` action for Google Drive. This allows users to overwrite an existing file with the same name and parent folder, or create a new file if no match is found.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 90d2c7a</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A clever option for the `upload-file` action,_
> _To replace or create a file on the clouded Drive_
> _With the same name and parent, as the user's faction._


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 90d2c7a</samp>

*  Increment action version to 0.1.2 for new feature of replacing existing file ([link](https://github.com/PipedreamHQ/pipedream/pull/8463/files?diff=unified&w=0#diff-9b91834da00c6e25e1a49dcd7ddfb1aba2fb78ff8ef82606dc1ba48ce1c713aeL13-R13))
*  Add `replaceFile` prop to let user choose whether to overwrite file with same name and parent folder ([link](https://github.com/PipedreamHQ/pipedream/pull/8463/files?diff=unified&w=0#diff-9b91834da00c6e25e1a49dcd7ddfb1aba2fb78ff8ef82606dc1ba48ce1c713aeL72-R93))
*  Extract filename from `name`, `fileUrl`, or `filePath` props and pass to `getFileIdForReplace` method to get file ID for replacement ([link](https://github.com/PipedreamHQ/pipedream/pull/8463/files?diff=unified&w=0#diff-9b91834da00c6e25e1a49dcd7ddfb1aba2fb78ff8ef82606dc1ba48ce1c713aeR107-R110))
*  Modify logic for creating or updating file based on file ID in `upload-file.mjs` ([link](https://github.com/PipedreamHQ/pipedream/pull/8463/files?diff=unified&w=0#diff-9b91834da00c6e25e1a49dcd7ddfb1aba2fb78ff8ef82606dc1ba48ce1c713aeL92-R141))
