### PR TITLE
[Action update] Notion - Add Block to Parent

### DIFF
--- a/components/notion/actions/create-page-from-database/create-page-from-database.mjs
+++ b/components/notion/actions/create-page-from-database/create-page-from-database.mjs
@@ -7,7 +7,7 @@ export default {
   key: "notion-create-page-from-database",
   name: "Create Page from Database",
   description: "Creates a page from a database. [See the docs](https://developers.notion.com/reference/post-page)",
-  version: "0.1.13",
+  version: "0.1.14",
   type: "action",
   props: {
     notion,

--- a/components/notion/actions/create-page/create-page.mjs
+++ b/components/notion/actions/create-page/create-page.mjs
@@ -7,7 +7,7 @@ export default {
   key: "notion-create-page",
   name: "Create Page",
   description: "Creates a page from a parent page. The only valid property is *title*. [See the documentation](https://developers.notion.com/reference/post-page)",
-  version: "0.2.10",
+  version: "0.2.11",
   type: "action",
   props: {
     notion,

--- a/components/notion/actions/duplicate-page/duplicate-page.mjs
+++ b/components/notion/actions/duplicate-page/duplicate-page.mjs
@@ -7,7 +7,7 @@ export default {
   key: "notion-duplicate-page",
   name: "Duplicate Page",
   description: "Creates a new page copied from an existing page block. [See the docs](https://developers.notion.com/reference/post-page)",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   props: {
     notion,

--- a/components/notion/actions/find-page/find-page.mjs
+++ b/components/notion/actions/find-page/find-page.mjs
@@ -5,7 +5,7 @@ export default {
   key: "notion-find-page",
   name: "Find a Page",
   description: "Searches for a page by its title. [See the docs](https://developers.notion.com/reference/post-search)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   methods: {
     getSummary({

--- a/components/notion/actions/query-database/query-database.mjs
+++ b/components/notion/actions/query-database/query-database.mjs
@@ -5,7 +5,7 @@ export default {
   key: "notion-query-database",
   name: "Query Database",
   description: "Query a database. [See the docs](https://developers.notion.com/reference/post-database-query)",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "action",
   props: {
     notion,

--- a/components/notion/actions/retrieve-block/retrieve-block.mjs
+++ b/components/notion/actions/retrieve-block/retrieve-block.mjs
@@ -4,7 +4,7 @@ export default {
   key: "notion-retrieve-block",
   name: "Retrieve Block",
   description: "Retrieves a block. A block object represents content within Notion. Blocks can be text, lists, media, and more. A page is also a type of block. [See the docs](https://developers.notion.com/reference/retrieve-a-block)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   props: {
     notion,

--- a/components/notion/actions/retrieve-database-content/retrieve-database-content.mjs
+++ b/components/notion/actions/retrieve-database-content/retrieve-database-content.mjs
@@ -4,7 +4,7 @@ export default {
   key: "notion-retrieve-database-content",
   name: "Retrieve Database Content",
   description: "Retreive the content of a database. [See the docs](https://developers.notion.com/reference/post-database-query)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   props: {
     notion,

--- a/components/notion/actions/retrieve-database-schema/retrieve-database-schema.mjs
+++ b/components/notion/actions/retrieve-database-schema/retrieve-database-schema.mjs
@@ -4,7 +4,7 @@ export default {
   key: "notion-retrieve-database-schema",
   name: "Retrieve Database Schema",
   description: "Retrieves a database object. Database objects describe the property schema of a database in Notion. [See the docs](https://developers.notion.com/reference/retrieve-a-database)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   props: {
     notion,

--- a/components/notion/actions/retrieve-page-property-item/retrieve-page-property-item.mjs
+++ b/components/notion/actions/retrieve-page-property-item/retrieve-page-property-item.mjs
@@ -4,7 +4,7 @@ export default {
   key: "notion-retrieve-page-property-item",
   name: "Retrieve Page Property Item",
   description: "Retrieves a `property_item` object for a given `page_id` and `property_id`.",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   props: {
     notion,

--- a/components/notion/actions/retrieve-page/retrieve-page.mjs
+++ b/components/notion/actions/retrieve-page/retrieve-page.mjs
@@ -4,7 +4,7 @@ export default {
   key: "notion-retrieve-page",
   name: "Retrieve Page",
   description: "Retrieves a page. [See the docs](https://developers.notion.com/reference/retrieve-a-page)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   props: {
     notion,

--- a/components/notion/actions/search/search.mjs
+++ b/components/notion/actions/search/search.mjs
@@ -5,7 +5,7 @@ export default {
   key: "notion-search",
   name: "Search",
   description: "Searches for a page or database. [See the docs](https://developers.notion.com/reference/post-search)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   props: {
     ...common.props,

--- a/components/notion/actions/update-page/update-page.mjs
+++ b/components/notion/actions/update-page/update-page.mjs
@@ -7,7 +7,7 @@ export default {
   key: "notion-update-page",
   name: "Update Page",
   description: "Updates page property values for the specified page. Properties that are not set will remain unchanged. To append page content, use the *append block* action. [See the docs](https://developers.notion.com/reference/patch-page)",
-  version: "1.1.1",
+  version: "1.1.2",
   type: "action",
   props: {
     notion,

--- a/components/notion/common/constants.mjs
+++ b/components/notion/common/constants.mjs
@@ -1,1 +1,11 @@
 export const MAX_BLOCKS = 100;
+export const POSITION_OPTION = {
+  PREPEND_TO_TOP: {
+    label: "Prepend to Top",
+    value: "prepend-to-top",
+  },
+  APPEND_TO_BOTTOM: {
+    label: "Append to Bottom",
+    value: "append-to-bottom",
+  },
+};

--- a/components/notion/notion.app.mjs
+++ b/components/notion/notion.app.mjs
@@ -287,10 +287,11 @@ export default {
         cursor = nextCursor;
       } while (cursor);
     },
-    async appendBlock(parentId, blocks) {
+    async appendBlock(parentId, blocks, after) {
       return this._getNotionClient().blocks.children.append({
         block_id: parentId,
         children: blocks,
+        after,
       });
     },
     async retrieveBlock(blockId) {

--- a/components/notion/package.json
+++ b/components/notion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/notion",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Pipedream Notion Components",
   "main": "notion.app.mjs",
   "keywords": [

--- a/components/notion/sources/new-database/new-database.mjs
+++ b/components/notion/sources/new-database/new-database.mjs
@@ -7,7 +7,7 @@ export default {
   key: "notion-new-database",
   name: "New Database",
   description: "Emit new event when a database is created. Note: Databases must be shared with your Pipedream Integtration to trigger event.",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "source",
   async run() {
     const databases = [];

--- a/components/notion/sources/new-page/new-page.mjs
+++ b/components/notion/sources/new-page/new-page.mjs
@@ -8,7 +8,7 @@ export default {
   key: "notion-new-page",
   name: "New Page in Database",
   description: "Emit new event when a page in a database is created",
-  version: "0.0.10",
+  version: "0.0.11",
   type: "source",
   props: {
     ...base.props,

--- a/components/notion/sources/page-or-subpage-updated/page-or-subpage-updated.mjs
+++ b/components/notion/sources/page-or-subpage-updated/page-or-subpage-updated.mjs
@@ -7,7 +7,7 @@ export default {
   key: "notion-page-or-subpage-updated",
   name: "Page or Subpage Updated", /* eslint-disable-line pipedream/source-name */
   description: "Emit new event when a page or one of its sub-pages is updated.",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/notion/sources/updated-page-id/updated-page-id.mjs
+++ b/components/notion/sources/updated-page-id/updated-page-id.mjs
@@ -7,7 +7,7 @@ export default {
   key: "notion-updated-page-id",
   name: "Updated Page ID", /* eslint-disable-line pipedream/source-name */
   description: "Emit new event when a selected page is updated",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/notion/sources/updated-page/updated-page.mjs
+++ b/components/notion/sources/updated-page/updated-page.mjs
@@ -8,7 +8,7 @@ export default {
   key: "notion-updated-page",
   name: "Updated Page in Database", /* eslint-disable-line pipedream/source-name */
   description: "Emit new event when a page in a database is updated. To select a specific page, use `Updated Page ID` instead",
-  version: "0.0.15",
+  version: "0.0.16",
   type: "source",
   dedupe: "unique",
   props: {


### PR DESCRIPTION
## WHY

Resolves #13527


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The "Append Block to Parent" action has been renamed to "Add Block to Parent," with enhanced functionality to specify block positions.
	- A new constant, `POSITION_OPTION`, added to offer more configuration options for block placement.

- **Version Updates**
	- Various components have received minor version updates, indicating potential enhancements and bug fixes, including:
		- `create-page`, `duplicate-page`, `find-page`, `query-database`, `retrieve-block`, and more.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->