### PR TITLE
Updating Salesforce documentation with step-by-step of permissions fo…

### DIFF
--- a/components/salesforce_rest_api/README.md
+++ b/components/salesforce_rest_api/README.md
@@ -14,6 +14,7 @@ The most straightforward way to add these permissions is to create a new Permiss
 Here is a step-by-step on how to do this:
 
 **Create New Permission Set**
+
 1. Navigate to your Salesforce instance, and click the Setup wheel in the top-right corner.
 2. Under the Administration tab on the lefthand sidebar, click Users --> Permission Sets.
 3. On the Permissions Set page, click New.
@@ -45,6 +46,7 @@ Here is a step-by-step on how to do this:
 <img src="https://res.cloudinary.com/dpenc2lit/image/upload/v1702598417/Screenshot_2023-12-14_at_3.10.17_PM_urgge8.png" width=500>
 
 **Add Permission Set to User**
+
 9. From the newly created Permission Set, click Manage Assignments, then Add Assignment.
 <img src="https://res.cloudinary.com/dpenc2lit/image/upload/v1702598514/Screenshot_2023-12-14_at_3.21.59_PM_rqedtd.png" width=500>
 

--- a/components/salesforce_rest_api/README.md
+++ b/components/salesforce_rest_api/README.md
@@ -51,6 +51,8 @@ Here is a step-by-step on how to do this:
 10. Select the user you'd like to assign this permission set to, and click Assign. The user should now show up under Current Assignments.
 <img src="https://res.cloudinary.com/dpenc2lit/image/upload/v1702598514/Screenshot_2023-12-14_at_3.52.42_PM_w4ge4p.png" width=500>
 
+11. You should now be able to use any of the Salesforce (Instant) Triggers on Pipedream!
+
 # Troubleshooting
 
 If you happen to stumble on the error: `UNKNOWN_EXCEPTION: admin operation already in progress` when creating an **Instant** trigger, you can follow the steps below to use the Salesforce Flow Builder to be able to use webhooks with Pipedream. This is a known error in Salesforce.

