### PR TITLE
Expose SQL proxy definitions

### DIFF
--- a/platform/dist/index.js
+++ b/platform/dist/index.js
@@ -10,6 +10,8 @@ Object.defineProperty(exports, "cloneSafe", { enumerable: true, get: function ()
 Object.defineProperty(exports, "jsonStringifySafe", { enumerable: true, get: function () { return utils_1.jsonStringifySafe; } });
 var errors_1 = require("./errors");
 Object.defineProperty(exports, "ConfigurationError", { enumerable: true, get: function () { return errors_1.ConfigurationError; } });
+var sql_proxy_1 = require("./sql-proxy");
+Object.defineProperty(exports, "sqlProxy", { enumerable: true, get: function () { return sql_proxy_1.default; } });
 var constants_1 = require("./constants");
 Object.defineProperty(exports, "DEFAULT_POLLING_SOURCE_TIMER_INTERVAL", { enumerable: true, get: function () { return constants_1.DEFAULT_POLLING_SOURCE_TIMER_INTERVAL; } });
 const SendPayload = t.union([

--- a/platform/lib/index.ts
+++ b/platform/lib/index.ts
@@ -15,6 +15,10 @@ export {
 } from "./errors";
 
 export {
+  default as sqlProxy,
+} from "./sql-proxy";
+
+export {
   DEFAULT_POLLING_SOURCE_TIMER_INTERVAL,
 } from "./constants";
 

--- a/platform/package.json
+++ b/platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/platform",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Pipedream platform globals (typing and runtime type checking)",
   "homepage": "https://pipedream.com",
   "main": "dist/index.js",


### PR DESCRIPTION
## WHY
We already have the SQL proxy types and method definitions in the platform code, but now we have to expose them to consumers of the `@pipedream/platform` package so that they can be used by components if needed.