### PR TITLE
Share Launchdarkly OAuth components

### DIFF
--- a/components/launch_darkly_oauth/actions/evaluate-feature-flag/evaluate-feature-flag.mjs
+++ b/components/launch_darkly_oauth/actions/evaluate-feature-flag/evaluate-feature-flag.mjs
@@ -1,0 +1,21 @@
+import { adjustPropDefinitions } from "../../common/utils.mjs";
+import component from "../../../launchdarkly/actions/evaluate-feature-flag/evaluate-feature-flag.mjs";
+import app from "../../launch_darkly_oauth.app.mjs";
+
+const {
+  name, description, type, ...others
+} = component;
+const props = adjustPropDefinitions(others.props, app);
+
+export default {
+  ...component,
+  key: "launch_darkly_oauth-evaluate-feature-flag",
+  version: "0.0.1",
+  name,
+  description,
+  type,
+  props: {
+    app,
+    ...props,
+  },
+};

--- a/components/launch_darkly_oauth/actions/toggle-feature-flag/toggle-feature-flag.mjs
+++ b/components/launch_darkly_oauth/actions/toggle-feature-flag/toggle-feature-flag.mjs
@@ -1,0 +1,21 @@
+import { adjustPropDefinitions } from "../../common/utils.mjs";
+import component from "../../../launchdarkly/actions/toggle-feature-flag/toggle-feature-flag.mjs";
+import app from "../../launch_darkly_oauth.app.mjs";
+
+const {
+  name, description, type, ...others
+} = component;
+const props = adjustPropDefinitions(others.props, app);
+
+export default {
+  ...component,
+  key: "launch_darkly_oauth-toggle-feature-flag",
+  version: "0.0.1",
+  name,
+  description,
+  type,
+  props: {
+    app,
+    ...props,
+  },
+};

--- a/components/launch_darkly_oauth/actions/update-feature-flag/update-feature-flag.mjs
+++ b/components/launch_darkly_oauth/actions/update-feature-flag/update-feature-flag.mjs
@@ -1,0 +1,21 @@
+import { adjustPropDefinitions } from "../../common/utils.mjs";
+import component from "../../../launchdarkly/actions/update-feature-flag/update-feature-flag.mjs";
+import app from "../../launch_darkly_oauth.app.mjs";
+
+const {
+  name, description, type, ...others
+} = component;
+const props = adjustPropDefinitions(others.props, app);
+
+export default {
+  ...component,
+  key: "launch_darkly_oauth-update-feature-flag",
+  version: "0.0.1",
+  name,
+  description,
+  type,
+  props: {
+    app,
+    ...props,
+  },
+};

--- a/components/launch_darkly_oauth/common/utils.mjs
+++ b/components/launch_darkly_oauth/common/utils.mjs
@@ -1,0 +1,40 @@
+export function adjustPropDefinitions(props, app) {
+  return Object.fromEntries(
+    Object.entries(props).map(([
+      key,
+      prop,
+    ]) => {
+      if (typeof prop === "string") return [
+        key,
+        prop,
+      ];
+      const {
+        propDefinition, ...otherValues
+      } = prop;
+      if (propDefinition) {
+        const [
+          , ...otherDefs
+        ] = propDefinition;
+        return [
+          key,
+          {
+            propDefinition: [
+              app,
+              ...otherDefs,
+            ],
+            ...otherValues,
+          },
+        ];
+      }
+      return [
+        key,
+        otherValues.type === "app"
+          ? null
+          : otherValues,
+      ];
+    })
+      .filter(([
+        , value,
+      ]) => value),
+  );
+}

