### PR TITLE
Formatting - Date Time Format - support custom output formats

### DIFF
--- a/components/formatting/actions/date-time-format/date-time-format.ts
+++ b/components/formatting/actions/date-time-format/date-time-format.ts
@@ -3,13 +3,14 @@ import { ConfigurationError } from "@pipedream/platform";
 import { DATE_FORMAT_PARSE_MAP } from "../../common/date-time/dateFormats";
 import commonDateTime from "../../common/date-time/commonDateTime";
 import app from "../../app/formatting.app";
+import moment from "moment";
 
 export default defineAction({
   ...commonDateTime,
   name: "[Date/Time] Format",
   description: "Format a date string to another date string",
   key: "formatting-date-time-format",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   props: {
     ...commonDateTime.props,
@@ -28,8 +29,8 @@ export default defineAction({
     const dateObj = this.getDateFromInput();
 
     try {
-      const { outputFn } = DATE_FORMAT_PARSE_MAP.get(outputFormat);
-      const output = outputFn(dateObj);
+      const response = DATE_FORMAT_PARSE_MAP.get(outputFormat);
+      const output = response ? response.outputFn(dateObj) : moment(dateObj).format(outputFormat);
 
       $.export("$summary", "Successfully formatted date/time");
       return output;

--- a/components/formatting/package.json
+++ b/components/formatting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/formatting",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream Formatting Components",
   "main": "dist/app/formatting.app.mjs",
   "keywords": [

--- a/components/formatting/package.json
+++ b/components/formatting/package.json
@@ -20,6 +20,7 @@
     "@pipedream/types": "^0.1.4",
     "html-to-text": "^8.2.1",
     "linkedom": "^0.14.26",
+    "moment": "^2.29.4",
     "pluralize": "^8.0.0",
     "showdown": "^2.1.0",
     "title-case": "^3.0.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1971,6 +1971,7 @@ importers:
       '@pipedream/types': ^0.1.4
       html-to-text: ^8.2.1
       linkedom: ^0.14.26
+      moment: ^2.29.4
       pluralize: ^8.0.0
       showdown: ^2.1.0
       title-case: ^3.0.3
@@ -1979,6 +1980,7 @@ importers:
       '@pipedream/types': 0.1.6
       html-to-text: 8.2.1
       linkedom: 0.14.26
+      moment: 2.29.4
       pluralize: 8.0.0
       showdown: 2.1.0
       title-case: 3.0.3
@@ -10331,12 +10333,12 @@ packages:
       kuler: 2.0.0
     dev: false
 
-  /@definitelytyped/header-parser/0.0.188:
-    resolution: {integrity: sha512-s2223ipUtaKy68u7Ku4QsB3ZmRLMKYGMlOrKALbG9dhkOF/zTO/jckcn1ZAU338oL0q+q5xDFMHja9qxs4TEaw==}
+  /@definitelytyped/header-parser/0.0.189:
+    resolution: {integrity: sha512-5zzTaVAJayCJXWgm6T3kn0V/J/TGY/5mqkfio9bGI0dlKvV/xt0gXCBUFpUT6a0buPcqpsr5eS540XftHvgThQ==}
     engines: {node: '>=16.17.0'}
     dependencies:
       '@definitelytyped/typescript-versions': 0.0.181
-      '@definitelytyped/utils': 0.0.186
+      '@definitelytyped/utils': 0.0.187
       semver: 7.5.4
     dev: true
 
@@ -10345,8 +10347,8 @@ packages:
     engines: {node: '>=16.17.0'}
     dev: true
 
-  /@definitelytyped/utils/0.0.186:
-    resolution: {integrity: sha512-T2e5QTVRFBP49B5yfk5kjbr3YYE2q1WqLkTTQNhhkJTTLoVFjhBSYF4PnWA0Op302aRiiCwDIuweqMmu3Zt8wg==}
+  /@definitelytyped/utils/0.0.187:
+    resolution: {integrity: sha512-sJlAKn7Rnqrw4qvgYudjs8vyqsOzgwWmqX20QWt7EW1c3Z1Pt7JkeaaSA3TSWDlwjP6gLGbf2pmDOBnQkAdR5w==}
     engines: {node: '>=16.17.0'}
     dependencies:
       '@definitelytyped/typescript-versions': 0.0.181
@@ -17196,7 +17198,7 @@ packages:
     peerDependencies:
       typescript: '*'
     dependencies:
-      '@definitelytyped/header-parser': 0.0.188
+      '@definitelytyped/header-parser': 0.0.189
       command-exists: 1.2.9
       rimraf: 3.0.2
       semver: 6.3.1
@@ -17212,9 +17214,9 @@ packages:
     peerDependencies:
       typescript: '>= 3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.7.0-dev || >= 3.8.0-dev || >= 3.9.0-dev || >= 4.0.0-dev'
     dependencies:
-      '@definitelytyped/header-parser': 0.0.188
+      '@definitelytyped/header-parser': 0.0.189
       '@definitelytyped/typescript-versions': 0.0.181
-      '@definitelytyped/utils': 0.0.186
+      '@definitelytyped/utils': 0.0.187
       dts-critic: 3.3.11_typescript@4.9.5
       fs-extra: 6.0.1
       json-stable-stringify: 1.0.2


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1e140d8</samp>

This pull request adds the `moment` library as a dependency and uses it to enhance the `formatting-date-time-format` action, which allows users to format dates and times in various ways. It also updates the `pnpm-lock.yaml` and `package.json` files to ensure consistent and reliable installation of the dependencies.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1e140d8</samp>

> _Sing, O Muse, of the skillful formatting component_
> _That added `moment` to its `package.json` file_
> _And thus enhanced the power of its date-time action_
> _To handle diverse and complex formats with style_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1e140d8</samp>

*  Add `moment` dependency to support more output formats for `formatting-date-time-format` action ([link](https://github.com/PipedreamHQ/pipedream/pull/8982/files?diff=unified&w=0#diff-1801eb79805592c437524df5c3e8014f248e0b7d7997c235d895a82be0dc61afR6), [link](https://github.com/PipedreamHQ/pipedream/pull/8982/files?diff=unified&w=0#diff-846687f3a83f906e5a9e53cc9486c91bb2d51f62c1505b5f1eef38f8379c47dbR23), [link](https://github.com/PipedreamHQ/pipedream/pull/8982/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1974), [link](https://github.com/PipedreamHQ/pipedream/pull/8982/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1983))
*  Update `run` function of `formatting-date-time-format` action to use `moment` as a fallback option ([link](https://github.com/PipedreamHQ/pipedream/pull/8982/files?diff=unified&w=0#diff-1801eb79805592c437524df5c3e8014f248e0b7d7997c235d895a82be0dc61afL31-R33))
*  Bump version of `formatting-date-time-format` action to `0.0.4` ([link](https://github.com/PipedreamHQ/pipedream/pull/8982/files?diff=unified&w=0#diff-1801eb79805592c437524df5c3e8014f248e0b7d7997c235d895a82be0dc61afL12-R13))
*  Update versions of `@definitelytyped/header-parser` and `@definitelytyped/utils` dependencies, which are used by some TypeScript declaration file utilities ([link](https://github.com/PipedreamHQ/pipedream/pull/8982/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10334-R10341), [link](https://github.com/PipedreamHQ/pipedream/pull/8982/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10348-R10351), [link](https://github.com/PipedreamHQ/pipedream/pull/8982/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL17199-R17201), [link](https://github.com/PipedreamHQ/pipedream/pull/8982/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL17215-R17219))
