### PR TITLE
Fix calls to unbounded MySQL app methods

### DIFF
--- a/components/mysql/actions/create-row/create-row.mjs
+++ b/components/mysql/actions/create-row/create-row.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Create Row",
   description: "Adds a new row. [See the docs here](https://dev.mysql.com/doc/refman/8.0/en/insert.html)",
   type: "action",
-  version: "2.0.0",
+  version: "2.0.1",
   props: {
     mysql,
     table: {

--- a/components/mysql/actions/delete-row/delete-row.mjs
+++ b/components/mysql/actions/delete-row/delete-row.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Delete Row",
   description: "Delete an existing row. [See the docs here](https://dev.mysql.com/doc/refman/8.0/en/delete.html)",
   type: "action",
-  version: "2.0.0",
+  version: "2.0.1",
   props: {
     mysql,
     table: {

--- a/components/mysql/actions/execute-query/execute-query.mjs
+++ b/components/mysql/actions/execute-query/execute-query.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Execute Query",
   description: "Find row(s) via a custom query. [See the docs here](https://dev.mysql.com/doc/refman/8.0/en/select.html)",
   type: "action",
-  version: "2.0.0",
+  version: "2.0.1",
   props: {
     mysql,
     table: {

--- a/components/mysql/actions/execute-raw-query/execute-raw-query.mjs
+++ b/components/mysql/actions/execute-raw-query/execute-raw-query.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Execute Raw Query",
   description: "Find row(s) via a custom raw query. [See the documentation](https://dev.mysql.com/doc/refman/8.0/en/select.html)",
   type: "action",
-  version: "1.0.0",
+  version: "1.0.1",
   props: {
     mysql,
     sql: {

--- a/components/mysql/actions/execute-stored-procedure/execute-stored-procedure.mjs
+++ b/components/mysql/actions/execute-stored-procedure/execute-stored-procedure.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Execute Stored Procedure",
   description: "Execute Stored Procedure. [See the docs here](https://dev.mysql.com/doc/refman/8.0/en/stored-programs-defining.html)",
   type: "action",
-  version: "2.0.0",
+  version: "2.0.1",
   props: {
     mysql,
     storedProcedure: {

--- a/components/mysql/actions/find-row/find-row.mjs
+++ b/components/mysql/actions/find-row/find-row.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Find Row",
   description: "Finds a row in a table via a lookup column. [See the docs here](https://dev.mysql.com/doc/refman/8.0/en/select.html)",
   type: "action",
-  version: "2.0.0",
+  version: "2.0.1",
   props: {
     mysql,
     table: {

--- a/components/mysql/actions/update-row/update-row.mjs
+++ b/components/mysql/actions/update-row/update-row.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Update Row",
   description: "Updates an existing row. [See the docs here](https://dev.mysql.com/doc/refman/8.0/en/update.html)",
   type: "action",
-  version: "2.0.0",
+  version: "2.0.1",
   props: {
     mysql,
     table: {

--- a/components/mysql/mysql.app.mjs
+++ b/components/mysql/mysql.app.mjs
@@ -141,17 +141,12 @@ export default {
      */
     getClientConfiguration() {
       const {
-        getSslConfig,
-        $auth: auth,
-      } = this;
-
-      const {
         host,
         port,
         username: user,
         password,
         database,
-      } = auth;
+      } = this.$auth;
 
       return {
         host,
@@ -159,7 +154,7 @@ export default {
         user,
         password,
         database,
-        ssl: getSslConfig(),
+        ssl: this.getSslConfig(),
       };
     },
     /**

--- a/components/mysql/package.json
+++ b/components/mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/mysql",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Pipedream MySQL Components",
   "main": "mysql.app.mjs",
   "keywords": [

--- a/components/mysql/sources/new-column/new-column.mjs
+++ b/components/mysql/sources/new-column/new-column.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Column",
   description: "Emit new event when you add a new column to a table. [See the docs here](https://dev.mysql.com/doc/refman/8.0/en/show-columns.html)",
   type: "source",
-  version: "2.0.0",
+  version: "2.0.1",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/mysql/sources/new-or-updated-row/new-or-updated-row.mjs
+++ b/components/mysql/sources/new-or-updated-row/new-or-updated-row.mjs
@@ -9,7 +9,7 @@ export default {
   name: "New or Updated Row",
   description: "Emit new event when you add or modify a new row in a table. [See the docs here](https://dev.mysql.com/doc/refman/8.0/en/select.html)",
   type: "source",
-  version: "2.0.0",
+  version: "2.0.1",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/mysql/sources/new-row-custom-query/new-row-custom-query.mjs
+++ b/components/mysql/sources/new-row-custom-query/new-row-custom-query.mjs
@@ -8,7 +8,7 @@ export default {
   key: "mysql-new-row-custom-query",
   name: "New Row (Custom Query)",
   description: "Emit new event when new rows are returned from a custom query. [See the docs here](https://dev.mysql.com/doc/refman/8.0/en/select.html)",
-  version: "2.0.0",
+  version: "2.0.1",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/mysql/sources/new-row/new-row.mjs
+++ b/components/mysql/sources/new-row/new-row.mjs
@@ -8,7 +8,7 @@ export default {
   name: "New Row",
   description: "Emit new event when you add a new row to a table. [See the docs here](https://dev.mysql.com/doc/refman/8.0/en/select.html)",
   type: "source",
-  version: "2.0.0",
+  version: "2.0.1",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/mysql/sources/new-table/new-table.mjs
+++ b/components/mysql/sources/new-table/new-table.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Table",
   description: "Emit new event when a new table is added to a database. [See the docs here](https://dev.mysql.com/doc/refman/8.0/en/select.html)",
   type: "source",
-  version: "2.0.0",
+  version: "2.0.1",
   dedupe: "unique",
   props: {
     ...common.props,


### PR DESCRIPTION
## WHY

Recently started getting issues when configuring MySQL clients in the SQL proxy:
```
Cannot read properties of undefined (reading '$auth')
```

Traced it back to an unbounded method call:
```
TypeError: Cannot read properties of undefined (reading '$auth')
    at getSslConfig (file:///backend/node_modules/@pipedream/mysql/mysql.app.mjs:107:16)
    at Object.getClientConfiguration (file:///backend/node_modules/@pipedream/mysql/mysql.app.mjs:162:14)
    at getClientConfiguration (file:///backend/lib/query_iterator.mjs:57:5)
```