### PR TITLE
Source credits docs

### DIFF
--- a/docs/docs/limits/README.md
+++ b/docs/docs/limits/README.md
@@ -35,7 +35,7 @@ You can view your credits usage at the bottom-left of the Pipedream UI.
 
 You can also see more detailed usage in [Billing and Usage Settings](https://pipedream.com/settings/billing). Here you'll find your usage for the last 30 days, broken out by day, by resource (e.g. your source / workflow).
 
-Your included credits count is reset, daily, at 00:00 (midnight) UTC.
+Your included credits count is reset daily at 00:00 (midnight) UTC.
 
 ### Included Credits Usage Notifications
 

--- a/docs/docs/pricing/README.md
+++ b/docs/docs/pricing/README.md
@@ -108,9 +108,7 @@ When a source is configured as a workflow trigger, the core value is in the work
 
 ::: tip
 
-This free credit per execution **only** applies to sources from the [Pipedream public registry](/sources).
-
-If you deploy a private custom source to your account, then all computation time including the inital {{ $site.themeConfig.base_credits_price.seconds }} seconds for that private source counts toward credits.
+This free credit per execution **only** applies to sources from the [Pipedream public registry](/sources). If you deploy a private custom source to your account, then all computation time including the inital {{ $site.themeConfig.base_credits_price.seconds }} seconds for that private source counts toward credits.
 
 :::
 
@@ -118,9 +116,7 @@ If you deploy a private custom source to your account, then all computation time
 
 For example, a source that polls an API for new events like [Airtable - New Row Added](https://pipedream.com/apps/airtable/triggers/new-records) only takes ~5 seconds to poll and emit events to subscribing workflows.
 
-This would result 0 credits per run because:
-
-- The **Airtable - New Row Added** source is a [publicly available component](https://pipedream.com/apps/airtable/triggers/new-records).
+This would result 0 credits per run because the **Airtable - New Row Added** source is a [publicly available component](https://pipedream.com/apps/airtable/triggers/new-records).
 
 :::
 
@@ -128,17 +124,13 @@ This would result 0 credits per run because:
 
 Consider an a source (like **RSS - New Item in Feed** for instance) that takes 60 seconds total to finish polling, per execution.
 
-Each execution of this source would result 0 credits because:
-
-- The **RSS - New Item in Feed** source is a [publicly available component](https://pipedream.com/apps/rss/triggers/new-item-in-feed).
+Each execution of this source would result in 0 credits because the **RSS - New Item in Feed** source is a [publicly available component](https://pipedream.com/apps/rss/triggers/new-item-in-feed).
 
 :::
 
 ::: details A custom source that finished under {{ $site.themeConfig.base_credits_price.seconds }} seconds per execution
 
-This would result in 1 credit per execution.
-
-- The initial free credit only applies to Pipedream Public Registry sources attached to at least one workflow.
+This would result in 1 credit per execution because the initial free credit only applies to Pipedream Public Registry sources attached to at least one workflow.
 
 :::
 

--- a/docs/docs/pricing/README.md
+++ b/docs/docs/pricing/README.md
@@ -116,21 +116,21 @@ This free credit per execution **only** applies to sources from the [Pipedream p
 
 For example, a source that polls an API for new events like [Airtable - New Row Added](https://pipedream.com/apps/airtable/triggers/new-records) only takes ~5 seconds to poll and emit events to subscribing workflows.
 
-This would result in 0 credits per run because the **Airtable - New Row Added** source is a [publicly available component](https://pipedream.com/apps/airtable/triggers/new-records).
+This would result in **0 credits** per run because the **Airtable - New Row Added** source is a [publicly available component](https://pipedream.com/apps/airtable/triggers/new-records).
 
 :::
 
 ::: details A polling source finishing over {{ $site.themeConfig.base_credits_price.seconds }} seconds per execution
 
-Consider an a source (like **RSS - New Item in Feed** for instance) that takes 60 seconds total to finish polling, per execution.
+Consider a source (like **RSS - New Item in Feed** for instance) that takes 60 seconds total to finish polling, per execution.
 
-Each execution of this source would result in 0 credits because the **RSS - New Item in Feed** source is a [publicly available component](https://pipedream.com/apps/rss/triggers/new-item-in-feed).
+Each execution of this source would result in **0 credits** because the **RSS - New Item in Feed** source is a [publicly available component](https://pipedream.com/apps/rss/triggers/new-item-in-feed).
 
 :::
 
 ::: details A custom source that finished under {{ $site.themeConfig.base_credits_price.seconds }} seconds per execution
 
-This would result in 1 credit per execution because the initial free credit only applies to Pipedream Public Registry sources attached to at least one workflow.
+This would result in **1 credit** per execution because the initial free credit only applies to Pipedream Public Registry sources attached to at least one workflow.
 
 :::
 

--- a/docs/docs/pricing/README.md
+++ b/docs/docs/pricing/README.md
@@ -116,7 +116,7 @@ This free credit per execution **only** applies to sources from the [Pipedream p
 
 For example, a source that polls an API for new events like [Airtable - New Row Added](https://pipedream.com/apps/airtable/triggers/new-records) only takes ~5 seconds to poll and emit events to subscribing workflows.
 
-This would result 0 credits per run because the **Airtable - New Row Added** source is a [publicly available component](https://pipedream.com/apps/airtable/triggers/new-records).
+This would result in 0 credits per run because the **Airtable - New Row Added** source is a [publicly available component](https://pipedream.com/apps/airtable/triggers/new-records).
 
 :::
 

--- a/docs/docs/pricing/README.md
+++ b/docs/docs/pricing/README.md
@@ -102,17 +102,15 @@ Execution time used to develop a workflow in the builder does not count towards 
 
 #### Source Credit Usage
 
-When an [event source](/sources) triggers a workflow, the first credit per source execution is included for free. This means that the first {{ $site.themeConfig.base_credits_price.seconds }} seconds of compute doesn't incur credits. This includes [Free Tier](/pricing/#free-tier) accounts.
+When an [event source](/sources) triggers a workflow, **the source execution is included for free.** This includes workspaces on the [Free Tier](/pricing/#free-tier).
 
-When a source is configured as a workflow trigger, the core value is in the workflow. You won't be charged for two credits (one to run the source, one to run the workflow) when the workflow contains the core logic. Sources that trigger workflows are called "dependent" sources.
-
-On the other hand, sources that don't trigger workflows are "independent", since they run independently. Pipedream charges credits for all indepedent source executions.
+When a source is configured as a workflow trigger, the core value is in the workflow. You won't be charged for two credits (one to run the source, one to run the workflow) when the workflow contains the core logic.
 
 ::: tip
 
-This free first credit per execution **only** applies to sources from the [Pipedream public registry](/sources).
+This free credit per execution **only** applies to sources from the [Pipedream public registry](/sources).
 
-If you deploy a private custom source to your account, then all computation time including the inital {{ $site.themeConfig.base_credits_price.seconds }} seconds for that private source counted toward credits. Even if the custom source is dependent and triggers at least one workflow.
+If you deploy a private custom source to your account, then all computation time including the inital {{ $site.themeConfig.base_credits_price.seconds }} seconds for that private source counts toward credits.
 
 :::
 
@@ -122,7 +120,6 @@ For example, a source that polls an API for new events like [Airtable - New Row 
 
 This would result 0 credits per run because:
 
-- The first {{ $site.themeConfig.base_credits_price.seconds }} of computation time per source execution is included.
 - The **Airtable - New Row Added** source is a [publicly available component](https://pipedream.com/apps/airtable/triggers/new-records).
 
 :::
@@ -131,9 +128,8 @@ This would result 0 credits per run because:
 
 Consider an a source (like **RSS - New Item in Feed** for instance) that takes 60 seconds total to finish polling, per execution.
 
-Each execution of this source would result 1 credit because:
+Each execution of this source would result 0 credits because:
 
-- The first {{ $site.themeConfig.base_credits_price.seconds }} of computation time per source execution is included.
 - The **RSS - New Item in Feed** source is a [publicly available component](https://pipedream.com/apps/rss/triggers/new-item-in-feed).
 
 :::
@@ -142,15 +138,10 @@ Each execution of this source would result 1 credit because:
 
 This would result in 1 credit per execution.
 
-The initial free credit only applies to Pipedream Public Registry sources attached to at least one workflow.
+- The initial free credit only applies to Pipedream Public Registry sources attached to at least one workflow.
 
 :::
 
-::: details A source not connected to any workflow
-
-A source that isn't connected to any workflow is called an [**Independent Source**](https://pipedream.com/docs/workflows/steps/triggers/#dependent-and-independent-sources). Independent sources incur credits per execution, regardless if any unique event is emitted.
-
-:::
 
 ### Billing Period
 


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0edb552</samp>

This pull request updates the documentation for source credit usage and limits. It simplifies the `docs/docs/pricing/README.md` file and fixes a punctuation error in the `docs/docs/limits/README.md` file.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0edb552</samp>

> _Sing, O Muse, of the skillful coder who refined_
> _the pricing page of source credits, that wondrous gift_
> _of the cloud-born gods, and made it clear and concise_
> _for the eager customers who seek to use its power._


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0edb552</samp>

*  Simplify and clarify source credit usage rules and examples ([link](https://github.com/PipedreamHQ/pipedream/pull/9175/files?diff=unified&w=0#diff-2193227971a8af8a512647a42d2f62a0e47de3a9dd43290bcb2c47125b87d26aL105-R112), [link](https://github.com/PipedreamHQ/pipedream/pull/9175/files?diff=unified&w=0#diff-2193227971a8af8a512647a42d2f62a0e47de3a9dd43290bcb2c47125b87d26aL123-R137)) in `docs/docs/pricing/README.md`
* Remove unnecessary comma in `docs/docs/limits/README.md` ([link](https://github.com/PipedreamHQ/pipedream/pull/9175/files?diff=unified&w=0#diff-2599474f3052698b90176fa3fe33f0215810638fc52f9ebc853fde980175261cL38-R38))
