### PR TITLE
chore: remove temporary continue-on-error fix for changed files

### DIFF
--- a/.github/workflows/pull-request-checks.yaml
+++ b/.github/workflows/pull-request-checks.yaml
@@ -21,7 +21,6 @@ jobs:
     - uses: Ana06/get-changed-files@v2.3.0
       id: changed_files
       name: Get changed files
-      continue-on-error: true
     - id: md_changed_files
       name: Spellcheck Markdown files
       run: |-
@@ -94,7 +93,6 @@ jobs:
         uses: Ana06/get-changed-files@v2.3.0
         with:
           format: 'space-delimited'
-        continue-on-error: true
       - name: Lint changed files
         run: npx eslint --quiet ${{ steps.changed_files_space.outputs.added_modified }} ${{ steps.changed_files_space.outputs.renamed }}
       - name: Get Changed Files (comma-separated)
@@ -102,7 +100,6 @@ jobs:
         uses: Ana06/get-changed-files@v2.3.0
         with:
           format: 'csv'
-        continue-on-error: true
       # NOTE: These steps are kept in this workflow to avoid re-rerunning the rest of the lint job
       # in the Components Checks workflow 
       - name: Check component keys


### PR DESCRIPTION
## WHY

A temporary fix for https://github.com/PipedreamHQ/pipedream/pull/11945#issuecomment-2111258358 was added in https://github.com/PipedreamHQ/pipedream/pull/11945. Since then the actual fix (replacing the outdated workflow action) has been merged in https://github.com/PipedreamHQ/pipedream/pull/11949, thus we can revert the temporary fix.

Reviewers of the original PRs were @lcaresia, @michelle0927 and @luancazarine 