### PR TITLE
SQL Interface Cleanup

### DIFF
--- a/platform/dist/sql-prop.d.ts
+++ b/platform/dist/sql-prop.d.ts
@@ -1,4 +1,5 @@
 import { JsonPrimitive } from "type-fest";
+import { ExecuteQueryArgs } from "./sql";
 export declare type ColumnSchema = {
     columnDefault: JsonPrimitive;
     dataType: string;
@@ -18,8 +19,20 @@ export declare type TableInfo = {
 export declare type DbInfo = {
     [tableName: string]: TableInfo;
 };
+export declare type SqlProp = {
+    query: string;
+    params?: string[];
+};
 declare const _default: {
     methods: {
+        /**
+         * A method that transforms the value of a prop of type `sql` so that it can
+         * be fed to the `executeQuery` method.
+         *
+         * @param sqlProp - The prop of type `sql`
+         * @returns The arguments to be passed to `executeQuery`
+         */
+        executeQueryAdapter(sqlProp: SqlProp): ExecuteQueryArgs;
         /**
          * A helper method to get the schema of the database. Used by other features
          * (like the `sql` prop) to enrich the code editor and provide the user with

--- a/platform/dist/sql-prop.js
+++ b/platform/dist/sql-prop.js
@@ -4,6 +4,17 @@ const errors_1 = require("./errors");
 exports.default = {
     methods: {
         /**
+         * A method that transforms the value of a prop of type `sql` so that it can
+         * be fed to the `executeQuery` method.
+         *
+         * @param sqlProp - The prop of type `sql`
+         * @returns The arguments to be passed to `executeQuery`
+         */
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        executeQueryAdapter(sqlProp) {
+            throw new errors_1.ConfigurationError("executeQueryAdapter not implemented");
+        },
+        /**
          * A helper method to get the schema of the database. Used by other features
          * (like the `sql` prop) to enrich the code editor and provide the user with
          * auto-complete and fields suggestion.

--- a/platform/dist/sql-proxy.d.ts
+++ b/platform/dist/sql-proxy.d.ts
@@ -1,9 +1,9 @@
+import { ExecuteQueryArgs } from "./sql";
 export declare type ClientConfiguration = object;
 export declare type ProxyArgs = {
     query: string;
     params?: unknown[];
 };
-export declare type ExecuteQueryArgs = object | string;
 export declare type Row = object;
 declare const _default: {
     methods: {
@@ -33,13 +33,6 @@ declare const _default: {
          * @returns The adapted query and parameters.
          */
         proxyAdapter(args: ExecuteQueryArgs): ProxyArgs;
-        /**
-         * A method that performs the inverse transformation of `proxyAdapter`.
-         *
-         * @param args - The output of `proxyAdapter`.
-         * @returns The query string or object to be sent to the DB.
-         */
-        executeQueryAdapter(args: ProxyArgs): ExecuteQueryArgs;
     };
 };
 export default _default;

--- a/platform/dist/sql-proxy.js
+++ b/platform/dist/sql-proxy.js
@@ -37,15 +37,5 @@ exports.default = {
         proxyAdapter(args) {
             throw new errors_1.ConfigurationError("proxyAdapter not implemented");
         },
-        /**
-         * A method that performs the inverse transformation of `proxyAdapter`.
-         *
-         * @param args - The output of `proxyAdapter`.
-         * @returns The query string or object to be sent to the DB.
-         */
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        executeQueryAdapter(args) {
-            throw new errors_1.ConfigurationError("executeQueryAdapter not implemented");
-        },
     },
 };

--- a/platform/dist/sql.d.ts
+++ b/platform/dist/sql.d.ts
@@ -1,0 +1,1 @@
+export declare type ExecuteQueryArgs = object | string;

--- a/platform/dist/sql.js
+++ b/platform/dist/sql.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/platform/lib/sql-prop.ts
+++ b/platform/lib/sql-prop.ts
@@ -1,5 +1,6 @@
 import { ConfigurationError } from "./errors";
 import { JsonPrimitive } from "type-fest";
+import { ExecuteQueryArgs } from "./sql";
 
 export type ColumnSchema = {
   columnDefault: JsonPrimitive;
@@ -25,8 +26,25 @@ export type DbInfo = {
   [tableName: string]: TableInfo;
 };
 
+export type SqlProp = {
+  query: string;
+  params?: string[];
+};
+
 export default {
   methods: {
+    /**
+     * A method that transforms the value of a prop of type `sql` so that it can
+     * be fed to the `executeQuery` method.
+     *
+     * @param sqlProp - The prop of type `sql`
+     * @returns The arguments to be passed to `executeQuery`
+     */
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    executeQueryAdapter(sqlProp: SqlProp): ExecuteQueryArgs {
+      throw new ConfigurationError("executeQueryAdapter not implemented");
+    },
+
     /**
      * A helper method to get the schema of the database. Used by other features
      * (like the `sql` prop) to enrich the code editor and provide the user with

--- a/platform/lib/sql-proxy.ts
+++ b/platform/lib/sql-proxy.ts
@@ -1,11 +1,11 @@
 import { ConfigurationError } from "./errors";
+import { ExecuteQueryArgs } from "./sql";
 
 export type ClientConfiguration = object;
 export type ProxyArgs = {
   query: string;
   params?: unknown[];
 };
-export type ExecuteQueryArgs = object | string;
 export type Row = object;
 
 export default {
@@ -45,17 +45,6 @@ export default {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     proxyAdapter(args: ExecuteQueryArgs): ProxyArgs {
       throw new ConfigurationError("proxyAdapter not implemented");
-    },
-
-    /**
-     * A method that performs the inverse transformation of `proxyAdapter`.
-     *
-     * @param args - The output of `proxyAdapter`.
-     * @returns The query string or object to be sent to the DB.
-     */
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    executeQueryAdapter(args: ProxyArgs): ExecuteQueryArgs {
-      throw new ConfigurationError("executeQueryAdapter not implemented");
     },
   },
 };

--- a/platform/lib/sql.ts
+++ b/platform/lib/sql.ts
@@ -1,0 +1,1 @@
+export type ExecuteQueryArgs = object | string;

--- a/platform/package.json
+++ b/platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/platform",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Pipedream platform globals (typing and runtime type checking)",
   "homepage": "https://pipedream.com",
   "main": "dist/index.js",


### PR DESCRIPTION
# Changelog
* Move `executeQueryAdapter` method declaration from `sql-proxy.ts` to `sql-prop.ts`
* Add new `SqlProp` type to reflect the data that `sql` props hold
* Add new `sql.ts` file with common declarations for anything SQL-related
* Bump `@pipedream/platform`'s major version

## WHY

To have a more stable SQL-related interface so that contributors can start supporting other DB engines for SQL prop and proxy.
