### PR TITLE
Adding missing optional params for generate images

### DIFF
--- a/components/openai/actions/create-image/create-image.mjs
+++ b/components/openai/actions/create-image/create-image.mjs
@@ -1,9 +1,8 @@
 import openai from "../../openai.app.mjs";
-import constants from "../common/constants.mjs";
 
 export default {
   name: "Create Image",
-  version: "0.1.5",
+  version: "0.1.8",
   key: "openai-create-image",
   description: "Creates an image given a prompt. returns a URL to the image. [See docs here](https://platform.openai.com/docs/api-reference/images)",
   type: "action",
@@ -36,14 +35,6 @@ export default {
       type: "integer",
       optional: true,
       default: 1,
-    },
-    size: {
-      label: "Size",
-      description: "The size of the generated images.",
-      type: "string",
-      optional: true,
-      options: constants.IMAGE_SIZES,
-      default: "1024x1024",
     },
     quality: {
       label: "Quality",
@@ -78,6 +69,52 @@ export default {
         },
       ],
       default: "natural",
+    },
+    responseFormat: {
+      label: "Response Format",
+      description: "The format in which the generated images are returned.",
+      type: "string",
+      optional: true,
+      options: [
+        {
+          label: "URL",
+          value: "url",
+        },
+        {
+          label: "Base64 JSON",
+          value: "b64_json",
+        },
+      ],
+      default: "url",
+    },
+    size: {
+      label: "Size",
+      description: "The size of the generated images.",
+      type: "string",
+      optional: true,
+      options: [
+        {
+          label: "256x256",
+          value: "256x256",
+        },
+        {
+          label: "512x512",
+          value: "512x512",
+        },
+        {
+          label: "1024x1024",
+          value: "1024x1024",
+        },
+        {
+          label: "1792x1024",
+          value: "1792x1024",
+        },
+        {
+          label: "1024x1792",
+          value: "1024x1792",
+        },
+      ],
+      default: "1024x1024",
     },
   },
   async run({ $ }) {

--- a/components/openai/package.json
+++ b/components/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/openai",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Pipedream OpenAI Components",
   "main": "openai.app.mjs",
   "keywords": [


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 93642e6</samp>

Improved the `create-image` action for OpenAI by adding an `output_format` prop and changing the `size` prop format. These changes allow users to customize the image generation and output more easily.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 93642e6</samp>

> _Oh we're the crew of the OpenAI_
> _And we create images on the fly_
> _We can choose the format of our art_
> _With the `outputFormat` prop so smart_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 93642e6</samp>

*  Add responseFormat prop to let user choose image output format ([link](https://github.com/PipedreamHQ/pipedream/pull/8958/files?diff=unified&w=0#diff-4ec8d858da6f4145f7038624e5562cd7c34bd627339c243b7257bf24fd053f13R73-R118))
*  Replace size prop with an array of objects with labels and values ([link](https://github.com/PipedreamHQ/pipedream/pull/8958/files?diff=unified&w=0#diff-4ec8d858da6f4145f7038624e5562cd7c34bd627339c243b7257bf24fd053f13R73-R118))
*  Update version number and remove unused import ([link](https://github.com/PipedreamHQ/pipedream/pull/8958/files?diff=unified&w=0#diff-4ec8d858da6f4145f7038624e5562cd7c34bd627339c243b7257bf24fd053f13L2-R5))
