### PR TITLE
Retrieve credentials for a single account

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,6 +1,13 @@
 <!-- markdownlint-disable MD024 -->
 # Changelog
 
+## [1.0.3] - 2024-11-14
+
+### Added
+
+- Added a new argument to the `getAccountById` method in the backend client to
+  allow the client to retrieve the credentials of the corresponding account.
+
 ## [1.0.2] - 2024-11-14
 
 ### Changed

--- a/packages/sdk/package-lock.json
+++ b/packages/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pipedream/sdk",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pipedream/sdk",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "simple-oauth2": "^5.1.0"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/sdk",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Pipedream SDK",
   "main": "dist/server/index.js",
   "module": "dist/server/index.js",

--- a/packages/sdk/src/server/__tests__/server.test.ts
+++ b/packages/sdk/src/server/__tests__/server.test.ts
@@ -352,6 +352,35 @@ describe("BackendClient", () => {
         expect.any(Object),
       );
     });
+
+    it("should include credentials when the flag is set", async () => {
+      fetchMock.mockResponseOnce(
+        JSON.stringify({
+          id: "account-1",
+          name: "Test Account",
+          credentials: {},
+        }),
+        {
+          headers: {
+            "Content-Type": "application/json",
+          },
+        },
+      );
+
+      const result = await client.getAccountById("account-1", {
+        include_credentials: true,
+      });
+
+      expect(result).toEqual({
+        id: "account-1",
+        name: "Test Account",
+        credentials: {},
+      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        `https://api.pipedream.com/v1/connect/${projectId}/accounts/account-1?include_credentials=true`,
+        expect.any(Object),
+      );
+    });
   });
 
   describe("Get accounts by app", () => {

--- a/packages/sdk/src/server/index.ts
+++ b/packages/sdk/src/server/index.ts
@@ -205,6 +205,16 @@ export type GetAccountOpts = {
 };
 
 /**
+ * Parameters for the retrieval of an account from the Connect API
+ */
+export type GetAccountByIdOpts = {
+  /**
+   * Whether to retrieve the account's credentials or not.
+   */
+  include_credentials?: boolean;
+};
+
+/**
  * End user account data, returned from the API.
  */
 export type Account = {
@@ -600,9 +610,13 @@ export class BackendClient {
    * console.log(account);
    * ```
    */
-  public getAccountById(accountId: string): Promise<Account> {
+  public getAccountById(
+    accountId: string,
+    params: GetAccountByIdOpts = {},
+  ): Promise<Account> {
     return this.makeConnectRequest(`/accounts/${accountId}`, {
       method: "GET",
+      params,
     });
   }
 


### PR DESCRIPTION
# Description
Accept the `include_credentials` parameter in the `getAccountById` method so that clients can retrieve the credentials of a single account.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an optional parameter in the `getAccountById` method to include associated credentials in the response.
	- Added a new flag, `fullResponse`, to `RequestOptions` for receiving complete HTTP response details.

- **Bug Fixes**
	- Deprecated the `environment_name` field, streamlining environment determination.

- **Documentation**
	- Updated changelog and method documentation to reflect new features and changes.

- **Tests**
	- Enhanced test coverage for the `getAccountById` method, including scenarios for credential retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->