### PR TITLE
airtable_oauth: search-records.mjs bugfix field name with spaces

### DIFF
--- a/components/airtable_oauth/actions/search-records/search-records.mjs
+++ b/components/airtable_oauth/actions/search-records/search-records.mjs
@@ -5,7 +5,7 @@ export default {
   key: "airtable_oauth-search-records",
   name: "Search Records",
   description: "Searches for a record by field value. Search Field must accept string values. [See the documentation](https://airtable.com/developers/web/api/list-records)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     ...common.props,

--- a/components/airtable_oauth/actions/search-records/search-records.mjs
+++ b/components/airtable_oauth/actions/search-records/search-records.mjs
@@ -36,7 +36,7 @@ export default {
   },
   async run({ $ }) {
     const params = {
-      filterByFormula: `FIND("${this.value}", ${this.fieldName})`,
+      filterByFormula: `FIND("${this.value}", {${this.fieldName}})`,
     };
     if (this.searchFormula) {
       params.filterByFormula = `AND(${params.filterByFormula}, ${this.searchFormula})`;

--- a/components/airtable_oauth/package.json
+++ b/components/airtable_oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/airtable_oauth",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Pipedream Airtable (OAuth) Components",
   "main": "airtable_oauth.app.mjs",
   "keywords": [


### PR DESCRIPTION
Per https://support.airtable.com/docs/formula-field-reference, field names with spaces must be wrapped in curly braces. (This is also acceptable for field names without spaces.)

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9433cd4</samp>

Fixed a bug in the `search-records` action of the Airtable OAuth component that prevented filtering by formula with certain field names. Updated the `filterByFormula` parameter syntax in `search-records.mjs`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9433cd4</samp>

> _`filterByFormula`_
> _Curly braces fix the bug_
> _Airtable breathes easy_


## WHY

I was trying to search a field with a space in the name and received an "invalid formula" error. I fixed the issue in my workflow by renaming the field in my base to one without spaces, but this PR should fix the underlying issue.


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9433cd4</samp>

* Fix bug in `filterByFormula` parameter for search records action ([link](https://github.com/PipedreamHQ/pipedream/pull/8513/files?diff=unified&w=0#diff-75f70208c41f7bc422c69c97c72fef932f98a62b67fc65d91377d0f1b5f45741L39-R39))
