### PR TITLE
Google Calendar improvements to New or Updated Event source

### DIFF
--- a/components/google_calendar/package.json
+++ b/components/google_calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_calendar",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "Pipedream Google_calendar Components",
   "main": "google_calendar.app.mjs",
   "keywords": [

--- a/components/google_calendar/sources/new-or-updated-event-instant/new-or-updated-event-instant.mjs
+++ b/components/google_calendar/sources/new-or-updated-event-instant/new-or-updated-event-instant.mjs
@@ -201,7 +201,6 @@ export default {
     },
     getCalendarIdForChannelId(incomingChannelId) {
       for (const calendarId of this.calendarIds) {
-        const channelId = this.db.get(`${calendarId}.channelId`);
         if (this.db.get(`${calendarId}.channelId`) === incomingChannelId) {
           return calendarId;
         }
@@ -255,7 +254,9 @@ export default {
     }
 
     // Fetch and emit events
-    const checkCalendarIds = calendarId ? [ calendarId ] : this.calendarIds;
+    const checkCalendarIds = calendarId
+      ? [calendarId]
+      : this.calendarIds;
     for (const calendarId of checkCalendarIds) {
       const syncToken = this.getNextSyncToken(calendarId);
       let nextSyncToken = null;
@@ -274,7 +275,7 @@ export default {
         });
         if (syncStatus === 410) {
           console.log("Sync token invalid, resyncing");
-          nextSyncToken = await this.googleCalendar.fullSync(this.calendarId);
+          nextSyncToken = await this.googleCalendar.fullSync(calendarId);
           break;
         }
         nextPageToken = syncData.nextPageToken;

--- a/components/google_calendar/sources/new-or-updated-event-instant/new-or-updated-event-instant.mjs
+++ b/components/google_calendar/sources/new-or-updated-event-instant/new-or-updated-event-instant.mjs
@@ -266,6 +266,7 @@ export default {
           syncToken,
           pageToken: nextPageToken,
           maxResults: 2500,
+          validateStatus: (status) => (status >= 200 && (status < 300 || status == 410)),
         });
         if (syncStatus === 410) {
           console.log("Sync token invalid, resyncing");

--- a/components/google_calendar/sources/new-or-updated-event-instant/new-or-updated-event-instant.mjs
+++ b/components/google_calendar/sources/new-or-updated-event-instant/new-or-updated-event-instant.mjs
@@ -8,7 +8,7 @@ export default {
   type: "source",
   name: "New Created or Updated Event (Instant)",
   description: "Emit new event when a Google Calendar events is created or updated (does not emit cancelled events)",
-  version: "0.1.13",
+  version: "0.1.14",
   dedupe: "unique",
   props: {
     googleCalendar,
@@ -255,7 +255,9 @@ export default {
 
     // Fetch and emit events
     const checkCalendarIds = calendarId
-      ? [calendarId]
+      ? [
+        calendarId,
+      ]
       : this.calendarIds;
     for (const calendarId of checkCalendarIds) {
       const syncToken = this.getNextSyncToken(calendarId);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24487,22 +24487,22 @@ packages:
   superagent@3.8.1:
     resolution: {integrity: sha512-VMBFLYgFuRdfeNQSMLbxGSLfmXL/xc+OO+BZp41Za/NRDBet/BNbkRJrYzCUu0u4GU0i/ml2dtT8b9qgkw9z6Q==}
     engines: {node: '>= 4.0'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
 
   superagent@4.1.0:
     resolution: {integrity: sha512-FT3QLMasz0YyCd4uIi5HNe+3t/onxMyEho7C3PSqmti3Twgy2rXT4fmkTz6wRL6bTF4uzPcfkUCa8u4JWHw8Ag==}
     engines: {node: '>= 6.0'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
 
   superagent@5.3.1:
     resolution: {integrity: sha512-wjJ/MoTid2/RuGCOFtlacyGNxN9QLMgcpYLDQlWFIhhdJ93kNscFonGvrpAHSCVjRVj++DGCglocF7Aej1KHvQ==}
     engines: {node: '>= 7.0.0'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
 
   superagent@7.1.6:
     resolution: {integrity: sha512-gZkVCQR1gy/oUXr+kxJMLDjla434KmSOKbx5iGD30Ql+AkJQ/YlPKECJy2nhqOsHLjGHzoDTXNSjhnvWhzKk7g==}
     engines: {node: '>=6.4.0 <13 || >=14'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please downgrade to v7.1.5 if you need IE/ActiveXObject support OR upgrade to v8.0.0 as we no longer support IE and published an incorrect patch version (see https://github.com/visionmedia/superagent/issues/1731)
 
   supports-color@2.0.0:
     resolution: {integrity: sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==}


### PR DESCRIPTION
Attention @michelle0927 who already made improvements to this source to address API rate limiting errors.

This pull request addresses two issues with the Google Calendar "New or Updated Event (Instant)" event source:

 * Bug fix for invalid sync token

Code to handle an invalid sync token was never reached, because when the API call returned a 410 status code an exception was thrown, instead of returning the 410 status.

This issue has been addressed by passing a custom validateStatus function that allows a 410 response to be returned to the code that handles this.

 * Reduced calls to Google APIs (to prevent rate limiting) when many calendars are configured.

Our application has approximately 30 calendar IDs configured in a single source.

The event handler would poll **all** configured calendars for updates whenever **any** notification was received. This would result in rate limiting errors from the Google Calendar API, quickly causing problems for all our workflows that use also Google Calendar APIs.

With the modified code, when a notification is received, the code checks which subscription triggered the notification, and then requests updates only for the relevant calendar ID. In our use case, this reduces calls to Google Calendar APIs by a factor of 30.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new method for retrieving calendar IDs based on incoming channel IDs.

- **Bug Fixes**
	- Enhanced error handling for event fetching, ensuring only successful responses are processed.

- **Refactor**
	- Streamlined the logic for verifying channel IDs and improved clarity in event handling processes.
	- Removed an outdated method to simplify the code.

- **Chores**
	- Updated the version number of the Google Calendar component to 0.5.7.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->