### PR TITLE
[FIX] salesforce terminology misalignment replaced object to record

### DIFF
--- a/components/salesforce_rest_api/package.json
+++ b/components/salesforce_rest_api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/salesforce_rest_api",
-  "version": "0.4.9",
+  "version": "1.0.0",
   "description": "Pipedream Salesforce (REST API) Components",
   "main": "salesforce_rest_api.app.mjs",
   "keywords": [

--- a/components/salesforce_rest_api/sources/new-record-instant/new-record-instant.mjs
+++ b/components/salesforce_rest_api/sources/new-record-instant/new-record-instant.mjs
@@ -4,10 +4,10 @@ import common from "../common-instant.mjs";
 export default {
   ...common,
   type: "source",
-  name: "New Object (Instant, of Selectable Type)",
-  key: "salesforce_rest_api-new-object-instant",
-  description: "Emit new event immediately after an object of arbitrary type (selected as an input parameter by the user) is created",
-  version: "0.1.4",
+  name: "New Record (Instant, of Selectable Type)",
+  key: "salesforce_rest_api-new-record-instant",
+  description: "Emit new event immediately after a record of arbitrary object type (selected as an input parameter by the user) is created",
+  version: "0.0.1",
   hooks: {
     ...common.hooks,
     async deploy() {

--- a/components/salesforce_rest_api/sources/new-record/new-record.mjs
+++ b/components/salesforce_rest_api/sources/new-record/new-record.mjs
@@ -5,10 +5,10 @@ import common from "../common.mjs";
 export default {
   ...common,
   type: "source",
-  name: "New Object (of Selectable Type)",
-  key: "salesforce_rest_api-new-object",
-  description: "Emit new event (at regular intervals) when an object of arbitrary type (selected as an input parameter by the user) is created. See [the docs](https://sforce.co/3yPSJZy) for more information.",
-  version: "0.1.7",
+  name: "New Record (of Selectable Type)",
+  key: "salesforce_rest_api-new-record",
+  description: "Emit new event (at regular intervals) when a record of arbitrary object type (selected as an input parameter by the user) is created. See [the docs](https://sforce.co/3yPSJZy) for more information.",
+  version: "0.0.1",
   methods: {
     ...common.methods,
     isItemRelevant(item, startTimestamp, endTimestamp) {

--- a/components/salesforce_rest_api/sources/record-deleted-instant/record-deleted-instant.mjs
+++ b/components/salesforce_rest_api/sources/record-deleted-instant/record-deleted-instant.mjs
@@ -5,10 +5,10 @@ import common from "../common-instant.mjs";
 export default {
   ...common,
   type: "source",
-  name: "New Deleted Object (Instant, of Selectable Type)",
-  key: "salesforce_rest_api-object-deleted-instant",
-  description: "Emit new event immediately after an object of arbitrary type (selected as an input parameter by the user) is deleted",
-  version: "0.1.3",
+  name: "New Deleted Record (Instant, of Selectable Type)",
+  key: "salesforce_rest_api-record-deleted-instant",
+  description: "Emit new event immediately after a record of arbitrary object type (selected as an input parameter by the user) is deleted",
+  version: "0.0.1",
   methods: {
     ...common.methods,
     generateMeta(data) {

--- a/components/salesforce_rest_api/sources/record-deleted/record-deleted.mjs
+++ b/components/salesforce_rest_api/sources/record-deleted/record-deleted.mjs
@@ -5,10 +5,10 @@ import common from "../common.mjs";
 export default {
   ...common,
   type: "source",
-  name: "New Deleted Object (of Selectable Type)",
-  key: "salesforce_rest_api-object-deleted",
-  description: "Emit new event (at regular intervals) when an object of arbitrary type (selected as an input parameter by the user) is deleted. [See the docs](https://sforce.co/3msDDEE) for more information.",
-  version: "0.1.6",
+  name: "New Deleted Record (of Selectable Type)",
+  key: "salesforce_rest_api-record-deleted",
+  description: "Emit new event (at regular intervals) when a record of arbitrary object type (selected as an input parameter by the user) is deleted. [See the docs](https://sforce.co/3msDDEE) for more information.",
+  version: "0.0.1",
   methods: {
     ...common.methods,
     generateMeta(item) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1533,6 +1533,9 @@ importers:
       form-data: 4.0.0
       fs: 0.0.1-security
 
+  components/diffy:
+    specifiers: {}
+
   components/digicert:
     specifiers: {}
 
@@ -1599,6 +1602,9 @@ importers:
       nanoid: 4.0.2
 
   components/dispatch:
+    specifiers: {}
+
+  components/dnsfilter:
     specifiers: {}
 
   components/dock_certs:
@@ -2912,6 +2918,9 @@ importers:
     dependencies:
       '@pipedream/platform': 0.10.0
 
+  components/illumidesk:
+    specifiers: {}
+
   components/ilovepdf:
     specifiers:
       '@pipedream/platform': 1.5.1
@@ -3297,6 +3306,9 @@ importers:
   components/kyvio:
     specifiers: {}
 
+  components/l3mbda:
+    specifiers: {}
+
   components/labs64_netlicensing:
     specifiers: {}
 
@@ -3415,6 +3427,9 @@ importers:
       form-data: 4.0.0
 
   components/linkedin_ads:
+    specifiers: {}
+
+  components/linkly:
     specifiers: {}
 
   components/linqs_cc:
@@ -3824,6 +3839,9 @@ importers:
       '@pipedream/platform': ^1.5.1
     dependencies:
       '@pipedream/platform': 1.5.1
+
+  components/microsoft_power_bi:
+    specifiers: {}
 
   components/microsoft_sql_server:
     specifiers:
@@ -5135,6 +5153,9 @@ importers:
     dependencies:
       '@pipedream/platform': 1.5.1
 
+  components/recruitis:
+    specifiers: {}
+
   components/recurly:
     specifiers:
       '@pipedream/platform': ^1.2.1
@@ -5237,6 +5258,9 @@ importers:
     dependencies:
       '@pipedream/platform': 1.5.1
       '@pipedream/types': 0.1.6
+
+  components/resource_guru:
+    specifiers: {}
 
   components/respond_io:
     specifiers: {}
@@ -6847,6 +6871,9 @@ importers:
   components/upwave:
     specifiers: {}
 
+  components/urlbae:
+    specifiers: {}
+
   components/urlbox_io:
     specifiers:
       '@pipedream/platform': ^1.4.1
@@ -7137,6 +7164,9 @@ importers:
       '@pipedream/platform': ^1.2.0
     dependencies:
       '@pipedream/platform': 1.5.1
+
+  components/whop:
+    specifiers: {}
 
   components/whosonlocation:
     specifiers: {}
@@ -7436,6 +7466,9 @@ importers:
       '@pipedream/platform': ^1.2.0
     dependencies:
       '@pipedream/platform': 1.5.1
+
+  components/zenrows:
+    specifiers: {}
 
   components/zerobounce:
     specifiers: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1686,6 +1686,9 @@ importers:
       '@pipedream/platform': 1.5.1
       lodash: 4.17.21
 
+  components/dreamhost:
+    specifiers: {}
+
   components/dreamstudio:
     specifiers:
       '@pipedream/platform': ^1.5.1


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1e659d1</samp>

This pull request adds new components to the `@pipedreamhq/platform` package that emit events from various web services and platforms. It also updates the `@pipedream/salesforce_rest_api` package to version `1.0.0` and renames the sources and files to use the term `record` instead of `object` to match the Salesforce terminology.


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1e659d1</samp>

*  Rename and update sources to use `record` instead of `object` in name, key, description, and version to match Salesforce terminology ([link](https://github.com/PipedreamHQ/pipedream/pull/9281/files?diff=unified&w=0#diff-4d33244013f381da4e72ac33b8d2a4f509243d27a17958877b5bba27382da111L7-R10),[link](https://github.com/PipedreamHQ/pipedream/pull/9281/files?diff=unified&w=0#diff-ba5234637ae917b7e6b98fb8daca5fe1039b8dc241f98fc19489c725f8087399L8-R11),[link](https://github.com/PipedreamHQ/pipedream/pull/9281/files?diff=unified&w=0#diff-38a0d767f3998125ff06af9ffc6fe61e67ef1ce6cffc2f8decdd55eae1b88a01L8-R11),[link](https://github.com/PipedreamHQ/pipedream/pull/9281/files?diff=unified&w=0#diff-fc094cb6d2b46787ac9fdd7d215e2de85b517cf793aa3716d86f15dd2748768aL8-R11))
* Bump up the version of the `@pipedream/salesforce_rest_api` package to `1.0.0` to reflect the breaking changes in the source names and keys ([link](https://github.com/PipedreamHQ/pipedream/pull/9281/files?diff=unified&w=0#diff-69edd3d7bcf28d5b76b6be1ff8f0765e83f1a3027b155032457ba767c04df46eL3-R3))
  - `diffy` for emitting events when a web page changes ([link](https://github.com/PipedreamHQ/pipedream/pull/9281/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1536-R1538))
  - `dnsfilter` for emitting events when a DNS query is blocked or allowed by a DNS filtering service ([link](https://github.com/PipedreamHQ/pipedream/pull/9281/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1607-R1609))
  - `illumidesk` for emitting events from the Illumidesk learning management system ([link](https://github.com/PipedreamHQ/pipedream/pull/9281/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2921-R2923))
  - `l3mbda` for emitting events from the L3mbda serverless platform ([link](https://github.com/PipedreamHQ/pipedream/pull/9281/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3309-R3311))
  - `linkly` for emitting events from the Linkly link management service ([link](https://github.com/PipedreamHQ/pipedream/pull/9281/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3432-R3434))
  - `microsoft_power_bi` for emitting events from the Microsoft Power BI analytics service ([link](https://github.com/PipedreamHQ/pipedream/pull/9281/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3843-R3845))
  - `recruitis` for emitting events from the Recruitis recruitment platform ([link](https://github.com/PipedreamHQ/pipedream/pull/9281/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5153-R5155))
  - `resource_guru` for emitting events from the Resource Guru resource management service ([link](https://github.com/PipedreamHQ/pipedream/pull/9281/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5259-R5261))
  - `urlbae` for emitting events from the UrlBae URL shortening service ([link](https://github.com/PipedreamHQ/pipedream/pull/9281/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR6867-R6869))
  - `whop` for emitting events from the Whop social media platform ([link](https://github.com/PipedreamHQ/pipedream/pull/9281/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR7161-R7163))
  - `zenrows` for emitting events from the ZenRows web scraping service ([link](https://github.com/PipedreamHQ/pipedream/pull/9281/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR7463-R7465))