--- a/components/salesforce_rest_api/README.md
+++ b/components/salesforce_rest_api/README.md
@@ -4,7 +4,7 @@ You can install the Pipedream Salesforce app in the [Accounts](https://pipedream
 
 ### Webhooks
 
-The following three permissions must be in place on your Salesforce user in order to use the Salesforce Instant (webhook) triggers:
+The following three permissions must be configured on your Salesforce user in order to use the Salesforce Instant (webhook) triggers:
 1. Apex REST Services
 2. API Enabled
 3. Author Apex (which adds in additional permissions.)

--- a/components/salesforce_rest_api/README.md
+++ b/components/salesforce_rest_api/README.md
@@ -4,6 +4,53 @@ You can install the Pipedream Salesforce app in the [Accounts](https://pipedream
 
 ### Webhooks
 
+The following three permissions must be in place on your Salesforce user in order to use the Salesforce Instant (webhook) triggers:
+1. Apex REST Services
+2. API Enabled
+3. Author Apex (which adds in additional permissions.)
+
+The most straightforward way to add these permissions is to create a new Permission Set, and to add it to the user once created.
+
+Here is a step-by-step on how to do this:
+
+**Create New Permission Set**
+1. Under the Administration tab on the lefthand sidebar, click Users --> Permission Sets.
+2. On the Permissions Set page, click New.
+3. Create a new permission set, give it a label, API name, and description. Example:
+**Label**: Pipedream API Access
+**API Name**: Pipedream
+**Description**: Adds a set of permissions required for Pipedream sources:
+- Apex REST Services
+- API Enabled
+- Author Apex
+
+ <img src="https://res.cloudinary.com/dpenc2lit/image/upload/v1702598220/Screenshot_2023-12-14_at_2.57.21_PM_dfgsrw.png" width=500>
+
+**Add Permissions**
+
+4. Now that the permission set is created, navigate to System Permissions.
+<img src="https://res.cloudinary.com/dpenc2lit/image/upload/v1702598358/Screenshot_2023-12-14_at_3.00.49_PM_axtws5.png" width=500>
+5. From System Permissions, click Edit.
+<img src="https://res.cloudinary.com/dpenc2lit/image/upload/v1702598417/Screenshot_2023-12-14_at_3.01.38_PM_pvbopv.png" width=500>
+
+6. Select the following permissions, and click Save.
+- Apex REST Services
+- API Enabled
+- Author Apex (which adds in additional permissions.)
+<img src="https://res.cloudinary.com/dpenc2lit/image/upload/v1702598514/Screenshot_2023-12-14_at_3.48.50_PM_pcychy.png" width=500>
+
+7. The list of added permissions should look like this, and click save again.
+<img src="https://res.cloudinary.com/dpenc2lit/image/upload/v1702598417/Screenshot_2023-12-14_at_3.10.17_PM_urgge8.png" width=500>
+
+**Add Permission Set to User**
+8. From the newly created Permission Set, click Manage Assignments, then Add Assignment.
+<img src="https://res.cloudinary.com/dpenc2lit/image/upload/v1702598514/Screenshot_2023-12-14_at_3.21.59_PM_rqedtd.png" width=500>
+
+9. Select the user you'd like to assign this permission set to, and click Assign. The user should now show up under Current Assignments.
+<img src="https://res.cloudinary.com/dpenc2lit/image/upload/v1702598514/Screenshot_2023-12-14_at_3.52.42_PM_w4ge4p.png" width=500>
+
+### Troubleshooting
+
 If you happen to stumble on the error: `UNKNOWN_EXCEPTION: admin operation already in progress` when creating an **Instant** trigger, you can follow the steps below to use the Salesforce Flow Builder to be able to use webhooks with Pipedream. This is a known error in Salesforce.
 
 1. Create a New Workflow on [Pipedream](https://pipedream.com) and [add a HTTP trigger](https://pipedream.com/docs/workflows/steps/triggers/#http).

--- a/components/salesforce_rest_api/README.md
+++ b/components/salesforce_rest_api/README.md
@@ -2,21 +2,22 @@
 
 You can install the Pipedream Salesforce app in the [Accounts](https://pipedream.com/accounts) section of your account, or directly in a workflow.
 
-### Webhooks
+## Configuring Webhook Sources in Salesforce
 
 The following three permissions must be configured on your Salesforce user in order to use the Salesforce Instant (webhook) triggers:
 1. Apex REST Services
 2. API Enabled
 3. Author Apex (which adds in additional permissions.)
 
-The most straightforward way to add these permissions is to create a new Permission Set, and to add it to the user once created.
+The most straightforward way to add these permissions is to create a new Permission Set in Salesforce, and to add it to the user once created.
 
 Here is a step-by-step on how to do this:
 
 **Create New Permission Set**
-1. Under the Administration tab on the lefthand sidebar, click Users --> Permission Sets.
-2. On the Permissions Set page, click New.
-3. Create a new permission set, give it a label, API name, and description. Example:
+1. Navigate to your Salesforce instance, and click the Setup wheel in the top-right corner.
+2. Under the Administration tab on the lefthand sidebar, click Users --> Permission Sets.
+3. On the Permissions Set page, click New.
+4. Create a new permission set, give it a label, API name, and description. Example:
 **Label**: Pipedream API Access
 **API Name**: Pipedream
 **Description**: Adds a set of permissions required for Pipedream sources:
@@ -28,28 +29,29 @@ Here is a step-by-step on how to do this:
 
 **Add Permissions**
 
-4. Now that the permission set is created, navigate to System Permissions.
+5. Now that the permission set is created, navigate to System Permissions.
 <img src="https://res.cloudinary.com/dpenc2lit/image/upload/v1702598358/Screenshot_2023-12-14_at_3.00.49_PM_axtws5.png" width=500>
-5. From System Permissions, click Edit.
+
+6. From System Permissions, click Edit.
 <img src="https://res.cloudinary.com/dpenc2lit/image/upload/v1702598417/Screenshot_2023-12-14_at_3.01.38_PM_pvbopv.png" width=500>
 
-6. Select the following permissions, and click Save.
+7. Select the following permissions, and click Save.
 - Apex REST Services
 - API Enabled
 - Author Apex (which adds in additional permissions.)
 <img src="https://res.cloudinary.com/dpenc2lit/image/upload/v1702598514/Screenshot_2023-12-14_at_3.48.50_PM_pcychy.png" width=500>
 
-7. The list of added permissions should look like this, and click save again.
+8. The list of added permissions should look like this, and click save again.
 <img src="https://res.cloudinary.com/dpenc2lit/image/upload/v1702598417/Screenshot_2023-12-14_at_3.10.17_PM_urgge8.png" width=500>
 
 **Add Permission Set to User**
-8. From the newly created Permission Set, click Manage Assignments, then Add Assignment.
+9. From the newly created Permission Set, click Manage Assignments, then Add Assignment.
 <img src="https://res.cloudinary.com/dpenc2lit/image/upload/v1702598514/Screenshot_2023-12-14_at_3.21.59_PM_rqedtd.png" width=500>
 
-9. Select the user you'd like to assign this permission set to, and click Assign. The user should now show up under Current Assignments.
+10. Select the user you'd like to assign this permission set to, and click Assign. The user should now show up under Current Assignments.
 <img src="https://res.cloudinary.com/dpenc2lit/image/upload/v1702598514/Screenshot_2023-12-14_at_3.52.42_PM_w4ge4p.png" width=500>
 
-### Troubleshooting
+# Troubleshooting
 
 If you happen to stumble on the error: `UNKNOWN_EXCEPTION: admin operation already in progress` when creating an **Instant** trigger, you can follow the steps below to use the Salesforce Flow Builder to be able to use webhooks with Pipedream. This is a known error in Salesforce.
 


### PR DESCRIPTION
…r webhooks.

## WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f758bd6</samp>

This change improves the README file for the `salesforce_rest_api` component by adding a guide on how to set up permissions for webhook triggers and a Troubleshooting section header.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f758bd6</samp>

> _Salesforce users need_
> _`permission set` for webhooks_
> _Autumn leaves fall fast_


## WHY

<!-- author to complete -->


## HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f758bd6</samp>

*  Add a guide on creating and assigning a permission set for webhook triggers ([link](https://github.com/PipedreamHQ/pipedream/pull/9306/files?diff=unified&w=0#diff-85dcf148c03d92a3529202035fd636ef9fed8a339f0c73819cde1a20216bb2a0R7-R53))
