### PR TITLE
12853 bug rss source not a feed error is thrown incorrectly

### DIFF
--- a/components/rss/actions/merge-rss-feeds/merge-rss-feeds.ts
+++ b/components/rss/actions/merge-rss-feeds/merge-rss-feeds.ts
@@ -5,7 +5,7 @@ export default defineAction({
   name: "Merge RSS Feeds",
   description: "Retrieve multiple RSS feeds and return a merged array of items sorted by date [See documentation](https://www.rssboard.org/rss-specification)",
   key: "rss-merge-rss-feeds",
-  version: "1.2.6",
+  version: "1.2.7",
   type: "action",
   props: {
     rss,

--- a/components/rss/app/rss.app.ts
+++ b/components/rss/app/rss.app.ts
@@ -1,13 +1,10 @@
-import { axios } from "@pipedream/platform";
-import FeedParser from "feedparser";
-import { Item } from "feedparser";
-import hash from "object-hash";
-import { defineApp } from "@pipedream/types";
 import {
-  ConfigurationError, DEFAULT_POLLING_SOURCE_TIMER_INTERVAL,
+  axios, ConfigurationError, DEFAULT_POLLING_SOURCE_TIMER_INTERVAL,
 } from "@pipedream/platform";
+import { defineApp } from "@pipedream/types";
+import FeedParser, { Item } from "feedparser";
 import { ReadStream } from "fs";
-import querystring from "querystring";
+import hash from "object-hash";
 
 export default defineApp({
   type: "app",
@@ -57,8 +54,6 @@ export default defineApp({
       return hash(item);
     },
     async fetchFeed(url: string): Promise<any> {
-      const params = querystring.parse(url);
-      url = url.split("?")[0];
       const res = await axios(this, {
         url,
         method: "GET",
@@ -68,7 +63,6 @@ export default defineApp({
         validateStatus: () => true, // does not throw on any bad status code
         responseType: "stream", // stream is required for feedparser
         returnFullResponse: true,
-        params,
       });
 
       // Handle status codes as error codes

--- a/components/rss/package.json
+++ b/components/rss/package.json
@@ -28,7 +28,6 @@
     "@pipedream/platform": "^1.4.0",
     "feedparser": "^2.2.10",
     "object-hash": "^3.0.0",
-    "querystring": "^0.2.1",
     "rss-parser": "^3.12.0",
     "string-to-stream": "^3.0.1"
   }

--- a/components/rss/package.json
+++ b/components/rss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/rss",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "Pipedream RSS Components",
   "main": "dist/app/rss.app.mjs",
   "types": "dist/app/rss.app.d.ts",

--- a/components/rss/sources/new-item-from-multiple-feeds/new-item-from-multiple-feeds.ts
+++ b/components/rss/sources/new-item-from-multiple-feeds/new-item-from-multiple-feeds.ts
@@ -8,7 +8,7 @@ export default defineSource({
   name: "New Item From Multiple RSS Feeds",
   type: "source",
   description: "Emit new items from multiple RSS feeds",
-  version: "1.2.6",
+  version: "1.2.7",
   props: {
     ...rssCommon.props,
     urls: {

--- a/components/rss/sources/new-item-in-feed/new-item-in-feed.ts
+++ b/components/rss/sources/new-item-in-feed/new-item-in-feed.ts
@@ -1,5 +1,5 @@
-import rss from "../../app/rss.app";
 import { defineSource } from "@pipedream/types";
+import rss from "../../app/rss.app";
 import rssCommon from "../common/common";
 
 export default defineSource({
@@ -7,7 +7,7 @@ export default defineSource({
   key: "rss-new-item-in-feed",
   name: "New Item in Feed",
   description: "Emit new items from an RSS feed",
-  version: "1.2.6",
+  version: "1.2.7",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/rss/sources/random-item-in-multiple-feeds/random-item-in-multiple-feeds.ts
+++ b/components/rss/sources/random-item-in-multiple-feeds/random-item-in-multiple-feeds.ts
@@ -8,7 +8,7 @@ export default defineSource({
   name: "Random item from multiple RSS feeds",
   type: "source",
   description: "Emit a random item from multiple RSS feeds",
-  version: "0.2.6",
+  version: "0.2.7",
   props: {
     ...rssCommon.props,
     urls: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7719,7 +7719,6 @@ importers:
       '@types/object-hash': ^2.2.1
       feedparser: ^2.2.10
       object-hash: ^3.0.0
-      querystring: ^0.2.1
       rss-parser: ^3.12.0
       string-to-stream: ^3.0.1
     dependencies:
@@ -7727,7 +7726,6 @@ importers:
       '@pipedream/platform': 1.5.1
       feedparser: 2.2.10
       object-hash: 3.0.0
-      querystring: 0.2.1
       rss-parser: 3.13.0
       string-to-stream: 3.0.1
     devDependencies:


### PR DESCRIPTION
Resolves #12853 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the "Merge RSS Feeds" action for improved merging and sorting by date.
  
- **Refactor**
  - Streamlined import structure in the RSS app.
  - Simplified the `fetchFeed` method by removing query parameter parsing.

- **Chores**
  - Updated various component versions to ensure compatibility and stability.
  - Removed unused `querystring` dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->