### PR TITLE
Google Sheets npm module: add google_drive dependency

### DIFF
--- a/components/google_sheets/package.json
+++ b/components/google_sheets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_sheets",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Pipedream Google_sheets Components",
   "main": "google_sheets.app.mjs",
   "keywords": [
@@ -12,6 +12,7 @@
   "dependencies": {
     "@googleapis/sheets": "^0.3.0",
     "@pipedream/platform": "^1.4.0",
+    "@pipedream/google_drive": "^0.6.12",
     "lodash": "^4.17.21",
     "uuidv4": "^6.2.6",
     "zlib": "^1.0.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2713,12 +2713,14 @@ importers:
   components/google_sheets:
     specifiers:
       '@googleapis/sheets': ^0.3.0
+      '@pipedream/google_drive': ^0.6.12
       '@pipedream/platform': ^1.4.0
       lodash: ^4.17.21
       uuidv4: ^6.2.6
       zlib: ^1.0.5
     dependencies:
       '@googleapis/sheets': 0.3.0
+      '@pipedream/google_drive': 0.6.15
       '@pipedream/platform': 1.5.1
       lodash: 4.17.21
       uuidv4: 6.2.13
@@ -4839,6 +4841,9 @@ importers:
       '@pipedream/platform': ^1.1.1
     dependencies:
       '@pipedream/platform': 1.5.1
+
+  components/piloterr:
+    specifiers: {}
 
   components/pilvio:
     specifiers: {}
@@ -12383,6 +12388,21 @@ packages:
       '@microsoft/kiota-serialization-text': 1.0.0-preview.23
     transitivePeerDependencies:
       - encoding
+    dev: false
+
+  /@pipedream/google_drive/0.6.15:
+    resolution: {integrity: sha512-r0H0A1HsSEDVTPVSvK4XXcExEeUnkpIqLMNVM2aLh1bwdOblTS1sxLZ9mz/7DwAr8wRNCoW6zlXZBEhexIyyAg==}
+    dependencies:
+      '@googleapis/drive': 2.4.0
+      '@pipedream/platform': 1.5.1
+      cron-parser: 4.9.0
+      lodash: 4.17.21
+      mime-db: 1.52.0
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - debug
+      - encoding
+      - supports-color
     dev: false
 
   /@pipedream/helper_functions/0.3.12:


### PR DESCRIPTION
## WHAT

copilot:summary

copilot:poem


## WHY

The google_sheets module is missing google drive from the dependencies

see https://pipedream-users.slack.com/archives/CPTJYRY5A/p1704905872767259


## HOW

copilot:walkthrough
