### PR TITLE
feat: rename Shopify New Shipment trigger and add New Fulfillment Event trigger

### DIFF
--- a/components/shopify_developer_app/sources/new-fulfillment-event-created/new-fulfillment-event-created.mjs
+++ b/components/shopify_developer_app/sources/new-fulfillment-event-created/new-fulfillment-event-created.mjs
@@ -1,0 +1,26 @@
+import constants from "../common/constants.mjs";
+import common from "../common/webhook-metafields.mjs";
+
+export default {
+  ...common,
+  key: "shopify_developer_app-new-fulfillment-event-created",
+  name: "New Fulfillment Event Created (Instant)",
+  type: "source",
+  description: "Emit new event when a fulfillment event is created.",
+  version: "0.0.1",
+  dedupe: "unique",
+  methods: {
+    ...common.methods,
+    getTopic() {
+      return constants.EVENT_TOPIC.FULFILLMENT_EVENTS_CREATE;
+    },
+    generateMeta(resource) {
+      const ts = Date.parse(resource.created_at);
+      return {
+        id: resource.id,
+        summary: `New Fulfillment Event ${resource.id}`,
+        ts,
+      };
+    },
+  },
+};

--- a/components/shopify_developer_app/sources/new-shipment/new-order-fulfilled.mjs
+++ b/components/shopify_developer_app/sources/new-shipment/new-order-fulfilled.mjs
@@ -3,11 +3,11 @@ import common from "../common/webhook-metafields.mjs";
 
 export default {
   ...common,
-  key: "shopify_developer_app-new-shipment",
-  name: "New Shipment (Instant)",
+  key: "shopify_developer_app-new-order-fulfilled",
+  name: "New Order Fulfilled (Instant)",
   type: "source",
-  description: "Emit new event for each new fulfillment event for a store.",
-  version: "0.0.4",
+  description: "Emit new event whenever an order is fulfilled.",
+  version: "0.0.1",
   dedupe: "unique",
   methods: {
     ...common.methods,
@@ -18,7 +18,7 @@ export default {
       const ts = Date.parse(resource.updated_at);
       return {
         id: ts,
-        summary: `New Shipped Order ${resource.id}.`,
+        summary: `Order ${resource.id} fulfilled`,
         ts,
       };
     },


### PR DESCRIPTION
Fixes #14873

Changes made:
- Renamed "Shopify - New Shipment" trigger to "Shopify - New Order Fulfilled" for better clarity
- Updated description to "Emits an event whenever an order is fulfilled"
- Added new "Shopify - New Fulfillment Event Created" trigger
- Updated trigger nomenclature to be more precise

Testing:
- [ ] Verified webhook registration works for both triggers
- [ ] Tested New Order Fulfilled trigger with sample order fulfillment
- [ ] Tested New Fulfillment Event Created trigger with sample fulfillment event