### PR TITLE
chore: replace unmaintained jitterbit/get-changed-files@v1

### DIFF
--- a/.github/actions/git-diff-on-components/README.md
+++ b/.github/actions/git-diff-on-components/README.md
@@ -14,7 +14,7 @@ This action takes care of all components with dependencies that were modified bu
 
 ### `all_files`
 
-**Required** List of all files comming from `changed_files` step in `check_version` job github action workflow. It is necessary to set the action `jitterbit/get-changed-files@v1` output in json format like
+**Required** List of all files comming from `changed_files` step in `check_version` job github action workflow. It is necessary to set the action `Ana06/get-changed-files@v2.3.0` output in json format like
 ```
 ...
 with:

--- a/.github/workflows/components-pr.yaml
+++ b/.github/workflows/components-pr.yaml
@@ -30,7 +30,7 @@ jobs:
           # we have to fetch the entire history. See
           # https://github.com/actions/checkout/issues/266#issuecomment-638346893
           fetch-depth: 0
-      - uses: jitterbit/get-changed-files@v1
+      - uses: Ana06/get-changed-files@v2.3.0
         id: changed_files
         name: Get changed files
         with:
@@ -76,7 +76,7 @@ jobs:
         run: npm run build > files.txt
       - name: Get Changed Files
         id: files
-        uses: jitterbit/get-changed-files@v1
+        uses: Ana06/get-changed-files@v2.3.0
         with:
           format: 'csv'
       - name: Check For Compiled TypeScript Files
@@ -165,7 +165,7 @@ jobs:
         run: npm run build > files.txt
       - name: Get Changed Files
         id: files
-        uses: jitterbit/get-changed-files@v1
+        uses: Ana06/get-changed-files@v2.3.0
         with:
           format: 'csv'
       - name: Publish TypeScript components (dry run)

--- a/.github/workflows/publish-components.yaml
+++ b/.github/workflows/publish-components.yaml
@@ -48,7 +48,7 @@ jobs:
           echo "org_id = $PD_ORG_ID" >> $HOME/.config/pipedream/config
       - name: Get Changed Files
         id: files
-        uses: jitterbit/get-changed-files@v1
+        uses: Ana06/get-changed-files@v2.3.0
         with:
           format: 'csv'
       - name: Publish and add to registry components/*.*js (that aren't .app.js files)
@@ -155,7 +155,7 @@ jobs:
         run: npm run build > files.txt
       - name: Get Changed Files
         id: files
-        uses: jitterbit/get-changed-files@v1
+        uses: Ana06/get-changed-files@v2.3.0
         with:
           format: 'csv'
       - name: Publish TypeScript components (dry run)

--- a/.github/workflows/publish-marketplace-content.yaml
+++ b/.github/workflows/publish-marketplace-content.yaml
@@ -36,7 +36,7 @@ jobs:
           cache: 'pnpm'
       - name: Get Changed Files
         id: files
-        uses: jitterbit/get-changed-files@v1
+        uses: Ana06/get-changed-files@v2.3.0
         with:
           format: 'csv'
       - name: Publish changes to marketplace content

--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4.1.5
       name: Checkout
-    - uses: jitterbit/get-changed-files@v1
+    - uses: Ana06/get-changed-files@v2.3.0
       id: changed_files
       name: Get changed files
     - id: md_changed_files
@@ -90,14 +90,14 @@ jobs:
       # ESLint only on changed files (not the same as the above super-linter)
       - name: Get Changed Files (space-separated)
         id: changed_files_space
-        uses: jitterbit/get-changed-files@v1
+        uses: Ana06/get-changed-files@v2.3.0
         with:
           format: 'space-delimited'
       - name: Lint changed files
         run: npx eslint --quiet ${{ steps.changed_files_space.outputs.added_modified }} ${{ steps.changed_files_space.outputs.renamed }}
       - name: Get Changed Files (comma-separated)
         id: changed_files
-        uses: jitterbit/get-changed-files@v1
+        uses: Ana06/get-changed-files@v2.3.0
         with:
           format: 'csv'
       # NOTE: These steps are kept in this workflow to avoid re-rerunning the rest of the lint job


### PR DESCRIPTION
## WHY

The `jitterbit/get-changed-files@v1` action hasn't been maintained in ~4 years.
There are some issues when rebasing and/or amending commits, see https://github.com/PipedreamHQ/pipedream/pull/11945#issuecomment-2111258358

https://github.com/Ana06/get-changed-files is a fork of the original project and a drop-in replacement with bugfixes for https://github.com/jitterbit/get-changed-files/issues/54, https://github.com/jitterbit/get-changed-files/issues/4, https://github.com/jitterbit/get-changed-files/issues/7 and https://github.com/jitterbit/get-changed-files/issues/11 and more.
