### PR TITLE
Adding ServiceNow troubleshooting guidance

### DIFF
--- a/components/servicenow/README.md
+++ b/components/servicenow/README.md
@@ -50,3 +50,24 @@ Collectively, the two apps you configured in your ServiceNow instance allow your
 ### ServiceNow Authorization Reference
 
 [This ServiceNow doc](https://docs.servicenow.com/bundle/orlando-platform-administration/page/administer/security/concept/c_OAuthAuthorizationCodeFlow.html) describes the general flow we ask you to implement above. In that doc, the app you create in **Step 2** is referred to as the **client application**, and the app in **Step 4** is referred to as the **OAuth provider application registry record**.
+
+### Additional Guidance For Hardened or Mature Instances ###
+
+The instructions above are likely to work on a fresh, out-of-the-box instance but may work imperfectly on ServiceNow instances that have been customized or have applied various security hardening recommendations such as the [explicit roles plugin](https://docs.servicenow.com/en-US/bundle/vancouver-platform-security/page/administer/security/reference/explicit-role-plugin.html).
+
+Symptoms of problems here may include getting a **504 Gateway Time-out** error when completing step 6 above. If you manually test the connection deatails in a tool like Postman, you may get an error like this:
+
+```
+{
+  "error_description":"access_denied",
+  "error":"server_error"
+}
+```
+
+In these instances, the following tips may be helpful:
+
+* Create a dedicated role for this purpose, and assign it to a service account that  is only used for this purpose.  You should not set it for web service access only, since interactive access is required to complete Pipedream setup.
+* Ensure that the dedicated role has ACLs configured to allow read for the oauth_credential table - both the table and table.\* for all fields. 
+* Assign snc_internal to this service account. This is important if you are using the explicit roles plugin as part of instance security hardening.
+
+Finally, while not required, you should also check that the role has associated ACLs for any tables you want to work with; by default they may if you use snc_internal, but some fields extended from task or other tables may require additional ACLs based on your instance's configuration.


### PR DESCRIPTION
Adding some tips and suggestions for users with security hardened instances experiencing authentication errors.

## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5c16ea7</samp>

Update `components/servicenow/README.md` to include a new subsection on how to troubleshoot authorization issues with customized or hardened ServiceNow instances. The change aims to help users avoid common errors and configure the necessary roles and permissions for Pipedream.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5c16ea7</samp>

> _`ServiceNow` woes_
> _Customized instances need_
> _More authorization_


## WHY

I experienced prolonged issues authenticating ServiceNow to Pipedream. Support was helpful in ruling out Pipedream as the problem, but I struggled to resolve what the issue was on my side. These additions summarize my tips and the solution that worked for me.


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5c16ea7</samp>

*  Add a new subsection to the ServiceNow Authorization Reference section of the README.md file to help users with customized or hardened ServiceNow instances ([link](https://github.com/PipedreamHQ/pipedream/pull/8799/files?diff=unified&w=0#diff-b3a6e2dcc8dc36db7e2ee842379ff6ff2d90d733838fc8278294e0b2a528b7b0R53-R73))
