### PR TITLE
Fix typo in SDK docs for `getAccountById`

### DIFF
--- a/docs-v2/pages/connect/api.mdx
+++ b/docs-v2/pages/connect/api.mdx
@@ -597,8 +597,6 @@ const pd = createBackendClient({
 });
 
 const account = await pd.getAccountById(accountId, {
-  app: "github", // optional, filter by app
-  external_user_id: "user-abc-123", // optional, filter by external user ID
   include_credentials: true, // optional, set to true to include credentials
 });
 
@@ -622,8 +620,6 @@ const pd = createBackendClient({
 const accountId = "{account_id}"; // Replace with your account ID
 
 const account = await pd.getAccountById(accountId, {
-  app: "github", // optional, filter by app
-  external_user_id: "user-abc-123", // optional, filter by external user ID
   include_credentials: true, // optional, set to true to include credentials
 });
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 # Changelog
 
+## [1.1.6] - 2025-01-21
+
+### Changed
+
+- Fixed the docs of the `getAccountById` method in the backend client to remove
+  arguments that are not actually supported.
+
 ## [1.1.5] - 2025-01-14
 
 ### Changed

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/sdk",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Pipedream SDK",
   "main": "dist/server/server/index.js",
   "module": "dist/server/server/index.js",

--- a/packages/sdk/src/server/index.ts
+++ b/packages/sdk/src/server/index.ts
@@ -262,11 +262,20 @@ export class BackendClient extends BaseClient {
    * Retrieves a specific account by ID.
    *
    * @param accountId - The ID of the account to retrieve.
+   * @param params - Additional options for the request.
    * @returns A promise resolving to the account.
    *
    * @example
    * ```typescript
    * const account = await client.getAccountById("account-id");
+   * console.log(account);
+   * ```
+   *
+   * @example
+   * ```typescript
+   * const account = await client.getAccountById("account-id", {
+   *   include_credentials: true,
+   * });
    * console.log(account);
    * ```
    */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2970,8 +2970,7 @@ importers:
         specifier: ^3.0.0
         version: 3.0.3
 
-  components/dovetail:
-    specifiers: {}
+  components/dovetail: {}
 
   components/dpd2:
     dependencies:
@@ -8297,8 +8296,7 @@ importers:
 
   components/propeller: {}
 
-  components/proposify:
-    specifiers: {}
+  components/proposify: {}
 
   components/proprofs_quiz_maker: {}
 
@@ -25087,22 +25085,22 @@ packages:
   superagent@3.8.1:
     resolution: {integrity: sha512-VMBFLYgFuRdfeNQSMLbxGSLfmXL/xc+OO+BZp41Za/NRDBet/BNbkRJrYzCUu0u4GU0i/ml2dtT8b9qgkw9z6Q==}
     engines: {node: '>= 4.0'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
 
   superagent@4.1.0:
     resolution: {integrity: sha512-FT3QLMasz0YyCd4uIi5HNe+3t/onxMyEho7C3PSqmti3Twgy2rXT4fmkTz6wRL6bTF4uzPcfkUCa8u4JWHw8Ag==}
     engines: {node: '>= 6.0'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
 
   superagent@5.3.1:
     resolution: {integrity: sha512-wjJ/MoTid2/RuGCOFtlacyGNxN9QLMgcpYLDQlWFIhhdJ93kNscFonGvrpAHSCVjRVj++DGCglocF7Aej1KHvQ==}
     engines: {node: '>= 7.0.0'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
 
   superagent@7.1.6:
     resolution: {integrity: sha512-gZkVCQR1gy/oUXr+kxJMLDjla434KmSOKbx5iGD30Ql+AkJQ/YlPKECJy2nhqOsHLjGHzoDTXNSjhnvWhzKk7g==}
     engines: {node: '>=6.4.0 <13 || >=14'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please downgrade to v7.1.5 if you need IE/ActiveXObject support OR upgrade to v8.0.0 as we no longer support IE and published an incorrect patch version (see https://github.com/visionmedia/superagent/issues/1731)
 
   supports-color@2.0.0:
     resolution: {integrity: sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==}


### PR DESCRIPTION
# Changelog
* Remove the unsupported opts from the Connect docs
* Add JSDoc example in the SDK with the actually supported params
* Bump patch version of the SDK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated documentation for the `getAccountById` method in the SDK
	- Added a newline character in the Connect API documentation

- **Version Update**
	- Bumped SDK package version from 1.1.5 to 1.1.6

- **Improvements**
	- Enhanced `getAccountById` method with optional `params` argument to provide more flexibility when retrieving account information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->