### PR TITLE
feat(sdk): add x-pd-sdk-version, triggerDeploy (1.0.9)

### DIFF
--- a/.github/workflows/pipedream-sdk-test.yaml
+++ b/.github/workflows/pipedream-sdk-test.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '22'
 
       - name: Install dependencies
         run: pnpm install

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,6 +2,7 @@ import jsonc from "eslint-plugin-jsonc";
 import putout from "eslint-plugin-putout";
 import pipedream from "eslint-plugin-pipedream";
 import typescriptEslint from "@typescript-eslint/eslint-plugin";
+import importPlugin from "eslint-plugin-import";
 import jest from "eslint-plugin-jest";
 import globals from "globals";
 import parser from "jsonc-eslint-parser";
@@ -52,6 +53,7 @@ export default [
       pipedream,
       "@typescript-eslint": typescriptEslint,
       jest,
+      "import": importPlugin,
     },
 
     languageOptions: {
@@ -311,6 +313,19 @@ export default [
 
     rules: {
       "react/react-in-jsx-scope": "off",
+    },
+  },
+  {
+    files: [
+      "packages/sdk/src/browser/**/*.ts",
+      "packages/sdk/src/shared/**/*.ts",
+    ],
+
+    rules: {
+      "import/extensions": [
+        "error",
+        "always",
+      ],
     },
   },
 ];

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,15 +7,18 @@ module.exports = {
     ".ts",
     ".mts",
   ],
-  globals: {
-    "ts-jest": {
-      useESM: true,
-    },
-  },
   moduleNameMapper: {
     "^(.+)\\.js$": "$1",
   },
   testPathIgnorePatterns: [
     "types/.*.types.test..*$",
   ],
+  transform: {
+    "\\.[jt]s?$": [
+      "ts-jest",
+      {
+        "useESM": true,
+      },
+    ],
+  },
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   testEnvironment: "node",
   // See https://kulshekhar.github.io/ts-jest/docs/guides/esm-support
   extensionsToTreatAsEsm: [
+    ".js",
     ".ts",
     ".mts",
   ],
