### PR TITLE
Biz/dj 2837 show label and keep selected remote option dropdown enabled

### DIFF
--- a/packages/connect-react/CHANGELOG.md
+++ b/packages/connect-react/CHANGELOG.md
@@ -1,6 +1,11 @@
 <!-- markdownlint-disable MD024 -->
 # Changelog
 
+# [1.0.0-preview.25] - 2025-01-28
+
+- Show prop labels instead of values after selecting dynamic props
+- Fix the bug where a remote option would not be reloaded when the form component is re-rendered
+
 # [1.0.0-preview.24] - 2025-01-24
 
 - Fix the bug where inputting multiple strings into an array prop would merge the strings into one

--- a/packages/connect-react/examples/nextjs/package-lock.json
+++ b/packages/connect-react/examples/nextjs/package-lock.json
@@ -23,7 +23,7 @@
     },
     "../..": {
       "name": "@pipedream/connect-react",
-      "version": "1.0.0-preview.24",
+      "version": "1.0.0-preview.25",
       "license": "MIT",
       "dependencies": {
         "@pipedream/sdk": "workspace:^",

--- a/packages/connect-react/package.json
+++ b/packages/connect-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/connect-react",
-  "version": "1.0.0-preview.24",
+  "version": "1.0.0-preview.25",
   "description": "Pipedream Connect library for React",
   "files": [
     "dist"

--- a/packages/connect-react/src/components/ControlSelect.tsx
+++ b/packages/connect-react/src/components/ControlSelect.tsx
@@ -171,26 +171,16 @@ export function ControlSelect<T>({
     if (o) {
       if (Array.isArray(o)) {
         if (typeof o[0] === "object" && "value" in o[0]) {
-          const vs = [];
-          for (const _o of o) {
-            if (prop.withLabel) {
-              vs.push(_o);
-            } else {
-              vs.push(_o.value);
-            }
-          }
-          onChange(vs);
-        } else {
-          onChange(o);
-        }
-      } else if (typeof o === "object" && "value" in o) {
-        if (prop.withLabel) {
           onChange({
             __lv: o,
           });
         } else {
-          onChange(o.value);
+          onChange(o);
         }
+      } else if (typeof o === "object" && "value" in o) {
+        onChange({
+          __lv: o,
+        });
       } else {
         throw new Error("unhandled option type"); // TODO
       }

--- a/packages/connect-react/src/hooks/form-context.tsx
+++ b/packages/connect-react/src/hooks/form-context.tsx
@@ -13,6 +13,7 @@ import {
   appPropErrors, arrayPropErrors, booleanPropErrors, integerPropErrors,
   stringPropErrors,
 } from "../utils/component";
+import _ from "lodash";
 
 export type DynamicProps<T extends ConfigurableProps> = { id: string; configurableProps: T; }; // TODO
 
@@ -374,6 +375,15 @@ export const FormContextProvider = <T extends ConfigurableProps>({
       }
     }
     // propsNeedConfiguring.splice(0, propsNeedConfiguring.length, ..._propsNeedConfiguring)
+
+    // Prevent useEffect/useState infinite loop by updating
+    // propsNeedConfiguring only if there is an actual change to the list of
+    // props that need to be configured.
+    // NB: The infinite loop is triggered because of calling
+    // checkPropsNeedConfiguring() from registerField, which is called
+    // from inside useEffect.
+    if (_propsNeedConfiguring && propsNeedConfiguring && _.isEqual(_propsNeedConfiguring, propsNeedConfiguring)) return;
+
     setPropsNeedConfiguring(_propsNeedConfiguring)
   }
 
@@ -382,6 +392,7 @@ export const FormContextProvider = <T extends ConfigurableProps>({
       fields[field.prop.name] = field
       return fields
     });
+    checkPropsNeedConfiguring()
   };
 
   // console.log("***", configurableProps, configuredProps)

--- a/packages/connect-react/src/hooks/form-context.tsx
+++ b/packages/connect-react/src/hooks/form-context.tsx
@@ -255,6 +255,12 @@ export const FormContextProvider = <T extends ConfigurableProps>({
   };
 
   useEffect(() => {
+    updateConfiguredPropsQueryDisabledIdx(_configuredProps)
+  }, [
+    _configuredProps,
+  ]);
+
+  useEffect(() => {
     const newConfiguredProps: ConfiguredProps<T> = {};
     for (const prop of configurableProps) {
       if (prop.hidden) {

--- a/packages/connect-react/src/hooks/form-context.tsx
+++ b/packages/connect-react/src/hooks/form-context.tsx
@@ -255,6 +255,9 @@ export const FormContextProvider = <T extends ConfigurableProps>({
   };
 
   useEffect(() => {
+    // Initialize queryDisabledIdx on load so that we don't force users
+    // to reconfigure a prop they've already configured whenever the page
+    // or component is reloaded
     updateConfiguredPropsQueryDisabledIdx(_configuredProps)
   }, [
     _configuredProps,

--- a/packages/connect-react/src/utils/component.ts
+++ b/packages/connect-react/src/utils/component.ts
@@ -40,7 +40,7 @@ export function valuesFromOptions<T>(value: unknown | T[] | PropOptions<T>): T[]
     }
     return results
   }
-  if (value && typeof value === "object" &&  "__lv" in value && Array.isArray(value.__lv)) {
+  if (value && typeof value === "object" && Array.isArray(value.__lv)) {
     return value.__lv as T[]
   }
   if (!Array.isArray(value))

--- a/packages/connect-react/src/utils/component.ts
+++ b/packages/connect-react/src/utils/component.ts
@@ -40,6 +40,9 @@ export function valuesFromOptions<T>(value: unknown | T[] | PropOptions<T>): T[]
     }
     return results
   }
+  if (value && typeof value === "object" &&  "__lv" in value && Array.isArray(value.__lv)) {
+    return value.__lv as T[]
+  }
   if (!Array.isArray(value))
     return []
   return value as T[]


### PR DESCRIPTION
## WHY

<!-- author to complete -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes for @pipedream/connect-react v1.0.0-preview.25

- **New Features**
  - Now displays prop labels instead of values after selecting dynamic props

- **Bug Fixes**
  - Resolved issue with remote options not reloading correctly when form component is re-rendered
  - Improved handling of input options in select controls

- **Performance**
  - Streamlined option processing logic in select components
  - Enhanced state management for configured properties on component load
  - Added flexible handling for input values with specific properties
<!-- end of auto-generated comment: release notes by coderabbit.ai -->