### PR TITLE
[Notion] config - ignore new pages but not updates

### DIFF
--- a/components/notion/package.json
+++ b/components/notion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/notion",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Notion Components",
   "main": "notion.app.mjs",
   "keywords": [

--- a/components/notion/sources/updated-page/updated-page.mjs
+++ b/components/notion/sources/updated-page/updated-page.mjs
@@ -9,7 +9,7 @@ export default {
   key: "notion-updated-page",
   name: "Updated Page in Database", /* eslint-disable-line pipedream/source-name */
   description: "Emit new event when a page in a database is updated. To select a specific page, use `Updated Page ID` instead",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/notion/sources/updated-page/updated-page.mjs
+++ b/components/notion/sources/updated-page/updated-page.mjs
@@ -171,7 +171,7 @@ export default {
           });
         }
 
-        if (!pageExistsInDB && this.includeNewPages) {
+        if (!pageExistsInDB) {
           isNewPage = true;
           propertyHasChanged = true;
           propertyValues[page.id] = {
@@ -183,6 +183,11 @@ export default {
             currentValue,
           });
         }
+      }
+
+      if (isNewPage && !this.includeNewPages) {
+        console.log(`Ignoring new page: ${page.id}`);
+        continue;
       }
 
       if (propertyHasChanged) {


### PR DESCRIPTION
Setting the `includeNewPages` prop to `false` should ignore newly created pages but not updates for them after they're created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced control over new page detection in the Notion integration, allowing users to ignore new pages based on the `includeNewPages` setting.
	- Improved event emission logic for distinguishing between new and updated pages.

- **Bug Fixes**
	- Adjusted handling of property changes to ensure only actual changes trigger events.

- **Version Updates**
	- Updated version numbers for the Notion component and the "Updated Page in Database" source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->