@@ -14,7 +15,7 @@ module.exports = {
     "types/.*.types.test..*$",
   ],
   transform: {
-    "\\.[jt]s?$": [
+    "\\.[jt]s$": [
       "ts-jest",
       {
         "useESM": true,

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,7 +13,7 @@ module.exports = {
     },
   },
   moduleNameMapper: {
-    "^(\\.{1,2}/.*)\\.js$": "$1",
+    "^(.+)\\.js$": "$1",
   },
   testPathIgnorePatterns: [
     "types/.*.types.test..*$",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@typescript-eslint/parser": "^8",
     "eslint": "^8",
     "eslint-config-next": "^15",
+    "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-jest": "^28",
     "eslint-plugin-jsonc": "^1.6.0",
     "eslint-plugin-pipedream": "0.2.4",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,6 +1,13 @@
 <!-- markdownlint-disable MD024 -->
 # Changelog
 
+## [1.0.9] - 2024-12-04
+
+### Added
+
+- `triggerDeploy` preview API
+- `client.version` and `x-pd-sdk-version` header
+
 ## [1.0.8] - 2024-11-29
 
 ### Changed

--- a/packages/sdk/examples/browser/Makefile
+++ b/packages/sdk/examples/browser/Makefile
@@ -1,0 +1,8 @@
+default:
+	make -j2 server delayed-open
+
+server:
+	cd ../.. && python -m http.server
+
+delayed-open:
+	sleep 1 && xdg-open http://localhost:8000/examples/browser/index.html

--- a/packages/sdk/examples/browser/index.html
+++ b/packages/sdk/examples/browser/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <h1>Load SDK in browser</h1>
+    <script type="importmap">
+    {
+      "imports": {
+        "@rails/actioncable": "/node_modules/@rails/actioncable/app/assets/javascripts/actioncable.esm.js"
+      }
+    }
+    </script>
+    <script type="module">
+      import { createFrontendClient } from "/dist/browser/browser/index.js"
+      const client = createFrontendClient()
+      const p = document.createElement("p")
+      p.textContent = "sdk version: " + client.version
+      document.body.appendChild(p)
+    </script>
+  </body>
+</html>

--- a/packages/sdk/examples/server/Makefile
+++ b/packages/sdk/examples/server/Makefile
@@ -1,0 +1,2 @@
+default:
+	@node index.mjs

--- a/packages/sdk/examples/server/index.mjs
+++ b/packages/sdk/examples/server/index.mjs
@@ -1,0 +1,10 @@
+import { createBackendClient } from "../../dist/server/server/index.js";
+
+const client = createBackendClient({
+  environment: "development",
+  credentials: {
+    clientId: "not-empty",
+    clientSecret: "not-empty",
+  },
+});
+console.log("sdk version: " + client.version);

--- a/packages/sdk/jest.config.js
+++ b/packages/sdk/jest.config.js
@@ -15,10 +15,13 @@ module.exports = {
     "ts",
     "js",
   ],
+  moduleNameMapper: {
+    "^(.+)\\.js$": "$1",
+  },
   transform: {
     // '^.+\\.[tj]sx?$' to process ts,js,tsx,jsx with `ts-jest`
     // '^.+\\.m?[tj]sx?$' to process ts,js,tsx,jsx,mts,mjs,mtsx,mjsx with `ts-jest`
-    "^.+\\.tsx?$": [
+    "^.+\\.[jt]sx?$": [
       "ts-jest",
       {
         tsconfig: "tsconfig.node.json",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -35,8 +35,9 @@
     "access": "public"
   },
   "scripts": {
-    "prepublish": "rm -rf dist && pnpm run build",
-    "build": "pnpm run build:node && pnpm run build:browser",
+    "prepublish": "pnpm run build",
+    "prebuild": "node scripts/updateVersion.mjs",
+    "build": "rm -rf dist && pnpm run prebuild && pnpm run build:node && pnpm run build:browser",
     "build:node": "tsc -p tsconfig.node.json",
     "build:browser": "tsc -p tsconfig.browser.json",
     "test": "jest",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/sdk",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Pipedream SDK",
   "main": "dist/server/server/index.js",
   "module": "dist/server/server/index.js",

--- a/packages/sdk/scripts/updateVersion.mjs
+++ b/packages/sdk/scripts/updateVersion.mjs
@@ -1,0 +1,13 @@
+import fs from "fs";
+import cp from "child_process";
+
+if (!process.env.CI) {
+  // make sure people building locally automatically do not track changes to version file
+  cp.execSync("git update-index --skip-worktree src/version.ts");
+}
+
+const pkg = JSON.parse(String(fs.readFileSync("./package.json", "utf8")))
+const versionTsPath = "./src/version.ts";
+const data = String(fs.readFileSync(versionTsPath, "utf8"));
+const newData = data.replace(/"(.*)"/, `"${pkg.version}"`);
+fs.writeFileSync(versionTsPath, newData);

--- a/packages/sdk/scripts/updateVersion.mjs
+++ b/packages/sdk/scripts/updateVersion.mjs
@@ -7,7 +7,5 @@ if (!process.env.CI) {
 }
 
 const pkg = JSON.parse(String(fs.readFileSync("./package.json", "utf8")))
-const versionTsPath = "./src/version.ts";
-const data = String(fs.readFileSync(versionTsPath, "utf8"));
-const newData = data.replace(/"(.*)"/, `"${pkg.version}"`);
-fs.writeFileSync(versionTsPath, newData);
+fs.writeFileSync("./src/version.ts", `// DO NOT EDIT, SET AT BUILD TIME
+export const version = "${pkg.version}";`);

--- a/packages/sdk/scripts/updateVersion.mjs
+++ b/packages/sdk/scripts/updateVersion.mjs
@@ -7,5 +7,7 @@ if (!process.env.CI) {
 }
 
 const pkg = JSON.parse(String(fs.readFileSync("./package.json", "utf8")))
-fs.writeFileSync("./src/version.ts", `// DO NOT EDIT, SET AT BUILD TIME
-export const version = "${pkg.version}";`);
+const versionTsPath = "./src/version.ts";
+const data = String(fs.readFileSync(versionTsPath, "utf8"));
+const newData = data.replace(/"(.*)"/, `"${pkg.version}"`);
+fs.writeFileSync(versionTsPath, newData);

--- a/packages/sdk/src/browser/async.ts
+++ b/packages/sdk/src/browser/async.ts
@@ -1,5 +1,5 @@
-import { AsyncResponseManager } from "../shared/async";
-import type { AsyncResponseManagerOpts } from "../shared/async";
+import { AsyncResponseManager } from "../shared/async.js";
+import type { AsyncResponseManagerOpts } from "../shared/async.js";
 
 export type BrowserAsyncResponseManagerOpts = {
   apiHost: string;

--- a/packages/sdk/src/browser/async.ts
+++ b/packages/sdk/src/browser/async.ts
@@ -1,5 +1,5 @@
-import { AsyncResponseManager } from "../shared/async.js";
-import type { AsyncResponseManagerOpts } from "../shared/async.js";
+import { AsyncResponseManager } from "../shared/async.ts";
+import type { AsyncResponseManagerOpts } from "../shared/async.ts";
 
 export type BrowserAsyncResponseManagerOpts = {
   apiHost: string;

--- a/packages/sdk/src/browser/async.ts
+++ b/packages/sdk/src/browser/async.ts
@@ -1,5 +1,5 @@
-import { AsyncResponseManager } from "../shared/async.ts";
-import type { AsyncResponseManagerOpts } from "../shared/async.ts";
+import { AsyncResponseManager } from "../shared/async.js";
+import type { AsyncResponseManagerOpts } from "../shared/async.js";
 
 export type BrowserAsyncResponseManagerOpts = {
   apiHost: string;

--- a/packages/sdk/src/browser/index.ts
+++ b/packages/sdk/src/browser/index.ts
@@ -4,14 +4,14 @@
 // operations, like connecting accounts via Pipedream Connect. See the server/
 // directory for the server client.
 
-import { BrowserAsyncResponseManager } from "./async";
+import { BrowserAsyncResponseManager } from "./async.js";
 import {
   AccountsRequestResponse,
   BaseClient,
   GetAccountOpts,
   type ConnectTokenResponse,
-} from "../shared";
-export type * from "../shared";
+} from "../shared/index.js";
+export type * from "../shared/index.js";
 
 /**
  * Options for creating a browser-side client. This is used to configure the

--- a/packages/sdk/src/browser/index.ts
+++ b/packages/sdk/src/browser/index.ts
@@ -4,14 +4,14 @@
 // operations, like connecting accounts via Pipedream Connect. See the server/
 // directory for the server client.
 
-import { BrowserAsyncResponseManager } from "./async.ts";
+import { BrowserAsyncResponseManager } from "./async.js";
 import {
   AccountsRequestResponse,
   BaseClient,
   GetAccountOpts,
   type ConnectTokenResponse,
-} from "../shared/index.ts";
-export type * from "../shared/index.ts";
+} from "../shared/index.js";
+export type * from "../shared/index.js";
 
 /**
  * Options for creating a browser-side client. This is used to configure the

--- a/packages/sdk/src/browser/index.ts
+++ b/packages/sdk/src/browser/index.ts
@@ -4,14 +4,14 @@
 // operations, like connecting accounts via Pipedream Connect. See the server/
 // directory for the server client.
 
-import { BrowserAsyncResponseManager } from "./async.js";
+import { BrowserAsyncResponseManager } from "./async.ts";
 import {
   AccountsRequestResponse,
   BaseClient,
   GetAccountOpts,
   type ConnectTokenResponse,
-} from "../shared/index.js";
-export type * from "../shared/index.js";
+} from "../shared/index.ts";
+export type * from "../shared/index.ts";
 
 /**
  * Options for creating a browser-side client. This is used to configure the

--- a/packages/sdk/src/server/async.ts
+++ b/packages/sdk/src/server/async.ts
@@ -26,7 +26,7 @@ export class ServerAsyncResponseManager extends AsyncResponseManager {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     global.removeEventListener = () => {};
     if (typeof adapters.WebSocket === "undefined")
-      adapters.WebSocket = WebSocket;
+      adapters.WebSocket = WebSocket as unknown as typeof adapters.WebSocket;
   }
 
   protected override async getOpts(): Promise<AsyncResponseManagerOpts> {

--- a/packages/sdk/src/shared/component.ts
+++ b/packages/sdk/src/shared/component.ts
@@ -94,3 +94,17 @@ export type V1Component<T extends ConfigurableProps = any> = { // eslint-disable
   version: string;
   configurable_props: T;
 };
+
+export type V1DeployedComponent<T extends ConfigurableProps = any> = {
+  id: string;
+  owner_id: string;
+  component_id: string;
+  configurable_props: T;
+  configured_props: ConfiguredProps<T>;
+  active: boolean;
+  created_at: number;
+  updated_at: number;
+  name: string;
+  name_slug: string;
+  callback_observations?: unknown;
+};

--- a/packages/sdk/src/shared/component.ts
+++ b/packages/sdk/src/shared/component.ts
@@ -95,7 +95,7 @@ export type V1Component<T extends ConfigurableProps = any> = { // eslint-disable
   configurable_props: T;
 };
 
-export type V1DeployedComponent<T extends ConfigurableProps = any> = {
+export type V1DeployedComponent<T extends ConfigurableProps = any> = { // eslint-disable-line @typescript-eslint/no-explicit-any
   id: string;
   owner_id: string;
   component_id: string;

--- a/packages/sdk/src/shared/index.ts
+++ b/packages/sdk/src/shared/index.ts
@@ -1,10 +1,11 @@
 // This code is meant to be shared between the browser and server.
-import { AsyncResponseManager } from "./async";
+import { AsyncResponseManager } from "./async.js";
 import type {
   AsyncResponse, AsyncErrorResponse,
-} from "./async";
-import type { V1Component } from "./component";
-export * from "./component";
+} from "./async.js";
+import type { V1Component } from "./component.js";
+export * from "./component.js";
+import { version as sdkVersion } from "../version.js";
 
 type RequestInit = globalThis.RequestInit;
 
@@ -290,6 +291,7 @@ export interface AsyncRequestOptions extends RequestOptions {
  * A client for interacting with the Pipedream Connect API on the server-side.
  */
 export abstract class BaseClient {
+  version = sdkVersion;
   protected apiHost: string;
   protected abstract asyncResponseManager: AsyncResponseManager;
   protected readonly baseApiUrl: string;
@@ -351,6 +353,7 @@ export abstract class BaseClient {
 
     const headers: Record<string, string> = {
       ...customHeaders,
+      "X-PD-SDK-Version": sdkVersion,
       "X-PD-Environment": this.environment,
     };
 

--- a/packages/sdk/src/shared/index.ts
+++ b/packages/sdk/src/shared/index.ts
@@ -1,7 +1,8 @@
 // This code is meant to be shared between the browser and server.
-import { AsyncResponseManager } from "./async.js";
 import type {
-  AsyncResponse, AsyncErrorResponse,
+  AsyncResponse,
+  AsyncErrorResponse,
+  AsyncResponseManager,
 } from "./async.js";
 import type { V1Component } from "./component.js";
 export * from "./component.js";

--- a/packages/sdk/src/shared/index.ts
+++ b/packages/sdk/src/shared/index.ts
@@ -4,7 +4,10 @@ import type {
   AsyncErrorResponse,
   AsyncResponseManager,
 } from "./async.ts";
-import type { V1Component, V1DeployedComponent } from "./component.ts";
+import type {
+  V1Component,
+  V1DeployedComponent,
+} from "./component.ts";
 export * from "./component.ts";
 import { version as sdkVersion } from "../version.ts";
 

--- a/packages/sdk/src/shared/index.ts
+++ b/packages/sdk/src/shared/index.ts
@@ -576,7 +576,6 @@ export abstract class BaseClient {
       prop_name: opts.propName,
       configured_props: opts.configuredProps,
       dynamic_props_id: opts.dynamicPropsId,
-      environment: this.environment,
     };
     return await this.makeConnectRequestAsync<{
       options: { label: string; value: string; }[];
@@ -596,7 +595,6 @@ export abstract class BaseClient {
       id: opts.componentId,
       configured_props: opts.configuredProps,
       dynamic_props_id: opts.dynamicPropsId,
-      environment: this.environment,
     };
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return await this.makeConnectRequestAsync<Record<string, any>>("/components/props", {
@@ -618,13 +616,33 @@ export abstract class BaseClient {
       id: opts.actionId,
       configured_props: opts.configuredProps,
       dynamic_props_id: opts.dynamicPropsId,
-      environment: this.environment,
     };
     return await this.makeConnectRequestAsync<{
       exports: unknown;
       os: unknown[];
       ret: unknown;
     }>("/actions/run", {
+      method: "POST",
+      body,
+    });
+  }
+
+  public async triggerDeploy(opts: {
+    userId: string;
+    triggerId: string;
+    configuredProps: Record<string, any>;  // eslint-disable-line @typescript-eslint/no-explicit-any
+    dynamicPropsId?: string;
+    webhookUrl?: string;
+  }) {
+    const body = {
+      async_handle: this.asyncResponseManager.createAsyncHandle(),
+      external_user_id: opts.userId,
+      id: opts.triggerId,
+      configured_props: opts.configuredProps,
+      dynamic_props_id: opts.dynamicPropsId,
+      webhook_url: opts.webhookUrl,
+    }
+    return await this.makeConnectRequestAsync("/triggers/deploy", {
       method: "POST",
       body,
     });

--- a/packages/sdk/src/shared/index.ts
+++ b/packages/sdk/src/shared/index.ts
@@ -3,13 +3,13 @@ import type {
   AsyncResponse,
   AsyncErrorResponse,
   AsyncResponseManager,
-} from "./async.ts";
+} from "./async.js";
 import type {
   V1Component,
   V1DeployedComponent,
-} from "./component.ts";
-export * from "./component.ts";
-import { version as sdkVersion } from "../version.ts";
+} from "./component.js";
+export * from "./component.js";
+import { version as sdkVersion } from "../version.js";
 
 type RequestInit = globalThis.RequestInit;
 

--- a/packages/sdk/src/shared/index.ts
+++ b/packages/sdk/src/shared/index.ts
@@ -3,10 +3,10 @@ import type {
   AsyncResponse,
   AsyncErrorResponse,
   AsyncResponseManager,
-} from "./async.js";
-import type { V1Component } from "./component.js";
-export * from "./component.js";
-import { version as sdkVersion } from "../version.js";
+} from "./async.ts";
+import type { V1Component, V1DeployedComponent } from "./component.ts";
+export * from "./component.ts";
+import { version as sdkVersion } from "../version.ts";
 
 type RequestInit = globalThis.RequestInit;
 
@@ -642,7 +642,7 @@ export abstract class BaseClient {
       dynamic_props_id: opts.dynamicPropsId,
       webhook_url: opts.webhookUrl,
     }
-    return await this.makeConnectRequestAsync("/triggers/deploy", {
+    return await this.makeConnectRequestAsync<V1DeployedComponent>("/triggers/deploy", {
       method: "POST",
       body,
     });

--- a/packages/sdk/src/version.ts
+++ b/packages/sdk/src/version.ts
@@ -1,0 +1,2 @@
+// DO NOT EDIT, SET AT BUILD TIME
+export const version = "0.0.0"

--- a/packages/sdk/src/version.ts
+++ b/packages/sdk/src/version.ts
@@ -1,2 +1,2 @@
 // DO NOT EDIT, SET AT BUILD TIME
-export const version = "0.0.0";
+export const version = "0.0.0"

--- a/packages/sdk/src/version.ts
+++ b/packages/sdk/src/version.ts
@@ -1,2 +1,2 @@
 // DO NOT EDIT, SET AT BUILD TIME
-export const version = "0.0.0"
+export const version = "0.0.0";

--- a/packages/sdk/tsconfig.browser.json
+++ b/packages/sdk/tsconfig.browser.json
@@ -11,7 +11,9 @@
     "moduleResolution": "node",
     "skipLibCheck": true,
     "types": [],
-    "allowImportingTsExtensions": true
+    "paths": {
+      "*.js": ["*.ts"]
+    }
   },
   "include": [
     "src/browser/**/*"

--- a/packages/sdk/tsconfig.browser.json
+++ b/packages/sdk/tsconfig.browser.json
@@ -11,10 +11,7 @@
     "moduleResolution": "node",
     "skipLibCheck": true,
     "types": [],
-    "allowJs": true,
-    "paths": {
-      "*.js": ["*.ts"]
-    }
+    "allowJs": true
   },
   "include": [
     "src/browser/**/*"

--- a/packages/sdk/tsconfig.browser.json
+++ b/packages/sdk/tsconfig.browser.json
@@ -10,7 +10,8 @@
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
     "skipLibCheck": true,
-    "types": []
+    "types": [],
+    "allowImportingTsExtensions": true
   },
   "include": [
     "src/browser/**/*"

--- a/packages/sdk/tsconfig.browser.json
+++ b/packages/sdk/tsconfig.browser.json
@@ -11,6 +11,7 @@
     "moduleResolution": "node",
     "skipLibCheck": true,
     "types": [],
+    "allowJs": true,
     "paths": {
       "*.js": ["*.ts"]
     }

--- a/packages/sdk/tsconfig.node.json
+++ b/packages/sdk/tsconfig.node.json
@@ -10,6 +10,7 @@
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
+    "allowJs": true,
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
     "sourceMap": true,

--- a/packages/sdk/tsconfig.node.json
+++ b/packages/sdk/tsconfig.node.json
@@ -19,7 +19,8 @@
       "node",
       "jest",
       "jest-fetch-mock"
-    ]
+    ],
+    "allowImportingTsExtensions": true
   },
   "include": [
     "src/server/**/*"

--- a/packages/sdk/tsconfig.node.json
+++ b/packages/sdk/tsconfig.node.json
@@ -20,7 +20,9 @@
       "jest",
       "jest-fetch-mock"
     ],
-    "allowImportingTsExtensions": true
+    "paths": {
+      "*.js": ["*.ts"]
+    }
   },
   "include": [
     "src/server/**/*"

--- a/packages/sdk/tsconfig.node.json
+++ b/packages/sdk/tsconfig.node.json
@@ -20,10 +20,7 @@
       "node",
       "jest",
       "jest-fetch-mock"
-    ],
-    "paths": {
-      "*.js": ["*.ts"]
-    }
+    ]
   },
   "include": [
     "src/server/**/*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,7 +101,7 @@ importers:
         version: 4.0.0
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0))(typescript@5.6.3)
+        version: 29.2.5(@babel/core@8.0.0-alpha.13)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@8.0.0-alpha.13))(jest@29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0))(typescript@5.6.3)
       tsc-esm-fix:
         specifier: ^2.18.0
         version: 2.20.27
@@ -12173,7 +12173,7 @@ importers:
         version: 1.0.7
       next:
         specifier: 15.0.3
-        version: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
+        version: 15.0.3(@babel/core@8.0.0-alpha.13)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
       react:
         specifier: 19.0.0-rc-66855b96-20241106
         version: 19.0.0-rc-66855b96-20241106
@@ -25825,7 +25825,7 @@ snapshots:
       '@babel/traverse': 7.25.9
       '@babel/types': 7.26.0
       convert-source-map: 2.0.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -25844,7 +25844,7 @@ snapshots:
       '@babel/traverse': 8.0.0-alpha.13
       '@babel/types': 8.0.0-alpha.13
       convert-source-map: 2.0.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 7.6.3
@@ -25927,7 +25927,7 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-compilation-targets': 7.25.9
       '@babel/helper-plugin-utils': 7.25.9
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -26076,20 +26076,44 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@8.0.0-alpha.13)':
+    dependencies:
+      '@babel/core': 8.0.0-alpha.13
+      '@babel/helper-plugin-utils': 7.25.9
+    optional: true
+
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
+
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@8.0.0-alpha.13)':
+    dependencies:
+      '@babel/core': 8.0.0-alpha.13
+      '@babel/helper-plugin-utils': 7.25.9
+    optional: true
 
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@8.0.0-alpha.13)':
+    dependencies:
+      '@babel/core': 8.0.0-alpha.13
+      '@babel/helper-plugin-utils': 7.25.9
+    optional: true
+
   '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
+
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@8.0.0-alpha.13)':
+    dependencies:
+      '@babel/core': 8.0.0-alpha.13
+      '@babel/helper-plugin-utils': 7.25.9
+    optional: true
 
   '@babel/plugin-syntax-import-assertions@7.26.0(@babel/core@7.26.0)':
     dependencies:
