### PR TITLE
Node 20 Playwright and Puppeteer support

### DIFF
--- a/components/playwright/actions/get-page-html/get-page-html.mjs
+++ b/components/playwright/actions/get-page-html/get-page-html.mjs
@@ -4,7 +4,7 @@ export default {
   key: "playwright-get-page-html",
   name: "Get Page HTML",
   description: "Returns the page's html. [See the documentation](https://playwright.dev/docs/api/class-page#page-content)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     playwright,

--- a/components/playwright/actions/get-page-title/get-page-title.mjs
+++ b/components/playwright/actions/get-page-title/get-page-title.mjs
@@ -4,7 +4,7 @@ export default {
   key: "playwright-get-page-title",
   name: "Get Page Title",
   description: "Returns the page's title. [See the documentation](https://playwright.dev/docs/api/class-page#page-title)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     playwright,

--- a/components/playwright/actions/page-pdf/page-pdf.mjs
+++ b/components/playwright/actions/page-pdf/page-pdf.mjs
@@ -4,7 +4,7 @@ export default {
   key: "playwright-page-pdf",
   name: "Page PDF",
   description: "Generates a pdf of the page and store it on /tmp directory. [See the documentation](https://playwright.dev/docs/api/class-page#page-pdf)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     playwright,

--- a/components/playwright/actions/take-screenshot/take-screenshot.mjs
+++ b/components/playwright/actions/take-screenshot/take-screenshot.mjs
@@ -4,7 +4,7 @@ export default {
   key: "playwright-take-screenshot",
   name: "Take Screenshot",
   description: "Store a new screenshot file on /tmp directory. [See the documentation](https://playwright.dev/docs/screenshots)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     playwright,

--- a/components/playwright/package.json
+++ b/components/playwright/package.json
@@ -13,6 +13,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sparticuz/chromium": "121.0.0"
+    "@sparticuz/chromium": "121.0.0",
+    "playwright-core": "1.41.2"
   }
 }

--- a/components/playwright/package.json
+++ b/components/playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/playwright",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Playwright Components",
   "main": "playwright.app.mjs",
   "keywords": [
@@ -13,6 +13,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@sparticuz/chromium": "112.0.2"
+    "@sparticuz/chromium": "121.0.0"
   }
 }

--- a/components/playwright/playwright.app.mjs
+++ b/components/playwright/playwright.app.mjs
@@ -3,8 +3,8 @@ import { defineApp } from "@pipedream/types";
 // can be found here: https://www.browserstack.com/docs/automate/playwright/browsers-and-os
 // The reason why playwright is locked to an old version is because
 // the latest Puppeeter Chromium version that works in a code step is chromium@112
-import { chromium as playwright } from "playwright-core@1.32.3";
-import chromium from "@sparticuz/chromium@112";
+import { chromium as playwright } from "playwright-core@1.41.2";
+import chromium from "@sparticuz/chromium@121.0.0";
 
 export default defineApp({
   type: "app",

--- a/components/puppeteer/actions/get-html/get-html.mjs
+++ b/components/puppeteer/actions/get-html/get-html.mjs
@@ -4,7 +4,7 @@ export default {
   key: "puppeteer-get-html",
   name: "Get HTML",
   description: "Get the HTML of a webpage using Puppeteer. [See the documentation](https://pptr.dev/api/puppeteer.page.content)",
-  version: "1.0.0",
+  version: "1.0.1",
   type: "action",
   props: {
     puppeteer,

--- a/components/puppeteer/actions/get-page-title/get-page-title.mjs
+++ b/components/puppeteer/actions/get-page-title/get-page-title.mjs
@@ -4,7 +4,7 @@ export default {
   key: "puppeteer-get-page-title",
   name: "Get Page Title",
   description: "Get the title of a webpage using Puppeteer. [See the documentation](https://pptr.dev/api/puppeteer.page.title)",
-  version: "1.0.0",
+  version: "1.0.1",
   type: "action",
   props: {
     puppeteer,

--- a/components/puppeteer/actions/get-pdf/get-pdf.mjs
+++ b/components/puppeteer/actions/get-pdf/get-pdf.mjs
@@ -6,7 +6,7 @@ export default {
   key: "puppeteer-get-pdf",
   name: "Get PDF",
   description: "Generate a PDF of a page using Puppeteer. [See the documentation](https://pptr.dev/api/puppeteer.page.pdf)",
-  version: "1.0.0",
+  version: "1.0.1",
   type: "action",
   props: {
     puppeteer,

--- a/components/puppeteer/actions/screenshot-page/screenshot-page.mjs
+++ b/components/puppeteer/actions/screenshot-page/screenshot-page.mjs
@@ -7,7 +7,7 @@ export default {
   key: "puppeteer-screenshot-page",
   name: "Screenshot a Page",
   description: "Captures a screenshot of a page using Puppeteer. [See the documentation](https://pptr.dev/api/puppeteer.page.screenshot)",
-  version: "1.0.0",
+  version: "1.0.1",
   type: "action",
   props: {
     puppeteer,

--- a/components/puppeteer/package.json
+++ b/components/puppeteer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/puppeteer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Pipedream Puppeteer Components",
   "main": "puppeteer.app.mjs",
   "keywords": [
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@pipedream/platform": "^1.5.1",
-    "@sparticuz/chromium": "112.0.2",
-    "puppeteer-core": "19.8.0"
+    "@sparticuz/chromium": "121.0.0",
+    "puppeteer-core": "21.11.0"
   }
 }

--- a/components/puppeteer/puppeteer.app.mjs
+++ b/components/puppeteer/puppeteer.app.mjs
@@ -1,8 +1,8 @@
 // Table for Chromium <> Puppeteer version support here: https://pptr.dev/chromium-support
 // @note: this is locked to an old chromium version
 //  because there's an unfulfilled promise bug in later version of puppeteer-core
-import puppeteer from "puppeteer-core@19.8.0";
-import chromium from "@sparticuz/chromium@112";
+import puppeteer from "puppeteer-core@21.11.0";
+import chromium from "@sparticuz/chromium@121.0.0";
 
 export default {
   type: "app",

--- a/packages/browsers/README.md
+++ b/packages/browsers/README.md
@@ -62,4 +62,4 @@ export default defineComponent({
 * Compatibility Table for Chromium <> Puppeteer version support here: https://pptr.dev/chromium-support
 * Compatibility Table for Chromium <> Playwright versions can be found here: https://www.browserstack.com/docs/automate/playwright/browsers-and-os
 
-The reason why playwright is locked to an old version is because the latest Puppeeter Chromium version that works in a code step is chromium@112.
+The reason why playwright is locked to an old version is because the latest Puppeeter Chromium version that works in a code step is chromium@121.

--- a/packages/browsers/package.json
+++ b/packages/browsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/browsers",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "For using puppeeter or playwright in Pipedream Node.js Code Steps. Includes the prebuilt binaries and specific versions for compatiblity with Pipedream.",
   "main": "index.mjs",
   "scripts": {
@@ -16,8 +16,8 @@
   "author": "Dylan Pierce <pierce@pipedream.com> (https://dylanjpierce.com)",
   "license": "ISC",
   "dependencies": {
-    "@sparticuz/chromium": "112.0.2",
-    "puppeteer-core": "19.8.0",
-    "playwright-core": "1.32.3"
+    "@sparticuz/chromium": "121.0.0",
+    "puppeteer-core": "21.11.0",
+    "playwright-core": "1.41.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5142,8 +5142,10 @@ importers:
   components/playwright:
     specifiers:
       '@sparticuz/chromium': 121.0.0
+      playwright-core: 1.41.2
     dependencies:
       '@sparticuz/chromium': 121.0.0
+      playwright-core: 1.41.2
 
   components/plecto:
     specifiers: {}
@@ -24933,6 +24935,12 @@ packages:
     dependencies:
       find-up: 6.3.0
     dev: true
+
+  /playwright-core/1.41.2:
+    resolution: {integrity: sha512-VaTvwCA4Y8kxEe+kfm2+uUUw5Lubf38RxF7FpBxLPmGe5sdNkSg5e3ChEigaGrX7qdqT3pt2m/98LiyvU2x6CA==}
+    engines: {node: '>=16'}
+    hasBin: true
+    dev: false
 
   /please-upgrade-node/3.2.0:
     resolution: {integrity: sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5141,9 +5141,9 @@ importers:
 
   components/playwright:
     specifiers:
-      '@sparticuz/chromium': 112.0.2
+      '@sparticuz/chromium': 121.0.0
     dependencies:
-      '@sparticuz/chromium': 112.0.2
+      '@sparticuz/chromium': 121.0.0
 
   components/plecto:
     specifiers: {}
@@ -5398,12 +5398,12 @@ importers:
   components/puppeteer:
     specifiers:
       '@pipedream/platform': ^1.5.1
-      '@sparticuz/chromium': 112.0.2
-      puppeteer-core: 19.8.0
+      '@sparticuz/chromium': 121.0.0
+      puppeteer-core: 21.11.0
     dependencies:
       '@pipedream/platform': 1.5.1
-      '@sparticuz/chromium': 112.0.2
-      puppeteer-core: 19.8.0
+      '@sparticuz/chromium': 121.0.0
+      puppeteer-core: 21.11.0
 
   components/push_by_techulus:
     specifiers:
@@ -12809,6 +12809,22 @@ packages:
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
     dev: false
 
+  /@puppeteer/browsers/1.9.1:
+    resolution: {integrity: sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==}
+    engines: {node: '>=16.3.0'}
+    hasBin: true
+    dependencies:
+      debug: 4.3.4
+      extract-zip: 2.0.1
+      progress: 2.0.3
+      proxy-agent: 6.3.1
+      tar-fs: 3.0.4
+      unbzip2-stream: 1.4.3
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@putout/babel/1.2.2:
     resolution: {integrity: sha512-/gy53WNIFbITV2yEjCl6WO99emLJFeFax5bOKXT82vSGXeSQ6mjgEBXkepzaXPOEF8FI/y39lLDSAlwS5EUW+Q==}
     engines: {node: '>=16'}
@@ -14758,12 +14774,12 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@sparticuz/chromium/112.0.2:
-    resolution: {integrity: sha512-tpoY0o4vhrFE4/mXmJF3fcPLKIeKIQxbokfLgZB62rYW7KOIljbQTqCTBARzRXGN/k2+kLvhys1LVv6PWGwWNw==}
-    engines: {node: '>= 14.18.0'}
+  /@sparticuz/chromium/121.0.0:
+    resolution: {integrity: sha512-0DiRzlCJljjMKOUh0W36zeR1ibG7EZkwIG+ve8Lg0+tbCM6TWaFlHMSt/6K6Y7o7PFy3eaPoLrUvGRRYUvd81g==}
+    engines: {node: '>= 16'}
     dependencies:
-      follow-redirects: 1.15.3
-      tar-fs: 2.1.1
+      follow-redirects: 1.15.5
+      tar-fs: 3.0.4
     transitivePeerDependencies:
       - debug
     dev: false
@@ -14865,6 +14881,10 @@ packages:
   /@tootallnate/once/2.0.0:
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
+    dev: false
+
+  /@tootallnate/quickjs-emscripten/0.23.0:
+    resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
     dev: false
 
   /@tryfabric/martian/1.2.4:
@@ -16186,7 +16206,6 @@ packages:
 
   /b4a/1.6.4:
     resolution: {integrity: sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw==}
-    dev: true
 
   /babel-code-frame/6.26.0:
     resolution: {integrity: sha512-XqYMR2dfdGMW+hd0IUZ2PwK+fGeFkOxZJ0wY+JaQAHzt1Zx8LcvpiZD2NiGkEG8qx0CfkAOr5xt76d1e8vG90g==}
@@ -16336,6 +16355,11 @@ packages:
 
   /base64-js/1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+    dev: false
+
+  /basic-ftp/5.0.4:
+    resolution: {integrity: sha512-8PzkB0arJFV4jJWSGOYR+OEic6aeKMu/osRhBULN6RY0ykby6LKhbmuQ5ublvaas5BOwboah5D87nrHyuh8PPA==}
+    engines: {node: '>=10.0.0'}
     dev: false
 
   /bcrypt-pbkdf/1.0.2:
@@ -16824,6 +16848,16 @@ packages:
     dependencies:
       devtools-protocol: 0.0.1107588
       mitt: 3.0.0
+    dev: false
+
+  /chromium-bidi/0.5.8_ncn5kdxe6rasr54dhc2fl42uoa:
+    resolution: {integrity: sha512-blqh+1cEQbHBKmok3rVJkBlBxt9beKBgOsxbFgs7UJcoVbbeZ+K7+6liAsjgpc8l1Xd55cQUy14fXZdGSb4zIw==}
+    peerDependencies:
+      devtools-protocol: '*'
+    dependencies:
+      devtools-protocol: 0.0.1232444
+      mitt: 3.0.1
+      urlpattern-polyfill: 10.0.0
     dev: false
 
   /ci-info/2.0.0:
@@ -17399,6 +17433,14 @@ packages:
     transitivePeerDependencies:
       - encoding
 
+  /cross-fetch/4.0.0:
+    resolution: {integrity: sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==}
+    dependencies:
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
   /cross-spawn/6.0.5:
     resolution: {integrity: sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==}
     engines: {node: '>=4.8'}
@@ -17528,6 +17570,11 @@ packages:
   /data-uri-to-buffer/4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
+    dev: false
+
+  /data-uri-to-buffer/6.0.1:
+    resolution: {integrity: sha512-MZd3VlchQkp8rdend6vrx7MmVDJzSNTBvghvKjirLkD+WTChA3KUf0jkE68Q4UyctNqI11zZO9/x2Yx+ub5Cvg==}
+    engines: {node: '>= 14'}
     dev: false
 
   /databox/2.0.1:
@@ -17735,6 +17782,15 @@ packages:
       vm2: 3.9.19
     dev: false
 
+  /degenerator/5.0.1:
+    resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
+    engines: {node: '>= 14'}
+    dependencies:
+      ast-types: 0.13.4
+      escodegen: 2.1.0
+      esprima: 4.0.1
+    dev: false
+
   /del/5.1.0:
     resolution: {integrity: sha512-wH9xOVHnczo9jN2IW68BabcecVPxacIA3g/7z6vhSU/4stOKQzeCRK0yD0A24WiAAUJmmVpWqrERcTxnLo3AnA==}
     engines: {node: '>=8'}
@@ -17883,6 +17939,10 @@ packages:
 
   /devtools-protocol/0.0.1107588:
     resolution: {integrity: sha512-yIR+pG9x65Xko7bErCUSQaDLrO/P1p3JUzEk7JCU4DowPcGHkTGUGQapcfcLc4qj0UaALwZ+cr0riFgiqpixcg==}
+    dev: false
+
+  /devtools-protocol/0.0.1232444:
+    resolution: {integrity: sha512-pM27vqEfxSxRkTMnF+XCmxSEb6duO5R+t8A9DEEJgy4Wz2RVanje2mmj99B6A3zv2r/qGfYlOvYznUhuokizmg==}
     dev: false
 
   /dezalgo/1.0.4:
@@ -18820,7 +18880,6 @@ packages:
 
   /fast-fifo/1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
-    dev: true
 
   /fast-glob/3.3.1:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
@@ -19186,6 +19245,16 @@ packages:
         optional: true
     dependencies:
       debug: 3.2.7
+    dev: false
+
+  /follow-redirects/1.15.5:
+    resolution: {integrity: sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
     dev: false
 
   /follow-redirects/1.5.10:
@@ -19588,6 +19657,18 @@ packages:
       file-uri-to-path: 2.0.0
       fs-extra: 8.1.0
       ftp: 0.3.10
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /get-uri/6.0.2:
+    resolution: {integrity: sha512-5KLucCJobh8vBY1K07EFV4+cPZH3mrV9YeAruUseCQKHB58SGjjT2l9/eA9LD082IiuMjSlFJEcdJ27TXvbZNw==}
+    engines: {node: '>= 14'}
+    dependencies:
+      basic-ftp: 5.0.4
+      data-uri-to-buffer: 6.0.1
+      debug: 4.3.4
+      fs-extra: 8.1.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -20376,6 +20457,16 @@ packages:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /http-proxy-agent/7.0.0:
+    resolution: {integrity: sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==}
+    engines: {node: '>= 14'}
+    dependencies:
+      agent-base: 7.1.0
       debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
@@ -22546,6 +22637,11 @@ packages:
     dependencies:
       yallist: 4.0.0
 
+  /lru-cache/7.18.3:
+    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
+    engines: {node: '>=12'}
+    dev: false
+
   /lru-memoizer/2.2.0:
     resolution: {integrity: sha512-QfOZ6jNkxCcM/BkIPnFsqDhtrazLRsghi9mBwFAzol5GCvj4EkFT899Za3+QwikCg5sRX8JstioBDwOxEyzaNw==}
     dependencies:
@@ -23567,6 +23663,10 @@ packages:
     resolution: {integrity: sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==}
     dev: false
 
+  /mitt/3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+    dev: false
+
   /mkdirp-classic/0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
     dev: false
@@ -24483,11 +24583,36 @@ packages:
       - supports-color
     dev: false
 
+  /pac-proxy-agent/7.0.1:
+    resolution: {integrity: sha512-ASV8yU4LLKBAjqIPMbrgtaKIvxQri/yh2OpI+S6hVa9JRkUI3Y3NPFbfngDtY7oFtSMD3w31Xns89mDa3Feo5A==}
+    engines: {node: '>= 14'}
+    dependencies:
+      '@tootallnate/quickjs-emscripten': 0.23.0
+      agent-base: 7.1.0
+      debug: 4.3.4
+      get-uri: 6.0.2
+      http-proxy-agent: 7.0.0
+      https-proxy-agent: 7.0.2
+      pac-resolver: 7.0.0
+      socks-proxy-agent: 8.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /pac-resolver/5.0.1:
     resolution: {integrity: sha512-cy7u00ko2KVgBAjuhevqpPeHIkCIqPe1v24cydhWjmeuzaBfmUWFCZJ1iAh5TuVzVZoUzXIW7K8sMYOZ84uZ9Q==}
     engines: {node: '>= 8'}
     dependencies:
       degenerator: 3.0.4
+      ip: 1.1.8
+      netmask: 2.0.2
+    dev: false
+
+  /pac-resolver/7.0.0:
+    resolution: {integrity: sha512-Fd9lT9vJbHYRACT8OhCbZBbxr6KRSawSovFpy8nDGshaK99S/EBhVIHp9+crhxrsZOuvLpgL1n23iyPg6Rl2hg==}
+    engines: {node: '>= 14'}
+    dependencies:
+      degenerator: 5.0.1
       ip: 1.1.8
       netmask: 2.0.2
     dev: false
@@ -24997,6 +25122,11 @@ packages:
     engines: {node: '>= 0.6.0'}
     dev: false
 
+  /progress/2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+    dev: false
+
   /promise-retry/2.0.1:
     resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
     engines: {node: '>=10'}
@@ -25163,6 +25293,22 @@ packages:
       - supports-color
     dev: false
 
+  /proxy-agent/6.3.1:
+    resolution: {integrity: sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==}
+    engines: {node: '>= 14'}
+    dependencies:
+      agent-base: 7.1.0
+      debug: 4.3.4
+      http-proxy-agent: 7.0.0
+      https-proxy-agent: 7.0.2
+      lru-cache: 7.18.3
+      pac-proxy-agent: 7.0.1
+      proxy-from-env: 1.1.0
+      socks-proxy-agent: 8.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /proxy-from-env/1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
@@ -25229,6 +25375,23 @@ packages:
       tar-fs: 2.1.1
       unbzip2-stream: 1.4.3
       ws: 8.13.0
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+    dev: false
+
+  /puppeteer-core/21.11.0:
+    resolution: {integrity: sha512-ArbnyA3U5SGHokEvkfWjW+O8hOxV1RSJxOgriX/3A4xZRqixt9ZFHD0yPgZQF05Qj0oAqi8H/7stDorjoHY90Q==}
+    engines: {node: '>=16.13.2'}
+    dependencies:
+      '@puppeteer/browsers': 1.9.1
+      chromium-bidi: 0.5.8_ncn5kdxe6rasr54dhc2fl42uoa
+      cross-fetch: 4.0.0
+      debug: 4.3.4
+      devtools-protocol: 0.0.1232444
+      ws: 8.16.0
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -25474,7 +25637,6 @@ packages:
 
   /queue-tick/1.0.1:
     resolution: {integrity: sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==}
-    dev: true
 
   /queue/6.0.2:
     resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
@@ -26646,6 +26808,17 @@ packages:
       - supports-color
     dev: false
 
+  /socks-proxy-agent/8.0.2:
+    resolution: {integrity: sha512-8zuqoLv1aP/66PHF5TqwJ7Czm3Yv32urJQHrVyhD7mmA6d61Zv8cIXQYPTWwmg6qlupnPvs/QKDmfa4P/qct2g==}
+    engines: {node: '>= 14'}
+    dependencies:
+      agent-base: 7.1.0
+      debug: 4.3.4
+      socks: 2.7.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /socks/2.7.1:
     resolution: {integrity: sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==}
     engines: {node: '>= 10.13.0', npm: '>= 3.0.0'}
@@ -26879,7 +27052,6 @@ packages:
     dependencies:
       fast-fifo: 1.3.2
       queue-tick: 1.0.1
-    dev: true
 
   /strict-uri-encode/2.0.0:
     resolution: {integrity: sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==}
@@ -27330,6 +27502,14 @@ packages:
       tar-stream: 2.2.0
     dev: false
 
+  /tar-fs/3.0.4:
+    resolution: {integrity: sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==}
+    dependencies:
+      mkdirp-classic: 0.5.3
+      pump: 3.0.0
+      tar-stream: 3.1.6
+    dev: false
+
   /tar-stream/2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
@@ -27347,7 +27527,6 @@ packages:
       b4a: 1.6.4
       fast-fifo: 1.3.2
       streamx: 2.15.5
-    dev: true
 
   /tar/6.2.0:
     resolution: {integrity: sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==}
@@ -28392,6 +28571,10 @@ packages:
       qs: 6.11.2
     dev: false
 
+  /urlpattern-polyfill/10.0.0:
+    resolution: {integrity: sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==}
+    dev: false
+
   /utf7/1.0.2:
     resolution: {integrity: sha512-qQrPtYLLLl12NF4DrM9CvfkxkYI97xOb5dsnGZHE3teFr0tWiEZ9UdgMPczv24vl708cYMpe6mGXGHrotIp3Bw==}
     dependencies:
@@ -28924,6 +29107,19 @@ packages:
 
   /ws/8.14.2:
     resolution: {integrity: sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: false
+
+  /ws/8.16.0:
+    resolution: {integrity: sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1


### PR DESCRIPTION
Fix the `@pipedream/browsers` package, Puppeteer components, and Playwright components.

Pin the `playwright-core`, `puppeteer-core`, and `@sparticuz/chromium` packages to the latest versions, which are compatible with Node 20.