### PR TITLE
Notion Update Page - improve error handling

### DIFF
--- a/components/notion/actions/update-page/update-page.mjs
+++ b/components/notion/actions/update-page/update-page.mjs
@@ -7,7 +7,7 @@ export default {
   key: "notion-update-page",
   name: "Update Page",
   description: "Updates page property values for the specified page. Properties that are not set will remain unchanged. To append page content, use the *append block* action. [See the docs](https://developers.notion.com/reference/patch-page)",
-  version: "1.0.0",
+  version: "1.0.1",
   type: "action",
   props: {
     notion,
@@ -78,10 +78,14 @@ export default {
     },
   },
   async run({ $ }) {
-    const currentPage = await this.notion.retrievePage(this.pageId);
-    const page = this.buildPage(currentPage);
-    const response = await this.notion.updatePage(this.pageId, page);
-    $.export("$summary", "Updated page successfully");
-    return response;
+    try {
+      const currentPage = await this.notion.retrievePage(this.pageId);
+      const page = this.buildPage(currentPage);
+      const response = await this.notion.updatePage(this.pageId, page);
+      $.export("$summary", "Updated page successfully");
+      return response;
+    } catch (error) {
+      throw new Error(error.body);
+    }
   },
 };

--- a/components/notion/package.json
+++ b/components/notion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/notion",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Pipedream Notion Components",
   "main": "notion.app.mjs",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -676,7 +676,13 @@ importers:
       crypto: 1.0.1
       uuid: 8.3.2
 
+  components/brilliant_directories:
+    specifiers: {}
+
   components/brosix:
+    specifiers: {}
+
+  components/browse_ai:
     specifiers: {}
 
   components/browserless:
@@ -694,6 +700,9 @@ importers:
     specifiers: {}
 
   components/builder_io:
+    specifiers: {}
+
+  components/builderall_mailingboss:
     specifiers: {}
 
   components/bulkgate:
@@ -1479,6 +1488,9 @@ importers:
       '@pipedream/platform': 1.5.1
 
   components/dokan:
+    specifiers: {}
+
+  components/doppler:
     specifiers: {}
 
   components/doppler_marketing_automation:
@@ -3053,6 +3065,9 @@ importers:
     dependencies:
       '@pipedream/platform': 1.5.1
 
+  components/lightspeed_vt:
+    specifiers: {}
+
   components/line:
     specifiers:
       '@line/bot-sdk': ^7.5.2
@@ -4292,6 +4307,9 @@ importers:
   components/placetel:
     specifiers: {}
 
+  components/placid:
+    specifiers: {}
+
   components/plain:
     specifiers: {}
 
@@ -4527,6 +4545,9 @@ importers:
       '@sparticuz/chromium': 112.0.2
       puppeteer-core: 19.8.0
 
+  components/push_by_techulus:
+    specifiers: {}
+
   components/pushcut:
     specifiers:
       '@pipedream/platform': ^1.5.1
@@ -4682,6 +4703,9 @@ importers:
     dependencies:
       '@pipedream/platform': 1.5.1
 
+  components/recruitee:
+    specifiers: {}
+
   components/recurly:
     specifiers:
       '@pipedream/platform': ^1.2.1
@@ -4705,6 +4729,9 @@ importers:
       qs: 6.11.2
 
   components/redmine:
+    specifiers: {}
+
+  components/referralhero:
     specifiers: {}
 
   components/referralrock:
@@ -4992,6 +5019,9 @@ importers:
       '@pipedream/platform': ^1.4.1
     dependencies:
       '@pipedream/platform': 1.5.1
+
+  components/satismeter:
+    specifiers: {}
 
   components/saucelabs:
     specifiers: {}
@@ -5867,6 +5897,9 @@ importers:
     dependencies:
       '@pipedream/platform': 1.5.1
 
+  components/teamup:
+    specifiers: {}
+
   components/teamwave:
     specifiers: {}
 
@@ -6278,6 +6311,9 @@ importers:
     dependencies:
       '@pipedream/platform': 1.5.1
       qs: 6.11.2
+
+  components/upollo:
+    specifiers: {}
 
   components/uptimerobot:
     specifiers: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3351,6 +3351,9 @@ importers:
     dependencies:
       '@pipedream/platform': 1.5.1
 
+  components/meetingpulse:
+    specifiers: {}
+
   components/meetup:
     specifiers: {}
 
@@ -5560,6 +5563,9 @@ importers:
       '@pipedream/platform': ^1.2.1
     dependencies:
       '@pipedream/platform': 1.5.1
+
+  components/sonix:
+    specifiers: {}
 
   components/sourceforge:
     specifiers:


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f776f09</samp>

This pull request fixes a bug and improves error handling in the `update page` action for Notion, and adds new components to the Pipedream project for integrating with various services and platforms. The Notion package version is also updated to 0.1.4.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f776f09</samp>

> _We're the masters of the Notion_
> _We update the pages with devotion_
> _We integrate with all the services_
> _We're the Pipedream of the masses_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f776f09</samp>

*  Incremented the version of the Notion package and the update page action to reflect the bug fix in the run method ([link](https://github.com/PipedreamHQ/pipedream/pull/8671/files?diff=unified&w=0#diff-851c6a1993b9f340f494f698005f8fe48f3ea8b6955c85a11630838716a780b1L3-R3), [link](https://github.com/PipedreamHQ/pipedream/pull/8671/files?diff=unified&w=0#diff-831f5bb6860a96dbc2afe3acb2e8c54de22a5a2dcdc8a4d0f1f7fbd1cc1e1088L10-R10))
*  Added error handling to the update page action to throw informative messages to the user ([link](https://github.com/PipedreamHQ/pipedream/pull/8671/files?diff=unified&w=0#diff-831f5bb6860a96dbc2afe3acb2e8c54de22a5a2dcdc8a4d0f1f7fbd1cc1e1088L81-R89))
*  Added several new components as dependencies of the Pipedream project to the pnpm-lock.yaml file: `brilliant_directories`, `builderall_mailingboss`, `doppler`, `lightspeed_vt`, `placid`, `push_by_techulus`, `recruitee`, `referralhero`, `satismeter`, `teamup`, and `upollo` ([link](https://github.com/PipedreamHQ/pipedream/pull/8671/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL679-R687), [link](https://github.com/PipedreamHQ/pipedream/pull/8671/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR705-R707), [link](https://github.com/PipedreamHQ/pipedream/pull/8671/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1493-R1495), [link](https://github.com/PipedreamHQ/pipedream/pull/8671/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3068-R3070), [link](https://github.com/PipedreamHQ/pipedream/pull/8671/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4310-R4312), [link](https://github.com/PipedreamHQ/pipedream/pull/8671/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4548-R4550), [link](https://github.com/PipedreamHQ/pipedream/pull/8671/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4706-R4708), [link](https://github.com/PipedreamHQ/pipedream/pull/8671/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4734-R4736), [link](https://github.com/PipedreamHQ/pipedream/pull/8671/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5023-R5025), [link](https://github.com/PipedreamHQ/pipedream/pull/8671/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5900-R5902), [link](https://github.com/PipedreamHQ/pipedream/pull/8671/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR6315-R6317))
