### PR TITLE
Notion: Append Block to Parent Action

### DIFF
--- a/components/notion/actions/append-block/append-block.mjs
+++ b/components/notion/actions/append-block/append-block.mjs
@@ -6,7 +6,7 @@ export default {
   key: "notion-append-block",
   name: "Append Block to Parent",
   description: "Creates and appends blocks to the specified parent. [See the documentation](https://developers.notion.com/reference/patch-block-children)",
-  version: "0.2.14",
+  version: "0.2.15",
   type: "action",
   props: {
     notion,
@@ -48,6 +48,7 @@ export default {
     },
   },
   methods: {
+    ...base.methods,
     chunkArray(array, chunkSize = 100) {
       const chunks = [];
       for (let i = 0; i < array.length; i += chunkSize) {

--- a/components/notion/package.json
+++ b/components/notion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/notion",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Pipedream Notion Components",
   "main": "notion.app.mjs",
   "keywords": [


### PR DESCRIPTION
## WHY

Fixed bug in Append Block to Parent action
Resolves #14159


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method, `chunkArray`, to split arrays into smaller chunks for improved data handling.
  
- **Bug Fixes**
	- Enhanced the `run` method for more efficient appending of blocks, ensuring accurate retrieval and formatting.

- **Chores**
	- Updated version numbers for the `notion-append-block` action and the `@pipedream/notion` package to reflect the latest changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->