### PR TITLE
[FEATURE] Return Record key as well as data in Data Stores: Get Record action

### DIFF
--- a/components/data_stores/actions/delete-single-record/delete-single-record.mjs
+++ b/components/data_stores/actions/delete-single-record/delete-single-record.mjs
@@ -4,7 +4,7 @@ export default {
   key: "data_stores-delete-single-record",
   name: "Delete a single record",
   description: "Delete a single record in your [Pipedream Data Store](https://pipedream.com/data-stores/).",
-  version: "0.0.9",
+  version: "0.0.10",
   type: "action",
   props: {
     app,
@@ -31,9 +31,11 @@ export default {
     if (record) {
       await this.dataStore.delete(this.key);
       $.export("$summary", `Successfully deleted the record for key, \`${this.key}\`.`);
+      $.export("key", this.key);
       return record;
     }
 
     $.export("$summary", `No record found for key, \`${this.key}\`. No data was deleted.`);
+    $.export("key", this.key);
   },
 };

--- a/components/data_stores/actions/get-record-or-create/get-record-or-create.mjs
+++ b/components/data_stores/actions/get-record-or-create/get-record-or-create.mjs
@@ -4,7 +4,7 @@ export default {
   key: "data_stores-get-record-or-create",
   name: "Get record (or create one if not found)",
   description: "Get a single record in your [Pipedream Data Store](https://pipedream.com/data-stores/) or create one if it doesn't exist.",
-  version: "0.0.11",
+  version: "0.0.12",
   type: "action",
   props: {
     app,
@@ -46,37 +46,41 @@ export default {
   },
   async run({ $ }) {
     const record = await this.dataStore.get(this.key);
+    let summary, response;
 
     if (record !== undefined) {
-      $.export("$summary", `Found data for the key, \`${this.key}\`.`);
-      return record;
+      summary = `Found data for the key, \`${this.key}\`.`;
+      response = record;
+    }
+    else if (!this.app.shouldAddRecord(this.addRecordIfNotFound)) {
+      summary = `No data found for key, \`${this.key}\`.`;
+    }
+    else {
+      const parsedValue = this.app.parseValue(this.value);
+
+      if (this.ttl) {
+        await this.dataStore.set(this.key, parsedValue, {
+          ttl: this.ttl,
+        });
+        summary = `Successfully added a new record with the key, \`${this.key}\` (expires in ${this.app.formatTtl(this.ttl)}).`;
+      } else {
+        await this.dataStore.set(this.key, parsedValue);
+        summary = `Successfully added a new record with the key, \`${this.key}\`.`;
+      }
+
+      // Include TTL information in the return value if it was set
+      if (this.ttl) {
+        return {
+          value: parsedValue,
+          ttl: this.ttl,
+        };
+      }
+
+      response = parsedValue;
     }
 
-    if (!this.app.shouldAddRecord(this.addRecordIfNotFound)) {
-      $.export("$summary", `No data found for key, \`${this.key}\`.`);
-      return;
-    }
-
-    const parsedValue = this.app.parseValue(this.value);
-
-    if (this.ttl) {
-      await this.dataStore.set(this.key, parsedValue, {
-        ttl: this.ttl,
-      });
-      $.export("$summary", `Successfully added a new record with the key, \`${this.key}\` (expires in ${this.app.formatTtl(this.ttl)}).`);
-    } else {
-      await this.dataStore.set(this.key, parsedValue);
-      $.export("$summary", `Successfully added a new record with the key, \`${this.key}\`.`);
-    }
-
-    // Include TTL information in the return value if it was set
-    if (this.ttl) {
-      return {
-        value: parsedValue,
-        ttl: this.ttl,
-      };
-    }
-
-    return parsedValue;
+    $.export("$summary", summary);
+    $.export("key", this.key);
+    return response;
   },
 };

--- a/components/data_stores/package.json
+++ b/components/data_stores/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/data_stores",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Pipedream Data Stores Components",
   "main": "data_stores.app.js",
   "keywords": [


### PR DESCRIPTION
Resolves #15858 

- Updated "Get record (or create one if not found)" and "Delete a single record" to export the `key`.
- Pipedream doesn't currently support a way to access the Data Store name from within the component.