### PR TITLE
Component props docs improvements 

### DIFF
--- a/docs/docs/components/api/README.md
+++ b/docs/docs/components/api/README.md
@@ -106,7 +106,7 @@ Props are custom attributes you can register on a component. When a value is pas
 | [User Input](#user-input-props) | Enable components to accept input on deploy                                                   |
 | [Interface](#interface-props)   | Attaches a Pipedream interface to your component (e.g., an HTTP interface or timer)           |
 | [Service](#service-props)       | Attaches a Pipedream service to your component (e.g., a key-value database to maintain state) |
-| [App](#user-input-props)        | Enables managed auth for a component                                                          |
+| [App](#app-props)               | Enables managed auth for a component                                                          |
 
 #### User Input Props
 

--- a/docs/docs/components/api/README.md
+++ b/docs/docs/components/api/README.md
@@ -108,6 +108,7 @@ Props are custom attributes you can register on a component. When a value is pas
 | [Service](#service-props)       | Attaches a Pipedream service to your component (e.g., a key-value database to maintain state) |
 | [App](#app-props)               | Enables managed auth for a component                                                          |
 | [Data Store](/data-stores/#using-data-stores-in-code-steps) | Provides access to a Pipedream [data store](/data-stores/)        |
+| [HTTP Request](#http-request-prop)| Enables components to execute HTTP requests based on user input                             |
 
 #### User Input Props
 
@@ -166,6 +167,7 @@ props: {
 | `$.interface.timer` |                 | ✓                     |                       |
 | `$.service.db`      |                 | ✓                     |                       |
 | `data_store`        |                 |                       | ✓                     |
+| `http_request`      |                 |                       | ✓                     |
 
 **Usage**
 
@@ -645,6 +647,41 @@ props: {
 | `this.myAppPropName.methodName()` | Execute a common method defined for an app from a component that includes the app as a prop      | **Parent Component:** `run()` `hooks` `methods` | n/a         |
 
 > **Note:** The specific `$auth` keys supported for each app will be published in the near future.
+
+#### HTTP Request Prop
+
+**Usage**
+
+| Code                              | Description                                                                                      | Read Scope                                      | Write Scope |
+| --------------------------------- | ------------------------------------------------------------------------------------------------ | ----------------------------------------------- | ----------- |
+| `this.myPropName.execute()`       | Execute an HTTP request as configured                                                            | n/a                                             | `run()` `methods` |
+
+**Example**
+
+Following is an example action that demonstrates how to accept an HTTP Request configuration as input and execute the request when the component is run:
+
+```javascript
+export default {
+  name: "HTTP Request Example",
+  version: "0.0.1",
+  props: {
+    httpRequest: {
+      type: "http_request",
+      label: "API Request",
+      default: {
+        method: "GET",
+        url: "https://jsonplaceholder.typicode.com/posts",
+      }
+    },
+  },
+  async run() {
+    const { data } = await this.httpRequest.execute();
+    return data;
+  },
+};
+```
+
+For more examples, see the [docs on making HTTP requests with Node.js](/code/nodejs/http-requests/#send-a-get-request-to-fetch-data).
 
 #### Limits on props
 

--- a/docs/docs/components/api/README.md
+++ b/docs/docs/components/api/README.md
@@ -430,7 +430,7 @@ async additionalProps(previousPropDefs) {
 },
 ```
 
-A dynamic props can have one of the following prop types:
+Dynamic props can have any one of the following prop types:
 
 - `app`
 - `boolean`

--- a/docs/docs/components/api/README.md
+++ b/docs/docs/components/api/README.md
@@ -128,7 +128,9 @@ props: {
     default: "",
     secret: true || false,
     min: <integer>,
-    max: <integer>
+    max: <integer>,
+    disabled: true || false,
+    hidden: true || false
   },
 },
 ```
@@ -146,6 +148,8 @@ props: {
 | `secret`         | `boolean`                            | optional  | If set to `true`, this field will hide your input in the browser like a password field, and its value will be encrypted in Pipedream's database. The value will be decrypted when the component is run in [the execution environment](/privacy-and-security/#execution-environment). Defaults to `false`. Only allowed for `string` props.                                                                                                                                     |
 | `min`            | `integer`                            | optional  | Minimum allowed integer value. Only allowed for `integer` props..                                                                                                                                                                                                                                                                                                                                                                                                              |
 | `max`            | `integer`                            | optional  | Maximum allowed integer value . Only allowed for `integer` props.                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `disabled`       | `boolean`                            | optional  | Set to `true` to disable usage of this prop. Defaults to `false`.   |
+| `hidden`         | `boolean`                            | optional  | Set to `true` to hide this field. Defaults to `false`.              |
 
 **`PropType`s**
 
@@ -434,7 +438,7 @@ props: {
 | Property  | Type     | Required? | Description                                                                                                                                  |
 | --------- | -------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | `type`    | `string` | required  | Must be set to `$.interface.timer`                                                                                                           |
-| `default` | `object` | optional  | **Define a default interval**<br>`{ intervalSeconds: 60, },`<br>&nbsp;<br>**Define a default cron expression**<br>` { cron: "0 0 * * *", },` |
+| `default` | `object` | optional  | **Define a default interval**<br>`{ intervalSeconds: 60, },`<br>&nbsp;<br>**Define a default cron expression**<br>`{ cron: "0 0 * * *", },` |
 
 **Usage**
 

--- a/docs/docs/components/api/README.md
+++ b/docs/docs/components/api/README.md
@@ -107,6 +107,7 @@ Props are custom attributes you can register on a component. When a value is pas
 | [Interface](#interface-props)   | Attaches a Pipedream interface to your component (e.g., an HTTP interface or timer)           |
 | [Service](#service-props)       | Attaches a Pipedream service to your component (e.g., a key-value database to maintain state) |
 | [App](#app-props)               | Enables managed auth for a component                                                          |
+| [Data Store](/data-stores/#using-data-stores-in-code-steps) | Provides access to a Pipedream [data store](/data-stores/)        |
 
 #### User Input Props
 
@@ -164,6 +165,7 @@ props: {
 | `$.interface.http`  |                 | ✓                     |                       |
 | `$.interface.timer` |                 | ✓                     |                       |
 | `$.service.db`      |                 | ✓                     |                       |
+| `data_store`        |                 |                       | ✓                     |
 
 **Usage**
 

--- a/docs/docs/components/api/README.md
+++ b/docs/docs/components/api/README.md
@@ -411,6 +411,21 @@ async additionalProps(previousPropDefs)
 
 where `previousPropDefs` are the full set of props (props merged with the previous `additionalProps`). When the function is executed, `this` is bound similar to when the `run` function is called, where you can access the values of the props as currently configured, and call any `methods`. The return value of `additionalProps` will replace any previous call, and that return value will be merged with props to define the final set of props.
 
+Following is an example that demonstrates how to use `additionalProps` to dynamically change a prop's `disabled` and `hidden` properties:
+
+```javascript
+async additionalProps(previousPropDefs) {
+  if (this.myCondition === "Yes") {
+    previousPropDefs.myPropName.disabled = true;
+    previousPropDefs.myPropName.hidden = true;
+  } else {
+    previousPropDefs.myPropName.disabled = false;
+    previousPropDefs.myPropName.hidden = false;
+  }
+  return previousPropDefs;
+},
+```
+
 #### Interface Props
 
 Interface props are infrastructure abstractions provided by the Pipedream platform. They declare how a source is invoked — via HTTP request, run on a schedule, etc. — and therefore define the shape of the events it processes.

--- a/docs/docs/components/api/README.md
+++ b/docs/docs/components/api/README.md
@@ -430,6 +430,19 @@ async additionalProps(previousPropDefs) {
 },
 ```
 
+A dynamic props can have one of the following prop types:
+
+- `app`
+- `boolean`
+- `integer`
+- `string`
+- `object`
+- `any`
+- `$.interface.http`
+- `$.interface.timer`
+- `data_store`
+- `http_request`
+
 #### Interface Props
 
 Interface props are infrastructure abstractions provided by the Pipedream platform. They declare how a source is invoked — via HTTP request, run on a schedule, etc. — and therefore define the shape of the events it processes.

--- a/docs/docs/components/api/README.md
+++ b/docs/docs/components/api/README.md
@@ -671,7 +671,7 @@ props: {
 
 **Example**
 
-Following is an example action that demonstrates how to accept an HTTP Request configuration as input and execute the request when the component is run:
+Following is an example action that demonstrates how to accept an HTTP request configuration as input and execute the request when the component is run:
 
 ```javascript
 export default {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1533,6 +1533,9 @@ importers:
       form-data: 4.0.0
       fs: 0.0.1-security
 
+  components/diffy:
+    specifiers: {}
+
   components/digicert:
     specifiers: {}
 
@@ -1599,6 +1602,9 @@ importers:
       nanoid: 4.0.2
 
   components/dispatch:
+    specifiers: {}
+
+  components/dnsfilter:
     specifiers: {}
 
   components/dock_certs:
@@ -2912,6 +2918,9 @@ importers:
     dependencies:
       '@pipedream/platform': 0.10.0
 
+  components/illumidesk:
+    specifiers: {}
+
   components/ilovepdf:
     specifiers:
       '@pipedream/platform': 1.5.1
@@ -3297,6 +3306,9 @@ importers:
   components/kyvio:
     specifiers: {}
 
+  components/l3mbda:
+    specifiers: {}
+
   components/labs64_netlicensing:
     specifiers: {}
 
@@ -3415,6 +3427,9 @@ importers:
       form-data: 4.0.0
 
   components/linkedin_ads:
+    specifiers: {}
+
+  components/linkly:
     specifiers: {}
 
   components/linqs_cc:
@@ -3824,6 +3839,9 @@ importers:
       '@pipedream/platform': ^1.5.1
     dependencies:
       '@pipedream/platform': 1.5.1
+
+  components/microsoft_power_bi:
+    specifiers: {}
 
   components/microsoft_sql_server:
     specifiers:
@@ -5135,6 +5153,9 @@ importers:
     dependencies:
       '@pipedream/platform': 1.5.1
 
+  components/recruitis:
+    specifiers: {}
+
   components/recurly:
     specifiers:
       '@pipedream/platform': ^1.2.1
@@ -5237,6 +5258,9 @@ importers:
     dependencies:
       '@pipedream/platform': 1.5.1
       '@pipedream/types': 0.1.6
+
+  components/resource_guru:
+    specifiers: {}
 
   components/respond_io:
     specifiers: {}
@@ -6843,6 +6867,9 @@ importers:
   components/upwave:
     specifiers: {}
 
+  components/urlbae:
+    specifiers: {}
+
   components/urlbox_io:
     specifiers:
       '@pipedream/platform': ^1.4.1
@@ -7133,6 +7160,9 @@ importers:
       '@pipedream/platform': ^1.2.0
     dependencies:
       '@pipedream/platform': 1.5.1
+
+  components/whop:
+    specifiers: {}
 
   components/whosonlocation:
     specifiers: {}
@@ -7432,6 +7462,9 @@ importers:
       '@pipedream/platform': ^1.2.0
     dependencies:
       '@pipedream/platform': 1.5.1
+
+  components/zenrows:
+    specifiers: {}
 
   components/zerobounce:
     specifiers: {}


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7055f08</samp>

This pull request updates the API component documentation to include new prop options for disabling and hiding props, and how to use them dynamically. It also fixes a formatting issue in the `docs/docs/components/api/README.md` file.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7055f08</samp>

> _Hidden and disabled, the props of doom_
> _They change and twist with `additionalProps`_
> _The schema defines their power and role_
> _The docs reveal their secrets and traps_


## WHY

Props now have optional `disabled` and `hidden` properties.


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7055f08</samp>

*  Add `disabled` and `hidden` properties to general prop definition schema to enable dynamic and flexible prop configuration ([link](https://github.com/PipedreamHQ/pipedream/pull/9287/files?diff=unified&w=0#diff-195aa8d3740a5cc69740bc77ca6abd2d9e5656c2609dd02df45198db1ca0086dL131-R133), [link](https://github.com/PipedreamHQ/pipedream/pull/9287/files?diff=unified&w=0#diff-195aa8d3740a5cc69740bc77ca6abd2d9e5656c2609dd02df45198db1ca0086dR151-R152))
*  Provide example code snippet for using `additionalProps` method to change `disabled` and `hidden` properties based on condition in `docs/docs/components/api/README.md` ([link](https://github.com/PipedreamHQ/pipedream/pull/9287/files?diff=unified&w=0#diff-195aa8d3740a5cc69740bc77ca6abd2d9e5656c2609dd02df45198db1ca0086dR414-R428))
*  Fix formatting issue in timer prop definition table in `docs/docs/components/api/README.md` ([link](https://github.com/PipedreamHQ/pipedream/pull/9287/files?diff=unified&w=0#diff-195aa8d3740a5cc69740bc77ca6abd2d9e5656c2609dd02df45198db1ca0086dL437-R456))
