### PR TITLE
Add SerpApi integration

### DIFF
--- a/components/serpapi/README.md
+++ b/components/serpapi/README.md
@@ -1,0 +1,11 @@
+# Overview
+
+Scrape Google and other search engines from our fast, easy, and complete API. See all of our [search engine APIs](https://serpapi.com/search-api)
+
+# Example Use Cases
+
+- **SERP Result**: Get search results from various search engines.
+
+- **Rank Tracking**: Monitor the search rankings of your website, compare it to your competitors and discover new opportunities to get into SERPs top results.
+
+- **News events monitoring**: Track important news events and breaking developments to produce actionable data based on them.

--- a/components/serpapi/package.json
+++ b/components/serpapi/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@pipedream/serpapi",
+  "version": "0.0.1",
+  "description": "Pipedream SerpApi Components",
+  "main": "serpapi.app.mjs",
+  "keywords": [
+    "pipedream",
+    "serpapi"
+  ],
+  "homepage": "https://pipedream.com/apps/serpapi",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/components/serpapi/serpapi.app.mjs
+++ b/components/serpapi/serpapi.app.mjs
@@ -11,11 +11,18 @@ export default {
       type: "string",
       label: "api_key",
       description: "Your SerpApi API key",
+      example: "YOUR_API_KEY_HERE",
+      required: true,
     },
     parameters: {
       type: "object",
       label: "Parameters",
       description: "Query parameters for SerpApi, specific to search engines.",
+      example: {
+        "engine": "google",
+        "q": "coffee",
+      },
+      required: true,
     },
   },
   async run({ $ }) {
@@ -30,6 +37,9 @@ export default {
         "Accept": "application/json",
         "Content-Type": "application/json",
       },
+      timeout: 10000,
+    }).catch((err) => {
+      throw new Error(`Failed to fetch data from SerpApi: ${err.response.status} - ${err.response.data}`);
     });
 
     if (!response) {

--- a/components/serpapi/serpapi.app.mjs
+++ b/components/serpapi/serpapi.app.mjs
@@ -1,0 +1,45 @@
+import { axios } from "@pipedream/platform";
+
+export default {
+  name: "SerpApi",
+  description: "SerpApi integration for Pipedream.",
+  key: "serpapi",
+  version: "0.0.7",
+  type: "action",
+  props: {
+    apiKey: {
+      type: "string",
+      label: "api_key",
+      description: "Your SerpApi API key",
+    },
+    parameters: {
+      type: "object",
+      label: "Parameters",
+      description: "Query parameters for SerpApi, specific to search engines.",
+    },
+  },
+  async run({ $ }) {
+    const apiKey = this.apiKey;
+    const parameters = this.parameters;
+
+    const url = `https://serpapi.com/search?api_key=${apiKey}&${new URLSearchParams(parameters).toString()}`;
+    const response = await axios($, {
+      url: url,
+      method: "GET",
+      headers: {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response) {
+      throw new Error("No response from SerpApi");
+    }
+
+    if (response.search_metadata.status !== "Success") {
+      throw new Error(`SerpApi error: ${response.search_metadata}`);
+    }
+
+    return response;
+  },
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7971,6 +7971,9 @@ importers:
   components/seqera:
     specifiers: {}
 
+  components/serpapi:
+    specifiers: {}
+
   components/serpdog:
     specifiers: {}
 


### PR DESCRIPTION
- add serpapi integration
- update pnpm-lock

## WHY

Enable Pipedream users to have access to various search engine data throught SerpApi.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced SerpApi integration for Pipedream, allowing users to scrape search results, track rankings, and monitor news events using an API.
  - Added action for requesting data from SerpApi with API key and custom parameters.
- **Documentation**
  - Added a README file with an overview and example use cases for SerpApi.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->