### PR TITLE
Fix Airtable URL field asking for object input

### DIFF
--- a/components/airtable_oauth/actions/create-comment/create-comment.mjs
+++ b/components/airtable_oauth/actions/create-comment/create-comment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "airtable_oauth-create-comment",
   name: "Create Comment",
   description: "Create a new comment on a record. [See the documentation](https://airtable.com/developers/web/api/create-comment)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   props: {
     ...common.props,

--- a/components/airtable_oauth/actions/create-field/create-field.mjs
+++ b/components/airtable_oauth/actions/create-field/create-field.mjs
@@ -4,7 +4,7 @@ export default {
   key: "airtable_oauth-create-field",
   name: "Create Field",
   description: "Create a new field in a table. [See the documentation](https://airtable.com/developers/web/api/create-field)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   props: {
     ...common.props,

--- a/components/airtable_oauth/actions/create-multiple-records/create-multiple-records.mjs
+++ b/components/airtable_oauth/actions/create-multiple-records/create-multiple-records.mjs
@@ -8,7 +8,7 @@ export default {
   key: "airtable_oauth-create-multiple-records",
   name: "Create Multiple Records",
   description: "Create one or more records in a table by passing an array of objects containing field names and values as key/value pairs. [See the documentation](https://airtable.com/developers/web/api/create-records)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   props: {
     ...common.props,

--- a/components/airtable_oauth/actions/create-or-update-record/create-or-update-record.mjs
+++ b/components/airtable_oauth/actions/create-or-update-record/create-or-update-record.mjs
@@ -6,7 +6,7 @@ export default {
   key: "airtable_oauth-create-or-update-record",
   name: "Create Single Record Or Update",
   description: "Updates a record if `recordId` is provided or adds a record to a table.",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   props: {
     ...common.props,

--- a/components/airtable_oauth/actions/create-single-record/create-single-record.mjs
+++ b/components/airtable_oauth/actions/create-single-record/create-single-record.mjs
@@ -6,7 +6,7 @@ export default {
   key: "airtable_oauth-create-single-record",
   name: "Create Single Record",
   description: "Adds a record to a table.",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   props: {
     ...common.props,

--- a/components/airtable_oauth/actions/create-table/create-table.mjs
+++ b/components/airtable_oauth/actions/create-table/create-table.mjs
@@ -4,7 +4,7 @@ export default {
   key: "airtable_oauth-create-table",
   name: "Create Table",
   description: "Create a new table. [See the documentation](https://airtable.com/developers/web/api/create-table)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   props: {
     airtable,

--- a/components/airtable_oauth/actions/delete-record/delete-record.mjs
+++ b/components/airtable_oauth/actions/delete-record/delete-record.mjs
@@ -5,7 +5,7 @@ export default {
   key: "airtable_oauth-delete-record",
   name: "Delete Record",
   description: "Delete a record from a table by record ID. [See the documentation](https://airtable.com/developers/web/api/delete-record)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   props: {
     ...common.props,

--- a/components/airtable_oauth/actions/get-record-or-create/get-record-or-create.mjs
+++ b/components/airtable_oauth/actions/get-record-or-create/get-record-or-create.mjs
@@ -6,7 +6,7 @@ export default {
   key: "airtable_oauth-get-record-or-create",
   name: "Get Record Or Create",
   description: "Get a record from a table by record ID or create a new register.",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   props: {
     ...common.props,

--- a/components/airtable_oauth/actions/get-record/get-record.mjs
+++ b/components/airtable_oauth/actions/get-record/get-record.mjs
@@ -6,7 +6,7 @@ export default {
   key: "airtable_oauth-get-record",
   name: "Get Record",
   description: "Get a record from a table by record ID. [See the documentation](https://airtable.com/developers/web/api/get-record)",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   props: {
     ...common.props,

--- a/components/airtable_oauth/actions/list-records-in-view/list-records-in-view.mjs
+++ b/components/airtable_oauth/actions/list-records-in-view/list-records-in-view.mjs
@@ -6,7 +6,7 @@ export default {
   name: "List Records in View",
   description: "Retrieve records in a view with automatic pagination. Optionally sort and filter results. Only available for Enterprise accounts.",
   type: "action",
-  version: "0.0.6",
+  version: "0.0.7",
   ...commonList,
   props: {
     ...common.props,

--- a/components/airtable_oauth/actions/list-records/list-records.mjs
+++ b/components/airtable_oauth/actions/list-records/list-records.mjs
@@ -6,7 +6,7 @@ export default {
   name: "List Records",
   description: "Retrieve records from a table with automatic pagination. Optionally sort and filter results.",
   type: "action",
-  version: "0.0.6",
+  version: "0.0.7",
   ...commonList,
   props: {
     ...common.props,

--- a/components/airtable_oauth/actions/search-records/search-records.mjs
+++ b/components/airtable_oauth/actions/search-records/search-records.mjs
@@ -5,7 +5,7 @@ export default {
   key: "airtable_oauth-search-records",
   name: "Search Records",
   description: "Searches for a record by formula or by field value. [See the documentation](https://airtable.com/developers/web/api/list-records)",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "action",
   props: {
     ...common.props,

--- a/components/airtable_oauth/actions/update-comment/update-comment.mjs
+++ b/components/airtable_oauth/actions/update-comment/update-comment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "airtable_oauth-update-comment",
   name: "Update Comment",
   description: "Updates an existing comment on a record. [See the documentation](https://airtable.com/developers/web/api/update-comment)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   props: {
     ...common.props,

--- a/components/airtable_oauth/actions/update-field/update-field.mjs
+++ b/components/airtable_oauth/actions/update-field/update-field.mjs
@@ -5,7 +5,7 @@ export default {
   key: "airtable_oauth-update-field",
   name: "Update Field",
   description: "Updates an existing field in a table. [See the documentation](https://airtable.com/developers/web/api/update-field)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   props: {
     ...common.props,

--- a/components/airtable_oauth/actions/update-record/update-record.mjs
+++ b/components/airtable_oauth/actions/update-record/update-record.mjs
@@ -6,7 +6,7 @@ export default {
   key: "airtable_oauth-update-record",
   name: "Update Record",
   description: "Update a single record in a table by Record ID. [See the documentation](https://airtable.com/developers/web/api/update-record)",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   props: {
     ...common.props,

--- a/components/airtable_oauth/actions/update-table/update-table.mjs
+++ b/components/airtable_oauth/actions/update-table/update-table.mjs
@@ -4,7 +4,7 @@ export default {
   key: "airtable_oauth-update-table",
   name: "Update Table",
   description: "Updates an existing table. [See the documentation](https://airtable.com/developers/web/api/update-table)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   props: {
     ...common.props,

--- a/components/airtable_oauth/common/constants.mjs
+++ b/components/airtable_oauth/common/constants.mjs
@@ -32,8 +32,8 @@ const FieldType = {
   EXTERNAL_SYNC_SOURCE: "externalSyncSource",
   LAST_MODIFIED_BY: "lastModifiedBy",
   LAST_MODIFIED_TIME: "lastModifiedTime",
-  URL: "url",
   // string
+  URL: "url",
   SINGLE_COLLABORATOR: "singleCollaborator",
   DATE: "date",
   DATE_TIME: "dateTime",

--- a/components/airtable_oauth/common/utils.mjs
+++ b/components/airtable_oauth/common/utils.mjs
@@ -37,9 +37,9 @@ function fieldTypeToPropType(fieldType) {
   case FieldType.EXTERNAL_SYNC_SOURCE:
   case FieldType.LAST_MODIFIED_BY:
   case FieldType.LAST_MODIFIED_TIME:
-  case FieldType.URL:
     return "object";
   // string
+  case FieldType.URL:
   case FieldType.SINGLE_COLLABORATOR:
   case FieldType.DATE:
   case FieldType.DATE_TIME:

--- a/components/airtable_oauth/package.json
+++ b/components/airtable_oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/airtable_oauth",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Pipedream Airtable (OAuth) Components",
   "main": "airtable_oauth.app.mjs",
   "keywords": [

--- a/components/airtable_oauth/sources/new-field/new-field.mjs
+++ b/components/airtable_oauth/sources/new-field/new-field.mjs
@@ -4,7 +4,7 @@ export default {
   name: "New Field",
   description: "Emit new event for each new field created in a table",
   key: "airtable_oauth-new-field",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "source",
   props: {
     ...common.props,

--- a/components/airtable_oauth/sources/new-modified-or-deleted-records-instant/new-modified-or-deleted-records-instant.mjs
+++ b/components/airtable_oauth/sources/new-modified-or-deleted-records-instant/new-modified-or-deleted-records-instant.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Modified or Deleted Records (Instant)",
   description: "Emit new event each time a record is added, updated, or deleted in an Airtable table. [See the documentation](https://airtable.com/developers/web/api/create-a-webhook)",
   key: "airtable_oauth-new-modified-or-deleted-records-instant",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/airtable_oauth/sources/new-modified-or-deleted-records/new-modified-or-deleted-records.mjs
+++ b/components/airtable_oauth/sources/new-modified-or-deleted-records/new-modified-or-deleted-records.mjs
@@ -5,7 +5,7 @@ export default {
   ...base,
   name: "New, Modified or Deleted Records",
   key: "airtable_oauth-new-modified-or-deleted-records",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "source",
   description: "Emit new event each time a record is added, updated, or deleted in an Airtable table. Supports tables up to 10,000 records",
   props: {

--- a/components/airtable_oauth/sources/new-or-modified-field/new-or-modified-field.mjs
+++ b/components/airtable_oauth/sources/new-or-modified-field/new-or-modified-field.mjs
@@ -4,7 +4,7 @@ export default {
   name: "New or Modified Field",
   description: "Emit new event for each new or modified field in a table",
   key: "airtable_oauth-new-or-modified-field",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "source",
   props: {
     ...common.props,

--- a/components/airtable_oauth/sources/new-or-modified-records-in-view/new-or-modified-records-in-view.mjs
+++ b/components/airtable_oauth/sources/new-or-modified-records-in-view/new-or-modified-records-in-view.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New or Modified Records in View",
   description: "Emit new event for each new or modified record in a view",
   key: "airtable_oauth-new-or-modified-records-in-view",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "source",
   props: {
     ...base.props,

--- a/components/airtable_oauth/sources/new-or-modified-records/new-or-modified-records.mjs
+++ b/components/airtable_oauth/sources/new-or-modified-records/new-or-modified-records.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New or Modified Records",
   key: "airtable_oauth-new-or-modified-records",
   description: "Emit new event for each new or modified record in a table",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "source",
   props: {
     ...base.props,

--- a/components/airtable_oauth/sources/new-records-in-view/new-records-in-view.mjs
+++ b/components/airtable_oauth/sources/new-records-in-view/new-records-in-view.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Records in View",
   description: "Emit new event for each new record in a view",
   key: "airtable_oauth-new-records-in-view",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "source",
   props: {
     ...base.props,

--- a/components/airtable_oauth/sources/new-records/new-records.mjs
+++ b/components/airtable_oauth/sources/new-records/new-records.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Records",
   description: "Emit new event for each new record in a table",
   key: "airtable_oauth-new-records",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "source",
   props: {
     ...base.props,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12241,7 +12241,7 @@ importers:
         version: 3.1.7
       ts-jest:
         specifier: ^29.2.5
-        version: 29.2.5(@babel/core@8.0.0-alpha.13)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@8.0.0-alpha.13))(jest@29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0))(typescript@5.7.2)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0))(typescript@5.7.2)
       typescript:
         specifier: ^5.6
         version: 5.7.2
@@ -39374,6 +39374,25 @@ snapshots:
     dependencies:
       typescript: 5.6.3
 
+  ts-jest@29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0))(typescript@5.7.2):
+    dependencies:
+      bs-logger: 0.2.6
+      ejs: 3.1.10
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0)
+      jest-util: 29.7.0
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.6.3
+      typescript: 5.7.2
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.26.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.26.0)
+
   ts-jest@29.2.5(@babel/core@8.0.0-alpha.13)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@8.0.0-alpha.13))(jest@29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0))(typescript@5.6.3):
     dependencies:
       bs-logger: 0.2.6
@@ -39386,25 +39405,6 @@ snapshots:
       make-error: 1.3.6
       semver: 7.6.3
       typescript: 5.6.3
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 8.0.0-alpha.13
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@8.0.0-alpha.13)
-
-  ts-jest@29.2.5(@babel/core@8.0.0-alpha.13)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@8.0.0-alpha.13))(jest@29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0))(typescript@5.7.2):
-    dependencies:
-      bs-logger: 0.2.6
-      ejs: 3.1.10
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0)
-      jest-util: 29.7.0
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.6.3
-      typescript: 5.7.2
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 8.0.0-alpha.13

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12241,7 +12241,7 @@ importers:
         version: 3.1.7
       ts-jest:
         specifier: ^29.2.5
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0))(typescript@5.7.2)
+        version: 29.2.5(@babel/core@8.0.0-alpha.13)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@8.0.0-alpha.13))(jest@29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0))(typescript@5.7.2)
       typescript:
         specifier: ^5.6
         version: 5.7.2
@@ -39374,25 +39374,6 @@ snapshots:
     dependencies:
       typescript: 5.6.3
 
-  ts-jest@29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0))(typescript@5.7.2):
-    dependencies:
-      bs-logger: 0.2.6
-      ejs: 3.1.10
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0)
-      jest-util: 29.7.0
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.6.3
-      typescript: 5.7.2
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.26.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.26.0)
-
   ts-jest@29.2.5(@babel/core@8.0.0-alpha.13)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@8.0.0-alpha.13))(jest@29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0))(typescript@5.6.3):
     dependencies:
       bs-logger: 0.2.6
@@ -39405,6 +39386,25 @@ snapshots:
       make-error: 1.3.6
       semver: 7.6.3
       typescript: 5.6.3
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 8.0.0-alpha.13
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@8.0.0-alpha.13)
+
+  ts-jest@29.2.5(@babel/core@8.0.0-alpha.13)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@8.0.0-alpha.13))(jest@29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0))(typescript@5.7.2):
+    dependencies:
+      bs-logger: 0.2.6
+      ejs: 3.1.10
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0)
+      jest-util: 29.7.0
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.6.3
+      typescript: 5.7.2
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 8.0.0-alpha.13


### PR DESCRIPTION
## WHY

Additional props (e.g. in the **Update Record** action) with the `URL` Airtable field type are given a prop type of "object". Based on the Airtable [docs](https://airtable.com/developers/extensions/api/FieldType#URL), the type should be "string", not "object".

Context: https://pipedream-users.slack.com/archives/CMZG4EBJ9/p1733276186749089

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new `viewId` property for enhanced record retrieval in the listing action.
	- Added flexible search options with a new `searchMethod` property, allowing users to choose between searching by field and value or by formula.

- **Version Updates**
	- Incremented version numbers for multiple components to reflect updates, including actions for creating, updating, and deleting records, as well as various sources.

- **Bug Fixes**
	- Corrected the description for the `fieldIds` property to improve clarity in the new-or-modified-records source.

These updates enhance functionality and maintain the stability of existing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->