### PR TITLE
Danny/gdrive conditional props patch

### DIFF
--- a/components/google_drive/actions/add-file-sharing-preference/add-file-sharing-preference.mjs
+++ b/components/google_drive/actions/add-file-sharing-preference/add-file-sharing-preference.mjs
@@ -20,7 +20,7 @@ export default {
   name: "Share File or Folder",
   description:
     "Add a [sharing permission](https://support.google.com/drive/answer/7166529) to the sharing preferences of a file or folder and provide a sharing URL. [See the documentation](https://developers.google.com/drive/api/v3/reference/permissions/create)",
-  version: "0.1.9",
+  version: "0.2.0",
   type: "action",
   props: {
     googleDrive,
@@ -31,6 +31,12 @@ export default {
       ],
       optional: true,
     },
+    propConfigAlert: {
+      type: "alert",
+      alertType: "info",
+      content: "Please select either a **file** or a **folder** to share.",
+      hidden: false,
+    },
     fileId: {
       propDefinition: [
         googleDrive,
@@ -40,6 +46,7 @@ export default {
         }),
       ],
       optional: true,
+      reloadProps: true,
       description: "The file to share. You must specify either a file or a folder.",
     },
     folderId: {
@@ -58,15 +65,15 @@ export default {
         googleDrive,
         "type",
       ],
+      hidden: true,
       reloadProps: true,
     },
   },
-  async additionalProps() {
+  async additionalProps(props) {
     const obj = {};
     const {
       fileId, folderId, type,
     } = this;
-    if (!(fileId || folderId) || !type) return obj;
 
     const emailAddress = {
       type: "string",
@@ -108,15 +115,19 @@ export default {
       options.push(GOOGLE_DRIVE_ROLE_OPTION_FILEORGANIZER);
     }
 
-    return {
-      ...obj,
-      role: {
-        type: "string",
-        label: "Role",
-        description: "The role granted by this permission",
-        options,
-      },
-    };
+    if (fileId || folderId) {
+      props.type.hidden = false;
+      props.propConfigAlert.hidden = true;
+      return {
+        ...obj,
+        role: {
+          type: "string",
+          label: "Role",
+          description: "The role granted by this permission",
+          options,
+        },
+      };
+    }
   },
   async run({ $ }) {
     const {

--- a/components/google_drive/package.json
+++ b/components/google_drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_drive",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "Pipedream Google_drive Components",
   "main": "google_drive.app.mjs",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5884,8 +5884,7 @@ importers:
         specifier: ^1.2.1
         version: 1.6.6
 
-  components/lightpanda:
-    specifiers: {}
+  components/lightpanda: {}
 
   components/lightspeed_retail_pos:
     dependencies:
@@ -22166,6 +22165,7 @@ packages:
 
   lodash.isequal@4.5.0:
     resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.isinteger@4.0.4:
     resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}


### PR DESCRIPTION
Right now either the `fileId` or `folderId` prop is required (but not both), so they're both optional. But this is confusing UX for users, since the rest of the action configuration relies on one of those props being set.

So we should add an `alert` prop that looks something like this:

```
propConfigAlert: {
  type: "alert",
  alertType: "info",
  content: "Please select either a **file** or a **folder** to share.",
  hidden: false,
},

// and also set `hidden: true` on the `type` prop
// and reloadProps: true on fileId and folderId
And in additionalProps, we'll do something like this:
if (fileId || folderId) {
  props.type.hidden = false;
  props.propConfigAlert.hidden = true;
}
```

So basically, we should render that alert first, and we only show the `type` and `role` props (and whatever other props we show based on those) once either the `fileId` or `folderId` props are set.