### PR TITLE
Republish components for Doppler, Fullenrich, & Parsehub

### DIFF
--- a/components/doppler_marketing_automation/actions/add-update-subscriber/add-update-subscriber.mjs
+++ b/components/doppler_marketing_automation/actions/add-update-subscriber/add-update-subscriber.mjs
@@ -7,7 +7,7 @@ export default {
   key: "doppler_marketing_automation-add-update-subscriber",
   name: "Add or Update Subscriber",
   description: "Adds a new subscriber or updates an existing one. [See the documentation](https://restapi.fromdoppler.com/docs/resources#!/Subscribers/AccountsByAccountNameListsByListIdSubscribersPost)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     app,

--- a/components/doppler_marketing_automation/actions/unsubscribe-email/unsubscribe-email.mjs
+++ b/components/doppler_marketing_automation/actions/unsubscribe-email/unsubscribe-email.mjs
@@ -4,7 +4,7 @@ export default {
   key: "doppler_marketing_automation-unsubscribe-email",
   name: "Unsubscribe Email",
   description: "Unsubscribe an email address from the account. Once unsubscribed, the user will not receive any more communication. [See the documentation](https://restapi.fromdoppler.com/docs/resources#!/Subscribers/AccountsByAccountNameUnsubscribedPost)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     app,

--- a/components/doppler_marketing_automation/package.json
+++ b/components/doppler_marketing_automation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/doppler_marketing_automation",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Doppler Marketing Automation Components",
   "main": "doppler_marketing_automation.app.mjs",
   "keywords": [

--- a/components/fullenrich/actions/enrich-contact/enrich-contact.mjs
+++ b/components/fullenrich/actions/enrich-contact/enrich-contact.mjs
@@ -5,7 +5,7 @@ export default {
   key: "fullenrich-enrich-contact",
   name: "Enrich Contact",
   description: "Starts the enrichment process for a specified contact. [See the documentation](https://docs.fullenrich.com/startbulk)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     app,

--- a/components/fullenrich/actions/get-enrichment-result/get-enrichment-result.mjs
+++ b/components/fullenrich/actions/get-enrichment-result/get-enrichment-result.mjs
@@ -4,7 +4,7 @@ export default {
   key: "fullenrich-get-enrichment-result",
   name: "Get Enrichment Result",
   description: "Get the enrichment result for a specified contact. [See the documentation](https://docs.fullenrich.com/getbulk).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     app,

--- a/components/fullenrich/package.json
+++ b/components/fullenrich/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/fullenrich",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream FullEnrich Components",
   "main": "fullenrich.app.mjs",
   "keywords": [

--- a/components/parsehub/actions/get-data-run/get-data-run.mjs
+++ b/components/parsehub/actions/get-data-run/get-data-run.mjs
@@ -4,7 +4,7 @@ export default {
   key: "parsehub-get-data-run",
   name: "Get Data for a Run",
   description: "Returns the data extracted by a specified run. [See the documentation](https://www.parsehub.com/docs/ref/api/v2/#get-data-for-a-run)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     app,

--- a/components/parsehub/actions/get-project/get-project.mjs
+++ b/components/parsehub/actions/get-project/get-project.mjs
@@ -4,7 +4,7 @@ export default {
   key: "parsehub-get-project",
   name: "Get Project Details",
   description: "Retrieves the details of a specified project within the user's account. [See the documentation](https://www.parsehub.com/docs/ref/api/v2/#get-a-project)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     app,

--- a/components/parsehub/actions/run-project/run-project.mjs
+++ b/components/parsehub/actions/run-project/run-project.mjs
@@ -4,7 +4,7 @@ export default {
   key: "parsehub-run-project",
   name: "Run Parsehub Project",
   description: "Initiates an instance of a specified project on the Parsehub cloud. [See the documentation](https://www.parsehub.com/docs/ref/api/v2/#run-a-project)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     app,

--- a/components/parsehub/package.json
+++ b/components/parsehub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/parsehub",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream ParseHub Components",
   "main": "parsehub.app.mjs",
   "keywords": [


### PR DESCRIPTION
## WHAT

Bump the versions for following components to republish them:

- Doppler Marketing Automation **Add or Update Subscriber**
- Doppler Marketing Automation **Unsubscribe Email**
- Fullenrich **Enrich Contact**
- Fullenrich **Get Enrichment Result**
- Parsehub **Get Data for a Run**
- Parsehub **Get Project Details**
- Parsehub **Run Parsehub Project**

## WHY

These components failed to publish to the Pipedream registry when initially pushed to the master branch. For a list of actions and sources in the Pipedream registry for each app, see their app pages:
- [Doppler Marketing Automation](https://pipedream.com/apps/doppler-marketing-automation)
- [FullEnrich](https://pipedream.com/apps/fullenrich)
- [ParseHub](https://pipedream.com/apps/parsehub)
