### PR TITLE
Fix pipedream/browsers screenshot missing text

### DIFF
--- a/packages/browsers/executable-path.mjs
+++ b/packages/browsers/executable-path.mjs
@@ -1,0 +1,30 @@
+import { default as chromium } from "@sparticuz/chromium";
+
+export default async function getExecutablePath() {
+  patchEnv();
+  return await chromium.executablePath();
+}
+
+/**
+ * Patch the environment to make it compatible with @spartacuz/chromium@121.0.0 and AWS Lambda
+ * Node.js 20.x. @spartacuz/chromium extracts required files to /tmp/fonts and /tmp/al2023/lib only
+ * if the AWS_EXECUTION_ENV includes "20.x".
+ * @see
+ * {@link https://github.com/Sparticuz/chromium/blob/6e07eb0d63aadbfa60914b1460e04b9fcf75de30/source/index.ts#L327-L341 chromium/source/index.ts}
+ */
+function patchEnv() {
+  process.env["AWS_EXECUTION_ENV"] = "nodejs20.x";
+  process.env["FONTCONFIG_PATH"] = "/tmp/fonts";
+  if (process.env["LD_LIBRARY_PATH"] === undefined) {
+    process.env["LD_LIBRARY_PATH"] = "/tmp/al2023/lib";
+  } else if (
+    process.env["LD_LIBRARY_PATH"].startsWith("/tmp/al2023/lib") !== true
+  ) {
+    process.env["LD_LIBRARY_PATH"] = [
+      ...new Set([
+        "/tmp/al2023/lib",
+        ...process.env["LD_LIBRARY_PATH"].split(":"),
+      ]),
+    ].join(":");
+  }
+}

--- a/packages/browsers/index.mjs
+++ b/packages/browsers/index.mjs
@@ -1,6 +1,7 @@
 import { default as puppeteerCore } from "puppeteer-core";
 import { default as chromium } from "@sparticuz/chromium";
 import { chromium as playwrightCore } from "playwright-core";
+import getExecutablePath from "./executable-path.mjs";
 
 export const puppeteer = {
   /**
@@ -13,7 +14,7 @@ export const puppeteer = {
      */
   async launch(opts = {}) {
     const browser = await puppeteerCore.launch({
-      executablePath: await chromium.executablePath(),
+      executablePath: await getExecutablePath(),
       headless: chromium.headless,
       ignoreHTTPSErrors: true,
       defaultViewport: chromium.defaultViewport,
@@ -88,7 +89,7 @@ export const playwright = {
      */
   async launch(opts = {}) {
     const browser = await playwrightCore.launch({
-      executablePath: await chromium.executablePath(),
+      executablePath: await getExecutablePath(),
       headless: true,
       ignoreHTTPSErrors: true,
       args: [

--- a/packages/browsers/package.json
+++ b/packages/browsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/browsers",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "For using puppeeter or playwright in Pipedream Node.js Code Steps. Includes the prebuilt binaries and specific versions for compatiblity with Pipedream.",
   "main": "index.mjs",
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -989,6 +989,9 @@ importers:
   components/captaindata:
     specifiers: {}
 
+  components/carbone:
+    specifiers: {}
+
   components/cardly:
     specifiers:
       '@pipedream/platform': ^1.5.1
@@ -3637,6 +3640,9 @@ importers:
     specifiers: {}
 
   components/key_app_demo_1:
+    specifiers: {}
+
+  components/keysender:
     specifiers: {}
 
   components/kickbox:
@@ -7332,6 +7338,9 @@ importers:
     dependencies:
       '@pipedream/platform': 0.10.0
       toggl-api: 1.0.2
+
+  components/token_metrics:
+    specifiers: {}
 
   components/tolstoy:
     specifiers:


### PR DESCRIPTION
## WHAT

Fix screenshots taken using `@pipedream/browsers` lacking text.

## WHY

When I execute the following code step, the resulting screenshot has no text:

```
import { puppeteer } from '@pipedream/browsers';
export default defineComponent({
  async run() {
    const browser = await puppeteer.browser()
    const page = await browser.newPage()
    await page.goto('https://pipedream.com/')
    await page.screenshot({
      path: '/tmp/1.png'
    })
    await browser.close()
  }
})
```

The fonts required to render the text may have been missing in the runtime.

## HOW

As a workaround, set the environment variables required by `@sparticuz/chromium@121.0.0` to support the AWS Lambda Node.js 20 runtime and provide the missing [fonts](https://github.com/Sparticuz/chromium/tree/master?tab=readme-ov-file#fonts).

Since the environment variables available to a code step may be different at runtime than they are at compile time, the required env vars must be set at runtime, before they are used in [`executablePath()`](https://github.com/Sparticuz/chromium/blob/6e07eb0d63aadbfa60914b1460e04b9fcf75de30/source/index.ts#L295) to [extract the fonts](https://github.com/Sparticuz/chromium/blob/6e07eb0d63aadbfa60914b1460e04b9fcf75de30/source/index.ts#L329) and other required files.

Fixes #10437 
