### PR TITLE
New Paystack Action: Charge Authorization

### DIFF
--- a/components/paystack/actions/charge-authorization/charge-authorization.mjs
+++ b/components/paystack/actions/charge-authorization/charge-authorization.mjs
@@ -4,7 +4,7 @@ export default {
   key: "paystack-charge-authorization",
   name: "Charge Authorization",
   description: "Charge a reusable authorization. [See the documentation](https://paystack.com/docs/api/transaction/#charge-authorization)",
-  version: "0.0.32",
+  version: "0.0.1",
   type: "action",
   props: {
     paystack,

--- a/components/paystack/actions/charge-authorization/charge-authorization.mjs
+++ b/components/paystack/actions/charge-authorization/charge-authorization.mjs
@@ -21,13 +21,15 @@ export default {
       ],
     },
     authorization_code: {
-        propDefinition: [
-            paystack,
-            "authorization_code",
-            (configuredProps) => ({ customer: configuredProps.email }),
-        ],
+      propDefinition: [
+        paystack,
+        "authorization_code",
+        (configuredProps) => ({
+          customer: configuredProps.email,
+        }),
+      ],
     },
-    },
+  },
   async run({ $ }) {
     const response = await this.paystack.chargeAuthorization({
       $,
@@ -35,11 +37,11 @@ export default {
         email: this.email,
         amount: this.amount,
         authorization_code: this.authorization_code,
-      }
-        
+      },
+
     });
 
-    $.export("$summary", `Authorization charged`);
+    $.export("$summary", "Authorization charged");
     return response;
   },
 };

--- a/components/paystack/actions/charge-authorization/charge-authorization.mjs
+++ b/components/paystack/actions/charge-authorization/charge-authorization.mjs
@@ -1,0 +1,45 @@
+import paystack from "../../paystack.app.mjs";
+
+export default {
+  key: "paystack-charge-authorization",
+  name: "Charge Authorization",
+  description: "Charge a reusable authorization. [See the documentation](https://paystack.com/docs/api/transaction/#charge-authorization)",
+  version: "0.0.32",
+  type: "action",
+  props: {
+    paystack,
+    email: {
+      propDefinition: [
+        paystack,
+        "email",
+      ],
+    },
+    amount: {
+      propDefinition: [
+        paystack,
+        "amount",
+      ],
+    },
+    authorization_code: {
+        propDefinition: [
+            paystack,
+            "authorization_code",
+            (configuredProps) => ({ customer: configuredProps.email }),
+        ],
+    },
+    },
+  async run({ $ }) {
+    const response = await this.paystack.chargeAuthorization({
+      $,
+      data: {
+        email: this.email,
+        amount: this.amount,
+        authorization_code: this.authorization_code,
+      }
+        
+    });
+
+    $.export("$summary", `Authorization charged`);
+    return response;
+  },
+};

