### PR TITLE
Gmail - parse name & email in parsedHeaders

### DIFF
--- a/components/gmail/package.json
+++ b/components/gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/gmail",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Pipedream Gmail Components",
   "main": "gmail.app.mjs",
   "keywords": [

--- a/components/gmail/sources/common/base.mjs
+++ b/components/gmail/sources/common/base.mjs
@@ -44,17 +44,39 @@ export default {
           decodedContent: Buffer.from(firstPart.body.data, "base64").toString(),
         };
     },
+    parseEmail(emailStr) {
+      if (!emailStr) {
+        return undefined;
+      }
+
+      const regex = /^(.*)<(.+)>$/;
+      const match = emailStr.match(regex);
+
+      if (match) {
+        return {
+          name: match[1].trim(),
+          email: match[2].trim(),
+        };
+      }
+      return {
+        name: null,
+        email: emailStr.trim(),
+      };
+    },
+    getHeaderValue(headers, key) {
+      return headers.find(({ name }) => name.toLowerCase() === key)?.value;
+    },
     processEmail(msg) {
       // Process and structure the email data
       const headers = msg.payload.headers;
       return {
         "id": msg.id,
         "threadId": msg.threadId,
-        "subject": headers.find((h) => h.name.toLowerCase() === "subject")?.value,
-        "from": headers.find((h) => h.name.toLowerCase() === "from")?.value,
-        "to": headers.find((h) => h.name.toLowerCase() === "to")?.value,
-        "reply-to": headers.find((h) => h.name.toLowerCase() === "reply-to")?.value,
-        "date": headers.find((h) => h.name.toLowerCase() === "date")?.value,
+        "subject": this.getHeaderValue(headers, "subject"),
+        "from": this.parseEmail(this.getHeaderValue(headers, "from")),
+        "to": this.parseEmail(this.getHeaderValue(headers, "to")),
+        "reply-to": this.parseEmail(this.getHeaderValue(headers, "reply-to")),
+        "date": this.getHeaderValue(headers, "date"),
         "snippet": msg.snippet,
       };
     },

--- a/components/gmail/sources/new-attachment-received/new-attachment-received.mjs
+++ b/components/gmail/sources/new-attachment-received/new-attachment-received.mjs
@@ -6,7 +6,7 @@ export default {
   key: "gmail-new-attachment-received",
   name: "New Attachment Received",
   description: "Emit new event for each attachment in a message received. This source is capped at 100 max new messages per run.",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/gmail/sources/new-email-matching-search/new-email-matching-search.mjs
+++ b/components/gmail/sources/new-email-matching-search/new-email-matching-search.mjs
@@ -6,7 +6,7 @@ export default {
   key: "gmail-new-email-matching-search",
   name: "New Email Matching Search",
   description: "Emit new event when an email matching the search criteria is received. This source is capped at 100 max new messages per run.",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/gmail/sources/new-email-received/new-email-received.mjs
+++ b/components/gmail/sources/new-email-received/new-email-received.mjs
@@ -15,7 +15,7 @@ export default {
   name: "New Email Received",
   description: "Emit new event when a new email is received.",
   type: "source",
-  version: "0.1.3",
+  version: "0.1.4",
   dedupe: "unique",
   props: {
     gmail,

--- a/components/gmail/sources/new-labeled-email/new-labeled-email.mjs
+++ b/components/gmail/sources/new-labeled-email/new-labeled-email.mjs
@@ -8,7 +8,7 @@ export default {
   name: "New Labeled Email",
   description: "Emit new event when a new email is labeled.",
   type: "source",
-  version: "0.0.4",
+  version: "0.0.5",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/gmail/sources/new-sent-email/new-sent-email.mjs
+++ b/components/gmail/sources/new-sent-email/new-sent-email.mjs
@@ -6,7 +6,7 @@ export default {
   key: "gmail-new-sent-email",
   name: "New Sent Email",
   description: "Emit new event for each new email sent. (Maximum of 100 events emited per execution)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "source",
   dedupe: "unique",
   props: {


### PR DESCRIPTION
Resolves #14100 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced two new methods for improved email processing: `parseEmail` for extracting names and email addresses, and `getHeaderValue` for retrieving header values.
  
- **Version Updates**
	- Updated version numbers for several components to reflect the latest changes:
		- `@pipedream/gmail`: 0.1.6 → 0.1.7
		- `gmail-new-attachment-received`: 0.0.4 → 0.0.5
		- `gmail-new-email-matching-search`: 0.0.3 → 0.0.4
		- `new-email-received`: 0.1.3 → 0.1.4
		- `new-labeled-email`: 0.0.4 → 0.0.5
		- `gmail-new-sent-email`: 0.0.4 → 0.0.5

<!-- end of auto-generated comment: release notes by coderabbit.ai -->