### PR TITLE
Use different request parameters when using a shared drive

### DIFF
--- a/components/google_drive/package.json
+++ b/components/google_drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_drive",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "description": "Pipedream Google_drive Components",
   "main": "google_drive.app.mjs",
   "keywords": [

--- a/components/google_drive/package.json
+++ b/components/google_drive/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@googleapis/drive": "^2.3.0",
     "@pipedream/platform": "^1.4.0",
+    "lodash": "^4.17.21",
     "mime-db": "^1.51.0",
     "uuid": "^8.3.2"
   },

--- a/components/google_drive/package.json
+++ b/components/google_drive/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@googleapis/drive": "^2.3.0",
     "@pipedream/platform": "^1.4.0",
+    "cron-parser": "^4.9.0",
     "lodash": "^4.17.21",
     "mime-db": "^1.51.0",
     "uuid": "^8.3.2"

--- a/components/google_drive/sources/changes-to-specific-files-shared-drive/changes-to-specific-files-shared-drive.mjs
+++ b/components/google_drive/sources/changes-to-specific-files-shared-drive/changes-to-specific-files-shared-drive.mjs
@@ -41,7 +41,7 @@ export default {
       default: [],
       options({ prevContext }) {
         const { nextPageToken } = prevContext;
-        return this.googleDrive.listFilesOptions(nextPageToken, this.getFilesOpts());
+        return this.googleDrive.listFilesOptions(nextPageToken, this.getListFilesOpts());
       },
     },
   },
