### PR TITLE
SQL Prop Type Improvements

### DIFF
--- a/platform/dist/index.d.ts
+++ b/platform/dist/index.d.ts
@@ -5,6 +5,7 @@ export { axios, transformConfigForOauth, };
 export { cloneSafe, jsonStringifySafe, } from "./utils";
 export { ConfigurationError, } from "./errors";
 export { default as sqlProp, } from "./sql-prop";
+export type { ColumnSchema, DbInfo, TableInfo, TableMetadata, TableSchema, } from "./sql-prop";
 export { default as sqlProxy, } from "./sql-proxy";
 export { DEFAULT_POLLING_SOURCE_TIMER_INTERVAL, } from "./constants";
 export declare const SendConfigEmail: t.PartialC<{

--- a/platform/dist/sql-prop.d.ts
+++ b/platform/dist/sql-prop.d.ts
@@ -1,18 +1,22 @@
 import { JsonPrimitive } from "type-fest";
-export declare type DbSchema = {
-    [tableName: string]: {
-        [columnName: string]: {
-            columnDefault: JsonPrimitive;
-            dataType: string;
-            isNullable: boolean;
-            tableSchema?: string;
-        };
-    };
+export declare type ColumnSchema = {
+    columnDefault: JsonPrimitive;
+    dataType: string;
+    isNullable: boolean;
+    tableSchema?: string;
 };
-export declare type RowCount = {
-    [tableName: string]: {
-        _rowCount?: number;
-    };
+export declare type TableMetadata = {
+    rowCount?: number;
+};
+export declare type TableSchema = {
+    [columnName: string]: ColumnSchema;
+};
+export declare type TableInfo = {
+    metadata: TableMetadata;
+    schema: TableSchema;
+};
+export declare type DbInfo = {
+    [tableName: string]: TableInfo;
 };
 declare const _default: {
     methods: {
@@ -21,11 +25,11 @@ declare const _default: {
          * (like the `sql` prop) to enrich the code editor and provide the user with
          * auto-complete and fields suggestion.
          *
-         * @returns {DbSchema} The schema of the database, which is a
+         * @returns {DbInfo} The schema of the database, which is a
          * JSON-serializable object.
          * @throws {ConfigurationError} If the method is not implemented.
          */
-        getSchema(): DbSchema | RowCount;
+        getSchema(): DbInfo;
     };
 };
 export default _default;

--- a/platform/dist/sql-prop.js
+++ b/platform/dist/sql-prop.js
@@ -8,7 +8,7 @@ exports.default = {
          * (like the `sql` prop) to enrich the code editor and provide the user with
          * auto-complete and fields suggestion.
          *
-         * @returns {DbSchema} The schema of the database, which is a
+         * @returns {DbInfo} The schema of the database, which is a
          * JSON-serializable object.
          * @throws {ConfigurationError} If the method is not implemented.
          */

--- a/platform/lib/index.ts
+++ b/platform/lib/index.ts
@@ -17,6 +17,13 @@ export {
 export {
   default as sqlProp,
 } from "./sql-prop";
+export type {
+  ColumnSchema,
+  DbInfo,
+  TableInfo,
+  TableMetadata,
+  TableSchema,
+} from "./sql-prop";
 
 export {
   default as sqlProxy,

--- a/platform/lib/sql-prop.ts
+++ b/platform/lib/sql-prop.ts
@@ -1,21 +1,28 @@
 import { ConfigurationError } from "./errors";
 import { JsonPrimitive } from "type-fest";
 
-export type DbSchema = {
-  [tableName: string]: {
-    [columnName: string]: {
-      columnDefault: JsonPrimitive;
-      dataType: string;
-      isNullable: boolean;
-      tableSchema?: string;
-    };
-  };
+export type ColumnSchema = {
+  columnDefault: JsonPrimitive;
+  dataType: string;
+  isNullable: boolean;
+  tableSchema?: string;
 };
 
-export type RowCount = {
-  [tableName: string]: {
-    _rowCount?: number;
-  };
+export type TableMetadata = {
+  rowCount?: number;
+};
+
+export type TableSchema = {
+  [columnName: string]: ColumnSchema;
+};
+
+export type TableInfo = {
+  metadata: TableMetadata;
+  schema: TableSchema;
+};
+
+export type DbInfo = {
+  [tableName: string]: TableInfo;
 };
 
 export default {
@@ -25,11 +32,11 @@ export default {
      * (like the `sql` prop) to enrich the code editor and provide the user with
      * auto-complete and fields suggestion.
      *
-     * @returns {DbSchema} The schema of the database, which is a
+     * @returns {DbInfo} The schema of the database, which is a
      * JSON-serializable object.
      * @throws {ConfigurationError} If the method is not implemented.
      */
-    getSchema(): DbSchema | RowCount {
+    getSchema(): DbInfo {
       throw new ConfigurationError("getSchema not implemented");
     },
   },

--- a/platform/package.json
+++ b/platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/platform",
-  "version": "1.6.5",
+  "version": "2.0.0",
   "description": "Pipedream platform globals (typing and runtime type checking)",
   "homepage": "https://pipedream.com",
   "main": "dist/index.js",


### PR DESCRIPTION
# Changelog
* Split DB schema info into 2 separate parts (i.e. `metadata` and `schema`)
* Define the types for each of the new parts of the DB schema
* Export all the types for the SQL prop so that they can be consumed by downstream dependencies
* Bump `@pipedream/platform` major version