### PR TITLE
fix(types): `additionalProps` context

### DIFF
--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -342,7 +342,7 @@ interface BaseSource<
   props?: SourcePropDefinitions;
   dedupe?: "last" | "greatest" | "unique";
   additionalProps?: (
-    this: SourcePropDefinitions,
+    this: PropThis<SourcePropDefinitions>,
     previousPropDefs: SourcePropDefinitions
   ) => Promise<SourcePropDefinitions>;
   run: (this: PropThis<SourcePropDefinitions> & Methods & EmitFunction, options?: SourceRunOptions) => void | Promise<void>;


### PR DESCRIPTION
`this` is bound to the current set of props.
See https://pipedream.com/docs/workflows/contributing/components/api/

<img width="1186" alt="SCR-20250325-omos" src="https://github.com/user-attachments/assets/e92da27f-1810-465c-ad87-94ee97de5342" />


Example: https://github.com/PipedreamHQ/pipedream/blob/3aea15a61225ce3a782f9ef3563a9a3bf60ee788/components/google_calendar/sources/upcoming-event-alert/upcoming-event-alert.mjs#L40



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Made behind-the-scenes improvements to enhance context management, boosting overall system consistency and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->