### PR TITLE
Make end reason optional

### DIFF
--- a/components/end/actions/end-workflow/end-workflow.mjs
+++ b/components/end/actions/end-workflow/end-workflow.mjs
@@ -3,7 +3,7 @@ import end from "../../end.app.mjs";
 export default {
   name: "End Workflow",
   description: "Terminate workflow execution",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   key: "end-end-workflow",
   props: {

--- a/components/end/end.app.mjs
+++ b/components/end/end.app.mjs
@@ -6,6 +6,7 @@ export default {
       type: "string",
       label: "Reason",
       description: "Reason for ending workflow execution",
+      optional: true,
     },
   },
   methods: {},

--- a/components/end/package.json
+++ b/components/end/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/end",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Pipedream End Components",
   "main": "end.app.mjs",
   "keywords": [


### PR DESCRIPTION
## WHY

<!-- author to complete -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- The `Reason` field is now optional when ending a workflow, providing enhanced flexibility for users.
- **Version Updates**
	- Updated the version of the `end-workflow` module from 0.0.2 to 0.0.3.
	- Incremented the version of the package `@pipedream/end` from 0.0.3 to 0.0.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->