### PR TITLE
Browserless pdf fix

### DIFF
--- a/components/browserless/actions/convert-html-to-pdf/convert-html-to-pdf.mjs
+++ b/components/browserless/actions/convert-html-to-pdf/convert-html-to-pdf.mjs
@@ -5,7 +5,7 @@ export default {
   key: "browserless-convert-html-to-pdf",
   name: "Generate PDF from HTML String",
   description: "See https://docs.browserless.io/docs/pdf.html",
-  version: "0.3.0",
+  version: "0.4.{{ts}}",
   type: "action",
   props: {
     browserless: {
@@ -28,6 +28,7 @@ export default {
         "Cache-Control": "no-cache",
         "Content-Type": "application/json",
       },
+      responseType: "arraybuffer",
       data: {
         html,
         options: {

--- a/components/browserless/actions/convert-html-to-pdf/convert-html-to-pdf.mjs
+++ b/components/browserless/actions/convert-html-to-pdf/convert-html-to-pdf.mjs
@@ -5,7 +5,7 @@ export default {
   key: "browserless-convert-html-to-pdf",
   name: "Generate PDF from HTML String",
   description: "See https://docs.browserless.io/docs/pdf.html",
-  version: "0.4.{{ts}}",
+  version: "0.4.0",
   type: "action",
   props: {
     browserless: {

--- a/components/browserless/package.json
+++ b/components/browserless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/browserless",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "Pipedream Browserless Components",
   "main": "browserless.app.mjs",
   "keywords": [
@@ -13,7 +13,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@pipedream/platform": "^1.4.1",
+    "@pipedream/platform": "^1.5.1",
     "puppeteer-core": "^19.7.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1504,6 +1504,9 @@ importers:
     dependencies:
       '@pipedream/platform': 1.5.1
 
+  components/document360:
+    specifiers: {}
+
   components/docupilot:
     specifiers:
       '@pipedream/platform': ^1.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -699,7 +699,7 @@ importers:
 
   components/browserless:
     specifiers:
-      '@pipedream/platform': ^1.4.1
+      '@pipedream/platform': ^1.5.1
       puppeteer-core: ^19.7.5
     dependencies:
       '@pipedream/platform': 1.5.1
@@ -10155,11 +10155,11 @@ packages:
       kuler: 2.0.0
     dev: false
 
-  /@definitelytyped/header-parser/0.0.182:
-    resolution: {integrity: sha512-SF4sN7UUbh3I1UwZk2fJqvgN/hUjb/adJ13fA7FG5u5dr7MuRQFVfcd/dMrXkLpl4G7/pKMNoLmGiL0N7VOodg==}
+  /@definitelytyped/header-parser/0.0.184:
+    resolution: {integrity: sha512-e5aTiMFYzrNu/xC9LqzVNXbkyF/e/EU88tJVsEyxKaWr8RjX7Y2ONsXmCJjsKbiQEUjKJobtSgk21XwhoSa3KQ==}
     dependencies:
       '@definitelytyped/typescript-versions': 0.0.179
-      '@definitelytyped/utils': 0.0.181
+      '@definitelytyped/utils': 0.0.182
       semver: 7.5.4
     dev: true
 
@@ -10167,15 +10167,14 @@ packages:
     resolution: {integrity: sha512-E0VjIZkVtOt2ozagGlmWULKJYvFZwMjS6A335QJX8dmn21idRP/0RodxRpjtMU2//ChtvCZZUuKrPZQ2D/owww==}
     dev: true
 
-  /@definitelytyped/utils/0.0.181:
-    resolution: {integrity: sha512-4FuIV3RK1HEaDJ8na7DStyp9WJRDJqWyaYLbhiObj+iivFnudO06V9FEvl9hDx8dbvrlJt0JvNN8bogyBn+M8A==}
+  /@definitelytyped/utils/0.0.182:
+    resolution: {integrity: sha512-ANeeI+ixK9FYgljDlVtlBqcaPi1Fi9R55MkhtGbNNUY/g4u1S1QXoBY/87oYF92VjQPpbxC0ZuiP8MnVuHqh6w==}
     dependencies:
       '@definitelytyped/typescript-versions': 0.0.179
       '@qiwi/npm-registry-client': 8.9.1
       '@types/node': 14.18.63
       charm: 1.0.2
       fs-extra: 8.1.0
-      fstream: 1.0.12
       tar: 6.2.0
       tar-stream: 2.2.0
     dev: true
@@ -16946,7 +16945,7 @@ packages:
     peerDependencies:
       typescript: '*'
     dependencies:
-      '@definitelytyped/header-parser': 0.0.182
+      '@definitelytyped/header-parser': 0.0.184
       command-exists: 1.2.9
       rimraf: 3.0.2
       semver: 6.3.1
@@ -16962,9 +16961,9 @@ packages:
     peerDependencies:
       typescript: '>= 3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.7.0-dev || >= 3.8.0-dev || >= 3.9.0-dev || >= 4.0.0-dev'
     dependencies:
-      '@definitelytyped/header-parser': 0.0.182
+      '@definitelytyped/header-parser': 0.0.184
       '@definitelytyped/typescript-versions': 0.0.179
-      '@definitelytyped/utils': 0.0.181
+      '@definitelytyped/utils': 0.0.182
       dts-critic: 3.3.11_typescript@4.9.5
       fs-extra: 6.0.1
       json-stable-stringify: 1.0.2
@@ -18203,16 +18202,6 @@ packages:
     os: [darwin]
     requiresBuild: true
     optional: true
-
-  /fstream/1.0.12:
-    resolution: {integrity: sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==}
-    engines: {node: '>=0.6'}
-    dependencies:
-      graceful-fs: 4.2.11
-      inherits: 2.0.4
-      mkdirp: 0.5.6
-      rimraf: 2.7.1
-    dev: true
 
   /ftp/0.3.10:
     resolution: {integrity: sha512-faFVML1aBx2UoDStmLwv2Wptt4vw5x03xxX172nhA5Y5HBshW5JweqQ2W4xL4dezQTG8inJsuYcpPHHU3X5OTQ==}
@@ -25291,13 +25280,6 @@ packages:
       - supports-color
     dev: false
 
-  /rimraf/2.7.1:
-    resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
-    hasBin: true
-    dependencies:
-      glob: 7.2.3
-    dev: true
-
   /rimraf/3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     hasBin: true
@@ -27529,7 +27511,7 @@ packages:
     dev: false
 
   /verror/1.10.0:
-    resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
+    resolution: {integrity: sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=}
     engines: {'0': node >=0.6.0}
     dependencies:
       assert-plus: 1.0.0


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 18bcb51</samp>

This pull request enhances the `convert-html-to-pdf` action of the `browserless` component by using a new versioning scheme and binary data handling. It also updates the dependencies of the repository and the `pnpm-lock.yaml` file accordingly.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 18bcb51</samp>

> _We're breaking the chains of the old `browserless`_
> _We're converting the HTML to the PDF darkness_
> _We're updating the lock with the new dependencies_
> _We're the masters of the `document360` legacy_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 18bcb51</samp>

*  Update `convert-html-to-pdf` action to use array buffer for PDF data and timestamp-based version ([link](https://github.com/PipedreamHQ/pipedream/pull/8775/files?diff=unified&w=0#diff-57bcc4789a804595e58965be33757f7e0fd0e304f69e9f8a7421032f046e96ecL8-R8), [link](https://github.com/PipedreamHQ/pipedream/pull/8775/files?diff=unified&w=0#diff-57bcc4789a804595e58965be33757f7e0fd0e304f69e9f8a7421032f046e96ecR31), [link](https://github.com/PipedreamHQ/pipedream/pull/8775/files?diff=unified&w=0#diff-94d60839d0d83949393662722b2c009a0e658e9bcaacf3b6559e62f41e2f8c2dL3-R3))
*  Update `@pipedream/platform` dependency to use latest features and bug fixes ([link](https://github.com/PipedreamHQ/pipedream/pull/8775/files?diff=unified&w=0#diff-94d60839d0d83949393662722b2c009a0e658e9bcaacf3b6559e62f41e2f8c2dL16-R16), [link](https://github.com/PipedreamHQ/pipedream/pull/8775/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL702-R702))
*  Add `document360` package as a new component in the repository ([link](https://github.com/PipedreamHQ/pipedream/pull/8775/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1507-R1509))
*  Update `@definitelytyped/header-parser` and `@definitelytyped/utils` dependencies to use latest versions ([link](https://github.com/PipedreamHQ/pipedream/pull/8775/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10155-R10162), [link](https://github.com/PipedreamHQ/pipedream/pull/8775/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10167-R10171), [link](https://github.com/PipedreamHQ/pipedream/pull/8775/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL16946-R16948), [link](https://github.com/PipedreamHQ/pipedream/pull/8775/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL16962-R16966))
*  Remove unused dependencies `fstream` and `rimraf` from the `pnpm-lock.yaml` file ([link](https://github.com/PipedreamHQ/pipedream/pull/8775/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10175), [link](https://github.com/PipedreamHQ/pipedream/pull/8775/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL18204-L18213), [link](https://github.com/PipedreamHQ/pipedream/pull/8775/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL25291-L25297), [link](https://github.com/PipedreamHQ/pipedream/pull/8775/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL27529-R27514))
