### PR TITLE
Docs - deprecate v1 banner

### DIFF
--- a/docs/docs/.vuepress/config.js
+++ b/docs/docs/.vuepress/config.js
@@ -37,7 +37,7 @@ module.exports = {
         ariaLabel: "Docs Version Menu",
         items: [
           {
-            text: "v1",
+            text: "v1 (deprecated)",
             link: "https://pipedream.com/docs/v1",
             internal: true,
             badge: "Deprecated",

--- a/docs/docs/.vuepress/config.js
+++ b/docs/docs/.vuepress/config.js
@@ -33,11 +33,11 @@ module.exports = {
     repo: "PipedreamHQ/pipedream",
     nav: [
       {
-        text: "v1",
+        text: "v1 (deprecated)",
         ariaLabel: "Docs Version Menu",
         items: [
           {
-            text: "v1 (deprecated)",
+            text: "v1",
             link: "https://pipedream.com/docs/v1",
             internal: true,
             badge: "Deprecated",

--- a/docs/docs/.vuepress/config.js
+++ b/docs/docs/.vuepress/config.js
@@ -40,6 +40,8 @@ module.exports = {
             text: "v1",
             link: "https://pipedream.com/docs/v1",
             internal: true,
+            badge: "Deprecated",
+            badgeVariation: "danger",
           },
           {
             text: "v2",

--- a/docs/docs/.vuepress/theme/components/Page.vue
+++ b/docs/docs/.vuepress/theme/components/Page.vue
@@ -1,5 +1,13 @@
 <template>
   <main class="page">
+    <div class="page">
+      <div class="deprecated-banner">
+        ⚠️ This version of the docs is deprecated. Looking for the latest features and updates?
+        <a href="https://pipedream.com/docs">Explore our latest documentation.</a>.
+      </div>
+      <Content/>
+    </div>
+
     <slot name="top" />
 
     <Content class="theme-default-content" />
@@ -9,14 +17,16 @@
 
     <slot name="bottom" />
   </main>
+
 </template>
 
 <script>
+import { Page } from '@theme/components/Page'
 import PageEdit from '@theme/components/PageEdit.vue'
 import PageNav from '@theme/components/PageNav.vue'
 
 export default {
-  components: { PageEdit, PageNav },
+  components: { PageEdit, PageNav, Content: Page.components.Content },
   props: ['sidebarItems']
 }
 </script>
@@ -27,5 +37,19 @@ export default {
 .page
   padding-bottom 2rem
   display block
+
+.deprecated-banner {
+  background-color: #ffee58;  /* Bright yellow background */
+  color: #333;  /* Dark text color for contrast */
+  padding: 1rem;
+  text-align: center;
+  border-bottom: 1px solid #eaecef;
+  font-weight: bold; /* Make text bold for emphasis */
+}
+
+.deprecated-banner a {
+  color: #0066cc;  /* A blue color for the link */
+  text-decoration: underline;  /* Underline for clarity */
+}
 
 </style>

--- a/docs/docs/.vuepress/theme/components/Page.vue
+++ b/docs/docs/.vuepress/theme/components/Page.vue
@@ -1,14 +1,11 @@
 <template>
   <main class="page">
-    <div class="page">
-      <div class="deprecated-banner">
-        ⚠️ This version of the docs is deprecated. Looking for the latest features and updates?
-        <a href="https://pipedream.com/docs">Explore our latest documentation.</a>.
-      </div>
-      <Content/>
-    </div>
-
     <slot name="top" />
+
+    <div class="deprecated-banner">
+      ⚠️ This version of the docs is deprecated. Looking for the latest features and updates?
+      Explore our <a href="https://pipedream.com/docs">latest documentation</a>.
+    </div>
 
     <Content class="theme-default-content" />
     <PageEdit />
@@ -21,12 +18,11 @@
 </template>
 
 <script>
-import { Page } from '@theme/components/Page'
 import PageEdit from '@theme/components/PageEdit.vue'
 import PageNav from '@theme/components/PageNav.vue'
 
 export default {
-  components: { PageEdit, PageNav, Content: Page.components.Content },
+  components: { PageEdit, PageNav },
   props: ['sidebarItems']
 }
 </script>
@@ -38,18 +34,17 @@ export default {
   padding-bottom 2rem
   display block
 
-.deprecated-banner {
+.deprecated-banner
   background-color: #ffee58;  /* Bright yellow background */
   color: #333;  /* Dark text color for contrast */
   padding: 1rem;
   text-align: center;
   border-bottom: 1px solid #eaecef;
   font-weight: bold; /* Make text bold for emphasis */
-}
+  margin-top: 4rem;
 
-.deprecated-banner a {
+.deprecated-banner a
   color: #0066cc;  /* A blue color for the link */
   text-decoration: underline;  /* Underline for clarity */
-}
 
 </style>

--- a/docs/docs/README.md
+++ b/docs/docs/README.md
@@ -3,10 +3,6 @@ prev: false
 next: false
 ---
 
-::: warning This documentation version is deprecated
-📢 For the most updated information, please visit [Pipedream Docs](https://pipedream.com/docs).
-:::
-
 # Overview
 
 ## What is Pipedream?
@@ -47,7 +43,7 @@ Pipedream provides a serverless platform to build and run workflows that connect
 - Use connected accounts to auth APIs in code steps or in "no code" building blocks
 - Compose steps into workflows and trigger on HTTP requests, schedules or app events
 
-Pipedream also provides easy to use services to solve common serverless and integration challenges including state management, execution rate and concurrency controls, large file support (up to 5TB) and more! 
+Pipedream also provides easy to use services to solve common serverless and integration challenges including state management, execution rate and concurrency controls, large file support (up to 5TB) and more!
 
 Watch a demo (4 mins):
 
@@ -55,7 +51,7 @@ Watch a demo (4 mins):
 
 ## Is Pipedream for Me?
 
-We make it easy to connect APIs with code-level control when you need it — and no code when you don't. If you and your team want to stop writing boilerplate code, struggling with authentication and managing infrastructure for integrations, then Pipedream is for you. 
+We make it easy to connect APIs with code-level control when you need it — and no code when you don't. If you and your team want to stop writing boilerplate code, struggling with authentication and managing infrastructure for integrations, then Pipedream is for you.
 
 Developers with a working knowledge of Node.js or Javascript will get the most value from Pipedream (Python, TypeScript, and GitHub integration are coming soon).
 
@@ -70,7 +66,7 @@ Pipedream is trusted by 150k+ developers from startups to Fortune 500 companies:
 Sign up for a [free account (no credit card required)](https://pipedream.com/auth/signup) and complete our [quickstart guide](/quickstart/) to learn the basic patterns for workflow development:
 
 - Trigger workflows on HTTP requests, schedules and app events
-- Return a custom response from your workflow on HTTP requests 
+- Return a custom response from your workflow on HTTP requests
 - Use connected accounts in actions and code steps
 - Pass data between code steps and no code actions
 - Use npm packages in Node.js code steps
@@ -90,7 +86,7 @@ Pipedream supports use cases from prototype to production and is trusted by 150k
 
 ![logos](https://res.cloudinary.com/pipedreamin/image/upload/v1612919944/homepage/logos_kcbviz.png)
 
-The platform processes billions of events and is built and [priced](https://pipedream.com/pricing/) for use at scale. [Our team](https://pipedream.com/about) has built internet scale applications and managed data pipelines in excess of 10 million events per second (EPS) at startups and high-growth environments like BrightRoll, Yahoo!, Affirm and Instacart. 
+The platform processes billions of events and is built and [priced](https://pipedream.com/pricing/) for use at scale. [Our team](https://pipedream.com/about) has built internet scale applications and managed data pipelines in excess of 10 million events per second (EPS) at startups and high-growth environments like BrightRoll, Yahoo!, Affirm and Instacart.
 
 Our [community](https://pipedream.com/community) uses Pipedream for a wide variety of use cases including:
 

--- a/docs/docs/README.md
+++ b/docs/docs/README.md
@@ -3,6 +3,10 @@ prev: false
 next: false
 ---
 
+::: warning This documentation version is deprecated
+📢 For the most updated information, please visit [Pipedream Docs](https://pipedream.com/docs).
+:::
+
 # Overview
 
 ## What is Pipedream?


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6e010a7</samp>

This pull request updates the documentation repository to match the new Pipedream platform and features. It adds a deprecation warning to the `README.md` file and modifies other files to reflect the latest Pipedream Docs website.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6e010a7</samp>

> _`README` warns you_
> _Old docs are deprecated_
> _Visit new website_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6e010a7</samp>

* Add a warning message to the deprecated README file ([link](https://github.com/PipedreamHQ/pipedream/pull/8714/files?diff=unified&w=0#diff-b7549c2451f9754e3dbe9f08dbbb0863f5a7e1967ca8670d6ddefaaa08e07635R6-R9))
