### PR TITLE
Updating Perplexity to latest models.

### DIFF
--- a/components/perplexity/actions/chat-completions/chat-completions.mjs
+++ b/components/perplexity/actions/chat-completions/chat-completions.mjs
@@ -4,7 +4,7 @@ export default {
   key: "perplexity-chat-completions",
   name: "Chat Completions",
   description: "Generates a model's response for the given chat conversation. [See the documentation](https://docs.perplexity.ai/reference/post_chat_completions)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     app,

--- a/components/perplexity/common/constants.mjs
+++ b/components/perplexity/common/constants.mjs
@@ -1,10 +1,11 @@
 export default {
   MODELS: [
-    "sonar-small-chat",
-    "sonar-small-online",
-    "sonar-medium-chat",
-    "sonar-medium-online",
-    "mistral-7b-instruct",
+    "llama-3-sonar-small-32k-chat",
+    "llama-3-sonar-small-32k-online",
+    "llama-3-sonar-large-32k-chat",
+    "llama-3-sonar-large-32k-online",
+    "llama-3-8b-instruct",
+    "llama-3-70b-instruct",
     "mixtral-8x7b-instruct",
   ],
   ROLES: [

--- a/components/perplexity/package.json
+++ b/components/perplexity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/perplexity",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Perplexity Components",
   "main": "perplexity.app.mjs",
   "keywords": [


### PR DESCRIPTION
## WHY

Perplexity is deprecating old models in favor of new Llama-3 models.
