### PR TITLE
fix(types): add missing `ServiceDB` interface

### DIFF
--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -247,6 +247,11 @@ export interface ServiceDBProp extends BasePropInterface {
   type: "$.service.db";
 }
 
+export interface ServiceDB {
+  get<T extends JSONValue>(key: string): T | undefined;
+  set(key: string, value: JSONValue): void;
+}
+
 // https://pipedream.com/docs/code/nodejs/using-data-stores/#using-the-data-store
 export interface DataStoreProp extends BasePropInterface {
   type: "data_store";


### PR DESCRIPTION
any property of `type: "$.service.db"` becomes an instance of `ServiceDB` at runtime.

## WHY

So the implementation in the implementation methods can benefit from it.
