### PR TITLE
(fix) Fixing components/sdk package to not publish

### DIFF
--- a/components/sdk/package.json
+++ b/components/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/sdk",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream SDK Components",
   "main": "sdk.app.mjs",
   "keywords": [
@@ -11,7 +11,5 @@
   ],
   "homepage": "https://pipedream.com/docs/connect/workflows",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-  "publishConfig": {
-    "access": "public"
-  }
+  "private": true
 }

--- a/package.json
+++ b/package.json
@@ -73,5 +73,10 @@
     "crypto": "^1.0.1",
     "uuid": "^8.3.2",
     "vue": "^2.6.14"
+  },
+  "pnpm": {
+    "publishConfig": {
+      "components/sdk": false
+    }
   }
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/sdk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Pipedream SDK",
   "main": "dist/server/index.js",
   "module": "dist/server/index.js",


### PR DESCRIPTION
(fix) Fixing components/sdk package to be private, so we no longer publish it

We had an incident where this package overwrote the packages/sdk version of the package.