### PR TITLE
[Pipedrive] Pin sdk version

### DIFF
--- a/components/pipedrive/pipedrive.app.mjs
+++ b/components/pipedrive/pipedrive.app.mjs
@@ -1,4 +1,4 @@
-import pipedrive from "pipedrive";
+import pipedrive from "pipedrive@13.2.7";
 import constants from "./common/constants.mjs";
 
 export default {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8719,8 +8719,7 @@ importers:
         specifier: ^1.2.0
         version: 1.6.6
 
-  components/real_id:
-    specifiers: {}
+  components/real_id: {}
 
   components/realgeeks:
     dependencies:


### PR DESCRIPTION
## WHY

Temporarily pin sdk version to 13.2.7. Requires refactoring components to latest version.
