### PR TITLE
Puppeteer remote browser docs

### DIFF
--- a/docs/docs/code/nodejs/browser-automation/README.md
+++ b/docs/docs/code/nodejs/browser-automation/README.md
@@ -583,4 +583,19 @@ export default defineComponent({
 ```
 
 Please see the [`@pipedream/browsers` source code](https://github.com/PipedreamHQ/pipedream/blob/17888e631857259a6535f9bd13c23a1e7ff95381/packages/browsers/index.mjs#L14) for the default arguments that Pipedream provides.
+
+### How to use `puppeteer.connect()`?
+
+To use `puppeteer.connect()` to connect to a remote browser instance, you can use the [`puppeteer-core`](https://github.com/puppeteer/puppeteer/tree/main?tab=readme-ov-file#puppeteer-core) package:
+
+```javascript
+import puppeteer from "puppeteer-core";
+```
+
+`puppeteer-core` does not download Chrome when installed, which decreases the size of your deployment and can improve cold start times.
+
+To connect to a remote browser instance using Playwright, you can use the [`playwright-core`](https://www.npmjs.com/package/playwright-core) package, which is the no-browser Playwright package:
+
+```javascript
+import playwright from "playwright-core";
 ```

--- a/docs/docs/code/nodejs/browser-automation/README.md
+++ b/docs/docs/code/nodejs/browser-automation/README.md
@@ -584,7 +584,7 @@ export default defineComponent({
 
 Please see the [`@pipedream/browsers` source code](https://github.com/PipedreamHQ/pipedream/blob/17888e631857259a6535f9bd13c23a1e7ff95381/packages/browsers/index.mjs#L14) for the default arguments that Pipedream provides.
 
-### How to use `puppeteer.connect()`?
+### How do I use `puppeteer.connect()`?
 
 To use `puppeteer.connect()` to connect to a remote browser instance, you can use the [`puppeteer-core`](https://github.com/puppeteer/puppeteer/tree/main?tab=readme-ov-file#puppeteer-core) package:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3308,6 +3308,9 @@ importers:
     dependencies:
       '@pipedream/platform': 1.5.1
 
+  components/join:
+    specifiers: {}
+
   components/joomla:
     specifiers:
       '@pipedream/platform': ^0.10.0


### PR DESCRIPTION
## WHAT

Adds FAQ for using [`puppeteer.connect()`](https://playwright.dev/docs/api/class-browsertype#browser-type-connect) to connect to a remote browser.

## WHY

If I try to use the `puppeteer` package in code step, I get the error:
```
Cannot require puppeteer. puppeteer is supported via a custom Pipedream package. Please see the docs: https://pipedream.com/docs/code/nodejs/browser-automation/
```

I can use the `puppeteer-core` package instead to connect to a remote browser instance with [`puppeteer.connect()`](https://playwright.dev/docs/api/class-browsertype#browser-type-connect).

## HOW

