### PR TITLE
Prevent SmartSuite webhooks from expiring

### DIFF
--- a/components/smartsuite/package.json
+++ b/components/smartsuite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/smartsuite",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream SmartSuite Components",
   "main": "smartsuite.app.mjs",
   "keywords": [

--- a/components/smartsuite/sources/common/base.mjs
+++ b/components/smartsuite/sources/common/base.mjs
@@ -5,6 +5,14 @@ export default {
     smartsuite,
     db: "$.service.db",
     http: "$.interface.http",
+    timer: {
+      label: "Webhook renewal schedule",
+      description: "The SmartSuite API requires occasional renewal of webhooks. **This runs in the background, so you should not need to modify this schedule**.",
+      type: "$.interface.timer",
+      static: {
+        intervalSeconds: 24 * 60 * 60, // once per day
+      },
+    },
     solutionId: {
       propDefinition: [
         smartsuite,

--- a/components/smartsuite/sources/new-record-created-instant/new-record-created-instant.mjs
+++ b/components/smartsuite/sources/new-record-created-instant/new-record-created-instant.mjs
@@ -6,7 +6,7 @@ export default {
   key: "smartsuite-new-record-created-instant",
   name: "New Record Created (Instant)",
   description: "Emit new event when a new record is created",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/smartsuite/sources/record-updated-instant/record-updated-instant.mjs
+++ b/components/smartsuite/sources/record-updated-instant/record-updated-instant.mjs
@@ -6,7 +6,7 @@ export default {
   key: "smartsuite-record-updated-instant",
   name: "Record Updated (Instant)",
   description: "Emit new event when an existing record is updated",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   dedupe: "unique",
   methods: {


### PR DESCRIPTION
Resolves #14384 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `timer` property for webhook renewal scheduling, enhancing configuration options.
  
- **Version Updates**
	- Updated version number for `@pipedream/smartsuite` package from 0.1.0 to 0.1.1.
	- Updated version number for `new-record-created-instant` module from 0.0.1 to 0.0.2.
	- Updated version number for `record-updated-instant` module from 0.0.1 to 0.0.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->