### PR TITLE
fix(types): missing user prop definitions

### DIFF
--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -232,6 +232,8 @@ export interface UserProp extends BasePropInterface {
   secret?: boolean;
   min?: number;
   max?: number;
+  disabled?: boolean;
+  hidden?: boolean;
 }
 
 // https://pipedream.com/docs/components/api/#interface-props


### PR DESCRIPTION
See https://pipedream.com/docs/components/api#user-input-props

## WHY

missing properties in type definitions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `disabled` and `hidden` properties for users, allowing user properties to be marked as disabled or hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->