### PR TITLE
[Bugfix] Gumroad - Add timer as editable prop

### DIFF
--- a/components/gumroad/package.json
+++ b/components/gumroad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/gumroad",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Pipedream Gumroad Components",
   "main": "gumroad.app.mjs",
   "keywords": [

--- a/components/gumroad/sources/common/common.mjs
+++ b/components/gumroad/sources/common/common.mjs
@@ -7,7 +7,7 @@ export default {
     db: "$.service.db",
     timer: {
       type: "$.interface.timer",
-      static: {
+      default: {
         intervalSeconds: DEFAULT_POLLING_SOURCE_TIMER_INTERVAL,
       },
     },

--- a/components/gumroad/sources/new-cancellation/new-cancellation.mjs
+++ b/components/gumroad/sources/new-cancellation/new-cancellation.mjs
@@ -3,7 +3,7 @@ import common from "../common/common.mjs";
 export default {
   ...common,
   name: "New Cancellation",
-  version: "0.0.3",
+  version: "0.0.4",
   key: "gumroad-new-cancellation",
   description: "Emit new event on a sale is cancelled.",
   type: "source",

--- a/components/gumroad/sources/new-product/new-product.mjs
+++ b/components/gumroad/sources/new-product/new-product.mjs
@@ -3,7 +3,7 @@ import common from "../common/common.mjs";
 export default {
   ...common,
   name: "New Product",
-  version: "0.0.3",
+  version: "0.0.4",
   key: "gumroad-new-product",
   description: "Emit new event on each new product.",
   type: "source",

--- a/components/gumroad/sources/new-refund/new-refund.mjs
+++ b/components/gumroad/sources/new-refund/new-refund.mjs
@@ -3,7 +3,7 @@ import common from "../common/common.mjs";
 export default {
   ...common,
   name: "New Refund",
-  version: "0.0.3",
+  version: "0.0.4",
   key: "gumroad-new-refund",
   description: "Emit new event on a sale is refunded.",
   type: "source",

--- a/components/gumroad/sources/new-sale/new-sale.mjs
+++ b/components/gumroad/sources/new-sale/new-sale.mjs
@@ -3,7 +3,7 @@ import common from "../common/common.mjs";
 export default {
   ...common,
   name: "New Sale",
-  version: "0.0.3",
+  version: "0.0.4",
   key: "gumroad-new-sale",
   description: "Emit new event on each new sale.",
   type: "source",


### PR DESCRIPTION
Closes #8521 

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9eff65f</samp>

Updated the `@pipedream/gumroad` package and its sources to make the `timer` prop configurable by the user. Bumped the versions of the package and the sources accordingly.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9eff65f</samp>

> _`Gumroad` package grows_
> _`timer` prop now flexible_
> _Autumn of updates_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9eff65f</samp>

*  Incremented the version of the `@pipedream/gumroad` package and the Gumroad sources to reflect the updates made to the components ([link](https://github.com/PipedreamHQ/pipedream/pull/8526/files?diff=unified&w=0#diff-41e2ade29f340c6bbf6fe3659b96f45ad5bcc9200ecb66ed486336bce30e51efL3-R3), [link](https://github.com/PipedreamHQ/pipedream/pull/8526/files?diff=unified&w=0#diff-df544b23d0249682531459c34e2bd414e9e90adca85796d38e7129a1c72ea142L6-R6), [link](https://github.com/PipedreamHQ/pipedream/pull/8526/files?diff=unified&w=0#diff-aa31102adf2ffe1e60f42b7e59a278bfecc245ce6b17f00b7802341cb2e6b47bL6-R6), [link](https://github.com/PipedreamHQ/pipedream/pull/8526/files?diff=unified&w=0#diff-5f03ab56af5e18c30508559dba46a6bda9f517b5d36fe61648a9d0f6afd522adL6-R6), [link](https://github.com/PipedreamHQ/pipedream/pull/8526/files?diff=unified&w=0#diff-7c13051ab761a6b315ae0e75033ca3fb85a1f4455cd60ca0a590c96a9daf584eL6-R6))
*  Changed the `timer` prop of the common base class for the Gumroad sources from `static` to `default` to make it configurable by the user ([link](https://github.com/PipedreamHQ/pipedream/pull/8526/files?diff=unified&w=0#diff-0c4543aba0ea606a755e73f756eb6334e938740a1bedf4858f7a29fc623d98f9L10-R10))
