### PR TITLE
docs/Workflows/Triggers: Fix GitHub capitalization

### DIFF
--- a/docs/docs/workflows/steps/triggers/README.md
+++ b/docs/docs/workflows/steps/triggers/README.md
@@ -6,7 +6,7 @@
 
 Today, we support the following triggers:
 
-- [Triggers for apps like Twitter, Github, and more](#app-based-triggers)
+- [Triggers for apps like Twitter, GitHub, and more](#app-based-triggers)
 - [HTTP / Webhook](#http)
 - [Schedule](#schedule)
 - [Email](#email)


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8a434fd</samp>

Fixed a minor typo in the documentation for triggers. Changed `Github` to `GitHub` in `docs/docs/workflows/steps/triggers/README.md`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8a434fd</samp>

> _`Github` to `GitHub`_
> _A small change for clarity_
> _Winter of typos_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8a434fd</samp>

* Correct the spelling of `GitHub` in the documentation ([link](https://github.com/PipedreamHQ/pipedream/pull/8648/files?diff=unified&w=0#diff-c153df7562f2ec0c61763203a535cdbe73f0126ffffa29581816cd597bb89415L9-R9))
