### PR TITLE
Adding defaultProtocolTimeout to puppeteer constructors

### DIFF
--- a/components/puppeteer/actions/get-html/get-html.mjs
+++ b/components/puppeteer/actions/get-html/get-html.mjs
@@ -4,7 +4,7 @@ export default {
   key: "puppeteer-get-html",
   name: "Get HTML",
   description: "Get the HTML of a webpage using Puppeteer. [See the documentation](https://pptr.dev/api/puppeteer.page.content)",
-  version: "0.0.7",
+  version: "1.0.0",
   type: "action",
   props: {
     puppeteer,

--- a/components/puppeteer/actions/get-page-title/get-page-title.mjs
+++ b/components/puppeteer/actions/get-page-title/get-page-title.mjs
@@ -4,7 +4,7 @@ export default {
   key: "puppeteer-get-page-title",
   name: "Get Page Title",
   description: "Get the title of a webpage using Puppeteer. [See the documentation](https://pptr.dev/api/puppeteer.page.title)",
-  version: "0.0.7",
+  version: "1.0.0",
   type: "action",
   props: {
     puppeteer,

--- a/components/puppeteer/actions/get-pdf/get-pdf.mjs
+++ b/components/puppeteer/actions/get-pdf/get-pdf.mjs
@@ -6,7 +6,7 @@ export default {
   key: "puppeteer-get-pdf",
   name: "Get PDF",
   description: "Generate a PDF of a page using Puppeteer. [See the documentation](https://pptr.dev/api/puppeteer.page.pdf)",
-  version: "0.0.7",
+  version: "1.0.0",
   type: "action",
   props: {
     puppeteer,

--- a/components/puppeteer/actions/screenshot-page/screenshot-page.mjs
+++ b/components/puppeteer/actions/screenshot-page/screenshot-page.mjs
@@ -7,7 +7,7 @@ export default {
   key: "puppeteer-screenshot-page",
   name: "Screenshot a Page",
   description: "Captures a screenshot of a page using Puppeteer. [See the documentation](https://pptr.dev/api/puppeteer.page.screenshot)",
-  version: "0.0.8",
+  version: "1.0.0",
   type: "action",
   props: {
     puppeteer,

--- a/components/puppeteer/package.json
+++ b/components/puppeteer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/puppeteer",
-  "version": "0.8.0",
+  "version": "1.0.0",
   "description": "Pipedream Puppeteer Components",
   "main": "puppeteer.app.mjs",
   "keywords": [

--- a/components/puppeteer/puppeteer.app.mjs
+++ b/components/puppeteer/puppeteer.app.mjs
@@ -30,6 +30,7 @@ export default {
           "--disable-web-security",
           "--font-render-hinting=none",
         ],
+        protocolTimeout: 240000,
         ...opts,
       });
 

--- a/packages/browsers/index.mjs
+++ b/packages/browsers/index.mjs
@@ -23,6 +23,7 @@ export const puppeteer = {
         "--hide-scrollbars",
         "--disable-web-security",
       ],
+      protocolTimeout: 240000,
       ...opts,
     });
 

--- a/packages/browsers/package.json
+++ b/packages/browsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/browsers",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "For using puppeeter or playwright in Pipedream Node.js Code Steps. Includes the prebuilt binaries and specific versions for compatiblity with Pipedream.",
   "main": "index.mjs",
   "scripts": {


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 03e101e</samp>

Updated the `puppeteer` app and its actions to version `1.0.0` to support the latest changes in the `browsers` package. Added the `protocolTimeout` option to the `launch` method of both the `puppeteer` app and the `browsers` package to increase the browser connection timeout and prevent errors on slow pages.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 03e101e</samp>

> _`puppeteer` changes_
> _major version and timeout_
> _winter of slow pages_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 03e101e</samp>

*  Bump the version of the `puppeteer` package and its actions to `1.0.0` to reflect major changes in the app and the `browsers` package ([link](https://github.com/PipedreamHQ/pipedream/pull/8827/files?diff=unified&w=0#diff-ae1be2b9632b8fb3ff8f7c46bcdb32bb15bade47e542d49d9356295a9171611cL7-R7), [link](https://github.com/PipedreamHQ/pipedream/pull/8827/files?diff=unified&w=0#diff-9293050daaf377120514fd4576dde6625c9388148426be810fea8ce5869a2f14L7-R7), [link](https://github.com/PipedreamHQ/pipedream/pull/8827/files?diff=unified&w=0#diff-edeac74108f5fcfd4372f1d6d2fb8269ae22e83111c7f3da9bdcd486b97c7d96L9-R9), [link](https://github.com/PipedreamHQ/pipedream/pull/8827/files?diff=unified&w=0#diff-7c651bdabaca3622a521ba2fc19123bd7ddef4eeba614a5b98e6e07c11deb94aL10-R10), [link](https://github.com/PipedreamHQ/pipedream/pull/8827/files?diff=unified&w=0#diff-9a902b32400f187d4ef83890980c121f01c8d62616231a7a846b2e55d32156c6L3-R3))
* Add the `protocolTimeout` option to the `launch` method of the `puppeteer` app and the `browsers` package to increase the timeout for the browser connection from 30 to 240 seconds ([link](https://github.com/PipedreamHQ/pipedream/pull/8827/files?diff=unified&w=0#diff-dc255ad27cc4062520ec7c2eec5816c3045003fbef1ce0171b478e8cd6c831abR33), [link](https://github.com/PipedreamHQ/pipedream/pull/8827/files?diff=unified&w=0#diff-3c6823116f58743e9268d54102e61eec6cb2557f1cfae151e2777ff293829102R26))
* Bump the version of the `browsers` package to `1.0.2` to reflect the addition of the `protocolTimeout` option ([link](https://github.com/PipedreamHQ/pipedream/pull/8827/files?diff=unified&w=0#diff-8e01e5bf2a1332f403d9036f727d9e3db6ee8406b4b3430630160b086f59d0dfL3-R3))
