### PR TITLE
[Notion] updated page trigger fix

### DIFF
--- a/components/notion/package.json
+++ b/components/notion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/notion",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "Pipedream Notion Components",
   "main": "notion.app.mjs",
   "keywords": [

--- a/components/notion/sources/updated-page/updated-page.mjs
+++ b/components/notion/sources/updated-page/updated-page.mjs
@@ -9,7 +9,7 @@ export default {
   key: "notion-updated-page",
   name: "Updated Page in Database", /* eslint-disable-line pipedream/source-name */
   description: "Emit new event when a page in a database is updated. To select a specific page, use `Updated Page ID` instead",
-  version: "0.0.17",
+  version: "0.0.18",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/notion/sources/updated-page/updated-page.mjs
+++ b/components/notion/sources/updated-page/updated-page.mjs
@@ -82,7 +82,7 @@ export default {
       return Object.keys(properties);
     },
     calculateHash(property) {
-      const clone = JSON.parse(JSON.stringify(property));
+      const clone = structuredClone(property);
       this.maybeRemoveFileSubItems(clone);
       return md5(JSON.stringify(clone));
     },


### PR DESCRIPTION
When adding a **Files & Media** property in the database, Notion constantly updates the `url` and `expiry_time` values. This causes the trigger to emit multiple events for a page.


According to Notion's documentation: [Working with files and media](https://developers.notion.com/docs/working-with-files-and-media)
> Each time a database or page is queried, a new public URL is generated for all files hosted by Notion.

This PR makes the trigger ignore changes for `url` and `expiry_time` fields for **Files & Media** properties, **but still exports the latest `url` and `expiry_time` values whenever there is a change**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of page properties in the Notion integration for improved accuracy during updates.
	- Introduced a new method to filter specific fields from file-type properties.

- **Version Updates**
	- Updated package version for `@pipedream/notion` from `0.1.22` to `0.1.23`.
	- Updated source component version for `notion-updated-page` from `0.0.17` to `0.0.18`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->