@@ -26101,15 +26125,33 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
+  '@babel/plugin-syntax-import-attributes@7.26.0(@babel/core@8.0.0-alpha.13)':
+    dependencies:
+      '@babel/core': 8.0.0-alpha.13
+      '@babel/helper-plugin-utils': 7.25.9
+    optional: true
+
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@8.0.0-alpha.13)':
+    dependencies:
+      '@babel/core': 8.0.0-alpha.13
+      '@babel/helper-plugin-utils': 7.25.9
+    optional: true
+
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
+
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@8.0.0-alpha.13)':
+    dependencies:
+      '@babel/core': 8.0.0-alpha.13
+      '@babel/helper-plugin-utils': 7.25.9
+    optional: true
 
   '@babel/plugin-syntax-jsx@7.25.9(@babel/core@7.26.0)':
     dependencies:
@@ -26121,40 +26163,88 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@8.0.0-alpha.13)':
+    dependencies:
+      '@babel/core': 8.0.0-alpha.13
+      '@babel/helper-plugin-utils': 7.25.9
+    optional: true
+
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
+
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@8.0.0-alpha.13)':
+    dependencies:
+      '@babel/core': 8.0.0-alpha.13
+      '@babel/helper-plugin-utils': 7.25.9
+    optional: true
 
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@8.0.0-alpha.13)':
+    dependencies:
+      '@babel/core': 8.0.0-alpha.13
+      '@babel/helper-plugin-utils': 7.25.9
+    optional: true
+
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
+
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@8.0.0-alpha.13)':
+    dependencies:
+      '@babel/core': 8.0.0-alpha.13
+      '@babel/helper-plugin-utils': 7.25.9
+    optional: true
 
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@8.0.0-alpha.13)':
+    dependencies:
+      '@babel/core': 8.0.0-alpha.13
+      '@babel/helper-plugin-utils': 7.25.9
+    optional: true
+
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
+
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@8.0.0-alpha.13)':
+    dependencies:
+      '@babel/core': 8.0.0-alpha.13
+      '@babel/helper-plugin-utils': 7.25.9
+    optional: true
 
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@8.0.0-alpha.13)':
+    dependencies:
+      '@babel/core': 8.0.0-alpha.13
+      '@babel/helper-plugin-utils': 7.25.9
+    optional: true
+
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
+
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@8.0.0-alpha.13)':
+    dependencies:
+      '@babel/core': 8.0.0-alpha.13
+      '@babel/helper-plugin-utils': 7.25.9
+    optional: true
 
   '@babel/plugin-syntax-typescript@7.25.9(@babel/core@7.26.0)':
     dependencies:
