### PR TITLE
Docs - add Python pinning package versions

### DIFF
--- a/docs/docs/code/python/README.md
+++ b/docs/docs/code/python/README.md
@@ -88,6 +88,21 @@ Use the built in [magic comment system to resolve these mismatches](/code/python
 import telegram
 ```
 
+### Pinning package versions
+
+Each time you deploy a workflow with Python code, Pipedream downloads the PyPi packages you `import` in your step. **By default, Pipedream deploys the latest version of the PyPi package each time you deploy a change**.
+
+There are many cases where you may want to specify the version of the packages you're using. If you'd like to use a _specific_ version of a package in a workflow, you can add that version in a [magic comment](/code/python/import-mappings/), for example:
+
+```python
+# python add-package pandas==2.0.0
+import pandas
+```
+
+::: warning
+Currently, you cannot use different versions of the same package in different steps in a workflow.
+:::
+
 ## Making an HTTP request
 
 We recommend using the popular `requests` HTTP client package available in Python to send HTTP requests.


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f09f9ac</samp>

Update Python documentation to explain package versioning. Add a new section to `docs/docs/code/python/README.md` that describes how to use the `pipedream add-package` command and how to pin PyPi package versions with a magic comment.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f09f9ac</samp>

> _`add-package` docs_
> _pin PyPi versions with comments_
> _beware conflicts in spring_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f09f9ac</samp>

*  Add documentation for pinning package versions in Python code ([link](https://github.com/PipedreamHQ/pipedream/pull/8717/files?diff=unified&w=0#diff-38e35d021282412c8ec948f5e76297d7b1a3f774174d0965b22c86a7222fdee2R91-R105))
