### PR TITLE
Types - allow sources to omit dedupe property

### DIFF
--- a/types/package-lock.json
+++ b/types/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pipedream/types",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pipedream/types",
-      "version": "0.3.0",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "typescript": "^5.2.2"

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/types",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Pipedream TypeScript types",
   "keywords": [
     "pipedream",

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -360,10 +360,23 @@ export type DedupedSource<
   run: (this: PropThis<SourcePropDefinitions> & Methods & IdEmitFunction, options?: SourceRunOptions) => void | Promise<void>;
 }>;
 
+export type NonDedupedSource<
+  Methods,
+  SourcePropDefinitions
+> = Modify<BaseSource<
+  Methods,
+  SourcePropDefinitions
+>, {
+  dedupe?: never;
+}>;
+
 export type Source<
   Methods,
   SourcePropDefinitions
 > = DedupedSource<
+  Methods,
+  SourcePropDefinitions
+> | NonDedupedSource<
   Methods,
   SourcePropDefinitions
 >;

--- a/types/src/types.test.ts
+++ b/types/src/types.test.ts
@@ -252,6 +252,23 @@ const source: Pipedream.Source<Pipedream.Methods, Pipedream.SourcePropDefinition
   },
 };
 
+const nonDedupedSource: Pipedream.Source<Pipedream.Methods, Pipedream.SourcePropDefinitions> = {
+  key: "source",
+  name: "Test Source",
+  description: "hello, world",
+  version: "0.0.1",
+  type: "source",
+  async run() {
+    this.$emit({
+      foo: "bar ",
+    }, {
+      name: "channel",
+      summary: "Summary",
+      ts: 123,
+    });
+  },
+};
+
 // Bad sources
 
 // @ts-expect-error $ExpectError - Missing key


### PR DESCRIPTION
## WHY

The only supported `Source` type was `DedupedSource`, which required the `dedupe` property and for the emit metadata to include an `id`. Since [`dedupe` and `id` are optional](https://pipedream.com/docs/components/api#component-structure),  the `Source` type should all include sources without the `dedupe` property.

For example, the following should pass TypeScript type checks:
```ts
import { defineSource } from "@pipedream/types";

export default defineSource({
  key: "source",
  name: "Test Source",
  description: "hello, world",
  version: "0.0.1",
  type: "source",
  async run() {
    this.$emit({
      foo: "bar ",
    }, {
      name: "channel",
      summary: "Summary",
      ts: 123,
    });
  },
});
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for non-deduplicated sources, expanding source definitions without a deduplication property.

- **Tests**
  - Added tests for non-deduplicated source functionality to ensure proper implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->