--- a/components/paystack/actions/fetch-transaction/fetch-transaction.mjs
+++ b/components/paystack/actions/fetch-transaction/fetch-transaction.mjs
@@ -4,7 +4,7 @@ export default {
   key: "paystack-fetch-transaction",
   name: "Fetch Transaction",
   description: "Fetch a single transaction. [See the documentation](https://paystack.com/docs/api/transaction/#fetch)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     paystack,

--- a/components/paystack/actions/initialize-transaction/initialize-transaction.mjs
+++ b/components/paystack/actions/initialize-transaction/initialize-transaction.mjs
@@ -4,7 +4,7 @@ export default {
   key: "paystack-initialize-transaction",
   name: "Initialize Transaction",
   description: "Initializes a new transaction on Paystack. [See the documentation](https://paystack.com/docs/api/transaction/#initialize)",
-  version: "0.0.2",
+  version: "0.1.0",
   type: "action",
   props: {
     paystack,

--- a/components/paystack/actions/list-transactions/list-transactions.mjs
+++ b/components/paystack/actions/list-transactions/list-transactions.mjs
@@ -4,7 +4,7 @@ export default {
   key: "paystack-list-transactions",
   name: "List Transactions",
   description: "List transactions carried out on your integration. [See the documentation](https://paystack.com/docs/api/transaction/#list)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     paystack,

--- a/components/paystack/actions/verify-transaction/verify-transaction.mjs
+++ b/components/paystack/actions/verify-transaction/verify-transaction.mjs
@@ -4,7 +4,7 @@ export default {
   key: "paystack-verify-transaction",
   name: "Verify Transaction",
   description: "Confirm the status of a transaction. [See the documentation](https://paystack.com/docs/api/transaction/#verify)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     paystack,

--- a/components/paystack/package.json
+++ b/components/paystack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/paystack",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Paystack Components",
   "main": "paystack.app.mjs",
   "keywords": [

--- a/components/paystack/paystack.app.mjs
+++ b/components/paystack/paystack.app.mjs
@@ -9,7 +9,9 @@ export default {
       type: "string",
       label: "Email",
       description: "Email address of the customer to charge",
-      async options({ page, query }) {
+      async options({
+        page, query,
+      }) {
         const { data } = await this.listCustomers({
           params: {
             page: page + 1,
@@ -18,7 +20,9 @@ export default {
         });
         console.log(data);
         return (
-          data?.map(({ email: value, email: label }) => ({
+          data?.map(({
+            email: value, email: label,
+          }) => ({
             label,
             value,
           })) || []
@@ -106,7 +110,9 @@ export default {
         });
         console.log(data);
         return (
-          data?.map(({ id: value, email: label }) => ({
+          data?.map(({
+            id: value, email: label,
+          }) => ({
             label,
             value,
           })) || []
@@ -119,7 +125,9 @@ export default {
       description:
         "Authorization code to charge. This is created whenever a customer makes a payment on your integration",
       async options({ customer }) {
-        const { data } = await this.fetchCustomer({ customer });
+        const { data } = await this.fetchCustomer({
+          customer,
+        });
         const authorizations = data?.authorizations || [];
         return authorizations
           .filter(({ reusable }) => reusable)
@@ -154,12 +162,14 @@ export default {
     },
     _headers() {
       return {
-        Authorization: `Bearer ${this.$auth.api_key}`,
+        "Authorization": `Bearer ${this.$auth.api_key}`,
         "Content-Type": "application/json",
         "user-agent": "@PaystackOSS/paystack v0.1",
       };
     },
-    _makeRequest({ $ = this, path = "/", ...opts }) {
+    _makeRequest({
+      $ = this, path = "/", ...opts
+    }) {
       return axios($, {
         url: `${this._baseUrl()}${path}`,
         headers: this._headers(),
@@ -173,7 +183,9 @@ export default {
         ...args,
       });
     },
-    verifyTransaction({ reference, ...args }) {
+    verifyTransaction({
+      reference, ...args
+    }) {
       return this._makeRequest({
         path: `/transaction/verify/${reference}`,
         ...args,
@@ -191,13 +203,17 @@ export default {
         ...args,
       });
     },
-    fetchTransaction({ transactionID, ...args }) {
+    fetchTransaction({
+      transactionID, ...args
+    }) {
       return this._makeRequest({
         path: `/transaction/${transactionID}`,
         ...args,
       });
     },
-    fetchCustomer({ customer, ...args }) {
+    fetchCustomer({
+      customer, ...args
+    }) {
       return this._makeRequest({
         path: `/customer/${customer}`,
         args,
@@ -206,11 +222,13 @@ export default {
     chargeAuthorization(args = {}) {
       return this._makeRequest({
         method: "POST",
-        path: `/transaction/charge_authorization`,
+        path: "/transaction/charge_authorization",
         ...args,
       });
     },
-    async *paginate({ resourceFn, args, max }) {
+    async *paginate({
+      resourceFn, args, max,
+    }) {
       args = {
         ...args,
         params: {

--- a/components/paystack/paystack.app.mjs
+++ b/components/paystack/paystack.app.mjs
@@ -18,7 +18,6 @@ export default {
             email: query,
           },
         });
-        console.log(data);
         return (
           data?.map(({
             email: value, email: label,
@@ -108,7 +107,6 @@ export default {
             page: page + 1,
           },
         });
-        console.log(data);
         return (
           data?.map(({
             id: value, email: label,

--- a/components/paystack/paystack.app.mjs
+++ b/components/paystack/paystack.app.mjs
@@ -9,6 +9,22 @@ export default {
       type: "string",
       label: "Email",
       description: "Email address of the customer to charge",
+      async options({ page, query }) {
+        const { data } = await this.listCustomers({
+          params: {
+            page: page + 1,
+            email: query,
+          },
+        });
+        console.log(data);
+        return (
+          data?.map(({ email: value, email: label }) => ({
+            label,
+            value,
+          })) || []
+        );
+      },
+      useQuery: true,
     },
     amount: {
       type: "string",
@@ -18,39 +34,46 @@ export default {
     currency: {
       type: "string",
       label: "Currency",
-      description: "Currency to use for the charge. Defaults to your integration currency",
+      description:
+        "Currency to use for the charge. Defaults to your integration currency",
       options: constants.CURRENCIES,
     },
     reference: {
       type: "string",
       label: "Reference",
-      description: "Unique transaction reference. Only alphanumeric characters and `-`, `.`, `=` are allowed",
+      description:
+        "Unique transaction reference. Only alphanumeric characters and `-`, `.`, `=` are allowed",
       async options({ page }) {
         const { data } = await this.listTransactions({
           params: {
             page: page + 1,
           },
         });
-        return data?.map(({ reference }) => ({
-          value: reference,
-          label: `${reference}`,
-        })) || [];
+        return (
+          data?.map(({ reference }) => ({
+            value: reference,
+            label: `${reference}`,
+          })) || []
+        );
       },
     },
     callbackUrl: {
       type: "string",
       label: "Callback URL",
-      description: "URL to redirect customers to after a successful transaction. Setting this overrides the callback URL set on the dashboard",
+      description:
+        "URL to redirect customers to after a successful transaction. Setting this overrides the callback URL set on the dashboard",
     },
     metadata: {
       type: "object",
       label: "Metadata",
-      description: "Stringified JSON object of custom data. Check the [Metadata docs](https://paystack.com/docs/payments/metadata/) for more information",
+      description:
+        "Stringified JSON object of custom data. Check the [Metadata docs](https://paystack.com/docs/payments/metadata/) for more information",
     },
     status: {
       type: "string",
       label: "Status",
-      description: "Status of a transaction. Possible values are success, failed, and abandoned.",
+      description:
+        "Status of a transaction. Possible values are success, failed, and abandoned.",
       options: constants.STATUS,
     },
     transactionID: {
@@ -63,10 +86,12 @@ export default {
             page: page + 1,
           },
         });
-        return data?.map(({ id }) => ({
-          value: id,
-          label: `${id}`,
-        })) || [];
+        return (
+          data?.map(({ id }) => ({
+            value: id,
+            label: `${id}`,
+          })) || []
+        );
       },
     },
     customerID: {
@@ -78,30 +103,49 @@ export default {
           params: {
             page: page + 1,
           },
-        }); console.log(data);
-        return data?.map(({
-          id: value, email: label,
-        }) => ({
-          label,
-          value,
-        })) || [];
+        });
+        console.log(data);
+        return (
+          data?.map(({ id: value, email: label }) => ({
+            label,
+            value,
+          })) || []
+        );
       },
     },
-    from: {
+    authorization_code: {
       type: "string",
-      label: "From",
-      description: "The start date for record retrieval, in ISO 8601 format (e.g., 2016-09-24T00:00:05.000Z or 2016-09-21).",
-    },
-    to: {
-      type: "string",
-      label: "To",
-      description: "The end date for record retrieval, in ISO 8601 format (e.g., 2016-09-24T00:00:05.000Z or 2016-09-21).",
-    },
-    maxResults: {
-      type: "integer",
-      label: "Max Results",
-      description: "The maximum number of results to return",
-      optional: true,
+      label: "Authorization Code",
+      description:
+        "Authorization code to charge. This is created whenever a customer makes a payment on your integration",
+      async options({ customer }) {
+        const { data } = await this.fetchCustomer({ customer });
+        const authorizations = data?.authorizations || [];
+        return authorizations
+          .filter(({ reusable }) => reusable)
+          .map((authorization) => {
+            const {
+              bank,
+              channel,
+              card_type,
+              last4,
+              exp_month,
+              exp_year,
+              authorization_code,
+            } = authorization;
+            if (channel === "card") {
+              return {
+                label: ` ${bank} ${card_type} card ending in ${last4} (expires ${exp_month}/${exp_year})`,
+                value: authorization_code,
+              };
+            } else if (channel === "direct_debit") {
+              return {
+                label: `${bank} account ending in (${last4})`,
+                value: authorization_code,
+              };
+            }
+          });
+      },
     },
   },
   methods: {
@@ -110,14 +154,12 @@ export default {
     },
     _headers() {
       return {
-        "Authorization": `Bearer ${this.$auth.api_key}`,
+        Authorization: `Bearer ${this.$auth.api_key}`,
         "Content-Type": "application/json",
         "user-agent": "@PaystackOSS/paystack v0.1",
       };
     },
-    _makeRequest({
-      $ = this, path = "/", ...opts
-    }) {
+    _makeRequest({ $ = this, path = "/", ...opts }) {
       return axios($, {
         url: `${this._baseUrl()}${path}`,
         headers: this._headers(),
@@ -131,9 +173,7 @@ export default {
         ...args,
       });
     },
-    verifyTransaction({
-      reference, ...args
-    }) {
+    verifyTransaction({ reference, ...args }) {
       return this._makeRequest({
         path: `/transaction/verify/${reference}`,
         ...args,
@@ -151,17 +191,26 @@ export default {
         ...args,
       });
     },
-    fetchTransaction({
-      transactionID, ...args
-    }) {
+    fetchTransaction({ transactionID, ...args }) {
       return this._makeRequest({
         path: `/transaction/${transactionID}`,
         ...args,
       });
     },
-    async *paginate({
-      resourceFn, args, max,
-    }) {
+    fetchCustomer({ customer, ...args }) {
+      return this._makeRequest({
+        path: `/customer/${customer}`,
+        args,
+      });
+    },
+    chargeAuthorization(args = {}) {
+      return this._makeRequest({
+        method: "POST",
+        path: `/transaction/charge_authorization`,
+        ...args,
+      });
+    },
+    async *paginate({ resourceFn, args, max }) {
       args = {
         ...args,
         params: {
@@ -170,7 +219,8 @@ export default {
           page: 1,
         },
       };
-      let total, count = 0;
+      let total,
+        count = 0;
       do {
         const { data } = await resourceFn(args);
         for (const item of data) {


### PR DESCRIPTION
## WHY

<!-- author to complete -->
Adds an action for the Paystack Charge Authorization endpoint. The endpoint lets merchants charge customers using an authorization code that represents a reusable payment instrument, like a card or bank account.

The PR also updates the email prop to let users select from existing customer emails or enter a new one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new action for charging reusable authorizations using the Paystack payment processing platform, enhancing the payment process.
	- Added an asynchronous method to retrieve customer options based on queries, improving user experience.
	- Introduced a new field for authorization codes, allowing users to fetch and utilize customer authorizations seamlessly.

- **Improvements**
	- Updated multiple action modules for fetching transactions, verifying transactions, and listing transactions to new versions, indicating potential improvements.
	- Enhanced formatting and readability of existing methods and descriptions for better clarity and consistency.
	- Updated the package version for Paystack integration, reflecting new functionalities and enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->