### PR TITLE
[BUG] Microsoft Outlook - new-email

### DIFF
--- a/components/microsoft_outlook/package.json
+++ b/components/microsoft_outlook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/microsoft_outlook",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Pipedream Microsoft Outlook Components",
   "main": "microsoft_outlook.app.mjs",
   "keywords": [

--- a/components/microsoft_outlook/sources/new-email/new-email.mjs
+++ b/components/microsoft_outlook/sources/new-email/new-email.mjs
@@ -7,7 +7,7 @@ export default {
   key: "microsoft_outlook-new-email",
   name: "New Email Event (Instant)",
   description: "Emit new event when an email is received in specified folders.",
-  version: "0.0.10",
+  version: "0.0.11",
   type: "source",
   dedupe: "unique",
   props: {
@@ -63,8 +63,8 @@ export default {
     },
     async getFolderIdByName(name) {
       const { value: folders } = await this.listFolders();
-      const { id } = folders.find(({ displayName }) => displayName === name);
-      return id;
+      const folder = folders.find(({ displayName }) => displayName === name);
+      return folder?.id;
     },
     async getSampleEvents({ pageSize }) {
       const folders = this.folderIds?.length

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9592,8 +9592,7 @@ importers:
 
   components/showpad: {}
 
-  components/shutterstock:
-    specifiers: {}
+  components/shutterstock: {}
 
   components/sidetracker: {}
 
@@ -31013,6 +31012,8 @@ snapshots:
       '@putout/operator-filesystem': 5.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))
       '@putout/operator-json': 2.2.0
       putout: 36.13.1(eslint@8.57.1)(typescript@5.6.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@putout/operator-regexp@1.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))':
     dependencies:


### PR DESCRIPTION
Resolves the bug observed [in this comment](https://github.com/PipedreamHQ/pipedream/pull/15001#issuecomment-2592297410).
```
025-01-15T11:39:05
error
TypeError: Cannot destructure property 'id' of 'folders.find(...)' as it is undefined.
at Object.getFolderIdByName (file:///var/task/user/sources/new-email/new-email.mjs:66:15)
at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
at async Object.deploy (file:///var/task/user/sources/new-email/new-email.mjs:34:39)
at async /var/task/index.js:95:13
at async captureObservations (/var/task/node_modules/@lambda-v2/component-runtime/src/captureObservations.js:28:5)
at async exports.main [as handler] (/var/task/index.js:60:20)
```
![image](https://github.com/user-attachments/assets/3d3ac98f-5357-4ef7-81d0-23cf62d5fad6)
