### PR TITLE
Fix buy me a coffee set last created time

### DIFF
--- a/components/buy_me_a_coffee/package.json
+++ b/components/buy_me_a_coffee/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/buy_me_a_coffee",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Pipedream Buy Me a Coffee Components",
   "main": "dist/app/buy_me_a_coffee.app.mjs",
   "keywords": [

--- a/components/buy_me_a_coffee/sources/common/common.ts
+++ b/components/buy_me_a_coffee/sources/common/common.ts
@@ -58,6 +58,6 @@ export default {
         newLastCreatedTime = createdTime;
       }
     }
-    this.getLastCreatedTime(newLastCreatedTime);
+    this.setLastCreatedTime(newLastCreatedTime);
   },
 };

--- a/components/buy_me_a_coffee/sources/new-item-purchased/new-item-purchased.ts
+++ b/components/buy_me_a_coffee/sources/new-item-purchased/new-item-purchased.ts
@@ -6,7 +6,7 @@ export default defineSource({
   key: "buy_me_a_coffee-new-item-purchased",
   name: "New Item Purchased",
   description: "Emit new events when a new item was purchased. [See the docs](https://developers.buymeacoffee.com/#/apireference?id=extra-purchases-v1extras)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/buy_me_a_coffee/sources/new-member-added/new-member-added.ts
+++ b/components/buy_me_a_coffee/sources/new-member-added/new-member-added.ts
@@ -6,7 +6,7 @@ export default defineSource({
   key: "buy_me_a_coffee-new-member-added",
   name: "New Member Added",
   description: "Emit new events when a new member was added. [See the docs](https://developers.buymeacoffee.com/#/apireference?id=members-v1subscriptions)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/buy_me_a_coffee/sources/new-supporter-added/new-supporter-added.ts
+++ b/components/buy_me_a_coffee/sources/new-supporter-added/new-supporter-added.ts
@@ -6,7 +6,7 @@ export default defineSource({
   key: "buy_me_a_coffee-new-supporter-added",
   name: "New Supporter Added",
   description: "Emit new events when a new supporter was added. [See the docs](https://developers.buymeacoffee.com/#/apireference?id=onetime-supporters-v1supporters)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "source",
   dedupe: "unique",
   methods: {


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 05236d7</samp>

Renamed a method in the `common.ts` file and updated the `version` fields in the `package.json` file and the Buy Me a Coffee sources to prepare for a new release of the components.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 05236d7</samp>

> _`version` updated_
> _`setLastCreatedTime` fixed_
> _autumn of refactor_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 05236d7</samp>

*  Bump up the version of the Buy Me a Coffee components package to `0.0.5` ([link](https://github.com/PipedreamHQ/pipedream/pull/8826/files?diff=unified&w=0#diff-8842f09a219ac9430c6723c919a7318949c33e652b67c6427226e1ad59e68c2aL3-R3))
* Rename the `getLastCreatedTime` method to `setLastCreatedTime` in the `common.ts` file to improve clarity and consistency ([link](https://github.com/PipedreamHQ/pipedream/pull/8826/files?diff=unified&w=0#diff-df3fe3dd9257e579fd4c6ff1c3bc02c8d0cd21a12fcd5c09d13f3fb52633efb8L61-R61))
* Update the version of the three sources that depend on the `common.ts` file to `0.0.3` to reflect the method name change: `new-item-purchased.ts`, `new-member-added.ts`, and `new-supporter-added.ts` ([link](https://github.com/PipedreamHQ/pipedream/pull/8826/files?diff=unified&w=0#diff-63f9d51a154c7bf86f4c1a8e3210db2825841d27bca665cb52d64b392ef6b1ceL9-R9), [link](https://github.com/PipedreamHQ/pipedream/pull/8826/files?diff=unified&w=0#diff-14308367743a7fa5bf92a6d15055e6eac013f1bf8530b3e7db64fdc66b14e79bL9-R9), [link](https://github.com/PipedreamHQ/pipedream/pull/8826/files?diff=unified&w=0#diff-bee15995f05742cafac92424b2d3410b13e71ea2d67bb01006b2f8adad2d58a0L9-R9))
