### PR TITLE
Ghost Admin API - Create Post: Add Featured prop to allow user to add featured post

### DIFF
--- a/components/ghost_org_admin_api/actions/create-post/create-post.mjs
+++ b/components/ghost_org_admin_api/actions/create-post/create-post.mjs
@@ -3,9 +3,9 @@ import ghostAdminApi from "../../ghost_org_admin_api.app.mjs";
 export default {
   key: "ghost_org_admin_api-create-post",
   name: "Create post",
-  description: "Create a post. [See the docs here](https://ghost.org/docs/admin-api/#creating-a-post).",
+  description: "Create a post. [See the documentation](https://ghost.org/docs/admin-api/#creating-a-post).",
   type: "action",
-  version: "0.0.3",
+  version: "0.0.4",
   props: {
     ghostAdminApi,
     title: {
@@ -41,6 +41,12 @@ export default {
       description: "Tags of the post",
       optional: true,
     },
+    featured: {
+      type: "boolean",
+      label: "Featured",
+      description: "Set to `true` to make the post featured",
+      optional: true,
+    },
   },
   async run({ $ }) {
     const {
@@ -49,6 +55,7 @@ export default {
       html,
       status,
       tags,
+      featured,
     } = this;
 
     const response = await this.ghostAdminApi.createPost({
@@ -64,6 +71,7 @@ export default {
             html,
             status,
             tags,
+            featured,
           },
         ],
       },

--- a/components/ghost_org_admin_api/package.json
+++ b/components/ghost_org_admin_api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/ghost_org_admin_api",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Pipedream Ghost_org_admin_api Components",
   "main": "ghost_org_admin_api.app.mjs",
   "keywords": [


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9a7fbfb</samp>

Added support for creating featured posts with the `ghost_org_admin_api` component. Updated the `create-post` action and the component version.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9a7fbfb</samp>

> _Oh, we're the crew of the Ghost ship, and we sail the web so free_
> _We write the code that makes the posts, with the `ghost_org_admin_api`_
> _And when we want to feature some, we use the `featured` prop_
> _We heave and ho and pull the rope, and we raise the version up_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9a7fbfb</samp>

*  Add `featured` prop to `create-post` action to enable marking posts as featured ([link](https://github.com/PipedreamHQ/pipedream/pull/8949/files?diff=unified&w=0#diff-7c850f36120470e56b1614303cc99ec0bc8a784ab7b04a37b646b6ca1c17ac79R44-R49), [link](https://github.com/PipedreamHQ/pipedream/pull/8949/files?diff=unified&w=0#diff-7c850f36120470e56b1614303cc99ec0bc8a784ab7b04a37b646b6ca1c17ac79R58), [link](https://github.com/PipedreamHQ/pipedream/pull/8949/files?diff=unified&w=0#diff-7c850f36120470e56b1614303cc99ec0bc8a784ab7b04a37b646b6ca1c17ac79R74))
*  Update description of `create-post` action to use concise link text ([link](https://github.com/PipedreamHQ/pipedream/pull/8949/files?diff=unified&w=0#diff-7c850f36120470e56b1614303cc99ec0bc8a784ab7b04a37b646b6ca1c17ac79L6-R8))
*  Bump version of `ghost_org_admin_api` package to reflect new feature ([link](https://github.com/PipedreamHQ/pipedream/pull/8949/files?diff=unified&w=0#diff-f2b088aeb6ebc07317bd513a6f899cf70df59e6d46c9e0742b00cdab14117b4cL3-R3))
