### PR TITLE
Updating OpenAI default chat model to gpt-4o-mini

### DIFF
--- a/components/openai/actions/analyze-image-content/analyze-image-content.mjs
+++ b/components/openai/actions/analyze-image-content/analyze-image-content.mjs
@@ -8,7 +8,7 @@ export default {
   key: "openai-analyze-image-content",
   name: "Analyze Image Content",
   description: "Send a message or question about an image and receive a response. [See the documentation](https://platform.openai.com/docs/api-reference/runs/createThreadAndRun)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   props: {
     openai,

--- a/components/openai/actions/cancel-run/cancel-run.mjs
+++ b/components/openai/actions/cancel-run/cancel-run.mjs
@@ -4,7 +4,7 @@ export default {
   key: "openai-cancel-run",
   name: "Cancel Run (Assistants)",
   description: "Cancels a run that is in progress. [See the documentation](https://platform.openai.com/docs/api-reference/runs/cancelRun)",
-  version: "0.0.9",
+  version: "0.0.10",
   type: "action",
   props: {
     openai,

--- a/components/openai/actions/chat-with-assistant/chat-with-assistant.mjs
+++ b/components/openai/actions/chat-with-assistant/chat-with-assistant.mjs
@@ -6,7 +6,7 @@ export default {
   key: "openai-chat-with-assistant",
   name: "Chat with Assistant",
   description: "Sends a message and generates a response, storing the message history for a continuous conversation. [See the documentation](https://platform.openai.com/docs/api-reference/runs/createThreadAndRun)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   props: {
     openai,

--- a/components/openai/actions/chat/chat.mjs
+++ b/components/openai/actions/chat/chat.mjs
@@ -5,7 +5,7 @@ import constants from "../../common/constants.mjs";
 export default {
   ...common,
   name: "Chat",
-  version: "0.1.12",
+  version: "0.1.13",
   key: "openai-chat",
   description: "The Chat API, using the `gpt-3.5-turbo` or `gpt-4` model. [See the documentation](https://platform.openai.com/docs/api-reference/chat)",
   type: "action",

--- a/components/openai/actions/classify-items-into-categories/classify-items-into-categories.mjs
+++ b/components/openai/actions/classify-items-into-categories/classify-items-into-categories.mjs
@@ -3,7 +3,7 @@ import common from "../common/common-helper.mjs";
 export default {
   ...common,
   name: "Classify Items into Categories",
-  version: "0.0.13",
+  version: "0.0.14",
   key: "openai-classify-items-into-categories",
   description: "Classify items into specific categories using the Chat API. [See the documentation](https://platform.openai.com/docs/api-reference/chat)",
   type: "action",

--- a/components/openai/actions/convert-text-to-speech/convert-text-to-speech.mjs
+++ b/components/openai/actions/convert-text-to-speech/convert-text-to-speech.mjs
@@ -5,7 +5,7 @@ export default {
   key: "openai-convert-text-to-speech",
   name: "Convert Text to Speech (TTS)",
   description: "Generates audio from the input text. [See the documentation](https://platform.openai.com/docs/api-reference/audio/createSpeech)",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "action",
   props: {
     openai,

--- a/components/openai/actions/create-assistant/create-assistant.mjs
+++ b/components/openai/actions/create-assistant/create-assistant.mjs
@@ -6,7 +6,7 @@ export default {
   key: "openai-create-assistant",
   name: "Create Assistant",
   description: "Creates an assistant with a model and instructions. [See the documentation](https://platform.openai.com/docs/api-reference/assistants/createAssistant)",
-  version: "0.1.6",
+  version: "0.1.7",
   type: "action",
   props: {
     openai,

--- a/components/openai/actions/create-batch/create-batch.mjs
+++ b/components/openai/actions/create-batch/create-batch.mjs
@@ -8,7 +8,7 @@ export default {
   key: "openai-create-batch",
   name: "Create Batch",
   description: "Creates and executes a batch from an uploaded file of requests. [See the documentation](https://platform.openai.com/docs/api-reference/batch/create)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   props: {
     openai,

--- a/components/openai/actions/create-embeddings/create-embeddings.mjs
+++ b/components/openai/actions/create-embeddings/create-embeddings.mjs
@@ -4,7 +4,7 @@ import common from "../common/common.mjs";
 
 export default {
   name: "Create Embeddings",
-  version: "0.0.11",
+  version: "0.0.12",
   key: "openai-create-embeddings",
   description: "Get a vector representation of a given input that can be easily consumed by machine learning models and algorithms. [See the documentation](https://platform.openai.com/docs/api-reference/embeddings)",
   type: "action",

--- a/components/openai/actions/create-fine-tuning-job/create-fine-tuning-job.mjs
+++ b/components/openai/actions/create-fine-tuning-job/create-fine-tuning-job.mjs
@@ -4,7 +4,7 @@ export default {
   key: "openai-create-fine-tuning-job",
   name: "Create Fine Tuning Job",
   description: "Creates a job that fine-tunes a specified model from a given dataset. [See the documentation](https://platform.openai.com/docs/api-reference/fine-tuning/create)",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "action",
   props: {
     openai,

--- a/components/openai/actions/create-image/create-image.mjs
+++ b/components/openai/actions/create-image/create-image.mjs
@@ -4,7 +4,7 @@ import fs from "fs";
 
 export default {
   name: "Create Image (Dall-E)",
-  version: "0.1.16",
+  version: "0.1.17",
   key: "openai-create-image",
   description: "Creates an image given a prompt returning a URL to the image. [See the documentation](https://platform.openai.com/docs/api-reference/images)",
   type: "action",

--- a/components/openai/actions/create-moderation/create-moderation.mjs
+++ b/components/openai/actions/create-moderation/create-moderation.mjs
@@ -5,7 +5,7 @@ export default {
   key: "openai-create-moderation",
   name: "Create Moderation",
   description: "Classifies if text is potentially harmful. [See the documentation](https://platform.openai.com/docs/api-reference/moderations/create)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   props: {
     openai,

--- a/components/openai/actions/create-thread/create-thread.mjs
+++ b/components/openai/actions/create-thread/create-thread.mjs
@@ -6,7 +6,7 @@ export default {
   key: "openai-create-thread",
   name: "Create Thread (Assistants)",
   description: "Creates a thread with optional messages and metadata, and optionally runs the thread using the specified assistant. [See the documentation](https://platform.openai.com/docs/api-reference/threads/createThread)",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "action",
   props: {
     openai,

--- a/components/openai/actions/create-transcription/create-transcription.mjs
+++ b/components/openai/actions/create-transcription/create-transcription.mjs
@@ -24,7 +24,7 @@ const pipelineAsync = promisify(stream.pipeline);
 
 export default {
   name: "Create Transcription (Whisper)",
-  version: "0.1.11",
+  version: "0.1.12",
   key: "openai-create-transcription",
   description: "Transcribes audio into the input language. [See the documentation](https://platform.openai.com/docs/api-reference/audio/create).",
   type: "action",

--- a/components/openai/actions/delete-file/delete-file.mjs
+++ b/components/openai/actions/delete-file/delete-file.mjs
@@ -4,7 +4,7 @@ export default {
   key: "openai-delete-file",
   name: "Delete File",
   description: "Deletes a specified file from OpenAI. [See the documentation](https://platform.openai.com/docs/api-reference/files/delete)",
-  version: "0.0.9",
+  version: "0.0.10",
   type: "action",
   props: {
     openai,

--- a/components/openai/actions/list-files/list-files.mjs
+++ b/components/openai/actions/list-files/list-files.mjs
@@ -4,7 +4,7 @@ export default {
   key: "openai-list-files",
   name: "List Files",
   description: "Returns a list of files that belong to the user's organization. [See the documentation](https://platform.openai.com/docs/api-reference/files/list)",
-  version: "0.0.9",
+  version: "0.0.10",
   type: "action",
   props: {
     openai,

--- a/components/openai/actions/list-messages/list-messages.mjs
+++ b/components/openai/actions/list-messages/list-messages.mjs
@@ -4,7 +4,7 @@ export default {
   key: "openai-list-messages",
   name: "List Messages (Assistants)",
   description: "Lists the messages for a given thread. [See the documentation](https://platform.openai.com/docs/api-reference/messages/listMessages)",
-  version: "0.0.10",
+  version: "0.0.11",
   type: "action",
   props: {
     openai,

--- a/components/openai/actions/list-run-steps/list-run-steps.mjs
+++ b/components/openai/actions/list-run-steps/list-run-steps.mjs
@@ -4,7 +4,7 @@ export default {
   key: "openai-list-run-steps",
   name: "List Run Steps (Assistants)",
   description: "Returns a list of run steps belonging to a run. [See the documentation](https://platform.openai.com/docs/api-reference/runs/list-run-steps)",
-  version: "0.0.9",
+  version: "0.0.10",
   type: "action",
   props: {
     openai,

--- a/components/openai/actions/list-runs/list-runs.mjs
+++ b/components/openai/actions/list-runs/list-runs.mjs
@@ -4,7 +4,7 @@ export default {
   key: "openai-list-runs",
   name: "List Runs (Assistants)",
   description: "Returns a list of runs belonging to a thread. [See the documentation](https://platform.openai.com/docs/api-reference/runs/list)",
-  version: "0.0.10",
+  version: "0.0.11",
   type: "action",
   props: {
     openai,

--- a/components/openai/actions/modify-assistant/modify-assistant.mjs
+++ b/components/openai/actions/modify-assistant/modify-assistant.mjs
@@ -6,7 +6,7 @@ export default {
   key: "openai-modify-assistant",
   name: "Modify an Assistant",
   description: "Modifies an existing OpenAI assistant. [See the documentation](https://platform.openai.com/docs/api-reference/assistants/modifyAssistant)",
-  version: "0.1.6",
+  version: "0.1.7",
   type: "action",
   props: {
     openai,

--- a/components/openai/actions/retrieve-file-content/retrieve-file-content.mjs
+++ b/components/openai/actions/retrieve-file-content/retrieve-file-content.mjs
@@ -5,7 +5,7 @@ export default {
   key: "openai-retrieve-file-content",
   name: "Retrieve File Content",
   description: "Retrieves the contents of the specified file. [See the documentation](https://platform.openai.com/docs/api-reference/files/retrieve-content)",
-  version: "0.0.9",
+  version: "0.0.10",
   type: "action",
   props: {
     openai,

--- a/components/openai/actions/retrieve-file/retrieve-file.mjs
+++ b/components/openai/actions/retrieve-file/retrieve-file.mjs
@@ -4,7 +4,7 @@ export default {
   key: "openai-retrieve-file",
   name: "Retrieve File",
   description: "Retrieves a specific file from OpenAI. [See the documentation](https://platform.openai.com/docs/api-reference/files/retrieve)",
-  version: "0.0.9",
+  version: "0.0.10",
   type: "action",
   props: {
     openai,

--- a/components/openai/actions/retrieve-run-step/retrieve-run-step.mjs
+++ b/components/openai/actions/retrieve-run-step/retrieve-run-step.mjs
@@ -4,7 +4,7 @@ export default {
   key: "openai-retrieve-run-step",
   name: "Retrieve Run Step (Assistants)",
   description: "Retrieve a specific run step in a thread. [See the documentation](https://platform.openai.com/docs/api-reference/runs/getRunStep)",
-  version: "0.0.9",
+  version: "0.0.10",
   type: "action",
   props: {
     openai,

--- a/components/openai/actions/retrieve-run/retrieve-run.mjs
+++ b/components/openai/actions/retrieve-run/retrieve-run.mjs
@@ -4,7 +4,7 @@ export default {
   key: "openai-retrieve-run",
   name: "Retrieve Run (Assistants)",
   description: "Retrieves a specific run within a thread. [See the documentation](https://platform.openai.com/docs/api-reference/runs/getRun)",
-  version: "0.0.9",
+  version: "0.0.10",
   type: "action",
   props: {
     openai,

--- a/components/openai/actions/send-prompt/send-prompt.mjs
+++ b/components/openai/actions/send-prompt/send-prompt.mjs
@@ -4,7 +4,7 @@ import common from "../common/common.mjs";
 export default {
   ...common,
   name: "Create Completion (Send Prompt)",
-  version: "0.1.10",
+  version: "0.1.11",
   key: "openai-send-prompt",
   description: "OpenAI recommends using the **Chat** action for the latest `gpt-3.5-turbo` API, since it's faster and 10x cheaper. This action creates a completion for the provided prompt and parameters using the older `/completions` API. [See the documentation](https://beta.openai.com/docs/api-reference/completions/create)",
   type: "action",

--- a/components/openai/actions/submit-tool-outputs-to-run/submit-tool-outputs-to-run.mjs
+++ b/components/openai/actions/submit-tool-outputs-to-run/submit-tool-outputs-to-run.mjs
@@ -5,7 +5,7 @@ export default {
   key: "openai-submit-tool-outputs-to-run",
   name: "Submit Tool Outputs to Run (Assistants)",
   description: "Submits tool outputs to a run that requires action. [See the documentation](https://platform.openai.com/docs/api-reference/runs/submitToolOutputs)",
-  version: "0.0.9",
+  version: "0.0.10",
   type: "action",
   props: {
     openai,

--- a/components/openai/actions/summarize/summarize.mjs
+++ b/components/openai/actions/summarize/summarize.mjs
@@ -4,7 +4,7 @@ import constants from "../../common/constants.mjs";
 export default {
   ...common,
   name: "Summarize Text",
-  version: "0.0.13",
+  version: "0.0.14",
   key: "openai-summarize",
   description: "Summarizes text using the Chat API. [See the documentation](https://platform.openai.com/docs/api-reference/chat)",
   type: "action",

--- a/components/openai/actions/translate-text/translate-text.mjs
+++ b/components/openai/actions/translate-text/translate-text.mjs
@@ -9,7 +9,7 @@ const langOptions = lang.LANGUAGES.map((l) => ({
 export default {
   ...common,
   name: "Translate Text (Whisper)",
-  version: "0.0.15",
+  version: "0.0.16",
   key: "openai-translate-text",
   description: "Translate text from one language to another using the Chat API. [See the documentation](https://platform.openai.com/docs/api-reference/chat)",
   type: "action",

--- a/components/openai/actions/upload-file/upload-file.mjs
+++ b/components/openai/actions/upload-file/upload-file.mjs
@@ -6,7 +6,7 @@ export default {
   key: "openai-upload-file",
   name: "Upload File",
   description: "Upload a file that can be used across various endpoints/features. The size of individual files can be a maximum of 512mb. [See the documentation](https://platform.openai.com/docs/api-reference/files/create)",
-  version: "0.0.12",
+  version: "0.0.13",
   type: "action",
   props: {
     openai,

--- a/components/openai/openai.app.mjs
+++ b/components/openai/openai.app.mjs
@@ -21,7 +21,7 @@ export default {
       async options() {
         return (await this.getChatCompletionModels({})).map((model) => model.id);
       },
-      default: "gpt-3.5-turbo",
+      default: "gpt-4o-mini",
     },
     embeddingsModelId: {
       label: "Model",

--- a/components/openai/package.json
+++ b/components/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/openai",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Pipedream OpenAI Components",
   "main": "openai.app.mjs",
   "keywords": [

--- a/components/openai/sources/new-batch-completed/new-batch-completed.mjs
+++ b/components/openai/sources/new-batch-completed/new-batch-completed.mjs
@@ -6,7 +6,7 @@ export default {
   key: "openai-new-batch-completed",
   name: "New Batch Completed",
   description: "Emit new event when a new batch is completed in OpenAI. [See the documentation](https://platform.openai.com/docs/api-reference/batch/list)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/openai/sources/new-file-created/new-file-created.mjs
+++ b/components/openai/sources/new-file-created/new-file-created.mjs
@@ -6,7 +6,7 @@ export default {
   key: "openai-new-file-created",
   name: "New File Created",
   description: "Emit new event when a new file is created in OpenAI. [See the documentation](https://platform.openai.com/docs/api-reference/files/list)",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/openai/sources/new-fine-tuning-job-created/new-fine-tuning-job-created.mjs
+++ b/components/openai/sources/new-fine-tuning-job-created/new-fine-tuning-job-created.mjs
@@ -6,7 +6,7 @@ export default {
   key: "openai-new-fine-tuning-job-created",
   name: "New Fine Tuning Job Created",
   description: "Emit new event when a new fine-tuning job is created in OpenAI. [See the documentation](https://platform.openai.com/docs/api-reference/fine-tuning/list)",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/openai/sources/new-run-state-changed/new-run-state-changed.mjs
+++ b/components/openai/sources/new-run-state-changed/new-run-state-changed.mjs
@@ -6,7 +6,7 @@ export default {
   key: "openai-new-run-state-changed",
   name: "New Run State Changed",
   description: "Emit new event every time a run changes its status. [See the documentation](https://platform.openai.com/docs/api-reference/runs/listRuns)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "source",
   dedupe: "unique",
   props: {


### PR DESCRIPTION
## WHY

<!-- author to complete -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated various components and actions to new minor versions, indicating potential enhancements or bug fixes.
	- Changed the default model identifier to `"gpt-4o-mini"` for improved performance.

- **Bug Fixes**
	- Minor version updates across multiple modules suggest bug fixes and improvements in functionality.

- **Documentation**
	- Updated package version from `0.5.5` to `0.5.6` for the `@pipedream/openai` package, indicating minor revisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->