### PR TITLE
add response format prop to chat

### DIFF
--- a/components/openai/actions/chat/chat.mjs
+++ b/components/openai/actions/chat/chat.mjs
@@ -39,6 +39,17 @@ export default {
       description: "Provide one or more images to [OpenAI's vision model](https://platform.openai.com/docs/guides/vision). Accepts URLs or base64 encoded strings. Compatible with the `gpt4-vision-preview model`",
       optional: true,
     },
+    responseFormat: {
+      type: "string",
+      label: "Response Format",
+      description: "Specify the format that the model must output. [Setting to `json_object` guarantees the message the model generates is valid JSON](https://platform.openai.com/docs/api-reference/chat/create#chat-create-response_format). Defaults to `text`",
+      optiions: [
+        "text",
+        "json_object",
+      ],
+      optional: true,
+      default: "text",
+    },
     ...common.props,
   },
   async run({ $ }) {

--- a/components/openai/actions/common/common.mjs
+++ b/components/openai/actions/common/common.mjs
@@ -148,6 +148,9 @@ export default {
 
       return {
         ...this._getCommonArgs(),
+        response_format: {
+          type: this.responseFormat,
+        },
         messages,
       };
     },


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c6cc462</samp>

This pull request adds a new `responseFormat` parameter to the `chat` action in the `openai` component, which lets the user choose the format of the response from the OpenAI chat API. It also modifies the `common.makeRequest` function to pass this parameter to the API request.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c6cc462</samp>

> _`chat` action grows_
> _`responseFormat` option_
> _winter of JSON_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c6cc462</samp>

*  Add `responseFormat` parameter to `chat` action to allow user to choose format of OpenAI chat API response ([link](https://github.com/PipedreamHQ/pipedream/pull/8944/files?diff=unified&w=0#diff-be714b11f9915dfbedb6f1fb6a1e3aa030b9a759e68c2071eed1afbd6e80730eR42-R52))
*  Pass `responseFormat` parameter to `common.makeRequest` function to include `response_format` query parameter in API request URL ([link](https://github.com/PipedreamHQ/pipedream/pull/8944/files?diff=unified&w=0#diff-cbdfecbe465e506d4cfb9d3fa823460787cb24d2224d6b210b94b81e39fad648R151-R153))
