### PR TITLE
chore: use node20 for git-diff-on-components action

### DIFF
--- a/.github/actions/git-diff-on-components/action.yml
+++ b/.github/actions/git-diff-on-components/action.yml
@@ -11,5 +11,5 @@ inputs:
     description: "List of all files comming from changed_files step in check_version job github action workflow"
     required: true
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"


### PR DESCRIPTION
## WHY

https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the GitHub Action to use Node.js version 20, enhancing performance and compatibility with new features.
- **Bug Fixes**
	- Improved execution context for the action, potentially resolving issues related to the previous Node.js version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->