### PR TITLE
Including common file exception in key check

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3195,6 +3195,9 @@ importers:
     dependencies:
       '@pipedream/platform': 1.5.1
 
+  components/intellihr:
+    specifiers: {}
+
   components/intercom:
     specifiers:
       '@pipedream/platform': ^1.2.0

--- a/scripts/findBadKeys.js
+++ b/scripts/findBadKeys.js
@@ -90,7 +90,7 @@ function checkKeys(p, nameSlug) {
     }
     if (name.endsWith(".mjs") || name.endsWith(".js") || name.endsWith(".ts") || name.endsWith(".mts")) {
       // ignore test-event files
-      if (isTestEventFile(name)) {
+      if (isCommonFile(name) || isTestEventFile(name)) {
         continue;
       }
       const data = fs.readFileSync(pp, "utf8");

--- a/scripts/findBadKeys.js
+++ b/scripts/findBadKeys.js
@@ -19,7 +19,7 @@ const isSourceFile = (subname) =>
   subname.endsWith(".mjs") || subname.endsWith(".js") || subname.endsWith(".mts") || subname.endsWith(".ts");
 
 const isCommonFile = (subname) => {
-  const regex = /\/common.*(\/|\.js|\.mjs|\.ts|\.mts|)/g;
+  const regex = /\/?common.*(\/|\.js|\.mjs|\.ts|\.mts|)/g;
   return regex.test(subname);
 };
 


### PR DESCRIPTION
## WHAT

copilot:summary

copilot:poem


## WHY

Common files should be ignored when checking for component keys, just like test event files


## HOW

copilot:walkthrough
