### PR TITLE
feat(slack/send-block-kit-message): allow to set unfurl properties in block messages

### DIFF
--- a/components/slack/actions/send-block-kit-message/send-block-kit-message.mjs
+++ b/components/slack/actions/send-block-kit-message/send-block-kit-message.mjs
@@ -6,7 +6,7 @@ export default {
   ...buildBlocks,
   name: "Build and Send a Block Kit Message (Beta)",
   description: "Configure custom blocks and send to a channel, group, or user. [See Slack's docs for more info](https://api.slack.com/tools/block-kit-builder).",
-  version: "0.3.1",
+  version: "0.3.2",
   type: "action",
   key: "slack-send-block-kit-message",
   props: {
@@ -21,6 +21,18 @@ export default {
       propDefinition: [
         common.props.slack,
         "notificationText",
+      ],
+    },
+    unfurl_links: {
+      propDefinition: [
+        common.props.slack,
+        "unfurl_links",
+      ],
+    },
+    unfurl_media: {
+      propDefinition: [
+        common.props.slack,
+        "unfurl_media",
       ],
     },
     ...common.props,

--- a/components/slack/package.json
+++ b/components/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/slack",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Pipedream Slack Components",
   "main": "slack.app.mjs",
   "keywords": [


### PR DESCRIPTION
## WHY

Adds `unfurl_media` and `unfurl_links` options to slack `send-block-kit-message` action.

### Background

Contrary to `send-custom-message` which had this functionality for a while: https://github.com/PipedreamHQ/pipedream/blob/f2ea490cf78f3021ca875a2a46a53e0e1a6c4366/components/slack/actions/send-custom-message/send-custom-message.mjs#L36-L47
currently, it is not possible to define whether to unfurl links and media in block messages or not.

This adds the two optional properties to the `send-block-kit-message` action.

> Note: there seem to be quite a few props that are not passed through to custom actions from https://github.com/PipedreamHQ/pipedream/blob/f2ea490cf78f3021ca875a2a46a53e0e1a6c4366/components/slack/slack.app.mjs#L7 - is there a specific reason for it? Otherwise we could all add them to `send-message` common module here: https://github.com/PipedreamHQ/pipedream/blob/f2ea490cf78f3021ca875a2a46a53e0e1a6c4366/components/slack/actions/common/send-message.mjs#L7 and they'd automatically inherited via https://github.com/PipedreamHQ/pipedream/blob/f2ea490cf78f3021ca875a2a46a53e0e1a6c4366/components/slack/actions/send-block-kit-message/send-block-kit-message.mjs#L38 in each of the consumers. That way all current supported options plus all future new options would automatically be supported by all slack action providers, which feels like is what we want?
