### PR TITLE
Add TTL functionality to Data Store actions

### DIFF
--- a/components/data_stores/actions/add-update-record/add-update-record.mjs
+++ b/components/data_stores/actions/add-update-record/add-update-record.mjs
@@ -4,7 +4,7 @@ export default {
   key: "data_stores-add-update-record",
   name: "Add or update a single record",
   description: "Add or update a single record in your [Pipedream Data Store](https://pipedream.com/data-stores/).",
-  version: "0.0.9",
+  version: "0.0.10",
   type: "action",
   props: {
     app,
@@ -30,20 +30,36 @@ export default {
         "value",
       ],
     },
+    ttl: {
+      propDefinition: [
+        app,
+        "ttl",
+      ],
+    },
   },
   async run({ $ }) {
     const {
       key,
       value,
+      ttl,
     } = this;
     const exists = await this.dataStore.has(key);
     const parsedValue = this.app.parseValue(value);
-    await this.dataStore.set(key, parsedValue);
+
+    if (ttl) {
+      await this.dataStore.set(key, parsedValue, {
+        ttl,
+      });
+    } else {
+      await this.dataStore.set(key, parsedValue);
+    }
+
     // eslint-disable-next-line multiline-ternary
-    $.export("$summary", `Successfully ${exists ? "updated the record for" : "added a new record with the"} key, \`${key}\`.`);
+    $.export("$summary", `Successfully ${exists ? "updated the record for" : "added a new record with the"} key, \`${key}\`${ttl ? ` (expires in ${this.app.formatTtl(ttl)})` : ""}.`);
     return {
       key,
       value: parsedValue,
+      ttl: ttl || null,
     };
   },
 };

