### PR TITLE
docs: file stores typo

### DIFF
--- a/docs/docs/projects/file-stores/README.md
+++ b/docs/docs/projects/file-stores/README.md
@@ -187,7 +187,7 @@ export default defineComponent({
     const readStream = got.stream('https://pdrm.co/logo')
 
     // Populate the file's content from the read stream
-    await $files.open("logo.png").fromReadableStream(readStream)
+    await $.files.open("logo.png").fromReadableStream(readStream)
   },
 })
 ```


### PR DESCRIPTION
## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ecf9f75</samp>

Fixed a typo in the code example for file stores in the documentation. The change uses the correct variable name for the file store object.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ecf9f75</samp>

> _`$` not `$files`_
> _A subtle fix for the code_
> _Clears the autumn fog_


## WHY

one more


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ecf9f75</samp>

* Fix code example to use correct variable name for file store (`[link](https://github.com/PipedreamHQ/pipedream/pull/9293/files?diff=unified&w=0#diff-282ed73d6e305d1b8f0dd08aa198eeb55824cb57e289efd681affe8da69bdd62L190-R190)`)
