### PR TITLE
[Components] convertkit #8620

### DIFF
--- a/components/convertkit/actions/add-subscriber-to-form/add-subscriber-to-form.mjs
+++ b/components/convertkit/actions/add-subscriber-to-form/add-subscriber-to-form.mjs
@@ -4,7 +4,7 @@ export default {
   key: "convertkit-add-subscriber-to-form",
   name: "Add subscriber to a form",
   description: "Add subscriber to a form. [See docs here](https://developers.convertkit.com/#add-subscriber-to-a-form)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     convertkit,

--- a/components/convertkit/actions/add-tag-to-subscriber/add-tag-to-subscriber.mjs
+++ b/components/convertkit/actions/add-tag-to-subscriber/add-tag-to-subscriber.mjs
@@ -3,7 +3,7 @@ import convertkit from "../../convertkit.app.mjs";
 export default {
   key: "convertkit-add-tag-to-subscriber",
   name: "Add tag to a subscriber",
-  description: "Add subscriber to a form. [See docs here](https://developers.convertkit.com/#tag-a-subscriber)",
+  description: "Add tag to a subscriber. [See docs here](https://developers.convertkit.com/#tag-a-subscriber)",
   version: "0.0.1",
   type: "action",
   props: {

--- a/components/convertkit/actions/add-tag-to-subscriber/add-tag-to-subscriber.mjs
+++ b/components/convertkit/actions/add-tag-to-subscriber/add-tag-to-subscriber.mjs
@@ -1,0 +1,36 @@
+import convertkit from "../../convertkit.app.mjs";
+
+export default {
+  key: "convertkit-add-tag-to-subscriber",
+  name: "Add tag to a subscriber",
+  description: "Add subscriber to a form. [See docs here](https://developers.convertkit.com/#tag-a-subscriber)",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    convertkit,
+    subscriber: {
+      propDefinition: [
+        convertkit,
+        "subscriber",
+        () => ({
+          returnField: "email_address",
+        }),
+      ],
+    },
+    tag: {
+      propDefinition: [
+        convertkit,
+        "tag",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.convertkit.addTagToSubscriber(this.subscriber, this.tag, $);
+
+    if (response) {
+      $.export("$summary", "Successfully added tag to subscriber");
+    }
+
+    return response;
+  },
+};

--- a/components/convertkit/actions/list-subscribers/list-subscribers.mjs
+++ b/components/convertkit/actions/list-subscribers/list-subscribers.mjs
@@ -5,7 +5,7 @@ export default {
   key: "convertkit-list-subscribers",
   name: "List subscribers",
   description: "Returns a list of your subscribers. [See docs here](https://developers.convertkit.com/#list-subscribers)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     convertkit,

--- a/components/convertkit/actions/view-single-subscribers/view-single-subscribers.mjs
+++ b/components/convertkit/actions/view-single-subscribers/view-single-subscribers.mjs
@@ -4,7 +4,7 @@ export default {
   key: "convertkit-view-single-subscribers",
   name: "View a Single Subscribers",
   description: "Returns data for a single subscriber. [See docs here](https://developers.convertkit.com/#view-a-single-subscriber)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     convertkit,

--- a/components/convertkit/convertkit.app.mjs
+++ b/components/convertkit/convertkit.app.mjs
@@ -34,6 +34,18 @@ export default {
         }));
       },
     },
+    tag: {
+      type: "integer",
+      label: "Tag",
+      description: "Select a tag",
+      async options() {
+        const response = await this.listTags();
+        return response.tags.map((tag) => ({
+          label: tag.name,
+          value: tag.id,
+        }));
+      },
+    },
   },
   methods: {
     _apiSecretToken() {
@@ -114,6 +126,14 @@ export default {
     },
     async addSubscriberToForm(email, formId, $) {
       return await this._makeRequest(`forms/${formId}/subscribe`, {
+        method: "post",
+        data: {
+          email,
+        },
+      }, $);
+    },
+    async addTagToSubscriber(email, tagId, $) {
+      return await this._makeRequest(`tags/${tagId}/subscribe`, {
         method: "post",
         data: {
           email,

--- a/components/convertkit/package.json
+++ b/components/convertkit/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pipedream/bitbucket",
+  "name": "@pipedream/convertkit",
   "version": "0.1.0",
   "description": "Pipedream Convertkit Components",
   "main": "convertkit.app.mjs",

--- a/components/convertkit/package.json
+++ b/components/convertkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/bitbucket",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "Pipedream Convertkit Components",
   "main": "convertkit.app.mjs",
   "keywords": [

--- a/components/convertkit/sources/new-subscriber-instant/new-subscriber-instant.mjs
+++ b/components/convertkit/sources/new-subscriber-instant/new-subscriber-instant.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Subscriber Activation (Instant)",
   key: "convertkit-new-subscriber-instant",
   description: "Emit new event when a new subscriber is activated. [See docs here](https://developers.convertkit.com/#create-a-webhook)",
-  version: "0.0.1",
+  version: "0.0.2",
   props: {
     ...common.props,
   },

--- a/components/convertkit/sources/new-unsubscription-instant/new-unsubscription-instant.mjs
+++ b/components/convertkit/sources/new-unsubscription-instant/new-unsubscription-instant.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Unsubscriber Activation (Instant)",
   key: "convertkit-new-unsubscription-instant",
   description: "Emit new event when a user  unsubscribers. [See docs here](https://developers.convertkit.com/#create-a-webhook)",
-  version: "0.0.1",
+  version: "0.0.2",
   props: {
     ...common.props,
   },

--- a/components/convertkit/sources/webhook-events/webhook-events.mjs
+++ b/components/convertkit/sources/webhook-events/webhook-events.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Webhook Event (Instant)",
   description: "Emit new event for each selected event types. [See docs here](https://developers.convertkit.com/#create-a-webhook)",
   type: "source",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1125,6 +1125,9 @@ importers:
       '@pipedream/platform': 1.5.1
       lodash: 4.17.21
 
+  components/convenia:
+    specifiers: {}
+
   components/convertapi:
     specifiers: {}
 


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 89ee5f4</samp>

Added support for tagging subscribers in ConvertKit. Updated the versions of the `convertkit` component, its actions, sources, and `package.json` file to reflect the new feature. Added `components/convenia` as a dependency in `pnpm-lock.yaml`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 89ee5f4</samp>

> _We are the ConvertKit rebels_
> _We tag our subscribers with fire_
> _We use the `addTagToSubscriber` method_
> _To unleash our marketing desire_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 89ee5f4</samp>

*  Added the `tag` prop and the `addTagToSubscriber` method to the `convertkit.app.mjs` file to enable tagging subscribers in ConvertKit ([link](https://github.com/PipedreamHQ/pipedream/pull/8697/files?diff=unified&w=0#diff-0dd62370282695ace5e45f4abfb9ec7f33431bf8d001642b06219294b9d8d1f2R37-R48), [link](https://github.com/PipedreamHQ/pipedream/pull/8697/files?diff=unified&w=0#diff-0dd62370282695ace5e45f4abfb9ec7f33431bf8d001642b06219294b9d8d1f2R135-R142))
* Updated the version of the `convertkit` component in the `package.json` file to reflect the new feature ([link](https://github.com/PipedreamHQ/pipedream/pull/8697/files?diff=unified&w=0#diff-aa3a7fc63a2bd6eda358baa2399c6d51eca602d6716085e10135086d5cfa5144L3-R3))
* Updated the versions of the actions and sources that depend on the `convertkit.app.mjs` file to match its version ([link](https://github.com/PipedreamHQ/pipedream/pull/8697/files?diff=unified&w=0#diff-cadfced3d2aa4d857cbeb7b7d91ce9415aced8eadc5bfb443c62d9dbee33132dL7-R7), [link](https://github.com/PipedreamHQ/pipedream/pull/8697/files?diff=unified&w=0#diff-07731e4ba18488c65331edbfb66dced5feb43b67d9f706180cd11f73e90879a5L8-R8), [link](https://github.com/PipedreamHQ/pipedream/pull/8697/files?diff=unified&w=0#diff-c721e05a0140f5448c93b26940f33e760d6d4890073b9e4c5c211f0b4b4eeffeL7-R7), [link](https://github.com/PipedreamHQ/pipedream/pull/8697/files?diff=unified&w=0#diff-65e8603cefa77add61811e77b4fcf5494dd2368cde228cbee8d9b776e23e76e6L9-R9), [link](https://github.com/PipedreamHQ/pipedream/pull/8697/files?diff=unified&w=0#diff-cbc110e484544e37e3f014fef14db7ddc8c42f5b7049fedb4702d1b7636a7625L9-R9), [link](https://github.com/PipedreamHQ/pipedream/pull/8697/files?diff=unified&w=0#diff-975f865f46e0e97a936e96d3ec3fe8dac2b387012b6fa02c26dbd97bead16d23L10-R10))
* Added the `components/convenia` entry to the `pnpm-lock.yaml` file as a dependency of the `convertkit` component ([link](https://github.com/PipedreamHQ/pipedream/pull/8697/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1128-R1130))
