### PR TITLE
Adding canoncial fix for the homepage

### DIFF
--- a/docs-v2/theme.config.tsx
+++ b/docs-v2/theme.config.tsx
@@ -46,7 +46,7 @@ const config: DocsThemeConfig = {
     return {
       titleTemplate: "%s - Pipedream",
       description: "Workflow automation for developers",
-      canonical: `https://pipedream.com/docs${route}`,
+      canonical: `https://pipedream.com/docs${ route === '/' ? '' : route}`,
       additionalLinkTags: [
         {
           href: "/docs/favicon.ico",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -412,6 +412,9 @@ importers:
   components/anthropic:
     specifiers: {}
 
+  components/anyflow:
+    specifiers: {}
+
   components/anymail_finder:
     specifiers: {}
 
@@ -931,6 +934,9 @@ importers:
   components/builderall_mailingboss:
     specifiers: {}
 
+  components/builtwith:
+    specifiers: {}
+
   components/bulkgate:
     specifiers:
       '@pipedream/platform': ^1.3.0
@@ -1124,6 +1130,9 @@ importers:
       '@pipedream/platform': 1.6.0
 
   components/chatfuel_dashboard_api_:
+    specifiers: {}
+
+  components/chatpdf:
     specifiers: {}
 
   components/chatrace:
@@ -1736,6 +1745,9 @@ importers:
   components/deepl:
     specifiers: {}
 
+  components/defastra:
+    specifiers: {}
+
   components/degreed:
     specifiers: {}
 
@@ -1819,6 +1831,9 @@ importers:
       '@types/node': 17.0.45
 
   components/dictionary_api:
+    specifiers: {}
+
+  components/diffbot:
     specifiers: {}
 
   components/diffchecker:
@@ -2003,6 +2018,9 @@ importers:
   components/dots_:
     specifiers: {}
 
+  components/dpd2:
+    specifiers: {}
+
   components/drata:
     specifiers:
       '@pipedream/platform': ^1.4.1
@@ -2110,6 +2128,9 @@ importers:
     dependencies:
       '@pipedream/platform': 1.5.1
       uuid: 9.0.1
+
+  components/easypost:
+    specifiers: {}
 
   components/easyship:
     specifiers: {}
@@ -3153,6 +3174,9 @@ importers:
     specifiers: {}
 
   components/graphhopper:
+    specifiers: {}
+
+  components/graphy:
     specifiers: {}
 
   components/gravity_forms:
@@ -4205,6 +4229,9 @@ importers:
       '@pipedream/platform': 1.5.1
       '@pipedream/types': 0.1.6
 
+  components/mailcheck:
+    specifiers: {}
+
   components/mailchimp:
     specifiers:
       '@mailchimp/mailchimp_marketing': ^3.0.74
@@ -5079,6 +5106,9 @@ importers:
       node-fetch: 2.7.0
       ongage: 1.1.7_node-fetch@2.7.0
 
+  components/onstrategy:
+    specifiers: {}
+
   components/ontraport:
     specifiers:
       '@pipedream/platform': ^1.3.0
@@ -5217,11 +5247,17 @@ importers:
   components/paperform:
     specifiers: {}
 
+  components/papertrail:
+    specifiers: {}
+
   components/papyrs:
     specifiers:
       '@pipedream/platform': ^1.2.1
     dependencies:
       '@pipedream/platform': 1.5.1
+
+  components/parsehub:
+    specifiers: {}
 
   components/parseur:
     specifiers:
@@ -5361,6 +5397,9 @@ importers:
       '@pipedream/platform': ^1.5.1
     dependencies:
       '@pipedream/platform': 1.5.1
+
+  components/php_point_of_sale:
+    specifiers: {}
 
   components/phrase:
     specifiers:
@@ -5774,6 +5813,9 @@ importers:
     dependencies:
       '@pipedream/platform': 1.6.0
 
+  components/pulsetic:
+    specifiers: {}
+
   components/puppeteer:
     specifiers:
       '@pipedream/platform': ^1.5.1
@@ -5936,6 +5978,9 @@ importers:
     specifiers: {}
 
   components/rd_station_crm:
+    specifiers: {}
+
+  components/reachmail:
     specifiers: {}
 
   components/readwise:
@@ -6245,6 +6290,9 @@ importers:
       graphql-request: 5.2.0_graphql@16.8.1
       moment: 2.29.4
 
+  components/rollbar:
+    specifiers: {}
+
   components/route4me:
     specifiers: {}
 
@@ -6503,6 +6551,9 @@ importers:
   components/sendblue:
     specifiers: {}
 
+  components/sendcloud:
+    specifiers: {}
+
   components/sender:
     specifiers: {}
 
@@ -6534,6 +6585,9 @@ importers:
     specifiers: {}
 
   components/sendle:
+    specifiers: {}
+
+  components/sendloop:
     specifiers: {}
 
   components/sendoso:
@@ -6607,6 +6661,9 @@ importers:
       '@pipedream/platform': ^1.5.1
     dependencies:
       '@pipedream/platform': 1.5.1
+
+  components/sevdesk:
+    specifiers: {}
 
   components/seven:
     specifiers: {}
@@ -6778,6 +6835,9 @@ importers:
     specifiers: {}
 
   components/signwell:
+    specifiers: {}
+
+  components/similarweb_digitalrank_api:
     specifiers: {}
 
   components/simple_analytics:
@@ -7376,6 +7436,9 @@ importers:
   components/tave:
     specifiers: {}
 
+  components/tawk_to:
+    specifiers: {}
+
   components/taxjar:
     specifiers: {}
 
@@ -7465,6 +7528,9 @@ importers:
       '@pipedream/platform': ^1.6.0
     dependencies:
       '@pipedream/platform': 1.6.0
+
+  components/tento8:
+    specifiers: {}
 
   components/terminus_app:
     specifiers: {}
@@ -8455,6 +8521,9 @@ importers:
       '@pipedream/platform': ^1.4.1
     dependencies:
       '@pipedream/platform': 1.5.1
+
+  components/wuf:
+    specifiers: {}
 
   components/wufoo:
     specifiers:


### PR DESCRIPTION
## WHAT

Update the v2 docs to use the correct canoncial URL for the homepage.

## WHY

The current canonical on the homepage is incorrectly including the trailing slash, which breaks the Algolia crawler.

This update removes the trailing slash only on the homepage, which should resolve the Algolia crawler's confusion.




![CleanShot 2024-03-06 at 10 27 00@2x](https://github.com/PipedreamHQ/pipedream/assets/2694734/50b279c9-bc9a-463a-af2e-84724249b945)


## HOW

Only changes the SEO meta on the homepage to _not_ include the trailing slash on the URL.
