### PR TITLE
docs: add tap info for brew installation

### DIFF
--- a/docs-v2/pages/cli/install.mdx
+++ b/docs-v2/pages/cli/install.mdx
@@ -10,6 +10,7 @@ import VideoPlayer from '@/components/VideoPlayer'
 ### Homebrew
 
 ```bash
+brew tap pipedreamhq/pd-cli
 brew install pipedreamhq/pd-cli/pipedream
 ```
 


### PR DESCRIPTION
adds brew tap instructions.
brew tap is idempotent, so adding it to the instructions is a no-op for people that have it tapped already but for new users:

## WHY

Without tapping it first you get the following error:
```
Warning: 'pipedreamhq/pd-cli/pipedream' formula is unreadable: No available formula with the name "pipedreamhq/pd-cli/pipedream".
Please tap it and then try again: brew tap pipedreamhq/pd-cli
```
