### PR TITLE
Ana06/get-changed-files v2.3.0 Considers renamed modified files as modified

### DIFF
--- a/.github/workflows/publish-components.yaml
+++ b/.github/workflows/publish-components.yaml
@@ -64,8 +64,9 @@ jobs:
           PUBLISHED=""
           ERRORS=""
           SKIPPED=""
-          mapfile -d ',' -t added_modified_renamed_files < <(printf '%s' '${{ steps.files.outputs.added_modified_renamed }}')
-          for added_modified_file in "${added_modified_renamed_files[@]}"; do
+          # Ana06/get-changed-files@v2.3.0 treats renamed files that are modified as modified. We shouldn't be renaming files without modification.
+          mapfile -d ',' -t added_modified_files < <(printf '%s' '${{ steps.files.outputs.added_modified }}')
+          for added_modified_file in "${added_modified_files[@]}"; do
           # starts with components, ends with .*js (e.g. .js and .mjs) and not app.js,
           # doesn't end with /common*.*js, and doesn't follow */common/
           if [[ $added_modified_file == components/* ]] && [[ $added_modified_file == *.*js ]] && [[ $added_modified_file != *.app.*js ]] \
@@ -178,10 +179,11 @@ jobs:
           PUBLISHED=""
           ERRORS=""
           SKIPPED=""
-          mapfile -d ',' -t added_modified_renamed_files < <(printf '%s,%s' '${{ steps.files.outputs.added_modified }}' '${{ steps.files.outputs.renamed }}')
+          # Ana06/get-changed-files@v2.3.0 treats renamed files that are modified as modified. We shouldn't be renaming files without modification.
+          mapfile -d ',' -t added_modified_files < <(printf '%s' '${{ steps.files.outputs.added_modified }}')
           # included in the components dir, ends with .ts and not app.ts,
           # doesn't end with /common*.ts, and doesn't follow */common/
-          for added_modified_file in "${added_modified_renamed_files[@]}";
+          for added_modified_file in "${added_modified_files[@]}";
           do
             echo "Checking if $added_modified_file is a publishable ts file"
             if [[ $added_modified_file == components/* ]] && [[ $added_modified_file == *.ts ]] && [[ $added_modified_file != *.app.ts ]] \

--- a/.github/workflows/publish-components.yaml
+++ b/.github/workflows/publish-components.yaml
@@ -64,7 +64,7 @@ jobs:
           PUBLISHED=""
           ERRORS=""
           SKIPPED=""
-          mapfile -d ',' -t added_modified_renamed_files < <(printf '%s,%s' '${{ steps.files.outputs.added_modified }}' '${{ steps.files.outputs.renamed }}')
+          mapfile -d ',' -t added_modified_renamed_files < <(printf '%s' '${{ steps.files.outputs.added_modified_renamed }}')
           for added_modified_file in "${added_modified_renamed_files[@]}"; do
           # starts with components, ends with .*js (e.g. .js and .mjs) and not app.js,
           # doesn't end with /common*.*js, and doesn't follow */common/


### PR DESCRIPTION
This caused any renamed and modified files to get added to the list of files to publish twice, which resulted in a publishing error on the second try.

We will switch to just using `added_modified`, as renamed files that have not been modified shouldn't affect anything, and will probably cause a separate failure during PR checks.

## WHY


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Updated the GitHub Actions workflow to streamline the handling of file change outputs, improving efficiency in processing modified files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->