### PR TITLE
Updating to latest Shopify Partner API Version

### DIFF
--- a/components/shopify_partner/actions/verify-webhook/verify-webhook.mjs
+++ b/components/shopify_partner/actions/verify-webhook/verify-webhook.mjs
@@ -3,7 +3,7 @@ import crypto from "crypto";
 
 export default {
   name: "Verify Webhook",
-  version: "0.0.4",
+  version: "0.1.3",
   key: "shopify_partner-verify-webhook",
   description:
     "Verify an incoming webhook from Shopify. Exits the workflow if the signature is not valid, otherwise returns `true`",

--- a/components/shopify_partner/actions/verify-webhook/verify-webhook.mjs
+++ b/components/shopify_partner/actions/verify-webhook/verify-webhook.mjs
@@ -3,7 +3,7 @@ import crypto from "crypto";
 
 export default {
   name: "Verify Webhook",
-  version: "0.1.3",
+  version: "0.0.5",
   key: "shopify_partner-verify-webhook",
   description:
     "Verify an incoming webhook from Shopify. Exits the workflow if the signature is not valid, otherwise returns `true`",

--- a/components/shopify_partner/package.json
+++ b/components/shopify_partner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/shopify_partner",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Pipedream Shopify Partner Components",
   "main": "shopify_partner.app.js",
   "keywords": [

--- a/components/shopify_partner/shopify_partner.app.mjs
+++ b/components/shopify_partner/shopify_partner.app.mjs
@@ -1,13 +1,16 @@
 import "graphql/language/index.js";
 import { GraphQLClient } from "graphql-request";
 
+export const PARTNER_API_VERSION = "2024-10";
+
 export default {
   type: "app",
   app: "shopify_partner",
   propDefinitions: {
     appId: {
       type: "string",
-      description: "Open your app in the partner portal, and look at the URL to find its ID. If your URL is *https://partners.shopify.com/3027494/apps/51358007297/overview*, enter `51358007297` here.",
+      description:
+        "Open your app in the partner portal, and look at the URL to find its ID. If your URL is *https://partners.shopify.com/3027494/apps/51358007297/overview*, enter `51358007297` here.",
       label: "Shopify App ID",
       reloadProps: true,
     },
@@ -45,7 +48,8 @@ export default {
           value: "backward",
         },
       ],
-      description: "Which direction to paginate through records. Forwards will only look into the future, whereas backwards will comb through all records.",
+      description:
+        "Which direction to paginate through records. Forwards will only look into the future, whereas backwards will comb through all records.",
       default: "forward",
     },
   },
@@ -74,7 +78,7 @@ export default {
       paginationDirection = "forward",
       recordsPerRun = 50,
     }) {
-      const endpoint = `https://partners.shopify.com/${this.$auth.organization_id}/api/2024-04/graphql.json`;
+      const endpoint = `https://partners.shopify.com/${this.$auth.organization_id}/api/${PARTNER_API_VERSION}/graphql.json`;
       const client = new GraphQLClient(endpoint, {
         headers: {
           "Content-Type": "application/json",

--- a/components/shopify_partner/sources/new-app-charges/new-app-charges.mjs
+++ b/components/shopify_partner/sources/new-app-charges/new-app-charges.mjs
@@ -5,7 +5,7 @@ export default {
   key: "shopify_partner-new-app-charges",
   name: "New App Charges",
   type: "source",
-  version: "0.0.17",
+  version: "0.1.3",
   description:
     "Emit new events when new app charges made to your partner account.",
   ...common,
@@ -28,9 +28,7 @@ export default {
   },
   async run() {
     const {
-      createdAtMin,
-      createdAtMax,
-      db,
+      createdAtMin, createdAtMax, db,
     } = this;
 
     const variables = {};
@@ -51,7 +49,9 @@ export default {
         return null;
       },
       handleEmit: (data) => {
-        console.log(data.transactions.edges.map(({ node: { ...txn } }) => txn.id));
+        console.log(
+          data.transactions.edges.map(({ node: { ...txn } }) => txn.id),
+        );
 
         data.transactions.edges.map(({ node: { ...txn } }) => {
           this.$emit(txn, {

--- a/components/shopify_partner/sources/new-app-charges/new-app-charges.mjs
+++ b/components/shopify_partner/sources/new-app-charges/new-app-charges.mjs
@@ -5,7 +5,7 @@ export default {
   key: "shopify_partner-new-app-charges",
   name: "New App Charges",
   type: "source",
-  version: "0.1.3",
+  version: "0.0.18",
   description:
     "Emit new events when new app charges made to your partner account.",
   ...common,

--- a/components/shopify_partner/sources/new-app-installs/new-app-installs.mjs
+++ b/components/shopify_partner/sources/new-app-installs/new-app-installs.mjs
@@ -6,7 +6,7 @@ export default {
   key: "shopify_partner-new-app-installs",
   name: "New App Installs",
   type: "source",
-  version: "0.1.2",
+  version: "0.1.3",
   description: "Emit new events when new shops install your app.",
   ...common,
   props: {
@@ -33,10 +33,7 @@ export default {
   },
   async run() {
     const {
-      appId,
-      occurredAtMin,
-      occurredAtMax,
-      db,
+      appId, occurredAtMin, occurredAtMax, db,
     } = this;
 
     const variables = {

--- a/components/shopify_partner/sources/new-app-relationship-events/new-app-relationship-events.mjs
+++ b/components/shopify_partner/sources/new-app-relationship-events/new-app-relationship-events.mjs
@@ -7,8 +7,9 @@ export default {
   key: "shopify_partner-new-app-relationship-events",
   name: "New App Relationship Events",
   type: "source",
-  version: "0.1.2",
-  description: "Emit new events when new shops installs, uninstalls, subscribes or unsubscribes your app.",
+  version: "0.1.3",
+  description:
+    "Emit new events when new shops installs, uninstalls, subscribes or unsubscribes your app.",
   ...common,
   props: {
     ...common.props,
@@ -69,9 +70,11 @@ export default {
     await this.shopify.query({
       db,
       key: "shopify_partner-relationship-events",
-      query: this.paginationDirection === "backward" || !this.db.get("shopify_partner-relationship-events") // on the first run, pull records from present day
-        ? getAppRelationshipEventsBackwards
-        : getAppRelationshipEventsForwards,
+      query:
+        this.paginationDirection === "backward" ||
+        !this.db.get("shopify_partner-relationship-events") // on the first run, pull records from present day
+          ? getAppRelationshipEventsBackwards
+          : getAppRelationshipEventsForwards,
       variables,
       handleEmit: (data) => {
         data.app.events.edges.map(({ node: { ...event } }) => {
@@ -94,11 +97,12 @@ export default {
           console.log("First event in batch: ", first);
           return first?.cursor;
         }
-
       },
-      hasNextPagePath: this.paginationDirection === "forward" || !this.db.get("shopify_partner-relationship-events")
-        ? "app.events.pageInfo.hasNextPage"
-        : "app.events.pageInfo.hasPreviousPage",
+      hasNextPagePath:
+        this.paginationDirection === "forward" ||
+        !this.db.get("shopify_partner-relationship-events")
+          ? "app.events.pageInfo.hasNextPage"
+          : "app.events.pageInfo.hasPreviousPage",
       paginationDirection,
       recordsPerRun,
     });

--- a/components/shopify_partner/sources/new-app-uninstalls/new-app-uninstalls.mjs
+++ b/components/shopify_partner/sources/new-app-uninstalls/new-app-uninstalls.mjs
@@ -6,7 +6,7 @@ export default {
   key: "shopify_partner-new-app-uninstalls",
   name: "New App Uninstalls",
   type: "source",
-  version: "0.1.2",
+  version: "0.1.3",
   description: "Emit new events when new shops uninstall your app.",
   ...common,
   props: {
@@ -32,10 +32,7 @@ export default {
   },
   async run() {
     const {
-      appId,
-      occurredAtMin,
-      occurredAtMax,
-      db,
+      appId, occurredAtMin, occurredAtMax, db,
     } = this;
 
     const variables = {


### PR DESCRIPTION
## WHY

Shopify Partner API's version has deprecated `2024-01` and needs to be updated in order to continue to function.

I've updated these components to use `2024-10` the latest version.

<!-- author to complete -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced dynamic API versioning in Shopify Partner integration.

- **Enhancements**
  - Improved logging and restructured variable declarations in various modules for better readability and maintainability.

- **Version Updates**
  - Updated versions across multiple modules for consistency and new features:
    - `@pipedream/shopify_partner` to 0.1.3.
    - Various source modules to 0.1.3.
    - `verify-webhook` action to 0.1.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->