### PR TITLE
Apollo.io - Set accountId as optional in Create Customer & Update Customer actions

### DIFF
--- a/components/apollo_io/actions/create-contact/create-contact.mjs
+++ b/components/apollo_io/actions/create-contact/create-contact.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Create Contact",
   description: "Creates a new contact in Apollo.io. [See the documentation](https://apolloio.github.io/apollo-api-docs/?shell#create-a-contact)",
   type: "action",
-  version: "0.0.1",
+  version: "0.0.2",
   props: {
     app,
     email: {
@@ -37,6 +37,7 @@ export default {
         app,
         "accountId",
       ],
+      optional: true,
     },
     websiteUrl: {
       propDefinition: [

--- a/components/apollo_io/actions/update-contact/update-contact.mjs
+++ b/components/apollo_io/actions/update-contact/update-contact.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Update Contact",
   description: "Updates an existing contact in Apollo.io. [See the documentation](https://apolloio.github.io/apollo-api-docs/?shell#update-a-contact)",
   type: "action",
-  version: "0.0.1",
+  version: "0.0.2",
   props: {
     app,
     contactId: {
@@ -45,6 +45,7 @@ export default {
         app,
         "accountId",
       ],
+      optional: true,
     },
     websiteUrl: {
       propDefinition: [

--- a/components/apollo_io/package.json
+++ b/components/apollo_io/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/apollo_io",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Apollo.io Components",
   "main": "apollo_io.app.mjs",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1564,6 +1564,9 @@ importers:
     dependencies:
       '@pipedream/platform': 1.5.1
 
+  components/deel:
+    specifiers: {}
+
   components/deepgram:
     specifiers:
       '@pipedream/platform': ^1.5.1


### PR DESCRIPTION
Requested by customer [here](https://github.com/PipedreamHQ/pipedream/pull/10000#issuecomment-1910249080).
