### PR TITLE
Removing dependent logic

### DIFF
--- a/docs/docs/pricing/README.md
+++ b/docs/docs/pricing/README.md
@@ -104,7 +104,7 @@ Execution time used to develop a workflow in the builder does not count towards 
 
 When an [event source](/sources) triggers a workflow, the first credit per source execution is included for free. This means that the first {{ $site.themeConfig.base_credits_price.seconds }} seconds of compute doesn't incur credits. This includes [Free Tier](/pricing/#free-tier) accounts.
 
-When a source is configured as a workflow trigger, the core value is in the workflow. You won't be charged for two credits (one to run the source, one to run the workflow) when the workflow contains the core logic. Sources that trigger workflows are called "dependent" sources.
+When a source is configured as a workflow trigger, the core value is in the workflow. You won't be charged for two credits (one to run the source, one to run the workflow) when the workflow contains the core logic.
 
 On the other hand, sources that don't trigger workflows are "independent", since they run independently. Pipedream charges credits for all indepedent source executions.
 


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9e7b0f8</samp>

Simplify pricing documentation by removing a redundant sentence from `docs/docs/pricing/README.md`.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9e7b0f8</samp>

> _`Source Credit Usage`_
> _Simpler without repetition_
> _Autumn leaves fall fast_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9e7b0f8</samp>

* Remove redundant sentence from `Source Credit Usage` section ([link](https://github.com/PipedreamHQ/pipedream/pull/9125/files?diff=unified&w=0#diff-2193227971a8af8a512647a42d2f62a0e47de3a9dd43290bcb2c47125b87d26aL107-R107))
