### PR TITLE
Google Drive - adding 'Use File or Folder' selection

### DIFF
--- a/components/google_drive/actions/add-file-sharing-preference/add-file-sharing-preference.mjs
+++ b/components/google_drive/actions/add-file-sharing-preference/add-file-sharing-preference.mjs
@@ -20,7 +20,7 @@ export default {
   name: "Share File or Folder",
   description:
     "Add a [sharing permission](https://support.google.com/drive/answer/7166529) to the sharing preferences of a file or folder and provide a sharing URL. [See the documentation](https://developers.google.com/drive/api/v3/reference/permissions/create)",
-  version: "0.1.9",
+  version: "0.2.0",
   type: "action",
   props: {
     googleDrive,
@@ -31,6 +31,16 @@ export default {
       ],
       optional: true,
     },
+    useFileOrFolder: {
+      type: "string",
+      label: "Use File or Folder",
+      description: "Whether to use a file or a folder for this action",
+      reloadProps: true,
+      options: [
+        "File",
+        "Folder",
+      ],
+    },
     fileId: {
       propDefinition: [
         googleDrive,
@@ -39,7 +49,7 @@ export default {
           drive: c.drive,
         }),
       ],
-      optional: true,
+      hidden: true,
       description: "The file to share. You must specify either a file or a folder.",
     },
     folderId: {
@@ -50,7 +60,7 @@ export default {
           drive: c.drive,
         }),
       ],
-      optional: true,
+      hidden: true,
       description: "The folder to share. You must specify either a file or a folder.",
     },
     type: {
@@ -61,11 +71,20 @@ export default {
       reloadProps: true,
     },
   },
-  async additionalProps() {
-    const obj = {};
+  async additionalProps(previousProps) {
     const {
-      fileId, folderId, type,
+      fileId, folderId, type, useFileOrFolder,
     } = this;
+
+    if (useFileOrFolder === "File") {
+      previousProps.fileId.hidden = false;
+      previousProps.folderId.hidden = true;
+    } else if (useFileOrFolder === "Folder") {
+      previousProps.fileId.hidden = true;
+      previousProps.folderId.hidden = false;
+    }
+
+    const obj = {};
     if (!(fileId || folderId) || !type) return obj;
 
     const emailAddress = {

--- a/components/google_drive/package.json
+++ b/components/google_drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_drive",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "Pipedream Google_drive Components",
   "main": "google_drive.app.mjs",
   "keywords": [


### PR DESCRIPTION
Improving the 'Share File' action to properly select either a file or a folder, and render props accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced Google Drive file/folder sharing action with a new option to specify whether sharing a file or folder
  - Dynamically show/hide file or folder ID based on user selection

- **Chores**
  - Updated package version for Google Drive component

<!-- end of auto-generated comment: release notes by coderabbit.ai -->