### PR TITLE
refactor(slack): move common props to common/send-message and remove superfluous fields

### DIFF
--- a/components/slack/actions/common/send-message.mjs
+++ b/components/slack/actions/common/send-message.mjs
@@ -55,6 +55,18 @@ export default {
         "metadata_event_payload",
       ],
     },
+    unfurl_links: {
+      propDefinition: [
+        slack,
+        "unfurl_links",
+      ],
+    },
+    unfurl_media: {
+      propDefinition: [
+        slack,
+        "unfurl_media",
+      ],
+    },
   },
   methods: {
     _makeSentViaPipedreamBlock() {

--- a/components/slack/actions/reply-to-a-message/reply-to-a-message.mjs
+++ b/components/slack/actions/reply-to-a-message/reply-to-a-message.mjs
@@ -6,7 +6,7 @@ export default {
   key: "slack-reply-to-a-message",
   name: "Reply to a Message Thread",
   description: "Send a message as a threaded reply. See [postMessage](https://api.slack.com/methods/chat.postMessage) or [scheduleMessage](https://api.slack.com/methods/chat.scheduleMessage) docs here",
-  version: "0.1.19",
+  version: "0.1.20",
   type: "action",
   props: {
     slack: common.props.slack,

--- a/components/slack/actions/send-block-kit-message/send-block-kit-message.mjs
+++ b/components/slack/actions/send-block-kit-message/send-block-kit-message.mjs
@@ -6,7 +6,7 @@ export default {
   ...buildBlocks,
   name: "Build and Send a Block Kit Message (Beta)",
   description: "Configure custom blocks and send to a channel, group, or user. [See Slack's docs for more info](https://api.slack.com/tools/block-kit-builder).",
-  version: "0.3.2",
+  version: "0.3.3",
   type: "action",
   key: "slack-send-block-kit-message",
   props: {
@@ -21,18 +21,6 @@ export default {
       propDefinition: [
         common.props.slack,
         "notificationText",
-      ],
-    },
-    unfurl_links: {
-      propDefinition: [
-        common.props.slack,
-        "unfurl_links",
-      ],
-    },
-    unfurl_media: {
-      propDefinition: [
-        common.props.slack,
-        "unfurl_media",
       ],
     },
     ...common.props,

--- a/components/slack/actions/send-custom-message/send-custom-message.mjs
+++ b/components/slack/actions/send-custom-message/send-custom-message.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack-send-custom-message",
   name: "Send a Custom Message",
   description: "Customize advanced setttings and send a message to a channel, group or user. See [postMessage](https://api.slack.com/methods/chat.postMessage) or [scheduleMessage](https://api.slack.com/methods/chat.scheduleMessage) docs here",
-  version: "0.2.18",
+  version: "0.2.19",
   type: "action",
   props: {
     slack: common.props.slack,
@@ -31,18 +31,6 @@ export default {
       propDefinition: [
         common.props.slack,
         "attachments",
-      ],
-    },
-    unfurl_links: {
-      propDefinition: [
-        common.props.slack,
-        "unfurl_links",
-      ],
-    },
-    unfurl_media: {
-      propDefinition: [
-        common.props.slack,
-        "unfurl_media",
       ],
     },
     parse: {

--- a/components/slack/actions/send-direct-message/send-direct-message.mjs
+++ b/components/slack/actions/send-direct-message/send-direct-message.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack-send-direct-message",
   name: "Send a Direct Message",
   description: "Send a direct message to a single user. See [postMessage](https://api.slack.com/methods/chat.postMessage) or [scheduleMessage](https://api.slack.com/methods/chat.scheduleMessage) docs here",
-  version: "0.2.19",
+  version: "0.2.20",
   type: "action",
   props: {
     slack: common.props.slack,
@@ -26,27 +26,6 @@ export default {
         common.props.slack,
         "mrkdwn",
       ],
-    },
-    username: {
-      propDefinition: [
-        common.props.slack,
-        "username",
-      ],
-      description: "Optionally customize your bot's username (default is `Pipedream`).",
-    },
-    icon_emoji: {
-      propDefinition: [
-        common.props.slack,
-        "icon_emoji",
-      ],
-      description: "Optionally use an emoji as the bot icon for this message (e.g., `:fire:`). This value overrides `icon_url` if both are provided.",
-    },
-    icon_url: {
-      propDefinition: [
-        common.props.slack,
-        "icon_url",
-      ],
-      description: "Optionally provide an image URL to use as the bot icon for this message.",
     },
     ...common.props,
   },

--- a/components/slack/actions/send-group-message/send-group-message.mjs
+++ b/components/slack/actions/send-group-message/send-group-message.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack-send-group-message",
   name: "Send Group Message",
   description: "Send a direct message to a group of users. See [postMessage](https://api.slack.com/methods/chat.postMessage) or [scheduleMessage](https://api.slack.com/methods/chat.scheduleMessage) docs here",
-  version: "0.2.19",
+  version: "0.2.20",
   type: "action",
   props: {
     slack: common.props.slack,
@@ -26,27 +26,6 @@ export default {
         common.props.slack,
         "mrkdwn",
       ],
-    },
-    username: {
-      propDefinition: [
-        common.props.slack,
-        "username",
-      ],
-      description: "Optionally customize your bot's username (default is `Pipedream`).",
-    },
-    icon_emoji: {
-      propDefinition: [
-        common.props.slack,
-        "icon_emoji",
-      ],
-      description: "Optionally use an emoji as the bot icon for this message (e.g., `:fire:`). This value overrides `icon_url` if both are provided.",
-    },
-    icon_url: {
-      propDefinition: [
-        common.props.slack,
-        "icon_url",
-      ],
-      description: "Optionally provide an image URL to use as the bot icon for this message.",
     },
     ...common.props,
   },

--- a/components/slack/actions/send-large-message/send-large-message.mjs
+++ b/components/slack/actions/send-large-message/send-large-message.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack-send-large-message",
   name: "Send a Large Message (3000+ characters)",
   description: "Send a large message (more than 3000 characters) to a channel, group or user. See [postMessage](https://api.slack.com/methods/chat.postMessage) or [scheduleMessage](https://api.slack.com/methods/chat.scheduleMessage) docs here",
-  version: "0.0.14",
+  version: "0.0.15",
   type: "action",
   props: {
     slack: common.props.slack,
@@ -26,27 +26,6 @@ export default {
         common.props.slack,
         "mrkdwn",
       ],
-    },
-    username: {
-      propDefinition: [
-        common.props.slack,
-        "username",
-      ],
-      description: "Optionally customize your bot's username (default is `Pipedream`).",
-    },
-    icon_emoji: {
-      propDefinition: [
-        common.props.slack,
-        "icon_emoji",
-      ],
-      description: "Optionally use an emoji as the bot icon for this message (e.g., `:fire:`). This value overrides `icon_url` if both are provided.",
-    },
-    icon_url: {
-      propDefinition: [
-        common.props.slack,
-        "icon_url",
-      ],
-      description: "Optionally provide an image URL to use as the bot icon for this message.",
     },
     ...common.props,
   },

--- a/components/slack/actions/send-message-private-channel/send-message-private-channel.mjs
+++ b/components/slack/actions/send-message-private-channel/send-message-private-channel.mjs
@@ -6,7 +6,7 @@ export default {
   key: "slack-send-message-private-channel",
   name: "Send Message to a Private Channel",
   description: "Send a message to a private channel and customize the name and avatar of the bot that posts the message. See [postMessage](https://api.slack.com/methods/chat.postMessage) or [scheduleMessage](https://api.slack.com/methods/chat.scheduleMessage) docs here",
-  version: "0.2.19",
+  version: "0.2.20",
   type: "action",
   props: {
     slack: common.props.slack,
@@ -32,27 +32,6 @@ export default {
         common.props.slack,
         "mrkdwn",
       ],
-    },
-    username: {
-      propDefinition: [
-        common.props.slack,
-        "username",
-      ],
-      description: "Optionally customize your bot's username (default is `Pipedream`).",
-    },
-    icon_emoji: {
-      propDefinition: [
-        common.props.slack,
-        "icon_emoji",
-      ],
-      description: "Optionally use an emoji as the bot icon for this message (e.g., `:fire:`). This value overrides `icon_url` if both are provided.",
-    },
-    icon_url: {
-      propDefinition: [
-        common.props.slack,
-        "icon_url",
-      ],
-      description: "Optionally provide an image URL to use as the bot icon for this message.",
     },
     ...common.props,
   },

--- a/components/slack/actions/send-message-public-channel/send-message-public-channel.mjs
+++ b/components/slack/actions/send-message-public-channel/send-message-public-channel.mjs
@@ -6,7 +6,7 @@ export default {
   key: "slack-send-message-public-channel",
   name: "Send Message to a Public Channel",
   description: "Send a message to a public channel and customize the name and avatar of the bot that posts the message. See [postMessage](https://api.slack.com/methods/chat.postMessage) or [scheduleMessage](https://api.slack.com/methods/chat.scheduleMessage) docs here",
-  version: "0.2.18",
+  version: "0.2.19",
   type: "action",
   props: {
     slack: common.props.slack,
@@ -32,27 +32,6 @@ export default {
         common.props.slack,
         "mrkdwn",
       ],
-    },
-    username: {
-      propDefinition: [
-        common.props.slack,
-        "username",
-      ],
-      description: "Optionally customize your bot's username (default is `Pipedream`).",
-    },
-    icon_emoji: {
-      propDefinition: [
-        common.props.slack,
-        "icon_emoji",
-      ],
-      description: "Optionally use an emoji as the bot icon for this message (e.g., `:fire:`). This value overrides `icon_url` if both are provided.",
-    },
-    icon_url: {
-      propDefinition: [
-        common.props.slack,
-        "icon_url",
-      ],
-      description: "Optionally provide an image URL to use as the bot icon for this message.",
     },
     ...common.props,
   },


### PR DESCRIPTION
## WHY

Currently, there are some common props that are duplicated in all Slack components that send messages in any way (direct messages, group messages, private messages, thread responses, etc.

This pull request moves the two new properties introduced in #12003 to the common props.
It also removes duplicated properties already defined in the common props that are splatted into each of the components depending on it.

cc @michelle0927 