### PR TITLE
Notion - add alert to trigger

### DIFF
--- a/components/notion/package.json
+++ b/components/notion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/notion",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Pipedream Notion Components",
   "main": "notion.app.mjs",
   "keywords": [

--- a/components/notion/sources/updated-page/updated-page.mjs
+++ b/components/notion/sources/updated-page/updated-page.mjs
@@ -9,7 +9,7 @@ export default {
   key: "notion-updated-page",
   name: "Updated Page in Database", /* eslint-disable-line pipedream/source-name */
   description: "Emit new event when a page in a database is updated. To select a specific page, use `Updated Page ID` instead",
-  version: "0.1.3",
+  version: "0.1.4",
   type: "source",
   dedupe: "unique",
   props: {
@@ -37,6 +37,11 @@ export default {
       ],
       description: "Only emit events when one or more of the selected properties have changed",
       optional: true,
+    },
+    alert: {
+      type: "alert",
+      alertType: "info",
+      content: "Source not saving? Your database might be too large. If deployment takes longer than one minute, an error will occur.",
     },
   },
   hooks: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30660,6 +30660,8 @@ snapshots:
       '@putout/operator-filesystem': 5.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))
       '@putout/operator-json': 2.2.0
       putout: 36.13.1(eslint@8.57.1)(typescript@5.6.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@putout/operator-regexp@1.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))':
     dependencies:


### PR DESCRIPTION
## WHY

<!-- author to complete -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated version of the Notion package to 0.2.6.
  - Introduced an `alert` property to the `notion-updated-page` component, providing users with information regarding potential issues related to database size.

- **Bug Fixes**
  - Enhanced user interaction by adding alerts for performance issues when saving large databases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->