### PR TITLE
Trigger paused docs

### DIFF
--- a/docs-v2/pages/troubleshooting.mdx
+++ b/docs-v2/pages/troubleshooting.mdx
@@ -78,6 +78,12 @@ https://pipedream.com/sources/dc_abc123
 
 Your source's ID is the value that starts with `dc_`. In this example: `dc_abc123`.
 
+## Why is my trigger paused?
+
+On the Free tier, Pipedream automatically disables sources with a 100% error rate in the past 5 days.
+
+To troubleshoot, you can look at the errors in the [source](/sources/) logs, and may need to reconnect your account and reenable the source for it to run again.
+
 ## Warnings
 
 Pipedream displays warnings below steps in certain conditions. These warnings do not stop the execution of your workflow, but can signal an issue you should be aware of.


### PR DESCRIPTION
This pull request includes a small update to the `docs-v2/pages/troubleshooting.mdx` file. The change adds a new section to the troubleshooting documentation to explain why a trigger might be paused and how to resolve it.

Documentation update:

* [`docs-v2/pages/troubleshooting.mdx`](diffhunk://#diff-2dea191cb03edf6640ed389d0dad6f714cee4f8ba469e88a9010b5644fc28cf3R81-R86): Added a new section titled "Why is my trigger paused?" explaining the automatic disabling of sources with a 100% error rate on the Free tier and providing troubleshooting steps.