### PR TITLE
removing node 14 reference

### DIFF
--- a/docs/docs/code/nodejs/README.md
+++ b/docs/docs/code/nodejs/README.md
@@ -16,9 +16,8 @@ It's important to understand the core difference between Node.js and the JavaScr
 
 1. Click the **+** button below any step of your workflow.
 2. Select the option to **Run custom code**.
-3. Select the `nodejs14.x` runtime.
 
-You can add any Node.js code in the editor that appears. For example, try:
+Note that new code steps will default to Node.js v{{$site.themeConfig.NODE_VERSION}}. You can add any Node.js code in the editor that appears. For example, try:
 
 ```javascript
 export default defineComponent({


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 774ae07</samp>

Updated Node.js documentation to use the new default version `{{$site.themeConfig.NODE_VERSION}}` and removed outdated instructions.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 774ae07</samp>

> _`Node.js` updated_
> _No need to choose runtime_
> _Docs are clear and fresh_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 774ae07</samp>

* Update the documentation to reflect the new default Node.js version for code steps ([link](https://github.com/PipedreamHQ/pipedream/pull/8847/files?diff=unified&w=0#diff-1dbf780045dde0c714450aa4abdcf9aa27308932d58b2c45e64a6027987422a6L19-R20))
