### PR TITLE
Adding reference to #run in the sidebar

### DIFF
--- a/docs/docs/.vuepress/configs/sidebarConfig.js
+++ b/docs/docs/.vuepress/configs/sidebarConfig.js
@@ -67,7 +67,11 @@ const docsNav = [
           "/environment-variables/",
           "/code/nodejs/async/",
           "/code/nodejs/sharing-code/",
-          "/code/nodejs/browser-automation/"
+          "/code/nodejs/browser-automation/",
+          {
+            title: "Reference",
+            path: "/components/api/#run"
+          }
         ],
       },
       {

--- a/docs/docs/components/api/README.md
+++ b/docs/docs/components/api/README.md
@@ -878,7 +878,7 @@ import axios from "axios";
 
 When you deploy a component, Pipedream downloads the latest versions of these packages and bundles them with your deployment.
 
-Some packages — for example, packages like [Puppeteer](https://pptr.dev/), which includes large dependencies like Chromium — may not work on Pipedream. Please [reach out](https://pipedream.com/community) if you encounter a specific issue.
+Some packages that rely on large dependencies or on unbundled binaries — may not work on Pipedream. Please [reach out](https://pipedream.com/support) if you encounter a specific issue.
 
 #### Referencing a specific version of a package
 


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f2bc8e5</samp>

This pull request updates the API docs to improve the navigation and the clarity of the warnings. It adds a link to the reference section in the sidebarConfig.js file and rephrases the warning about npm packages in the README.md file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f2bc8e5</samp>

> _`run` method docs_
> _added to sidebar nav link_
> _spring cleaning the site_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f2bc8e5</samp>

* Add a link to the reference section of the API docs in the sidebar navigation (`[link](https://github.com/PipedreamHQ/pipedream/pull/8829/files?diff=unified&w=0#diff-156430f05d7fa65cf93077cd044dce865e7edc33a36b4f4b58e011699a188b16L70-R74)`)
