### PR TITLE
Remove DOM type definitions from types package

### DIFF
--- a/types/package-lock.json
+++ b/types/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pipedream/types",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pipedream/types",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "typescript": "^5.2.2"

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/types",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream TypeScript types",
   "keywords": [
     "pipedream",

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -115,13 +115,13 @@ export interface IApi {
 
 export interface IFile {
   delete(): Promise<void>;
-  createReadStream(): Promise<ReadableStream<any>>;
-  createWriteStream(contentType?: string, contentLength?: number): Promise<WritableStream<any>>;
+  createReadStream(): Promise<NodeJS.ReadableStream>;
+  createWriteStream(contentType?: string, contentLength?: number): Promise<NodeJS.WritableStream>;
   toEncodedString(encoding?: string, start?: number, end?: number): Promise<string>;
   toUrl(): Promise<string>;
   toFile(localFilePath: string): Promise<void>;
   toBuffer(): Promise<Buffer>;
-  fromReadableStream(readableStream: ReadableStream<any>, contentType?: string, contentSize?: number): Promise<IFile>;
+  fromReadableStream(readableStream: NodeJS.ReadableStream, contentType?: string, contentSize?: number): Promise<IFile>;
   fromFile(localFilePath: string, contentType?: string): Promise<IFile>;
   fromUrl(url: string, options?: any): Promise<IFile>;
   toJSON(): any;

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -8,7 +8,7 @@
     "forceConsistentCasingInFileNames": true,         /* Ensure that casing is correct in imports. */
     "noImplicitAny": true,                            /* Enable error reporting when a type hasn't been explicity specified. */
     "noImplicitThis": true,                           /* Enable error reporting when `this` is given the type `any`. */
-    "lib": ["es6", "dom"],
+    "lib": ["es6"],
     "strictFunctionTypes": true,
     "strictNullChecks": true,
     "baseUrl": ".",


### PR DESCRIPTION
## WHAT

Removes the DOM lib from the TS config for the `@pipedream/types` package and replaces DOM types with corresponding Node.js types.

## WHY

This program is not intended to run in a browser environment, so it and its dependents should not require DOM types.

For example, attempting to compile the `mattermost` TypeScript project without the `"DOM"` lib produces the following [error](https://github.com/PipedreamHQ/pipedream/actions/runs/8192186466/job/22403145536):
```
> npx tsc --build components/mattermost/
node_modules/.pnpm/@pipedream+types@0.2.0/node_modules/@pipedream/types/dist/index.d.ts:99:33 - error TS2304: Cannot find name 'ReadableStream'.

99     createReadStream(): Promise<ReadableStream<any>>;
```

With the changes in this PR, `mattermost` compiles successfully:
```
> cd components/mattermost
> npm install ../../types
> npx tsc --build
TSFILE: /Users/jacobpines/Documents/pipedream/pipedream/components/mattermost/dist/actions/post-message/post-message.js
TSFILE: /Users/jacobpines/Documents/pipedream/pipedream/components/mattermost/dist/actions/post-message/post-message.d.ts
TSFILE: /Users/jacobpines/Documents/pipedream/pipedream/components/mattermost/dist/app/mattermost.app.js
TSFILE: /Users/jacobpines/Documents/pipedream/pipedream/components/mattermost/dist/app/mattermost.app.d.ts
TSFILE: /Users/jacobpines/Documents/pipedream/pipedream/components/mattermost/dist/common/types.js
TSFILE: /Users/jacobpines/Documents/pipedream/pipedream/components/mattermost/dist/common/types.d.ts
TSFILE: /Users/jacobpines/Documents/pipedream/pipedream/components/mattermost/dist/sources/new-message-sent-in-channel/new-message-sent-in-channel.js
TSFILE: /Users/jacobpines/Documents/pipedream/pipedream/components/mattermost/dist/sources/new-message-sent-in-channel/new-message-sent-in-channel.d.ts
TSFILE: /Users/jacobpines/Documents/pipedream/pipedream/components/mattermost/dist/tsconfig.tsbuildinfo
```