### PR TITLE
Updating source names for SDK triggers

### DIFF
--- a/components/sdk/package.json
+++ b/components/sdk/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@pipedream/sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream SDK Components",
   "main": "sdk.app.mjs",
   "keywords": [
     "pipedream",
-    "sdk"
+    "sdk",
+    "integrations",
+    "api"
   ],
-  "homepage": "https://pipedream.com/apps/sdk",
+  "homepage": "https://pipedream.com/docs/connect/workflows",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "publishConfig": {
     "access": "public"

--- a/components/sdk/sources/nextjs-event-received/nextjs-event-received.mjs
+++ b/components/sdk/sources/nextjs-event-received/nextjs-event-received.mjs
@@ -1,10 +1,12 @@
+/* eslint-disable pipedream/source-description */
+/* eslint-disable pipedream/source-name */
 import sdk from "../../sdk.app.mjs";
 
 export default {
-  name: "New Event Received from the Next.js Pipedream SDK",
-  version: "0.0.1",
+  name: "Next.js",
+  version: "0.0.2",
   key: "sdk-nextjs-event-received",
-  description: "Emit new event via the Next.js Pipedream SDK.",
+  description: "Emit a new event via the Next.js Pipedream SDK.",
   props: {
     sdk,
   },

--- a/components/sdk/sources/nodejs-event-received/nodejs-event-received.mjs
+++ b/components/sdk/sources/nodejs-event-received/nodejs-event-received.mjs
@@ -1,10 +1,12 @@
+/* eslint-disable pipedream/source-description */
+/* eslint-disable pipedream/source-name */
 import sdk from "../../sdk.app.mjs";
 
 export default {
-  name: "New Event Received from the Node.js Pipedream SDK",
-  version: "0.0.1",
+  name: "Node.js",
+  version: "0.0.2",
   key: "sdk-nodejs-event-received",
-  description: "Emit new event via the Node.js Pipedream SDK.",
+  description: "Emit a new event via the Node.js Pipedream SDK.",
   props: {
     sdk,
   },

--- a/components/sdk/sources/nuxtjs-event-received/nuxtjs-event-received.mjs
+++ b/components/sdk/sources/nuxtjs-event-received/nuxtjs-event-received.mjs
@@ -1,10 +1,12 @@
+/* eslint-disable pipedream/source-description */
+/* eslint-disable pipedream/source-name */
 import sdk from "../../sdk.app.mjs";
 
 export default {
-  name: "New Event Received from the Nuxt.js Pipedream SDK",
-  version: "0.0.1",
+  name: "NuxtJS",
+  version: "0.0.2",
   key: "sdk-nuxtjs-event-received",
-  description: "Emit new event via the Nuxt.js Pipedream SDK.",
+  description: "Emit a new event via the Nuxt.js Pipedream SDK.",
   props: {
     sdk,
   },

--- a/components/sdk/sources/python-event-received/python-event-received.mjs
+++ b/components/sdk/sources/python-event-received/python-event-received.mjs
@@ -1,10 +1,12 @@
+/* eslint-disable pipedream/source-description */
+/* eslint-disable pipedream/source-name */
 import sdk from "../../sdk.app.mjs";
 
 export default {
-  name: "New Event Received from the Python Pipedream SDK",
-  version: "0.0.1",
+  name: "Python",
+  version: "0.0.2",
   key: "sdk-python-event-received",
-  description: "Emit new event via the Python Pipedream SDK.",
+  description: "Emit a new event via the Python Pipedream SDK.",
   props: {
     sdk,
   },

--- a/components/sdk/sources/reactjs-event-received/reactjs-event-received.mjs
+++ b/components/sdk/sources/reactjs-event-received/reactjs-event-received.mjs
@@ -1,10 +1,12 @@
+/* eslint-disable pipedream/source-description */
+/* eslint-disable pipedream/source-name */
 import sdk from "../../sdk.app.mjs";
 
 export default {
-  name: "New Event Received from the React.js Pipedream SDK",
-  version: "0.0.1",
+  name: "React.js",
+  version: "0.0.2",
   key: "sdk-reactjs-event-received",
-  description: "Emit new event via the React.js Pipedream SDK.",
+  description: "Emit a new event via the React.js Pipedream SDK.",
   props: {
     sdk,
   },

--- a/components/sdk/sources/vue-event-received/vue-event-received.mjs
+++ b/components/sdk/sources/vue-event-received/vue-event-received.mjs
@@ -1,10 +1,12 @@
+/* eslint-disable pipedream/source-description */
+/* eslint-disable pipedream/source-name */
 import sdk from "../../sdk.app.mjs";
 
 export default {
-  name: "New Event Received from the Vue Pipedream SDK",
-  version: "0.0.1",
+  name: "Vue",
+  version: "0.0.2",
   key: "sdk-vue-event-received",
-  description: "Emit new event via the Vue Pipedream SDK.",
+  description: "Emit a new event via the Vue Pipedream SDK.",
   props: {
     sdk,
   },


### PR DESCRIPTION
## WHY

<!-- author to complete -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the version of the Pipedream SDK to 0.1.1.
	- Simplified naming conventions for various event sources (Next.js, Node.js, NuxtJS, Python, React.js, Vue).
	- Enhanced descriptions for event sources for grammatical correctness.

- **Bug Fixes**
	- Corrected minor grammatical issues in descriptions across multiple event sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->