### PR TITLE
Republish Piggy & Mattermost components

### DIFF
--- a/components/mattermost/actions/post-message/post-message.ts
+++ b/components/mattermost/actions/post-message/post-message.ts
@@ -9,7 +9,7 @@ export default defineAction({
   description:
     "Create a new post in a channel [See docs here](https://api.mattermost.com/#tag/posts/operation/CreatePost)",
   key: "mattermost-post-message",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     mattermost,

--- a/components/mattermost/package.json
+++ b/components/mattermost/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/mattermost",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Mattermost Components",
   "main": "dist/app/mattermost.app.mjs",
   "keywords": [
@@ -17,6 +17,6 @@
   },
   "dependencies": {
     "@pipedream/platform": "^1.6.0",
-    "@pipedream/types": "^0.2.0"
+    "@pipedream/types": "^0.3.0"
   }
 }

--- a/components/mattermost/sources/new-message-sent-in-channel/new-message-sent-in-channel.ts
+++ b/components/mattermost/sources/new-message-sent-in-channel/new-message-sent-in-channel.ts
@@ -8,7 +8,7 @@ export default defineSource({
   description:
     "Emit new event when a message matching the requirements is sent in a channel. [See the documentation](https://api.mattermost.com/#tag/webhooks/operation/CreateOutgoingWebhook)",
   key: "mattermost-new-message-sent-in-channel",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/piggy/actions/find-or-create-contact/find-or-create-contact.mjs
+++ b/components/piggy/actions/find-or-create-contact/find-or-create-contact.mjs
@@ -2,7 +2,7 @@ import app from "../../piggy.app.mjs";
 
 export default {
   name: "Find Or Create Contact",
-  version: "0.0.1",
+  version: "0.0.2",
   key: "piggy-find-or-create-contact",
   description: "Find or create a contact. [See the documentation](https://docs.piggy.eu/v3/oauth/contacts#:~:text=Possible%20errors-,Find%20or%20Create%20Contact,-Find%20Contact%20by)",
   type: "action",

--- a/components/piggy/package.json
+++ b/components/piggy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/piggy",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Piggy Components",
   "main": "piggy.app.mjs",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4784,10 +4784,10 @@ importers:
   components/mattermost:
     specifiers:
       '@pipedream/platform': ^1.6.0
-      '@pipedream/types': ^0.2.0
+      '@pipedream/types': ^0.3.0
     dependencies:
       '@pipedream/platform': 1.6.0
-      '@pipedream/types': 0.2.0
+      '@pipedream/types': 0.3.0
 
   components/mautic:
     specifiers:
@@ -14205,8 +14205,8 @@ packages:
     dependencies:
       typescript: 4.9.5
 
-  /@pipedream/types/0.2.0:
-    resolution: {integrity: sha512-n+yf9InY0pNqlcU7Ckn99Dp+LIWLyW6klh1jDTss9qEHF+Z6HlasXksU6y371o1c3qavaHtiDTmyU9TJTO99rw==}
+  /@pipedream/types/0.3.0:
+    resolution: {integrity: sha512-cG71shIBMVN9a7vCJxIiIuawwTV+brw4ZwS0QJs7cCFiQxNXQzMCUrN/Q4PjbXOzHvCuX8P3+qskYTsDQ6Uj+w==}
     dependencies:
       typescript: 5.3.3
     dev: false


### PR DESCRIPTION
## WHAT

Republish the following components which aren't in the Pipedream registry:

- Piggy **Find Or Create Contact**
- Mattermost **New Message Sent in Channel**
- Mattermost **Post Message** (latest version failed to publish)

## WHY

- Piggy **Find or Create Contact** is [missing](https://pipedream.com/apps/piggy#popular-piggy-actions) from the Pipedream registry.
- Mattermost **New Message Sent in Channel** is [missing](https://pipedream.com/apps/mattermost#popular-mattermost-actions) from the Pipedream registry.
- Mattermost **Post Message** had version "0.0.2" in the repo and only ["0.0.1" in the registry](https://pipedream.com/apps/mattermost/actions/post-message#details).
- The Mattermost package [previously](https://github.com/PipedreamHQ/pipedream/commit/86a2d911f335aa6d6fc64e7cd28aa0fbf8262a85#diff-daf577c1277127015573926f20031027063a5fd4ead6468e5e89202aed5bb6cd) failed to compile to JavaScript since it doesn't include "dom" type definitions via `tsconfig.json`, while its `@pipedream/types` dependency used some "dom" types.

## HOW

- Update Mattermost's `@pipedream/types` package dependency to its latest version, which [removes its dependency on "dom" types](https://github.com/PipedreamHQ/pipedream/commit/f424412a7383f6ac3b98b4355194c1207139a5b7). This should allow the Mattermost components to be compiled successfully.
- Bump component and package versions.