### PR TITLE
Seqera: List Workflows, not Runs

### DIFF
--- a/components/seqera/actions/create-action/create-action.mjs
+++ b/components/seqera/actions/create-action/create-action.mjs
@@ -6,7 +6,7 @@ export default {
   key: "seqera-create-action",
   name: "Create Pipeline Action",
   description: "Creates a new pipeline action in Seqera. [See the documentation](https://docs.seqera.io/platform/23.3.0/api/overview)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     app,

--- a/components/seqera/actions/create-compute-environment/create-compute-environment.mjs
+++ b/components/seqera/actions/create-compute-environment/create-compute-environment.mjs
@@ -5,7 +5,7 @@ export default {
   key: "seqera-create-compute-environment",
   name: "Create Compute Environment",
   description: "Creates a new compute environment in Seqera Tower. [See the documentation](https://docs.seqera.io/platform/23.3.0/api/overview)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     app,

--- a/components/seqera/actions/create-pipeline/create-pipeline.mjs
+++ b/components/seqera/actions/create-pipeline/create-pipeline.mjs
@@ -5,7 +5,7 @@ export default {
   key: "seqera-create-pipeline",
   name: "Create Pipeline",
   description: "Creates a new pipeline in a user context. [See the documentation](https://docs.seqera.io/platform/23.3.0/api/overview)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     app,

--- a/components/seqera/package.json
+++ b/components/seqera/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/seqera",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Seqera Components",
   "main": "seqera.app.mjs",
   "keywords": [
@@ -11,5 +11,8 @@
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^3.0.3"
   }
 }

--- a/components/seqera/seqera.app.mjs
+++ b/components/seqera/seqera.app.mjs
@@ -165,9 +165,9 @@ export default {
         ...args,
       });
     },
-    listRuns(args = {}) {
+    listWorkflows(args = {}) {
       return this._makeRequest({
-        path: "/ga4gh/wes/v1/runs",
+        path: "/workflow?workspaceId=${workspaceId}",
         ...args,
       });
     },

--- a/components/seqera/seqera.app.mjs
+++ b/components/seqera/seqera.app.mjs
@@ -165,9 +165,11 @@ export default {
         ...args,
       });
     },
-    listWorkflows(args = {}) {
+    listWorkflows({
+      workspaceId, ...args
+    }) {
       return this._makeRequest({
-        path: "/workflow?workspaceId=${workspaceId}",
+        path: `/workflow?workspaceId=${workspaceId}`,
         ...args,
       });
     },
@@ -177,18 +179,18 @@ export default {
       resourceName,
       max = constants.DEFAULT_MAX,
     }) {
-      let nextPageToken;
+      const params = {
+        ...resourcesFnArgs?.params,
+        max: constants.DEFAULT_LIMIT,
+        offset: 0,
+      };
       let resourcesCount = 0;
 
       while (true) {
         const response =
           await resourcesFn({
             ...resourcesFnArgs,
-            params: {
-              ...resourcesFnArgs?.params,
-              page_size: constants.DEFAULT_LIMIT,
-              page_token: nextPageToken,
-            },
+            params,
           });
 
         const nextResources = resourceName && response[resourceName] || response;
@@ -207,12 +209,12 @@ export default {
           }
         }
 
-        if (Number(response.next_page_token) === 0) {
+        if (resourcesCount >= response.totalSize) {
           console.log("No more pages found");
           return;
         }
 
-        nextPageToken = response.next_page_token;
+        params.offset += params.max;
       }
     },
     paginate(args = {}) {

--- a/components/seqera/sources/new-run-created/new-run-created.mjs
+++ b/components/seqera/sources/new-run-created/new-run-created.mjs
@@ -5,7 +5,7 @@ export default {
   key: "seqera-new-run-created",
   name: "New Run Created",
   description: "Emit new event when a new run is created in Seqera. [See the documentation](https://docs.seqera.io/platform/23.3.0/api/overview)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   dedupe: "unique",
   props: {
@@ -18,22 +18,31 @@ export default {
         intervalSeconds: DEFAULT_POLLING_SOURCE_TIMER_INTERVAL,
       },
     },
+    workspaceId: {
+      propDefinition: [
+        app,
+        "workspaceId",
+      ],
+      optional: false,
+    },
   },
   methods: {
     getResourceName() {
-      return "runs";
+      return "workflows";
     },
     getResourcesFn() {
-      return this.app.listRuns;
+      return this.app.listWorkflows;
     },
     getResourcesFnArgs() {
-      return;
-    },
-    generateMeta(resource) {
       return {
-        id: resource.run_id,
-        summary: `New Run: ${resource.run_id}`,
-        ts: Date.now(),
+        workspaceId: this.workspaceId,
+      };
+    },
+    generateMeta({ workflow }) {
+      return {
+        id: workflow.id,
+        summary: `New Run: ${workflow.id}`,
+        ts: Date.parse(workflow.dateCreated),
       };
     },
     processResource(resource) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8934,7 +8934,10 @@ importers:
       slugify: 1.6.6
 
   components/seqera:
-    specifiers: {}
+    specifiers:
+      '@pipedream/platform': ^3.0.3
+    dependencies:
+      '@pipedream/platform': 3.0.3
 
   components/serpapi:
     specifiers:


### PR DESCRIPTION
## WHY

As mentioned (https://github.com/PipedreamHQ/pipedream/issues/14358), Seqera "runs" turns out to be named "workflows" in the API (unlike "runs", which I called them in my original request https://github.com/PipedreamHQ/pipedream/issues/10142). The Seqera Pipedream app needs to call `/workflows` in the API, while specifying the workspace ID with `workspaceId`. From my testing, If `workspaceId` is not specified, then no workflow runs are returned, so `workspaceId` is required, and I think should be specified when creating the integration, kind of like with Notion, you specify which databases the integration has access to.

`getResourcesFn` in `components/seqera/sources/new-run-created/new-run-created.mjs` also needs to be updated to `listWorkflows`:

https://github.com/PipedreamHQ/pipedream/blob/46e7530d240251261c8f64dd8e38b104e4b3c3a3/components/seqera/sources/new-run-created/new-run-created.mjs#L27

Let me know how I can help!

<!-- author to complete -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The method for retrieving workflows has been updated and renamed from `listRuns` to `listWorkflows`, enhancing clarity in functionality.
	- The API endpoint has been changed to align with updated specifications, requiring a `workspaceId` for workflow retrieval.
	- New property `workspaceId` added to support event emission for new workflows.

- **Bug Fixes**
	- Adjustments made to ensure proper invocation of the workflow retrieval method with the new parameters.
	- Metadata generation for new workflows updated to reflect the new resource type and timestamping method. 

- **Chores**
	- Version numbers updated across various components to reflect the latest changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->