### PR TITLE
[Notion] updated page trigger improvements

### DIFF
--- a/components/notion/package.json
+++ b/components/notion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/notion",
-  "version": "0.1.24",
+  "version": "0.2.0",
   "description": "Pipedream Notion Components",
   "main": "notion.app.mjs",
   "keywords": [

--- a/components/notion/sources/updated-page/updated-page.mjs
+++ b/components/notion/sources/updated-page/updated-page.mjs
@@ -105,7 +105,7 @@ export default {
       const ts = Date.now();
       return {
         id: `${id}-${ts}`,
-        summary: `${summary}: ${title} - ${id}`,
+        summary: `${summary}: ${title}`,
         ts,
       };
     },

--- a/components/notion/sources/updated-page/updated-page.mjs
+++ b/components/notion/sources/updated-page/updated-page.mjs
@@ -9,7 +9,7 @@ export default {
   key: "notion-updated-page",
   name: "Updated Page in Database", /* eslint-disable-line pipedream/source-name */
   description: "Emit new event when a page in a database is updated. To select a specific page, use `Updated Page ID` instead",
-  version: "0.0.19",
+  version: "0.1.0",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/notion/sources/updated-page/updated-page.mjs
+++ b/components/notion/sources/updated-page/updated-page.mjs
@@ -60,7 +60,7 @@ export default {
           Date.parse(page.last_edited_time),
         );
         if (count++ < 25) {
-          this.emitEvent(page, [], true);
+          this.emitEvent(page);
         }
       }
       this._setPropertyValues(propertyValues);
@@ -109,7 +109,7 @@ export default {
         ts,
       };
     },
-    emitEvent(page, changes, isNewPage) {
+    emitEvent(page, changes = [], isNewPage = true) {
       const meta = isNewPage
         ? this.generateMeta(page, constants.summaries.PAGE_ADDED)
         : this.generateMeta(page, constants.summaries.PAGE_UPDATED);
@@ -165,6 +165,7 @@ export default {
             [propertyName]: currentValue,
           };
           changes.push({
+            property: propertyName,
             previousValue,
             currentValue,
           });
@@ -177,6 +178,7 @@ export default {
             [propertyName]: currentValue,
           };
           changes.push({
+            property: propertyName,
             previousValue,
             currentValue,
           });

--- a/components/notion/sources/updated-page/updated-page.mjs
+++ b/components/notion/sources/updated-page/updated-page.mjs
@@ -141,16 +141,17 @@ export default {
       const changes = [];
       let isNewPage = false;
       let propertyHasChanged = false;
+
       newLastUpdatedTimestamp = Math.max(
         newLastUpdatedTimestamp,
         Date.parse(page.last_edited_time),
       );
 
-      for (const propertyName of propertiesToCheck) {
-        if (lastCheckedTimestamp > Date.parse(page.last_edited_time)) {
-          break;
-        }
+      if (lastCheckedTimestamp > Date.parse(page.last_edited_time)) {
+        break;
+      }
 
+      for (const propertyName of propertiesToCheck) {
         const previousValue = structuredClone(propertyValues[page.id]?.[propertyName]);
         const currentValue = this.maybeRemoveFileSubItems(page.properties[propertyName]);
 

--- a/components/notion/sources/updated-page/updated-page.mjs
+++ b/components/notion/sources/updated-page/updated-page.mjs
@@ -2,6 +2,7 @@ import notion from "../../notion.app.mjs";
 import sampleEmit from "./test-event.mjs";
 import base from "../common/base.mjs";
 import constants from "../common/constants.mjs";
+import zlib from "zlib";
 
 export default {
   ...base,
@@ -69,10 +70,15 @@ export default {
   methods: {
     ...base.methods,
     _getPropertyValues() {
-      return this.db.get("propertyValues");
+      const compressed = this.db.get("propertyValues");
+      const buffer = Buffer.from(compressed, "base64");
+      const decompressed = zlib.inflateSync(buffer).toString();
+      return JSON.parse(decompressed);
     },
     _setPropertyValues(propertyValues) {
-      this.db.set("propertyValues", propertyValues);
+      const string = JSON.stringify(propertyValues);
+      const compressed = zlib.deflateSync(string).toString("base64");
+      this.db.set("propertyValues", compressed);
     },
     async getPropertiesToCheck() {
       if (this.properties?.length) {

--- a/components/notion/sources/updated-page/updated-page.mjs
+++ b/components/notion/sources/updated-page/updated-page.mjs
@@ -19,6 +19,12 @@ export default {
         "databaseId",
       ],
     },
+    includeNewPages: {
+      type: "boolean",
+      label: "Include New Pages",
+      description: "Set to `true` to emit events when pages are created. Set to `false` to ignore new pages.",
+      default: true,
+    },
     properties: {
       propDefinition: [
         notion,
@@ -30,12 +36,6 @@ export default {
       ],
       description: "Only emit events when one or more of the selected properties have changed",
       optional: true,
-    },
-    includeNewPages: {
-      type: "boolean",
-      label: "Include New Pages",
-      description: "Set to `true` to emit events when pages are created. Set to `false` to ignore new pages.",
-      default: true,
     },
   },
   hooks: {


### PR DESCRIPTION
- [x]  save all properties compressed instead of each property hash in db
- [x]  implement `changes` array that exports the previous and the current values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the version of the Notion package to 0.2.0, indicating potential new functionality.
	- Introduced a new property `includeNewPages` for event emissions related to newly created pages.
	- Enhanced event emission logic for better detection of updated and newly created pages.

- **Improvements**
	- Streamlined the process for detecting changes in properties.
	- Simplified the storage of property values during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->