### PR TITLE
Fixing app main file imports

### DIFF
--- a/components/algolia/package.json
+++ b/components/algolia/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/algolia",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Algolia Components",
-  "main": "algolia.app.js",
+  "main": "algolia.app.mjs",
   "keywords": [
     "pipedream",
     "algolia"

--- a/components/amazon_ses/package.json
+++ b/components/amazon_ses/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/amazon_ses",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Pipedream Amazon SES Components",
-  "main": "amazon_ses.app.js",
+  "main": "amazon_ses.app.mjs",
   "keywords": [
     "pipedream",
     "amazon_ses"

--- a/components/bandwidth/package.json
+++ b/components/bandwidth/package.json
@@ -2,7 +2,7 @@
   "name": "@pipedream/bandwidth",
   "version": "1.0.3",
   "description": "Pipedream Bandwidth Components",
-  "main": "index.js",
+  "main": "bandwidth.app.js",
   "keywords": [
     "pipedream",
     "bandwidth"

--- a/components/basecamp/package.json
+++ b/components/basecamp/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/basecamp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Basecamp Components",
-  "main": "basecamp.app.js",
+  "main": "basecamp.app.mjs",
   "keywords": [
     "pipedream",
     "basecamp"

--- a/components/blogger/package.json
+++ b/components/blogger/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/blogger",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Pipedream Blogger Components",
-  "main": "blogger.app.js",
+  "main": "blogger.app.mjs",
   "keywords": [
     "pipedream",
     "blogger"

--- a/components/brex/package.json
+++ b/components/brex/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/brex",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Brex Components",
-  "main": "brex.app.js",
+  "main": "brex.app.mjs",
   "keywords": [
     "pipedream",
     "brex"

--- a/components/brex_staging/package.json
+++ b/components/brex_staging/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/brex_staging",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Pipedream Brex Staging Components",
-  "main": "brex_staging.app.js",
+  "main": "brex_staging.app.mjs",
   "keywords": [
     "pipedream",
     "brex_staging"

--- a/components/chartmogul/package.json
+++ b/components/chartmogul/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/chartmogul",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Pipedream ChartMogul Components",
-  "main": "chartmogul.app.js",
+  "main": "chartmogul.app.mjs",
   "keywords": [
     "pipedream",
     "chartmogul"

--- a/components/chatbot/package.json
+++ b/components/chatbot/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/chatbot",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Pipedream ChatBot Components",
-  "main": "chatbot.app.js",
+  "main": "chatbot.app.mjs",
   "keywords": [
     "pipedream",
     "chatbot"

--- a/components/commercehq/package.json
+++ b/components/commercehq/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/commercehq",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Pipedream CommerceHQ Components",
-  "main": "commercehq.app.js",
+  "main": "commercehq.app.mjs",
   "keywords": [
     "pipedream",
     "commercehq"

--- a/components/crove_app/package.json
+++ b/components/crove_app/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/crove_app",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Pipedream Crove Components",
-  "main": "crove_app.app.js",
+  "main": "crove_app.app.mjs",
   "keywords": [
     "pipedream",
     "crove_app"

--- a/components/customer_io/package.json
+++ b/components/customer_io/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/customer_io",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Pipedream Customer.io Components",
-  "main": "customer_io.app.js",
+  "main": "customer_io.app.mjs",
   "keywords": [
     "pipedream",
     "customerio",

--- a/components/data_stores/package.json
+++ b/components/data_stores/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/data_stores",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Pipedream Data Stores Components",
-  "main": "data_stores.app.js",
+  "main": "data_stores.app.mjs",
   "keywords": [
     "pipedream",
     "blogger"

--- a/components/demio/package.json
+++ b/components/demio/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/demio",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Pipedream Demio Components",
-  "main": "demio.app.js",
+  "main": "demio.app.mjs",
   "keywords": [
     "pipedream",
     "demio"

--- a/components/dev_to/package.json
+++ b/components/dev_to/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/dev_to",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "Pipedream Dev_to Components",
-  "main": "dev_to.app.js",
+  "main": "dev_to.app.mjs",
   "keywords": [
     "pipedream",
     "dev_to"

--- a/components/discord_bot/package.json
+++ b/components/discord_bot/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/discord_bot",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Pipedream Discord_bot Components",
-  "main": "discord_bot.app.js",
+  "main": "discord_bot.app.mjs",
   "keywords": [
     "pipedream",
     "discord_bot"

--- a/components/doppler_ops/package.json
+++ b/components/doppler_ops/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/doppler_ops",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Pipedream Doppler Secrets Manager Components",
-  "main": "doppler_ops.app.js",
+  "main": "doppler_ops.app.mjs",
   "keywords": [
     "pipedream",
     "doppler_ops"

--- a/components/ecwid/package.json
+++ b/components/ecwid/package.json
@@ -1,14 +1,11 @@
 {
   "name": "@pipedream/ecwid",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Pipedream Ecwid Components",
-  "main": "dist/ecwid.app.mjs",
+  "main": "ecwid.app.mjs",
   "keywords": [
     "pipedream",
     "ecwid"
-  ],
-  "files": [
-    "dist"
   ],
   "homepage": "https://pipedream.com/apps/ecwid",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",

--- a/components/emailoctopus/package.json
+++ b/components/emailoctopus/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/emailoctopus",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream Emailoctopus Components",
-  "main": "emailoctopus.app.js",
+  "main": "emailoctopus.app.mjs",
   "keywords": [
     "pipedream",
     "emailoctopus"

--- a/components/eventbrite/package.json
+++ b/components/eventbrite/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/eventbrite",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Eventbrite Components",
-  "main": "eventbrite.app.js",
+  "main": "eventbrite.app.mjs",
   "keywords": [
     "pipedream",
     "eventbrite"

--- a/components/eversign/package.json
+++ b/components/eversign/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/eversign",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Pipedream Eversign Components",
-  "main": "eversign.app.js",
+  "main": "eversign.app.mjs",
   "keywords": [
     "pipedream",
     "eversign"

--- a/components/givebutter/package.json
+++ b/components/givebutter/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/givebutter",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Pipedream Givebutter Components",
-  "main": "givebutter.app.js",
+  "main": "givebutter.app.mjs",
   "keywords": [
     "pipedream",
     "givebutter"

--- a/components/http/package.json
+++ b/components/http/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/http",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Pipedream Http Components",
-  "main": "http.app.js",
+  "main": "http.app.mjs",
   "keywords": [
     "pipedream",
     "http"

--- a/components/inksprout/package.json
+++ b/components/inksprout/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/inksprout",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Pipedream Inksprout Components",
-  "main": "inksprout.app.js",
+  "main": "inksprout.app.mjs",
   "keywords": [
     "pipedream",
     "inksprout"

--- a/components/knack/package.json
+++ b/components/knack/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/knack",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Pipedream Knack Components",
-  "main": "knack.app.js",
+  "main": "knack.app.mjs",
   "keywords": [
     "pipedream",
     "knack"

--- a/components/mailchimp/package.json
+++ b/components/mailchimp/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/mailchimp",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Pipedream Mailchimp Components",
-  "main": "mailchimp.app.js",
+  "main": "mailchimp.app.mjs",
   "keywords": [
     "pipedream",
     "mailchimp"

--- a/components/microsoft_onedrive/package.json
+++ b/components/microsoft_onedrive/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/microsoft_onedrive",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Pipedream Microsoft OneDrive components",
-  "main": "microsoft_onedrive.app.js",
+  "main": "microsoft_onedrive.app.mjs",
   "homepage": "https://pipedream.com/apps/microsoft-onedrive",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "publishConfig": {

--- a/components/miestro/package.json
+++ b/components/miestro/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/miestro",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Miestro Components",
-  "main": "miestro.app.js",
+  "main": "miestro.app.mjs",
   "keywords": [
     "pipedream",
     "miestro"

--- a/components/mixmax/package.json
+++ b/components/mixmax/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/mixmax",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Pipedream MixMax Components",
-  "main": "mixmax.app.js",
+  "main": "mixmax.app.mjs",
   "keywords": [
     "pipedream",
     "mixmax"

--- a/components/netlify/package.json
+++ b/components/netlify/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/netlify",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Pipedream Netlify Components",
-  "main": "netlify.app.js",
+  "main": "netlify.app.mjs",
   "keywords": [
     "pipedream",
     "netlify"

--- a/components/new_relic/package.json
+++ b/components/new_relic/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/new-relic",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Pipedream New Relic Components",
-  "main": "new_relic.app.js",
+  "main": "new_relic.app.mjs",
   "keywords": [
     "pipedream",
     "new relic"

--- a/components/orbit/package.json
+++ b/components/orbit/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/orbit",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Orbit Components",
-  "main": "orbit.app.js",
+  "main": "orbit.app.mjs",
   "keywords": [
     "pipedream",
     "orbit"

--- a/components/papyrs/package.json
+++ b/components/papyrs/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/papyrs",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Pipedream Papyrs Components",
-  "main": "papyrs.app.js",
+  "main": "papyrs.app.mjs",
   "keywords": [
     "pipedream",
     "papyrs"

--- a/components/pointagram/package.json
+++ b/components/pointagram/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/pointagram",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Pipedream Pointagram Components",
-  "main": "pointagram.app.js",
+  "main": "pointagram.app.mjs",
   "keywords": [
     "pipedream",
     "pointagram"

--- a/components/quipu/package.json
+++ b/components/quipu/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/quipu",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Pipedream Quipu Components",
-  "main": "quipu.app.js",
+  "main": "quipu.app.mjs",
   "keywords": [
     "pipedream",
     "quipu"

--- a/components/raindrop/package.json
+++ b/components/raindrop/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/raindrop",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "description": "Pipedream Raindrop.io Components",
-  "main": "raindrop.app.js",
+  "main": "raindrop.app.mjs",
   "keywords": [
     "pipedream",
     "raindrop",

--- a/components/rd_station_crm/package.json
+++ b/components/rd_station_crm/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/rd_station_crm",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Pipedream RD Station CRM Components",
-  "main": "rd_station_crm.app.js",
+  "main": "rd_station_crm.app.mjs",
   "keywords": [
     "pipedream",
     "rd_station_crm"

--- a/components/refersion/package.json
+++ b/components/refersion/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/refersion",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Pipedream Refersion Components",
-  "main": "refersion.app.js",
+  "main": "refersion.app.mjs",
   "keywords": [
     "pipedream",
     "refersion"

--- a/components/repairshopr/package.json
+++ b/components/repairshopr/package.json
@@ -1,8 +1,8 @@
 {
     "name": "@pipedream/repairshopr",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "description": "Pipedream Repairshopr Components",
-    "main": "repairshopr.app.js",
+    "main": "repairshopr.app.mjs",
     "keywords": [
         "pipedream",
         "repairshopr"

--- a/components/roll/package.json
+++ b/components/roll/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/roll",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Pipedream Roll Components",
-  "main": "roll.app.js",
+  "main": "roll.app.mjs",
   "keywords": [
     "pipedream",
     "roll"

--- a/components/sendgrid/package.json
+++ b/components/sendgrid/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/sendgrid",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Pipedream Sendgrid Components",
-  "main": "sendgrid.app.js",
+  "main": "sendgrid.app.mjs",
   "keywords": [
     "pipedream",
     "sendgrid"

--- a/components/sendoso/package.json
+++ b/components/sendoso/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/sendoso",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Pipedream Sendoso Components",
-  "main": "sendoso.app.js",
+  "main": "sendoso.app.mjs",
   "keywords": [
     "pipedream",
     "sendoso"

--- a/components/sentry/package.json
+++ b/components/sentry/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/sentry",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Pipedream Sentry Components",
-  "main": "sentry.app.js",
+  "main": "sentry.app.mjs",
   "keywords": [
     "pipedream",
     "sentry"

--- a/components/seventodos/package.json
+++ b/components/seventodos/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/seventodos",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Pipedream 7todos Components",
-  "main": "seventodos.app.js",
+  "main": "seventodos.app.mjs",
   "keywords": [
     "pipedream",
     "seventodos"

--- a/components/shopify_partner/package.json
+++ b/components/shopify_partner/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/shopify_partner",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Pipedream Shopify Partner Components",
-  "main": "shopify_partner.app.js",
+  "main": "shopify_partner.app.mjs",
   "keywords": [
     "pipedream",
     "shopify",

--- a/components/shortcut/package.json
+++ b/components/shortcut/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/shortcut",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Pipedream Shortcut Components",
-  "main": "shortcut.app.js",
+  "main": "shortcut.app.mjs",
   "keywords": [
     "pipedream",
     "shortcut"

--- a/components/siteleaf/package.json
+++ b/components/siteleaf/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/siteleaf",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Pipedream Siteleaf Components",
-  "main": "siteleaf.app.js",
+  "main": "siteleaf.app.mjs",
   "keywords": [
     "pipedream",
     "siteleaf"

--- a/components/smtp2go/package.json
+++ b/components/smtp2go/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/smtp2go",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Pipedream SMTP2GO Components",
-  "main": "dist/smtp2go.app.ts",
+  "main": "dist/app/smtp2go.app.mjs",
   "keywords": [
     "pipedream",
     "smtp2go"

--- a/components/spondyr/package.json
+++ b/components/spondyr/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/spondyr",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Pipedream Spondyr Components",
-  "main": "spondyr.app.js",
+  "main": "spondyr.app.mjs",
   "keywords": [
     "pipedream",
     "spondyr"

--- a/components/spotify/package.json
+++ b/components/spotify/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/spotify",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Pipedream Spotify Components",
-  "main": "spotify.app.js",
+  "main": "spotify.app.mjs",
   "keywords": [
     "pipedream",
     "spotify"

--- a/components/squarespace/package.json
+++ b/components/squarespace/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/squarespace",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Pipedream Squarespace Components",
-  "main": "squarespace.app.js",
+  "main": "squarespace.app.mjs",
   "keywords": [
     "pipedream",
     "squarespace"

--- a/components/ssh/package.json
+++ b/components/ssh/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/ssh",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Pipedream SSH Components",
-  "main": "ssh.app.js",
+  "main": "ssh.app.mjs",
   "keywords": [
     "pipedream",
     "ssh"

--- a/components/stack_exchange/package.json
+++ b/components/stack_exchange/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/stack_exchange",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Pipedream Stack_exchange Components",
-  "main": "stack_exchange.app.js",
+  "main": "stack_exchange.app.mjs",
   "keywords": [
     "pipedream",
     "stack_exchange"

--- a/components/stormboard/package.json
+++ b/components/stormboard/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/stormboard",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Pipedream Stormboard Components",
-  "main": "stormboard.app.js",
+  "main": "stormboard.app.mjs",
   "keywords": [
     "pipedream",
     "stormboard"

--- a/components/strava/package.json
+++ b/components/strava/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/strava",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Pipedream Strava Components",
-  "main": "strava.app.js",
+  "main": "strava.app.mjs",
   "keywords": [
     "pipedream",
     "strava"

--- a/components/superdocu/package.json
+++ b/components/superdocu/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/superdocu",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Pipedream Superdocu Components",
-  "main": "superdocu.app.js",
+  "main": "superdocu.app.mjs",
   "keywords": [
     "pipedream",
     "superdocu"

--- a/components/teamgate/package.json
+++ b/components/teamgate/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/teamgate",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Pipedream Teamgate Components",
-  "main": "teamgate.app.js",
+  "main": "teamgate.app.mjs",
   "keywords": [
     "pipedream",
     "teamgate"

--- a/components/toggl/package.json
+++ b/components/toggl/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/toggl",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Toggl Components",
-  "main": "toggl.app.js",
+  "main": "toggl.app.mjs",
   "keywords": [
     "pipedream",
     "toggl"

--- a/components/vend/package.json
+++ b/components/vend/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/vend",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Pipedream Vend Components",
-  "main": "vend.app.js",
+  "main": "vend.app.mjs",
   "keywords": [
     "pipedream",
     "vend"

--- a/components/voice_monkey/package.json
+++ b/components/voice_monkey/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/voice_monkey",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Pipedream Voice Monkey Components",
-  "main": "voice_monkey.app.js",
+  "main": "voice_monkey.app.mjs",
   "keywords": [
     "pipedream",
     "voice_monkey"

--- a/components/weworkbook/package.json
+++ b/components/weworkbook/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/weworkbook",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Pipedream Weworkbook Components",
-  "main": "weworkbook.app.js",
+  "main": "weworkbook.app.mjs",
   "keywords": [
     "pipedream",
     "weworkbook"

--- a/components/woxo/package.json
+++ b/components/woxo/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/woxo",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Pipedream WOXO Components",
-  "main": "woxo.app.js",
+  "main": "woxo.app.mjs",
   "keywords": [
     "pipedream",
     "woxo"

--- a/components/yotpo/package.json
+++ b/components/yotpo/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/yotpo",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Pipedream Yotpo Components",
-  "main": "yotpo.app.js",
+  "main": "yotpo.app.mjs",
   "keywords": [
     "pipedream",
     "yotpo"

--- a/components/you_need_a_budget/package.json
+++ b/components/you_need_a_budget/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/you_need_a_budget",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream You Need A Budget Components",
-  "main": "you_need_a_budget.app.js",
+  "main": "you_need_a_budget.app.mjs",
   "keywords": [
     "pipedream",
     "you_need_a_budget"

--- a/components/zerotier/package.json
+++ b/components/zerotier/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/zerotier",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Pipedream Zerotier Components",
-  "main": "zerotier.app.js",
+  "main": "zerotier.app.mjs",
   "keywords": [
     "pipedream",
     "zerotier"

--- a/components/zonka_feedback/package.json
+++ b/components/zonka_feedback/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/zonka_feedback",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Pipedream Zonka Feedback Components",
-  "main": "zonka_feedback.app.js",
+  "main": "zonka_feedback.app.mjs",
   "keywords": [
     "pipedream",
     "zonka",

--- a/components/zoom_admin/package.json
+++ b/components/zoom_admin/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pipedream/zoom_admin",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Pipedream Zoom_admin Components",
-  "main": "zoom_admin.app.js",
+  "main": "zoom_admin.app.mjs",
   "keywords": [
     "pipedream",
     "zoom_admin"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4658,9 +4658,6 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
 
-  components/formatting:
-    specifiers: {}
-
   components/formbricks:
     dependencies:
       '@pipedream/platform':
@@ -8040,8 +8037,7 @@ importers:
         specifier: ^3.0.0
         version: 3.0.3
 
-  components/miyn:
-    specifiers: {}
+  components/miyn: {}
 
   components/moaform:
     dependencies:
@@ -9325,8 +9321,7 @@ importers:
 
   components/perry_github_test: {}
 
-  components/persanaai:
-    specifiers: {}
+  components/persanaai: {}
 
   components/persistiq:
     dependencies:


### PR DESCRIPTION
All these packages were pointing to a non-existent file in their main field, meaning they couldn't be imported in a code step.

Can be reproduced with a Node.js code step such as the following:

```
import app from "@pipedream/spotify"
export default defineComponent({
  props: {
    app,
  },
  async run({steps, $}) {
    return this.app.$auth;
  },
})
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Minor version bumps applied across multiple integrations.
  - Main module entry points have been updated to use the modern ES module format.
  - Packaging adjustments were made for greater consistency across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->