### PR TITLE
Fix names of Salesforce New Object Updated sources

### DIFF
--- a/components/salesforce_rest_api/package.json
+++ b/components/salesforce_rest_api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/salesforce_rest_api",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Pipedream Salesforce (REST API) Components",
   "main": "salesforce_rest_api.app.mjs",
   "keywords": [

--- a/components/salesforce_rest_api/sources/record-updated-instant/record-updated-instant.mjs
+++ b/components/salesforce_rest_api/sources/record-updated-instant/record-updated-instant.mjs
@@ -5,10 +5,10 @@ import common from "../common-instant.mjs";
 export default {
   ...common,
   type: "source",
-  name: "New Updated Object (Instant, of Selectable Type)",
-  key: "salesforce_rest_api-object-updated-instant",
-  description: "Emit new event immediately after an object of arbitrary type (selected as an input parameter by the user) is updated",
-  version: "0.1.6",
+  name: "New Updated Record (Instant, of Selectable Type)",
+  key: "salesforce_rest_api-record-updated-instant",
+  description: "Emit new event immediately after a record of arbitrary type (selected as an input parameter by the user) is updated",
+  version: "0.1.7",
   methods: {
     ...common.methods,
     generateMeta(data) {

--- a/components/salesforce_rest_api/sources/record-updated/record-updated.mjs
+++ b/components/salesforce_rest_api/sources/record-updated/record-updated.mjs
@@ -5,10 +5,10 @@ import constants from "../../common/constants.mjs";
 export default {
   ...common,
   type: "source",
-  name: "New Updated Object (of Selectable Type)",
-  key: "salesforce_rest_api-object-updated",
-  description: "Emit new event (at regular intervals) when an object of arbitrary type (selected as an input parameter by the user) is updated. [See the docs](https://sforce.co/3yPSJZy) for more information.",
-  version: "0.1.11",
+  name: "New Updated Record (of Selectable Type)",
+  key: "salesforce_rest_api-record-updated",
+  description: "Emit new event (at regular intervals) when a record of arbitrary type (selected as an input parameter by the user) is updated. [See the docs](https://sforce.co/3yPSJZy) for more information.",
+  version: "0.1.12",
   hooks: {
     ...common.hooks,
     async activate() {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -775,6 +775,9 @@ importers:
   components/blue:
     specifiers: {}
 
+  components/bluesky_by_unshape:
+    specifiers: {}
+
   components/bolt_iot:
     specifiers: {}
 
@@ -2141,6 +2144,9 @@ importers:
     specifiers: {}
 
   components/enormail:
+    specifiers: {}
+
+  components/enrow:
     specifiers: {}
 
   components/envoy:
@@ -6130,6 +6136,9 @@ importers:
   components/rudderstack_transformation:
     specifiers: {}
 
+  components/ruly:
+    specifiers: {}
+
   components/rytr:
     specifiers: {}
 
@@ -6741,6 +6750,9 @@ importers:
       '@pipedream/platform': ^1.5.1
     dependencies:
       '@pipedream/platform': 1.5.1
+
+  components/sms_everyone:
+    specifiers: {}
 
   components/sms_it:
     specifiers: {}


### PR DESCRIPTION
Replace references to "object" with "record" in the names, keys, and descriptions of the Salesforce New Object Updated sources.

In Salesforce the Object is the table and Record is a row within a Table/Object.

Related: #9281