### PR TITLE
Add $.flow.trigger

### DIFF
--- a/docs-v2/pages/code/nodejs/index.mdx
+++ b/docs-v2/pages/code/nodejs/index.mdx
@@ -360,7 +360,7 @@ This is an alpha feature and is subject to change without prior notice.
 
 You can invoke another workflow in your workspace with `$.flow.trigger`:
 
-```javascript
+```
 await $.flow.trigger(
   workflowId, // your Pipedream workflow ID, e.g. p_abc123
   payload, // any JSON-serializable data

--- a/docs-v2/pages/code/nodejs/index.mdx
+++ b/docs-v2/pages/code/nodejs/index.mdx
@@ -358,7 +358,20 @@ You can return HTTP responses from [HTTP-triggered workflows](/workflows/steps/t
 This is an alpha feature and is subject to change without prior notice.
 </Callout>
 
-You can invoke another workflow in your workspace by running `await $.flow.trigger(workflowId, event)`, where `event` is an object containing the data to send to the workflow. Here's how you can [find your workflow's ID](/troubleshooting#where-do-i-find-my-workflows-id). This invocation remains within Pipedream — you don't need to configure a trigger, and the request does not leave the platform.
+You can invoke another workflow in your workspace with `$.flow.trigger`:
+
+```javascript
+await $.flow.trigger(
+  workflowId, // your Pipedream workflow ID, e.g. p_abc123
+  payload, // any JSON-serializable data
+)
+```
+
+[Find your workflow's ID here.](/troubleshooting#where-do-i-find-my-workflows-id)
+
+This invokes the workflow directly -- you don't need to configure a trigger, and the request does not leave the platform.
+
+We also provide a [Trigger Workflow](https://pipedream.com/apps/helper-functions/actions/trigger-workflow) action in the [Helper Functions](https://pipedream.com/apps/helper-functions) app so you don't need to do it by code!
 
 ## Ending a workflow early
 

--- a/docs-v2/pages/code/nodejs/index.mdx
+++ b/docs-v2/pages/code/nodejs/index.mdx
@@ -352,6 +352,14 @@ In general, if you just need to make an HTTP request but don't care about the re
 
 You can return HTTP responses from [HTTP-triggered workflows](/workflows/steps/triggers/#http) using the [`$.respond()` function](/workflows/steps/triggers/#http-responses).
 
+## Invoke another workflow
+
+<Callout type="warning">
+This is an alpha feature and is subject to change without prior notice.
+</Callout>
+
+You can invoke another workflow in your workspace by running `await $.flow.trigger(workflowId, event)`, where event is an object containing the data to send to the workflow. Here's how you can [find your workflow's ID](/troubleshooting#where-do-i-find-my-workflows-id). This invocation remains within Pipedream — you don't need to configure a trigger, and the request does not leave the platform.
+
 ## Ending a workflow early
 
 <VideoPlayer title="Conditionally run Workflows" src="https://www.youtube.com/embed/sajgIH3dG58" startAt="205" />

--- a/docs-v2/pages/code/nodejs/index.mdx
+++ b/docs-v2/pages/code/nodejs/index.mdx
@@ -358,7 +358,7 @@ You can return HTTP responses from [HTTP-triggered workflows](/workflows/steps/t
 This is an alpha feature and is subject to change without prior notice.
 </Callout>
 
-You can invoke another workflow in your workspace by running `await $.flow.trigger(workflowId, event)`, where event is an object containing the data to send to the workflow. Here's how you can [find your workflow's ID](/troubleshooting#where-do-i-find-my-workflows-id). This invocation remains within Pipedream — you don't need to configure a trigger, and the request does not leave the platform.
+You can invoke another workflow in your workspace by running `await $.flow.trigger(workflowId, event)`, where `event` is an object containing the data to send to the workflow. Here's how you can [find your workflow's ID](/troubleshooting#where-do-i-find-my-workflows-id). This invocation remains within Pipedream — you don't need to configure a trigger, and the request does not leave the platform.
 
 ## Ending a workflow early
 

--- a/docs-v2/pages/code/python/index.mdx
+++ b/docs-v2/pages/code/python/index.mdx
@@ -128,7 +128,7 @@ _Don't forget_ to [configure your workflow's HTTP trigger to allow a custom resp
 
 ## Invoke another workflow
 
-This functionality is currently not supported in Python steps. However, you can invoke another workflow using Node.js steps. For more information, see [Invoke another workflow in Node.js](/code/nodejs#invoke-another-workflow).
+This is currently not supported in Python steps. However, you can invoke another workflow using Node.js steps. For more information, see [Invoke another workflow in Node.js](/code/nodejs#invoke-another-workflow).
 
 ## Sharing data between steps
 

--- a/docs-v2/pages/code/python/index.mdx
+++ b/docs-v2/pages/code/python/index.mdx
@@ -126,6 +126,10 @@ Unlike the [Node.js equivalent](https://pipedream.com/docs/workflows/steps/trigg
 _Don't forget_ to [configure your workflow's HTTP trigger to allow a custom response](/workflows/steps/triggers/#http-responses). Otherwise your workflow will return the default response.
 </Callout>
 
+## Invoke another workflow
+
+This functionality is currently not supported in Python steps. However, you can invoke another workflow using Node.js steps. For more information, see [Invoke another workflow in Node.js](/code/nodejs#invoke-another-workflow).
+
 ## Sharing data between steps
 
 A step can accept data from other steps in the same workflow, or pass data downstream to others.

--- a/docs-v2/pages/code/python/index.mdx
+++ b/docs-v2/pages/code/python/index.mdx
@@ -126,10 +126,6 @@ Unlike the [Node.js equivalent](https://pipedream.com/docs/workflows/steps/trigg
 _Don't forget_ to [configure your workflow's HTTP trigger to allow a custom response](/workflows/steps/triggers/#http-responses). Otherwise your workflow will return the default response.
 </Callout>
 
-## Invoke another workflow
-
-This is currently not supported in Python steps. However, you can invoke another workflow using Node.js steps. For more information, see [Invoke another workflow in Node.js](/code/nodejs#invoke-another-workflow).
-
 ## Sharing data between steps
 
 A step can accept data from other steps in the same workflow, or pass data downstream to others.

--- a/docs-v2/pages/troubleshooting.mdx
+++ b/docs-v2/pages/troubleshooting.mdx
@@ -62,6 +62,12 @@ https://pipedream.com/@dylburger/p_abc123/edit
 
 Your workflow's ID is the value that starts with `p_`. In this example: `p_abc123`.
 
+## How do I invoke another workflow?
+
+We provide a [Trigger Workflow](https://pipedream.com/apps/helper-functions/actions/trigger-workflow) action in the [Helper Functions](https://pipedream.com/apps/helper-functions) app. [See more here](/code/nodejs#invoke-another-workflow).
+
+Another option is to make an HTTP request to a Pipedream HTTP webhook trigger.
+
 ## Where do I find my event source's ID?
 
 Open [https://pipedream.com/sources](https://pipedream.com/sources) and click on your event source. Copy the URL that appears in your browser's address bar. For example:


### PR DESCRIPTION
## WHY

<!-- author to complete -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced documentation on invoking another workflow within the Pipedream platform using Node.js.
	- Clarified that invoking workflows is not supported in Python steps, directing users to Node.js for this functionality.
	- Added a "Trigger Workflow" action in the Helper Functions app for code-free workflow invocation.

- **Documentation**
	- Updated Node.js documentation with details on the new workflow invocation feature.
	- Added a note in Python documentation regarding the limitations of workflow invocation.
	- Included a new section in troubleshooting documentation on invoking another workflow and alternative methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->