### PR TITLE
Hubspot new task version fix

### DIFF
--- a/components/hubspot/package.json
+++ b/components/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/hubspot",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Pipedream Hubspot Components",
   "main": "hubspot.app.mjs",
   "keywords": [

--- a/components/hubspot/sources/new-task/new-task.mjs
+++ b/components/hubspot/sources/new-task/new-task.mjs
@@ -8,7 +8,7 @@ export default {
   key: "hubspot-new-task",
   name: "New Task Created",
   description: "Emit new event for each new task created. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/engagements/tasks#get-%2Fcrm%2Fv3%2Fobjects%2Ftasks)",
-  version: "0.0.1",
+  version: "0.0.13",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -853,8 +853,7 @@ importers:
 
   components/autobound: {}
 
-  components/autodesk:
-    specifiers: {}
+  components/autodesk: {}
 
   components/autoklose: {}
 


### PR DESCRIPTION
## WHY

<!-- author to complete -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated package version for `@pipedream/hubspot` from `0.13.0` to `0.13.1`
	- Updated version of new-task source from `0.0.1` to `0.0.13`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->