--- a/components/launch_darkly_oauth/launch_darkly_oauth.app.mjs
+++ b/components/launch_darkly_oauth/launch_darkly_oauth.app.mjs
@@ -1,11 +1,16 @@
+import launchdarkly from "../launchdarkly/launchdarkly.app.mjs";
+
 export default {
-  type: "app",
+  ...launchdarkly,
   app: "launch_darkly_oauth",
-  propDefinitions: {},
   methods: {
-    // this.$auth contains connected account data
-    authKeys() {
-      console.log(Object.keys(this.$auth));
+    ...launchdarkly.methods,
+    getHeaders(headers) {
+      return {
+        "Content-Type": "application/json",
+        ...headers,
+        "Authorization": `Bearer ${this.$auth.oauth_access_token}`,
+      };
     },
   },
 };

--- a/components/launch_darkly_oauth/package.json
+++ b/components/launch_darkly_oauth/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@pipedream/launch_darkly_oauth",
+  "version": "0.0.1",
+  "description": "Pipedream LaunchDarkly (OAuth) Components",
+  "main": "launch_darkly_oauth.app.mjs",
+  "keywords": [
+    "pipedream",
+    "launch_darkly_oauth"
+  ],
+  "homepage": "https://pipedream.com/apps/launch_darkly_oauth",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^3.0.3"
+  }
+}

--- a/components/launch_darkly_oauth/sources/common/webhook.mjs
+++ b/components/launch_darkly_oauth/sources/common/webhook.mjs
@@ -1,0 +1,14 @@
+import app from "../../launch_darkly_oauth.app.mjs";
+import common from "../../../launchdarkly/sources/common/webhook.mjs";
+
+export default {
+  ...common,
+  props: {
+    app,
+    db: "$.service.db",
+    http: {
+      type: "$.interface.http",
+      customResponse: true,
+    },
+  },
+};

--- a/components/launch_darkly_oauth/sources/new-access-token-event/new-access-token-event.mjs
+++ b/components/launch_darkly_oauth/sources/new-access-token-event/new-access-token-event.mjs
@@ -1,0 +1,24 @@
+import common from "../common/webhook.mjs";
+import component from "../../../launchdarkly/sources/new-access-token-event/new-access-token-event.mjs";
+
+const {
+  name, description, type,
+} = component;
+
+export default {
+  ...component,
+  key: "launch_darkly_oauth-new-access-token-event",
+  version: "0.0.1",
+  name,
+  description,
+  type,
+  props: {
+    ...common.props,
+    memberId: {
+      propDefinition: [
+        common.props.app,
+        "memberId",
+      ],
+    },
+  },
+};

--- a/components/launch_darkly_oauth/sources/new-flag-event/new-flag-event.mjs
+++ b/components/launch_darkly_oauth/sources/new-flag-event/new-flag-event.mjs
@@ -1,0 +1,16 @@
+import common from "../common/webhook.mjs";
+import component from "../../../launchdarkly/sources/new-flag-event/new-flag-event.mjs";
+
+const {
+  name, description, type,
+} = component;
+
+export default {
+  ...component,
+  key: "launch_darkly_oauth-new-flag-event",
+  version: "0.0.1",
+  name,
+  description,
+  type,
+  props: common.props,
+};

--- a/components/launch_darkly_oauth/sources/new-user-event/new-user-event.mjs
+++ b/components/launch_darkly_oauth/sources/new-user-event/new-user-event.mjs
@@ -1,0 +1,16 @@
+import common from "../common/webhook.mjs";
+import component from "../../../launchdarkly/sources/new-user-event/new-user-event.mjs";
+
+const {
+  name, description, type,
+} = component;
+
+export default {
+  ...component,
+  key: "launch_darkly_oauth-new-user-event",
+  version: "0.0.1",
+  name,
+  description,
+  type,
+  props: common.props,
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5695,6 +5695,12 @@ importers:
 
   components/lattice: {}
 
+  components/launch_darkly_oauth:
+    dependencies:
+      '@pipedream/platform':
+        specifier: ^3.0.3
+        version: 3.0.3
+
   components/launchdarkly:
     dependencies:
       '@pipedream/platform':


### PR DESCRIPTION
Closes #15151 

The components are being shared replacing only the app prop being imported, which changes the base request. There should be no behavior differences between the components of the two apps.