### PR TITLE
fix(types): dedupe unique and greatest strategy needs id

### DIFF
--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -310,15 +310,23 @@ export interface EmitMetadata {
   ts?: number;
 }
 
+export interface IdEmitMetadata extends EmitMetadata {
+  id: string | number;
+}
+
 type EmitFunction = {
   $emit: (event: JSONValue, metadata?: EmitMetadata) => Promise<void>;
+};
+
+type IdEmitFunction = {
+  $emit: (event: JSONValue, metadata: IdEmitMetadata) => Promise<void>;
 };
 
 type PropThis<Props> = {
   [Prop in keyof Props]: Props[Prop] extends App<Methods, AppPropDefinitions> ? any : any
 };
 
-export interface Source<
+interface BaseSource<
   Methods,
   SourcePropDefinitions
 > {
@@ -334,8 +342,42 @@ export interface Source<
   additionalProps?: (
     previousPropDefs: SourcePropDefinitions
   ) => Promise<SourcePropDefinitions>;
+  run: (this: PropThis<SourcePropDefinitions> & Methods & ( EmitFunction | IdEmitFunction), options?: SourceRunOptions) => void | Promise<void>;
+}
+
+export interface LastSource<
+  Methods,
+  SourcePropDefinitions
+> extends BaseSource<
+  Methods,
+  SourcePropDefinitions
+> {
+  dedupe?: "last";
   run: (this: PropThis<SourcePropDefinitions> & Methods & EmitFunction, options?: SourceRunOptions) => void | Promise<void>;
 }
+
+
+export interface DedupedSource<
+  Methods,
+  SourcePropDefinitions
+> extends BaseSource<
+  Methods,
+  SourcePropDefinitions
+> {
+  dedupe: "greatest" | "unique";
+  run: (this: PropThis<SourcePropDefinitions> & Methods & IdEmitFunction, options?: SourceRunOptions) => void | Promise<void>;
+}
+
+export type Source<
+  Methods,
+  SourcePropDefinitions
+> = LastSource<
+  Methods,
+  SourcePropDefinitions
+> | DedupedSource<
+  Methods,
+  SourcePropDefinitions
+>;
 
 export function defineSource<
   Methods,

--- a/types/src/types.test.ts
+++ b/types/src/types.test.ts
@@ -352,3 +352,15 @@ const actionWrongType: Pipedream.Action<Pipedream.Methods, Pipedream.ActionPropD
   type: "source",
   run() { console.log("foo"); },
 };
+
+Pipedream.defineSource({
+  key: "source",
+  version: "0.0.1",
+  type: "source",
+  dedupe: "unique",
+  run() {
+    this.$emit({},
+    // @ts-expect-error $ExpectError - Missing id property in metadata object
+    {});
+  }
+});


### PR DESCRIPTION
## WHY

When using the dedupe strategy `unique` and omitting the `id` field in the metadata, events are not emitted correctly. They seem to be swallowed and also don't show up in the event interface.