### PR TITLE
Gmail Developer App: Fix "In Reply To" parameter in "create_draft"

### DIFF
--- a/components/gmail/actions/send-email/send-email.mjs
+++ b/components/gmail/actions/send-email/send-email.mjs
@@ -5,7 +5,7 @@ export default {
   key: "gmail-send-email",
   name: "Send Email",
   description: "Send an email from your Google Workspace email account",
-  version: "0.0.10",
+  version: "0.0.11",
   type: "action",
   props: {
     gmail,

--- a/components/gmail/gmail.app.mjs
+++ b/components/gmail/gmail.app.mjs
@@ -359,8 +359,8 @@ export default {
         const response = await this._client().users.drafts.create({
           userId: constants.USER_ID,
           requestBody: {
-            threadId: threadId,
             message: {
+              threadId: threadId,
               raw: message.toString("base64"),
             },
           },

--- a/components/gmail/package.json
+++ b/components/gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/gmail",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Pipedream Gmail Components",
   "main": "gmail.app.mjs",
   "keywords": [

--- a/components/gmail_custom_oauth/actions/add-label-to-email/add-label-to-email.mjs
+++ b/components/gmail_custom_oauth/actions/add-label-to-email/add-label-to-email.mjs
@@ -4,7 +4,7 @@ export default {
   key: "gmail_custom_oauth-add-label-to-email",
   name: "Add Label to Email",
   description: "Add a label to an email message. [See the docs](https://developers.google.com/gmail/api/reference/rest/v1/users.messages/modify)",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   props: {
     gmail,

--- a/components/gmail_custom_oauth/actions/create-draft/create-draft.mjs
+++ b/components/gmail_custom_oauth/actions/create-draft/create-draft.mjs
@@ -5,7 +5,7 @@ export default {
   key: "gmail_custom_oauth-create-draft",
   name: "Create Draft",
   description: "Create a draft from your Google Workspace email account",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   props: {
     gmail,
@@ -66,8 +66,11 @@ export default {
     inReplyTo: {
       propDefinition: [
         gmail,
-        "inReplyTo",
+        "message",
       ],
+      label: "In Reply To",
+      description: "Specify the `message-id` this email is replying to.",
+      optional: true,
     },
     mimeType: {
       propDefinition: [

--- a/components/gmail_custom_oauth/actions/download-attachment/download-attachment.mjs
+++ b/components/gmail_custom_oauth/actions/download-attachment/download-attachment.mjs
@@ -6,7 +6,7 @@ export default {
   key: "gmail_custom_oauth-download-attachment",
   name: "Download Attachement",
   description: "Download an attachment by attachmentId to the /tmp directory. [See the docs](https://developers.google.com/gmail/api/reference/rest/v1/users.messages.attachments/get)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     gmail,

--- a/components/gmail_custom_oauth/actions/find-email/find-email.mjs
+++ b/components/gmail_custom_oauth/actions/find-email/find-email.mjs
@@ -4,7 +4,7 @@ export default {
   key: "gmail_custom_oauth-find-email",
   name: "Find Email",
   description: "Find an email using Google's Search Engine. [See the docs](https://developers.google.com/gmail/api/reference/rest/v1/users.messages/list)",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "action",
   props: {
     gmail,

--- a/components/gmail_custom_oauth/actions/send-email/send-email.mjs
+++ b/components/gmail_custom_oauth/actions/send-email/send-email.mjs
@@ -10,7 +10,7 @@ overrideApp(base);
 export default {
   ...base,
   key: "gmail_custom_oauth-send-email",
-  version: "0.0.12",
+  version: "0.0.13",
   props: {
     ...base.props,
     inReplyTo: {

--- a/components/gmail_custom_oauth/actions/update-org-signature/update-org-signature.mjs
+++ b/components/gmail_custom_oauth/actions/update-org-signature/update-org-signature.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Update Signature for Email in Organization",
   description: `Update the signature for a specific email address in an organization.
     A Google Cloud service account with delegated domain-wide authority is required for this action. [See docs here](https://developers.google.com/gmail/api/reference/rest/v1/users.settings.sendAs/update)`,
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   props: {
     gmail: base.props.gmail,

--- a/components/gmail_custom_oauth/actions/update-primary-signature/update-primary-signature.mjs
+++ b/components/gmail_custom_oauth/actions/update-primary-signature/update-primary-signature.mjs
@@ -4,7 +4,7 @@ export default {
   key: "gmail_custom_oauth-update-primary-signature",
   name: "Update Signature for Primary Email Address",
   description: "Update the signature for the primary email address. [See docs here](https://developers.google.com/gmail/api/reference/rest/v1/users.settings.sendAs/update)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   props: {
     gmail,

--- a/components/gmail_custom_oauth/package.json
+++ b/components/gmail_custom_oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/gmail_custom_oauth",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Pipedream Gmail (Consumer) Components",
   "main": "gmail_custom_oauth.app.mjs",
   "keywords": [

--- a/components/gmail_custom_oauth/sources/new-attachment-received/new-attachment-received.mjs
+++ b/components/gmail_custom_oauth/sources/new-attachment-received/new-attachment-received.mjs
@@ -5,7 +5,7 @@ export default {
   key: "gmail_custom_oauth-new-attachment-received",
   name: "New Attachment Received",
   description: "Emit new event for each attachment in a message received. This source is capped at 100 max new messages per run.",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/gmail_custom_oauth/sources/new-email-received/new-email-received.mjs
+++ b/components/gmail_custom_oauth/sources/new-email-received/new-email-received.mjs
@@ -5,7 +5,7 @@ export default {
   key: "gmail_custom_oauth-new-email-received",
   name: "New Email Received",
   description: "Emit new event when an email is received. This source is capped at 100 max new messages per run.",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/gmail_custom_oauth/sources/new-labeled-email/new-labeled-email.mjs
+++ b/components/gmail_custom_oauth/sources/new-labeled-email/new-labeled-email.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Labeled Email",
   description: "Emit new event when a new email is labeled.",
   type: "source",
-  version: "0.0.3",
+  version: "0.0.4",
   dedupe: "unique",
   props: {
     gmail,

--- a/components/gmail_custom_oauth/sources/new-sent-email/new-sent-email.mjs
+++ b/components/gmail_custom_oauth/sources/new-sent-email/new-sent-email.mjs
@@ -5,7 +5,7 @@ export default {
   key: "gmail_custom_oauth-new-sent-email",
   name: "New Sent Email",
   description: "Emit new event for each new email sent. (Maximum of 300 events emited per execution)",
-  version: "0.04",
+  version: "0.0.4",
   type: "source",
   props: {
     app,

--- a/components/gmail_custom_oauth/sources/new-sent-email/new-sent-email.mjs
+++ b/components/gmail_custom_oauth/sources/new-sent-email/new-sent-email.mjs
@@ -5,7 +5,7 @@ export default {
   key: "gmail_custom_oauth-new-sent-email",
   name: "New Sent Email",
   description: "Emit new event for each new email sent. (Maximum of 300 events emited per execution)",
-  version: "0.0.3",
+  version: "0.04",
   type: "source",
   props: {
     app,


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fabfd34</samp>

This pull request updates the Gmail and Gmail Custom OAuth components to support replying to emails by specifying the `message-id` and `threadId` of the original email. It also increments the versions of all the affected components and packages to reflect the changes.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fabfd34</samp>

> _We made some changes to `gmail.app.mjs`_
> _To support replying to emails in various ways_
> _We bumped up the versions_
> _Of actions and sources_
> _And fixed the `requestBody` for `messages.send`_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fabfd34</samp>

*  Incremented the version of the `@pipedream/gmail` package and the `Send Email` action to support replying to emails by specifying the `message-id` ([link](https://github.com/PipedreamHQ/pipedream/pull/8753/files?diff=unified&w=0#diff-17948e81581ecb2933efbc8d4037e562e832c72b779ccb136bfb3f8a2933b5fdL3-R3), [link](https://github.com/PipedreamHQ/pipedream/pull/8753/files?diff=unified&w=0#diff-6e43703d5c1ecdffff4fabaa24e6093f976f4940589b5907b0e9054e5953baf4L8-R8))
*  Modified the `gmail.users.messages.send` API call to nest the `message` object inside another `message` object when passing the `threadId` parameter ([link](https://github.com/PipedreamHQ/pipedream/pull/8753/files?diff=unified&w=0#diff-bee86e91099402a954cb6e1730162a776a2ac215f35771f5ca1a97814d143142L362-R363))
*  Incremented the version of the `@pipedream/gmail_custom_oauth` package and all the Gmail Custom OAuth components to keep them consistent with the changes in the `gmail.app.mjs` file ([link](https://github.com/PipedreamHQ/pipedream/pull/8753/files?diff=unified&w=0#diff-109931734abd441d61be7324be2595d386dd4605e07ffbd25af184f2eb505151L3-R3), [link](https://github.com/PipedreamHQ/pipedream/pull/8753/files?diff=unified&w=0#diff-65bebf3ea18dbc1d3aabdeb1f62c3614d5213454c16827e4932811984233af9eL7-R7), [link](https://github.com/PipedreamHQ/pipedream/pull/8753/files?diff=unified&w=0#diff-28fb546a9275ef78b2a0276d0d13c9eb211d7cab672e78cd50db6116558adbf6L8-R8), [link](https://github.com/PipedreamHQ/pipedream/pull/8753/files?diff=unified&w=0#diff-0c7c4a4e0196ec21388ce63e4487fd26bff60b6725f3ee32e0b9676acaee0c6cL9-R9), [link](https://github.com/PipedreamHQ/pipedream/pull/8753/files?diff=unified&w=0#diff-ff20696fedba2969a237b22f8f2558c72058306d7fa6210f01380272a751a4c7L7-R7), [link](https://github.com/PipedreamHQ/pipedream/pull/8753/files?diff=unified&w=0#diff-7da6b9575c2a343fb29613a0068f75cb737895404f1d97ba8396dbfdc85776d6L13-R13), [link](https://github.com/PipedreamHQ/pipedream/pull/8753/files?diff=unified&w=0#diff-1ee98ee853020c6f829aa4938ca7e38e1eedde5464a1fd437fa8faa468d504a9L10-R10), [link](https://github.com/PipedreamHQ/pipedream/pull/8753/files?diff=unified&w=0#diff-eb535afab8fd3a977b648d70b87d764c308c4379e7c987a9293b62779c652119L7-R7), [link](https://github.com/PipedreamHQ/pipedream/pull/8753/files?diff=unified&w=0#diff-630e723faa3bbce1be9b34a0b9083a3b20e9ee14076e1f7dfbb2354ab3d778a5L8-R8), [link](https://github.com/PipedreamHQ/pipedream/pull/8753/files?diff=unified&w=0#diff-0e2f3db9134f5f8213dd229dae913e9f543f2f440cab62b86cde10c408a4525cL8-R8), [link](https://github.com/PipedreamHQ/pipedream/pull/8753/files?diff=unified&w=0#diff-d4f8f80b34c93c55959d8567ff2ee60db5e6cd2ef0bd36b2f4906c87559265c5L10-R10), [link](https://github.com/PipedreamHQ/pipedream/pull/8753/files?diff=unified&w=0#diff-a589a7fba6ef86d124b282ec7d01a786f97d66469abf7d7bb96447db2d79d078L8-R8))
*  Renamed the `inReplyTo` prop of the `Create Draft` action to `message`, and added a label and a description to clarify its usage ([link](https://github.com/PipedreamHQ/pipedream/pull/8753/files?diff=unified&w=0#diff-28fb546a9275ef78b2a0276d0d13c9eb211d7cab672e78cd50db6116558adbf6L69-R73))