@@ -26595,7 +26685,7 @@ snapshots:
       '@babel/parser': 7.26.2
       '@babel/template': 7.25.9
       '@babel/types': 7.26.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -26607,7 +26697,7 @@ snapshots:
       '@babel/parser': 8.0.0-alpha.13
       '@babel/template': 8.0.0-alpha.13
       '@babel/types': 8.0.0-alpha.13
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       globals: 15.12.0
     transitivePeerDependencies:
       - supports-color
@@ -26865,7 +26955,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -26879,7 +26969,7 @@ snapshots:
   '@eslint/eslintrc@3.2.0':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       espree: 10.3.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -27378,7 +27468,7 @@ snapshots:
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -28384,7 +28474,7 @@ snapshots:
       '@putout/babel': 2.9.0
       '@putout/engine-parser': 11.0.1
       '@putout/operate': 12.14.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       jessy: 3.1.1
       nessy: 4.0.0
     transitivePeerDependencies:
@@ -28439,7 +28529,7 @@ snapshots:
       '@putout/operator-filesystem': 5.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))
       '@putout/operator-json': 2.2.0
       '@putout/plugin-filesystem': 6.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       fullstore: 3.0.0
       jessy: 3.1.1
       nessy: 4.0.0
@@ -28579,8 +28669,6 @@ snapshots:
       '@putout/operator-filesystem': 5.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))
       '@putout/operator-json': 2.2.0
       putout: 36.13.1(eslint@8.57.1)(typescript@5.6.3)
-    transitivePeerDependencies:
-      - supports-color
 
   '@putout/operator-regexp@1.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))':
     dependencies:
@@ -30251,7 +30339,7 @@ snapshots:
       '@typescript-eslint/types': 8.15.0
       '@typescript-eslint/typescript-estree': 8.15.0(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 8.15.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       eslint: 8.57.1
     optionalDependencies:
       typescript: 5.6.3
@@ -30267,7 +30355,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 8.15.0(typescript@5.6.3)
       '@typescript-eslint/utils': 8.15.0(eslint@8.57.1)(typescript@5.6.3)
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       eslint: 8.57.1
       ts-api-utils: 1.4.0(typescript@5.6.3)
     optionalDependencies:
@@ -30279,7 +30367,7 @@ snapshots:
 
   '@typescript-eslint/typescript-estree@2.34.0(typescript@3.9.10)':
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       eslint-visitor-keys: 1.3.0
       glob: 7.2.3
       is-glob: 4.0.3
@@ -30295,7 +30383,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.15.0
       '@typescript-eslint/visitor-keys': 8.15.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       fast-glob: 3.3.2
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -30423,13 +30511,13 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
   agent-base@7.1.1:
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -30869,6 +30957,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  babel-jest@29.7.0(@babel/core@8.0.0-alpha.13):
+    dependencies:
+      '@babel/core': 8.0.0-alpha.13
+      '@jest/transform': 29.7.0
+      '@types/babel__core': 7.20.5
+      babel-plugin-istanbul: 6.1.1
+      babel-preset-jest: 29.6.3(@babel/core@8.0.0-alpha.13)
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   babel-plugin-istanbul@6.1.1:
     dependencies:
       '@babel/helper-plugin-utils': 7.25.9
@@ -30935,11 +31037,38 @@ snapshots:
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.26.0)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.26.0)
 
