### PR TITLE
Enable private key auth in Snowflake

### DIFF
--- a/components/snowflake/actions/execute-sql-query/execute-sql-query.mjs
+++ b/components/snowflake/actions/execute-sql-query/execute-sql-query.mjs
@@ -2,7 +2,7 @@ import snowflake from "../../snowflake.app.mjs";
 
 export default {
   name: "Execute Query",
-  version: "0.0.1",
+  version: "0.1.0",
   key: "snowflake-execute-sql-query",
   description: "Execute a custom Snowflake query. See [our docs](https://pipedream.com/docs/databases/working-with-sql) to learn more about working with SQL in Pipedream.",
   type: "action",

--- a/components/snowflake/actions/insert-multiple-rows/insert-multiple-rows.mjs
+++ b/components/snowflake/actions/insert-multiple-rows/insert-multiple-rows.mjs
@@ -6,7 +6,7 @@ export default {
   key: "snowflake-insert-multiple-rows",
   name: "Insert Multiple Rows",
   description: "Insert multiple rows into a table",
-  version: "0.0.11",
+  version: "0.1.0",
   props: {
     snowflake,
     database: {

--- a/components/snowflake/actions/insert-row/insert-row.mjs
+++ b/components/snowflake/actions/insert-row/insert-row.mjs
@@ -5,7 +5,7 @@ export default {
   key: "snowflake-insert-row",
   name: "Insert Single Row",
   description: "Insert a row into a table",
-  version: "1.0.10",
+  version: "1.1.0",
   props: {
     snowflake,
     database: {

--- a/components/snowflake/package.json
+++ b/components/snowflake/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/snowflake",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Pipedream Snowflake Components",
   "main": "snowflake.app.mjs",
   "keywords": [

--- a/components/snowflake/package.json
+++ b/components/snowflake/package.json
@@ -17,7 +17,7 @@
     "@pipedream/platform": "^2.0.0",
     "asn1.js": "^5.0.0",
     "lodash-es": "^4.17.21",
-    "snowflake-sdk": "^1.6.10",
+    "snowflake-sdk": "^1.7.0",
     "uuid": "^8.3.2"
   }
 }

--- a/components/snowflake/snowflake.app.mjs
+++ b/components/snowflake/snowflake.app.mjs
@@ -100,8 +100,8 @@ export default {
       return this.connection;
     },
     _extractPrivateKey(key, passphrase) {
-      if (!key.startsWith("-----BEGIN ENCRYPTED PRIVATE KEY-----")) {
-        // Key is not encrypted, no need to extract anything
+      if (!key?.startsWith("-----BEGIN ENCRYPTED PRIVATE KEY-----")) {
+        // Key undefined or is not encrypted, no need to extract anything
         return key;
       }
 

--- a/components/snowflake/snowflake.app.mjs
+++ b/components/snowflake/snowflake.app.mjs
@@ -106,14 +106,22 @@ export default {
      * @returns The configuration object for the Snowflake client
      */
     getClientConfiguration() {
+      // Snowflake docs:
+      // https://docs.snowflake.com/en/developer-guide/node-js/nodejs-driver-options#authentication-options
       const {
         private_key: privateKey,
+        private_key_pass: privateKeyPass,
         ...auth
       } = this.$auth;
+      const authenticator = privateKey
+        ? "SNOWFLAKE_JWT"
+        : "SNOWFLAKE";
       return {
-        privateKey,
         ...auth,
         application: "PIPEDREAM_PIPEDREAM",
+        authenticator,
+        privateKey,
+        privateKeyPass,
       };
     },
     /**

--- a/components/snowflake/snowflake.app.mjs
+++ b/components/snowflake/snowflake.app.mjs
@@ -93,12 +93,28 @@ export default {
         return this.connection;
       }
 
-      this.connection = snowflake.createConnection({
-        ...this.$auth,
-        application: "PIPEDREAM_PIPEDREAM",
-      });
+      const options = this.getClientConfiguration();
+      this.connection = snowflake.createConnection(options);
       await promisify(this.connection.connect).bind(this.connection)();
       return this.connection;
+    },
+    /**
+     * A helper method to get the configuration object that's directly fed to
+     * the Snowflake client constructor. Used by other features (like SQL proxy)
+     * to initialize their client in an identical way.
+     *
+     * @returns The configuration object for the Snowflake client
+     */
+    getClientConfiguration() {
+      const {
+        private_key: privateKey,
+        ...auth
+      } = this.$auth;
+      return {
+        privateKey,
+        ...auth,
+        application: "PIPEDREAM_PIPEDREAM",
+      };
     },
     /**
      * A helper method to get the schema of the database. Used by other features

--- a/components/snowflake/sources/change-to-warehouse/change-to-warehouse.mjs
+++ b/components/snowflake/sources/change-to-warehouse/change-to-warehouse.mjs
@@ -17,7 +17,7 @@ export default {
   // eslint-disable-next-line
   name: "New, Updated, or Deleted Warehouse",
   description: "Emit new events when a warehouse is created, altered, or dropped",
-  version: "0.0.13",
+  version: "0.1.0",
   async run() {
     await this.watchObjectsAndEmitChanges("WAREHOUSE", this.warehouses, this.queryTypes);
   },

--- a/components/snowflake/sources/deleted-role/deleted-role.mjs
+++ b/components/snowflake/sources/deleted-role/deleted-role.mjs
@@ -6,7 +6,7 @@ export default {
   key: "snowflake-deleted-role",
   name: "New Deleted Role",
   description: "Emit new event when a role is deleted",
-  version: "0.0.9",
+  version: "0.1.0",
   methods: {
     ...common.methods,
     getSqlText() {

--- a/components/snowflake/sources/deleted-user/deleted-user.mjs
+++ b/components/snowflake/sources/deleted-user/deleted-user.mjs
@@ -6,7 +6,7 @@ export default {
   key: "snowflake-deleted-user",
   name: "New Deleted User",
   description: "Emit new event when a user is deleted",
-  version: "0.0.9",
+  version: "0.1.0",
   methods: {
     ...common.methods,
     getSqlText() {

--- a/components/snowflake/sources/failed-task-in-schema/failed-task-in-schema.mjs
+++ b/components/snowflake/sources/failed-task-in-schema/failed-task-in-schema.mjs
@@ -39,7 +39,7 @@ export default {
   // eslint-disable-next-line
   name: "Failed Task in Schema",
   description: "Emit new events when a task fails in a database schema",
-  version: "0.0.14",
+  version: "0.1.0",
   async run() {
     await this.emitFailedTasks({
       database: this.database,

--- a/components/snowflake/sources/new-database/new-database.mjs
+++ b/components/snowflake/sources/new-database/new-database.mjs
@@ -7,7 +7,7 @@ export default {
   key: "snowflake-new-database",
   name: "New Database",
   description: "Emit new event when a database is created",
-  version: "0.0.12",
+  version: "0.1.0",
   methods: {
     ...common.methods,
     alwaysRunInSingleProcessMode() {

--- a/components/snowflake/sources/new-role/new-role.mjs
+++ b/components/snowflake/sources/new-role/new-role.mjs
@@ -6,7 +6,7 @@ export default {
   key: "snowflake-new-role",
   name: "New Role",
   description: "Emit new event when a role is created",
-  version: "0.0.11",
+  version: "0.1.0",
   methods: {
     ...common.methods,
     alwaysRunInSingleProcessMode() {

--- a/components/snowflake/sources/new-row/new-row.mjs
+++ b/components/snowflake/sources/new-row/new-row.mjs
@@ -6,7 +6,7 @@ export default {
   key: "snowflake-new-row",
   name: "New Row",
   description: "Emit new event when a row is added to a table",
-  version: "0.1.13",
+  version: "0.2.0",
   methods: {
     ...common.methods,
     async getStatement(lastResultId) {

--- a/components/snowflake/sources/new-schema/new-schema.mjs
+++ b/components/snowflake/sources/new-schema/new-schema.mjs
@@ -7,7 +7,7 @@ export default {
   key: "snowflake-new-schema",
   name: "New Schema",
   description: "Emit new event when a schema is created",
-  version: "0.0.12",
+  version: "0.1.0",
   methods: {
     ...common.methods,
     alwaysRunInSingleProcessMode() {

--- a/components/snowflake/sources/new-table/new-table.mjs
+++ b/components/snowflake/sources/new-table/new-table.mjs
@@ -7,7 +7,7 @@ export default {
   key: "snowflake-new-table",
   name: "New Table",
   description: "Emit new event when a table is created",
-  version: "0.0.12",
+  version: "0.1.0",
   methods: {
     ...common.methods,
     alwaysRunInSingleProcessMode() {

--- a/components/snowflake/sources/new-user/new-user.mjs
+++ b/components/snowflake/sources/new-user/new-user.mjs
@@ -6,7 +6,7 @@ export default {
   key: "snowflake-new-user",
   name: "New User",
   description: "Emit new event when a user is created",
-  version: "0.0.11",
+  version: "0.1.0",
   methods: {
     ...common.methods,
     alwaysRunInSingleProcessMode() {

--- a/components/snowflake/sources/query-results/query-results.mjs
+++ b/components/snowflake/sources/query-results/query-results.mjs
@@ -8,7 +8,7 @@ export default {
   name: "New Query Results",
   // eslint-disable-next-line
   description: "Run a SQL query on a schedule, triggering a workflow for each row of results",
-  version: "0.1.13",
+  version: "0.2.0",
   props: {
     ...common.props,
     sqlQuery: {

--- a/components/snowflake/sources/updated-role/updated-role.mjs
+++ b/components/snowflake/sources/updated-role/updated-role.mjs
@@ -6,7 +6,7 @@ export default {
   key: "snowflake-updated-role",
   name: "New Update Role",
   description: "Emit new event when a role is updated",
-  version: "0.0.9",
+  version: "0.1.0",
   methods: {
     ...common.methods,
     getLookUpKey() {

--- a/components/snowflake/sources/updated-user/updated-user.mjs
+++ b/components/snowflake/sources/updated-user/updated-user.mjs
@@ -6,7 +6,7 @@ export default {
   key: "snowflake-updated-user",
   name: "New Update User",
   description: "Emit new event when a user is updated",
-  version: "0.0.9",
+  version: "0.1.0",
   methods: {
     ...common.methods,
     getLookUpKey() {

--- a/components/snowflake/sources/usage-monitor/usage-monitor.mjs
+++ b/components/snowflake/sources/usage-monitor/usage-monitor.mjs
@@ -6,7 +6,7 @@ export default {
   key: "snowflake-usage-monitor",
   name: "New Usage Monitor",
   description: "Emit new event when a query is executed in the specified params",
-  version: "0.0.9",
+  version: "0.1.0",
   dedupe: "unique",
   props: {
     snowflake,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8279,7 +8279,7 @@ importers:
       '@pipedream/platform': ^2.0.0
       asn1.js: ^5.0.0
       lodash-es: ^4.17.21
-      snowflake-sdk: ^1.6.10
+      snowflake-sdk: ^1.7.0
       uuid: ^8.3.2
     dependencies:
       '@pipedream/platform': 2.0.0
@@ -22848,6 +22848,7 @@ packages:
 
   /glob/7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6


### PR DESCRIPTION
## WHY

To support the `privateKey` [authentication option](https://docs.snowflake.com/en/developer-guide/node-js/nodejs-driver-options#authentication-options) when connecting to Snowflake.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added method to centralize Snowflake client configuration, enhancing code modularity and readability.
  
- **Refactor**
  - Refactored Snowflake connection setup to use a new configuration method, improving maintainability.

- **Updates**
  - Updated version numbers across multiple Snowflake components to reflect new features and enhancements.
  - Added new methods to various Snowflake components for improved functionality and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->