### PR TITLE
Jira - Bug Fix to Create Issue for Transition Prop

### DIFF
--- a/components/jira/actions/common/issue.mjs
+++ b/components/jira/actions/common/issue.mjs
@@ -23,12 +23,6 @@ export default {
       ],
       description: "Details of issue properties to be add or update, please provide an array of objects with keys and values.",
     },
-    transitionLooped: {
-      type: "boolean",
-      label: "Transition Looped",
-      description: "Whether the transition is looped.",
-      optional: true,
-    },
     update: {
       type: "object",
       label: "Update",

--- a/components/jira/actions/create-issue/create-issue.mjs
+++ b/components/jira/actions/create-issue/create-issue.mjs
@@ -7,7 +7,7 @@ export default {
   key: "jira-create-issue",
   name: "Create Issue",
   description: "Creates an issue or, where the option to create subtasks is enabled in Jira, a subtask, [See the docs](https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-rest-api-3-issue-post)",
-  version: "0.1.15",
+  version: "0.1.16",
   type: "action",
   props: {
     ...common.props,
@@ -36,19 +36,6 @@ export default {
         }) => ({
           cloudId,
           projectId,
-        }),
-      ],
-    },
-    transitionId: {
-      label: "Transition ID",
-      propDefinition: [
-        common.props.app,
-        "transition",
-        ({
-          cloudId, issueIdOrKey,
-        }) => ({
-          cloudId,
-          issueIdOrKey,
         }),
       ],
     },
@@ -97,8 +84,6 @@ export default {
       updateHistory,
       historyMetadata,
       properties,
-      transitionId,
-      transitionLooped,
       update,
       additionalProperties,
       ...dynamicFields
@@ -116,13 +101,6 @@ export default {
       additionalProps: this.formatFields(dynamicFields),
     });
 
-    const transition = utils.reduceProperties({
-      additionalProps: {
-        id: transitionId,
-        looped: transitionLooped,
-      },
-    });
-
     const params = utils.reduceProperties({
       additionalProps: {
         updateHistory,
@@ -137,7 +115,6 @@ export default {
         fields,
         historyMetadata: utils.parseObject(historyMetadata),
         properties: utils.parse(properties),
-        transition,
         update: utils.parseObject(update),
         ...utils.parseObject(additionalProperties),
       },

--- a/components/jira/actions/update-issue/update-issue.mjs
+++ b/components/jira/actions/update-issue/update-issue.mjs
@@ -8,7 +8,7 @@ export default {
   key: "jira-update-issue",
   name: "Update Issue",
   description: "Updates an issue. A transition may be applied and issue properties updated as part of the edit, [See the docs](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-put)",
-  version: "0.2.9",
+  version: "0.2.10",
   type: "action",
   props: {
     ...common.props,
@@ -77,6 +77,12 @@ export default {
           issueIdOrKey,
         }),
       ],
+    },
+    transitionLooped: {
+      type: "boolean",
+      label: "Transition Looped",
+      description: "Whether the transition is looped.",
+      optional: true,
     },
   },
   async additionalProps() {

--- a/components/jira/package.json
+++ b/components/jira/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/jira",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Pipedream Jira Components",
   "main": "jira.app.mjs",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7003,6 +7003,9 @@ importers:
   components/wakatime:
     specifiers: {}
 
+  components/wappalyzer:
+    specifiers: {}
+
   components/warpcast:
     specifiers: {}
 


### PR DESCRIPTION
The `transitionId` prop requires an issue ID or Key in order to list options. Since we won't have the issue ID yet in the Create Issue action, I've removed `transitionId` and `transitionLooped` props from Create Issue and left them present in Update Issue.
## WHAT

copilot:summary

copilot:poem


## WHY

<!-- author to complete -->


## HOW

copilot:walkthrough
