### PR TITLE
Adding pinning for cacheDirectory on puppeteer

### DIFF
--- a/components/puppeteer/actions/get-html/get-html.mjs
+++ b/components/puppeteer/actions/get-html/get-html.mjs
@@ -4,7 +4,7 @@ export default {
   key: "puppeteer-get-html",
   name: "Get HTML",
   description: "Get the HTML of a webpage using Puppeteer. [See the documentation](https://pptr.dev/api/puppeteer.page.content)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   props: {
     puppeteer,

--- a/components/puppeteer/actions/get-page-title/get-page-title.mjs
+++ b/components/puppeteer/actions/get-page-title/get-page-title.mjs
@@ -4,7 +4,7 @@ export default {
   key: "puppeteer-get-page-title",
   name: "Get Page Title",
   description: "Get the title of a webpage using Puppeteer. [See the documentation](https://pptr.dev/api/puppeteer.page.title)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   props: {
     puppeteer,

--- a/components/puppeteer/actions/get-pdf/get-pdf.mjs
+++ b/components/puppeteer/actions/get-pdf/get-pdf.mjs
@@ -6,7 +6,7 @@ export default {
   key: "puppeteer-get-pdf",
   name: "Get PDF",
   description: "Generate a PDF of a page using Puppeteer. [See the documentation](https://pptr.dev/api/puppeteer.page.pdf)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   props: {
     puppeteer,

--- a/components/puppeteer/actions/screenshot-page/screenshot-page.mjs
+++ b/components/puppeteer/actions/screenshot-page/screenshot-page.mjs
@@ -7,7 +7,7 @@ export default {
   key: "puppeteer-screenshot-page",
   name: "Screenshot a Page",
   description: "Captures a screenshot of a page using Puppeteer. [See the documentation](https://pptr.dev/api/puppeteer.page.screenshot)",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   props: {
     puppeteer,

--- a/components/puppeteer/package.json
+++ b/components/puppeteer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/puppeteer",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Pipedream Puppeteer Components",
   "main": "puppeteer.app.mjs",
   "keywords": [

--- a/components/puppeteer/puppeteer.app.mjs
+++ b/components/puppeteer/puppeteer.app.mjs
@@ -21,12 +21,14 @@ export default {
       const browser = await puppeteer.launch({
         executablePath: await chromium.executablePath(),
         headless: chromium.headless,
+        cacheDirectory: "/tmp",
         ignoreHTTPSErrors: true,
         defaultViewport: chromium.defaultViewport,
         args: [
           ...chromium.args,
           "--hide-scrollbars",
           "--disable-web-security",
+          "--font-render-hinting=none",
         ],
         ...opts,
       });

--- a/packages/browsers/index.mjs
+++ b/packages/browsers/index.mjs
@@ -17,6 +17,7 @@ export const puppeteer = {
       headless: chromium.headless,
       ignoreHTTPSErrors: true,
       defaultViewport: chromium.defaultViewport,
+      cacheDirectory: "/tmp",
       args: [
         ...chromium.args,
         "--hide-scrollbars",

--- a/packages/browsers/package.json
+++ b/packages/browsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/browsers",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "For using puppeeter or playwright in Pipedream Node.js Code Steps. Includes the prebuilt binaries and specific versions for compatiblity with Pipedream.",
   "main": "index.mjs",
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1785,6 +1785,9 @@ importers:
   components/float:
     specifiers: {}
 
+  components/flodesk:
+    specifiers: {}
+
   components/fluent_support:
     specifiers: {}
 


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e652286</samp>

This pull request enhances the `browsers` package by adding a new option for caching browser data and a new flag for disabling font rendering hinting. It also updates the `pnpm-lock.yaml` file to include the `components/flodesk` dependency.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e652286</samp>

> _Sing, O Muse, of the skillful hackers who devised_
> _A clever way to launch the browsers of the web_
> _With options to cache their data in chosen paths_
> _And flags to tame the fonts that cause them trouble._


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e652286</samp>

*  Add `cacheDirectory` option to `launch` methods of `puppeteer` and `browsers` apps ([link](https://github.com/PipedreamHQ/pipedream/pull/8545/files?diff=unified&w=0#diff-dc255ad27cc4062520ec7c2eec5816c3045003fbef1ce0171b478e8cd6c831abR24), [link](https://github.com/PipedreamHQ/pipedream/pull/8545/files?diff=unified&w=0#diff-3c6823116f58743e9268d54102e61eec6cb2557f1cfae151e2777ff293829102R20))
*  Disable font rendering hinting for `puppeteer` app with `--font-render-hinting=none` flag ([link](https://github.com/PipedreamHQ/pipedream/pull/8545/files?diff=unified&w=0#diff-dc255ad27cc4062520ec7c2eec5816c3045003fbef1ce0171b478e8cd6c831abR31))
*  Bump up `browsers` package version to `1.0.1` in `package.json` ([link](https://github.com/PipedreamHQ/pipedream/pull/8545/files?diff=unified&w=0#diff-8e01e5bf2a1332f403d9036f727d9e3db6ee8406b4b3430630160b086f59d0dfL3-R3))
*  Update `pnpm-lock.yaml` file with `components/flodesk` entry ([link](https://github.com/PipedreamHQ/pipedream/pull/8545/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1788-R1790))
