### PR TITLE
Fix doc typo for Google-Sheets action: add-single-row

### DIFF
--- a/components/google_sheets/actions/add-single-row/add-single-row.mjs
+++ b/components/google_sheets/actions/add-single-row/add-single-row.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_sheets-add-single-row",
   name: "Add Single Row",
   description: "Add a single row of data to Google Sheets",
-  version: "2.1.2",
+  version: "2.1.3",
   type: "action",
   props: {
     googleSheets,

--- a/components/google_sheets/actions/add-single-row/add-single-row.mjs
+++ b/components/google_sheets/actions/add-single-row/add-single-row.mjs
@@ -53,7 +53,7 @@ export default {
     if (this.hasHeaders === "Yes") {
       const { values } = await this.googleSheets.getSpreadsheetValues(sheetId, `${this.sheetName}!1:1`);
       if (!values[0]?.length) {
-        throw new ConfigurationError("Cound not find a header row. Please either add headers and click \"Refresh fields\" or adjust the action configuration to continue.");
+        throw new ConfigurationError("Could not find a header row. Please either add headers and click \"Refresh fields\" or adjust the action configuration to continue.");
       }
       for (let i = 0; i < values[0]?.length; i++) {
         props[`col_${i.toString().padStart(4, "0")}`] = {

--- a/components/google_sheets/package.json
+++ b/components/google_sheets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_sheets",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Pipedream Google_sheets Components",
   "main": "google_sheets.app.mjs",
   "keywords": [


### PR DESCRIPTION
## WHAT

I stumbled upon a typo in the documentation


## HOW

copilot:walkthrough
