### PR TITLE
Google Drive - Add File Sharing Preference - add support for folder IDs

### DIFF
--- a/components/google_drive/actions/add-file-sharing-preference/add-file-sharing-preference.mjs
+++ b/components/google_drive/actions/add-file-sharing-preference/add-file-sharing-preference.mjs
@@ -10,8 +10,8 @@ export default {
   key: "google_drive-add-file-sharing-preference",
   name: "Add File Sharing Preference",
   description:
-    "Add a [sharing](https://support.google.com/drive/answer/7166529) permission to the sharing preferences of a file and provide a sharing URL. [See the docs](https://developers.google.com/drive/api/v3/reference/permissions/create) for more information",
-  version: "0.1.1",
+    "Add a [sharing](https://support.google.com/drive/answer/7166529) permission to the sharing preferences of a file or folder and provide a sharing URL. [See the docs](https://developers.google.com/drive/api/v3/reference/permissions/create) for more information",
+  version: "0.1.2",
   type: "action",
   props: {
     googleDrive,
@@ -22,16 +22,16 @@ export default {
       ],
       optional: true,
     },
-    fileId: {
+    fileOrFolderId: {
       propDefinition: [
         googleDrive,
-        "fileId",
+        "fileOrFolderId",
         (c) => ({
           drive: c.drive,
         }),
       ],
       optional: false,
-      description: "The file to share",
+      description: "The file or folder to share",
     },
     role: {
       propDefinition: [
@@ -60,14 +60,14 @@ export default {
   },
   async run({ $ }) {
     const {
-      fileId,
+      fileOrFolderId,
       role,
       type,
       domain,
       emailAddress,
     } = this;
     // Create the permission for the file
-    await this.googleDrive.createPermission(fileId, {
+    await this.googleDrive.createPermission(fileOrFolderId, {
       role,
       type,
       domain,
@@ -75,7 +75,7 @@ export default {
     });
 
     // Get the file to get the `webViewLink` sharing URL
-    const resp = await this.googleDrive.getFile(this.fileId);
+    const resp = await this.googleDrive.getFile(this.fileOrFolderId);
     const webViewLink = resp.webViewLink;
     $.export("$summary", `Successfully added a sharing permission to the file, "${resp.name}"`);
     return webViewLink;

--- a/components/google_drive/package.json
+++ b/components/google_drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_drive",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "description": "Pipedream Google_drive Components",
   "main": "google_drive.app.mjs",
   "keywords": [


### PR DESCRIPTION
The action to create permissions already exists as `add-file-sharing-preference`. However, it previously only listed fileIds and not folderIds as async options. Updated to work for either files or folders in order to satisfy the user's [request](https://github.com/PipedreamHQ/pipedream/issues/6884).

## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8f5d19b</samp>

Added support for folders to the `add-file-sharing-preference` action of the google_drive component. Renamed `fileId` to `fileOrFolderId` in the action code and updated the package version.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8f5d19b</samp>

> _To share files and folders with ease_
> _We updated the google_drive package_
> _The `fileId` prop was too narrow a scope_
> _So we renamed it to `fileOrFolderId`, I hope_
> _That this change will not cause too much rage_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8f5d19b</samp>

*  Bump the version of the `google_drive` package to reflect the change in the action ([link](https://github.com/PipedreamHQ/pipedream/pull/9001/files?diff=unified&w=0#diff-de4d353bb32ba5ea73b7929d490a1b8a65635e5037da35eb0ec70ac281818338L3-R3))
*  Rename the `fileId` prop and variable to `fileOrFolderId` to support both files and folders in the `add-file-sharing-preference` action ([link](https://github.com/PipedreamHQ/pipedream/pull/9001/files?diff=unified&w=0#diff-d00b49807eb641cb15b4ac4ca8fdfaec858f811dc85c802c6f29755e2d12fa3cL25-R28), [link](https://github.com/PipedreamHQ/pipedream/pull/9001/files?diff=unified&w=0#diff-d00b49807eb641cb15b4ac4ca8fdfaec858f811dc85c802c6f29755e2d12fa3cL34-R34), [link](https://github.com/PipedreamHQ/pipedream/pull/9001/files?diff=unified&w=0#diff-d00b49807eb641cb15b4ac4ca8fdfaec858f811dc85c802c6f29755e2d12fa3cL63-R63), [link](https://github.com/PipedreamHQ/pipedream/pull/9001/files?diff=unified&w=0#diff-d00b49807eb641cb15b4ac4ca8fdfaec858f811dc85c802c6f29755e2d12fa3cL70-R70), [link](https://github.com/PipedreamHQ/pipedream/pull/9001/files?diff=unified&w=0#diff-d00b49807eb641cb15b4ac4ca8fdfaec858f811dc85c802c6f29755e2d12fa3cL78-R78))
*  Update the description of the `add-file-sharing-preference` action and the `fileOrFolderId` prop to match the name change and the functionality ([link](https://github.com/PipedreamHQ/pipedream/pull/9001/files?diff=unified&w=0#diff-d00b49807eb641cb15b4ac4ca8fdfaec858f811dc85c802c6f29755e2d12fa3cL13-R14), [link](https://github.com/PipedreamHQ/pipedream/pull/9001/files?diff=unified&w=0#diff-d00b49807eb641cb15b4ac4ca8fdfaec858f811dc85c802c6f29755e2d12fa3cL34-R34))
