### PR TITLE
Refactoring Microsoft Teams code to reliably check for external users.

### DIFF
--- a/components/microsoft_teams/actions/create-channel/create-channel.mjs
+++ b/components/microsoft_teams/actions/create-channel/create-channel.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Create Channel",
   description: "Create a new channel in Microsoft Teams. [See the docs here](https://docs.microsoft.com/en-us/graph/api/channel-post?view=graph-rest-1.0&tabs=http)",
   type: "action",
-  version: "0.0.7",
+  version: "0.0.8",
   props: {
     microsoftTeams,
     teamId: {

--- a/components/microsoft_teams/actions/list-channels/list-channels.mjs
+++ b/components/microsoft_teams/actions/list-channels/list-channels.mjs
@@ -5,7 +5,7 @@ export default {
   name: "List Channels",
   description: "Lists all channels in a Microsoft Team. [See the docs here](https://docs.microsoft.com/en-us/graph/api/channel-list?view=graph-rest-1.0&tabs=http)",
   type: "action",
-  version: "0.0.7",
+  version: "0.0.8",
   props: {
     microsoftTeams,
     teamId: {

--- a/components/microsoft_teams/actions/list-shifts/list-shifts.mjs
+++ b/components/microsoft_teams/actions/list-shifts/list-shifts.mjs
@@ -5,7 +5,7 @@ export default {
   name: "List Shifts",
   description: "Get the list of shift instances for a team. [See the documentation](https://learn.microsoft.com/en-us/graph/api/schedule-list-shifts?view=graph-rest-1.0&tabs=http)",
   type: "action",
-  version: "0.0.4",
+  version: "0.0.5",
   props: {
     microsoftTeams,
     teamId: {

--- a/components/microsoft_teams/actions/send-channel-message/send-channel-message.mjs
+++ b/components/microsoft_teams/actions/send-channel-message/send-channel-message.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Send Channel Message",
   description: "Send a message to a team&#39;s channel. [See the docs here](https://docs.microsoft.com/en-us/graph/api/channel-post-messages?view=graph-rest-1.0&tabs=http)",
   type: "action",
-  version: "0.0.7",
+  version: "0.0.8",
   props: {
     microsoftTeams,
     teamId: {

--- a/components/microsoft_teams/actions/send-chat-message/send-chat-message.mjs
+++ b/components/microsoft_teams/actions/send-chat-message/send-chat-message.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Send Chat Message",
   description: "Send a message to a team&#39;s chat. [See the docs here](https://docs.microsoft.com/en-us/graph/api/chat-post-messages?view=graph-rest-1.0&tabs=http)",
   type: "action",
-  version: "0.0.7",
+  version: "0.0.8",
   props: {
     microsoftTeams,
     chatId: {

--- a/components/microsoft_teams/microsoft_teams.app.mjs
+++ b/components/microsoft_teams/microsoft_teams.app.mjs
@@ -34,7 +34,8 @@ export default {
       label: "Channel",
       description: "Team Channel",
       async options({
-        teamId, prevContext,
+        teamId,
+        prevContext,
       }) {
         const response = prevContext.nextLink
           ? await this.makeRequest({
@@ -79,27 +80,27 @@ export default {
         const options = [];
         
         for (const chat of response.value) {
-          let members = chat.members.map(member => ({
+          let members = chat.members.map((member) => ({
             displayName: member.displayName,
             wasNull: !member.displayName,
             userId: member.userId,
-            email: member.email
+            email: member.email,
           }));
           
-          if (members.some(member => !member.displayName)) {
+          if (members.some((member) => !member.displayName)) {
             try {
               const messages = await this.makeRequest({
                 path: `/chats/${chat.id}/messages?$top=10&$orderby=createdDateTime desc`,
               });
               
               const nameMap = new Map();
-              messages.value.forEach(msg => {
+              messages.value.forEach((msg) => {
                 if (msg.from?.user?.id && msg.from?.user?.displayName) {
                   nameMap.set(msg.from.user.id, msg.from.user.displayName);
                 }
               });
               
-              members = members.map(member => ({
+              members = members.map((member) => ({
                 ...member,
                 displayName: member.displayName || nameMap.get(member.userId) || member.email || "Unknown User",
               }));
@@ -108,10 +109,10 @@ export default {
             }
           }
           
-          const memberNames = members.map(member => 
+          const memberNames = members.map((member) => 
             member.wasNull 
               ? `${member.displayName} (External)`
-              : member.displayName
+              : member.displayName,
           );
           
           options.push({
@@ -168,7 +169,10 @@ export default {
       });
     },
     async makeRequest({
-      method, path, params = {}, content,
+      method,
+      path,
+      params = {},
+      content,
     }) {
       const api = this.client().api(path);
 
@@ -215,7 +219,8 @@ export default {
       });
     },
     async createChannel({
-      teamId, content,
+      teamId,
+      content,
     }) {
       return this.makeRequest({
         method: "post",
@@ -224,7 +229,9 @@ export default {
       });
     },
     async sendChannelMessage({
-      teamId, channelId, content,
+      teamId,
+      channelId,
+      content,
     }) {
       return this.makeRequest({
         method: "post",
@@ -233,7 +240,8 @@ export default {
       });
     },
     async sendChatMessage({
-      chatId, content,
+      chatId,
+      content,
     }) {
       return this.makeRequest({
         method: "post",
@@ -263,7 +271,8 @@ export default {
         .get();
     },
     async listChannelMessages({
-      teamId, channelId,
+      teamId,
+      channelId,
     }) {
       return this.makeRequest({
         path: `/teams/${teamId}/channels/${channelId}/messages/delta`,

--- a/components/microsoft_teams/microsoft_teams.app.mjs
+++ b/components/microsoft_teams/microsoft_teams.app.mjs
@@ -61,13 +61,13 @@ export default {
       label: "Chat",
       description: "Select a chat (type to search by participant names)",
       async options({
-        prevContext, searchTerm,
+        prevContext, query,
       }) {
         let path = "/chats?$expand=members";
         path += "&$top=20";
 
-        if (searchTerm) {
-          path += `&$search="${searchTerm}"`;
+        if (query) {
+          path += `&$search="${query}"`;
         }
 
         const response = prevContext?.nextLink

--- a/components/microsoft_teams/package.json
+++ b/components/microsoft_teams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/microsoft_teams",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Pipedream Microsoft Teams Components",
   "main": "microsoft_teams.app.mjs",
   "keywords": [

--- a/components/microsoft_teams/sources/new-channel-message/new-channel-message.mjs
+++ b/components/microsoft_teams/sources/new-channel-message/new-channel-message.mjs
@@ -5,7 +5,7 @@ export default {
   key: "microsoft_teams-new-channel-message",
   name: "New Channel Message",
   description: "Emit new event when a new message is posted in a channel",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/microsoft_teams/sources/new-channel/new-channel.mjs
+++ b/components/microsoft_teams/sources/new-channel/new-channel.mjs
@@ -5,7 +5,7 @@ export default {
   key: "microsoft_teams-new-channel",
   name: "New Channel",
   description: "Emit new event when a new channel is created within a team",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/microsoft_teams/sources/new-chat-message/new-chat-message.mjs
+++ b/components/microsoft_teams/sources/new-chat-message/new-chat-message.mjs
@@ -5,7 +5,7 @@ export default {
   key: "microsoft_teams-new-chat-message",
   name: "New Chat Message",
   description: "Emit new event when a new message is received in a chat",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/microsoft_teams/sources/new-chat/new-chat.mjs
+++ b/components/microsoft_teams/sources/new-chat/new-chat.mjs
@@ -5,7 +5,7 @@ export default {
   key: "microsoft_teams-new-chat",
   name: "New Chat",
   description: "Emit new event when a new chat is created",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/microsoft_teams/sources/new-team-member/new-team-member.mjs
+++ b/components/microsoft_teams/sources/new-team-member/new-team-member.mjs
@@ -5,7 +5,7 @@ export default {
   key: "microsoft_teams-new-team-member",
   name: "New Team Member",
   description: "Emit new event when a new member is added to a team",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/microsoft_teams/sources/new-team/new-team.mjs
+++ b/components/microsoft_teams/sources/new-team/new-team.mjs
@@ -5,7 +5,7 @@ export default {
   key: "microsoft_teams-new-team",
   name: "New Team",
   description: "Emit new event when a new team is joined by the authenticated user",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "source",
   dedupe: "unique",
   methods: {


### PR DESCRIPTION
… and label them without Global Admin permissions.

## WHY

The previous implementation required Global Admin permissions to identify external Teams users, which was too restrictive for most deployments. This refactor improves the user experience by:

Using chat message history to reliably identify external users without elevated permissions
Implementing pagination and search to handle enterprise-scale Teams deployments
Maintaining performance by only fetching additional data when needed
Adding caching to minimize redundant API calls

This change makes the Microsoft Teams integration more accessible while maintaining reliability and performance at scale.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced chat selection process: Users can now search by participant names in the chat property.
	
- **Version Updates**
	- Incremented version numbers for various Microsoft Teams actions and sources to reflect ongoing improvements:
		- Create Channel: 0.0.7 → 0.0.8
		- List Channels: 0.0.7 → 0.0.8
		- List Shifts: 0.0.4 → 0.0.5
		- Send Channel Message: 0.0.7 → 0.0.8
		- Send Chat Message: 0.0.7 → 0.0.8
		- New Channel Message: 0.0.8 → 0.0.9
		- New Channel: 0.0.8 → 0.0.9
		- New Chat Message: 0.0.8 → 0.0.9
		- New Chat: 0.0.8 → 0.0.9
		- New Team Member: 0.0.8 → 0.0.9
		- New Team: 0.0.8 → 0.0.9
		- Package version: 0.1.3 → 0.1.4
<!-- end of auto-generated comment: release notes by coderabbit.ai -->