### PR TITLE
Hubspot custom object request updates

### DIFF
--- a/components/hubspot/actions/add-contact-to-list/add-contact-to-list.mjs
+++ b/components/hubspot/actions/add-contact-to-list/add-contact-to-list.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-add-contact-to-list",
   name: "Add Contact to List",
   description: "Adds a contact to a specific static list. [See the documentation](https://legacydocs.hubspot.com/docs/methods/lists/add_contact_to_list)",
-  version: "0.0.13",
+  version: "0.0.14",
   type: "action",
   props: {
     hubspot,

--- a/components/hubspot/actions/batch-create-or-update-contact/batch-create-or-update-contact.mjs
+++ b/components/hubspot/actions/batch-create-or-update-contact/batch-create-or-update-contact.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-batch-create-or-update-contact",
   name: "Batch Create or Update Contact",
   description: "Create or update a batch of contacts by its ID or email. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts)",
-  version: "0.0.10",
+  version: "0.0.11",
   type: "action",
   props: {
     hubspot,

--- a/components/hubspot/actions/create-associations/create-associations.mjs
+++ b/components/hubspot/actions/create-associations/create-associations.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-create-associations",
   name: "Create Associations",
   description: "Create associations between objects. [See the documentation](https://developers.hubspot.com/docs/api/crm/associations#endpoint?spec=POST-/crm/v3/associations/{fromObjectType}/{toObjectType}/batch/create)",
-  version: "0.0.13",
+  version: "1.0.0",
   type: "action",
   props: {
     hubspot,

--- a/components/hubspot/actions/create-communication/create-communication.mjs
+++ b/components/hubspot/actions/create-communication/create-communication.mjs
@@ -8,7 +8,7 @@ export default {
   key: "hubspot-create-communication",
   name: "Create Communication",
   description: "Create a WhatsApp, LinkedIn, or SMS message. [See the documentation](https://developers.hubspot.com/beta-docs/reference/api/crm/engagements/communications/v3#post-%2Fcrm%2Fv3%2Fobjects%2Fcommunications)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   props: {
     ...appProp.props,

--- a/components/hubspot/actions/create-company/create-company.mjs
+++ b/components/hubspot/actions/create-company/create-company.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-create-company",
   name: "Create Company",
   description: "Create a company in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/companies#endpoint?spec=POST-/crm/v3/objects/companies)",
-  version: "0.0.17",
+  version: "0.0.18",
   type: "action",
   methods: {
     ...common.methods,

--- a/components/hubspot/actions/create-custom-object/create-custom-object.mjs
+++ b/components/hubspot/actions/create-custom-object/create-custom-object.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-create-custom-object",
   name: "Create Custom Object",
   description: "Create a new custom object in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/custom-objects#create-a-custom-object)",
-  version: "0.0.5",
+  version: "1.0.0",
   type: "action",
   props: {
     ...appProp.props,

--- a/components/hubspot/actions/create-deal/create-deal.mjs
+++ b/components/hubspot/actions/create-deal/create-deal.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-create-deal",
   name: "Create Deal",
   description: "Create a deal in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/deals#endpoint?spec=POST-/crm/v3/objects/deals)",
-  version: "0.0.17",
+  version: "0.0.18",
   type: "action",
   props: {
     ...common.props,

--- a/components/hubspot/actions/create-engagement/create-engagement.mjs
+++ b/components/hubspot/actions/create-engagement/create-engagement.mjs
@@ -9,7 +9,7 @@ export default {
   key: "hubspot-create-engagement",
   name: "Create Engagement",
   description: "Create a new engagement for a contact. [See the documentation](https://developers.hubspot.com/docs/api/crm/engagements)",
-  version: "0.0.16",
+  version: "0.0.17",
   type: "action",
   props: {
     ...common.props,

--- a/components/hubspot/actions/create-lead/create-lead.mjs
+++ b/components/hubspot/actions/create-lead/create-lead.mjs
@@ -9,7 +9,7 @@ export default {
   key: "hubspot-create-lead",
   name: "Create Lead",
   description: "Create a lead in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/leads#create-leads)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   props: {
     ...appProp.props,

--- a/components/hubspot/actions/create-or-update-contact/create-or-update-contact.mjs
+++ b/components/hubspot/actions/create-or-update-contact/create-or-update-contact.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-create-or-update-contact",
   name: "Create or Update Contact",
   description: "Create or update a contact in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts#endpoint?spec=POST-/crm/v3/objects/contacts)",
-  version: "0.0.15",
+  version: "0.0.16",
   type: "action",
   props: {
     ...common.props,

--- a/components/hubspot/actions/create-ticket/create-ticket.mjs
+++ b/components/hubspot/actions/create-ticket/create-ticket.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-create-ticket",
   name: "Create Ticket",
   description: "Create a ticket in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/tickets)",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "action",
   props: {
     ...common.props,

--- a/components/hubspot/actions/enroll-contact-into-workflow/enroll-contact-into-workflow.mjs
+++ b/components/hubspot/actions/enroll-contact-into-workflow/enroll-contact-into-workflow.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-enroll-contact-into-workflow",
   name: "Enroll Contact Into Workflow",
   description: "Add a contact to a workflow. Note: The Workflows API currently only supports contact-based workflows and is only available for Marketing Hub Enterprise accounts. [See the documentation](https://legacydocs.hubspot.com/docs/methods/workflows/add_contact)",
-  version: "0.0.13",
+  version: "0.0.14",
   type: "action",
   props: {
     hubspot,

--- a/components/hubspot/actions/get-company/get-company.mjs
+++ b/components/hubspot/actions/get-company/get-company.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-get-company",
   name: "Get Company",
   description: "Gets a company. [See the documentation](https://developers.hubspot.com/docs/api/crm/companies#endpoint?spec=GET-/crm/v3/objects/companies/{companyId})",
-  version: "0.0.13",
+  version: "0.0.14",
   type: "action",
   props: {
     ...common.props,

--- a/components/hubspot/actions/get-contact/get-contact.mjs
+++ b/components/hubspot/actions/get-contact/get-contact.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-get-contact",
   name: "Get Contact",
   description: "Gets a contact. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts#endpoint?spec=GET-/crm/v3/objects/contacts/{contactId})",
-  version: "0.0.13",
+  version: "0.0.14",
   type: "action",
   props: {
     ...common.props,

--- a/components/hubspot/actions/get-deal/get-deal.mjs
+++ b/components/hubspot/actions/get-deal/get-deal.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-get-deal",
   name: "Get Deal",
   description: "Gets a deal. [See the documentation](https://developers.hubspot.com/docs/api/crm/deals#endpoint?spec=GET-/crm/v3/objects/deals/{dealId})",
-  version: "0.0.13",
+  version: "0.0.14",
   type: "action",
   props: {
     ...common.props,

--- a/components/hubspot/actions/get-file-public-url/get-file-public-url.mjs
+++ b/components/hubspot/actions/get-file-public-url/get-file-public-url.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-get-file-public-url",
   name: "Get File Public URL",
   description: "Get a publicly available URL for a file that was uploaded using a Hubspot form. [See the documentation](https://developers.hubspot.com/docs/api/files/files#endpoint?spec=GET-/files/v3/files/{fileId}/signed-url)",
-  version: "0.0.13",
+  version: "0.0.14",
   type: "action",
   props: {
     hubspot,

--- a/components/hubspot/actions/search-crm/search-crm.mjs
+++ b/components/hubspot/actions/search-crm/search-crm.mjs
@@ -71,12 +71,20 @@ export default {
       schema = await this.hubspot.getSchema({
         objectType,
       });
+      const properties = schema.properties;
+      const searchableProperties = schema.searchableProperties?.map((prop) => {
+        const propData = properties.find(({ name }) => name === prop);
+        return {
+          label: propData.label,
+          value: propData.name,
+        };
+      });
 
       props.searchProperty = {
         type: "string",
         label: "Search Property",
         description: "The field to search",
-        options: schema.searchableProperties,
+        options: searchableProperties,
       };
     } catch {
       props.searchProperty = {

--- a/components/hubspot/actions/search-crm/search-crm.mjs
+++ b/components/hubspot/actions/search-crm/search-crm.mjs
@@ -16,7 +16,7 @@ export default {
   key: "hubspot-search-crm",
   name: "Search CRM",
   description: "Search companies, contacts, deals, feedback submissions, products, tickets, line-items, quotes, leads, or custom objects. [See the documentation](https://developers.hubspot.com/docs/api/crm/search)",
-  version: "0.0.13",
+  version: "1.0.0",
   type: "action",
   props: {
     hubspot,

--- a/components/hubspot/actions/search-crm/search-crm.mjs
+++ b/components/hubspot/actions/search-crm/search-crm.mjs
@@ -50,7 +50,7 @@ export default {
         props.customObjectType = {
           type: "string",
           label: "Custom Object Type",
-          options: await this.getCustomObjectTypes(),
+          options: async () => await this.getCustomObjectTypes(),
           reloadProps: true,
         };
       } catch {
@@ -185,7 +185,7 @@ export default {
       }
     },
     async getCustomObjectTypes() {
-      const { results } = await this.listSchemas();
+      const { results } = await this.hubspot.listSchemas();
       return results?.map(({
         fullyQualifiedName: value, labels,
       }) => ({

--- a/components/hubspot/actions/update-company/update-company.mjs
+++ b/components/hubspot/actions/update-company/update-company.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-update-company",
   name: "Update Company",
   description: "Update a company in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/companies)",
-  version: "0.0.13",
+  version: "0.0.14",
   type: "action",
   methods: {
     ...common.methods,

--- a/components/hubspot/actions/update-contact/update-contact.mjs
+++ b/components/hubspot/actions/update-contact/update-contact.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-update-contact",
   name: "Update Contact",
   description: "Update a contact in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts#endpoint?spec=POST-/crm/v3/objects/contacts)",
-  version: "0.0.14",
+  version: "0.0.15",
   type: "action",
   methods: {
     ...common.methods,

--- a/components/hubspot/actions/update-custom-object/update-custom-object.mjs
+++ b/components/hubspot/actions/update-custom-object/update-custom-object.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-update-custom-object",
   name: "Update Custom Object",
   description: "Update a custom object in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/custom-objects#update-existing-custom-objects)",
-  version: "0.0.5",
+  version: "1.0.0",
   type: "action",
   methods: {
     ...common.methods,

--- a/components/hubspot/actions/update-deal/update-deal.mjs
+++ b/components/hubspot/actions/update-deal/update-deal.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-update-deal",
   name: "Update Deal",
   description: "Update a deal in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/deals#update-deals)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   methods: {
     ...common.methods,

--- a/components/hubspot/actions/update-lead/update-lead.mjs
+++ b/components/hubspot/actions/update-lead/update-lead.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-update-lead",
   name: "Update Lead",
   description: "Update a lead in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/leads#update-leads)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   methods: {
     ...common.methods,

--- a/components/hubspot/hubspot.app.mjs
+++ b/components/hubspot/hubspot.app.mjs
@@ -88,7 +88,7 @@ export default {
         if (includeCustom) {
           const { results } = await this.listSchemas();
           const customObjects = results?.map(({
-            name: value, labels,
+            fullyQualifiedName: value, labels,
           }) => ({
             value,
             label: labels.plural,
@@ -437,10 +437,15 @@ export default {
     customObjectType: {
       type: "string",
       label: "Custom Object Type",
-      description: "Tye type of custom object to create",
+      description: "The type of custom object to create",
       async options() {
         const { results } = await this.listSchemas();
-        return results?.map(({ name }) => name ) || [];
+        return results?.map(({
+          name, fullyQualifiedName,
+        }) => ({
+          label: name,
+          value: fullyQualifiedName,
+        }) ) || [];
       },
     },
   },

--- a/components/hubspot/package.json
+++ b/components/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/hubspot",
-  "version": "0.13.3",
+  "version": "1.0.0",
   "description": "Pipedream Hubspot Components",
   "main": "hubspot.app.mjs",
   "keywords": [

--- a/components/hubspot/sources/delete-blog-article/delete-blog-article.mjs
+++ b/components/hubspot/sources/delete-blog-article/delete-blog-article.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-delete-blog-article",
   name: "Deleted Blog Posts",
   description: "Emit new event for each deleted blog post.",
-  version: "0.0.18",
+  version: "0.0.19",
   dedupe: "unique",
   type: "source",
   methods: {

--- a/components/hubspot/sources/new-company-property-change/new-company-property-change.mjs
+++ b/components/hubspot/sources/new-company-property-change/new-company-property-change.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-new-company-property-change",
   name: "New Company Property Change",
   description: "Emit new event when a specified property is provided or updated on a company. [See the documentation](https://developers.hubspot.com/docs/api/crm/companies)",
-  version: "0.0.11",
+  version: "0.0.12",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-contact-property-change/new-contact-property-change.mjs
+++ b/components/hubspot/sources/new-contact-property-change/new-contact-property-change.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-new-contact-property-change",
   name: "New Contact Property Change",
   description: "Emit new event when a specified property is provided or updated on a contact. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts)",
-  version: "0.0.13",
+  version: "0.0.14",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-custom-object-property-change/new-custom-object-property-change.mjs
+++ b/components/hubspot/sources/new-custom-object-property-change/new-custom-object-property-change.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-new-custom-object-property-change",
   name: "New Custom Object Property Change",
   description: "Emit new event when a specified property is provided or updated on a custom object.",
-  version: "0.0.3",
+  version: "0.0.4",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-deal-in-stage/new-deal-in-stage.mjs
+++ b/components/hubspot/sources/new-deal-in-stage/new-deal-in-stage.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-new-deal-in-stage",
   name: "New Deal In Stage",
   description: "Emit new event for each new deal in a stage.",
-  version: "0.0.22",
+  version: "0.0.23",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-deal-property-change/new-deal-property-change.mjs
+++ b/components/hubspot/sources/new-deal-property-change/new-deal-property-change.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-new-deal-property-change",
   name: "New Deal Property Change",
   description: "Emit new event when a specified property is provided or updated on a deal. [See the documentation](https://developers.hubspot.com/docs/api/crm/deals)",
-  version: "0.0.12",
+  version: "0.0.13",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-email-event/new-email-event.mjs
+++ b/components/hubspot/sources/new-email-event/new-email-event.mjs
@@ -8,7 +8,7 @@ export default {
   key: "hubspot-new-email-event",
   name: "New Email Event",
   description: "Emit new event for each new Hubspot email event.",
-  version: "0.0.21",
+  version: "0.0.22",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-email-subscriptions-timeline/new-email-subscriptions-timeline.mjs
+++ b/components/hubspot/sources/new-email-subscriptions-timeline/new-email-subscriptions-timeline.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-new-email-subscriptions-timeline",
   name: "New Email Subscriptions Timeline",
   description: "Emit new event when a new email timeline subscription is added for the portal.",
-  version: "0.0.18",
+  version: "0.0.19",
   dedupe: "unique",
   type: "source",
   methods: {

--- a/components/hubspot/sources/new-engagement/new-engagement.mjs
+++ b/components/hubspot/sources/new-engagement/new-engagement.mjs
@@ -8,7 +8,7 @@ export default {
   key: "hubspot-new-engagement",
   name: "New Engagement",
   description: "Emit new event for each new engagement created. This action returns a maximum of 5000 records at a time, make sure you set a correct time range so you don't miss any events",
-  version: "0.0.23",
+  version: "0.0.24",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-event/new-event.mjs
+++ b/components/hubspot/sources/new-event/new-event.mjs
@@ -8,7 +8,7 @@ export default {
   key: "hubspot-new-event",
   name: "New Events",
   description: "Emit new event for each new Hubspot event. Note: Only available for Marketing Hub Enterprise, Sales Hub Enterprise, Service Hub Enterprise, or CMS Hub Enterprise accounts",
-  version: "0.0.22",
+  version: "0.0.23",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-form-submission/new-form-submission.mjs
+++ b/components/hubspot/sources/new-form-submission/new-form-submission.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-new-form-submission",
   name: "New Form Submission",
   description: "Emit new event for each new submission of a form.",
-  version: "0.0.23",
+  version: "0.0.24",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-note/new-note.mjs
+++ b/components/hubspot/sources/new-note/new-note.mjs
@@ -8,7 +8,7 @@ export default {
   key: "hubspot-new-note",
   name: "New Note Created",
   description: "Emit new event for each new note created. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/engagements/notes#get-%2Fcrm%2Fv3%2Fobjects%2Fnotes)",
-  version: "0.0.2",
+  version: "1.0.0",
   type: "source",
   dedupe: "unique",
   methods: {
@@ -34,7 +34,7 @@ export default {
 
       const objectTypes = OBJECT_TYPES.map(({ value }) => value);
       const { results: custom } = await this.hubspot.listSchemas();
-      const customObjects = custom?.map(({ name }) => name);
+      const customObjects = custom?.map(({ fullyQualifiedName }) => fullyQualifiedName);
       const associations = [
         ...objectTypes,
         ...customObjects,

--- a/components/hubspot/sources/new-or-updated-blog-article/new-or-updated-blog-article.mjs
+++ b/components/hubspot/sources/new-or-updated-blog-article/new-or-updated-blog-article.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-new-or-updated-blog-article",
   name: "New or Updated Blog Post",
   description: "Emit new event for each new or updated blog post in Hubspot.",
-  version: "0.0.5",
+  version: "0.0.6",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-company/new-or-updated-company.mjs
+++ b/components/hubspot/sources/new-or-updated-company/new-or-updated-company.mjs
@@ -9,7 +9,7 @@ export default {
   key: "hubspot-new-or-updated-company",
   name: "New or Updated Company",
   description: "Emit new event for each new or updated company in Hubspot.",
-  version: "0.0.5",
+  version: "0.0.6",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-contact/new-or-updated-contact.mjs
+++ b/components/hubspot/sources/new-or-updated-contact/new-or-updated-contact.mjs
@@ -9,7 +9,7 @@ export default {
   key: "hubspot-new-or-updated-contact",
   name: "New or Updated Contact",
   description: "Emit new event for each new or updated contact in Hubspot.",
-  version: "0.0.5",
+  version: "0.0.6",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-crm-object/new-or-updated-crm-object.mjs
+++ b/components/hubspot/sources/new-or-updated-crm-object/new-or-updated-crm-object.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-new-or-updated-crm-object",
   name: "New or Updated CRM Object",
   description: "Emit new event each time a CRM Object of the specified object type is updated.",
-  version: "0.0.18",
+  version: "0.0.19",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-custom-object/new-or-updated-custom-object.mjs
+++ b/components/hubspot/sources/new-or-updated-custom-object/new-or-updated-custom-object.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-new-or-updated-custom-object",
   name: "New or Updated Custom Object",
   description: "Emit new event each time a Custom Object of the specified schema is updated.",
-  version: "0.0.7",
+  version: "0.0.8",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-deal/new-or-updated-deal.mjs
+++ b/components/hubspot/sources/new-or-updated-deal/new-or-updated-deal.mjs
@@ -9,7 +9,7 @@ export default {
   key: "hubspot-new-or-updated-deal",
   name: "New or Updated Deal",
   description: "Emit new event for each new or updated deal in Hubspot",
-  version: "0.0.5",
+  version: "0.0.6",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-line-item/new-or-updated-line-item.mjs
+++ b/components/hubspot/sources/new-or-updated-line-item/new-or-updated-line-item.mjs
@@ -9,7 +9,7 @@ export default {
   key: "hubspot-new-or-updated-line-item",
   name: "New or Updated Line Item",
   description: "Emit new event for each new line item added or updated in Hubspot.",
-  version: "0.0.5",
+  version: "0.0.6",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-product/new-or-updated-product.mjs
+++ b/components/hubspot/sources/new-or-updated-product/new-or-updated-product.mjs
@@ -9,7 +9,7 @@ export default {
   key: "hubspot-new-or-updated-product",
   name: "New or Updated Product",
   description: "Emit new event for each new or updated product in Hubspot.",
-  version: "0.0.5",
+  version: "0.0.6",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-social-media-message/new-social-media-message.mjs
+++ b/components/hubspot/sources/new-social-media-message/new-social-media-message.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-new-social-media-message",
   name: "New Social Media Message",
   description: "Emit new event when a message is posted from HubSpot to the specified social media channel. Note: Only available for Marketing Hub Enterprise accounts",
-  version: "0.0.18",
+  version: "0.0.19",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/hubspot/sources/new-task/new-task.mjs
+++ b/components/hubspot/sources/new-task/new-task.mjs
@@ -8,7 +8,7 @@ export default {
   key: "hubspot-new-task",
   name: "New Task Created",
   description: "Emit new event for each new task created. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/engagements/tasks#get-%2Fcrm%2Fv3%2Fobjects%2Ftasks)",
-  version: "0.0.14",
+  version: "1.0.0",
   type: "source",
   dedupe: "unique",
   methods: {
@@ -34,7 +34,7 @@ export default {
 
       const objectTypes = OBJECT_TYPES.map(({ value }) => value);
       const { results: custom } = await this.hubspot.listSchemas();
-      const customObjects = custom?.map(({ name }) => name);
+      const customObjects = custom?.map(({ fullyQualifiedName }) => fullyQualifiedName);
       const associations = [
         ...objectTypes,
         ...customObjects,

--- a/components/hubspot/sources/new-ticket-property-change/new-ticket-property-change.mjs
+++ b/components/hubspot/sources/new-ticket-property-change/new-ticket-property-change.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-new-ticket-property-change",
   name: "New Ticket Property Change",
   description: "Emit new event when a specified property is provided or updated on a ticket. [See the documentation](https://developers.hubspot.com/docs/api/crm/tickets)",
-  version: "0.0.12",
+  version: "0.0.13",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-ticket/new-ticket.mjs
+++ b/components/hubspot/sources/new-ticket/new-ticket.mjs
@@ -9,7 +9,7 @@ export default {
   key: "hubspot-new-ticket",
   name: "New Ticket",
   description: "Emit new event for each new ticket created.",
-  version: "0.0.18",
+  version: "0.0.19",
   dedupe: "unique",
   type: "source",
   props: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32187,6 +32187,8 @@ snapshots:
       '@putout/operator-filesystem': 5.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))
       '@putout/operator-json': 2.2.0
       putout: 36.13.1(eslint@8.57.1)(typescript@5.6.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@putout/operator-regexp@1.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))':
     dependencies:


### PR DESCRIPTION
Adhering to the [breaking change announced by HubSpot](https://developers.hubspot.com/changelog/breaking-change-removed-support-for-referencing-custom-object-types-by-base-name)

Custom objects are now referenced by their `fullyQualifiedName` instead of `name`.

Components affected by this change:
- Create Associations
- Create Custom Object
- Search CRM
- Update Custom Object
- New Note Created
- New Task Created

We also have 'New or Updated Custom Object' and 'New Custom Object Property Change', but those were not modified since they already use the custom object's ID instead of its name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Upgraded the HubSpot integration to version 1.0.0 across all actions and sources.
- **Refactor**
  - Refined the display of custom object options to provide clearer labels and more consistent identifiers for an improved user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->