### PR TITLE
[Google Drive] Generate a new channelID when renewing subscription

### DIFF
--- a/components/google_drive/actions/add-file-sharing-preference/add-file-sharing-preference.mjs
+++ b/components/google_drive/actions/add-file-sharing-preference/add-file-sharing-preference.mjs
@@ -11,7 +11,7 @@ export default {
   name: "Add File Sharing Preference",
   description:
     "Add a [sharing](https://support.google.com/drive/answer/7166529) permission to the sharing preferences of a file or folder and provide a sharing URL. [See the docs](https://developers.google.com/drive/api/v3/reference/permissions/create) for more information",
-  version: "0.1.2",
+  version: "0.1.3",
   type: "action",
   props: {
     googleDrive,

--- a/components/google_drive/actions/copy-file/copy-file.mjs
+++ b/components/google_drive/actions/copy-file/copy-file.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-copy-file",
   name: "Copy File",
   description: "Create a copy of the specified file. [See the docs](https://developers.google.com/drive/api/v3/reference/files/copy) for more information",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
   props: {
     googleDrive,

--- a/components/google_drive/actions/create-file-from-template/create-file-from-template.mjs
+++ b/components/google_drive/actions/create-file-from-template/create-file-from-template.mjs
@@ -8,7 +8,7 @@ export default {
   key: "google_drive-create-file-from-template",
   name: "Create New File From Template",
   description: "Create a new Google Docs file from a template. Optionally include placeholders in the template document that will get replaced from this action. [See documentation](https://www.npmjs.com/package/google-docs-mustaches)",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
   props: {
     googleDrive,

--- a/components/google_drive/actions/create-file-from-text/create-file-from-text.mjs
+++ b/components/google_drive/actions/create-file-from-text/create-file-from-text.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_drive-create-file-from-text",
   name: "Create New File From Text",
   description: "Create a new file from plain text. [See the docs](https://developers.google.com/drive/api/v3/reference/files/create) for more information",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
   props: {
     googleDrive,

--- a/components/google_drive/actions/create-file/create-file.mjs
+++ b/components/google_drive/actions/create-file/create-file.mjs
@@ -1,6 +1,6 @@
 import googleDrive from "../../google_drive.app.mjs";
 import fs from "fs";
-import got from "got@13.0.0";
+import got from "got";
 import { toSingleLineString } from "../../common/utils.mjs";
 
 export default {

--- a/components/google_drive/actions/create-file/create-file.mjs
+++ b/components/google_drive/actions/create-file/create-file.mjs
@@ -7,7 +7,7 @@ export default {
   key: "google_drive-create-file",
   name: "Create a New File",
   description: "Create a new file from a URL or /tmp/filepath. [See the docs](https://developers.google.com/drive/api/v3/reference/files/create) for more information",
-  version: "0.1.3",
+  version: "0.1.4",
   type: "action",
   props: {
     googleDrive,

--- a/components/google_drive/actions/create-file/create-file.mjs
+++ b/components/google_drive/actions/create-file/create-file.mjs
@@ -1,6 +1,6 @@
 import googleDrive from "../../google_drive.app.mjs";
 import fs from "fs";
-import got from "got";
+import got from "got@13.0.0";
 import { toSingleLineString } from "../../common/utils.mjs";
 
 export default {

--- a/components/google_drive/actions/create-folder/create-folder.mjs
+++ b/components/google_drive/actions/create-folder/create-folder.mjs
@@ -13,7 +13,7 @@ export default {
   key: "google_drive-create-folder",
   name: "Create Folder",
   description: "Create a new empty folder. [See the docs](https://developers.google.com/drive/api/v3/reference/files/create) for more information",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
   props: {
     googleDrive,

--- a/components/google_drive/actions/create-shared-drive/create-shared-drive.mjs
+++ b/components/google_drive/actions/create-shared-drive/create-shared-drive.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-create-shared-drive",
   name: "Create Shared Drive",
   description: "Create a new shared drive. [See the docs](https://developers.google.com/drive/api/v3/reference/drives/create) for more information",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
   props: {
     googleDrive,

--- a/components/google_drive/actions/delete-file/delete-file.mjs
+++ b/components/google_drive/actions/delete-file/delete-file.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Delete File",
   description:
     "Permanently delete a file or folder without moving it to the trash. [See the docs](https://developers.google.com/drive/api/v3/reference/files/delete) for more information",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
   props: {
     googleDrive,

--- a/components/google_drive/actions/delete-shared-drive/delete-shared-drive.mjs
+++ b/components/google_drive/actions/delete-shared-drive/delete-shared-drive.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-delete-shared-drive",
   name: "Delete Shared Drive",
   description: "Delete a shared drive without any content. [See the docs](https://developers.google.com/drive/api/v3/reference/drives/delete) for more information",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
   props: {
     googleDrive,

--- a/components/google_drive/actions/download-file/download-file.mjs
+++ b/components/google_drive/actions/download-file/download-file.mjs
@@ -18,7 +18,7 @@ export default {
   key: "google_drive-download-file",
   name: "Download File",
   description: "Download a file. [See the docs](https://developers.google.com/drive/api/v3/manage-downloads) for more information",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
   props: {
     googleDrive,

--- a/components/google_drive/actions/find-file/find-file.mjs
+++ b/components/google_drive/actions/find-file/find-file.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_drive-find-file",
   name: "Find File",
   description: "Search for a specific file by name. [See the docs](https://developers.google.com/drive/api/v3/search-files) for more information",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
   props: {
     googleDrive,

--- a/components/google_drive/actions/find-folder/find-folder.mjs
+++ b/components/google_drive/actions/find-folder/find-folder.mjs
@@ -7,7 +7,7 @@ export default {
   key: "google_drive-find-folder",
   name: "Find Folder",
   description: "Search for a specific folder by name. [See the docs](https://developers.google.com/drive/api/v3/search-files) for more information",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
   props: {
     googleDrive,

--- a/components/google_drive/actions/find-forms/find-forms.mjs
+++ b/components/google_drive/actions/find-forms/find-forms.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_drive-find-forms",
   name: "Find Forms",
   description: "List Google Form documents or search for a Form by name. [See the docs](https://developers.google.com/drive/api/v3/search-files) for more information",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     googleDrive,

--- a/components/google_drive/actions/find-spreadsheets/find-spreadsheets.mjs
+++ b/components/google_drive/actions/find-spreadsheets/find-spreadsheets.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_drive-find-spreadsheets",
   name: "Find Spreadsheets",
   description: "Search for a specific spreadsheet by name. [See the docs](https://developers.google.com/drive/api/v3/search-files) for more information",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
   props: {
     googleDrive,

--- a/components/google_drive/actions/get-folder-id-for-path/get-folder-id-for-path.mjs
+++ b/components/google_drive/actions/get-folder-id-for-path/get-folder-id-for-path.mjs
@@ -12,7 +12,7 @@ export default {
   key: "google_drive-get-folder-id-for-path",
   name: "Get Folder ID for a Path",
   description: "Retrieve a folderId for a path. [See the docs](https://developers.google.com/drive/api/v3/search-files) for more information",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
   props: {
     googleDrive,

--- a/components/google_drive/actions/get-shared-drive/get-shared-drive.mjs
+++ b/components/google_drive/actions/get-shared-drive/get-shared-drive.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-get-shared-drive",
   name: "Get Shared Drive",
   description: "Get a shared drive's metadata by ID. [See the docs](https://developers.google.com/drive/api/v3/reference/drives/get) for more information",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
   props: {
     googleDrive,

--- a/components/google_drive/actions/list-files/list-files.mjs
+++ b/components/google_drive/actions/list-files/list-files.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_drive-list-files",
   name: "List Files",
   description: "List files from a specific folder. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/list) for more information",
-  version: "0.1.5",
+  version: "0.1.6",
   type: "action",
   props: {
     googleDrive,

--- a/components/google_drive/actions/move-file-to-trash/move-file-to-trash.mjs
+++ b/components/google_drive/actions/move-file-to-trash/move-file-to-trash.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_drive-move-file-to-trash",
   name: "Move File to Trash",
   description: "Move a file or folder to trash. [See the docs](https://developers.google.com/drive/api/v3/reference/files/update) for more information",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
   props: {
     googleDrive,

--- a/components/google_drive/actions/move-file/move-file.mjs
+++ b/components/google_drive/actions/move-file/move-file.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-move-file",
   name: "Move File",
   description: "Move a file from one folder to another. [See the docs](https://developers.google.com/drive/api/v3/reference/files/update) for more information",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
   props: {
     googleDrive,

--- a/components/google_drive/actions/replace-file/replace-file.mjs
+++ b/components/google_drive/actions/replace-file/replace-file.mjs
@@ -15,7 +15,7 @@ export default {
   key: "google_drive-replace-file",
   name: "Replace File",
   description: "Upload a file that replaces an existing file. [See the docs](https://developers.google.com/drive/api/v3/reference/files/update) for more information",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
   props: {
     googleDrive,

--- a/components/google_drive/actions/search-shared-drives/search-shared-drives.mjs
+++ b/components/google_drive/actions/search-shared-drives/search-shared-drives.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-search-shared-drives",
   name: "Search for Shared Drives",
   description: "Search for shared drives with query options. [See the docs](https://developers.google.com/drive/api/v3/search-shareddrives) for more information",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
   props: {
     googleDrive,

--- a/components/google_drive/actions/update-file/update-file.mjs
+++ b/components/google_drive/actions/update-file/update-file.mjs
@@ -8,7 +8,7 @@ export default {
   key: "google_drive-update-file",
   name: "Update File",
   description: "Update a file's metadata and/or content. [See the docs](https://developers.google.com/drive/api/v3/reference/files/update) for more information",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
   props: {
     googleDrive,

--- a/components/google_drive/actions/update-shared-drive/update-shared-drive.mjs
+++ b/components/google_drive/actions/update-shared-drive/update-shared-drive.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-update-shared-drive",
   name: "Update Shared Drive",
   description: "Update an existing shared drive. [See the docs](https://developers.google.com/drive/api/v3/reference/drives/update) for more information",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
   props: {
     googleDrive,

--- a/components/google_drive/actions/upload-file/upload-file.mjs
+++ b/components/google_drive/actions/upload-file/upload-file.mjs
@@ -10,7 +10,7 @@ export default {
   key: "google_drive-upload-file",
   name: "Upload File",
   description: "Copy an existing file to Google Drive. [See the docs](https://developers.google.com/drive/api/v3/manage-uploads) for more information",
-  version: "0.1.3",
+  version: "0.1.4",
   type: "action",
   props: {
     googleDrive,

--- a/components/google_drive/google_drive.app.mjs
+++ b/components/google_drive/google_drive.app.mjs
@@ -851,16 +851,16 @@ export default {
       await this.stopNotifications(channelID, resourceId);
     },
     async renewSubscription(drive, subscription, url, channelID, pageToken) {
-      const newChannelID = channelID || uuid();
       const driveId = this.getDriveId(drive);
       const newPageToken = pageToken || (await this.getPageToken(driveId));
 
       const {
         expiration,
         resourceId,
+        newChannelID,
       } = await this.checkResubscription(
         subscription,
-        newChannelID,
+        channelID,
         newPageToken,
         url,
         drive,
@@ -880,6 +880,7 @@ export default {
       endpoint,
       drive,
     ) {
+      const newChannelID = uuid();
       const driveId = this.getDriveId(drive);
       if (subscription && subscription.resourceId) {
         console.log(
@@ -893,7 +894,7 @@ export default {
         expiration,
         resourceId,
       } = await this.watchDrive(
-        channelID,
+        newChannelID,
         endpoint,
         pageToken,
         driveId,
@@ -901,6 +902,7 @@ export default {
       return {
         expiration,
         resourceId,
+        newChannelID,
       };
     },
     async renewFileSubscription(subscription, url, channelID, fileId, nextRunTimestamp) {

--- a/components/google_drive/package.json
+++ b/components/google_drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_drive",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "description": "Pipedream Google_drive Components",
   "main": "google_drive.app.mjs",
   "keywords": [

--- a/components/google_drive/package.json
+++ b/components/google_drive/package.json
@@ -14,6 +14,7 @@
     "@pipedream/platform": "^1.4.0",
     "cron-parser": "^4.9.0",
     "google-docs-mustaches": "^1.2.2",
+    "got": "13.0.0",
     "lodash": "^4.17.21",
     "mime-db": "^1.51.0",
     "uuid": "^8.3.2"

--- a/components/google_drive/package.json
+++ b/components/google_drive/package.json
@@ -13,6 +13,7 @@
     "@googleapis/drive": "^2.3.0",
     "@pipedream/platform": "^1.4.0",
     "cron-parser": "^4.9.0",
+    "google-docs-mustaches": "^1.2.2",
     "lodash": "^4.17.21",
     "mime-db": "^1.51.0",
     "uuid": "^8.3.2"

--- a/components/google_drive/sources/changes-to-specific-files-shared-drive/changes-to-specific-files-shared-drive.mjs
+++ b/components/google_drive/sources/changes-to-specific-files-shared-drive/changes-to-specific-files-shared-drive.mjs
@@ -26,7 +26,7 @@ export default {
   key: "google_drive-changes-to-specific-files-shared-drive",
   name: "Changes to Specific Files (Shared Drive)",
   description: "Watches for changes to specific files in a shared drive, emitting an event any time a change is made to one of those files",
-  version: "0.1.3",
+  version: "0.1.4",
   type: "source",
   // Dedupe events based on the "x-goog-message-number" header for the target channel:
   // https://developers.google.com/drive/api/v3/push#making-watch-requests

--- a/components/google_drive/sources/changes-to-specific-files/changes-to-specific-files.mjs
+++ b/components/google_drive/sources/changes-to-specific-files/changes-to-specific-files.mjs
@@ -17,7 +17,7 @@ export default {
   key: "google_drive-changes-to-specific-files",
   name: "Changes to Specific Files",
   description: "Watches for changes to specific files, emitting an event any time a change is made to one of those files. To watch for changes to [shared drive](https://support.google.com/a/users/answer/9310351) files, use the **Changes to Specific Files (Shared Drive)** source instead.",
-  version: "0.1.3",
+  version: "0.1.4",
   type: "source",
   // Dedupe events based on the "x-goog-message-number" header for the target channel:
   // https://developers.google.com/drive/api/v3/push#making-watch-requests

--- a/components/google_drive/sources/new-files-instant/new-files-instant.mjs
+++ b/components/google_drive/sources/new-files-instant/new-files-instant.mjs
@@ -10,7 +10,7 @@ export default {
   key: "google_drive-new-files-instant",
   name: "New Files (Instant)",
   description: "Emit new event any time a new file is added in your linked Google Drive",
-  version: "0.1.4",
+  version: "0.1.5",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_drive/sources/new-or-modified-comments/new-or-modified-comments.mjs
+++ b/components/google_drive/sources/new-or-modified-comments/new-or-modified-comments.mjs
@@ -17,7 +17,7 @@ export default {
   name: "New or Modified Comments",
   description:
     "Emits a new event any time a file comment is added, modified, or deleted in your linked Google Drive",
-  version: "0.1.4",
+  version: "0.1.5",
   type: "source",
   // Dedupe events based on the "x-goog-message-number" header for the target channel:
   // https://developers.google.com/drive/api/v3/push#making-watch-requests

--- a/components/google_drive/sources/new-or-modified-files/new-or-modified-files.mjs
+++ b/components/google_drive/sources/new-or-modified-files/new-or-modified-files.mjs
@@ -21,7 +21,7 @@ export default {
   key: "google_drive-new-or-modified-files",
   name: "New or Modified Files",
   description: "Emit new event any time any file in your linked Google Drive is added, modified, or deleted",
-  version: "0.2.0",
+  version: "0.2.1",
   type: "source",
   // Dedupe events based on the "x-goog-message-number" header for the target channel:
   // https://developers.google.com/drive/api/v3/push#making-watch-requests

--- a/components/google_drive/sources/new-or-modified-folders/new-or-modified-folders.mjs
+++ b/components/google_drive/sources/new-or-modified-folders/new-or-modified-folders.mjs
@@ -20,7 +20,7 @@ export default {
   key: "google_drive-new-or-modified-folders",
   name: "New or Modified Folders",
   description: "Emit new event any time any folder in your linked Google Drive is added, modified, or deleted",
-  version: "0.1.2",
+  version: "0.1.3",
   type: "source",
   // Dedupe events based on the "x-goog-message-number" header for the target channel:
   // https://developers.google.com/drive/api/v3/push#making-watch-requests

--- a/components/google_drive/sources/new-shared-drive/new-shared-drive.mjs
+++ b/components/google_drive/sources/new-shared-drive/new-shared-drive.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_drive-new-shared-drive",
   name: "New Shared Drive",
   description: "Emits a new event any time a shared drive is created.",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_drive/sources/new-spreadsheet/new-spreadsheet.mjs
+++ b/components/google_drive/sources/new-spreadsheet/new-spreadsheet.mjs
@@ -6,7 +6,7 @@ export default {
   type: "source",
   name: "New Spreadsheet (Instant)",
   description: "Emit new event each time a new spreadsheet is created in a drive.",
-  version: "0.1.2",
+  version: "0.1.3",
   props: {
     googleDrive: newFilesInstant.props.googleDrive,
     db: newFilesInstant.props.db,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3353,6 +3353,7 @@ importers:
       '@googleapis/drive': ^2.3.0
       '@pipedream/platform': ^1.4.0
       cron-parser: ^4.9.0
+      google-docs-mustaches: ^1.2.2
       lodash: ^4.17.21
       mime-db: ^1.51.0
       uuid: ^8.3.2
@@ -3360,6 +3361,7 @@ importers:
       '@googleapis/drive': 2.4.0
       '@pipedream/platform': 1.5.1
       cron-parser: 4.9.0
+      google-docs-mustaches: 1.2.2
       lodash: 4.17.21
       mime-db: 1.52.0
       uuid: 8.3.2
@@ -20601,6 +20603,11 @@ packages:
       sax: 1.3.0
     dev: false
 
+  /fetch-blob/1.0.6:
+    resolution: {integrity: sha512-XTotUY7hVtqdbHE0Ilm/u/nnXRv1T8nepxhMHzB885O0EkVvI05UlZq7rHQSd6hVDCNAGx4HTjbJO60Onjfckw==}
+    engines: {node: '>=6'}
+    dev: false
+
   /fetch-blob/2.1.2:
     resolution: {integrity: sha512-YKqtUDwqLyfyMnmbw8XD6Q8j9i/HggKtPEI+pZ1+8bvheBu78biSmNaXWusx1TauGqtUUGx/cBb1mKdq2rLYow==}
     engines: {node: ^10.17.0 || >=12.3.0}
@@ -21466,6 +21473,15 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
+    dev: false
+
+  /google-docs-mustaches/1.2.2:
+    resolution: {integrity: sha512-RkV/3468jlT6TNOiPKVIPS+Q+P7OFffTkrW/z5s9u7GO/aad9tIT2XTmHwpAgXvT8Lekf/bNOjeKMWIuRtlXdg==}
+    dependencies:
+      cross-fetch: 3.1.8
+      fetch-blob: 1.0.6
+    transitivePeerDependencies:
+      - encoding
     dev: false
 
   /google-gax/2.30.5:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3354,6 +3354,7 @@ importers:
       '@pipedream/platform': ^1.4.0
       cron-parser: ^4.9.0
       google-docs-mustaches: ^1.2.2
+      got: 13.0.0
       lodash: ^4.17.21
       mime-db: ^1.51.0
       uuid: ^8.3.2
@@ -3362,6 +3363,7 @@ importers:
       '@pipedream/platform': 1.5.1
       cron-parser: 4.9.0
       google-docs-mustaches: 1.2.2
+      got: 13.0.0
       lodash: 4.17.21
       mime-db: 1.52.0
       uuid: 8.3.2


### PR DESCRIPTION
Whenever a subscription was being renewed, the same `channelID` was given to the Google SDK for the new Channel ID.
[Google's docs](https://developers.google.com/drive/api/guides/push#renew-notification-channels) indicate the opposite:
> As always, you must use a unique value for the id property of the new channel

This fix ensures a new `channelID` is given when requesting a new subscription (and correctly stops the previous `channelID` subscription).