### PR TITLE
Postgres - remove ssl object when unnecessary

### DIFF
--- a/components/postgresql/actions/delete-rows/delete-rows.mjs
+++ b/components/postgresql/actions/delete-rows/delete-rows.mjs
@@ -4,7 +4,7 @@ export default {
   name: "Delete Row(s)",
   key: "postgresql-delete-rows",
   description: "Deletes a row or rows from a table. [See the documentation](https://node-postgres.com/features/queries)",
-  version: "2.0.6",
+  version: "2.0.7",
   type: "action",
   props: {
     postgresql,

--- a/components/postgresql/actions/execute-custom-query/execute-custom-query.mjs
+++ b/components/postgresql/actions/execute-custom-query/execute-custom-query.mjs
@@ -4,7 +4,7 @@ export default {
   name: "Execute SQL Query",
   key: "postgresql-execute-custom-query",
   description: "Execute a custom PostgreSQL query. See [our docs](https://pipedream.com/docs/databases/working-with-sql) to learn more about working with SQL in Pipedream.",
-  version: "3.0.1",
+  version: "3.0.2",
   type: "action",
   props: {
     postgresql,

--- a/components/postgresql/actions/find-row-custom-query/find-row-custom-query.mjs
+++ b/components/postgresql/actions/find-row-custom-query/find-row-custom-query.mjs
@@ -4,7 +4,7 @@ export default {
   name: "Find Row With Custom Query",
   key: "postgresql-find-row-custom-query",
   description: "Finds a row in a table via a custom query. [See the documentation](https://node-postgres.com/features/queries)",
-  version: "2.0.6",
+  version: "2.0.7",
   type: "action",
   props: {
     postgresql,

--- a/components/postgresql/actions/find-row/find-row.mjs
+++ b/components/postgresql/actions/find-row/find-row.mjs
@@ -4,7 +4,7 @@ export default {
   name: "Find Row",
   key: "postgresql-find-row",
   description: "Finds a row in a table via a lookup column. [See the documentation](https://node-postgres.com/features/queries)",
-  version: "2.0.6",
+  version: "2.0.7",
   type: "action",
   props: {
     postgresql,

--- a/components/postgresql/actions/insert-row/insert-row.mjs
+++ b/components/postgresql/actions/insert-row/insert-row.mjs
@@ -4,7 +4,7 @@ export default {
   name: "Insert Row",
   key: "postgresql-insert-row",
   description: "Adds a new row. [See the documentation](https://node-postgres.com/features/queries)",
-  version: "2.0.6",
+  version: "2.0.7",
   type: "action",
   props: {
     postgresql,

--- a/components/postgresql/actions/update-row/update-row.mjs
+++ b/components/postgresql/actions/update-row/update-row.mjs
@@ -4,7 +4,7 @@ export default {
   name: "Update Row",
   key: "postgresql-update-row",
   description: "Updates an existing row. [See the documentation](https://node-postgres.com/features/queries)",
-  version: "2.0.6",
+  version: "2.0.7",
   type: "action",
   props: {
     postgresql,

--- a/components/postgresql/actions/upsert-row/upsert-row.mjs
+++ b/components/postgresql/actions/upsert-row/upsert-row.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Upsert Row",
   key: "postgresql-upsert-row",
   description: "Adds a new row or updates an existing row. [See the documentation](https://node-postgres.com/features/queries)",
-  version: "2.0.6",
+  version: "2.0.7",
   type: "action",
   props: {
     postgresql,

--- a/components/postgresql/package.json
+++ b/components/postgresql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/postgresql",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Pipedream PostgreSQL Components",
   "main": "postgresql.app.mjs",
   "keywords": [

--- a/components/postgresql/postgresql.app.mjs
+++ b/components/postgresql/postgresql.app.mjs
@@ -93,8 +93,11 @@ export default {
         ...(cert && {
           cert,
         }),
-        rejectUnauthorized: mode !== "skip_verification",
       };
+
+      if (mode === "verify_identity") {
+        ssl.rejectUnauthorized = true;
+      }
 
       return Object.keys(ssl).length > 0
         ? ssl

--- a/components/postgresql/sources/new-column/new-column.mjs
+++ b/components/postgresql/sources/new-column/new-column.mjs
@@ -5,7 +5,7 @@ export default {
   name: "New Column",
   key: "postgresql-new-column",
   description: "Emit new event when a new column is added to a table. [See the documentation](https://node-postgres.com/features/queries)",
-  version: "2.0.6",
+  version: "2.0.7",
   type: "source",
   props: {
     ...common.props,

--- a/components/postgresql/sources/new-or-updated-row/new-or-updated-row.mjs
+++ b/components/postgresql/sources/new-or-updated-row/new-or-updated-row.mjs
@@ -5,7 +5,7 @@ export default {
   name: "New or Updated Row",
   key: "postgresql-new-or-updated-row",
   description: "Emit new event when a row is added or modified. [See the documentation](https://node-postgres.com/features/queries)",
-  version: "2.0.6",
+  version: "2.0.7",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/postgresql/sources/new-row-custom-query/new-row-custom-query.mjs
+++ b/components/postgresql/sources/new-row-custom-query/new-row-custom-query.mjs
@@ -5,7 +5,7 @@ export default {
   name: "New Row Custom Query",
   key: "postgresql-new-row-custom-query",
   description: "Emit new event when new rows are returned from a custom query that you provide. [See the documentation](https://node-postgres.com/features/queries)",
-  version: "2.0.6",
+  version: "2.0.7",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/postgresql/sources/new-row/new-row.mjs
+++ b/components/postgresql/sources/new-row/new-row.mjs
@@ -5,7 +5,7 @@ export default {
   name: "New Row",
   key: "postgresql-new-row",
   description: "Emit new event when a new row is added to a table. [See the documentation](https://node-postgres.com/features/queries)",
-  version: "3.0.6",
+  version: "3.0.7",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/postgresql/sources/new-table/new-table.mjs
+++ b/components/postgresql/sources/new-table/new-table.mjs
@@ -5,7 +5,7 @@ export default {
   name: "New Table",
   key: "postgresql-new-table",
   description: "Emit new event when a new table is added to the database. [See the documentation](https://node-postgres.com/features/queries)",
-  version: "2.0.6",
+  version: "2.0.7",
   type: "source",
   props: {
     ...common.props,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8225,8 +8225,7 @@ importers:
         specifier: ^1.2.1
         version: 1.6.6
 
-  components/quriiri:
-    specifiers: {}
+  components/quriiri: {}
 
   components/qwilr: {}
 
@@ -12205,10 +12204,10 @@ importers:
         version: 14.2.19(@babel/core@8.0.0-alpha.13)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       nextra:
         specifier: latest
-        version: 3.2.5(@types/react@18.3.12)(acorn@8.14.0)(next@14.2.19(@babel/core@8.0.0-alpha.13)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+        version: 3.3.0(@types/react@18.3.12)(acorn@8.14.0)(next@14.2.19(@babel/core@8.0.0-alpha.13)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       nextra-theme-docs:
         specifier: latest
-        version: 3.2.5(next@14.2.19(@babel/core@8.0.0-alpha.13)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nextra@3.2.5(@types/react@18.3.12)(acorn@8.14.0)(next@14.2.19(@babel/core@8.0.0-alpha.13)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 3.3.0(next@14.2.19(@babel/core@8.0.0-alpha.13)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nextra@3.3.0(@types/react@18.3.12)(acorn@8.14.0)(next@14.2.19(@babel/core@8.0.0-alpha.13)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -22408,16 +22407,16 @@ packages:
       sass:
         optional: true
 
-  nextra-theme-docs@3.2.5:
-    resolution: {integrity: sha512-eF0j1VNNS1rFjZOfYqlrXISaCU3+MhZ9hhXY+TUydRlfELrFWpGzrpW6MiL7hq4JvUR7OBtHHs8+A+8AYcETBQ==}
+  nextra-theme-docs@3.3.0:
+    resolution: {integrity: sha512-4JSbDmsbtaYa2eKHsNymWy6So4/fAAXuNPSkjgQ3S+aLRiC730mR9djdkTd1iRca4+czetzBWaqxu+HwTVSSCA==}
     peerDependencies:
       next: '>=13'
-      nextra: 3.2.5
+      nextra: 3.3.0
       react: '>=18'
       react-dom: '>=18'
 
-  nextra@3.2.5:
-    resolution: {integrity: sha512-n665DRpI/brjHXM83G5LdlbYA2nOtjaLcWJs7mZS3gkuRDmEXpJj4XJ860xrhkYZW2iYoUMu32zzhPuFByU7VA==}
+  nextra@3.3.0:
+    resolution: {integrity: sha512-//+bQW3oKrpLrrIFD5HJow310+YcNYhGIgdM4y+EjYuIXScJcgp6Q4Upsq8c2s2fQKEJjeuf+hXKusx9fvH/2w==}
     engines: {node: '>=18'}
     peerDependencies:
       next: '>=13'
@@ -23468,6 +23467,12 @@ packages:
     peerDependencies:
       '@types/react': '>=18'
       react: '>=18'
+
+  react-medium-image-zoom@5.2.12:
+    resolution: {integrity: sha512-BbQ9jLBFxu6z+viH5tzQzAGqHOJQoYUM7iT1KUkamWKOO6vR1pC33os7LGLrHvOcyySMw74rUdoUCXFdeglwCQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   react-select@5.8.3:
     resolution: {integrity: sha512-lVswnIq8/iTj1db7XCG74M/3fbGB6ZaluCzvwPGT5ZOjCdL/k0CLWhEK0vCBLuU5bHTEf6Gj8jtSvi+3v+tO1w==}
@@ -39742,7 +39747,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  nextra-theme-docs@3.2.5(next@14.2.19(@babel/core@8.0.0-alpha.13)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nextra@3.2.5(@types/react@18.3.12)(acorn@8.14.0)(next@14.2.19(@babel/core@8.0.0-alpha.13)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  nextra-theme-docs@3.3.0(next@14.2.19(@babel/core@8.0.0-alpha.13)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(nextra@3.3.0(@types/react@18.3.12)(acorn@8.14.0)(next@14.2.19(@babel/core@8.0.0-alpha.13)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@headlessui/react': 2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
@@ -39750,13 +39755,13 @@ snapshots:
       flexsearch: 0.7.43
       next: 14.2.19(@babel/core@8.0.0-alpha.13)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-themes: 0.4.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      nextra: 3.2.5(@types/react@18.3.12)(acorn@8.14.0)(next@14.2.19(@babel/core@8.0.0-alpha.13)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      nextra: 3.3.0(@types/react@18.3.12)(acorn@8.14.0)(next@14.2.19(@babel/core@8.0.0-alpha.13)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       scroll-into-view-if-needed: 3.1.0
       zod: 3.23.8
 
-  nextra@3.2.5(@types/react@18.3.12)(acorn@8.14.0)(next@14.2.19(@babel/core@8.0.0-alpha.13)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3):
+  nextra@3.3.0(@types/react@18.3.12)(acorn@8.14.0)(next@14.2.19(@babel/core@8.0.0-alpha.13)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.5.8
       '@headlessui/react': 2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -39783,6 +39788,7 @@ snapshots:
       p-limit: 6.1.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+      react-medium-image-zoom: 5.2.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       rehype-katex: 7.0.1
       rehype-pretty-code: 0.14.0(shiki@1.24.0)
       rehype-raw: 7.0.0
@@ -41219,6 +41225,11 @@ snapshots:
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
+
+  react-medium-image-zoom@5.2.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   react-select@5.8.3(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:


### PR DESCRIPTION
## WHY

A user was facing connection issues when the SSL object was being passed in the PG client configuration even with just `rejectUnauthorized = false`.

<!-- author to complete -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced SSL configuration logic for PostgreSQL component.
- **Bug Fixes**
	- Improved error messaging for SSL verification issues.
- **Chores**
	- Updated package versions for various PostgreSQL actions and sources from 2.0.6 to 2.0.7 and from 3.0.6 to 3.0.7.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->