### PR TITLE
ESLint PR check improvement

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,11 @@ node_modules
 package-lock.json
 pnpm-lock.yaml
 platform/dist
+*.md
+*.txt
+*.yml
+*.yaml
+*.lock
+*.py
+*.png
+

--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -94,7 +94,7 @@ jobs:
         with:
           format: 'space-delimited'
       - name: Lint changed files
-        run: npx eslint ${{ steps.changed_files_space.outputs.added_modified }} ${{ steps.changed_files_space.outputs.renamed }}
+        run: npx eslint --quiet ${{ steps.changed_files_space.outputs.added_modified }} ${{ steps.changed_files_space.outputs.renamed }}
       - name: Get Changed Files (comma-separated)
         id: changed_files
         uses: jitterbit/get-changed-files@v1


### PR DESCRIPTION
Added commonly used non-lintable file extensions to .eslintignore. This file does not seem to support more advanced glob patterns (or at least I couldn't get any to work) so I had to add them each individually.

Also added --quiet to suppress warnings (since we're mostly interested in errors, and ignored files will each generate a warning since they are being passed explicitly as the PR's changed files)