### PR TITLE
Adding markdown notes for Google Tasks Triggers

### DIFF
--- a/components/google_tasks/README.md
+++ b/components/google_tasks/README.md
@@ -5,3 +5,11 @@ With the Google Tasks API, you can build applications that
 - Create new tasks
 - Read, update, and delete existing tasks
 - View task lists
+
+# Troubleshooting
+
+## Some Tasks are not triggering events
+
+There is a known issue with the Google Tasks API, that tasks created or assigned from Google Docs are not available via the API. 
+
+This is a limitation with the Google Task APIs. For more information, please visit [Google's Issue Tracker](https://issuetracker.google.com/issues/244387279).

--- a/components/google_tasks/actions/create-task-list/create-task-list.mjs
+++ b/components/google_tasks/actions/create-task-list/create-task-list.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_tasks-create-task-list",
   name: "Create Task List",
   description: "Creates a new task list and adds it to the authenticated user's task lists. [See the docs here](https://developers.google.com/tasks/reference/rest/v1/tasklists/insert)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     app,

--- a/components/google_tasks/actions/create-task/create-task.mjs
+++ b/components/google_tasks/actions/create-task/create-task.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_tasks-create-task",
   name: "Create Task",
   description: "Creates a new task and adds it to the authenticated user's task lists. [See the docs here](https://developers.google.com/tasks/reference/rest/v1/tasks/insert)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     app,

--- a/components/google_tasks/actions/delete-task-list/delete-task-list.mjs
+++ b/components/google_tasks/actions/delete-task-list/delete-task-list.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_tasks-delete-task-list",
   name: "Delete Task List",
   description: "Deletes the authenticated user's specified task list. [See the docs here](https://developers.google.com/tasks/reference/rest/v1/tasklists/delete)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     app,

--- a/components/google_tasks/actions/delete-task/delete-task.mjs
+++ b/components/google_tasks/actions/delete-task/delete-task.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_tasks-delete-task",
   name: "Delete Task",
   description: "Deletes the authenticated user's specified task. [See the docs here](https://developers.google.com/tasks/reference/rest/v1/tasks/delete)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     app,

--- a/components/google_tasks/actions/list-task-lists/list-task-lists.mjs
+++ b/components/google_tasks/actions/list-task-lists/list-task-lists.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_tasks-list-task-lists",
   name: "List Task Lists",
   description: "Lists the authenticated user's task lists. [See the docs here](https://developers.google.com/tasks/reference/rest/v1/tasklists/list)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     app,

--- a/components/google_tasks/actions/list-tasks/list-tasks.mjs
+++ b/components/google_tasks/actions/list-tasks/list-tasks.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_tasks-list-tasks",
   name: "List Tasks",
   description: "Returns all tasks in the specified task list. [See the docs here](https://developers.google.com/tasks/reference/rest/v1/tasks/list)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     app,

--- a/components/google_tasks/actions/update-task-list/update-task-list.mjs
+++ b/components/google_tasks/actions/update-task-list/update-task-list.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_tasks-update-task-list",
   name: "Update Task List",
   description: "Updates the authenticated user's specified task list. [See the docs here](https://developers.google.com/tasks/reference/rest/v1/tasklists/update)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     app,

--- a/components/google_tasks/actions/update-task/update-task.mjs
+++ b/components/google_tasks/actions/update-task/update-task.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_tasks-update-task",
   name: "Update Task",
   description: "Updates the authenticated user's specified task. [See the docs here](https://developers.google.com/tasks/reference/rest/v1/tasks/update)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     app,

--- a/components/google_tasks/google_tasks.app.mjs
+++ b/components/google_tasks/google_tasks.app.mjs
@@ -73,6 +73,11 @@ export default {
       description: "Due date of the task (as a [RFC 3339](https://en.wikipedia.org/wiki/ISO_8601) timestamp). Optional. The due date only records date information; the time portion of the timestamp is discarded when setting the due date. It isn't possible to read or write the time that a task is due via the API.",
       optional: true,
     },
+    alert: {
+      type: "alert",
+      alertType: "info",
+      content: "Please note that this component is not able to use tasks created from Google Docs, as this is a limitation with the Google Task APIs. For more information, please visit [Google's Issue Tracker](https://issuetracker.google.com/issues/244387279).",
+    },
   },
   methods: {
     _getBaseUrl() {

--- a/components/google_tasks/package.json
+++ b/components/google_tasks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_tasks",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Google Tasks Components",
   "main": "google_tasks.app.mjs",
   "keywords": [

--- a/components/google_tasks/sources/new-task-added/new-task-added.mjs
+++ b/components/google_tasks/sources/new-task-added/new-task-added.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_tasks-new-task-added",
   name: "New Task Added",
   description: "Emit new event for each task added to Google Tasks. [See the documentation](https://developers.google.com/tasks/reference/rest/v1/tasks/list)",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
   type: "source",
   props: {
@@ -16,11 +16,17 @@ export default {
         "taskListId",
       ],
     },
+    alert: {
+      propDefinition: [
+        common.props.googleTasks,
+        "alert",
+      ],
+    },
   },
   methods: {
     ...common.methods,
     emitEvents(tasks) {
-      const sortedTasks = tasks.sort((t1, t2) => ((new Date(t1.updated)) - (new Date(t2.updated))));
+      const sortedTasks = tasks.sort((t1, t2) => (new Date(t1.updated) - new Date(t2.updated)));
       for (const task of sortedTasks) {
         this.$emit(task, this.generateMeta(task));
       }

--- a/components/google_tasks/sources/new-task-updated/new-task-updated.mjs
+++ b/components/google_tasks/sources/new-task-updated/new-task-updated.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_tasks-new-task-updated",
   name: "New Task Updated",
   description: "Emit new event for each task added or updated to Google Tasks. [See the documentation](https://developers.google.com/tasks/reference/rest/v1/tasks/list)",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
   type: "source",
   props: {


### PR DESCRIPTION
## WHAT
Adds markdown notes as well as information in the README to explain to the user why Tasks created in Google Docs will not trigger events with our components.

![Screenshot 2024-01-23 at 3 13 00 PM](https://github.com/PipedreamHQ/pipedream/assets/42158621/76d233c5-942b-4db0-8c21-b1a77da91c00)
![Screenshot 2024-01-23 at 3 12 54 PM](https://github.com/PipedreamHQ/pipedream/assets/42158621/5f8548bc-7594-4620-8d42-6d0c315e0a03)

copilot:summary

copilot:poem


## WHY

<!-- author to complete -->


## HOW

copilot:walkthrough
