### PR TITLE
Update new-email.mjs

### DIFF
--- a/components/microsoft_outlook/sources/new-email/new-email.mjs
+++ b/components/microsoft_outlook/sources/new-email/new-email.mjs
@@ -13,7 +13,7 @@ export default {
     async activate() {
       await this.activate({
         changeType: "created",
-        resource: "/me/mailfolders('inbox')/messages",
+        resource: "/me/messages",
       });
     },
     async deactivate() {


### PR DESCRIPTION
Allow for all folders in Outlook to be checked for new emails

## WHY

Currently, the node only checks for new emails in the inbox folder. If by certain rules, an email is directly moved into a separate folder, it is ignored by the trigger.