+  babel-preset-current-node-syntax@1.1.0(@babel/core@8.0.0-alpha.13):
+    dependencies:
+      '@babel/core': 8.0.0-alpha.13
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@8.0.0-alpha.13)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@8.0.0-alpha.13)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@8.0.0-alpha.13)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@8.0.0-alpha.13)
+      '@babel/plugin-syntax-import-attributes': 7.26.0(@babel/core@8.0.0-alpha.13)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@8.0.0-alpha.13)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@8.0.0-alpha.13)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@8.0.0-alpha.13)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@8.0.0-alpha.13)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@8.0.0-alpha.13)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@8.0.0-alpha.13)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@8.0.0-alpha.13)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@8.0.0-alpha.13)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@8.0.0-alpha.13)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@8.0.0-alpha.13)
+    optional: true
+
   babel-preset-jest@29.6.3(@babel/core@7.26.0):
     dependencies:
       '@babel/core': 7.26.0
       babel-plugin-jest-hoist: 29.6.3
       babel-preset-current-node-syntax: 1.1.0(@babel/core@7.26.0)
+
+  babel-preset-jest@29.6.3(@babel/core@8.0.0-alpha.13):
+    dependencies:
+      '@babel/core': 8.0.0-alpha.13
+      babel-plugin-jest-hoist: 29.6.3
+      babel-preset-current-node-syntax: 1.1.0(@babel/core@8.0.0-alpha.13)
+    optional: true
 
   backoff@2.5.0:
     dependencies:
@@ -31999,7 +32128,7 @@ snapshots:
 
   detective-less@1.0.2:
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       gonzales-pe: 4.3.0
       node-source-walk: 4.3.0
     transitivePeerDependencies:
@@ -32007,7 +32136,7 @@ snapshots:
 
   detective-postcss@3.0.1:
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       is-url: 1.2.4
       postcss: 7.0.39
       postcss-values-parser: 1.5.0
@@ -32490,7 +32619,7 @@ snapshots:
   eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.15.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       enhanced-resolve: 5.17.1
       eslint: 8.57.1
       eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.15.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
@@ -32691,7 +32820,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -32861,7 +32990,7 @@ snapshots:
 
   extract-zip@2.0.1:
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -33425,7 +33554,7 @@ snapshots:
     dependencies:
       '@tootallnate/once': 1.1.2
       data-uri-to-buffer: 3.0.1
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       file-uri-to-path: 2.0.0
       fs-extra: 8.1.0
       ftp: 0.3.10
@@ -33436,7 +33565,7 @@ snapshots:
     dependencies:
       basic-ftp: 5.0.5
       data-uri-to-buffer: 6.0.2
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       fs-extra: 11.2.0
     transitivePeerDependencies:
       - supports-color
@@ -34044,7 +34173,7 @@ snapshots:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -34052,14 +34181,14 @@ snapshots:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -34084,14 +34213,14 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.5:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -34491,7 +34620,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -35092,7 +35221,7 @@ snapshots:
     dependencies:
       '@types/express': 4.17.21
       '@types/jsonwebtoken': 8.5.9
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       jose: 2.0.7
       limiter: 1.1.5
       lru-memoizer: 2.3.0
@@ -35397,7 +35526,7 @@ snapshots:
   log4js@6.4.4:
     dependencies:
       date-format: 4.0.14
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       flatted: 3.3.2
       rfdc: 1.4.1
       streamroller: 3.1.5
@@ -35924,7 +36053,7 @@ snapshots:
 
   micromark@2.11.4:
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       parse-entities: 2.0.0
     transitivePeerDependencies:
       - supports-color
@@ -35932,7 +36061,7 @@ snapshots:
   micromark@4.0.1:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.2
@@ -36101,7 +36230,7 @@ snapshots:
     dependencies:
       '@tediousjs/connection-string': 0.5.0
       commander: 11.1.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       rfdc: 1.4.1
       tarn: 3.0.2
       tedious: 16.7.1
@@ -36226,7 +36355,7 @@ snapshots:
 
   next-tick@1.1.0: {}
 
-  next@15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106):
+  next@15.0.3(@babel/core@8.0.0-alpha.13)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106):
     dependencies:
       '@next/env': 15.0.3
       '@swc/counter': 0.1.3
@@ -36236,7 +36365,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.0.0-rc-66855b96-20241106
       react-dom: 19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106)
-      styled-jsx: 5.1.6(@babel/core@7.26.0)(babel-plugin-macros@3.1.0)(react@19.0.0-rc-66855b96-20241106)
+      styled-jsx: 5.1.6(@babel/core@8.0.0-alpha.13)(babel-plugin-macros@3.1.0)(react@19.0.0-rc-66855b96-20241106)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.0.3
       '@next/swc-darwin-x64': 15.0.3
@@ -36677,7 +36806,7 @@ snapshots:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       get-uri: 3.0.2
       http-proxy-agent: 4.0.1
       https-proxy-agent: 5.0.1
@@ -36691,7 +36820,7 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.1
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       get-uri: 6.0.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.5
@@ -37004,7 +37133,7 @@ snapshots:
   precinct@6.3.1:
     dependencies:
       commander: 2.20.3
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       detective-amd: 3.1.2
       detective-cjs: 3.1.3
       detective-es6: 2.2.2
@@ -37180,7 +37309,7 @@ snapshots:
   proxy-agent@5.0.0:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       http-proxy-agent: 4.0.1
       https-proxy-agent: 5.0.1
       lru-cache: 5.1.1
@@ -37193,7 +37322,7 @@ snapshots:
   proxy-agent@6.3.1:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.5
       lru-cache: 7.18.3
@@ -37424,7 +37553,7 @@ snapshots:
       ajv: 8.17.1
       chalk: 5.3.0
       ci-info: 4.1.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       deepmerge: 4.3.1
       escalade: 3.2.0
       fast-glob: 3.3.2
@@ -38094,7 +38223,7 @@ snapshots:
 
   retry-request@4.2.2:
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       extend: 3.0.2
     transitivePeerDependencies:
       - supports-color
@@ -38102,7 +38231,7 @@ snapshots:
 
   retry-request@5.0.2:
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       extend: 3.0.2
     transitivePeerDependencies:
       - supports-color
@@ -38410,7 +38539,7 @@ snapshots:
     dependencies:
       '@hapi/hoek': 11.0.7
       '@hapi/wreck': 18.1.0
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       joi: 17.13.3
     transitivePeerDependencies:
       - supports-color
@@ -38497,7 +38626,7 @@ snapshots:
   socks-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       socks: 2.8.3
     transitivePeerDependencies:
       - supports-color
@@ -38505,7 +38634,7 @@ snapshots:
   socks-proxy-agent@8.0.4:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       socks: 2.8.3
     transitivePeerDependencies:
       - supports-color
@@ -38647,7 +38776,7 @@ snapshots:
   streamroller@3.1.5:
     dependencies:
       date-format: 4.0.14
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       fs-extra: 8.1.0
     transitivePeerDependencies:
       - supports-color
@@ -38805,12 +38934,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.4
 
