### PR TITLE
fix(types): add `reloadProps` property

### DIFF
--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -234,6 +234,7 @@ export interface UserProp extends BasePropInterface {
   max?: number;
   disabled?: boolean;
   hidden?: boolean;
+  reloadProps?: boolean;
 }
 
 // https://pipedream.com/docs/components/api/#interface-props


### PR DESCRIPTION
User properties can define whether properties are reloaded after init. See: https://github.com/PipedreamHQ/pipedream/blob/3aea15a61225ce3a782f9ef3563a9a3bf60ee788/components/google_calendar/sources/upcoming-event-alert/upcoming-event-alert.mjs#L35
