### PR TITLE
Removing text-transform on prop labels

### DIFF
--- a/packages/connect-react/package.json
+++ b/packages/connect-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/connect-react",
-  "version": "1.0.0-preview.16",
+  "version": "1.0.0-preview.17",
   "description": "Pipedream Connect library for React",
   "files": [
     "dist"

--- a/packages/connect-react/src/components/Label.tsx
+++ b/packages/connect-react/src/components/Label.tsx
@@ -23,7 +23,6 @@ export function Label<T extends ConfigurableProps, U extends ConfigurableProp>(p
     color: theme.colors.neutral90,
     fontWeight: 450,
     gridArea: "label",
-    textTransform: "capitalize",
     lineHeight: "1.5",
   };
 

--- a/packages/connect-react/src/components/Label.tsx
+++ b/packages/connect-react/src/components/Label.tsx
@@ -1,5 +1,7 @@
 import type { CSSProperties } from "react";
-import type { ConfigurableProp, ConfigurableProps } from "@pipedream/sdk";
+import type {
+  ConfigurableProp, ConfigurableProps,
+} from "@pipedream/sdk";
 import { useCustomize } from "../hooks/customization-context";
 import type { FormFieldContext } from "../hooks/form-field-context";
 import { FormContext } from "../hooks/form-context";
@@ -28,6 +30,7 @@ export function Label<T extends ConfigurableProps, U extends ConfigurableProp>(p
 
   // XXX have to fix typing in customization (and elsewere really)
   return (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     <label htmlFor={id} {...getProps("label", baseStyles, props as any)}>{text}</label>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5204,8 +5204,7 @@ importers:
         specifier: ^1.5.1
         version: 1.6.6
 
-  components/instantly:
-    specifiers: {}
+  components/instantly: {}
 
   components/instapaper:
     dependencies:
@@ -6644,8 +6643,7 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
 
-  components/motive:
-    specifiers: {}
+  components/motive: {}
 
   components/moxie:
     dependencies:
@@ -10832,8 +10830,7 @@ importers:
         specifier: ^1.5.1
         version: 1.6.6
 
-  components/traffit:
-    specifiers: {}
+  components/traffit: {}
 
   components/trainual: {}
 
@@ -24721,22 +24718,22 @@ packages:
   superagent@3.8.1:
     resolution: {integrity: sha512-VMBFLYgFuRdfeNQSMLbxGSLfmXL/xc+OO+BZp41Za/NRDBet/BNbkRJrYzCUu0u4GU0i/ml2dtT8b9qgkw9z6Q==}
     engines: {node: '>= 4.0'}
-    deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
+    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
 
   superagent@4.1.0:
     resolution: {integrity: sha512-FT3QLMasz0YyCd4uIi5HNe+3t/onxMyEho7C3PSqmti3Twgy2rXT4fmkTz6wRL6bTF4uzPcfkUCa8u4JWHw8Ag==}
     engines: {node: '>= 6.0'}
-    deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
+    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
 
   superagent@5.3.1:
     resolution: {integrity: sha512-wjJ/MoTid2/RuGCOFtlacyGNxN9QLMgcpYLDQlWFIhhdJ93kNscFonGvrpAHSCVjRVj++DGCglocF7Aej1KHvQ==}
     engines: {node: '>= 7.0.0'}
-    deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
+    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
 
   superagent@7.1.6:
     resolution: {integrity: sha512-gZkVCQR1gy/oUXr+kxJMLDjla434KmSOKbx5iGD30Ql+AkJQ/YlPKECJy2nhqOsHLjGHzoDTXNSjhnvWhzKk7g==}
     engines: {node: '>=6.4.0 <13 || >=14'}
-    deprecated: Please downgrade to v7.1.5 if you need IE/ActiveXObject support OR upgrade to v8.0.0 as we no longer support IE and published an incorrect patch version (see https://github.com/visionmedia/superagent/issues/1731)
+    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
 
   supports-color@2.0.0:
     resolution: {integrity: sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==}


### PR DESCRIPTION
## WHY

<!-- author to complete -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Package Version**
	- Updated `@pipedream/connect-react` from `1.0.0-preview.16` to `1.0.0-preview.17`

- **Style Changes**
	- Removed automatic text capitalization for the Label component, allowing text to retain its original casing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->