### PR TITLE
[BUG] Fix stripe canceled subscription

### DIFF
--- a/components/stripe/package.json
+++ b/components/stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/stripe",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Pipedream Stripe Components",
   "main": "stripe.app.mjs",
   "keywords": [

--- a/components/stripe/sources/canceled-subscription/canceled-subscription.mjs
+++ b/components/stripe/sources/canceled-subscription/canceled-subscription.mjs
@@ -5,13 +5,14 @@ export default {
   key: "stripe-canceled-subscription",
   name: "Canceled Subscription",
   type: "source",
-  version: "0.0.1",
+  version: "0.0.2",
   description: "Emit new event for each new canceled subscription",
   methods: {
     ...common.methods,
     getEvents() {
       return [
         "subscription_schedule.canceled",
+        "customer.subscription.deleted",
       ];
     },
   },


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 04ae676</samp>

Added new components for various services and updated the `Canceled Subscription` source component for `stripe` to handle subscription deletion events. Bumped the `@pipedream/stripe` package version and updated the `pnpm-lock.yaml` file accordingly.


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 04ae676</samp>

*  Incremented the version of the `@pipedream/stripe` package and the `Canceled Subscription` source component to reflect the changes in the event types ([link](https://github.com/PipedreamHQ/pipedream/pull/8591/files?diff=unified&w=0#diff-731f6694b62d00bab34491f9eed82a3638d50935d54fc32fb3abe6d91db3fcd2L3-R3), [link](https://github.com/PipedreamHQ/pipedream/pull/8591/files?diff=unified&w=0#diff-7d92649a03810ea8796c11ae75f08833869b7ffe3b18f1dec57e204d49f93cb1L8-R8))
*  Added the event type `customer.subscription.deleted` to the `Canceled Subscription` source component to emit events when a subscription is canceled by the customer or the Stripe system ([link](https://github.com/PipedreamHQ/pipedream/pull/8591/files?diff=unified&w=0#diff-7d92649a03810ea8796c11ae75f08833869b7ffe3b18f1dec57e204d49f93cb1R15))
*  Added six new component entries to the `pnpm-lock.yaml` file to indicate that the `algomo`, `centralstationcrm`, `click2mail2`, `cometly`, `riskadvisor`, and `webvizio` components were added to the repository and their dependencies were resolved by the package manager ([link](https://github.com/PipedreamHQ/pipedream/pull/8591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR243-R245), [link](https://github.com/PipedreamHQ/pipedream/pull/8591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR803-R805), [link](https://github.com/PipedreamHQ/pipedream/pull/8591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR905-R907), [link](https://github.com/PipedreamHQ/pipedream/pull/8591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1051-R1053), [link](https://github.com/PipedreamHQ/pipedream/pull/8591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4820-R4822), [link](https://github.com/PipedreamHQ/pipedream/pull/8591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR6481-R6483))
