### PR TITLE
Invoke workflows via the SDK

### DIFF
--- a/packages/sdk/src/server/index.ts
+++ b/packages/sdk/src/server/index.ts
@@ -627,7 +627,13 @@ class ServerClient {
    * HTTP POST request with the provided body.
    *
    * @param url - The URL of the workflow's HTTP interface.
-   * @param body - The body to send with the request.
+   * @param opts - The options for the request.
+   * @param opts.body - The body of the request. It must be a JSON-serializable
+   * value (e.g. an object, `null`, a string, etc.).
+   * @param opts.headers - The headers to include in the request. Note that the
+   * `Authorization` header will always be set with an OAuth access token
+   * retrieved by the client.
+   *
    * @returns A promise resolving to the response from the workflow.
    *
    * @example
@@ -635,17 +641,28 @@ class ServerClient {
    * const response: JSON = await client.invokeWorkflow(
    *   "https://eoy64t2rbte1u2p.m.pipedream.net",
    *   {
-   *     foo: 123,
-   *     bar: "abc",
-   *     baz: null,
+   *     body: {
+   *       foo: 123,
+   *       bar: "abc",
+   *       baz: null,
+   *     },
+   *     headers: {
+   *       "Accept": "application/json",
+   *     },
    *   },
    * );
    */
-  async invokeWorkflow(url: string, body: unknown = null): Promise<unknown> {
+  async invokeWorkflow(url: string, opts: RequestOptions = {}): Promise<unknown> {
+    const {
+      body = null,
+      headers = {},
+    } = opts;
+
     return this._makeRequest("", {
       baseURL: url,
       method: "POST",
       headers: {
+        ...headers,
         "Authorization": await this._oauthAuthorizationHeader(),
       },
       body: JSON.stringify(body),

--- a/packages/sdk/src/server/index.ts
+++ b/packages/sdk/src/server/index.ts
@@ -289,7 +289,7 @@ class ServerClient {
   environment?: string;
   secretKey: string;
   publicKey: string;
-  oauthClient: ClientCredentials;
+  oauthClient?: ClientCredentials;
   oauthToken?: AccessToken;
   baseURL: string;
 
@@ -344,6 +344,10 @@ class ServerClient {
   }
 
   async _oauthAuthorizationHeader(): Promise<string> {
+    if (!this.oauthClient) {
+      throw new Error("OAuth client not configured");
+    }
+
     if (!this.oauthToken || this.oauthToken.expired()) {
       this.oauthToken = await this.oauthClient.getToken({});
     }


### PR DESCRIPTION
# Changelog
* Refactor `_makeRequest` to accept an optional `baseURL` argument, so that it can target URLs other than the API
* Implement `invokeWorkflow` to make a request to the HTTP interface of a workflow

## WHY

To support authenticated workflow invocations via the SDK.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an optional `baseURL` property in request options for enhanced flexibility in URL construction.
	- Added a new method to the `ServerClient` class for invoking workflows via HTTP POST requests, expanding interaction capabilities with external workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->