### PR TITLE
Implement `getSchema` method for MySQL and PostgreSQL

### DIFF
--- a/components/mysql/actions/create-row/create-row.mjs
+++ b/components/mysql/actions/create-row/create-row.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Create Row",
   description: "Adds a new row. [See the docs here](https://dev.mysql.com/doc/refman/8.0/en/insert.html)",
   type: "action",
-  version: "2.0.2",
+  version: "2.0.3",
   props: {
     mysql,
     table: {

--- a/components/mysql/actions/delete-row/delete-row.mjs
+++ b/components/mysql/actions/delete-row/delete-row.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Delete Row",
   description: "Delete an existing row. [See the docs here](https://dev.mysql.com/doc/refman/8.0/en/delete.html)",
   type: "action",
-  version: "2.0.2",
+  version: "2.0.3",
   props: {
     mysql,
     table: {

--- a/components/mysql/actions/execute-query/execute-query.mjs
+++ b/components/mysql/actions/execute-query/execute-query.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Execute Query",
   description: "Find row(s) via a custom query. [See the docs here](https://dev.mysql.com/doc/refman/8.0/en/select.html)",
   type: "action",
-  version: "2.0.2",
+  version: "2.0.3",
   props: {
     mysql,
     table: {

--- a/components/mysql/actions/execute-raw-query/execute-raw-query.mjs
+++ b/components/mysql/actions/execute-raw-query/execute-raw-query.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Execute Raw Query",
   description: "Find row(s) via a custom raw query. [See the documentation](https://dev.mysql.com/doc/refman/8.0/en/select.html)",
   type: "action",
-  version: "1.0.2",
+  version: "1.0.3",
   props: {
     mysql,
     sql: {

--- a/components/mysql/actions/execute-stored-procedure/execute-stored-procedure.mjs
+++ b/components/mysql/actions/execute-stored-procedure/execute-stored-procedure.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Execute Stored Procedure",
   description: "Execute Stored Procedure. [See the docs here](https://dev.mysql.com/doc/refman/8.0/en/stored-programs-defining.html)",
   type: "action",
-  version: "2.0.2",
+  version: "2.0.3",
   props: {
     mysql,
     storedProcedure: {

--- a/components/mysql/actions/find-row/find-row.mjs
+++ b/components/mysql/actions/find-row/find-row.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Find Row",
   description: "Finds a row in a table via a lookup column. [See the docs here](https://dev.mysql.com/doc/refman/8.0/en/select.html)",
   type: "action",
-  version: "2.0.2",
+  version: "2.0.3",
   props: {
     mysql,
     table: {

--- a/components/mysql/actions/update-row/update-row.mjs
+++ b/components/mysql/actions/update-row/update-row.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Update Row",
   description: "Updates an existing row. [See the docs here](https://dev.mysql.com/doc/refman/8.0/en/update.html)",
   type: "action",
-  version: "2.0.2",
+  version: "2.0.3",
   props: {
     mysql,
     table: {

--- a/components/mysql/mysql.app.mjs
+++ b/components/mysql/mysql.app.mjs
@@ -102,7 +102,7 @@ export default {
   methods: {
     ...sqlProxy.methods,
     ...sqlProp.methods,
-    getSslConfig() {
+    _getSslConfig() {
       const {
         ca,
         key,
@@ -158,7 +158,7 @@ export default {
         user,
         password,
         database,
-        ssl: this.getSslConfig(),
+        ssl: this._getSslConfig(),
       };
     },
     /**
@@ -225,7 +225,7 @@ export default {
 
       } finally {
         if (connection) {
-          await this.closeConnection(connection);
+          await this._closeConnection(connection);
         }
       }
     },
@@ -269,7 +269,7 @@ export default {
         return acc;
       }, {});
     },
-    async closeConnection(connection) {
+    async _closeConnection(connection) {
       await connection.end();
       return new Promise((resolve) => {
         connection.connection.stream.on("close", resolve);
@@ -298,7 +298,8 @@ export default {
       });
     },
     listBaseTables({
-      lastResult, ...args
+      lastResult,
+      ...args
     } = {}) {
       return this.executeQuery({
         sql: `
@@ -314,7 +315,8 @@ export default {
       });
     },
     listTopTables({
-      maxCount = 10, ...args
+      maxCount = 10,
+      ...args
     } = {}) {
       return this.executeQuery({
         sql: `
@@ -327,7 +329,8 @@ export default {
       });
     },
     listColumns({
-      table, ...args
+      table,
+      ...args
     } = {}) {
       return this.executeQuery({
         sql: `SHOW COLUMNS FROM \`${table}\``,
@@ -335,7 +338,9 @@ export default {
       });
     },
     listNewColumns({
-      table, previousColumns, ...args
+      table,
+      previousColumns,
+      ...args
     } = {}) {
       return this.executeQuery({
         sql: `
@@ -357,7 +362,10 @@ export default {
      * that has been previously returned.
      */
     listRows({
-      table, column, lastResult, ...args
+      table,
+      column,
+      lastResult,
+      ...args
     } = {}) {
       return this.executeQuery({
         sql: `
@@ -381,7 +389,10 @@ export default {
      * @param {number} maxCount - Maximum number of results to return.
      */
     listMaxRows({
-      table, column, maxCount = 10, ...args
+      table,
+      column,
+      maxCount = 10,
+      ...args
     } = {}) {
       return this.executeQuery({
         sql: `
@@ -393,7 +404,8 @@ export default {
       });
     },
     getPrimaryKey({
-      table, ...args
+      table,
+      ...args
     } = {}) {
       return this.executeQuery({
         sql: "SHOW KEYS FROM ? WHERE Key_name = 'PRIMARY'",
@@ -404,7 +416,8 @@ export default {
       });
     },
     async listColumnNames({
-      table, ...args
+      table,
+      ...args
     } = {}) {
       const columns = await this.listColumns({
         table,
@@ -413,7 +426,10 @@ export default {
       return columns.map((column) => column.Field);
     },
     findRows({
-      table, condition, values = [], ...args
+      table,
+      condition,
+      values = [],
+      ...args
     } = {}) {
       return this.executeQuery({
         sql: `SELECT * FROM \`${table}\` WHERE ${condition}`,
@@ -422,7 +438,10 @@ export default {
       });
     },
     deleteRows({
-      table, condition, values = [], ...args
+      table,
+      condition,
+      values = [],
+      ...args
     } = {}) {
       return this.executeQuery({
         sql: `DELETE FROM \`${table}\` WHERE ${condition}`,
@@ -431,7 +450,10 @@ export default {
       });
     },
     insertRow({
-      table, columns = [], values = [], ...args
+      table,
+      columns = [],
+      values = [],
+      ...args
     } = {}) {
       const placeholder = values.map(() => "?").join(",");
       return this.executeQuery({
@@ -444,8 +466,11 @@ export default {
       });
     },
     updateRow({
-      table, condition,
-      conditionValues = [], columnsToUpdate = [], valuesToUpdate = [],
+      table,
+      condition,
+      conditionValues = [],
+      columnsToUpdate = [],
+      valuesToUpdate = [],
       ...args
     } = {}) {
       const updates =
@@ -465,7 +490,9 @@ export default {
       });
     },
     executeStoredProcedure({
-      storedProcedure, values = [], ...args
+      storedProcedure,
+      values = [],
+      ...args
     } = {}) {
       return this.executeQuery({
         sql: `CALL ${storedProcedure}(${values.map(() => "?")})`,

--- a/components/mysql/package.json
+++ b/components/mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/mysql",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Pipedream MySQL Components",
   "main": "mysql.app.mjs",
   "keywords": [

--- a/components/mysql/sources/new-column/new-column.mjs
+++ b/components/mysql/sources/new-column/new-column.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Column",
   description: "Emit new event when you add a new column to a table. [See the docs here](https://dev.mysql.com/doc/refman/8.0/en/show-columns.html)",
   type: "source",
-  version: "2.0.2",
+  version: "2.0.3",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/mysql/sources/new-or-updated-row/new-or-updated-row.mjs
+++ b/components/mysql/sources/new-or-updated-row/new-or-updated-row.mjs
@@ -9,7 +9,7 @@ export default {
   name: "New or Updated Row",
   description: "Emit new event when you add or modify a new row in a table. [See the docs here](https://dev.mysql.com/doc/refman/8.0/en/select.html)",
   type: "source",
-  version: "2.0.2",
+  version: "2.0.3",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/mysql/sources/new-row-custom-query/new-row-custom-query.mjs
+++ b/components/mysql/sources/new-row-custom-query/new-row-custom-query.mjs
@@ -8,7 +8,7 @@ export default {
   key: "mysql-new-row-custom-query",
   name: "New Row (Custom Query)",
   description: "Emit new event when new rows are returned from a custom query. [See the docs here](https://dev.mysql.com/doc/refman/8.0/en/select.html)",
-  version: "2.0.2",
+  version: "2.0.3",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/mysql/sources/new-row/new-row.mjs
+++ b/components/mysql/sources/new-row/new-row.mjs
@@ -8,7 +8,7 @@ export default {
   name: "New Row",
   description: "Emit new event when you add a new row to a table. [See the docs here](https://dev.mysql.com/doc/refman/8.0/en/select.html)",
   type: "source",
-  version: "2.0.2",
+  version: "2.0.3",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/mysql/sources/new-table/new-table.mjs
+++ b/components/mysql/sources/new-table/new-table.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Table",
   description: "Emit new event when a new table is added to a database. [See the docs here](https://dev.mysql.com/doc/refman/8.0/en/select.html)",
   type: "source",
-  version: "2.0.2",
+  version: "2.0.3",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/postgresql/actions/delete-rows/delete-rows.mjs
+++ b/components/postgresql/actions/delete-rows/delete-rows.mjs
@@ -4,7 +4,7 @@ export default {
   name: "Delete Row(s)",
   key: "postgresql-delete-rows",
   description: "Deletes a row or rows from a table. [See the documentation](https://node-postgres.com/features/queries)",
-  version: "2.0.4",
+  version: "2.0.5",
   type: "action",
   props: {
     postgresql,

--- a/components/postgresql/actions/execute-custom-query/execute-custom-query.mjs
+++ b/components/postgresql/actions/execute-custom-query/execute-custom-query.mjs
@@ -4,7 +4,7 @@ export default {
   name: "Execute Custom Query",
   key: "postgresql-execute-custom-query",
   description: "Executes a custom query you provide. [See the documentation](https://node-postgres.com/features/queries)",
-  version: "2.0.4",
+  version: "2.0.5",
   type: "action",
   props: {
     postgresql,

--- a/components/postgresql/actions/find-row-custom-query/find-row-custom-query.mjs
+++ b/components/postgresql/actions/find-row-custom-query/find-row-custom-query.mjs
@@ -4,7 +4,7 @@ export default {
   name: "Find Row With Custom Query",
   key: "postgresql-find-row-custom-query",
   description: "Finds a row in a table via a custom query. [See the documentation](https://node-postgres.com/features/queries)",
-  version: "2.0.4",
+  version: "2.0.5",
   type: "action",
   props: {
     postgresql,

--- a/components/postgresql/actions/find-row/find-row.mjs
+++ b/components/postgresql/actions/find-row/find-row.mjs
@@ -4,7 +4,7 @@ export default {
   name: "Find Row",
   key: "postgresql-find-row",
   description: "Finds a row in a table via a lookup column. [See the documentation](https://node-postgres.com/features/queries)",
-  version: "2.0.4",
+  version: "2.0.5",
   type: "action",
   props: {
     postgresql,

--- a/components/postgresql/actions/insert-row/insert-row.mjs
+++ b/components/postgresql/actions/insert-row/insert-row.mjs
@@ -4,7 +4,7 @@ export default {
   name: "Insert Row",
   key: "postgresql-insert-row",
   description: "Adds a new row. [See the documentation](https://node-postgres.com/features/queries)",
-  version: "2.0.4",
+  version: "2.0.5",
   type: "action",
   props: {
     postgresql,

--- a/components/postgresql/actions/update-row/update-row.mjs
+++ b/components/postgresql/actions/update-row/update-row.mjs
@@ -4,7 +4,7 @@ export default {
   name: "Update Row",
   key: "postgresql-update-row",
   description: "Updates an existing row. [See the documentation](https://node-postgres.com/features/queries)",
-  version: "2.0.4",
+  version: "2.0.5",
   type: "action",
   props: {
     postgresql,

--- a/components/postgresql/actions/upsert-row/upsert-row.mjs
+++ b/components/postgresql/actions/upsert-row/upsert-row.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Upsert Row",
   key: "postgresql-upsert-row",
   description: "Adds a new row or updates an existing row. [See the documentation](https://node-postgres.com/features/queries)",
-  version: "2.0.4",
+  version: "2.0.5",
   type: "action",
   props: {
     postgresql,

--- a/components/postgresql/package.json
+++ b/components/postgresql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/postgresql",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Pipedream PostgreSQL Components",
   "main": "postgresql.app.mjs",
   "keywords": [

--- a/components/postgresql/postgresql.app.mjs
+++ b/components/postgresql/postgresql.app.mjs
@@ -23,7 +23,7 @@ export default {
       label: "Table",
       description: "Database table",
       async options({ schema }) {
-        return this.getTables(this.getNormalizedSchema(schema));
+        return this.getTables(this._getNormalizedSchema(schema));
       },
     },
     column: {
@@ -33,7 +33,7 @@ export default {
       async options({
         table, schema,
       }) {
-        return this.getColumns(table, this.getNormalizedSchema(schema));
+        return this.getColumns(table, this._getNormalizedSchema(schema));
       },
     },
     query: {
@@ -55,7 +55,7 @@ export default {
         table, column, prevContext, schema,
       }) {
         const limit = 20;
-        const normalizedSchema = this.getNormalizedSchema(schema);
+        const normalizedSchema = this._getNormalizedSchema(schema);
         const { offset = 0 } = prevContext;
         return {
           options: await this
@@ -75,7 +75,7 @@ export default {
   methods: {
     ...sqlProp.methods,
     ...sqlProxy.methods,
-    getSslConfig() {
+    _getSslConfig() {
       const {
         ca,
         key,
@@ -122,10 +122,10 @@ export default {
         user,
         password,
         database,
-        ssl: this.getSslConfig(),
+        ssl: this._getSslConfig(),
       };
     },
-    async getClient() {
+    async _getClient() {
       const config = this.getClientConfiguration();
       const client = new pg.Client(config);
       try {
@@ -139,7 +139,7 @@ export default {
       }
       return client;
     },
-    async endClient(client) {
+    async _endClient(client) {
       return client.end();
     },
     /**
@@ -195,13 +195,13 @@ export default {
      * query.
      */
     async executeQuery(query) {
-      const client = await this.getClient();
+      const client = await this._getClient();
 
       try {
         const { rows } = await client.query(query);
         return rows;
       } finally {
-        await this.endClient(client);
+        await this._endClient(client);
       }
     },
     /**
@@ -376,7 +376,7 @@ export default {
      * @returns The newly updated row
      */
     async updateRow(schema, table, lookupColumn, lookupValue, rowValues) {
-      const columnsPlaceholders = this.getColumnsPlaceholders({
+      const columnsPlaceholders = this._getColumnsPlaceholders({
         rowValues,
         fromIndex: 2,
       });
@@ -396,7 +396,7 @@ export default {
       });
       return response[0];
     },
-    getColumnsPlaceholders({
+    _getColumnsPlaceholders({
       rowValues = {},
       fromIndex = 1,
     } = {}) {
@@ -440,7 +440,7 @@ export default {
       return this.executeQuery(query);
     },
     /**Normalize Schema**/
-    getNormalizedSchema(schema) {
+    _getNormalizedSchema(schema) {
       return schema ?? "public";
     },
   },

--- a/components/postgresql/sources/new-column/new-column.mjs
+++ b/components/postgresql/sources/new-column/new-column.mjs
@@ -5,7 +5,7 @@ export default {
   name: "New Column",
   key: "postgresql-new-column",
   description: "Emit new event when a new column is added to a table. [See the documentation](https://node-postgres.com/features/queries)",
-  version: "2.0.4",
+  version: "2.0.5",
   type: "source",
   props: {
     ...common.props,

--- a/components/postgresql/sources/new-or-updated-row/new-or-updated-row.mjs
+++ b/components/postgresql/sources/new-or-updated-row/new-or-updated-row.mjs
@@ -5,7 +5,7 @@ export default {
   name: "New or Updated Row",
   key: "postgresql-new-or-updated-row",
   description: "Emit new event when a row is added or modified. [See the documentation](https://node-postgres.com/features/queries)",
-  version: "2.0.4",
+  version: "2.0.5",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/postgresql/sources/new-row-custom-query/new-row-custom-query.mjs
+++ b/components/postgresql/sources/new-row-custom-query/new-row-custom-query.mjs
@@ -5,7 +5,7 @@ export default {
   name: "New Row Custom Query",
   key: "postgresql-new-row-custom-query",
   description: "Emit new event when new rows are returned from a custom query that you provide. [See the documentation](https://node-postgres.com/features/queries)",
-  version: "2.0.4",
+  version: "2.0.5",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/postgresql/sources/new-row/new-row.mjs
+++ b/components/postgresql/sources/new-row/new-row.mjs
@@ -5,7 +5,7 @@ export default {
   name: "New Row",
   key: "postgresql-new-row",
   description: "Emit new event when a new row is added to a table. [See the documentation](https://node-postgres.com/features/queries)",
-  version: "3.0.4",
+  version: "3.0.5",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/postgresql/sources/new-table/new-table.mjs
+++ b/components/postgresql/sources/new-table/new-table.mjs
@@ -5,7 +5,7 @@ export default {
   name: "New Table",
   key: "postgresql-new-table",
   description: "Emit new event when a new table is added to the database. [See the documentation](https://node-postgres.com/features/queries)",
-  version: "2.0.4",
+  version: "2.0.5",
   type: "source",
   props: {
     ...common.props,


### PR DESCRIPTION
## WHY

To comply with the SQL prop interface, which uses the `getSchema` method in the app component to fetch metadata information about the current DB's schema (e.g. fields, data types, etc.).

This PR also renames all private methods in the app components so that we keep their interfaces clean and minimize unexpected usage.