### PR TITLE
Notion - Add status property

### DIFF
--- a/components/notion/actions/append-block/append-block.mjs
+++ b/components/notion/actions/append-block/append-block.mjs
@@ -6,7 +6,7 @@ export default {
   key: "notion-append-block",
   name: "Append Block to Parent",
   description: "Creates and appends blocks to the specified parent. [See the documentation](https://developers.notion.com/reference/patch-block-children)",
-  version: "0.2.11",
+  version: "0.2.12",
   type: "action",
   props: {
     notion,

--- a/components/notion/actions/common/base-page-builder.mjs
+++ b/components/notion/actions/common/base-page-builder.mjs
@@ -38,7 +38,8 @@ export default {
      * @returns prop description
      */
     _buildPropDescription(type, example) {
-      const description = `The type of this property is \`${type}\`. [See ${type} type docs here](https://developers.notion.com/reference/property-object#${type}-configuration).`;
+      const typeName = type.replace(/_/g, "-");
+      const description = `The type of this property is \`${type}\`. [See ${type} type docs here](https://developers.notion.com/reference/property-object#${typeName}).`;
       const descriptionExample = example
         ? `e.g. ${example}.`
         : "";

--- a/components/notion/actions/create-page-from-database/create-page-from-database.mjs
+++ b/components/notion/actions/create-page-from-database/create-page-from-database.mjs
@@ -7,7 +7,7 @@ export default {
   key: "notion-create-page-from-database",
   name: "Create Page from Database",
   description: "Creates a page from a database. [See the docs](https://developers.notion.com/reference/post-page)",
-  version: "0.1.10",
+  version: "0.1.11",
   type: "action",
   props: {
     notion,

--- a/components/notion/actions/create-page/create-page.mjs
+++ b/components/notion/actions/create-page/create-page.mjs
@@ -7,7 +7,7 @@ export default {
   key: "notion-create-page",
   name: "Create Page",
   description: "Creates a page from a parent page. The only valid property is *title*. [See the documentation](https://developers.notion.com/reference/post-page)",
-  version: "0.2.8",
+  version: "0.2.9",
   type: "action",
   props: {
     notion,

--- a/components/notion/actions/duplicate-page/duplicate-page.mjs
+++ b/components/notion/actions/duplicate-page/duplicate-page.mjs
@@ -7,7 +7,7 @@ export default {
   key: "notion-duplicate-page",
   name: "Duplicate Page",
   description: "Creates a new page copied from an existing page block. [See the docs](https://developers.notion.com/reference/post-page)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   props: {
     notion,

--- a/components/notion/actions/update-page/update-page.mjs
+++ b/components/notion/actions/update-page/update-page.mjs
@@ -7,7 +7,7 @@ export default {
   key: "notion-update-page",
   name: "Update Page",
   description: "Updates page property values for the specified page. Properties that are not set will remain unchanged. To append page content, use the *append block* action. [See the docs](https://developers.notion.com/reference/patch-page)",
-  version: "1.0.2",
+  version: "1.1.0",
   type: "action",
   props: {
     notion,

--- a/components/notion/common/notion-page-properties.mjs
+++ b/components/notion/common/notion-page-properties.mjs
@@ -33,9 +33,17 @@ const NOTION_PAGE_PROPERTIES = {
       number: property.value,
     }),
   },
+  status: {
+    type: "string",
+    options: (property) => property.status?.options.map((option) => option.name),
+    convertToNotion: (property) => ({
+      status: {
+        name: property.value,
+      },
+    }),
+  },
   select: {
     type: "string",
-    example: "3f806034-9c48-4519-871e-60c9c32d73d8",
     options: (property) => property.select?.options.map((option) => option.name),
     convertToNotion: (property) => ({
       select: {

--- a/components/notion/package.json
+++ b/components/notion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/notion",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Pipedream Notion Components",
   "main": "notion.app.mjs",
   "keywords": [


### PR DESCRIPTION
Notion finally added support for changing the `status` property with the API.
This PR also adapts the Notion API Reference docs URLs for the property types.