### PR TITLE
Adding date time format

### DIFF
--- a/components/formatting/actions/add-subtract-time/add-subtract-time.ts
+++ b/components/formatting/actions/add-subtract-time/add-subtract-time.ts
@@ -17,7 +17,7 @@ export default defineAction({
   name: "[Date/Time] Add/Subtract Time",
   description: "Add or subtract time from a given input",
   key: "formatting-add-subtract-time",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     ...commonDateTime.props,
@@ -89,10 +89,9 @@ export default defineAction({
 
       $.export(
         "$summary",
-        `Successfully ${
-          operation === OPERATION_OPTIONS.SUBTRACT
-            ? "subtracted"
-            : "added"
+        `Successfully ${operation === OPERATION_OPTIONS.SUBTRACT
+          ? "subtracted"
+          : "added"
         } time`,
       );
       return output;

--- a/components/formatting/actions/compare-dates/compare-dates.ts
+++ b/components/formatting/actions/compare-dates/compare-dates.ts
@@ -9,7 +9,7 @@ export default defineAction({
   description:
     "Get the duration between two dates in days, hours, minutes, and seconds along with checking if they are the same.",
   key: "formatting-compare-dates",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     ...commonDateTime.props,

--- a/components/formatting/actions/convert-html-to-markdown/convert-html-to-markdown.ts
+++ b/components/formatting/actions/convert-html-to-markdown/convert-html-to-markdown.ts
@@ -7,7 +7,7 @@ export default defineAction({
   name: "[Text] Convert HTML to Markdown",
   description: "Convert valid HTML to Markdown text",
   key: "formatting-convert-html-to-markdown",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   props: {
     app,

--- a/components/formatting/actions/convert-html-to-text/convert-html-to-text.ts
+++ b/components/formatting/actions/convert-html-to-text/convert-html-to-text.ts
@@ -6,7 +6,7 @@ export default defineAction({
   name: "[Text] Convert HTML to text",
   description: "Convert valid HTML to text",
   key: "formatting-convert-html-to-text",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     app,

--- a/components/formatting/actions/convert-json-to-string/convert-json-to-string.ts
+++ b/components/formatting/actions/convert-json-to-string/convert-json-to-string.ts
@@ -5,7 +5,7 @@ export default defineAction({
   name: "[Data] Convert JSON to String",
   description: "Convert an object to a JSON format string",
   key: "formatting-convert-json-to-string",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     app,

--- a/components/formatting/actions/convert-markdown-to-html/convert-markdown-to-html.ts
+++ b/components/formatting/actions/convert-markdown-to-html/convert-markdown-to-html.ts
@@ -7,7 +7,7 @@ export default defineAction({
   name: "[Text] Convert Markdown to HTML",
   description: "Convert Markdown text to HTML",
   key: "formatting-convert-markdown-to-html",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   props: {
     app,

--- a/components/formatting/actions/date-time-format/date-time-format.ts
+++ b/components/formatting/actions/date-time-format/date-time-format.ts
@@ -9,7 +9,7 @@ export default defineAction({
   name: "[Date/Time] Format",
   description: "Format a date string to another date string",
   key: "formatting-date-time-format",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     ...commonDateTime.props,

--- a/components/formatting/actions/extract-by-regular-expression/extract-by-regular-expression.ts
+++ b/components/formatting/actions/extract-by-regular-expression/extract-by-regular-expression.ts
@@ -7,7 +7,7 @@ export default defineAction({
   description:
     "Find a match for a regular expression pattern. Returns all matched groups with start and end position.",
   key: "formatting-extract-by-regular-expression",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     app,

--- a/components/formatting/actions/extract-email-address/extract-email-address.ts
+++ b/components/formatting/actions/extract-email-address/extract-email-address.ts
@@ -7,7 +7,7 @@ export default defineAction({
   description:
     "Find an email address out of a text field. Finds the first email address only.",
   key: "formatting-extract-email-address",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   props: {
     ...commonExtractText.props,

--- a/components/formatting/actions/extract-number/extract-number.ts
+++ b/components/formatting/actions/extract-number/extract-number.ts
@@ -7,7 +7,7 @@ export default defineAction({
   description:
     "Find a number out of a text field. Finds the first number only.",
   key: "formatting-extract-number",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     ...commonExtractText.props,

--- a/components/formatting/actions/extract-phone-number/extract-phone-number.ts
+++ b/components/formatting/actions/extract-phone-number/extract-phone-number.ts
@@ -7,7 +7,7 @@ export default defineAction({
   description:
     "Find a complete phone number out of a text field. Finds the first number only.",
   key: "formatting-extract-phone-number",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     ...commonExtractText.props,

--- a/components/formatting/actions/extract-url/extract-url.ts
+++ b/components/formatting/actions/extract-url/extract-url.ts
@@ -7,7 +7,7 @@ export default defineAction({
   description:
     "Find a web URL out of a text field. Finds the first URL only.",
   key: "formatting-extract-url",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     ...commonExtractText.props,

--- a/components/formatting/actions/format-currency/format-currency.ts
+++ b/components/formatting/actions/format-currency/format-currency.ts
@@ -9,7 +9,7 @@ export default defineAction({
   name: "[Numbers] Format Currency",
   description: "Format a number as a currency",
   key: "formatting-format-currency",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     app,
@@ -68,18 +68,18 @@ export default defineAction({
     result += numberString;
 
     switch (currencyFormat.match(/¤+$/g)?.[0].length) {
-    default:
-      break;
+      default:
+        break;
 
       // ¤¤ - ISO currency symbol: USD, BRL, etc.
-    case 2:
-      result += ` ${isoCode}`;
-      break;
+      case 2:
+        result += ` ${isoCode}`;
+        break;
 
       // ¤¤¤ - Currency display name: United States dollar, Brazilian real, etc.
-    case 3:
-      result += ` ${currencyName}`;
-      break;
+      case 3:
+        result += ` ${currencyName}`;
+        break;
     }
 
     $.export("$summary", "Successfully formatted as currency");

--- a/components/formatting/actions/format-number/format-number.ts
+++ b/components/formatting/actions/format-number/format-number.ts
@@ -11,7 +11,7 @@ export default defineAction({
   description:
     "Format a number to a new style. Does not perform any rounding or padding of the number.",
   key: "formatting-format-number",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     app,

--- a/components/formatting/actions/parse-json/parse-json.ts
+++ b/components/formatting/actions/parse-json/parse-json.ts
@@ -5,7 +5,7 @@ export default defineAction({
   name: "[Data] Parse JSON",
   description: "Parse a JSON string",
   key: "formatting-parse-json",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     app,

--- a/components/formatting/actions/replace-text/replace-text.ts
+++ b/components/formatting/actions/replace-text/replace-text.ts
@@ -9,7 +9,7 @@ export default defineAction({
   description:
     "Replace all instances of any character, word or phrase in the text with another character, word or phrase.",
   key: "formatting-replace-text",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     app,

--- a/components/formatting/actions/set-default-value/set-default-value.ts
+++ b/components/formatting/actions/set-default-value/set-default-value.ts
@@ -5,7 +5,7 @@ export default defineAction({
   name: "[Text] Set Default Value",
   description: "Return a default value if the text is empty",
   key: "formatting-set-default-value",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     app,

--- a/components/formatting/actions/split-text/split-text.ts
+++ b/components/formatting/actions/split-text/split-text.ts
@@ -10,7 +10,7 @@ export default defineAction({
   description:
     "Split the text on a character or word and return one or all segments",
   key: "formatting-split-text",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     app,
@@ -52,22 +52,22 @@ export default defineAction({
       summary = `Successfully split text into ${length} segments`;
 
       switch (segmentIndex) {
-      case INDEX_ALL_SEGMENTS:
-        result = arrResults;
-        break;
+        case INDEX_ALL_SEGMENTS:
+          result = arrResults;
+          break;
 
         // this case would not be needed if 0 was accepted as an option
         // see issue #5429
-      case INDEX_ALL_SEGMENTS * -1:
-        result = arrResults[0];
-        break;
+        case INDEX_ALL_SEGMENTS * -1:
+          result = arrResults[0];
+          break;
 
-      default:
-        result =
+        default:
+          result =
             arrResults[segmentIndex < 0
               ? length + segmentIndex
               : segmentIndex];
-        break;
+          break;
       }
     }
 

--- a/components/formatting/actions/transform-case/transform-case.ts
+++ b/components/formatting/actions/transform-case/transform-case.ts
@@ -9,7 +9,7 @@ export default defineAction({
   name: "[Text] Transform Case",
   description: "Transform case for a text input",
   key: "formatting-transform-case",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     app,

--- a/components/formatting/actions/trim-whitespace/trim-whitespace.ts
+++ b/components/formatting/actions/trim-whitespace/trim-whitespace.ts
@@ -5,7 +5,7 @@ export default defineAction({
   name: "[Text] Trim Whitespace",
   description: "Removes leading and trailing whitespace",
   key: "formatting-trim-whitespace",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     app,

--- a/components/formatting/actions/url-decode/url-decode.ts
+++ b/components/formatting/actions/url-decode/url-decode.ts
@@ -5,7 +5,7 @@ export default defineAction({
   name: "[Text] Decode URL",
   description: "Decode a URL string",
   key: "formatting-url-decode",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     app,

--- a/components/formatting/actions/url-encode/url-encode.ts
+++ b/components/formatting/actions/url-encode/url-encode.ts
@@ -5,7 +5,7 @@ export default defineAction({
   name: "[Text] Encode URL",
   description: "Encode a string as a URL",
   key: "formatting-url-encode",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     app,

--- a/components/formatting/common/date-time/dateFormats.ts
+++ b/components/formatting/common/date-time/dateFormats.ts
@@ -76,8 +76,18 @@ const DATE_FORMATS: DateFormat[] = [
     },
   },
   {
+    label: "2006-01-22T23:04:05",
+    value: "YYYY-MM-DDTHH:mm:ss",
+    outputFn(dateObj) {
+      return dateObj
+        .toISOString()
+        .replace(/\.[0-9]{3}/g, "")
+        .replace(/Z/, "-0000");
+    },
+  },
+  {
     label: "2006-01-22T23:04:05-0000",
-    value: DEFAULT_FORMAT_VALUE,
+    value: "YYYY-MM-DDTHH:mm:ss",
     outputFn(dateObj) {
       return dateObj
         .toISOString()

--- a/components/formatting/package.json
+++ b/components/formatting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/formatting",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Formatting Components",
   "main": "dist/app/formatting.app.mjs",
   "keywords": [


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 97b1b0a</samp>

Added a new date format option to the `date-time-format` action to support ISO 8601 without milliseconds and timezone. Refactored the existing date format options to avoid duplication and simplify the output function.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 97b1b0a</samp>

> _`action` version_
> _more date formats to choose_
> _winter time `-0000`_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 97b1b0a</samp>

*  Add a new date format option for ISO 8601 without milliseconds and timezone ([link](https://github.com/PipedreamHQ/pipedream/pull/8978/files?diff=unified&w=0#diff-e16fa92a01dc5305f4293939a00734a81b62a122236c3e3505b29e4c26819023L79-R90))
*  Refactor the existing date format option for ISO 8601 with "-0000" suffix to use the same value as the new option ([link](https://github.com/PipedreamHQ/pipedream/pull/8978/files?diff=unified&w=0#diff-e16fa92a01dc5305f4293939a00734a81b62a122236c3e3505b29e4c26819023L79-R90))
*  Update the outputFn function for both options to format the date string accordingly ([link](https://github.com/PipedreamHQ/pipedream/pull/8978/files?diff=unified&w=0#diff-e16fa92a01dc5305f4293939a00734a81b62a122236c3e3505b29e4c26819023L79-R90))
*  Increment the version of the `date-time-format` action to reflect the new feature ([link](https://github.com/PipedreamHQ/pipedream/pull/8978/files?diff=unified&w=0#diff-1801eb79805592c437524df5c3e8014f248e0b7d7997c235d895a82be0dc61afL12-R12))
