### PR TITLE
New Components - octopush_sms

### DIFF
--- a/components/octopush_sms/actions/add-contact/add-contact.mjs
+++ b/components/octopush_sms/actions/add-contact/add-contact.mjs
@@ -1,0 +1,57 @@
+import octopush from "../../octopush_sms.app.mjs";
+
+export default {
+  key: "octopush_sms-add-contact",
+  name: "Add Contact",
+  description: "Adds a new contact to a list in the Octopush SMS Gateway. [See the documentation](https://dev.octopush.com/en/sms-gateway-api-documentation/add-a-contact/)",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    octopush,
+    phone: {
+      type: "string",
+      label: "Phone Number",
+      description: "Phone number of the contact",
+    },
+    firstName: {
+      type: "string",
+      label: "First Name",
+      description: "First name of the contact",
+    },
+    lastName: {
+      type: "string",
+      label: "Last Name",
+      description: "Last name of the contact",
+    },
+    listName: {
+      type: "string",
+      label: "List Name",
+      description: "  Name of the list to which the contact should be added",
+      optional: true,
+    },
+    tag: {
+      type: "string",
+      label: "Tag Name",
+      description: "Name of the tag that will be attached to the contact",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const response = await this.octopush.createContact({
+      $,
+      data: {
+        list_name: this.listName,
+        contacts: [
+          {
+            phone_number: this.phone,
+            first_name: this.firstName,
+            last_name: this.lastName,
+          },
+        ],
+        tag_name: this.tag,
+      },
+    });
+    $.export("$summary", "Successfully created contact.");
+    return response;
+  },
+};

--- a/components/octopush_sms/actions/send-new-sms/send-new-sms.mjs
+++ b/components/octopush_sms/actions/send-new-sms/send-new-sms.mjs
@@ -1,0 +1,97 @@
+import octopush from "../../octopush_sms.app.mjs";
+
+export default {
+  key: "octopush_sms-send-new-sms",
+  name: "Send New SMS",
+  description: "Sends a new SMS using Octopush SMS. [See the documentation](https://dev.octopush.com/en/sms-gateway-api-documentation/send-sms/)",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    octopush,
+    text: {
+      type: "string",
+      label: "Text",
+      description: "The message text (from 1 to 1224 characters).",
+    },
+    phone: {
+      type: "string",
+      label: "Phone Number",
+      description: "Phone number of the recipient",
+    },
+    firstName: {
+      type: "string",
+      label: "First Name",
+      description: "First name of the recipient",
+    },
+    lastName: {
+      type: "string",
+      label: "Last Name",
+      description: "Last name of the recipient",
+    },
+    type: {
+      type: "string",
+      label: "Type",
+      description: "Campaign Type",
+      options: [
+        "sms_premium",
+        "sms_low_cost",
+      ],
+    },
+    sender: {
+      type: "string",
+      label: "Sender",
+      description: "Sender of the message (if the user allows it), 3-11 alphanumeric characters (a-zA-Z0-9)",
+      optional: true,
+    },
+    sendAt: {
+      type: "string",
+      label: "Send At",
+      description: "When you want to send the sms campaign. Format: DateTime ISO8601 (for ex: “2018-10-03T07:42:39-07:00”)",
+      optional: true,
+    },
+    purpose: {
+      type: "string",
+      label: "Purpose",
+      description: "Campaign purpose",
+      options: [
+        "alert",
+        "wholesale",
+      ],
+      optional: true,
+    },
+    withReplies: {
+      type: "boolean",
+      label: "With Replies",
+      description: "Set to `true` to get back recipient replies",
+      optional: true,
+    },
+    simulationMode: {
+      type: "boolean",
+      label: "Simulation Mode",
+      description: "If this value is `true`, your request will be simulated, and you will receive a fake result",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const response = await this.octopush.sendSMS({
+      $,
+      data: {
+        text: this.text,
+        recipients: [
+          {
+            phone_number: this.phone,
+            first_name: this.firstName,
+            last_name: this.lastName,
+          },
+        ],
+        type: this.type,
+        send_at: this.sendAt,
+        purpose: this.purpose,
+        with_replies: this.withReplies,
+        simulation_mode: this.simulationMode,
+      },
+    });
+    $.export("$summary", "Successfully send new SMS.");
+    return response;
+  },
+};

