### PR TITLE
Hubspot new source

### DIFF
--- a/components/hubspot/hubspot.app.mjs
+++ b/components/hubspot/hubspot.app.mjs
@@ -89,6 +89,20 @@ export default {
       description: "Watch for new events concerning the object type specified.",
       options: OBJECT_TYPES,
     },
+    objectSchema: {
+      type: "string",
+      label: "Object Schema",
+      description: "Watch for new events of objects with the specified custom schema.",
+      async options() {
+        const response = await this.listSchemas();
+        return response?.results?.map(({
+          objectTypeId, name,
+        }) => ({
+          label: name,
+          value: objectTypeId,
+        }));
+      },
+    },
     objectId: {
       type: "string",
       label: "Object ID",
@@ -564,6 +578,11 @@ export default {
     },
     async getProperties(objectType, $) {
       return this.makeRequest(API_PATH.CRMV3, `/properties/${objectType}`, {
+        $,
+      });
+    },
+    async listSchemas($) {
+      return this.makeRequest(API_PATH.CRMV3, "/schemas", {
         $,
       });
     },

--- a/components/hubspot/package.json
+++ b/components/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/hubspot",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Pipedream Hubspot Components",
   "main": "hubspot.app.mjs",
   "keywords": [

--- a/components/hubspot/sources/new-or-updated-custom-object/new-or-updated-custom-object.mjs
+++ b/components/hubspot/sources/new-or-updated-custom-object/new-or-updated-custom-object.mjs
@@ -1,0 +1,58 @@
+import common from "../common/common.mjs";
+
+export default {
+  ...common,
+  key: "hubspot-new-or-updated-custom-object",
+  name: "New or Updated Custom Object",
+  description: "Emit new event each time a Custom Object of the specified schema is updated.",
+  version: "0.0.1",
+  dedupe: "unique",
+  type: "source",
+  props: {
+    ...common.props,
+    objectSchema: {
+      propDefinition: [
+        common.props.hubspot,
+        "objectSchema",
+      ],
+    },
+  },
+  hooks: {},
+  methods: {
+    ...common.methods,
+    getTs(object) {
+      return Date.parse(object.updatedAt);
+    },
+    generateMeta(object) {
+      const { id } = object;
+      const ts = this.getTs(object);
+      return {
+        id: `${id}${ts}`,
+        summary: `Record ID: ${id}`,
+        ts,
+      };
+    },
+    isRelevant(object, updatedAfter) {
+      return this.getTs(object) > updatedAfter;
+    },
+    getParams() {
+      return null;
+    },
+    getObjectParams(object) {
+      return {
+        limit: 100,
+        sorts: [
+          {
+            propertyName: "hs_lastmodifieddate",
+            direction: "DESCENDING",
+          },
+        ],
+        object,
+      };
+    },
+    async processResults(after) {
+      const params = this.getObjectParams(this.objectSchema);
+      await this.searchCRM(params, after);
+    },
+  },
+};


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5413195</samp>

This pull request adds support for custom schemas for Hubspot CRM objects to the `hubspot` app. It includes a new app property and method to fetch and display the schemas, a new source component to emit events for updated custom objects, and a version bump in the `package.json` file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5413195</samp>

> _`hubspot` app grows_
> _new source for custom objects_
> _autumn of updates_


## WHY

Closes #8450 
Closes #2995 


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5413195</samp>

*  Add a new source component `new-or-updated-custom-object` to emit events for updated custom objects of a specified schema ([link](https://github.com/PipedreamHQ/pipedream/pull/8572/files?diff=unified&w=0#diff-f972d2e44ee86bf9ef57b9089a517b09256ade1abe2d2c8a6ef4e0be0b1a30c4R1-R58))
*  Add a new app property `objectSchema` to allow the user to select a custom schema for the Hubspot objects they want to watch ([link](https://github.com/PipedreamHQ/pipedream/pull/8572/files?diff=unified&w=0#diff-4a128799f58cfa4618d7363237ef52755555a0e4f8e4baeec48ffd18453ca0b7R92-R105))
*  Add a new app method `listSchemas` to fetch the available custom schemas from the Hubspot API ([link](https://github.com/PipedreamHQ/pipedream/pull/8572/files?diff=unified&w=0#diff-4a128799f58cfa4618d7363237ef52755555a0e4f8e4baeec48ffd18453ca0b7R584-R588))
*  Update the app version to `0.7.0` in `package.json` to reflect the new features and functionality ([link](https://github.com/PipedreamHQ/pipedream/pull/8572/files?diff=unified&w=0#diff-3af45ab9a0aa17b8bfa5e3ac7c49f6add0d896b8a54ef1bb4f9ed0d0114ceb60L3-R3))
