### PR TITLE
Google Drive - new files shared drive polling trigger

### DIFF
--- a/components/google_drive/package.json
+++ b/components/google_drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_drive",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "description": "Pipedream Google_drive Components",
   "main": "google_drive.app.mjs",
   "keywords": [

--- a/components/google_drive/sources/new-files-instant/new-files-instant.mjs
+++ b/components/google_drive/sources/new-files-instant/new-files-instant.mjs
@@ -10,11 +10,18 @@ export default {
   key: "google_drive-new-files-instant",
   name: "New Files (Instant)",
   description: "Emit new event when a new file is added in your linked Google Drive",
-  version: "0.1.11",
+  version: "0.1.12",
   type: "source",
   dedupe: "unique",
   props: {
     ...common.props,
+    alert: {
+      type: "alert",
+      content: "For shared drives, prefer to use [New Files (Shared Drive)](https://pipedream.com/apps/google-drive/triggers/new-files-shared-drive) instead. \
+      It provides a more reliable way to track changes using polling. \
+      Shared drive notifications may be delayed or incomplete, as they don't immediately reflect all changes made by other users. \
+      For more details, see [Google's documentation](https://developers.google.com/drive/api/guides/about-changes#track_shared_drives).",
+    },
     folders: {
       type: "string[]",
       label: "Folders",

--- a/components/google_drive/sources/new-files-shared-drive/new-files-shared-drive.mjs
+++ b/components/google_drive/sources/new-files-shared-drive/new-files-shared-drive.mjs
@@ -1,0 +1,63 @@
+import googleDrive from "../../google_drive.app.mjs";
+import sourceComponent from "../new-files-instant/new-files-instant.mjs";
+import sampleEmit from "../new-files-instant/test-event.mjs";
+import { DEFAULT_POLLING_SOURCE_TIMER_INTERVAL } from "@pipedream/platform";
+
+export default {
+  key: "google_drive-new-files-shared-drive",
+  name: "New Files (Shared Drive)",
+  description: "Emit new event when a new file is added in your shared Google Drive",
+  version: "0.0.1",
+  type: "source",
+  dedupe: "unique",
+  props: {
+    googleDrive,
+    db: "$.service.db",
+    timer: {
+      label: "Polling interval",
+      description: "Interval to poll the Google Drive API for new files",
+      type: "$.interface.timer",
+      default: {
+        intervalSeconds: DEFAULT_POLLING_SOURCE_TIMER_INTERVAL,
+      },
+    },
+    drive: {
+      propDefinition: [
+        googleDrive,
+        "sharedDrive",
+      ],
+      description: "Select a [Shared Drive](https://support.google.com/a/users/answer/9310351) from this list",
+      optional: false,
+    },
+    folders: sourceComponent.props.folders,
+  },
+  hooks: {
+    async deploy() {
+      // Get initial page token for change tracking
+      const startPageToken = await this.googleDrive.getPageToken(this.getDriveId());
+      this._setPageToken(startPageToken);
+      this._setLastFileCreatedTime(Date.now());
+
+      // Emit the most recent files
+      await sourceComponent.hooks.deploy.bind(this)();
+    },
+  },
+  methods: sourceComponent.methods,
+  async run() {
+    const pageToken = this._getPageToken();
+
+    const driveId = this.getDriveId();
+    const changedFilesStream = this.googleDrive.listChanges(pageToken, driveId);
+    for await (const changedFilesPage of changedFilesStream) {
+      const { nextPageToken } = changedFilesPage;
+
+      // Process all the changed files retrieved from the current page
+      await this.processChanges();
+
+      // After successfully processing the changed files, we store the page
+      // token of the next page
+      this._setPageToken(nextPageToken);
+    }
+  },
+  sampleEmit,
+};


### PR DESCRIPTION
## WHY

This PR introduces a new polling source for new files in shared drives, ensuring more reliable detection of new files compared to relying solely on Google's notifications. While normal drives benefit from immediate notifications, in shared drives, for new files created by another user they will be delayed until the user accesses the file manually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated package version numbers.
  
- **New Features**
  - Added a guidance message to clarify potential delays or limitations with shared drive notifications.
  - Introduced a new component that monitors and emits events when files are added to shared drives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->