### PR TITLE
Notion Update Page - fix import

### DIFF
--- a/components/notion/actions/update-page/update-page.mjs
+++ b/components/notion/actions/update-page/update-page.mjs
@@ -1,13 +1,13 @@
 import notion from "../../notion.app.mjs";
 import base from "../common/base-page-builder.mjs";
-import { pick } from "lodash-es";
+import pick from "lodash-es/pick.js";
 
 export default {
   ...base,
   key: "notion-update-page",
   name: "Update Page",
   description: "Updates page property values for the specified page. Properties that are not set will remain unchanged. To append page content, use the *append block* action. [See the docs](https://developers.notion.com/reference/patch-page)",
-  version: "1.0.1",
+  version: "1.0.2",
   type: "action",
   props: {
     notion,

--- a/components/notion/package.json
+++ b/components/notion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/notion",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Pipedream Notion Components",
   "main": "notion.app.mjs",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3065,6 +3065,9 @@ importers:
     dependencies:
       '@pipedream/platform': 1.5.1
 
+  components/lightspeed_retail_pos:
+    specifiers: {}
+
   components/lightspeed_vt:
     specifiers: {}
 


### PR DESCRIPTION
`lodash` import was causing too many open files, so we should import only `pick`

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 37ef8a7</samp>

Improved the `update-page` action for Notion by using a more efficient function and bumped the package version. Added a missing entry to the `pnpm-lock.yaml` file for the `lightspeed_retail_pos` component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 37ef8a7</samp>

> _We made some changes to Notion_
> _To update pages with more motion_
> _We used `lodash-es`_
> _To import what we need less_
> _And bumped up the package version_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 37ef8a7</samp>

* Import `pick` function from `lodash-es` module to optimize bundle size and performance ([link](https://github.com/PipedreamHQ/pipedream/pull/8685/files?diff=unified&w=0#diff-831f5bb6860a96dbc2afe3acb2e8c54de22a5a2dcdc8a4d0f1f7fbd1cc1e1088L3-R3))
* Bump `update-page` action version to trigger new deployment ([link](https://github.com/PipedreamHQ/pipedream/pull/8685/files?diff=unified&w=0#diff-831f5bb6860a96dbc2afe3acb2e8c54de22a5a2dcdc8a4d0f1f7fbd1cc1e1088L10-R10))
* Bump `@pipedream/notion` package version to publish new version to npm ([link](https://github.com/PipedreamHQ/pipedream/pull/8685/files?diff=unified&w=0#diff-851c6a1993b9f340f494f698005f8fe48f3ea8b6955c85a11630838716a780b1L3-R3))
* Add `components/lightspeed_retail_pos` entry to `pnpm-lock.yaml` file to lock dependencies ([link](https://github.com/PipedreamHQ/pipedream/pull/8685/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3068-R3070))