--- a/components/data_stores/actions/delete-all-records/delete-all-records.mjs
+++ b/components/data_stores/actions/delete-all-records/delete-all-records.mjs
@@ -4,7 +4,7 @@ export default {
   key: "data_stores-delete-all-records",
   name: "Delete All Records",
   description: "Delete all records in your [Pipedream Data Store](https://pipedream.com/data-stores/).",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     app,

--- a/components/data_stores/actions/delete-single-record/delete-single-record.mjs
+++ b/components/data_stores/actions/delete-single-record/delete-single-record.mjs
@@ -4,7 +4,7 @@ export default {
   key: "data_stores-delete-single-record",
   name: "Delete a single record",
   description: "Delete a single record in your [Pipedream Data Store](https://pipedream.com/data-stores/).",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "action",
   props: {
     app,

--- a/components/data_stores/actions/get-all-records/get-all-records.mjs
+++ b/components/data_stores/actions/get-all-records/get-all-records.mjs
@@ -4,7 +4,7 @@ export default {
   key: "data_stores-get-all-records",
   name: "Get all records",
   description: "Get all records in your [Pipedream Data Store](https://pipedream.com/data-stores/). The memory consumption of the workflow can be affected, since this action will be exposing, to the workflow, the entire data from the selected datastore.",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   props: {
     app,

--- a/components/data_stores/actions/get-difference/get-difference.mjs
+++ b/components/data_stores/actions/get-difference/get-difference.mjs
@@ -5,7 +5,7 @@ export default {
   key: "data_stores-get-difference",
   name: "Get Difference",
   description: "Get the difference between two data stores. Result contains key/value pairs where the key exists in one data store, but not the other. [Pipedream Data Stores](https://pipedream.com/data-stores/).",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     app,

--- a/components/data_stores/actions/get-record-keys/get-record-keys.mjs
+++ b/components/data_stores/actions/get-record-keys/get-record-keys.mjs
@@ -4,7 +4,7 @@ export default {
   key: "data_stores-get-record-keys",
   name: "Get Record Keys",
   description: "Get all record keys in your [Pipedream Data Store](https://pipedream.com/data-stores/) that matches with your query. The memory consumption of the workflow can be affected, since this action will be exposing, to the workflow, the entire data from the selected datastore",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   props: {
     app,

--- a/components/data_stores/actions/get-record-or-create/get-record-or-create.mjs
+++ b/components/data_stores/actions/get-record-or-create/get-record-or-create.mjs
@@ -4,7 +4,7 @@ export default {
   key: "data_stores-get-record-or-create",
   name: "Get record (or create one if not found)",
   description: "Get a single record in your [Pipedream Data Store](https://pipedream.com/data-stores/) or create one if it doesn't exist.",
-  version: "0.0.10",
+  version: "0.0.11",
   type: "action",
   props: {
     app,
@@ -30,6 +30,12 @@ export default {
         "addRecordIfNotFound",
       ],
     },
+    ttl: {
+      propDefinition: [
+        app,
+        "ttl",
+      ],
+    },
   },
   async additionalProps() {
     const props = {};
@@ -52,8 +58,25 @@ export default {
     }
 
     const parsedValue = this.app.parseValue(this.value);
-    await this.dataStore.set(this.key, parsedValue);
-    $.export("$summary", `Successfully added a new record with the key, \`${this.key}\`.`);
+
+    if (this.ttl) {
+      await this.dataStore.set(this.key, parsedValue, {
+        ttl: this.ttl,
+      });
+      $.export("$summary", `Successfully added a new record with the key, \`${this.key}\` (expires in ${this.app.formatTtl(this.ttl)}).`);
+    } else {
+      await this.dataStore.set(this.key, parsedValue);
+      $.export("$summary", `Successfully added a new record with the key, \`${this.key}\`.`);
+    }
+
+    // Include TTL information in the return value if it was set
+    if (this.ttl) {
+      return {
+        value: parsedValue,
+        ttl: this.ttl,
+      };
+    }
+
     return parsedValue;
   },
 };

--- a/components/data_stores/actions/has-key-or-create/has-key-or-create.mjs
+++ b/components/data_stores/actions/has-key-or-create/has-key-or-create.mjs
@@ -4,7 +4,7 @@ export default {
   key: "data_stores-has-key-or-create",
   name: "Check for existence of key",
   description: "Check if a key exists in your [Pipedream Data Store](https://pipedream.com/data-stores/) or create one if it doesn't exist.",
-  version: "0.1.2",
+  version: "0.1.3",
   type: "action",
   props: {
     app,
@@ -28,6 +28,12 @@ export default {
       propDefinition: [
         app,
         "addRecordIfNotFound",
+      ],
+    },
+    ttl: {
+      propDefinition: [
+        app,
+        "ttl",
       ],
     },
   },
@@ -58,13 +64,22 @@ export default {
     }
 
     const parsedValue = this.app.parseValue(this.value);
-    await this.dataStore.set(this.key, parsedValue);
-    $.export("$summary", `Key \`${this.key}\` was not found. Successfully added a new record.`);
+
+    if (this.ttl) {
+      await this.dataStore.set(this.key, parsedValue, {
+        ttl: this.ttl,
+      });
+      $.export("$summary", `Key \`${this.key}\` was not found. Successfully added a new record (expires in ${this.app.formatTtl(this.ttl)}).`);
+    } else {
+      await this.dataStore.set(this.key, parsedValue);
+      $.export("$summary", `Key \`${this.key}\` was not found. Successfully added a new record.`);
+    }
 
     return {
       existingKeyFound: false,
       newKeyCreated: true,
       value: parsedValue,
+      ttl: this.ttl || null,
     };
   },
 };

--- a/components/data_stores/actions/list-keys/list-keys.mjs
+++ b/components/data_stores/actions/list-keys/list-keys.mjs
@@ -4,7 +4,7 @@ export default {
   key: "data_stores-list-keys",
   name: "List keys",
   description: "List all keys in your [Pipedream Data Store](https://pipedream.com/data-stores/).",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     app,

--- a/components/data_stores/actions/list-records/list-records.mjs
+++ b/components/data_stores/actions/list-records/list-records.mjs
@@ -6,7 +6,7 @@ export default {
   key: "data_stores-list-records",
   name: "List Records",
   description: "List all records in your [Pipedream Data Store](https://pipedream.com/data-stores/).",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   props: {
     app,

--- a/components/data_stores/actions/update-ttl/update-ttl.mjs
+++ b/components/data_stores/actions/update-ttl/update-ttl.mjs
@@ -1,0 +1,121 @@
+import app from "../../data_stores.app.mjs";
+
+export default {
+  key: "data_stores-update-ttl",
+  name: "Update record expiration",
+  description: "Update the expiration time for a record in your [Pipedream Data Store](https://pipedream.com/data-stores/).",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    app,
+    dataStore: {
+      propDefinition: [
+        app,
+        "dataStore",
+      ],
+    },
+    key: {
+      propDefinition: [
+        app,
+        "key",
+        ({ dataStore }) => ({
+          dataStore,
+        }),
+      ],
+      description: "Select the key for the record you'd like to update the expiration time.",
+    },
+    ttlOption: {
+      type: "string",
+      label: "Expiration Type",
+      description: "Choose a common expiration time or specify a custom value",
+      options: [
+        {
+          label: "Custom value",
+          value: "custom",
+        },
+        {
+          label: "No expiration (remove expiry)",
+          value: "0",
+        },
+        {
+          label: "1 hour",
+          value: "3600",
+        },
+        {
+          label: "1 day",
+          value: "86400",
+        },
+        {
+          label: "1 week",
+          value: "604800",
+        },
+        {
+          label: "30 days",
+          value: "2592000",
+        },
+        {
+          label: "90 days",
+          value: "7776000",
+        },
+        {
+          label: "1 year",
+          value: "31536000",
+        },
+      ],
+      reloadProps: true,
+    },
+  },
+  async additionalProps() {
+    const props = {};
+    if (this.ttlOption === "custom") {
+      props.ttl = {
+        type: "integer",
+        label: "Custom TTL (seconds)",
+        description: "The number of seconds until this record expires and is automatically deleted. Use 0 to remove expiration.",
+        min: 0,
+        max: 63072000, // 2 years (safe upper limit)
+      };
+    }
+    return props;
+  },
+  async run({ $ }) {
+    const {
+      key, ttlOption, ttl,
+    } = this;
+
+    // Determine TTL value to use
+    const ttlValue = ttlOption === "custom"
+      ? ttl
+      : parseInt(ttlOption, 10);
+
+    if (!await this.dataStore.has(key)) {
+      $.export("$summary", `No record found with key \`${key}\`.`);
+      return {
+        success: false,
+        message: `No record found with key ${key}`,
+      };
+    }
+
+    if (ttlValue === 0) {
+      // Remove expiration
+      await this.dataStore.setTtl(key, null);
+      $.export("$summary", `Successfully removed expiration for key \`${key}\`.`);
+      return {
+        success: true,
+        key,
+        ttl: null,
+        message: "Expiration removed",
+      };
+    } else {
+      // Update TTL
+      await this.dataStore.setTtl(key, ttlValue);
+      $.export("$summary", `Successfully updated expiration for key \`${key}\` (expires in ${this.app.formatTtl(ttlValue)}).`);
+      return {
+        success: true,
+        key,
+        ttl: ttlValue,
+        ttlFormatted: this.app.formatTtl(ttlValue),
+      };
+    }
+  },
+};

--- a/components/data_stores/actions/update-ttl/update-ttl.mjs
+++ b/components/data_stores/actions/update-ttl/update-ttl.mjs
@@ -2,7 +2,7 @@ import app from "../../data_stores.app.mjs";
 
 export default {
   key: "data_stores-update-ttl",
-  name: "Update record expiration",
+  name: "Update Record Expiration",
   description: "Update the expiration time for a record in your [Pipedream Data Store](https://pipedream.com/data-stores/).",
   version: "0.0.1",
   type: "action",

--- a/components/data_stores/actions/update-ttl/update-ttl.mjs
+++ b/components/data_stores/actions/update-ttl/update-ttl.mjs
@@ -73,7 +73,7 @@ export default {
         label: "Custom TTL (seconds)",
         description: "The number of seconds until this record expires and is automatically deleted. Use 0 to remove expiration.",
         min: 0,
-        max: 63072000, // 2 years (safe upper limit)
+        max: 31536000, // 1 year (safe upper limit)
       };
     }
     return props;

--- a/components/data_stores/data_stores.app.mjs
+++ b/components/data_stores/data_stores.app.mjs
@@ -33,7 +33,7 @@ export default {
       description: "The number of seconds until this record expires and is automatically deleted. Examples: 3600 (1 hour), 86400 (1 day), 604800 (1 week). Leave blank for records that should not expire.",
       optional: true,
       min: 0,
-      max: 63072000, // 2 years (safe upper limit)
+      max: 31536000, // 1 year (safe upper limit)
     },
     addRecordIfNotFound: {
       label: "Create a new record if the key is not found?",

--- a/components/data_stores/data_stores.app.mjs
+++ b/components/data_stores/data_stores.app.mjs
@@ -27,6 +27,14 @@ export default {
       type: "any",
       description: "Enter a string, object, or array.",
     },
+    ttl: {
+      label: "Time to Live (TTL)",
+      type: "integer",
+      description: "The number of seconds until this record expires and is automatically deleted. Examples: 3600 (1 hour), 86400 (1 day), 604800 (1 week). Leave blank for records that should not expire.",
+      optional: true,
+      min: 0,
+      max: 63072000, // 2 years (safe upper limit)
+    },
     addRecordIfNotFound: {
       label: "Create a new record if the key is not found?",
       description: "Create a new record if no records are found for the specified key.",
@@ -65,6 +73,47 @@ export default {
       } catch (err) {
         return value;
       }
+    },
+    formatTtl(seconds) {
+      if (!seconds) return "";
+
+      // Format TTL in a human-readable way
+      if (seconds < 60) {
+        return `${seconds} second${seconds === 1
+          ? ""
+          : "s"}`;
+      }
+      if (seconds < 3600) {
+        const minutes = Math.round(seconds / 60);
+        return `${minutes} minute${minutes === 1
+          ? ""
+          : "s"}`;
+      }
+      if (seconds < 86400) {
+        const hours = Math.round(seconds / 3600);
+        return `${hours} hour${hours === 1
+          ? ""
+          : "s"}`;
+      }
+      if (seconds < 604800) {
+        const days = Math.round(seconds / 86400);
+        return `${days} day${days === 1
+          ? ""
+          : "s"}`;
+      }
+      const weeks = Math.round(seconds / 604800);
+      return `${weeks} week${weeks === 1
+        ? ""
+        : "s"}`;
+    },
+    async updateTtlIfNeeded(dataStore, key, ttl) {
+      if (!ttl) return false;
+
+      if (await dataStore.has(key)) {
+        await dataStore.setTtl(key, ttl);
+        return true;
+      }
+      return false;
     },
   },
 };

--- a/components/data_stores/package.json
+++ b/components/data_stores/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/data_stores",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Pipedream Data Stores Components",
   "main": "data_stores.app.js",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5988,8 +5988,7 @@ importers:
         specifier: ^1.6.0
         version: 1.6.6
 
-  components/hr_cloud:
-    specifiers: {}
+  components/hr_cloud: {}
 
   components/hr_partner: {}
 
@@ -6500,8 +6499,7 @@ importers:
 
   components/jellyreach: {}
 
-  components/jenkins:
-    specifiers: {}
+  components/jenkins: {}
 
   components/jibble:
     dependencies:
@@ -11961,8 +11959,7 @@ importers:
         specifier: ^1.2.0
         version: 1.6.6
 
-  components/splunk:
-    specifiers: {}
+  components/splunk: {}
 
   components/splunk_http_event_collector: {}
 


### PR DESCRIPTION
## Summary
- Added TTL prop to all Data Store actions to support record expiration
- Created helper methods for human-readable TTL formatting (e.g., "3 hours" instead of "10800 seconds")
- Added a new "Update record expiration" action for modifying TTL on existing records
- Added preset TTL options for common time periods (1 hour, 1 day, 1 week, etc.)
- Improved summaries and return values with TTL information

## Test plan
1. Test creating new records with TTL in each action
2. Test updating existing records with the new Update TTL action
3. Verify that records expire after the specified TTL
4. Verify that the human-readable format appears in summaries

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configurable Time-to-Live (TTL) option across data store actions, allowing users to set expiration times for records.
  - Enhanced response messages to include formatted details about record expiration.
  - Introduced a new capability to update record expiration, supporting both preset and custom TTL values.
  
- **Version Updates**
  - Incremented version numbers for various data store actions and the overall package to reflect the latest changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->