-  styled-jsx@5.1.6(@babel/core@7.26.0)(babel-plugin-macros@3.1.0)(react@19.0.0-rc-66855b96-20241106):
+  styled-jsx@5.1.6(@babel/core@8.0.0-alpha.13)(babel-plugin-macros@3.1.0)(react@19.0.0-rc-66855b96-20241106):
     dependencies:
       client-only: 0.0.1
       react: 19.0.0-rc-66855b96-20241106
     optionalDependencies:
-      '@babel/core': 7.26.0
+      '@babel/core': 8.0.0-alpha.13
       babel-plugin-macros: 3.1.0
 
   stylelint-config-recommended@14.0.1(stylelint@16.10.0(typescript@5.6.3)):
@@ -38840,7 +38969,7 @@ snapshots:
       cosmiconfig: 9.0.0(typescript@5.6.3)
       css-functions-list: 3.2.3
       css-tree: 3.0.1
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       fast-glob: 3.3.2
       fastest-levenshtein: 1.0.16
       file-entry-cache: 9.1.0
@@ -38882,7 +39011,7 @@ snapshots:
 
   superagent-proxy@3.0.0(superagent@7.1.6):
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       proxy-agent: 5.0.0
       superagent: 7.1.6
     transitivePeerDependencies:
@@ -38907,7 +39036,7 @@ snapshots:
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       form-data: 2.5.2
       formidable: 1.2.6
       methods: 1.1.2
@@ -38921,7 +39050,7 @@ snapshots:
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       fast-safe-stringify: 2.1.1
       form-data: 3.0.2
       formidable: 1.2.6
@@ -38937,7 +39066,7 @@ snapshots:
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       fast-safe-stringify: 2.1.1
       form-data: 4.0.1
       formidable: 2.1.2
@@ -39248,25 +39377,6 @@ snapshots:
     dependencies:
       typescript: 5.6.3
 
-  ts-jest@29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0))(typescript@5.6.3):
-    dependencies:
-      bs-logger: 0.2.6
-      ejs: 3.1.10
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0)
-      jest-util: 29.7.0
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.6.3
-      typescript: 5.6.3
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.26.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.26.0)
-
   ts-jest@29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0))(typescript@5.7.2):
     dependencies:
       bs-logger: 0.2.6
@@ -39285,6 +39395,25 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.26.0)
+
+  ts-jest@29.2.5(@babel/core@8.0.0-alpha.13)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@8.0.0-alpha.13))(jest@29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0))(typescript@5.6.3):
+    dependencies:
+      bs-logger: 0.2.6
+      ejs: 3.1.10
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0)
+      jest-util: 29.7.0
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.6.3
+      typescript: 5.6.3
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 8.0.0-alpha.13
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@8.0.0-alpha.13)
 
   tsc-esm-fix@2.20.27:
     dependencies:
@@ -39820,7 +39949,7 @@ snapshots:
       '@volar/typescript': 2.4.10
       '@vue/language-core': 2.1.6(typescript@5.7.2)
       compare-versions: 6.1.1
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.4.0)
       kolorist: 1.8.0
       local-pkg: 0.5.1
       magic-string: 0.30.13

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       eslint-config-next:
         specifier: ^15
         version: 15.0.3(eslint@8.57.1)(typescript@5.6.3)
+      eslint-plugin-import:
+        specifier: ^2.31.0
+        version: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
       eslint-plugin-jest:
         specifier: ^28
         version: 28.9.0(@typescript-eslint/eslint-plugin@8.15.0(@typescript-eslint/parser@8.15.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(jest@29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0))(typescript@5.6.3)
@@ -98,7 +101,7 @@ importers:
         version: 4.0.0
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@8.0.0-alpha.13)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@8.0.0-alpha.13))(jest@29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0))(typescript@5.6.3)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0))(typescript@5.6.3)
       tsc-esm-fix:
         specifier: ^2.18.0
         version: 2.20.27
@@ -12170,7 +12173,7 @@ importers:
         version: 1.0.7
       next:
         specifier: 15.0.3
-        version: 15.0.3(@babel/core@8.0.0-alpha.13)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
+        version: 15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
       react:
         specifier: 19.0.0-rc-66855b96-20241106
         version: 19.0.0-rc-66855b96-20241106
@@ -25822,7 +25825,7 @@ snapshots:
       '@babel/traverse': 7.25.9
       '@babel/types': 7.26.0
       convert-source-map: 2.0.0
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -25841,7 +25844,7 @@ snapshots:
       '@babel/traverse': 8.0.0-alpha.13
       '@babel/types': 8.0.0-alpha.13
       convert-source-map: 2.0.0
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 7.6.3
@@ -25924,7 +25927,7 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-compilation-targets': 7.25.9
       '@babel/helper-plugin-utils': 7.25.9
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -26073,44 +26076,20 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@8.0.0-alpha.13)':
-    dependencies:
-      '@babel/core': 8.0.0-alpha.13
-      '@babel/helper-plugin-utils': 7.25.9
-    optional: true
-
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
-
-  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@8.0.0-alpha.13)':
-    dependencies:
-      '@babel/core': 8.0.0-alpha.13
-      '@babel/helper-plugin-utils': 7.25.9
-    optional: true
 
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@8.0.0-alpha.13)':
-    dependencies:
-      '@babel/core': 8.0.0-alpha.13
-      '@babel/helper-plugin-utils': 7.25.9
-    optional: true
-
   '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
-
-  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@8.0.0-alpha.13)':
-    dependencies:
-      '@babel/core': 8.0.0-alpha.13
-      '@babel/helper-plugin-utils': 7.25.9
-    optional: true
 
   '@babel/plugin-syntax-import-assertions@7.26.0(@babel/core@7.26.0)':
     dependencies:
@@ -26122,33 +26101,15 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-import-attributes@7.26.0(@babel/core@8.0.0-alpha.13)':
-    dependencies:
-      '@babel/core': 8.0.0-alpha.13
-      '@babel/helper-plugin-utils': 7.25.9
-    optional: true
-
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@8.0.0-alpha.13)':
-    dependencies:
-      '@babel/core': 8.0.0-alpha.13
-      '@babel/helper-plugin-utils': 7.25.9
-    optional: true
-
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
-
-  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@8.0.0-alpha.13)':
-    dependencies:
-      '@babel/core': 8.0.0-alpha.13
-      '@babel/helper-plugin-utils': 7.25.9
-    optional: true
 
   '@babel/plugin-syntax-jsx@7.25.9(@babel/core@7.26.0)':
     dependencies:
@@ -26160,88 +26121,40 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@8.0.0-alpha.13)':
-    dependencies:
-      '@babel/core': 8.0.0-alpha.13
-      '@babel/helper-plugin-utils': 7.25.9
-    optional: true
-
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
-
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@8.0.0-alpha.13)':
-    dependencies:
-      '@babel/core': 8.0.0-alpha.13
-      '@babel/helper-plugin-utils': 7.25.9
-    optional: true
 
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@8.0.0-alpha.13)':
-    dependencies:
-      '@babel/core': 8.0.0-alpha.13
-      '@babel/helper-plugin-utils': 7.25.9
-    optional: true
-
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
-
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@8.0.0-alpha.13)':
-    dependencies:
-      '@babel/core': 8.0.0-alpha.13
-      '@babel/helper-plugin-utils': 7.25.9
-    optional: true
 
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@8.0.0-alpha.13)':
-    dependencies:
-      '@babel/core': 8.0.0-alpha.13
-      '@babel/helper-plugin-utils': 7.25.9
-    optional: true
-
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
-
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@8.0.0-alpha.13)':
-    dependencies:
-      '@babel/core': 8.0.0-alpha.13
-      '@babel/helper-plugin-utils': 7.25.9
-    optional: true
 
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@8.0.0-alpha.13)':
-    dependencies:
-      '@babel/core': 8.0.0-alpha.13
-      '@babel/helper-plugin-utils': 7.25.9
-    optional: true
-
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
-
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@8.0.0-alpha.13)':
-    dependencies:
-      '@babel/core': 8.0.0-alpha.13
-      '@babel/helper-plugin-utils': 7.25.9
-    optional: true
 
   '@babel/plugin-syntax-typescript@7.25.9(@babel/core@7.26.0)':
     dependencies:
