### PR TITLE
Pinning last known working minor version of Snowflake SDK (1.9.0)

### DIFF
--- a/components/snowflake/actions/execute-sql-query/execute-sql-query.mjs
+++ b/components/snowflake/actions/execute-sql-query/execute-sql-query.mjs
@@ -2,7 +2,7 @@ import snowflake from "../../snowflake.app.mjs";
 
 export default {
   name: "Execute Query",
-  version: "0.1.0",
+  version: "0.1.1",
   key: "snowflake-execute-sql-query",
   description: "Execute a custom Snowflake query. See [our docs](https://pipedream.com/docs/databases/working-with-sql) to learn more about working with SQL in Pipedream.",
   type: "action",

--- a/components/snowflake/actions/insert-multiple-rows/insert-multiple-rows.mjs
+++ b/components/snowflake/actions/insert-multiple-rows/insert-multiple-rows.mjs
@@ -6,7 +6,7 @@ export default {
   key: "snowflake-insert-multiple-rows",
   name: "Insert Multiple Rows",
   description: "Insert multiple rows into a table",
-  version: "0.1.0",
+  version: "0.1.1",
   props: {
     snowflake,
     database: {

--- a/components/snowflake/actions/insert-row/insert-row.mjs
+++ b/components/snowflake/actions/insert-row/insert-row.mjs
@@ -5,7 +5,7 @@ export default {
   key: "snowflake-insert-row",
   name: "Insert Single Row",
   description: "Insert a row into a table",
-  version: "1.1.0",
+  version: "1.1.1",
   props: {
     snowflake,
     database: {

--- a/components/snowflake/package.json
+++ b/components/snowflake/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/snowflake",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Pipedream Snowflake Components",
   "main": "snowflake.app.mjs",
   "keywords": [

--- a/components/snowflake/snowflake.app.mjs
+++ b/components/snowflake/snowflake.app.mjs
@@ -1,5 +1,5 @@
 import { createPrivateKey } from "crypto";
-import snowflake from "snowflake-sdk";
+import snowflake from "snowflake-sdk@1.9.0";
 import { promisify } from "util";
 import { sqlProp } from "@pipedream/platform";
 

--- a/components/snowflake/sources/change-to-warehouse/change-to-warehouse.mjs
+++ b/components/snowflake/sources/change-to-warehouse/change-to-warehouse.mjs
@@ -17,7 +17,7 @@ export default {
   // eslint-disable-next-line
   name: "New, Updated, or Deleted Warehouse",
   description: "Emit new events when a warehouse is created, altered, or dropped",
-  version: "0.1.0",
+  version: "0.1.1",
   async run() {
     await this.watchObjectsAndEmitChanges("WAREHOUSE", this.warehouses, this.queryTypes);
   },

--- a/components/snowflake/sources/deleted-role/deleted-role.mjs
+++ b/components/snowflake/sources/deleted-role/deleted-role.mjs
@@ -6,7 +6,7 @@ export default {
   key: "snowflake-deleted-role",
   name: "New Deleted Role",
   description: "Emit new event when a role is deleted",
-  version: "0.1.0",
+  version: "0.1.1",
   methods: {
     ...common.methods,
     getSqlText() {

--- a/components/snowflake/sources/deleted-user/deleted-user.mjs
+++ b/components/snowflake/sources/deleted-user/deleted-user.mjs
@@ -6,7 +6,7 @@ export default {
   key: "snowflake-deleted-user",
   name: "New Deleted User",
   description: "Emit new event when a user is deleted",
-  version: "0.1.0",
+  version: "0.1.1",
   methods: {
     ...common.methods,
     getSqlText() {

--- a/components/snowflake/sources/failed-task-in-schema/failed-task-in-schema.mjs
+++ b/components/snowflake/sources/failed-task-in-schema/failed-task-in-schema.mjs
@@ -39,7 +39,7 @@ export default {
   // eslint-disable-next-line
   name: "Failed Task in Schema",
   description: "Emit new events when a task fails in a database schema",
-  version: "0.1.0",
+  version: "0.1.1",
   async run() {
     await this.emitFailedTasks({
       database: this.database,

--- a/components/snowflake/sources/new-database/new-database.mjs
+++ b/components/snowflake/sources/new-database/new-database.mjs
@@ -7,7 +7,7 @@ export default {
   key: "snowflake-new-database",
   name: "New Database",
   description: "Emit new event when a database is created",
-  version: "0.1.0",
+  version: "0.1.1",
   methods: {
     ...common.methods,
     alwaysRunInSingleProcessMode() {

--- a/components/snowflake/sources/new-role/new-role.mjs
+++ b/components/snowflake/sources/new-role/new-role.mjs
@@ -6,7 +6,7 @@ export default {
   key: "snowflake-new-role",
   name: "New Role",
   description: "Emit new event when a role is created",
-  version: "0.1.0",
+  version: "0.1.1",
   methods: {
     ...common.methods,
     alwaysRunInSingleProcessMode() {

--- a/components/snowflake/sources/new-row/new-row.mjs
+++ b/components/snowflake/sources/new-row/new-row.mjs
@@ -6,7 +6,7 @@ export default {
   key: "snowflake-new-row",
   name: "New Row",
   description: "Emit new event when a row is added to a table",
-  version: "0.2.0",
+  version: "0.2.1",
   methods: {
     ...common.methods,
     async getStatement(lastResultId) {

--- a/components/snowflake/sources/new-schema/new-schema.mjs
+++ b/components/snowflake/sources/new-schema/new-schema.mjs
@@ -7,7 +7,7 @@ export default {
   key: "snowflake-new-schema",
   name: "New Schema",
   description: "Emit new event when a schema is created",
-  version: "0.1.0",
+  version: "0.1.1",
   methods: {
     ...common.methods,
     alwaysRunInSingleProcessMode() {

--- a/components/snowflake/sources/new-table/new-table.mjs
+++ b/components/snowflake/sources/new-table/new-table.mjs
@@ -7,7 +7,7 @@ export default {
   key: "snowflake-new-table",
   name: "New Table",
   description: "Emit new event when a table is created",
-  version: "0.1.0",
+  version: "0.1.1",
   methods: {
     ...common.methods,
     alwaysRunInSingleProcessMode() {

--- a/components/snowflake/sources/new-user/new-user.mjs
+++ b/components/snowflake/sources/new-user/new-user.mjs
@@ -6,7 +6,7 @@ export default {
   key: "snowflake-new-user",
   name: "New User",
   description: "Emit new event when a user is created",
-  version: "0.1.0",
+  version: "0.1.1",
   methods: {
     ...common.methods,
     alwaysRunInSingleProcessMode() {

--- a/components/snowflake/sources/query-results/query-results.mjs
+++ b/components/snowflake/sources/query-results/query-results.mjs
@@ -8,7 +8,7 @@ export default {
   name: "New Query Results",
   // eslint-disable-next-line
   description: "Run a SQL query on a schedule, triggering a workflow for each row of results",
-  version: "0.2.0",
+  version: "0.2.1",
   props: {
     ...common.props,
     sqlQuery: {

--- a/components/snowflake/sources/updated-role/updated-role.mjs
+++ b/components/snowflake/sources/updated-role/updated-role.mjs
@@ -6,7 +6,7 @@ export default {
   key: "snowflake-updated-role",
   name: "New Update Role",
   description: "Emit new event when a role is updated",
-  version: "0.1.0",
+  version: "0.1.1",
   methods: {
     ...common.methods,
     getLookUpKey() {

--- a/components/snowflake/sources/updated-user/updated-user.mjs
+++ b/components/snowflake/sources/updated-user/updated-user.mjs
@@ -6,7 +6,7 @@ export default {
   key: "snowflake-updated-user",
   name: "New Update User",
   description: "Emit new event when a user is updated",
-  version: "0.1.0",
+  version: "0.1.1",
   methods: {
     ...common.methods,
     getLookUpKey() {

--- a/components/snowflake/sources/usage-monitor/usage-monitor.mjs
+++ b/components/snowflake/sources/usage-monitor/usage-monitor.mjs
@@ -6,7 +6,7 @@ export default {
   key: "snowflake-usage-monitor",
   name: "New Usage Monitor",
   description: "Emit new event when a query is executed in the specified params",
-  version: "0.1.0",
+  version: "0.1.1",
   dedupe: "unique",
   props: {
     snowflake,


### PR DESCRIPTION
## WHY

The latest version of Snowflake SDK `1.11.0` is not working and failing for on Lambda.

Testing the most recent minor versions, `1.9.0` is the last working version. 
:x:1.11.0 (current)
:x:1.10.0
:white_check_mark: 1.9.0
:white_check_mark: 1.8.0
:white_check_mark: 1.7.0