### PR TITLE
Fix Filestore example toUrl

### DIFF
--- a/docs/docs/projects/file-stores/README.md
+++ b/docs/docs/projects/file-stores/README.md
@@ -134,7 +134,7 @@ export default defineComponent({
     const file = await $.files.open('pipedream.png').fromUrl('https://res.cloudinary.com/pipedreamin/image/upload/t_logo48x48/v1597038956/docs/HzP2Yhq8_400x400_1_sqhs70.jpg')
 
     // display the uploaded file's URL from the File Store:
-    console.log(await file.toURL())
+    console.log(await file.toUrl())
   },
 })
 ```


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c6313ac</samp>

Renamed `toURL` method to `toUrl` in File Store documentation. This improves consistency and clarity of the File Store API.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c6313ac</samp>

> _`toURL` becomes_
> _`toUrl` in camelCase_
> _autumn of refactor_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c6313ac</samp>

* Rename `toURL` method to `toUrl` to follow camelCase convention ([link](https://github.com/PipedreamHQ/pipedream/pull/9278/files?diff=unified&w=0#diff-282ed73d6e305d1b8f0dd08aa198eeb55824cb57e289efd681affe8da69bdd62L137-R137))
