### PR TITLE
Docsearch dark theme

### DIFF
--- a/docs-v2/styles/globals.css
+++ b/docs-v2/styles/globals.css
@@ -14,16 +14,34 @@ pre {
   font-size: calc(1em - 2px) !important;
 }
 
-html.dark .DocSearch-Button {
-  --docsearch-highlight-color: hsl(var(--nextra-primary-hue)var(--nextra-primary-saturation)50%/.5);
-  --docsearch-text-color: rgba(241,245,249,var(--tw-text-opacity));
-  --docsearch-muted-color: var(--tw-grayscale);
+:root {
+  --docsearch-primary-color: hsl(var(--nextra-primary-hue)var(--nextra-primary-saturation)30%) !important;
+}
+
+html.dark {
+  --docsearch-text-color: rgba(243,244,246,var(--tw-text-opacity));
+  --docsearch-container-background: rgba(10, 10, 10, 0.8);
+  --docsearch-modal-background: rgb(17,17,17);
+  --docsearch-modal-shadow: inset 1px 1px 0 0 rgb(50, 50, 50),
+    0 3px 8px 0 rgb(3, 3, 3);
+  --docsearch-searchbox-background: rgb(10, 10, 10);
+  --docsearch-searchbox-focus-background: #000;
+  --docsearch-hit-color: rgb(226, 232, 240);
+  --docsearch-hit-shadow: none;
+  --docsearch-hit-background: rgb(10, 10, 10);
   --docsearch-key-gradient: linear-gradient(
     -26.5deg,
-    0 0%,
-    0 100%
+    rgb(99, 99, 99) 0%,
+    rgb(69, 69, 69) 100%
   );
-  --docsearch-searchbox-focus-background: black;
+  --docsearch-key-shadow: inset 0 -2px 0 0 rgb(64, 64, 64),
+    inset 0 0 1px 1px rgb(81, 87, 125), 0 2px 2px 0 rgba(5, 5, 5, 0.3);
+  --docsearch-key-pressed-shadow: inset 0 -2px 0 0 #424242, inset 0 0 1px 1px #646464, 0 1px 1px 0 #0505054d;
+  --docsearch-footer-background: rgb(41, 41, 41);
+  --docsearch-footer-shadow: inset 0 1px 0 0 rgba(89, 89, 89, 0.5),
+    0 -4px 8px 0 rgba(0, 0, 0, 0.2);
+  --docsearch-logo-color: rgb(255, 255, 255);
+  --docsearch-muted-color: rgb(140, 140, 140);
 }
 
 .DocSearch input.DocSearch-Input:focus-visible {

--- a/docs-v2/theme.config.tsx
+++ b/docs-v2/theme.config.tsx
@@ -59,7 +59,6 @@ const config: DocsThemeConfig = {
   },
   search: {
     component: DocSearch,
-    // component: Docsearch,
   },
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -668,6 +668,9 @@ importers:
   components/beanstalkapp:
     specifiers: {}
 
+  components/beebole:
+    specifiers: {}
+
   components/beehiiv:
     specifiers:
       '@pipedream/platform': ^1.1.1


### PR DESCRIPTION
Make the DocSearch modal dark in Dark mode.

## Before

<img width="1100" alt="docsearch-dark-before" src="https://github.com/PipedreamHQ/pipedream/assets/19861096/d3336efc-6567-44dc-a327-530117da2acc">


## After

<img width="1100" alt="docsearch-dark" src="https://github.com/PipedreamHQ/pipedream/assets/19861096/84be2f10-36fa-4442-87e9-5ed2a9ddb2ca">
