### PR TITLE
[Google Drive] fix create folder action

### DIFF
--- a/components/google_drive/actions/create-folder/create-folder.mjs
+++ b/components/google_drive/actions/create-folder/create-folder.mjs
@@ -13,7 +13,7 @@ export default {
   key: "google_drive-create-folder",
   name: "Create Folder",
   description: "Create a new empty folder. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/create) for more information",
-  version: "0.1.7",
+  version: "0.1.8",
   type: "action",
   props: {
     googleDrive,

--- a/components/google_drive/actions/create-folder/create-folder.mjs
+++ b/components/google_drive/actions/create-folder/create-folder.mjs
@@ -78,9 +78,17 @@ export default {
       } else {
         q += ` and '${driveId}' in parents`;
       }
-      const folders = (await this.googleDrive.listFilesInPage(null, getListFilesOpts(drive, {
+
+      const opts = getListFilesOpts(driveId, {
+        // Used for querying 'shared with me' folders that the user does not have direct access to
+        // within a shared drive (e.g., when the user can't select the driveId of the shared drive).
+        corpora: "user",
+        includeItemsFromAllDrives: true,
+        supportsAllDrives: true,
         q,
-      }))).files;
+      });
+
+      const folders = (await this.googleDrive.listFilesInPage(null, opts)).files;
 
       if (folders.length) {
         $.export("$summary", "Found existing folder, therefore not creating folder. Returning found folder.");

--- a/components/google_drive/package.json
+++ b/components/google_drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_drive",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "Pipedream Google_drive Components",
   "main": "google_drive.app.mjs",
   "keywords": [


### PR DESCRIPTION
## WHY

When creating a folder with a unique name, we encountered a special case where the parent folder was located in a shared folder within a shared drive that the user did not have direct access to. As a result, the parent folder could not be found using the search query.

Changing the `corpora` parameter to `user` resolved the issue.