@@ -26682,7 +26595,7 @@ snapshots:
       '@babel/parser': 7.26.2
       '@babel/template': 7.25.9
       '@babel/types': 7.26.0
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -26694,7 +26607,7 @@ snapshots:
       '@babel/parser': 8.0.0-alpha.13
       '@babel/template': 8.0.0-alpha.13
       '@babel/types': 8.0.0-alpha.13
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       globals: 15.12.0
     transitivePeerDependencies:
       - supports-color
@@ -26952,7 +26865,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -26966,7 +26879,7 @@ snapshots:
   '@eslint/eslintrc@3.2.0':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       espree: 10.3.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -27465,7 +27378,7 @@ snapshots:
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -28471,7 +28384,7 @@ snapshots:
       '@putout/babel': 2.9.0
       '@putout/engine-parser': 11.0.1
       '@putout/operate': 12.14.0
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       jessy: 3.1.1
       nessy: 4.0.0
     transitivePeerDependencies:
@@ -28526,7 +28439,7 @@ snapshots:
       '@putout/operator-filesystem': 5.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))
       '@putout/operator-json': 2.2.0
       '@putout/plugin-filesystem': 6.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       fullstore: 3.0.0
       jessy: 3.1.1
       nessy: 4.0.0
@@ -28666,6 +28579,8 @@ snapshots:
       '@putout/operator-filesystem': 5.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))
       '@putout/operator-json': 2.2.0
       putout: 36.13.1(eslint@8.57.1)(typescript@5.6.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@putout/operator-regexp@1.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))':
     dependencies:
@@ -30336,7 +30251,7 @@ snapshots:
       '@typescript-eslint/types': 8.15.0
       '@typescript-eslint/typescript-estree': 8.15.0(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 8.15.0
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       eslint: 8.57.1
     optionalDependencies:
       typescript: 5.6.3
@@ -30352,7 +30267,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 8.15.0(typescript@5.6.3)
       '@typescript-eslint/utils': 8.15.0(eslint@8.57.1)(typescript@5.6.3)
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       eslint: 8.57.1
       ts-api-utils: 1.4.0(typescript@5.6.3)
     optionalDependencies:
@@ -30364,7 +30279,7 @@ snapshots:
 
   '@typescript-eslint/typescript-estree@2.34.0(typescript@3.9.10)':
     dependencies:
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       eslint-visitor-keys: 1.3.0
       glob: 7.2.3
       is-glob: 4.0.3
@@ -30380,7 +30295,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.15.0
       '@typescript-eslint/visitor-keys': 8.15.0
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       fast-glob: 3.3.2
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -30508,13 +30423,13 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   agent-base@7.1.1:
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -30954,20 +30869,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-jest@29.7.0(@babel/core@8.0.0-alpha.13):
-    dependencies:
-      '@babel/core': 8.0.0-alpha.13
-      '@jest/transform': 29.7.0
-      '@types/babel__core': 7.20.5
-      babel-plugin-istanbul: 6.1.1
-      babel-preset-jest: 29.6.3(@babel/core@8.0.0-alpha.13)
-      chalk: 4.1.2
-      graceful-fs: 4.2.11
-      slash: 3.0.0
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   babel-plugin-istanbul@6.1.1:
     dependencies:
       '@babel/helper-plugin-utils': 7.25.9
@@ -31034,38 +30935,11 @@ snapshots:
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.26.0)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.26.0)
 
-  babel-preset-current-node-syntax@1.1.0(@babel/core@8.0.0-alpha.13):
-    dependencies:
-      '@babel/core': 8.0.0-alpha.13
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@8.0.0-alpha.13)
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@8.0.0-alpha.13)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@8.0.0-alpha.13)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@8.0.0-alpha.13)
-      '@babel/plugin-syntax-import-attributes': 7.26.0(@babel/core@8.0.0-alpha.13)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@8.0.0-alpha.13)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@8.0.0-alpha.13)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@8.0.0-alpha.13)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@8.0.0-alpha.13)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@8.0.0-alpha.13)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@8.0.0-alpha.13)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@8.0.0-alpha.13)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@8.0.0-alpha.13)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@8.0.0-alpha.13)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@8.0.0-alpha.13)
-    optional: true
-
   babel-preset-jest@29.6.3(@babel/core@7.26.0):
     dependencies:
       '@babel/core': 7.26.0
       babel-plugin-jest-hoist: 29.6.3
       babel-preset-current-node-syntax: 1.1.0(@babel/core@7.26.0)
-
-  babel-preset-jest@29.6.3(@babel/core@8.0.0-alpha.13):
-    dependencies:
-      '@babel/core': 8.0.0-alpha.13
-      babel-plugin-jest-hoist: 29.6.3
-      babel-preset-current-node-syntax: 1.1.0(@babel/core@8.0.0-alpha.13)
-    optional: true
 
   backoff@2.5.0:
     dependencies:
@@ -32125,7 +31999,7 @@ snapshots:
 
   detective-less@1.0.2:
     dependencies:
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       gonzales-pe: 4.3.0
       node-source-walk: 4.3.0
     transitivePeerDependencies:
@@ -32133,7 +32007,7 @@ snapshots:
 
   detective-postcss@3.0.1:
     dependencies:
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       is-url: 1.2.4
       postcss: 7.0.39
       postcss-values-parser: 1.5.0
@@ -32616,7 +32490,7 @@ snapshots:
   eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.15.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       enhanced-resolve: 5.17.1
       eslint: 8.57.1
       eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.15.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
@@ -32817,7 +32691,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -32987,7 +32861,7 @@ snapshots:
 
   extract-zip@2.0.1:
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.7(supports-color@5.5.0)
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -33551,7 +33425,7 @@ snapshots:
     dependencies:
       '@tootallnate/once': 1.1.2
       data-uri-to-buffer: 3.0.1
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       file-uri-to-path: 2.0.0
       fs-extra: 8.1.0
       ftp: 0.3.10
@@ -33562,7 +33436,7 @@ snapshots:
     dependencies:
       basic-ftp: 5.0.5
       data-uri-to-buffer: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.7(supports-color@5.5.0)
       fs-extra: 11.2.0
     transitivePeerDependencies:
       - supports-color
@@ -34170,7 +34044,7 @@ snapshots:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -34178,14 +34052,14 @@ snapshots:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.4
+      debug: 4.3.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -34210,14 +34084,14 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.5:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -34617,7 +34491,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -35218,7 +35092,7 @@ snapshots:
     dependencies:
       '@types/express': 4.17.21
       '@types/jsonwebtoken': 8.5.9
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       jose: 2.0.7
       limiter: 1.1.5
       lru-memoizer: 2.3.0
@@ -35523,7 +35397,7 @@ snapshots:
   log4js@6.4.4:
     dependencies:
       date-format: 4.0.14
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       flatted: 3.3.2
       rfdc: 1.4.1
       streamroller: 3.1.5
@@ -36050,7 +35924,7 @@ snapshots:
 
   micromark@2.11.4:
     dependencies:
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       parse-entities: 2.0.0
     transitivePeerDependencies:
       - supports-color
@@ -36058,7 +35932,7 @@ snapshots:
   micromark@4.0.1:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.2
