### PR TITLE
Google Drive "Share File or Folder" bugfix

### DIFF
--- a/components/google_drive/actions/add-file-sharing-preference/add-file-sharing-preference.mjs
+++ b/components/google_drive/actions/add-file-sharing-preference/add-file-sharing-preference.mjs
@@ -20,7 +20,7 @@ export default {
   name: "Share File or Folder",
   description:
     "Add a [sharing permission](https://support.google.com/drive/answer/7166529) to the sharing preferences of a file or folder and provide a sharing URL. [See the documentation](https://developers.google.com/drive/api/v3/reference/permissions/create)",
-  version: "0.1.6",
+  version: "0.1.7",
   type: "action",
   props: {
     googleDrive,

--- a/components/google_drive/actions/add-file-sharing-preference/add-file-sharing-preference.mjs
+++ b/components/google_drive/actions/add-file-sharing-preference/add-file-sharing-preference.mjs
@@ -1,5 +1,5 @@
+import { ConfigurationError } from "@pipedream/platform";
 import {
-  GOOGLE_DRIVE_FOLDER_MIME_TYPE,
   GOOGLE_DRIVE_GRANTEE_DOMAIN,
   GOOGLE_DRIVE_GRANTEE_GROUP,
   GOOGLE_DRIVE_GRANTEE_USER,
@@ -31,17 +31,27 @@ export default {
       ],
       optional: true,
     },
-    fileOrFolderId: {
+    fileId: {
       propDefinition: [
         googleDrive,
-        "fileOrFolderId",
+        "fileId",
         (c) => ({
           drive: c.drive,
         }),
       ],
-      optional: false,
-      description: "The file or folder to share",
-      reloadProps: true,
+      optional: true,
+      description: "The file to share. You must specify either a file or a folder.",
+    },
+    folderId: {
+      propDefinition: [
+        googleDrive,
+        "folderId",
+        (c) => ({
+          drive: c.drive,
+        }),
+      ],
+      optional: true,
+      description: "The folder to share. You must specify either a file or a folder.",
     },
     type: {
       propDefinition: [
@@ -54,13 +64,9 @@ export default {
   async additionalProps() {
     const obj = {};
     const {
-      fileOrFolderId, type,
+      fileId, folderId, type,
     } = this;
-    if (!fileOrFolderId || !type) return obj;
-
-    const { mimeType } = await this.googleDrive.getFile(this.fileOrFolderId, {
-      fields: "mimeType",
-    });
+    if (!(fileId || folderId) || !type) return obj;
 
     const emailAddress = {
       type: "string",
@@ -93,7 +99,7 @@ export default {
       break;
     }
 
-    const isFolder = mimeType === GOOGLE_DRIVE_FOLDER_MIME_TYPE;
+    const isFolder = !!folderId;
     const options = GOOGLE_DRIVE_ROLE_OPTIONS;
 
     if (isFolder) {
@@ -114,10 +120,13 @@ export default {
   },
   async run({ $ }) {
     const {
-      fileOrFolderId, role, type, domain, emailAddress,
+      fileId, folderId, role, type, domain, emailAddress,
     } = this;
+    if (!(fileId || folderId)) {
+      throw new ConfigurationError("You must specify either a file or a folder");
+    }
     // Create the permission for the file
-    await this.googleDrive.createPermission(fileOrFolderId, {
+    await this.googleDrive.createPermission(folderId ?? fileId, {
       role,
       type,
       domain,
@@ -125,11 +134,13 @@ export default {
     });
 
     // Get the file to get the `webViewLink` sharing URL
-    const resp = await this.googleDrive.getFile(this.fileOrFolderId);
+    const resp = await this.googleDrive.getFile(folderId ?? fileId);
     const webViewLink = resp.webViewLink;
     $.export(
       "$summary",
-      `Successfully shared file "${resp.name}" with ${type} "${
+      `Successfully shared ${folderId
+        ? "folder"
+        : "file"} "${resp.name}" with ${type} "${
         emailAddress ?? domain ?? ""
       }" with role '${role}'`,
     );

--- a/components/google_drive/package.json
+++ b/components/google_drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_drive",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Pipedream Google_drive Components",
   "main": "google_drive.app.mjs",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9972,9 +9972,6 @@ importers:
       form-data: 4.0.0
       oauth-1.0a: 2.2.6
 
-  components/twitter:
-    specifiers: {}
-
   components/twitter_ads:
     specifiers: {}
 


### PR DESCRIPTION
Closes #13585 

The "File or Folder" prop was split into "File" and "Folder" as optional props, to add compatibility with custom values from previous steps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced distinct properties for sharing files (`fileId`) and folders (`folderId`), enhancing clarity in sharing actions.
	- Improved error handling to provide better user feedback when neither file nor folder ID is specified.

- **Version Updates**
	- Updated the version of the file-sharing preference action to 0.1.7.
	- Incremented the package version of `@pipedream/google_drive` to 0.8.3, indicating new updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->