@@ -51,14 +51,14 @@ export default {
       daysAgo.setDate(daysAgo.getDate() - 30);
       const timeString = daysAgo.toISOString();
 
-      const args = this.getFilesOpts({
+      const args = this.getListFilesOpts({
         q: `mimeType != "application/vnd.google-apps.folder" and modifiedTime > "${timeString}" and trashed = false`,
         fields: "files",
       });
 
-      const { data } = await this.googleDrive.drive().files.list(args);
+      const { files } = await this.googleDrive.listFilesInPage(null, args);
 
-      this.processChanges(data.files);
+      this.processChanges(files);
     },
     ...common.hooks,
   },

--- a/components/google_drive/sources/changes-to-specific-files-shared-drive/changes-to-specific-files-shared-drive.mjs
+++ b/components/google_drive/sources/changes-to-specific-files-shared-drive/changes-to-specific-files-shared-drive.mjs
@@ -26,7 +26,7 @@ export default {
   key: "google_drive-changes-to-specific-files-shared-drive",
   name: "Changes to Specific Files (Shared Drive)",
   description: "Watches for changes to specific files in a shared drive, emitting an event any time a change is made to one of those files",
-  version: "0.1.2",
+  version: "0.1.3",
   type: "source",
   // Dedupe events based on the "x-goog-message-number" header for the target channel:
   // https://developers.google.com/drive/api/v3/push#making-watch-requests

--- a/components/google_drive/sources/changes-to-specific-files/changes-to-specific-files.mjs
+++ b/components/google_drive/sources/changes-to-specific-files/changes-to-specific-files.mjs
@@ -17,7 +17,7 @@ export default {
   key: "google_drive-changes-to-specific-files",
   name: "Changes to Specific Files",
   description: "Watches for changes to specific files, emitting an event any time a change is made to one of those files. To watch for changes to [shared drive](https://support.google.com/a/users/answer/9310351) files, use the **Changes to Specific Files (Shared Drive)** source instead.",
-  version: "0.1.2",
+  version: "0.1.3",
   type: "source",
   // Dedupe events based on the "x-goog-message-number" header for the target channel:
   // https://developers.google.com/drive/api/v3/push#making-watch-requests

--- a/components/google_drive/sources/common-webhook.mjs
+++ b/components/google_drive/sources/common-webhook.mjs
@@ -3,6 +3,7 @@ import { v4 as uuid } from "uuid";
 
 import googleDrive from "../google_drive.app.mjs";
 import { WEBHOOK_SUBSCRIPTION_RENEWAL_SECONDS } from "../constants.mjs";
+import { getListFilesOpts } from "../common/utils.mjs";
 
 export default {
   props: {
@@ -96,20 +97,11 @@ export default {
     getDriveId(drive = this.drive) {
       return googleDrive.methods.getDriveId(drive);
     },
-    getFilesOpts(args = {}) {
-      const opts = {
+    getListFilesOpts(args = {}) {
+      return getListFilesOpts(this.drive, {
         q: "mimeType != 'application/vnd.google-apps.folder' and trashed = false",
         ...args,
-      };
-      return this.isMyDrive()
-        ? opts
-        : {
-          ...opts,
-          corpora: "drive",
-          driveId: this.getDriveId(),
-          includeItemsFromAllDrives: true,
-          supportsAllDrives: true,
-        };
+      });
     },
     /**
      * This method returns the types of updates/events from Google Drive that

--- a/components/google_drive/sources/new-files-instant/new-files-instant.mjs
+++ b/components/google_drive/sources/new-files-instant/new-files-instant.mjs
@@ -10,7 +10,7 @@ export default {
   key: "google_drive-new-files-instant",
   name: "New Files (Instant)",
   description: "Emit new event any time a new file is added in your linked Google Drive",
-  version: "0.1.3",
+  version: "0.1.4",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_drive/sources/new-files-instant/new-files-instant.mjs
+++ b/components/google_drive/sources/new-files-instant/new-files-instant.mjs
@@ -98,11 +98,26 @@ export default {
       const lastFileCreatedTime = this._getLastFileCreatedTime();
       const timeString = new Date(lastFileCreatedTime).toISOString();
 
-      const { data } = await this.googleDrive.drive().files.list({
+      let params = {
         q: `mimeType != "application/vnd.google-apps.folder" and createdTime > "${timeString}" and trashed = false`,
         orderBy: "createdTime desc",
         fields: "*",
-      });
+      };
+
+      // As with many of the methods for Google Drive, we must
+      // pass a request of a different shape when we're requesting
+      // changes for a shared drive vs My Drive
+      if (!this.isMyDrive()) {
+        params = {
+          ...params,
+          corpora: "drive",
+          driveId: this.getDriveId(),
+          includeItemsFromAllDrives: true,
+          supportsAllDrives: true,
+        };
+      }
+
+      const { data } = await this.googleDrive.drive().files.list(params);
 
       if (!data.files?.length) {
         return;

--- a/components/google_drive/sources/new-or-modified-comments/new-or-modified-comments.mjs
+++ b/components/google_drive/sources/new-or-modified-comments/new-or-modified-comments.mjs
@@ -29,14 +29,14 @@ export default {
       daysAgo.setDate(daysAgo.getDate() - 30);
       const timeString = daysAgo.toISOString();
 
-      const args = this.getFilesOpts({
+      const args = this.getListFilesOpts({
         q: `mimeType != "application/vnd.google-apps.folder" and modifiedTime > "${timeString}" and trashed = false`,
         fields: "files",
       });
 
-      const { data } = await this.googleDrive.drive().files.list(args);
+      const { files } = await this.googleDrive.listFilesInPage(null, args);
 
-      await this.processChanges(data.files);
+      await this.processChanges(files);
     },
     async activate() {
       await common.hooks.activate.bind(this)();

--- a/components/google_drive/sources/new-or-modified-comments/new-or-modified-comments.mjs
+++ b/components/google_drive/sources/new-or-modified-comments/new-or-modified-comments.mjs
@@ -17,8 +17,7 @@ export default {
   name: "New or Modified Comments",
   description:
     "Emits a new event any time a file comment is added, modified, or deleted in your linked Google Drive",
-  // version: "0.1.1",
-  version: "0.1.3",
+  version: "0.1.4",
   type: "source",
   // Dedupe events based on the "x-goog-message-number" header for the target channel:
   // https://developers.google.com/drive/api/v3/push#making-watch-requests

--- a/components/google_drive/sources/new-or-modified-files/new-or-modified-files.mjs
+++ b/components/google_drive/sources/new-or-modified-files/new-or-modified-files.mjs
@@ -21,7 +21,7 @@ export default {
   key: "google_drive-new-or-modified-files",
   name: "New or Modified Files",
   description: "Emit new event any time any file in your linked Google Drive is added, modified, or deleted",
-  version: "0.1.2",
+  version: "0.1.3",
   type: "source",
   // Dedupe events based on the "x-goog-message-number" header for the target channel:
   // https://developers.google.com/drive/api/v3/push#making-watch-requests

--- a/components/google_drive/sources/new-or-modified-files/new-or-modified-files.mjs
+++ b/components/google_drive/sources/new-or-modified-files/new-or-modified-files.mjs
@@ -32,12 +32,14 @@ export default {
       daysAgo.setDate(daysAgo.getDate() - 30);
       const timeString = daysAgo.toISOString();
 
-      const { data } = await this.googleDrive.drive().files.list({
+      const args = this.getListFilesOpts({
         q: `mimeType != "application/vnd.google-apps.folder" and modifiedTime > "${timeString}" and trashed = false`,
         fields: "files",
       });
 
-      await this.processChanges(data.files);
+      const { files } = await this.googleDrive.listFilesInPage(null, args);
+
+      await this.processChanges(files);
     },
     ...common.hooks,
   },

--- a/components/google_drive/sources/new-or-modified-folders/new-or-modified-folders.mjs
+++ b/components/google_drive/sources/new-or-modified-folders/new-or-modified-folders.mjs
@@ -31,12 +31,14 @@ export default {
       daysAgo.setDate(daysAgo.getDate() - 30);
       const timeString = daysAgo.toISOString();
 
-      const { data } = await this.googleDrive.drive().files.list({
+      const args = this.getListFilesOpts({
         q: `mimeType = "application/vnd.google-apps.folder" and modifiedTime > "${timeString}" and trashed = false`,
         fields: "files(id, mimeType)",
       });
 
-      await this.processChanges(data.files);
+      const { files } = await this.googleDrive.listFilesInPage(null, args);
+
+      await this.processChanges(files);
     },
     ...common.hooks,
   },

--- a/components/google_drive/sources/new-or-modified-folders/new-or-modified-folders.mjs
+++ b/components/google_drive/sources/new-or-modified-folders/new-or-modified-folders.mjs
@@ -20,7 +20,7 @@ export default {
   key: "google_drive-new-or-modified-folders",
   name: "New or Modified Folders",
   description: "Emit new event any time any folder in your linked Google Drive is added, modified, or deleted",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "source",
   // Dedupe events based on the "x-goog-message-number" header for the target channel:
   // https://developers.google.com/drive/api/v3/push#making-watch-requests

--- a/components/google_drive/sources/new-spreadsheet/new-spreadsheet.mjs
+++ b/components/google_drive/sources/new-spreadsheet/new-spreadsheet.mjs
@@ -6,7 +6,7 @@ export default {
   type: "source",
   name: "New Spreadsheet (Instant)",
   description: "Emit new event each time a new spreadsheet is created in a drive.",
-  version: "0.1.1",
+  version: "0.1.2",
   props: {
     googleDrive: newFilesInstant.props.googleDrive,
     db: newFilesInstant.props.db,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2601,11 +2601,13 @@ importers:
     specifiers:
       '@googleapis/drive': ^2.3.0
       '@pipedream/platform': ^1.4.0
+      lodash: ^4.17.21
       mime-db: ^1.51.0
       uuid: ^8.3.2
     dependencies:
       '@googleapis/drive': 2.4.0
       '@pipedream/platform': 1.5.1
+      lodash: 4.17.21
       mime-db: 1.52.0
       uuid: 8.3.2
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2601,12 +2601,14 @@ importers:
     specifiers:
       '@googleapis/drive': ^2.3.0
       '@pipedream/platform': ^1.4.0
+      cron-parser: ^4.9.0
       lodash: ^4.17.21
       mime-db: ^1.51.0
       uuid: ^8.3.2
     dependencies:
       '@googleapis/drive': 2.4.0
       '@pipedream/platform': 1.5.1
+      cron-parser: 4.9.0
       lodash: 4.17.21
       mime-db: 1.52.0
       uuid: 8.3.2
@@ -16982,6 +16984,13 @@ packages:
       - supports-color
       - ts-node
     dev: true
+
+  /cron-parser/4.9.0:
+    resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      luxon: 3.4.3
+    dev: false
 
   /cross-fetch/3.1.5:
     resolution: {integrity: sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==}


### PR DESCRIPTION
## WHAT

This PR fixes and updates listing function calls (`drive.files.list`) to support both My Drive and Shared Drives correctly.

## WHY

Previous code was listing files from My Drive only, therefore new files in Shared Drives were not being noticed.

## HOW

Refactored all `drive().files.list()` calls to use the existing functions `googleDrive.listFilesInPage()` and `utils.getListFilesOpts()`.