@@ -36227,7 +36101,7 @@ snapshots:
     dependencies:
       '@tediousjs/connection-string': 0.5.0
       commander: 11.1.0
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       rfdc: 1.4.1
       tarn: 3.0.2
       tedious: 16.7.1
@@ -36352,7 +36226,7 @@ snapshots:
 
   next-tick@1.1.0: {}
 
-  next@15.0.3(@babel/core@8.0.0-alpha.13)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106):
+  next@15.0.3(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106):
     dependencies:
       '@next/env': 15.0.3
       '@swc/counter': 0.1.3
@@ -36362,7 +36236,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.0.0-rc-66855b96-20241106
       react-dom: 19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106)
-      styled-jsx: 5.1.6(@babel/core@8.0.0-alpha.13)(babel-plugin-macros@3.1.0)(react@19.0.0-rc-66855b96-20241106)
+      styled-jsx: 5.1.6(@babel/core@7.26.0)(babel-plugin-macros@3.1.0)(react@19.0.0-rc-66855b96-20241106)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.0.3
       '@next/swc-darwin-x64': 15.0.3
@@ -36803,7 +36677,7 @@ snapshots:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       get-uri: 3.0.2
       http-proxy-agent: 4.0.1
       https-proxy-agent: 5.0.1
@@ -36817,7 +36691,7 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.1
-      debug: 4.3.4
+      debug: 4.3.7(supports-color@5.5.0)
       get-uri: 6.0.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.5
@@ -37130,7 +37004,7 @@ snapshots:
   precinct@6.3.1:
     dependencies:
       commander: 2.20.3
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       detective-amd: 3.1.2
       detective-cjs: 3.1.3
       detective-es6: 2.2.2
@@ -37306,7 +37180,7 @@ snapshots:
   proxy-agent@5.0.0:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       http-proxy-agent: 4.0.1
       https-proxy-agent: 5.0.1
       lru-cache: 5.1.1
@@ -37319,7 +37193,7 @@ snapshots:
   proxy-agent@6.3.1:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.4
+      debug: 4.3.7(supports-color@5.5.0)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.5
       lru-cache: 7.18.3
@@ -37550,7 +37424,7 @@ snapshots:
       ajv: 8.17.1
       chalk: 5.3.0
       ci-info: 4.1.0
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       deepmerge: 4.3.1
       escalade: 3.2.0
       fast-glob: 3.3.2
@@ -38220,7 +38094,7 @@ snapshots:
 
   retry-request@4.2.2:
     dependencies:
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       extend: 3.0.2
     transitivePeerDependencies:
       - supports-color
@@ -38228,7 +38102,7 @@ snapshots:
 
   retry-request@5.0.2:
     dependencies:
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       extend: 3.0.2
     transitivePeerDependencies:
       - supports-color
@@ -38536,7 +38410,7 @@ snapshots:
     dependencies:
       '@hapi/hoek': 11.0.7
       '@hapi/wreck': 18.1.0
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       joi: 17.13.3
     transitivePeerDependencies:
       - supports-color
@@ -38623,7 +38497,7 @@ snapshots:
   socks-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       socks: 2.8.3
     transitivePeerDependencies:
       - supports-color
@@ -38631,7 +38505,7 @@ snapshots:
   socks-proxy-agent@8.0.4:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.4
+      debug: 4.3.7(supports-color@5.5.0)
       socks: 2.8.3
     transitivePeerDependencies:
       - supports-color
@@ -38773,7 +38647,7 @@ snapshots:
   streamroller@3.1.5:
     dependencies:
       date-format: 4.0.14
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       fs-extra: 8.1.0
     transitivePeerDependencies:
       - supports-color
@@ -38931,12 +38805,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.4
 
-  styled-jsx@5.1.6(@babel/core@8.0.0-alpha.13)(babel-plugin-macros@3.1.0)(react@19.0.0-rc-66855b96-20241106):
+  styled-jsx@5.1.6(@babel/core@7.26.0)(babel-plugin-macros@3.1.0)(react@19.0.0-rc-66855b96-20241106):
     dependencies:
       client-only: 0.0.1
       react: 19.0.0-rc-66855b96-20241106
     optionalDependencies:
-      '@babel/core': 8.0.0-alpha.13
+      '@babel/core': 7.26.0
       babel-plugin-macros: 3.1.0
 
   stylelint-config-recommended@14.0.1(stylelint@16.10.0(typescript@5.6.3)):
@@ -38966,7 +38840,7 @@ snapshots:
       cosmiconfig: 9.0.0(typescript@5.6.3)
       css-functions-list: 3.2.3
       css-tree: 3.0.1
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       fast-glob: 3.3.2
       fastest-levenshtein: 1.0.16
       file-entry-cache: 9.1.0
@@ -39008,7 +38882,7 @@ snapshots:
 
   superagent-proxy@3.0.0(superagent@7.1.6):
     dependencies:
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       proxy-agent: 5.0.0
       superagent: 7.1.6
     transitivePeerDependencies:
@@ -39033,7 +38907,7 @@ snapshots:
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       form-data: 2.5.2
       formidable: 1.2.6
       methods: 1.1.2
@@ -39047,7 +38921,7 @@ snapshots:
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       fast-safe-stringify: 2.1.1
       form-data: 3.0.2
       formidable: 1.2.6
@@ -39063,7 +38937,7 @@ snapshots:
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       fast-safe-stringify: 2.1.1
       form-data: 4.0.1
       formidable: 2.1.2
@@ -39374,6 +39248,25 @@ snapshots:
     dependencies:
       typescript: 5.6.3
 
+  ts-jest@29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0))(typescript@5.6.3):
+    dependencies:
+      bs-logger: 0.2.6
+      ejs: 3.1.10
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0)
+      jest-util: 29.7.0
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.6.3
+      typescript: 5.6.3
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.26.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.26.0)
+
   ts-jest@29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0))(typescript@5.7.2):
     dependencies:
       bs-logger: 0.2.6
@@ -39392,25 +39285,6 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.26.0)
-
-  ts-jest@29.2.5(@babel/core@8.0.0-alpha.13)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@8.0.0-alpha.13))(jest@29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0))(typescript@5.6.3):
-    dependencies:
-      bs-logger: 0.2.6
-      ejs: 3.1.10
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0)
-      jest-util: 29.7.0
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.6.3
-      typescript: 5.6.3
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 8.0.0-alpha.13
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@8.0.0-alpha.13)
 
   tsc-esm-fix@2.20.27:
     dependencies:
@@ -39946,7 +39820,7 @@ snapshots:
       '@volar/typescript': 2.4.10
       '@vue/language-core': 2.1.6(typescript@5.7.2)
       compare-versions: 6.1.1
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       kolorist: 1.8.0
       local-pkg: 0.5.1
       magic-string: 0.30.13


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new HTML example file to demonstrate loading the SDK in a browser environment.
	- Added a version property to the SDK, enhancing version tracking in API requests.
	- Implemented a default target in Makefiles for easier execution of server-related tasks.
	- Added a new method `triggerDeploy` in the SDK for deploying triggers with specified parameters.

- **Improvements**
	- Streamlined the build process for the SDK with automated version updates.
	- Updated import paths to include file extensions for compatibility.
	- Enhanced linting capabilities by integrating `eslint-plugin-import` for better import management.
	- Updated Node.js version in the testing workflow to ensure compatibility with newer features.
	- Improved error handling and type safety in the SDK's response management.

- **Bug Fixes**
	- Resolved issues with import statements to ensure correct module resolution.

These updates enhance the SDK's usability and maintainability, providing a better experience for developers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->