### PR TITLE
Updating Twitter appValidation request to getRecentTweets.

### DIFF
--- a/components/twitter/actions/add-user-to-list/add-user-to-list.ts
+++ b/components/twitter/actions/add-user-to-list/add-user-to-list.ts
@@ -12,7 +12,7 @@ export default defineAction({
   key: "twitter-add-user-to-list",
   name: "Add User To List",
   description: `Add a member to a list owned by the user. [See the documentation](${DOCS_LINK})`,
-  version: "2.0.6",
+  version: "2.0.7",
   type: "action",
   props: {
     ...common.props,

--- a/components/twitter/actions/create-tweet/create-tweet.ts
+++ b/components/twitter/actions/create-tweet/create-tweet.ts
@@ -10,7 +10,7 @@ export default defineAction({
   key: "twitter-create-tweet",
   name: "Create Tweet",
   description: `Create a new tweet. [See the documentation](${DOCS_LINK})`,
-  version: "2.1.4",
+  version: "2.1.5",
   type: "action",
   props: {
     app,

--- a/components/twitter/actions/delete-tweet/delete-tweet.ts
+++ b/components/twitter/actions/delete-tweet/delete-tweet.ts
@@ -11,7 +11,7 @@ export default defineAction({
   key: "twitter-delete-tweet",
   name: "Delete Tweet",
   description: `Remove a posted tweet. [See the documentation](${DOCS_LINK})`,
-  version: "2.0.6",
+  version: "2.0.7",
   type: "action",
   props: {
     ...common.props,

--- a/components/twitter/actions/follow-user/follow-user.ts
+++ b/components/twitter/actions/follow-user/follow-user.ts
@@ -12,7 +12,7 @@ export default defineAction({
   key: "twitter-follow-user",
   name: "Follow User",
   description: `Follow a user. [See the documentation](${DOCS_LINK})`,
-  version: "2.0.6",
+  version: "2.0.7",
   type: "action",
   props: {
     ...common.props,

--- a/components/twitter/actions/get-tweet/get-tweet.ts
+++ b/components/twitter/actions/get-tweet/get-tweet.ts
@@ -15,7 +15,7 @@ export default defineAction({
   key: "twitter-get-tweet",
   name: "Get Tweet",
   description: `Return a single tweet specified by ID. [See the documentation](${DOCS_LINK})`,
-  version: "2.0.6",
+  version: "2.0.7",
   type: "action",
   props: {
     ...common.props,

--- a/components/twitter/actions/get-user/get-user.ts
+++ b/components/twitter/actions/get-user/get-user.ts
@@ -17,7 +17,7 @@ export default defineAction({
   key: "twitter-get-user",
   name: "Get User",
   description: `Get information about a user. [See the documentation](${DOCS_LINK})`,
-  version: "2.0.6",
+  version: "2.0.7",
   type: "action",
   props: {
     ...common.props,

--- a/components/twitter/actions/like-tweet/like-tweet.ts
+++ b/components/twitter/actions/like-tweet/like-tweet.ts
@@ -11,7 +11,7 @@ export default defineAction({
   key: "twitter-like-tweet",
   name: "Like Tweet",
   description: `Like a tweet specified by its ID. [See the documentation](${DOCS_LINK})`,
-  version: "2.0.6",
+  version: "2.0.7",
   type: "action",
   props: {
     ...common.props,

--- a/components/twitter/actions/list-favorites/list-favorites.ts
+++ b/components/twitter/actions/list-favorites/list-favorites.ts
@@ -23,7 +23,7 @@ export default defineAction({
   key: "twitter-list-favorites",
   name: "List Liked Tweets",
   description: `Return the most recent tweets liked by you or the specified user. [See the documentation](${DOCS_LINK})`,
-  version: "2.0.6",
+  version: "2.0.7",
   type: "action",
   props: {
     ...common.props,

--- a/components/twitter/actions/list-followers/list-followers.ts
+++ b/components/twitter/actions/list-followers/list-followers.ts
@@ -23,7 +23,7 @@ export default defineAction({
   key: "twitter-list-followers",
   name: "List Followers",
   description: `Return a collection of user objects for users following the specified user. [See the documentation](${DOCS_LINK})`,
-  version: "2.0.6",
+  version: "2.0.7",
   type: "action",
   props: {
     ...common.props,

--- a/components/twitter/actions/list-lists/list-lists.ts
+++ b/components/twitter/actions/list-lists/list-lists.ts
@@ -23,7 +23,7 @@ export default defineAction({
   key: "twitter-list-lists",
   name: "List Lists",
   description: `Get all lists owned by a user. [See the documentation](${DOCS_LINK})`,
-  version: "2.0.6",
+  version: "2.0.7",
   type: "action",
   props: {
     ...common.props,

--- a/components/twitter/actions/list-mentions/list-mentions.ts
+++ b/components/twitter/actions/list-mentions/list-mentions.ts
@@ -23,7 +23,7 @@ export default defineAction({
   key: "twitter-list-mentions",
   name: "List Mentions",
   description: `Return the most recent mentions for the specified user. [See the documentation](${DOCS_LINK})`,
-  version: "2.0.7",
+  version: "2.0.8",
   type: "action",
   props: {
     ...common.props,

--- a/components/twitter/actions/list-user-tweets/list-user-tweets.ts
+++ b/components/twitter/actions/list-user-tweets/list-user-tweets.ts
@@ -23,7 +23,7 @@ export default defineAction({
   key: "twitter-list-user-tweets",
   name: "List User Tweets",
   description: `Return a collection of the most recent tweets posted by a user. [See the documentation](${DOCS_LINK})`,
-  version: "2.0.6",
+  version: "2.0.7",
   type: "action",
   props: {
     ...common.props,

--- a/components/twitter/actions/retweet/retweet.ts
+++ b/components/twitter/actions/retweet/retweet.ts
@@ -11,7 +11,7 @@ export default defineAction({
   key: "twitter-retweet",
   name: "Retweet a tweet",
   description: `Retweet a tweet specified by ID. [See the documentation](${DOCS_LINK})`,
-  version: "2.0.6",
+  version: "2.0.7",
   type: "action",
   props: {
     ...common.props,

--- a/components/twitter/actions/send-dm/send-dm.ts
+++ b/components/twitter/actions/send-dm/send-dm.ts
@@ -12,7 +12,7 @@ export default defineAction({
   key: "twitter-send-dm",
   name: "Send Direct Message (DM)",
   description: `Send a message to a user. [See the documentation](${DOCS_LINK})`,
-  version: "1.0.4",
+  version: "1.0.5",
   type: "action",
   props: {
     ...common.props,

--- a/components/twitter/actions/simple-search-in-list/simple-search-in-list.ts
+++ b/components/twitter/actions/simple-search-in-list/simple-search-in-list.ts
@@ -21,7 +21,7 @@ export default defineAction({
   key: "twitter-simple-search-in-list",
   name: "Search Tweets in List",
   description: `Search Tweets by text in a list. [See the documentation](${DOCS_LINK})`,
-  version: "2.0.6",
+  version: "2.0.7",
   type: "action",
   props: {
     ...common.props,

--- a/components/twitter/actions/simple-search/simple-search.ts
+++ b/components/twitter/actions/simple-search/simple-search.ts
@@ -21,7 +21,7 @@ export default defineAction({
   key: "twitter-simple-search",
   name: "Search Tweets",
   description: `Retrieve Tweets from the last seven days that match a query. [See the documentation](${DOCS_LINK})`,
-  version: "2.0.6",
+  version: "2.0.7",
   type: "action",
   props: {
     ...common.props,

--- a/components/twitter/actions/unfollow-user/unfollow-user.ts
+++ b/components/twitter/actions/unfollow-user/unfollow-user.ts
@@ -12,7 +12,7 @@ export default defineAction({
   key: "twitter-unfollow-user",
   name: "Unfollow User",
   description: `Unfollow a user. [See the documentation](${DOCS_LINK})`,
-  version: "2.0.6",
+  version: "2.0.7",
   type: "action",
   props: {
     ...common.props,

--- a/components/twitter/actions/unlike-tweet/unlike-tweet.ts
+++ b/components/twitter/actions/unlike-tweet/unlike-tweet.ts
@@ -11,7 +11,7 @@ export default defineAction({
   key: "twitter-unlike-tweet",
   name: "Unlike Tweet",
   description: `Unlike a tweet specified by its ID. [See the documentation](${DOCS_LINK})`,
-  version: "2.0.6",
+  version: "2.0.7",
   type: "action",
   props: {
     ...common.props,

--- a/components/twitter/actions/upload-media/upload-media.ts
+++ b/components/twitter/actions/upload-media/upload-media.ts
@@ -13,7 +13,7 @@ export default defineAction({
   key: "twitter-upload-media",
   name: "Upload Media",
   description: `Upload new media. [See the documentation](${DOCS_LINK})`,
-  version: "0.0.10",
+  version: "0.0.11",
   type: "action",
   props: {
     ...common.props,

--- a/components/twitter/common/appValidation.ts
+++ b/components/twitter/common/appValidation.ts
@@ -8,10 +8,10 @@ export default {
     },
   },
   async additionalProps(): Promise<any> {
-    const tweetId = "1228393702244134912";
-    const data = await this.getTweets({
+    const q = "Pipedream";
+    const data = await this.getRecentTweets({
       params: {
-        ids: tweetId,
+        query: q,
       },
       validateStatus: () => true,
     });
@@ -20,9 +20,9 @@ export default {
     return {};
   },
   methods: {
-    getTweets(args = {}) {
+    getRecentTweets(args = {}) {
       return this.app._httpRequest({
-        url: "/tweets",
+        url: "/tweets/search/recent",
         ...args,
       });
     },

--- a/components/twitter/package.json
+++ b/components/twitter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/twitter",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Pipedream Twitter Components",
   "main": "dist/app/twitter.app.mjs",
   "keywords": [

--- a/components/twitter/sources/common/base.ts
+++ b/components/twitter/sources/common/base.ts
@@ -17,7 +17,11 @@ export default {
   },
   hooks: {
     async deploy() {
-      const data = await this.getTweets({
+      const q = "Pipedream";
+      const data = await this.getRecentTweets({
+        params: {
+          query: q,
+        },
         validateStatus: () => true,
       });
       this.app.throwError(data);

--- a/components/twitter/sources/new-follower-of-user/new-follower-of-user.ts
+++ b/components/twitter/sources/new-follower-of-user/new-follower-of-user.ts
@@ -14,7 +14,7 @@ export default defineSource({
   key: "twitter-new-follower-of-user",
   name: "New Follower Received by User",
   description: `Emit new event when the specified User receives a Follower [See the documentation](${DOCS_LINK})`,
-  version: "2.0.6",
+  version: "2.0.7",
   type: "source",
   props: {
     ...common.props,

--- a/components/twitter/sources/new-list-followed/new-list-followed.ts
+++ b/components/twitter/sources/new-list-followed/new-list-followed.ts
@@ -14,7 +14,7 @@ export default defineSource({
   key: "twitter-new-list-followed",
   name: "New List Followed by User",
   description: `Emit new event when the specified User follows a List [See the documentation](${DOCS_LINK})`,
-  version: "2.0.6",
+  version: "2.0.7",
   type: "source",
   props: {
     ...common.props,

--- a/components/twitter/sources/new-mention-received-by-user/new-mention-received-by-user.ts
+++ b/components/twitter/sources/new-mention-received-by-user/new-mention-received-by-user.ts
@@ -14,7 +14,7 @@ export default defineSource({
   key: "twitter-new-mention-received-by-user",
   name: "New Mention Received by User",
   description: `Emit new event when the specified User is mentioned in a Tweet [See the documentation](${DOCS_LINK})`,
-  version: "0.0.4",
+  version: "0.0.5",
   type: "source",
   props: {
     ...common.props,

--- a/components/twitter/sources/new-message/new-message.ts
+++ b/components/twitter/sources/new-message/new-message.ts
@@ -13,7 +13,7 @@ export default defineSource({
   key: "twitter-new-message",
   name: "New Message Received",
   description: `Emit new event when a new Direct Message (DM) is received [See the documentation](${DOCS_LINK})`,
-  version: "1.0.4",
+  version: "1.0.5",
   type: "source",
   methods: {
     ...common.methods,

--- a/components/twitter/sources/new-tweet-in-list/new-tweet-in-list.ts
+++ b/components/twitter/sources/new-tweet-in-list/new-tweet-in-list.ts
@@ -13,7 +13,7 @@ export default defineSource({
   key: "twitter-new-tweet-in-list",
   name: "New Tweet Posted in List",
   description: `Emit new event when a Tweet is posted in the specified list [See the documentation](${DOCS_LINK})`,
-  version: "2.0.6",
+  version: "2.0.7",
   type: "source",
   props: {
     ...common.props,

--- a/components/twitter/sources/new-tweet-liked-by-user/new-tweet-liked-by-user.ts
+++ b/components/twitter/sources/new-tweet-liked-by-user/new-tweet-liked-by-user.ts
@@ -14,7 +14,7 @@ export default defineSource({
   key: "twitter-new-tweet-liked-by-user",
   name: "New Tweet Liked by User",
   description: `Emit new event when a Tweet is liked by the specified User [See the documentation](${DOCS_LINK})`,
-  version: "2.0.6",
+  version: "2.0.7",
   type: "source",
   props: {
     ...common.props,

--- a/components/twitter/sources/new-tweet-metrics/new-tweet-metrics.ts
+++ b/components/twitter/sources/new-tweet-metrics/new-tweet-metrics.ts
@@ -11,7 +11,7 @@ export default defineSource({
   key: "twitter-new-tweet-metrics",
   name: "New Tweet Metrics",
   description: `Emit new event when a Tweet has new metrics [See the documentation](${DOCS_LINK})`,
-  version: "1.0.4",
+  version: "1.0.5",
   type: "source",
   props: {
     ...common.props,

--- a/components/twitter/sources/new-tweet-posted-by-user/new-tweet-posted-by-user.ts
+++ b/components/twitter/sources/new-tweet-posted-by-user/new-tweet-posted-by-user.ts
@@ -14,7 +14,7 @@ export default defineSource({
   key: "twitter-new-tweet-posted-by-user",
   name: "New Tweet Posted by User",
   description: `Emit new event when the specified User posts a Tweet [See the documentation](${DOCS_LINK})`,
-  version: "2.0.6",
+  version: "2.0.7",
   type: "source",
   props: {
     ...common.props,

--- a/components/twitter/sources/new-tweet-posted-matching-query/new-tweet-posted-matching-query.ts
+++ b/components/twitter/sources/new-tweet-posted-matching-query/new-tweet-posted-matching-query.ts
@@ -13,7 +13,7 @@ export default defineSource({
   key: "twitter-new-tweet-posted-matching-query",
   name: "New Tweet Posted Matching Query",
   description: `Emit new event when a new tweet matching the specified query is posted [See the documentation](${DOCS_LINK})`,
-  version: "2.0.6",
+  version: "2.0.7",
   type: "source",
   props: {
     ...common.props,

--- a/components/twitter/sources/new-unfollower-of-user/new-unfollower-of-user.ts
+++ b/components/twitter/sources/new-unfollower-of-user/new-unfollower-of-user.ts
@@ -14,7 +14,7 @@ export default defineSource({
   key: "twitter-new-unfollower-of-user",
   name: "New Unfollower of User",
   description: `Emit new event when the specified User loses a Follower [See the documentation](${DOCS_LINK})`,
-  version: "2.0.6",
+  version: "2.0.7",
   type: "source",
   props: {
     ...common.props,

--- a/components/twitter/sources/new-user-followed/new-user-followed.ts
+++ b/components/twitter/sources/new-user-followed/new-user-followed.ts
@@ -14,7 +14,7 @@ export default defineSource({
   key: "twitter-new-user-followed",
   name: "New User Followed by User",
   description: `Emit new event when the specified User follows another User [See the documentation](${DOCS_LINK})`,
-  version: "2.0.6",
+  version: "2.0.7",
   type: "source",
   props: {
     ...common.props,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2716,6 +2716,9 @@ importers:
       lodash-es: 4.17.21
       uuid: 8.3.2
 
+  components/google_cloud_vision_api:
+    specifiers: {}
+
   components/google_contacts:
     specifiers:
       '@pipedream/platform': ^0.10.0


### PR DESCRIPTION
## WHAT
There was a bug with Twitter's sources as it the deployHook was not including a required param `ids`. 

After further investigation, I switched the request that is used for app validation from `GET_2_tweets` to `GET_2_tweets_search_recent`, as this has 4x the rate limit.

See here for rate limit details on Twitter API v2.
https://developer.twitter.com/en/docs/twitter-api/rate-limits#v2-limits-basic

## WHY
Given that we are making a call to a Twitter paid-endpoint to check whether the user on a paid plan or not, it is better to do it with a different endpoint with a limit of 60 calls / 15 min vs. 15/15min.