### PR TITLE
Fix examples in Python docs

### DIFF
--- a/docs/docs/code/python/README.md
+++ b/docs/docs/code/python/README.md
@@ -97,7 +97,7 @@ Each time you deploy a workflow with Python code, Pipedream downloads the PyPi p
 There are many cases where you may want to specify the version of the packages you're using. If you'd like to use a _specific_ version of a package in a workflow, you can add that version in a [magic comment](/code/python/import-mappings/), for example:
 
 ```python
-# python add-package pandas==2.0.0
+# pipedream add-package pandas==2.0.0
 import pandas
 ```
 
@@ -126,7 +126,7 @@ r = requests.get(url)
 print(r.text)
 
 # The response status code is logged in your Pipedream step results:
-print(r.status)
+print(r.status_code)
 ```
 
 ### Making a POST request
@@ -145,7 +145,7 @@ r = requests.post(url, data)
 print(r.text)
 
 # The response status code is logged in your Pipedream step results:
-print(r.status)
+print(r.status_code)
 ```
 
 ### Sending files
@@ -228,6 +228,7 @@ To share data created, retrieved, transformed or manipulated by a step to others
 ```python
 # This step is named "code" in the workflow
 from pipedream.script_helpers import (steps, export)
+import requests
 
 r = requests.get("https://pokeapi.co/api/v2/pokemon/charizard")
 # Store the JSON contents into a variable called "pokemon"
@@ -256,7 +257,6 @@ To access them, use the `os` module.
 
 ```python
 import os
-import requests
 
 token = os.environ['AIRTABLE_API_KEY']
 
@@ -279,7 +279,7 @@ token = os.environ['AIRTABLE_API_KEY']
 
 url = 'https://api.airtable.com/v0/your-airtable-base/your-table'
 
-headers { 'Authorization': f"Bearer {token}"}
+headers = { 'Authorization': f"Bearer {token}"}
 r = requests.get(url, headers=headers)
 
 print(r.text)
@@ -318,7 +318,7 @@ Sometimes you want to end your workflow early, or otherwise stop or cancel the e
 
 ```python
 def handler(pd: 'pipedream'):
-    return pd.flow.exit()
+    return pd.flow.exit("reason")
     print("This code will not run, since pd.flow.exit() was called above it")
 ```
 
@@ -333,10 +333,12 @@ def handler(pd: 'pipedream'):
 Or exit the workflow early within a conditional:
 
 ```python
+import random
+
 def handler(pd: 'pipedream'):
     # Flip a coin, running pd.flow.exit() for 50% of events
     if random.randint(0, 100) <= 50:
-        return pd.flow.exit()
+        return pd.flow.exit("reason")
 
     print("This code will only run 50% of the time");
 ```
@@ -370,9 +372,7 @@ Now `/tmp/python-logo.png` holds the official Python logo.
 You can also open files you have previously stored in the `/tmp` directory. Let's open the `python-logo.png` file.
 
 ```python
-import os
-
-with open('/tmp/python-logo.png') as f:
+with open('/tmp/python-logo.png', 'rb') as f:
     # Store the contents of the file into a variable
     file_data = f.read()
 ```


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c15a9d9</samp>

This pull request updates the Python code examples in `docs/docs/code/python/README.md` to fix errors, improve readability, and align with the Pipedream style guide.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c15a9d9</samp>

> _Sing, O Muse, of the skillful coder who refined_
> _the Python examples in the sacred docs, and shined_
> _a light of clarity on imports, args, and comments,_
> _like Hephaestus who forged the gods' bright ornaments._


## WHY

Some Python code step examples in the docs had minor errors.

When `$.flow.exit()` was not passed any arguments, I got the following error:

<img width="534" alt="pd-flow-exit-missing-reason" src="https://github.com/PipedreamHQ/pipedream/assets/19861096/45a30b7f-35ab-4a4b-a990-82ba08bd82fa">

## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c15a9d9</samp>

*  Fix code comment and syntax errors in `docs/docs/code/python/README.md` ([link](https://github.com/PipedreamHQ/pipedream/pull/9047/files?diff=unified&w=0#diff-38e35d021282412c8ec948f5e76297d7b1a3f774174d0965b22c86a7222fdee2L100-R100), [link](https://github.com/PipedreamHQ/pipedream/pull/9047/files?diff=unified&w=0#diff-38e35d021282412c8ec948f5e76297d7b1a3f774174d0965b22c86a7222fdee2L129-R129), [link](https://github.com/PipedreamHQ/pipedream/pull/9047/files?diff=unified&w=0#diff-38e35d021282412c8ec948f5e76297d7b1a3f774174d0965b22c86a7222fdee2L148-R148), [link](https://github.com/PipedreamHQ/pipedream/pull/9047/files?diff=unified&w=0#diff-38e35d021282412c8ec948f5e76297d7b1a3f774174d0965b22c86a7222fdee2L282-R282))
*  Add missing imports and remove redundant ones in `docs/docs/code/python/README.md` ([link](https://github.com/PipedreamHQ/pipedream/pull/9047/files?diff=unified&w=0#diff-38e35d021282412c8ec948f5e76297d7b1a3f774174d0965b22c86a7222fdee2R231), [link](https://github.com/PipedreamHQ/pipedream/pull/9047/files?diff=unified&w=0#diff-38e35d021282412c8ec948f5e76297d7b1a3f774174d0965b22c86a7222fdee2L259), [link](https://github.com/PipedreamHQ/pipedream/pull/9047/files?diff=unified&w=0#diff-38e35d021282412c8ec948f5e76297d7b1a3f774174d0965b22c86a7222fdee2L336-R341))
*  Update code examples to use `pd.flow.exit()` with a reason argument in `docs/docs/code/python/README.md` ([link](https://github.com/PipedreamHQ/pipedream/pull/9047/files?diff=unified&w=0#diff-38e35d021282412c8ec948f5e76297d7b1a3f774174d0965b22c86a7222fdee2L321-R321), [link](https://github.com/PipedreamHQ/pipedream/pull/9047/files?diff=unified&w=0#diff-38e35d021282412c8ec948f5e76297d7b1a3f774174d0965b22c86a7222fdee2L336-R341))
*  Open file in binary mode to avoid decoding error in `docs/docs/code/python/README.md` ([link](https://github.com/PipedreamHQ/pipedream/pull/9047/files?diff=unified&w=0#diff-38e35d021282412c8ec948f5e76297d7b1a3f774174d0965b22c86a7222fdee2L373-R375))
