### PR TITLE
Fix GSheets Upsert Row hidden sheet cleanup

### DIFF
--- a/components/google_sheets/package.json
+++ b/components/google_sheets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_sheets",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Pipedream Google_sheets Components",
   "main": "google_sheets.app.mjs",
   "keywords": [


### PR DESCRIPTION
## WHAT

Ensure that the hidden sheet (used to find a row to update) is deleted even if there is an error adding rows to the sheet.

## WHY

The Google Sheets **Upsert Row** action is supposed to clean up the hidden sheet it creates by [deleting it](https://github.com/PipedreamHQ/pipedream/blob/cea6c044c712b426c098423c1631afa54f23a176/components/google_sheets/google_sheets.app.mjs#L521) after it finds a matched row, [here](https://github.com/PipedreamHQ/pipedream/blob/cea6c044c712b426c098423c1631afa54f23a176/components/google_sheets/actions/upsert-row/upsert-row.mjs#L160) or [here](https://github.com/PipedreamHQ/pipedream/blob/cea6c044c712b426c098423c1631afa54f23a176/components/google_sheets/actions/upsert-row/upsert-row.mjs#L183).

If the Google Sheets API call to add rows to the hidden sheet failed, then the action would end and the hidden sheet wouldn't get deleted.

Additional context: https://pipedream-users.slack.com/archives/CMZG4EBJ9/p1704911469220419?thread_ts=1703064669.892689&cid=CMZG4EBJ9


## HOW

Move the Google Sheets API calls to the `try` block of a `try...finally` statement, where the hidden sheet is deleted in the `finally` block.
