### PR TITLE
Biz/dj 2786 fix issue with loading dynamic props

### DIFF
--- a/packages/connect-react/package.json
+++ b/packages/connect-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/connect-react",
-  "version": "1.0.0-preview.15",
+  "version": "1.0.0-preview.16",
   "description": "Pipedream Connect library for React",
   "files": [
     "dist"

--- a/packages/connect-react/src/hooks/form-context.tsx
+++ b/packages/connect-react/src/hooks/form-context.tsx
@@ -129,12 +129,13 @@ export const FormContextProvider = <T extends ConfigurableProps>({
     configuredProps,
     dynamicPropsId: dynamicProps?.id,
   };
+  const queryKey = reloadPropIdx ? `dynamicProps:${reloadPropIdx}` : "dynamicProps"
   const {
     isFetching: dynamicPropsQueryIsFetching,
     // TODO error
   } = useQuery({
     queryKey: [
-      "dynamicProps",
+      queryKey
     ],
     queryFn: async () => {
       const { dynamicProps } = await client.componentReloadProps(componentReloadPropsInput);

--- a/packages/connect-react/src/hooks/form-context.tsx
+++ b/packages/connect-react/src/hooks/form-context.tsx
@@ -129,13 +129,17 @@ export const FormContextProvider = <T extends ConfigurableProps>({
     configuredProps,
     dynamicPropsId: dynamicProps?.id,
   };
-  const queryKey = reloadPropIdx ? `dynamicProps:${reloadPropIdx}` : "dynamicProps"
+  const queryKeyInput = {
+    ...componentReloadPropsInput,
+  }
+
   const {
     isFetching: dynamicPropsQueryIsFetching,
     // TODO error
   } = useQuery({
     queryKey: [
-      queryKey
+      "dynamicProps",
+      queryKeyInput
     ],
     queryFn: async () => {
       const { dynamicProps } = await client.componentReloadProps(componentReloadPropsInput);

--- a/packages/connect-react/src/hooks/form-context.tsx
+++ b/packages/connect-react/src/hooks/form-context.tsx
@@ -139,7 +139,7 @@ export const FormContextProvider = <T extends ConfigurableProps>({
   } = useQuery({
     queryKey: [
       "dynamicProps",
-      queryKeyInput
+      queryKeyInput,
     ],
     queryFn: async () => {
       const { dynamicProps } = await client.componentReloadProps(componentReloadPropsInput);


### PR DESCRIPTION
## WHY

Dynamic props aren't loading (this only happens if we need to reload props more than once, eg. Google sheets, where we fetch dynamicProps for the first time after selecting the sheet. But we also need to fetch the dynamic props after selecting a worksheet, and so on.) The root cause appears to be `useQuery`, which only executes `queryFn` once for a given queryKey. Ideally, useQuery should run once for a given `reloadPropIdx`. So far the only thing that works is invalidating the `queryKey`.

<!-- author to complete -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Version Update**
	- Updated `@pipedream/connect-react` package version from `1.0.0-preview.15` to `1.0.0-preview.16`

- **Improvements**
	- Enhanced query key handling in form context hook to improve dynamic property management
<!-- end of auto-generated comment: release notes by coderabbit.ai -->