### PR TITLE
updated incorrect height label

### DIFF
--- a/components/urlbox_io/urlbox_io.app.mjs
+++ b/components/urlbox_io/urlbox_io.app.mjs
@@ -43,7 +43,7 @@ export default {
     },
     height: {
       type: "integer",
-      label: "Width",
+      label: "Height",
       description: "Viewport height of the browser in pixels. Default is 1024.",
       optional: true,
     },


### PR DESCRIPTION
## WHAT
Changed incorrect label for height
![image](https://github.com/PipedreamHQ/pipedream/assets/99721216/a99df86a-10b3-42ca-9606-96f3c9d89cf0)

## WHY


## HOW

copilot:walkthrough
