### PR TITLE
Adding a new prop to pre-process transcripts for human-readability.

### DIFF
--- a/components/gong/actions/retrieve-transcripts-of-calls/retrieve-transcripts-of-calls.mjs
+++ b/components/gong/actions/retrieve-transcripts-of-calls/retrieve-transcripts-of-calls.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Retrieve Transcripts Of Calls",
   description: "Retrieve transcripts of calls. [See the documentation](https://us-66463.app.gong.io/settings/api/documentation#post-/v2/calls/transcript)",
   type: "action",
-  version: "0.0.2",
+  version: "0.0.3",
   props: {
     app,
     fromDateTime: {
@@ -35,6 +35,13 @@ export default {
         "callIds",
       ],
     },
+    returnSimplifiedTranscript: {
+      type: "boolean",
+      label: "Return Simplified Transcript",
+      description: "If true, returns a simplified version of the transcript with normalized speaker IDs and formatted timestamps",
+      optional: true,
+      default: false,
+    },
   },
   methods: {
     retrieveTranscriptsOfCalls(args = {}) {
@@ -43,21 +50,102 @@ export default {
         ...args,
       });
     },
+
+    millisToTimestamp(millis) {
+      const totalSeconds = Math.floor(millis / 1000);
+      const minutes = Math.floor(totalSeconds / 60);
+      const seconds = totalSeconds % 60;
+
+      return `[${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}]`;
+    },
+
+    simplifyTranscript(originalResponse) {
+      const simplified = {
+        ...originalResponse,
+        callTranscripts: originalResponse.callTranscripts.map((callTranscript) => {
+          // Create a map of unique speaker IDs to simplified names
+          const speakerMap = new Map();
+          let speakerCounter = 1;
+          let currentSpeaker = null;
+          let currentTopic = null;
+          let formattedTranscript = "";
+
+          // Process each sentence maintaining chronological order
+          const allSentences = callTranscript.transcript.reduce((acc, segment) => {
+            const sentences = segment.sentences.map((sentence) => ({
+              ...sentence,
+              speakerId: segment.speakerId,
+              topic: segment.topic,
+            }));
+            return [
+              ...acc,
+              ...sentences,
+            ];
+          }, []);
+
+          // Sort by start time
+          allSentences.sort((a, b) => a.start - b.start);
+
+          // Process sentences
+          allSentences.forEach((sentence) => {
+            // Map speaker ID to simplified name
+            if (!speakerMap.has(sentence.speakerId)) {
+              speakerMap.set(sentence.speakerId, `Speaker ${speakerCounter}`);
+              speakerCounter++;
+            }
+
+            const speaker = speakerMap.get(sentence.speakerId);
+            const timestamp = this.millisToTimestamp(sentence.start);
+
+            // Handle topic changes
+            if (sentence.topic !== currentTopic) {
+              currentTopic = sentence.topic;
+              if (currentTopic) {
+                formattedTranscript += `\nTopic: ${currentTopic}\n-------------------\n\n`;
+              }
+            }
+
+            // Add speaker name only if it changes
+            if (speaker !== currentSpeaker) {
+              currentSpeaker = speaker;
+              formattedTranscript += `\n${speaker}:\n`;
+            }
+
+            // Add timestamp and text
+            formattedTranscript += `${timestamp} ${sentence.text}\n`;
+          });
+
+          return {
+            callId: callTranscript.callId,
+            formattedTranscript: formattedTranscript.trim(),
+          };
+        }),
+      };
+
+      return simplified;
+    },
   },
-  run({ $: step }) {
+
+  async run({ $: step }) {
     const {
-      // eslint-disable-next-line no-unused-vars
-      app,
       retrieveTranscriptsOfCalls,
+      returnSimplifiedTranscript,
+      simplifyTranscript,
       ...filter
     } = this;
 
-    return retrieveTranscriptsOfCalls({
+    const response = await retrieveTranscriptsOfCalls({
       step,
       data: {
         filter,
       },
       summary: (response) => `Successfully retrieved transcripts of calls with request ID \`${response.requestId}\`.`,
     });
+
+    if (returnSimplifiedTranscript) {
+      return simplifyTranscript(response);
+    }
+
+    return response;
   },
 };

--- a/components/gong/actions/retrieve-transcripts-of-calls/retrieve-transcripts-of-calls.mjs
+++ b/components/gong/actions/retrieve-transcripts-of-calls/retrieve-transcripts-of-calls.mjs
@@ -71,17 +71,16 @@ export default {
           let formattedTranscript = "";
 
           // Process each sentence maintaining chronological order
-          const allSentences = callTranscript.transcript.reduce((acc, segment) => {
-            const sentences = segment.sentences.map((sentence) => ({
-              ...sentence,
-              speakerId: segment.speakerId,
-              topic: segment.topic,
-            }));
-            return [
-              ...acc,
-              ...sentences,
-            ];
-          }, []);
+          const allSentences = [];
+          callTranscript.transcript.forEach((segment) => {
+            segment.sentences.forEach((sentence) => {
+              allSentences.push({
+                ...sentence,
+                speakerId: segment.speakerId,
+                topic: segment.topic,
+              });
+            });
+          });
 
           // Sort by start time
           allSentences.sort((a, b) => a.start - b.start);

--- a/components/gong/package.json
+++ b/components/gong/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/gong",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream Gong Components",
   "main": "gong.app.mjs",
   "keywords": [


### PR DESCRIPTION
Added a new optional boolean prop returnSimplifiedTranscript to the Gong Retrieve Transcripts action that transforms the raw transcript data into a human-readable format. When enabled, the output presents the conversation in a clean, chronological format with simplified speaker identification (e.g., "Speaker 1"), timestamps in [MM:SS] format, and topic markers where available. The formatted transcript only shows speaker changes when they occur and maintains proper spacing and sectioning, making it much easier to read and analyze conversation flow. This enhancement simplifies downstream use cases where transcript readability is important, while still maintaining the original API response structure when the option is disabled.

**Before:**
<img width="632" alt="Screenshot 2024-11-20 at 12 26 33 PM" src="https://github.com/user-attachments/assets/29950b34-a63c-4fe0-9a3e-175744c34085">

**After:**
<img width="721" alt="Screenshot 2024-11-20 at 12 26 44 PM" src="https://github.com/user-attachments/assets/e34df5b3-dc9a-442d-99ca-09d1d89d7a5e">



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an optional property `returnSimplifiedTranscript` for requesting simplified call transcripts.
	- Added methods for converting milliseconds to timestamps and simplifying transcripts for better readability.

- **Improvements**
	- Enhanced the `run` method to support asynchronous operations and improved control flow for transcript retrieval.

- **Version Update**
	- Updated package version from `0.1.1` to `0.1.2`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->