### PR TITLE
Setting num_tries to 1

### DIFF
--- a/packages/component_code_gen/main.py
+++ b/packages/component_code_gen/main.py
@@ -20,7 +20,7 @@ if __name__ == '__main__':
     parser.add_argument('--urls', help='A list of (space-separated) api docs urls to be parsed and sent with the prompt',
                         default=[], nargs="*")
     parser.add_argument('--num_tries', dest='tries', help='The number of times we call the model to generate code',
-                        default=3, type=int)
+                        default=1, type=int)
     parser.add_argument(
         '--custom_path', help='The path for the location of custom files')
     parser.add_argument('--output_dir', help='The path for the output dir',


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ee3a738</samp>

Reduced the default number of code generation attempts for each component from 3 to 1 in `main.py`. This is to speed up the code generation process and facilitate testing and debugging.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ee3a738</samp>

> _`--num_tries` one_
> _Less time and resources_
> _Model still unsure_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ee3a738</samp>

* Reduce the default number of tries for code generation from 3 to 1 (`--num_tries` argument in [link](https://github.com/PipedreamHQ/pipedream/pull/8892/files?diff=unified&w=0#diff-38d985e2c8bd73ed773e44c2b976a924b869118a50bef45eabdbe864dff02064L23-R23)). This speeds up the process and helps debug the experimental model.
