### PR TITLE
Insites QA adjustments

### DIFF
--- a/components/insites/package.json
+++ b/components/insites/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/insites",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Insites Components",
   "main": "insites.app.mjs",
   "keywords": [

--- a/components/insites/sources/analysis-complete/analysis-complete.mjs
+++ b/components/insites/sources/analysis-complete/analysis-complete.mjs
@@ -9,8 +9,8 @@ export default {
   type: "source",
   key: "insites-analysis-complete",
   name: "New Analysis Complete",
-  description: "Emit new event when a new analysis is completed.",
-  version: "0.0.1",
+  description: "Emit new event when a new analysis is completed. [See the documentation](https://help.insites.com/en/articles/7994946-report-api#h_e59622a8e7)",
+  version: "0.0.2",
   props: {
     app,
     db: "$.service.db",
@@ -23,7 +23,7 @@ export default {
     filter: {
       type: "string",
       label: "Filter",
-      description: "JSON encoded string – attributes by which the reports should be filtered by.",
+      description: "JSON encoded string - attributes by which the reports should be filtered by. [See the documentation for more details](https://help.insites.com/en/articles/7994946-report-api#h_e59622a8e7). Example: `[{\"operator\":\"equal\",\"property\":\"mobile.is_mobile\",\"targetValue\":false}]`",
       optional: true,
     },
     includeHistoric: {


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6f47c9b</samp>

Improved the documentation and usability of the `insites-analysis-complete` source component for the Insites app. Bumped the `@pipedream/insites` package version to `0.1.1`.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6f47c9b</samp>

> _Sing, O Muse, of the skillful coder who updated the source_
> _`insites-analysis-complete`, the wise and versatile tool_
> _That fetches and filters the data from the Insites Report API_
> _And triggers workflows with insights, the precious and powerful fuel_


## WHY

Closes #8574 


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6f47c9b</samp>

*  Incremented the version of the `@pipedream/insites` package to reflect the updates to the `insites-analysis-complete` source component ([link](https://github.com/PipedreamHQ/pipedream/pull/8986/files?diff=unified&w=0#diff-cf48239eb5d285f274b11706c1b850c229a40f0a34a4c18cc0a6a855a8d014b6L3-R3))
*  Added links to the Insites Report API documentation and an example filter to the description of the `insites-analysis-complete` source component and its `filter` prop ([link](https://github.com/PipedreamHQ/pipedream/pull/8986/files?diff=unified&w=0#diff-6743a27c7b1de45c69796a60380a6d3bf0fecd510fcee98b5fef08cea76c9473L12-R13), [link](https://github.com/PipedreamHQ/pipedream/pull/8986/files?diff=unified&w=0#diff-6743a27c7b1de45c69796a60380a6d3bf0fecd510fcee98b5fef08cea76c9473L26-R26))
