### PR TITLE
Treat empty string prop value as a valid input

### DIFF
--- a/packages/connect-react/CHANGELOG.md
+++ b/packages/connect-react/CHANGELOG.md
@@ -1,6 +1,10 @@
 <!-- markdownlint-disable MD024 -->
 # Changelog
 
+# [1.0.0-preview.20] - 2025-01-16
+
+- Check if a string prop is set instead of inspecting the contents of the string
+
 # [1.0.0-preview.15] - 2024-12-18
 
 - Emit dynamic props via `onUpdateDynamicProps`

--- a/packages/connect-react/examples/nextjs/package-lock.json
+++ b/packages/connect-react/examples/nextjs/package-lock.json
@@ -566,9 +566,9 @@
       "link": true
     },
     "node_modules/@pipedream/sdk": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@pipedream/sdk/-/sdk-1.1.4.tgz",
-      "integrity": "sha512-Xjozgk/uhUyz+3h8OHXNUTaEDik1Y4kzDPmlfjeHqimwyLmY+QuRVsQCqvs4VZBSCt4fhzQt197O1aqFE+5E2g==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@pipedream/sdk/-/sdk-1.1.5.tgz",
+      "integrity": "sha512-q+dGMsNSvIcDCi6JZES7pwNBW8Ms318WMNavO71Cye0bCtloeDSj5TiFbScy64/2FHja9keKAZ9ev8yVSsM+ew==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@rails/actioncable": "^8.0.0",

--- a/packages/connect-react/package.json
+++ b/packages/connect-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/connect-react",
-  "version": "1.0.0-preview.19",
+  "version": "1.0.0-preview.20",
   "description": "Pipedream Connect library for React",
   "files": [
     "dist"

--- a/packages/connect-react/src/utils/component.ts
+++ b/packages/connect-react/src/utils/component.ts
@@ -94,15 +94,13 @@ export function integerPropErrors(opts: ValidationOpts<ConfigurablePropInteger>)
 }
 
 export function stringPropErrors(opts: ValidationOpts<ConfigurablePropString>): string[] | undefined {
-  const _value = valueFromOption(opts.value)
+  const {
+    prop, value: valueOpt,
+  } = opts
 
-  if (!opts.prop.default) {
-    if (typeof _value === "undefined" || _value == null) {
-      return [
-        "required",
-      ]
-    }
-  }
+  if (!prop.default && (valueOpt == null || typeof value === "undefined")) return [
+    "required",
+  ]
 }
 
 type AppWithExtractedCustomFields = App & {

--- a/packages/connect-react/src/utils/component.ts
+++ b/packages/connect-react/src/utils/component.ts
@@ -97,12 +97,11 @@ export function stringPropErrors(opts: ValidationOpts<ConfigurablePropString>): 
   const _value = valueFromOption(opts.value)
 
   if (!opts.prop.default) {
-    if (typeof _value === "undefined" || _value == null) return [
-      "required",
-    ]
-    if (!String(_value).length) return [
-      "string must not be empty",
-    ]
+    if (typeof _value === "undefined" || _value == null) {
+      return [
+        "required",
+      ]
+    }
   }
 }
 


### PR DESCRIPTION
An empty prop value is a valid configuration. In the following example, configuring the Dropbox new file trigger returns Root Folder async option with an empty value. There might be other cases where something like this is also true but I only tested dropbox. 

Request
`https://api.pipedream.com/v1/connect/components/configure`
```json
{
  "external_user_id": "demo-98522368-0f2e-4aeb-a237-902d170fa9c7",
  "id": "dropbox-new-file",
  "prop_name": "path",
  "configured_props": {
    "dropbox": {
      "authProvisionId": "apn_mnhGBaE"
    }
  },
  "page": 0
}
```

Response
```json
{
    "observations": [],
    "context": {
        "cursor": null
    },
    "options": [
        {
            "label": "Root Folder",
            "value": ""
        }
    ],
    "errors": [],
    "timings": {
        "api_to_sidekiq": 1737064862392.3438,
        "sidekiq_received": 1737064862426.3557,
        "sidekiq_to_lambda": 1737064862432.2803,
        "sidekiq_done": 1737064862848.1416,
        "lambda_configure_prop_called": 1737064862540,
        "lambda_done": 1737064862841
    },
    "stringOptions": null
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Version Update**
	- Updated package version from `1.0.0-preview.19` to `1.0.0-preview.20`

- **Bug Fixes**
	- Improved string property validation logic to simplify error handling and prop checking

- **Documentation**
	- Updated CHANGELOG with details of the validation logic changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->