### PR TITLE
[Feature] Add conference room as prop

### DIFF
--- a/components/google_calendar/package.json
+++ b/components/google_calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_calendar",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "description": "Pipedream Google_calendar Components",
   "main": "google_calendar.app.mjs",
   "keywords": [


### PR DESCRIPTION
Closes #8286 

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1a7509c</samp>

Added a feature to the `create-event` action of the `google_calendar` component that allows users to create a Google Meet room for their calendar events. Updated the component version in `package.json`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1a7509c</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A wondrous feature for the `google_calendar` component_
> _To create a virtual meeting room with ease and speed_
> _Using the `uuid` module and the `conferenceData` API._


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1a7509c</samp>

*  Add `createMeetRoom` prop to `create-event` action to enable creating a Google Meet room for the event ([link](https://github.com/PipedreamHQ/pipedream/pull/8524/files?diff=unified&w=0#diff-9e688c872b97395de002d4223a104f31407f762a112548eb4203875993ea7275R19-R24))
*  Import `uuid` module to generate a unique request ID for the conference data ([link](https://github.com/PipedreamHQ/pipedream/pull/8524/files?diff=unified&w=0#diff-9e688c872b97395de002d4223a104f31407f762a112548eb4203875993ea7275R3))
*  Refactor `createEvent` parameters into a `data` variable to avoid repetition ([link](https://github.com/PipedreamHQ/pipedream/pull/8524/files?diff=unified&w=0#diff-9e688c872b97395de002d4223a104f31407f762a112548eb4203875993ea7275L29-R36))
*  Add `conferenceData` and `conferenceDataVersion` properties to `data` object if `createMeetRoom` is true, using the request ID and the conference solution key ([link](https://github.com/PipedreamHQ/pipedream/pull/8524/files?diff=unified&w=0#diff-9e688c872b97395de002d4223a104f31407f762a112548eb4203875993ea7275L47-R69))
