### PR TITLE
Slack updates to send-message action

### DIFF
--- a/components/slack/actions/add-emoji-reaction/add-emoji-reaction.mjs
+++ b/components/slack/actions/add-emoji-reaction/add-emoji-reaction.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack-add-emoji-reaction",
   name: "Add Emoji Reaction",
   description: "Add an emoji reaction to a message. [See the documentation](https://api.slack.com/methods/reactions.add)",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "action",
   props: {
     slack,

--- a/components/slack/actions/archive-channel/archive-channel.mjs
+++ b/components/slack/actions/archive-channel/archive-channel.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack-archive-channel",
   name: "Archive Channel",
   description: "Archive a channel. [See the documentation](https://api.slack.com/methods/conversations.archive)",
-  version: "0.0.16",
+  version: "0.0.17",
   type: "action",
   props: {
     slack,

--- a/components/slack/actions/create-channel/create-channel.mjs
+++ b/components/slack/actions/create-channel/create-channel.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack-create-channel",
   name: "Create a Channel",
   description: "Create a new channel. [See the documentation](https://api.slack.com/methods/conversations.create)",
-  version: "0.0.17",
+  version: "0.0.18",
   type: "action",
   props: {
     slack,

--- a/components/slack/actions/create-reminder/create-reminder.mjs
+++ b/components/slack/actions/create-reminder/create-reminder.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack-create-reminder",
   name: "Create Reminder",
   description: "Create a reminder. [See the documentation](https://api.slack.com/methods/reminders.add)",
-  version: "0.0.17",
+  version: "0.0.18",
   type: "action",
   props: {
     slack,

--- a/components/slack/actions/delete-file/delete-file.mjs
+++ b/components/slack/actions/delete-file/delete-file.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack-delete-file",
   name: "Delete File",
   description: "Delete a file. [See the documentation](https://api.slack.com/methods/files.delete)",
-  version: "0.0.16",
+  version: "0.0.17",
   type: "action",
   props: {
     slack,

--- a/components/slack/actions/delete-message/delete-message.mjs
+++ b/components/slack/actions/delete-message/delete-message.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack-delete-message",
   name: "Delete Message",
   description: "Delete a message. [See the documentation](https://api.slack.com/methods/chat.delete)",
-  version: "0.0.16",
+  version: "0.0.17",
   type: "action",
   props: {
     slack,

--- a/components/slack/actions/find-message/find-message.mjs
+++ b/components/slack/actions/find-message/find-message.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack-find-message",
   name: "Find Message",
   description: "Find a Slack message. [See the documentation](https://api.slack.com/methods/search.messages)",
-  version: "0.0.16",
+  version: "0.0.17",
   type: "action",
   props: {
     slack,

--- a/components/slack/actions/find-user-by-email/find-user-by-email.mjs
+++ b/components/slack/actions/find-user-by-email/find-user-by-email.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack-find-user-by-email",
   name: "Find User by Email",
   description: "Find a user by matching against their email. [See the documentation](https://api.slack.com/methods/users.lookupByEmail)",
-  version: "0.0.16",
+  version: "0.0.17",
   type: "action",
   props: {
     slack,

--- a/components/slack/actions/get-file/get-file.mjs
+++ b/components/slack/actions/get-file/get-file.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack-get-file",
   name: "Get File",
   description: "Return information about a file. [See the documentation](https://api.slack.com/methods/files.info)",
-  version: "0.0.16",
+  version: "0.0.17",
   type: "action",
   props: {
     slack,

--- a/components/slack/actions/invite-user-to-channel/invite-user-to-channel.mjs
+++ b/components/slack/actions/invite-user-to-channel/invite-user-to-channel.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack-invite-user-to-channel",
   name: "Invite User to Channel",
   description: "Invite a user to an existing channel. [See the documentation](https://api.slack.com/methods/conversations.invite)",
-  version: "0.0.16",
+  version: "0.0.17",
   type: "action",
   props: {
     slack,

--- a/components/slack/actions/kick-user/kick-user.mjs
+++ b/components/slack/actions/kick-user/kick-user.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack-kick-user",
   name: "Kick User",
   description: "Remove a user from a conversation. [See the documentation](https://api.slack.com/methods/conversations.kick)",
-  version: "0.0.16",
+  version: "0.0.17",
   type: "action",
   props: {
     slack,

--- a/components/slack/actions/list-channels/list-channels.mjs
+++ b/components/slack/actions/list-channels/list-channels.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack-list-channels",
   name: "List Channels",
   description: "Return a list of all channels in a workspace. [See the documentation](https://api.slack.com/methods/conversations.list)",
-  version: "0.0.16",
+  version: "0.0.17",
   type: "action",
   props: {
     slack,

--- a/components/slack/actions/list-files/list-files.mjs
+++ b/components/slack/actions/list-files/list-files.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack-list-files",
   name: "List Files",
   description: "Return a list of files within a team. [See the documentation](https://api.slack.com/methods/files.list)",
-  version: "0.0.44",
+  version: "0.0.45",
   type: "action",
   props: {
     slack,

--- a/components/slack/actions/list-group-members/list-group-members.mjs
+++ b/components/slack/actions/list-group-members/list-group-members.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack-list-group-members",
   name: "List Group Members",
   description: "List all users in a User Group. [See the documentation](https://api.slack.com/methods/usergroups.users.list)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     slack,

--- a/components/slack/actions/list-members-in-channel/list-members-in-channel.mjs
+++ b/components/slack/actions/list-members-in-channel/list-members-in-channel.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack-list-members-in-channel",
   name: "List Members in Channel",
   description: "Retrieve members of a channel. [See the documentation](https://api.slack.com/methods/conversations.members)",
-  version: "0.0.16",
+  version: "0.0.17",
   type: "action",
   props: {
     slack,

--- a/components/slack/actions/list-replies/list-replies.mjs
+++ b/components/slack/actions/list-replies/list-replies.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack-list-replies",
   name: "List Replies",
   description: "Retrieve a thread of messages posted to a conversation. [See the documentation](https://api.slack.com/methods/conversations.replies)",
-  version: "0.0.16",
+  version: "0.0.17",
   type: "action",
   props: {
     slack,

--- a/components/slack/actions/list-users/list-users.mjs
+++ b/components/slack/actions/list-users/list-users.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack-list-users",
   name: "List Users",
   description: "Return a list of all users in a workspace. [See the documentation](https://api.slack.com/methods/users.list)",
-  version: "0.0.16",
+  version: "0.0.17",
   type: "action",
   props: {
     slack,

--- a/components/slack/actions/reply-to-a-message/reply-to-a-message.mjs
+++ b/components/slack/actions/reply-to-a-message/reply-to-a-message.mjs
@@ -6,7 +6,7 @@ export default {
   key: "slack-reply-to-a-message",
   name: "Reply to a Message Thread",
   description: "Send a message as a threaded reply. See [postMessage](https://api.slack.com/methods/chat.postMessage) or [scheduleMessage](https://api.slack.com/methods/chat.scheduleMessage) docs here",
-  version: "0.1.21",
+  version: "0.1.22",
   type: "action",
   props: {
     slack: common.props.slack,

--- a/components/slack/actions/send-custom-message/send-custom-message.mjs
+++ b/components/slack/actions/send-custom-message/send-custom-message.mjs
@@ -7,7 +7,7 @@ export default {
   key: "slack-send-custom-message",
   name: "Send a Custom Message",
   description: "Customize advanced setttings and send a message to a channel, group or user. See [postMessage](https://api.slack.com/methods/chat.postMessage) or [scheduleMessage](https://api.slack.com/methods/chat.scheduleMessage) docs here",
-  version: "0.2.20",
+  version: "0.2.21",
   type: "action",
   props: {
     slack: common.props.slack,

--- a/components/slack/actions/send-large-message/send-large-message.mjs
+++ b/components/slack/actions/send-large-message/send-large-message.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack-send-large-message",
   name: "Send a Large Message (3000+ characters)",
   description: "Send a large message (more than 3000 characters) to a channel, group or user. See [postMessage](https://api.slack.com/methods/chat.postMessage) or [scheduleMessage](https://api.slack.com/methods/chat.scheduleMessage) docs here",
-  version: "0.0.16",
+  version: "0.0.17",
   type: "action",
   props: {
     slack: common.props.slack,

--- a/components/slack/actions/send-message/send-message.mjs
+++ b/components/slack/actions/send-message/send-message.mjs
@@ -6,7 +6,7 @@ export default {
   key: "slack-send-message",
   name: "Send Message",
   description: "Send a message to a user, group, private channel or public channel. [See the documentation](https://api.slack.com/methods/chat.postMessage)",
-  version: "0.0.11",
+  version: "0.0.12",
   type: "action",
   props: {
     slack: common.props.slack,
@@ -14,7 +14,26 @@ export default {
       type: "string",
       label: "Channel Type",
       description: "The type of channel to send to. User/Direct Message (im), Group (mpim), Private Channel or Public Channel",
-      options: Object.values(constants.CHANNEL_TYPE),
+      async options() {
+        return [
+          {
+            label: "Public Channel",
+            value: constants.CHANNEL_TYPE.PUBLIC,
+          },
+          {
+            label: "Private Channel",
+            value: constants.CHANNEL_TYPE.PRIVATE,
+          },
+          {
+            label: "Group",
+            value: constants.CHANNEL_TYPE.MPIM,
+          },
+          {
+            label: "User / Direct Message",
+            value: constants.CHANNEL_TYPE.IM,
+          },
+        ];
+      },
     },
     conversation: {
       propDefinition: [

--- a/components/slack/actions/send-message/send-message.mjs
+++ b/components/slack/actions/send-message/send-message.mjs
@@ -15,24 +15,7 @@ export default {
       label: "Channel Type",
       description: "The type of channel to send to. User/Direct Message (im), Group (mpim), Private Channel or Public Channel",
       async options() {
-        return [
-          {
-            label: "Public Channel",
-            value: constants.CHANNEL_TYPE.PUBLIC,
-          },
-          {
-            label: "Private Channel",
-            value: constants.CHANNEL_TYPE.PRIVATE,
-          },
-          {
-            label: "Group",
-            value: constants.CHANNEL_TYPE.MPIM,
-          },
-          {
-            label: "User / Direct Message",
-            value: constants.CHANNEL_TYPE.IM,
-          },
-        ];
+        return constants.CHANNEL_TYPE_OPTIONS;
       },
     },
     conversation: {

--- a/components/slack/actions/set-channel-description/set-channel-description.mjs
+++ b/components/slack/actions/set-channel-description/set-channel-description.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack-set-channel-description",
   name: "Set Channel Description",
   description: "Change the description or purpose of a channel. [See the documentation](https://api.slack.com/methods/conversations.setPurpose)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     slack,

--- a/components/slack/actions/set-channel-topic/set-channel-topic.mjs
+++ b/components/slack/actions/set-channel-topic/set-channel-topic.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack-set-channel-topic",
   name: "Set Channel Topic",
   description: "Set the topic on a selected channel. [See the documentation](https://api.slack.com/methods/conversations.setTopic)",
-  version: "0.0.16",
+  version: "0.0.17",
   type: "action",
   props: {
     slack,

--- a/components/slack/actions/set-status/set-status.mjs
+++ b/components/slack/actions/set-status/set-status.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack-set-status",
   name: "Set Status",
   description: "Set the current status for a user. [See the documentation](https://api.slack.com/methods/users.profile.set)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     slack,

--- a/components/slack/actions/update-group-members/update-group-members.mjs
+++ b/components/slack/actions/update-group-members/update-group-members.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack-update-group-members",
   name: "Update Groups Members",
   description: "Update the list of users for a User Group. [See the documentation](https://api.slack.com/methods/usergroups.users.update)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     slack,

--- a/components/slack/actions/update-message/update-message.mjs
+++ b/components/slack/actions/update-message/update-message.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack-update-message",
   name: "Update Message",
   description: "Update a message. [See the documentation](https://api.slack.com/methods/chat.update)",
-  version: "0.1.16",
+  version: "0.1.17",
   type: "action",
   props: {
     slack,

--- a/components/slack/actions/update-profile/update-profile.mjs
+++ b/components/slack/actions/update-profile/update-profile.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack-update-profile",
   name: "Update Profile",
   description: "Update basic profile field such as name or title. [See the documentation](https://api.slack.com/methods/users.profile.set)",
-  version: "0.0.16",
+  version: "0.0.17",
   type: "action",
   props: {
     slack,

--- a/components/slack/actions/upload-file/upload-file.mjs
+++ b/components/slack/actions/upload-file/upload-file.mjs
@@ -6,7 +6,7 @@ export default {
   key: "slack-upload-file",
   name: "Upload File",
   description: "Upload a file. [See the documentation](https://api.slack.com/methods/files.upload)",
-  version: "0.0.19",
+  version: "0.0.20",
   type: "action",
   props: {
     slack,

--- a/components/slack/actions/verify-slack-signature/verify-slack-signature.mjs
+++ b/components/slack/actions/verify-slack-signature/verify-slack-signature.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack-verify-slack-signature",
   name: "Verify Slack Signature",
   description: "Verifying requests from Slack, slack signs its requests using a secret that's unique to your app. [See the documentation](https://api.slack.com/authentication/verifying-requests-from-slack)",
-  version: "0.0.9",
+  version: "0.0.10",
   type: "action",
   props: {
     slack,

--- a/components/slack/common/constants.mjs
+++ b/components/slack/common/constants.mjs
@@ -8,8 +8,28 @@ const CHANNEL_TYPE = {
   IM: "im",
 };
 
+const CHANNEL_TYPE_OPTIONS = [
+  {
+    label: "Public Channel",
+    value: CHANNEL_TYPE.PUBLIC,
+  },
+  {
+    label: "Private Channel",
+    value: CHANNEL_TYPE.PRIVATE,
+  },
+  {
+    label: "Group",
+    value: CHANNEL_TYPE.MPIM,
+  },
+  {
+    label: "User / Direct Message",
+    value: CHANNEL_TYPE.IM,
+  },
+];
+
 export default {
   MAX_RESOURCES,
   LIMIT,
   CHANNEL_TYPE,
+  CHANNEL_TYPE_OPTIONS,
 };

--- a/components/slack/package.json
+++ b/components/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/slack",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Pipedream Slack Components",
   "main": "slack.app.mjs",
   "keywords": [

--- a/components/slack/slack.app.mjs
+++ b/components/slack/slack.app.mjs
@@ -181,12 +181,26 @@ export default {
 
         const options = channels
           .filter(channelsFilter)
-          .map((c) => ({
-            value: c.id,
-            label: c.is_im
-              ? `@${userNames[c.user]}`
-              : c.name,
-          }));
+          .map((c) => {
+            if (c.is_im) {
+              return {
+                label: `Direct messaging with: @${userNames[c.user]}`,
+                value: c.id,
+              };
+            } else if (c.is_mpim) {
+              return {
+                label: c.purpose.value,
+                value: c.id,
+              };
+            } else {
+              return {
+                label: `${c.is_private
+                  ? "Private"
+                  : "Public"} channel: ${c.name}`,
+                value: c.id,
+              };
+            }
+          });
 
         return {
           options,

--- a/components/slack/sources/new-channel-created/new-channel-created.mjs
+++ b/components/slack/sources/new-channel-created/new-channel-created.mjs
@@ -5,7 +5,7 @@ export default {
   ...common,
   key: "slack-new-channel-created",
   name: "New Channel Created (Instant)",
-  version: "0.0.3",
+  version: "0.0.4",
   description: "Emit new event when a new channel is created.",
   type: "source",
   dedupe: "unique",

--- a/components/slack/sources/new-direct-message/new-direct-message.mjs
+++ b/components/slack/sources/new-direct-message/new-direct-message.mjs
@@ -5,7 +5,7 @@ export default {
   ...common,
   key: "slack-new-direct-message",
   name: "New Direct Message (Instant)",
-  version: "1.0.15",
+  version: "1.0.16",
   description: "Emit new event when a message was posted in a direct message channel",
   type: "source",
   dedupe: "unique",

--- a/components/slack/sources/new-interaction-event-received/new-interaction-event-received.mjs
+++ b/components/slack/sources/new-interaction-event-received/new-interaction-event-received.mjs
@@ -3,7 +3,7 @@ import sampleEmit from "./test-event.mjs";
 
 export default {
   name: "New Interaction Events (Instant)",
-  version: "0.0.13",
+  version: "0.0.14",
   key: "slack-new-interaction-event-received",
   description: "Emit new events on new Slack [interactivity events](https://api.slack.com/interactivity) sourced from [Block Kit interactive elements](https://api.slack.com/interactivity/components), [Slash commands](https://api.slack.com/interactivity/slash-commands), or [Shortcuts](https://api.slack.com/interactivity/shortcuts).",
   type: "source",

--- a/components/slack/sources/new-keyword-mention/new-keyword-mention.mjs
+++ b/components/slack/sources/new-keyword-mention/new-keyword-mention.mjs
@@ -6,7 +6,7 @@ export default {
   ...common,
   key: "slack-new-keyword-mention",
   name: "New Keyword Mention (Instant)",
-  version: "0.0.1",
+  version: "0.0.2",
   description: "Emit new event when a specific keyword is mentioned in a channel",
   type: "source",
   dedupe: "unique",

--- a/components/slack/sources/new-message-in-channels/new-message-in-channels.mjs
+++ b/components/slack/sources/new-message-in-channels/new-message-in-channels.mjs
@@ -6,7 +6,7 @@ export default {
   ...common,
   key: "slack-new-message-in-channels",
   name: "New Message In Channels (Instant)",
-  version: "1.0.17",
+  version: "1.0.18",
   description: "Emit new event when a new message is posted to one or more channels",
   type: "source",
   dedupe: "unique",

--- a/components/slack/sources/new-reaction-added/new-reaction-added.mjs
+++ b/components/slack/sources/new-reaction-added/new-reaction-added.mjs
@@ -5,7 +5,7 @@ export default {
   ...common,
   key: "slack-new-reaction-added",
   name: "New Reaction Added (Instant)",
-  version: "1.1.19",
+  version: "1.1.20",
   description: "Emit new event when a member has added an emoji reaction to a message",
   type: "source",
   dedupe: "unique",

--- a/components/slack/sources/new-user-mention/new-user-mention.mjs
+++ b/components/slack/sources/new-user-mention/new-user-mention.mjs
@@ -6,7 +6,7 @@ export default {
   ...common,
   key: "slack-new-user-mention",
   name: "New User Mention (Instant)",
-  version: "0.0.1",
+  version: "0.0.2",
   description: "Emit new event when a username or specific keyword is mentioned in a channel",
   type: "source",
   dedupe: "unique",

--- a/components/slack_bot/actions/send-message/send-message.mjs
+++ b/components/slack_bot/actions/send-message/send-message.mjs
@@ -14,5 +14,5 @@ export default {
   }),
   key: "slack_bot-send-message",
   description: "Send a message to a user, group, private channel or public channel (Bot). See [postMessage](https://api.slack.com/methods/chat.postMessage) or [scheduleMessage](https://api.slack.com/methods/chat.scheduleMessage) docs here",
-  version: "0.0.1",
+  version: "0.0.2",
 };

--- a/components/slack_bot/package.json
+++ b/components/slack_bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/slack_bot",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Pipedream Slack_bot Components",
   "main": "slack_bot.app.mjs",
   "keywords": [


### PR DESCRIPTION
- Have Channel Type just have human readable values (User / Direct Message, Group, Private Channel, Public Channel)
- For some reason, channel ID prop isn't reloading for me when I select different channel types.