### PR TITLE
docs: flow.exit updates

### DIFF
--- a/docs-v2/pages/code/nodejs/index.mdx
+++ b/docs-v2/pages/code/nodejs/index.mdx
@@ -387,16 +387,28 @@ Sometimes you want to end your workflow early, or otherwise stop or cancel the e
 **In any code step, calling `return $.flow.exit()` will end the execution of the workflow immediately.** No remaining code in that step, and no code or destination steps below, will run for the current event.
 
 <Callout type="info">
-It's a good practice to use `return $.flow.exit()` to immediately exit the workflow.
-In contrast, `$.flow.exit()` on its own will end the workflow only after executing all remaining code in the step.
+`$.flow.exit()` does not exit the workflow immediately, only after all remaining code has been executed.
+If you want to exit the workflow immediately, you need to use other control structures to do so.
+It is best practice to return the value of `$.flow.exit()`.
 </Callout>
+
+```javascript
+export default defineComponent({
+  async run({ steps, $ }) {
+    $.flow.exit();
+    console.log(
+      "This code will still run, the workflow is ended after"
+    );
+  },
+});
+```
 
 ```javascript
 export default defineComponent({
   async run({ steps, $ }) {
     return $.flow.exit();
     console.log(
-      "This code will not run, since $.flow.exit() was called above it"
+      "This code will not run, as we returned from the `run` function early"
     );
   },
 });


### PR DESCRIPTION
## WHY

The reasoning on why the flow exits early was incorrect. `return`ing from a function is just a standard way to exit the current flow, it is independent of `$.flow.exit`'s behavior.

<!-- author to complete -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Clarified the behavior of the `$.flow.exit()` function with new examples.
	- Expanded error handling section to include `ConfigurationError` guidance.
	- Emphasized the use of environment variables for sensitive information management.
	- Refined npm package usage section to clarify CommonJS and ESM imports with examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->