### PR TITLE
docs: File stores s/description/descriptor/

### DIFF
--- a/docs/docs/projects/file-stores/reference/README.md
+++ b/docs/docs/projects/file-stores/reference/README.md
@@ -14,7 +14,7 @@ The `$.files` helper is the main module to interact with the Project's File Stor
 
 ### `$.files.openDescriptor(fileDescriptor)`
 
-*Sync.* Creates a new `File` from the JSON friendly description of a file. Useful for recreating a `File` from a step export.
+*Sync.* Creates a new `File` from the JSON friendly descriptor of a file. Useful for recreating a `File` from a step export.
 
 For example, export a `File` as a step export which will render the `File` as JSON:
 
@@ -31,14 +31,14 @@ export default defineComponent({
 }
 ```
 
-Then in a downstream step recreate the `File` instance from the step export friendly _description_:
+Then in a downstream step recreate the `File` instance from the step export friendly _descriptor_:
 
 ```javascript
 // download_file
 // Opens a file downloaded from a previous step, and saves it.
 export default defineComponent({
   async run({ steps, $ }) {
-    // Convert the the description of the file back into a File instance
+    // Convert the the descriptor of the file back into a File instance
     const file = $.files.openDescriptor(steps.create_file.$return_value)
     // Download the file to the local /tmp directory
     await $.file.download('/tmp/example.png')


### PR DESCRIPTION
Appears to me that 'description' is a typo; the concept being worked with here is a descriptor ($.files.openDescriptor).

## WHAT

copilot:summary

copilot:poem


## WHY

In my reading of the docs, 'description' doesn't make sense here but 'descriptor' does.


## HOW

copilot:walkthrough
