### PR TITLE
[FIX] gmail_custom_oauth: Source New Attachment Received: Fixed getMessageWithRetry to support try/catch block instead

### DIFF
--- a/components/gmail_custom_oauth/actions/add-label-to-email/add-label-to-email.mjs
+++ b/components/gmail_custom_oauth/actions/add-label-to-email/add-label-to-email.mjs
@@ -4,7 +4,7 @@ export default {
   key: "gmail_custom_oauth-add-label-to-email",
   name: "Add Label to Email",
   description: "Add a label to an email message. [See the docs](https://developers.google.com/gmail/api/reference/rest/v1/users.messages/modify)",
-  version: "0.0.10",
+  version: "0.0.11",
   type: "action",
   props: {
     gmail,

--- a/components/gmail_custom_oauth/actions/create-draft/create-draft.mjs
+++ b/components/gmail_custom_oauth/actions/create-draft/create-draft.mjs
@@ -5,7 +5,7 @@ export default {
   key: "gmail_custom_oauth-create-draft",
   name: "Create Draft",
   description: "Create a draft from your Google Workspace email account",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   props: {
     gmail,

--- a/components/gmail_custom_oauth/actions/download-attachment/download-attachment.mjs
+++ b/components/gmail_custom_oauth/actions/download-attachment/download-attachment.mjs
@@ -6,7 +6,7 @@ export default {
   key: "gmail_custom_oauth-download-attachment",
   name: "Download Attachement",
   description: "Download an attachment by attachmentId to the /tmp directory. [See the docs](https://developers.google.com/gmail/api/reference/rest/v1/users.messages.attachments/get)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   props: {
     gmail,

--- a/components/gmail_custom_oauth/actions/find-email/find-email.mjs
+++ b/components/gmail_custom_oauth/actions/find-email/find-email.mjs
@@ -4,7 +4,7 @@ export default {
   key: "gmail_custom_oauth-find-email",
   name: "Find Email",
   description: "Find an email using Google's Search Engine. [See the docs](https://developers.google.com/gmail/api/reference/rest/v1/users.messages/list)",
-  version: "0.0.11",
+  version: "0.0.12",
   type: "action",
   props: {
     gmail,

--- a/components/gmail_custom_oauth/actions/send-email/send-email.mjs
+++ b/components/gmail_custom_oauth/actions/send-email/send-email.mjs
@@ -10,7 +10,7 @@ overrideApp(base);
 export default {
   ...base,
   key: "gmail_custom_oauth-send-email",
-  version: "0.1.3",
+  version: "0.1.4",
   props: {
     ...base.props,
     inReplyTo: {

--- a/components/gmail_custom_oauth/actions/update-org-signature/update-org-signature.mjs
+++ b/components/gmail_custom_oauth/actions/update-org-signature/update-org-signature.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Update Signature for Email in Organization",
   description: `Update the signature for a specific email address in an organization.
     A Google Cloud service account with delegated domain-wide authority is required for this action. [See docs here](https://developers.google.com/gmail/api/reference/rest/v1/users.settings.sendAs/update)`,
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   props: {
     gmail: base.props.gmail,

--- a/components/gmail_custom_oauth/actions/update-primary-signature/update-primary-signature.mjs
+++ b/components/gmail_custom_oauth/actions/update-primary-signature/update-primary-signature.mjs
@@ -4,7 +4,7 @@ export default {
   key: "gmail_custom_oauth-update-primary-signature",
   name: "Update Signature for Primary Email Address",
   description: "Update the signature for the primary email address. [See docs here](https://developers.google.com/gmail/api/reference/rest/v1/users.settings.sendAs/update)",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   props: {
     gmail,

--- a/components/gmail_custom_oauth/gmail_custom_oauth.app.mjs
+++ b/components/gmail_custom_oauth/gmail_custom_oauth.app.mjs
@@ -91,23 +91,24 @@ export default {
       });
       return data;
     },
-    async getMessagesWithRetry(ids = [], retryCount = 0) {
-      const promises = ids.map((id) =>
-        this.getMessage({
-          id,
-        })
-          .catch((err) => {
-            console.error(`Failed to get message with id ${id}:`, err);
-            if (retryCount < 3) {
-              console.log("Retrying...");
-              return this.getMessagesWithRetry([
-                id,
-              ], retryCount + 1);
-            }
+    getMessagesWithRetry(ids = [], maxRetries = 3) {
+      const getMessageWithRetry = async (id, retryCount = 0) => {
+        try {
+          return await this.getMessage({
+            id,
+          });
+        } catch (err) {
+          console.error(`Failed to get message with id ${id}:`, err);
+          if (retryCount < maxRetries) {
+            console.log("Retrying...");
+            return await getMessageWithRetry(id, retryCount + 1);
+          }
+          console.error("Failed after 3 attempts.");
+          return null;
+        }
+      };
 
-            console.error("Failed after 3 attempts.");
-            return null;
-          }));
+      const promises = ids.map((id) => getMessageWithRetry(id));
       return Promise.all(promises);
     },
   },

--- a/components/gmail_custom_oauth/package.json
+++ b/components/gmail_custom_oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/gmail_custom_oauth",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Pipedream Gmail (Consumer) Components",
   "main": "gmail_custom_oauth.app.mjs",
   "keywords": [

--- a/components/gmail_custom_oauth/sources/new-attachment-received/new-attachment-received.mjs
+++ b/components/gmail_custom_oauth/sources/new-attachment-received/new-attachment-received.mjs
@@ -5,7 +5,7 @@ export default {
   key: "gmail_custom_oauth-new-attachment-received",
   name: "New Attachment Received",
   description: "Emit new event for each attachment in a message received. This source is capped at 100 max new messages per run.",
-  version: "0.0.9",
+  version: "0.0.10",
   type: "source",
   dedupe: "unique",
   methods: {
@@ -43,6 +43,7 @@ export default {
     },
     async processMessageIds(messageIds) {
       const messages = await this.gmail.getMessagesWithRetry(messageIds);
+      console.log("Fetched messages", JSON.stringify(messages, null, 2));
       this.emitEvents(messages);
     },
   },

--- a/components/gmail_custom_oauth/sources/new-email-received/new-email-received.mjs
+++ b/components/gmail_custom_oauth/sources/new-email-received/new-email-received.mjs
@@ -5,7 +5,7 @@ export default {
   key: "gmail_custom_oauth-new-email-received",
   name: "New Email Received",
   description: "Emit new event when an email is received. This source is capped at 100 max new messages per run.",
-  version: "0.0.10",
+  version: "0.0.11",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/gmail_custom_oauth/sources/new-labeled-email/new-labeled-email.mjs
+++ b/components/gmail_custom_oauth/sources/new-labeled-email/new-labeled-email.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Labeled Email",
   description: "Emit new event when a new email is labeled.",
   type: "source",
-  version: "0.0.7",
+  version: "0.0.8",
   dedupe: "unique",
   props: {
     gmail,

--- a/components/gmail_custom_oauth/sources/new-sent-email/new-sent-email.mjs
+++ b/components/gmail_custom_oauth/sources/new-sent-email/new-sent-email.mjs
@@ -5,7 +5,7 @@ export default {
   key: "gmail_custom_oauth-new-sent-email",
   name: "New Sent Email",
   description: "Emit new event for each new email sent. (Maximum of 300 events emited per execution)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "source",
   props: {
     app,


### PR DESCRIPTION
## WHY

Issue reported in slack at https://pipedream-users.slack.com/archives/CN1BUB92B/p1718202238151149?thread_ts=1716570844.150569&cid=CN1BUB92B


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed versioning inconsistencies across various Gmail custom OAuth actions and sources.

- **Refactor**
  - Improved reliability of the `getMessagesWithRetry` method for better message retrieval.

- **Chores**
  - Added logging for better debugging and monitoring in the new attachment received process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->