### PR TITLE
docs: CLI via Nix

### DIFF
--- a/docs-v2/pages/cli/install.mdx
+++ b/docs-v2/pages/cli/install.mdx
@@ -63,6 +63,10 @@ Pipedream publishes the following builds of the CLI. If you need to use the CLI 
 | macOS            | amd64        | [download](https://cli.pipedream.com/darwin/amd64/latest/pd.zip)  |
 | Windows          | amd64        | [download](https://cli.pipedream.com/windows/amd64/latest/pd.zip) |
 
+## Via [Nix](https://nixos.org/) [flake](https://nixos.wiki/wiki/Flakes)
+
+The `pd` binary is available via Nix flake [here](https://github.com/planet-a-ventures/pipedream-cli)
+
 Run `pd` to see a list of all commands, or `pd help <command>` to display help docs for a specific command.
 
 See the [CLI reference](/cli/reference/) for detailed usage and examples for each command.

--- a/docs-v2/pages/cli/install.mdx
+++ b/docs-v2/pages/cli/install.mdx
@@ -63,9 +63,17 @@ Pipedream publishes the following builds of the CLI. If you need to use the CLI 
 | macOS            | amd64        | [download](https://cli.pipedream.com/darwin/amd64/latest/pd.zip)  |
 | Windows          | amd64        | [download](https://cli.pipedream.com/windows/amd64/latest/pd.zip) |
 
-## Via [Nix](https://nixos.org/) [flake](https://nixos.wiki/wiki/Flakes)
+## Community Libraries
+
+<Callout type="warning">
+Please note that Pipedream does not verify the correctness or security of these community libraries. Use them at your own risk.
+</Callout>
+
+### Via [Nix](https://nixos.org/) [flake](https://nixos.wiki/wiki/Flakes)
 
 The `pd` binary is available via Nix flake [here](https://github.com/planet-a-ventures/pipedream-cli)
+
+## Help
 
 Run `pd` to see a list of all commands, or `pd help <command>` to display help docs for a specific command.
 


### PR DESCRIPTION
This adds a section for users of Nix and how to install the `pd` binary via flakes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new section detailing the availability of the `pd` binary via Nix flake, including a link for easy access. This expands installation options and improves documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->