### PR TITLE
[Notion] reset state after restart

### DIFF
--- a/components/notion/package.json
+++ b/components/notion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/notion",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Pipedream Notion Components",
   "main": "notion.app.mjs",
   "keywords": [

--- a/components/notion/sources/updated-page/updated-page.mjs
+++ b/components/notion/sources/updated-page/updated-page.mjs
@@ -42,7 +42,7 @@ export default {
   hooks: {
     async activate() {
       console.log("Activating: fetching pages and properties");
-      this.setLastUpdatedTimestamp(new Date());
+      this._setLastUpdatedTimestamp(Date.now());
       const propertyValues = {};
       const propertiesToCheck = await this._getPropertiesToCheck();
       const params = this.lastUpdatedSortParam();
@@ -60,11 +60,17 @@ export default {
     },
     async deactivate() {
       console.log("Deactivating: clearing states");
-      this.setLastUpdatedTimestamp(null);
+      this._setLastUpdatedTimestamp(null);
     },
   },
   methods: {
     ...base.methods,
+    _getLastUpdatedTimestamp() {
+      return this.db.get(constants.timestamps.LAST_EDITED_TIME);
+    },
+    _setLastUpdatedTimestamp(ts) {
+      this.db.set(constants.timestamps.LAST_EDITED_TIME, ts);
+    },
     _getPropertyValues() {
       const compressed = this.db.get("propertyValues");
       const buffer = Buffer.from(compressed, "base64");
@@ -119,10 +125,10 @@ export default {
     },
   },
   async run() {
-    const lastCheckedTimestamp = this.getLastUpdatedTimestamp();
+    const lastCheckedTimestamp = this._getLastUpdatedTimestamp();
     const propertyValues = this._getPropertyValues();
 
-    if (lastCheckedTimestamp == null) {
+    if (!lastCheckedTimestamp) {
       // recently updated (deactivated / activated), skip execution
       console.log("Awaiting restart completion: skipping execution");
       return;
@@ -203,7 +209,7 @@ export default {
       }
     }
 
-    this.setLastUpdatedTimestamp(newLastUpdatedTimestamp);
+    this._setLastUpdatedTimestamp(newLastUpdatedTimestamp);
     this._setPropertyValues(propertyValues);
   },
   sampleEmit,

--- a/components/notion/sources/updated-page/updated-page.mjs
+++ b/components/notion/sources/updated-page/updated-page.mjs
@@ -41,10 +41,10 @@ export default {
   },
   hooks: {
     async activate() {
-      console.log("Restarting -- fetching all pages and properties");
-      const now = new Date();
-      const propertiesToCheck = await this._getPropertiesToCheck();
+      console.log("Activating: fetching pages and properties");
+      this.setLastUpdatedTimestamp(new Date());
       const propertyValues = {};
+      const propertiesToCheck = await this._getPropertiesToCheck();
       const params = this.lastUpdatedSortParam();
       const pagesStream = this.notion.getPages(this.databaseId, params);
       for await (const page of pagesStream) {
@@ -57,9 +57,9 @@ export default {
         }
       }
       this._setPropertyValues(propertyValues);
-      this.setLastUpdatedTimestamp(now);
     },
     async deactivate() {
+      console.log("Deactivating: clearing states");
       this.setLastUpdatedTimestamp(null);
     },
   },
@@ -124,6 +124,7 @@ export default {
 
     if (lastCheckedTimestamp == null) {
       // recently updated (deactivated / activated), skip execution
+      console.log("Awaiting restart completion: skipping execution");
       return;
     }
 

--- a/components/notion/sources/updated-page/updated-page.mjs
+++ b/components/notion/sources/updated-page/updated-page.mjs
@@ -40,32 +40,6 @@ export default {
     },
   },
   hooks: {
-    async deploy() {
-      const propertiesToCheck = await this._getPropertiesToCheck();
-      const propertyValues = {};
-      const params = this.lastUpdatedSortParam();
-      const pagesStream = this.notion.getPages(this.databaseId, params);
-      let count = 0;
-      let lastUpdatedTimestamp = 0;
-      for await (const page of pagesStream) {
-        for (const propertyName of propertiesToCheck) {
-          const currentValue = this._maybeRemoveFileSubItems(page.properties[propertyName]);
-          propertyValues[page.id] = {
-            ...propertyValues[page.id],
-            [propertyName]: currentValue,
-          };
-        }
-        lastUpdatedTimestamp = Math.max(
-          lastUpdatedTimestamp,
-          Date.parse(page.last_edited_time),
-        );
-        if (count++ < 25) {
-          this._emitEvent(page);
-        }
-      }
-      this._setPropertyValues(propertyValues);
-      this.setLastUpdatedTimestamp(lastUpdatedTimestamp);
-    },
     async activate() {
       console.log("Restarting -- fetching all pages and properties");
       const now = new Date();

--- a/components/notion/sources/updated-page/updated-page.mjs
+++ b/components/notion/sources/updated-page/updated-page.mjs
@@ -9,7 +9,7 @@ export default {
   key: "notion-updated-page",
   name: "Updated Page in Database", /* eslint-disable-line pipedream/source-name */
   description: "Emit new event when a page in a database is updated. To select a specific page, use `Updated Page ID` instead",
-  version: "0.1.2",
+  version: "0.1.3",
   type: "source",
   dedupe: "unique",
   props: {


### PR DESCRIPTION
## WHY

<!-- author to complete -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `notion-updated-page` component to include new activation and deactivation hooks for improved lifecycle management.
	- Added methods to manage last updated timestamps.

- **Version Updates**
	- Incremented version numbers for both `@pipedream/notion` package and `notion-updated-page` component. 

- **Improvements**
	- Streamlined internal method naming for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->