### PR TITLE
Abstract OAuth implementation in the SDK

### DIFF
--- a/packages/sdk/package-lock.json
+++ b/packages/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pipedream/sdk",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pipedream/sdk",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@types/node": "^20.14.9",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/sdk",
-  "version": "0.0.13",
+  "version": "0.1.0",
   "description": "Pipedream SDK",
   "type": "module",
   "main": "dist/server/index.js",
@@ -40,6 +40,10 @@
   ],
   "devDependencies": {
     "@types/node": "^20.14.9",
+    "@types/simple-oauth2": "^5.0.7",
     "typescript": "^5.5.2"
+  },
+  "dependencies": {
+    "simple-oauth2": "^5.1.0"
   }
 }

--- a/packages/sdk/src/server/index.ts
+++ b/packages/sdk/src/server/index.ts
@@ -30,12 +30,12 @@ export type CreateServerClientOpts = {
   /**
    * The client ID of your workspace's OAuth application.
    */
-  oauthClientId: string;
+  oauthClientId?: string;
 
   /**
    * The client secret of your workspace's OAuth application.
    */
-  oauthClientSecret: string;
+  oauthClientSecret?: string;
 
   /**
    * The API host URL. Used by Pipedream employees. Defaults to "api.pipedream.com" if not provided.
@@ -246,7 +246,7 @@ export type ErrorResponse = {
 export type ConnectAPIResponse<T> = T | ErrorResponse;
 
 /**
- * Options for making a request to the Connect API.
+ * Options for making a request to the Pipedream API.
  */
 interface RequestOptions extends Omit<RequestInit, "headers"> {
   /**
@@ -301,13 +301,27 @@ class ServerClient {
     const { apiHost = "api.pipedream.com" } = opts;
     this.baseURL = `https://${apiHost}/v1`;
 
+    this._configureOauthClient(opts, this.baseURL);
+  }
+
+  private _configureOauthClient(
+    {
+      oauthClientId: id,
+      oauthClientSecret: secret,
+    }: CreateServerClientOpts,
+    tokenHost: string,
+  ) {
+    if (!id || !secret) {
+      return;
+    }
+
     this.oauthClient = new ClientCredentials({
       client: {
-        id: opts.oauthClientId,
-        secret: opts.oauthClientSecret,
+        id,
+        secret,
       },
       auth: {
-        tokenHost: this.baseURL,
+        tokenHost,
         tokenPath: "/v1/oauth/token",
       },
     });
@@ -395,7 +409,7 @@ class ServerClient {
   }
 
   /**
-   * Makes a request to the Connect API.
+   * Makes a request to the Pipedream API.
    *
    * @template T - The expected response type.
    * @param path - The API endpoint path.

--- a/packages/sdk/src/server/index.ts
+++ b/packages/sdk/src/server/index.ts
@@ -2,7 +2,10 @@
 // Pipedream project's public and secret keys and access customer credentials.
 // See the browser/ directory for the browser client.
 
-import { ClientCredentials } from "simple-oauth2";
+import {
+  AccessToken,
+  ClientCredentials,
+} from "simple-oauth2";
 
 /**
  * Options for creating a server-side client.
@@ -282,6 +285,7 @@ class ServerClient {
   secretKey: string;
   publicKey: string;
   oauthClient: ClientCredentials;
+  oauthToken?: AccessToken;
   baseURL: string;
 
   /**
@@ -321,8 +325,11 @@ class ServerClient {
   }
 
   async _oauthAuthorizationHeader(): Promise<string> {
-    const { token: { access_token: accessToken } } = await this.oauthClient.getToken({});
-    return `Bearer ${accessToken}`;
+    if (!this.oauthToken || this.oauthToken.expired()) {
+      this.oauthToken = await this.oauthClient.getToken({});
+    }
+
+    return `Bearer ${this.oauthToken.token.access_token}`;
   }
 
   /**

--- a/packages/sdk/src/server/index.ts
+++ b/packages/sdk/src/server/index.ts
@@ -2,6 +2,8 @@
 // Pipedream project's public and secret keys and access customer credentials.
 // See the browser/ directory for the browser client.
 
+import { ClientCredentials } from "simple-oauth2";
+
 /**
  * Options for creating a server-side client.
  * This is used to configure the ServerClient instance.
@@ -21,6 +23,16 @@ export type CreateServerClientOpts = {
    * The secret API key for accessing the service. This key is required.
    */
   secretKey: string;
+
+  /**
+   * The client ID of your workspace's OAuth application.
+   */
+  oauthClientId: string;
+
+  /**
+   * The client secret of your workspace's OAuth application.
+   */
+  oauthClientSecret: string;
 
   /**
    * The API host URL. Used by Pipedream employees. Defaults to "api.pipedream.com" if not provided.
@@ -233,7 +245,7 @@ export type ConnectAPIResponse<T> = T | ErrorResponse;
 /**
  * Options for making a request to the Connect API.
  */
-interface ConnectRequestOptions extends Omit<RequestInit, "headers"> {
+interface RequestOptions extends Omit<RequestInit, "headers"> {
   /**
    * Query parameters to include in the request URL.
    */
@@ -269,6 +281,7 @@ class ServerClient {
   environment?: string;
   secretKey: string;
   publicKey: string;
+  oauthClient: ClientCredentials;
   baseURL: string;
 
   /**
@@ -283,20 +296,37 @@ class ServerClient {
 
     const { apiHost = "api.pipedream.com" } = opts;
     this.baseURL = `https://${apiHost}/v1`;
+
+    this.oauthClient = new ClientCredentials({
+      client: {
+        id: opts.oauthClientId,
+        secret: opts.oauthClientSecret,
+      },
+      auth: {
+        tokenHost: this.baseURL,
+        tokenPath: "/v1/oauth/token",
+      },
+    });
   }
 
   /**
-   * Generates an Authorization header using the public and secret keys.
+   * Generates an Authorization header for Connect using the public and secret
+   * keys of the target project.
    *
    * @returns The authorization header as a string.
    */
-  private _authorizationHeader(): string {
+  private _connectAuthorizationHeader(): string {
     const encoded = Buffer.from(`${this.publicKey}:${this.secretKey}`).toString("base64");
     return `Basic ${encoded}`;
   }
 
+  async _oauthAuthorizationHeader(): Promise<string> {
+    const { token: { access_token: accessToken } } = await this.oauthClient.getToken({});
+    return `Bearer ${accessToken}`;
+  }
+
   /**
-   * Makes a request to the Connect API.
+   * Makes an HTTP request
    *
    * @template T - The expected response type.
    * @param path - The API endpoint path.
@@ -304,9 +334,9 @@ class ServerClient {
    * @returns A promise resolving to the API response.
    * @throws Will throw an error if the response status is not OK.
    */
-  async _makeConnectRequest<T>(
+  async _makeRequest<T>(
     path: string,
-    opts: ConnectRequestOptions = {},
+    opts: RequestOptions = {},
   ): Promise<T> {
     const {
       params,
@@ -315,7 +345,7 @@ class ServerClient {
       method = "GET",
       ...fetchOpts
     } = opts;
-    const url = new URL(`${this.baseURL}/connect${path}`);
+    const url = new URL(`${this.baseURL}${path}`);
 
     if (params) {
       Object.entries(params).forEach(([
@@ -329,7 +359,6 @@ class ServerClient {
     }
 
     const headers = {
-      "Authorization": this._authorizationHeader(),
       "Content-Type": "application/json",
       ...customHeaders,
     };
@@ -356,6 +385,52 @@ class ServerClient {
 
     const result = await response.json() as unknown as T;
     return result;
+  }
+
+  /**
+   * Makes a request to the Connect API.
+   *
+   * @template T - The expected response type.
+   * @param path - The API endpoint path.
+   * @param opts - The options for the request.
+   * @returns A promise resolving to the API response.
+   * @throws Will throw an error if the response status is not OK.
+   */
+  async _makeApiRequest<T>(
+    path: string,
+    opts: RequestOptions = {},
+  ): Promise<T> {
+    const headers = {
+      ...opts.headers ?? {},
+      "Authorization": await this._oauthAuthorizationHeader(),
+    };
+    return this._makeRequest<T>(path, {
+      headers,
+      ...opts,
+    });
+  }
+
+  /**
+   * Makes a request to the Connect API.
+   *
+   * @template T - The expected response type.
+   * @param path - The API endpoint path.
+   * @param opts - The options for the request.
+   * @returns A promise resolving to the API response.
+   * @throws Will throw an error if the response status is not OK.
+   */
+  async _makeConnectRequest<T>(
+    path: string,
+    opts: RequestOptions = {},
+  ): Promise<T> {
+    const headers = {
+      ...opts.headers ?? {},
+      "Authorization": this._connectAuthorizationHeader(),
+    };
+    return this._makeRequest<T>(`/connect${path}`, {
+      headers,
+      ...opts,
+    });
   }
 
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11485,9 +11485,14 @@ importers:
   packages/sdk:
     specifiers:
       '@types/node': ^20.14.9
+      '@types/simple-oauth2': ^5.0.7
+      simple-oauth2: ^5.1.0
       typescript: ^5.5.2
+    dependencies:
+      simple-oauth2: 5.1.0
     devDependencies:
       '@types/node': 20.16.1
+      '@types/simple-oauth2': 5.0.7
       typescript: 5.5.4
 
   packages/snowflake-sdk:
@@ -16534,6 +16539,20 @@ packages:
       yargs: 17.7.2
     dev: false
 
+  /@hapi/boom/10.0.1:
+    resolution: {integrity: sha512-ERcCZaEjdH3OgSJlyjVk8pHIFeus91CjKP3v+MpgBNp5IvGzP2l/bRiD78nqYcKPaZdbKkK5vDBVPd2ohHBlsA==}
+    dependencies:
+      '@hapi/hoek': 11.0.4
+    dev: false
+
+  /@hapi/bourne/3.0.0:
+    resolution: {integrity: sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w==}
+    dev: false
+
+  /@hapi/hoek/11.0.4:
+    resolution: {integrity: sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ==}
+    dev: false
+
   /@hapi/hoek/9.3.0:
     resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
     dev: false
@@ -16542,6 +16561,14 @@ packages:
     resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
     dependencies:
       '@hapi/hoek': 9.3.0
+    dev: false
+
+  /@hapi/wreck/18.1.0:
+    resolution: {integrity: sha512-0z6ZRCmFEfV/MQqkQomJ7sl/hyxvcZM7LtuVqN3vdAO4vM9eBbowl0kaqQj9EJJQab+3Uuh1GxbGIBFy4NfJ4w==}
+    dependencies:
+      '@hapi/boom': 10.0.1
+      '@hapi/bourne': 3.0.0
+      '@hapi/hoek': 11.0.4
     dev: false
 
   /@huggingface/inference/1.8.0:
@@ -21106,6 +21133,10 @@ packages:
       '@types/mime': 3.0.2
       '@types/node': 20.16.1
     dev: false
+
+  /@types/simple-oauth2/5.0.7:
+    resolution: {integrity: sha512-8JbWVJbiTSBQP/7eiyGKyXWAqp3dKQZpaA+pdW16FCi32ujkzRMG8JfjoAzdWt6W8U591ZNdHcPtP2D7ILTKuA==}
+    dev: true
 
   /@types/source-map/0.5.7:
     resolution: {integrity: sha512-LrnsgZIfJaysFkv9rRJp4/uAyqw87oVed3s1hhF83nwbo9c7MG9g5DqR0seHP+lkX4ldmMrVolPjQSe2ZfD0yA==}
@@ -33037,6 +33068,17 @@ packages:
 
   /simple-lru-cache/0.0.2:
     resolution: {integrity: sha512-uEv/AFO0ADI7d99OHDmh1QfYzQk/izT1vCmu/riQfh7qjBVUUgRT87E5s5h7CxWCA/+YoZerykpEthzVrW3LIw==}
+    dev: false
+
+  /simple-oauth2/5.1.0:
+    resolution: {integrity: sha512-gWDa38Ccm4MwlG5U7AlcJxPv3lvr80dU7ARJWrGdgvOKyzSj1gr3GBPN1rABTedAYvC/LsGYoFuFxwDBPtGEbw==}
+    dependencies:
+      '@hapi/hoek': 11.0.4
+      '@hapi/wreck': 18.1.0
+      debug: 4.3.6
+      joi: 17.10.2
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /simple-swizzle/0.2.2:


### PR DESCRIPTION
# Changelog
* Install `simple-oauth2` to handle OAuth client requests
* Rename some methods and types to reuse them
* Abstract the HTTP requests so that it can be used for Connect and for normal API requests
* Implement logic to fetch OAuth client credentials
* Bump minor version of the SDK

## WHY

So that we can make API requests using the OAuth credentials.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced support for OAuth 2.0 authentication in the SDK.
	- Enhanced `ServerClient` functionality with new methods for handling API requests securely.
- **Improvements**
	- Updated SDK version to 0.1.0, reflecting new features and enhancements.
	- Added new dependencies to support OAuth 2.0 functionality, including TypeScript definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->