### PR TITLE
Ignores node_modules when creating the Draft PR in the AI Tool

### DIFF
--- a/packages/component_code_gen/code_gen/generate_for_github_issue.py
+++ b/packages/component_code_gen/code_gen/generate_for_github_issue.py
@@ -181,7 +181,7 @@ You can call methods from the app file using `this.{app}.<method name>`. Think a
         # GitPython requires to manually check .gitignore paths when adding files to index
         # so this is easier
         run_command(f"npx eslint {app_base_path} --fix")
-        run_command(f"git add -f {app_base_path} {repo_path}/pnpm-lock.yaml")
+        run_command(f"git add -f {app_base_path}")
         run_command(f"git commit --no-verify -m '{app} init'")
         run_command(f"git push -f --set-upstream {remote_name} {branch_name}")
         run_command(


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0408ac1</samp>

The change improves the code generation for GitHub issue-based components by excluding the `node_modules` folder from linting and staging. This avoids unnecessary work and potential errors when running the `generate_for_github_issue.py` script.


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0408ac1</samp>

*  Exclude node_modules folder from linting and adding ([link](https://github.com/PipedreamHQ/pipedream/pull/8676/files?diff=unified&w=0#diff-69bedac25cab56c4653721b18b35683ac9f1958fcf91f090470a07db747ee17bL183-R185))
