### PR TITLE
fix(types): allow Date

### DIFF
--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -5,6 +5,7 @@ export type JSONValue =
   | number
   | boolean
   | null
+  | Date
   | JSONValue[]
   | { [key: string]: JSONValue; };
 


### PR DESCRIPTION
This allows `Date` to be exported. It automatically gets serialized into it's string value.

![2024-07-31_11-13](https://github.com/user-attachments/assets/3929c228-4e07-4569-af96-5bfc2f6af8ca)
