### PR TITLE
Notion updated page trigger fix

### DIFF
--- a/components/notion/package.json
+++ b/components/notion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/notion",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Pipedream Notion Components",
   "main": "notion.app.mjs",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2658,6 +2658,9 @@ importers:
     dependencies:
       '@pipedream/platform': 1.5.1
 
+  components/insites:
+    specifiers: {}
+
   components/instagram_business:
     specifiers:
       '@pipedream/platform': ^1.5.1


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b06a441</samp>

This pull request updates the `Updated Page in Database` source for Notion to make it more efficient and reliable, and adds a new package for Insites components. It also updates the `@pipedream/notion` package version and the `pnpm-lock.yaml` file accordingly.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b06a441</samp>

> _We are the pipedreamers, we defy the notion_
> _We update our sources with precision and devotion_
> _We optimize our code, we track the latest time_
> _We skip the unchanged pages, we leave them in their slime_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b06a441</samp>

*  Incremented the version of the `@pipedream/notion` package and the `Updated Page in Database` source to reflect the changes in the source code and dependencies ([link](https://github.com/PipedreamHQ/pipedream/pull/8575/files?diff=unified&w=0#diff-851c6a1993b9f340f494f698005f8fe48f3ea8b6955c85a11630838716a780b1L3-R3), [link](https://github.com/PipedreamHQ/pipedream/pull/8575/files?diff=unified&w=0#diff-f360e9ae1cb6c6df63b20e36636b396709c6dd3001e14e964f9c466990c0c15cL11-R11))
  - Declaring a new variable `newLastUpdatedTimestamp` to store the maximum timestamp of the updated pages ([link](https://github.com/PipedreamHQ/pipedream/pull/8575/files?diff=unified&w=0#diff-f360e9ae1cb6c6df63b20e36636b396709c6dd3001e14e964f9c466990c0c15cR26))
  - Replacing the `break` statement with a `continue` statement to skip the pages that were not updated since the last check ([link](https://github.com/PipedreamHQ/pipedream/pull/8575/files?diff=unified&w=0#diff-f360e9ae1cb6c6df63b20e36636b396709c6dd3001e14e964f9c466990c0c15cL31-R32))
  - Moving the `setLastUpdatedTimestamp` method outside the loop and calling it with the `newLastUpdatedTimestamp` variable, instead of calling it with each page's timestamp ([link](https://github.com/PipedreamHQ/pipedream/pull/8575/files?diff=unified&w=0#diff-f360e9ae1cb6c6df63b20e36636b396709c6dd3001e14e964f9c466990c0c15cL44-R51))
*  Added a new entry for the `components/insites` package to the `pnpm-lock.yaml` file, which specifies the dependencies and versions of the package ([link](https://github.com/PipedreamHQ/pipedream/pull/8575/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2661-R2663))