--- a/components/octopush_sms/octopush_sms.app.mjs
+++ b/components/octopush_sms/octopush_sms.app.mjs
@@ -1,11 +1,44 @@
+import { axios } from "@pipedream/platform";
+
 export default {
   type: "app",
   app: "octopush_sms",
   propDefinitions: {},
   methods: {
-    // this.$auth contains connected account data
-    authKeys() {
-      console.log(Object.keys(this.$auth));
+    _baseUrl() {
+      return "https://api.octopush.com/v1/public";
+    },
+    _headers() {
+      return {
+        "Content-Type": "application/json",
+        "api-login": `${this.$auth.api_login}`,
+        "api-key": `${this.$auth.api_key}`,
+      };
+    },
+    _makeRequest({
+      $ = this,
+      path,
+      ...opts
+    }) {
+      return axios($, {
+        url: `${this._baseUrl()}${path}`,
+        headers: this._headers(),
+        ...opts,
+      });
+    },
+    createContact(opts = {}) {
+      return this._makeRequest({
+        method: "POST",
+        path: "/contact/create",
+        ...opts,
+      });
+    },
+    sendSMS(opts = {}) {
+      return this._makeRequest({
+        method: "POST",
+        path: "/sms-campaign/send",
+        ...opts,
+      });
     },
   },
 };

--- a/components/octopush_sms/package.json
+++ b/components/octopush_sms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/octopush_sms",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Pipedream Octopush SMS Components",
   "main": "octopush_sms.app.mjs",
   "keywords": [
@@ -11,5 +11,8 @@
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^1.6.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -412,6 +412,9 @@ importers:
   components/anthropic:
     specifiers: {}
 
+  components/anymail_finder:
+    specifiers: {}
+
   components/apex_27:
     specifiers: {}
 
@@ -1756,6 +1759,9 @@ importers:
   components/desktime:
     specifiers: {}
 
+  components/detectify:
+    specifiers: {}
+
   components/detrack:
     specifiers:
       '@pipedream/platform': ^1.1.0
@@ -1917,6 +1923,9 @@ importers:
     dependencies:
       '@pipedream/platform': 1.5.1
 
+  components/docmosis:
+    specifiers: {}
+
   components/docraptor:
     specifiers: {}
 
@@ -1931,6 +1940,9 @@ importers:
       '@pipedream/platform': ^1.5.1
     dependencies:
       '@pipedream/platform': 1.5.1
+
+  components/docugenerate:
+    specifiers: {}
 
   components/document360:
     specifiers:
@@ -2060,6 +2072,9 @@ importers:
       '@pipedream/platform': ^1.5.1
     dependencies:
       '@pipedream/platform': 1.5.1
+
+  components/droxy:
+    specifiers: {}
 
   components/dub:
     specifiers:
@@ -2253,6 +2268,9 @@ importers:
       lodash: 4.17.21
       timezones-list: 3.0.2
 
+  components/eventee:
+    specifiers: {}
+
   components/eversign:
     specifiers:
       '@pipedream/platform': ^1.1.1
@@ -2349,6 +2367,9 @@ importers:
     specifiers: {}
 
   components/faire:
+    specifiers: {}
+
+  components/faktoora:
     specifiers: {}
 
   components/faraday:
@@ -2484,6 +2505,9 @@ importers:
     specifiers: {}
 
   components/focuster:
+    specifiers: {}
+
+  components/fogbugz:
     specifiers: {}
 
   components/follow_up_boss:
@@ -2787,6 +2811,9 @@ importers:
       '@pipedream/platform': ^1.5.1
     dependencies:
       '@pipedream/platform': 1.5.1
+
+  components/glide:
+    specifiers: {}
 
   components/gmail:
     specifiers:
@@ -3339,6 +3366,9 @@ importers:
     dependencies:
       '@pipedream/platform': 1.5.1
 
+  components/hr_partner:
+    specifiers: {}
+
   components/html_css_to_image:
     specifiers:
       '@pipedream/platform': ^1.1.0
@@ -3422,6 +3452,9 @@ importers:
       lodash.pickby: 4.6.0
 
   components/icontact:
+    specifiers: {}
+
+  components/icypeas:
     specifiers: {}
 
   components/idealpostcodes:
@@ -3902,6 +3935,9 @@ importers:
       '@pipedream/platform': ^1.2.1
     dependencies:
       '@pipedream/platform': 1.5.1
+
+  components/lastpass:
+    specifiers: {}
 
   components/leadboxer:
     specifiers: {}
@@ -4642,6 +4678,9 @@ importers:
   components/mozilla_observatory:
     specifiers: {}
 
+  components/mumara:
+    specifiers: {}
+
   components/murlist:
     specifiers: {}
 
@@ -4740,6 +4779,9 @@ importers:
       '@pipedream/platform': ^1.5.1
     dependencies:
       '@pipedream/platform': 1.5.1
+
+  components/netatmo:
+    specifiers: {}
 
   components/nethunt_crm:
     specifiers:
@@ -4937,6 +4979,12 @@ importers:
 
   components/octopus_deploy:
     specifiers: {}
+
+  components/octopush_sms:
+    specifiers:
+      '@pipedream/platform': ^1.6.0
+    dependencies:
+      '@pipedream/platform': 1.6.0
 
   components/oksign:
     specifiers: {}
@@ -5699,6 +5747,9 @@ importers:
     dependencies:
       '@pipedream/platform': 1.5.1
 
+  components/proofly:
+    specifiers: {}
+
   components/propelauth:
     specifiers: {}
 
@@ -5865,6 +5916,9 @@ importers:
     specifiers: {}
 
   components/rat_genome_database:
+    specifiers: {}
+
+  components/ratecard:
     specifiers: {}
 
   components/raven_tools:
@@ -6123,6 +6177,9 @@ importers:
   components/reviews_io:
     specifiers: {}
 
+  components/reward_sciences:
+    specifiers: {}
+
   components/rewardful:
     specifiers: {}
 
@@ -6294,6 +6351,9 @@ importers:
     specifiers: {}
 
   components/samcart:
+    specifiers: {}
+
+  components/sapling:
     specifiers: {}
 
   components/sapling_ai:
@@ -6487,6 +6547,9 @@ importers:
       '@pipedream/platform': ^1.2.0
     dependencies:
       '@pipedream/platform': 1.5.1
+
+  components/sendy:
+    specifiers: {}
 
   components/senta:
     specifiers:
@@ -6800,6 +6863,9 @@ importers:
   components/small_improvements:
     specifiers: {}
 
+  components/smartengage:
+    specifiers: {}
+
   components/smartproxy:
     specifiers: {}
 
@@ -6852,6 +6918,9 @@ importers:
     specifiers: {}
 
   components/sms_magic:
+    specifiers: {}
+
+  components/sms_partner:
     specifiers: {}
 
   components/smsapi:
@@ -7042,6 +7111,9 @@ importers:
       he: 1.2.0
       lodash: 4.17.21
 
+  components/stackshare_api:
+    specifiers: {}
+
   components/stammer_ai:
     specifiers:
       '@pipedream/platform': ^1.6.0
@@ -7117,6 +7189,9 @@ importers:
       '@pipedream/platform': ^1.5.1
     dependencies:
       '@pipedream/platform': 1.5.1
+
+  components/streamwish:
+    specifiers: {}
 
   components/stripe:
     specifiers:
@@ -7510,6 +7585,9 @@ importers:
     dependencies:
       '@pipedream/platform': 1.5.1
 
+  components/time_doctor:
+    specifiers: {}
+
   components/time_tracker_by_ebillity:
     specifiers: {}
 
@@ -7657,6 +7735,9 @@ importers:
       '@pipedream/platform': 1.5.1
       crypto-js: 4.1.1
 
+  components/trestle:
+    specifiers: {}
+
   components/triggercmd:
     specifiers: {}
 
@@ -7797,6 +7878,9 @@ importers:
     dependencies:
       '@pipedream/platform': 1.5.1
       moment: 2.29.4
+
+  components/unione:
+    specifiers: {}
 
   components/unisender:
     specifiers:
@@ -8022,6 +8106,9 @@ importers:
       xml2js: 0.6.2
 
   components/vivifyscrum:
+    specifiers: {}
+
+  components/vivocalendar:
     specifiers: {}
 
   components/vk:
@@ -8253,6 +8340,9 @@ importers:
       '@pipedream/platform': ^1.5.1
     dependencies:
       '@pipedream/platform': 1.5.1
+
+  components/wonderchat:
+    specifiers: {}
 
   components/woocommerce:
     specifiers:


### PR DESCRIPTION
Resolves #10757 

Note: I combined `send-premium-alert-sms` and `send-new-sms` into one because the endpoint to send an sms allows the user to select type="sms_premium" and purpose="alert".
I skipped the source `new-inbound-sms` because I couldn't find any endpoints to support it, and webhooks in Octopush must be setup within the UI.