### PR TITLE
Removing feature flag reference

### DIFF
--- a/docs-v2/pages/connect/quickstart.mdx
+++ b/docs-v2/pages/connect/quickstart.mdx
@@ -18,10 +18,6 @@ And here's the technical flow between your frontend, backend, and Pipedream's AP
 
 <Steps>
 
-### Enable the feature flag
-
-Enable the feature flag for **Pipedream Connect** in your [account settings](https://pipedream.com/settings/alpha).
-
 ### Choose the apps you want to integrate
 
 There are two types of apps in Pipedream:


### PR DESCRIPTION
## WHY

<!-- author to complete -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the quickstart guide by removing the section on enabling the feature flag for Pipedream Connect, simplifying the onboarding process for users integrating apps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->