### PR TITLE
Docs - broken links in docs/components

### DIFF
--- a/docs-v2/pages/components/index.mdx
+++ b/docs-v2/pages/components/index.mdx
@@ -94,8 +94,8 @@ Finally, the target app must be integrated with Pipedream. You can explore all a
 
 ### Quickstart Guides
 
-- [Sources](quickstart/nodejs/sources/)
-- [Actions](quickstart/nodejs/actions/)
+- [Sources](/components/sources-quickstart/)
+- [Actions](/components/actions-quickstart/)
 
 ### Component API Reference
 


### PR DESCRIPTION
## WHY

Resolves #14592

Minor fix for two links, `Sources` and `Actions` under `Quickstart Guides` that are broken (under docs/components)

<!-- author to complete -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated links in the "Quickstart Guides" for better clarity and accessibility.
	- Enhanced readability and organization of the documentation for Pipedream components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->