### PR TITLE
Adding new prop for requestTimeout for Azure SQL

### DIFF
--- a/components/azure_sql/actions/execute-query/execute-query.mjs
+++ b/components/azure_sql/actions/execute-query/execute-query.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Execute Query",
   description: "Executes a SQL query and returns the results. [See the documentation](https://learn.microsoft.com/en-us/sql/t-sql/queries/select-transact-sql?view=azuresqldb-current)",
   type: "action",
-  version: "0.0.5",
+  version: "0.0.6",
   props: {
     app,
     query: {
@@ -20,18 +20,26 @@ export default {
       description: "The inputs to the query. These will be available as @input_parameter in the query. For example, if you provide an input named 'id', you can use @id in the query.",
       optional: true,
     },
+    requestTimeout: {
+      propDefinition: [
+        app,
+        "requestTimeout",
+      ],
+    },
   },
   run({ $ }) {
     const {
       app,
       inputs,
       query,
+      requestTimeout,
     } = this;
 
     return app.executeQuery({
       $,
       query,
       inputs,
+      requestTimeout,
       summary: () => "Successfully executed query.",
     });
   },

--- a/components/azure_sql/actions/execute-raw-query/execute-raw-query.mjs
+++ b/components/azure_sql/actions/execute-raw-query/execute-raw-query.mjs
@@ -5,10 +5,9 @@ export default {
   name: "Execute SQL Query",
   description: "Execute a custom SQL query. See [our docs](https://pipedream.com/docs/databases/working-with-sql) to learn more about working with SQL in Pipedream.",
   type: "action",
-  version: "0.0.4",
+  version: "0.0.5",
   props: {
     app,
-    // eslint-disable-next-line pipedream/props-description
     sql: {
       type: "sql",
       auth: {
@@ -16,9 +15,16 @@ export default {
       },
       label: "SQL Query",
     },
+    requestTimeout: {
+      propDefinition: [
+        app,
+        "requestTimeout",
+      ],
+    },
   },
   async run({ $ }) {
     const args = this.app.executeQueryAdapter(this.sql);
+    args.requestTimeout = this.requestTimeout;
     const response = await this.app.executeQuery(args);
     $.export("$summary", "Successfully executed query.");
     return response;

--- a/components/azure_sql/actions/insert-row/insert-row.mjs
+++ b/components/azure_sql/actions/insert-row/insert-row.mjs
@@ -4,7 +4,7 @@ export default {
   key: "azure_sql-insert-row",
   name: "Insert Row",
   description: "Inserts a new row in a table. [See the documentation](https://learn.microsoft.com/en-us/sql/t-sql/statements/insert-transact-sql?view=azuresqldb-current)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   props: {
     app,
@@ -15,6 +15,12 @@ export default {
         "table",
       ],
       reloadProps: true,
+    },
+    requestTimeout: {
+      propDefinition: [
+        app,
+        "requestTimeout",
+      ],
     },
   },
   async additionalProps() {
@@ -41,6 +47,7 @@ export default {
     const {
       app,
       table,
+      requestTimeout,
       ...inputs
     } = this;
 
@@ -48,6 +55,7 @@ export default {
       $,
       table,
       inputs,
+      requestTimeout,
       summary: () => "Successfully inserted row.",
     });
   },

--- a/components/azure_sql/azure_sql.app.mjs
+++ b/components/azure_sql/azure_sql.app.mjs
@@ -65,6 +65,14 @@ export default {
     getConnection() {
       return sql.connect(this.getConfig());
     },
+    /**
+     * A helper method to get the schema of the database. Used by other features
+     * (like the `sql` prop) to enrich the code editor and provide the user with
+     * auto-complete and fields suggestion.
+     *
+     * @returns {DbInfo} The schema of the database, which is a
+     * JSON-serializable object.
+     */
     async getSchema() {
       const sql = `
         SELECT t.TABLE_SCHEMA AS tableSchema,
@@ -97,6 +105,15 @@ export default {
         return acc;
       }, {});
     },
+    /**
+     * Adapts the arguments to `executeQuery` so that they can be consumed by
+     * the SQL proxy (when applicable). Note that this method is not intended to
+     * be used by the component directly.
+     * @param {object} preparedStatement The prepared statement to be sent to the DB.
+     * @param {string} preparedStatement.sql The prepared SQL query to be executed.
+     * @param {string[]} preparedStatement.values The values to replace in the SQL query.
+     * @returns {object} - The adapted query and parameters.
+     */
     proxyAdapter(preparedStatement = {}) {
       const { query } = preparedStatement;
       const inputs = preparedStatement?.inputs || {};
@@ -111,6 +128,16 @@ export default {
         params: [],
       };
     },
+    /**
+     * A method that performs the inverse transformation of `proxyAdapter`.
+     *
+     * @param {object} proxyArgs - The output of `proxyAdapter`.
+     * @param {string} proxyArgs.query - The SQL query to be executed.
+     * @param {string[]} proxyArgs.params - The values to replace in the SQL
+     * query.
+     * @returns {object} - The adapted query and parameters, compatible with
+     * `executeQuery`.
+     */
     executeQueryAdapter(proxyArgs = {}) {
       let { query } = proxyArgs;
       const params = proxyArgs?.params || [];

--- a/components/azure_sql/package.json
+++ b/components/azure_sql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/azure_sql",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Pipedream Microsoft Azure SQL Database Components",
   "main": "azure_sql.app.mjs",
   "keywords": [

--- a/components/azure_sql/sources/new-column/new-column.mjs
+++ b/components/azure_sql/sources/new-column/new-column.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Column",
   description: "Triggers when a new column is added to a table.",
   type: "source",
-  version: "0.0.5",
+  version: "0.0.6",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/azure_sql/sources/new-or-updated-row/new-or-updated-row.mjs
+++ b/components/azure_sql/sources/new-or-updated-row/new-or-updated-row.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New or Updated Row",
   description: "Triggers when a new row is added or an existing row is updated.",
   type: "source",
-  version: "0.0.5",
+  version: "0.0.6",
   dedupe: "unique",
   props: {
     ...common.props,


### PR DESCRIPTION
See example workflow (Test Request Timeout [step](https://pipedream.com/@pd-component-dev/projects/proj_W7seoE9/p_aNCV2nZ/build)) for testing the prop.

## WHY

Per the feedback [here](https://github.com/PipedreamHQ/pipedream/pull/14152#issuecomment-2386623256), we should create a requestTimeout prop to make the query timeout window configurable. It used to default to 30s, then we bumped to 60s, but if a user needs to configure this to be longer than 60s, they should be able to for maximum flexibility.
