### PR TITLE
Gmail Developer App - Download Attachment action to only return file path to tmp dir

### DIFF
--- a/components/gmail_custom_oauth/actions/download-attachment/download-attachment.mjs
+++ b/components/gmail_custom_oauth/actions/download-attachment/download-attachment.mjs
@@ -5,8 +5,8 @@ import path from "path";
 export default {
   key: "gmail_custom_oauth-download-attachment",
   name: "Download Attachement",
-  description: "Download an attachment by attachmentId to the /tmp directory. [See the docs](https://developers.google.com/gmail/api/reference/rest/v1/users.messages.attachments/get)",
-  version: "0.0.5",
+  description: "Download an attachment by attachmentId to the /tmp directory. [See the documentation](https://developers.google.com/gmail/api/reference/rest/v1/users.messages.attachments/get)",
+  version: "0.0.6",
   type: "action",
   props: {
     gmail,
@@ -45,7 +45,6 @@ export default {
 
     return {
       filePath,
-      ...attachment,
     };
   },
 };

--- a/components/gmail_custom_oauth/package.json
+++ b/components/gmail_custom_oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/gmail_custom_oauth",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Pipedream Gmail (Consumer) Components",
   "main": "gmail_custom_oauth.app.mjs",
   "keywords": [


### PR DESCRIPTION
Resolves #12356 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced description for the attachment download functionality in the Gmail custom OAuth module.

- **Chores**
	- Updated version details for enhanced consistency and tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->