### PR TITLE
Docs - fix bash command example

### DIFF
--- a/docs/docs/code/bash/README.md
+++ b/docs/docs/code/bash/README.md
@@ -68,7 +68,7 @@ In this example, we'll pretend this data is coming into our HTTP trigger via a P
 In our Bash script, we can access this data via the `$PIPEDREAM_STEPS` file. Specifically, this data from the POST request into our workflow is available in the `trigger` object.
 
 ```bash
-echo $PIPEDREAM_STEPS | jq .trigger.event
+cat $PIPEDREAM_STEPS | jq .trigger.event
 
 # Results in { id: 1, name: "Bulbasaur", type: "plant" }
 ```

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2456,6 +2456,9 @@ importers:
   components/helcim:
     specifiers: {}
 
+  components/helloleads:
+    specifiers: {}
+
   components/hellosign:
     specifiers:
       '@pipedream/platform': ^1.5.1


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 932190b</samp>

The pull request updates the Bash code example in the docs and adds a dependency on the `helloleads` component package in `pnpm-lock.yaml`. These changes are part of using pnpm as the package manager and fixing a potential bug with `jq` parsing.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 932190b</samp>

> _`cat` reads JSON_
> _pnpm for components_
> _autumn of updates_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 932190b</samp>

* Use `cat` instead of `echo` to read JSON data from `$PIPEDREAM_STEPS` ([link](https://github.com/PipedreamHQ/pipedream/pull/8640/files?diff=unified&w=0#diff-c40573f3fa5001bdd09ec9e543da3ecd81eada53950bd4eff819aa4acbcdc748L71-R71))
* Add dependency on `components/helloleads` package to `pnpm-lock.yaml` ([link](https://github.com/PipedreamHQ/pipedream/pull/8640/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2459-R2461))
