### PR TITLE
docs: file stores typo

### DIFF
--- a/docs/docs/projects/file-stores/reference/README.md
+++ b/docs/docs/projects/file-stores/reference/README.md
@@ -218,7 +218,7 @@ export default defineComponent({
     const readStream = got.stream('https://pdrm.co/logo')
 
     // Populate the file's content from the read stream
-    await $files.open("logo.png").fromReadStream(readStream, "image/png", 2153)
+    await $.files.open("logo.png").fromReadStream(readStream, "image/png", 2153)
   },
 })
 ```


### PR DESCRIPTION
Helper specified incorrectly

## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0c4a5b0</samp>

Fixed a code example typo in the file store reference documentation. Updated the code to use the `$` global object instead of `$files`.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0c4a5b0</samp>

> _`$` is the key_
> _not `$files`, a typo_
> _docs are clear now_


## WHY

Noticed while reading the docs


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0c4a5b0</samp>

* Fix typo in code example for accessing the `$` global object ([link](https://github.com/PipedreamHQ/pipedream/pull/9290/files?diff=unified&w=0#diff-277fa6dc5b3ac5e207f0cd59feaac97dc5b4bbfb691f02dcf47e8b6b4725ecd8L221-R221))
