### PR TITLE
@pipedream/google_sheets module: add google_drive dependency

### DIFF
--- a/components/google_sheets/package.json
+++ b/components/google_sheets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_sheets",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Pipedream Google_sheets Components",
   "main": "google_sheets.app.mjs",
   "keywords": [

--- a/components/google_sheets/package.json
+++ b/components/google_sheets/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@googleapis/sheets": "^0.3.0",
     "@pipedream/platform": "^1.4.0",
+    "@pipedream/google_drive": "^0.6.12",
     "lodash": "^4.17.21",
     "uuidv4": "^6.2.6",
     "zlib": "^1.0.5"


### PR DESCRIPTION
## WHAT

copilot:summary

copilot:poem


## WHY

The google_sheets module is missing google drive from the dependencies

see https://pipedream-users.slack.com/archives/CPTJYRY5A/p1704905872767259


## HOW

copilot:walkthrough
