### PR TITLE
Add webhook_uri to webhook_uri

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/sdk",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Pipedream SDK",
   "main": "dist/server/index.js",
   "module": "dist/server/index.js",

--- a/packages/sdk/src/server/index.ts
+++ b/packages/sdk/src/server/index.ts
@@ -56,6 +56,11 @@ export type ConnectTokenCreateOpts = {
    * The optional url to redirect the user to upon failed connection.
    */
   error_redirect_uri?: string;
+
+  /**
+   * An optional webhook uri that Pipedream can invoke on success or failure of connection requests.
+   */
+  webhook_uri?: string;
 };
 
 export type AppInfo = {


### PR DESCRIPTION
## WHY

<!-- author to complete -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an optional `webhook_uri` property for enhanced handling of connection events in the SDK.
  
- **Version Updates**
	- Updated the version of the `@pipedream/sdk` package from 0.1.7 to 0.1.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->