### PR TITLE
[Bug] Tags async options prop returning an error

### DIFF
--- a/components/asana/actions/add-task-to-section/add-task-to-section.mjs
+++ b/components/asana/actions/add-task-to-section/add-task-to-section.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Add Task To Section",
   description: "Add a task to a specific, existing section. This will remove the task from other sections of the project. [See the documentation](https://developers.asana.com/docs/add-task-to-section)",
   key: "asana-add-task-to-section",
-  version: "0.2.7",
+  version: "0.2.8",
   type: "action",
   props: {
     ...common.props,

--- a/components/asana/actions/create-project/create-project.mjs
+++ b/components/asana/actions/create-project/create-project.mjs
@@ -5,7 +5,7 @@ export default {
   key: "asana-create-project",
   name: "Create Project",
   description: "Create a new project in a workspace or team. [See the documentation](https://developers.asana.com/docs/create-a-project)",
-  version: "0.10.0",
+  version: "0.10.1",
   type: "action",
   props: {
     asana,

--- a/components/asana/actions/create-subtask/create-subtask.mjs
+++ b/components/asana/actions/create-subtask/create-subtask.mjs
@@ -5,7 +5,7 @@ export default {
   key: "asana-create-subtask",
   name: "Create Subtask",
   description: "Creates a new subtask and adds it to the parent task. [See the documentation](https://developers.asana.com/docs/create-a-subtask)",
-  version: "0.4.0",
+  version: "0.4.1",
   type: "action",
   props: {
     ...common.props,
@@ -105,6 +105,9 @@ export default {
       propDefinition: [
         asana,
         "tags",
+        ({ workspace }) => ({
+          workspace,
+        }),
       ],
       optional: true,
     },

--- a/components/asana/actions/create-task-comment/create-task-comment.mjs
+++ b/components/asana/actions/create-task-comment/create-task-comment.mjs
@@ -5,7 +5,7 @@ export default {
   key: "asana-create-task-comment",
   name: "Create Task Comment",
   description: "Adds a comment to a task. [See the documentation](https://developers.asana.com/docs/create-a-story-on-a-task)",
-  version: "0.2.7",
+  version: "0.2.8",
   type: "action",
   props: {
     ...common.props,

--- a/components/asana/actions/create-task-from-template/create-task-from-template.mjs
+++ b/components/asana/actions/create-task-from-template/create-task-from-template.mjs
@@ -4,7 +4,7 @@ export default {
   name: "Create Task from Template",
   key: "asana-create-task-from-template",
   description: "Creates a new task from a task template. [See the documentation](https://developers.asana.com/reference/instantiatetask)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     ...common.props,

--- a/components/asana/actions/create-task/create-task.mjs
+++ b/components/asana/actions/create-task/create-task.mjs
@@ -5,7 +5,7 @@ export default {
   key: "asana-create-task",
   name: "Create Task",
   description: "Creates a new task. [See the documentation](https://developers.asana.com/docs/create-a-task)",
-  version: "0.4.0",
+  version: "0.4.1",
   type: "action",
   props: {
     ...common.props,
@@ -18,6 +18,9 @@ export default {
       propDefinition: [
         asana,
         "tags",
+        ({ workspace }) => ({
+          workspace,
+        }),
       ],
       optional: true,
     },

--- a/components/asana/actions/delete-task/delete-task.mjs
+++ b/components/asana/actions/delete-task/delete-task.mjs
@@ -5,7 +5,7 @@ export default {
   key: "asana-delete-task",
   name: "Delete Task",
   description: "Deletes a specific and existing task. [See the documentation](https://developers.asana.com/docs/delete-a-task)",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "action",
   props: {
     ...common.props,

--- a/components/asana/actions/find-task-by-id/find-task-by-id.mjs
+++ b/components/asana/actions/find-task-by-id/find-task-by-id.mjs
@@ -5,7 +5,7 @@ export default {
   key: "asana-find-task-by-id",
   name: "Find Task by ID",
   description: "Searches for a task by id. Returns the complete task record for a single task. [See the documentation](https://developers.asana.com/docs/get-a-task)",
-  version: "0.2.7",
+  version: "0.2.8",
   type: "action",
   props: {
     ...common.props,

--- a/components/asana/actions/get-tasks-from-task-list/get-tasks-from-task-list.mjs
+++ b/components/asana/actions/get-tasks-from-task-list/get-tasks-from-task-list.mjs
@@ -4,7 +4,7 @@ export default {
   key: "asana-get-tasks-from-task-list",
   name: "Get Tasks From Task List",
   description: "Returns the compact list of tasks in a user’s My Tasks list. [See the documentation](https://developers.asana.com/reference/gettasksforusertasklist)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   props: {
     ...common.props,

--- a/components/asana/actions/search-projects/search-projects.mjs
+++ b/components/asana/actions/search-projects/search-projects.mjs
@@ -3,7 +3,7 @@ import asana from "../../asana.app.mjs";
 export default {
   type: "action",
   key: "asana-search-projects",
-  version: "0.2.7",
+  version: "0.2.8",
   name: "Search Projects",
   description: "Finds an existing project. [See the documentation](https://developers.asana.com/docs/get-multiple-projects)",
   props: {

--- a/components/asana/actions/search-sections/search-sections.mjs
+++ b/components/asana/actions/search-sections/search-sections.mjs
@@ -4,7 +4,7 @@ export default {
   key: "asana-search-sections",
   name: "Search Sections",
   description: "Searches for a section by name within a particular project. [See the documentation](https://developers.asana.com/docs/get-sections-in-a-project)",
-  version: "0.2.7",
+  version: "0.2.8",
   type: "action",
   props: {
     ...common.props,

--- a/components/asana/actions/search-tasks/search-tasks.mjs
+++ b/components/asana/actions/search-tasks/search-tasks.mjs
@@ -5,7 +5,7 @@ export default {
   key: "asana-search-tasks",
   name: "Search Tasks",
   description: "Searches for a Task by name within a Project. [See the documentation](https://developers.asana.com/docs/get-multiple-tasks)",
-  version: "0.3.0",
+  version: "0.3.1",
   type: "action",
   props: {
     ...common.props,

--- a/components/asana/actions/search-user-projects/search-user-projects.mjs
+++ b/components/asana/actions/search-user-projects/search-user-projects.mjs
@@ -5,7 +5,7 @@ export default {
   key: "asana-search-user-projects",
   name: "Get list of user projects",
   description: "Return list of projects given the user and workspace gid. [See the documentation](https://developers.asana.com/docs/get-multiple-projects)",
-  version: "0.5.0",
+  version: "0.5.1",
   type: "action",
   props: {
     asana,

--- a/components/asana/actions/update-task/update-task.mjs
+++ b/components/asana/actions/update-task/update-task.mjs
@@ -5,7 +5,7 @@ export default {
   key: "asana-update-task",
   name: "Update Task",
   description: "Updates a specific and existing task. [See the documentation](https://developers.asana.com/docs/update-a-task)",
-  version: "0.4.0",
+  version: "0.4.1",
   type: "action",
   props: {
     ...common.props,

--- a/components/asana/asana.app.mjs
+++ b/components/asana/asana.app.mjs
@@ -92,9 +92,12 @@ export default {
       label: "Tags",
       description: "List of tags. This field uses the tag GID.",
       type: "string[]",
-      async options({ prevContext }) {
+      async options({
+        prevContext, workspace,
+      }) {
         const params = {
           limit: DEFAULT_LIMIT,
+          workspace,
         };
         if (prevContext?.offset) {
           params.offset = prevContext.offset;
@@ -480,9 +483,9 @@ export default {
     getTag({
       tagId, ...opts
     }) {
-      return  this._makeRequest({
+      return this._makeRequest({
         path: `tags/${tagId}`,
-        opts,
+        ...opts,
       });
     },
     /**

--- a/components/asana/package.json
+++ b/components/asana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/asana",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Pipedream Asana Components",
   "main": "asana.app.mjs",
   "keywords": [

--- a/components/asana/sources/new-completed-task/new-completed-task.mjs
+++ b/components/asana/sources/new-completed-task/new-completed-task.mjs
@@ -7,7 +7,7 @@ export default {
   type: "source",
   name: "New Completed Task (Instant)",
   description: "Emit new event for each task completed in a project.",
-  version: "0.1.7",
+  version: "0.1.8",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/asana/sources/new-project/new-project.mjs
+++ b/components/asana/sources/new-project/new-project.mjs
@@ -6,7 +6,7 @@ export default {
   key: "asana-new-project",
   name: "New Project Added To Workspace (Instant)",
   description: "Emit new event for each new project added to a workspace.",
-  version: "0.1.7",
+  version: "0.1.8",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/asana/sources/new-story/new-story.mjs
+++ b/components/asana/sources/new-story/new-story.mjs
@@ -7,7 +7,7 @@ export default {
   type: "source",
   name: "New Story Added To Project (Instant)",
   description: "Emit new event for each story added to a project.",
-  version: "0.1.7",
+  version: "0.1.8",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/asana/sources/new-subtask/new-subtask.mjs
+++ b/components/asana/sources/new-subtask/new-subtask.mjs
@@ -7,7 +7,7 @@ export default {
   type: "source",
   name: "New Subtask (Instant)",
   description: "Emit new event for each subtask added to a project.",
-  version: "1.0.7",
+  version: "1.0.8",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/asana/sources/new-tag/new-tag.mjs
+++ b/components/asana/sources/new-tag/new-tag.mjs
@@ -6,7 +6,7 @@ export default {
   type: "source",
   name: "New Tag",
   description: "Emit new event for each tag created in a workspace.",
-  version: "0.0.9",
+  version: "0.0.10",
   dedupe: "unique",
   props: {
     asana,

--- a/components/asana/sources/new-task/new-task.mjs
+++ b/components/asana/sources/new-task/new-task.mjs
@@ -7,7 +7,7 @@ export default {
   type: "source",
   name: "New Task (Instant)",
   description: "Emit new event for each task added to a project. [See docs here](https://developers.asana.com/docs/establish-a-webhook)",
-  version: "0.1.7",
+  version: "0.1.8",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/asana/sources/new-team/new-team.mjs
+++ b/components/asana/sources/new-team/new-team.mjs
@@ -6,7 +6,7 @@ export default {
   type: "source",
   name: "New Team",
   description: "Emit new event for each team added to an organization.",
-  version: "0.1.8",
+  version: "0.1.9",
   dedupe: "unique",
   props: {
     asana,

--- a/components/asana/sources/new-user/new-user.mjs
+++ b/components/asana/sources/new-user/new-user.mjs
@@ -6,7 +6,7 @@ export default {
   type: "source",
   name: "New User (Instant)",
   description: "Emit new event for each user added to a workspace.",
-  version: "0.1.7",
+  version: "0.1.8",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/asana/sources/new-workspace/new-workspace.mjs
+++ b/components/asana/sources/new-workspace/new-workspace.mjs
@@ -6,7 +6,7 @@ export default {
   key: "asana-new-workspace",
   name: "New Workspace Added",
   description: "Emit new event each time you add a new workspace/organization.",
-  version: "0.1.8",
+  version: "0.1.9",
   dedupe: "unique",
   props: {
     asana,

--- a/components/asana/sources/tag-added-to-task/tag-added-to-task.mjs
+++ b/components/asana/sources/tag-added-to-task/tag-added-to-task.mjs
@@ -7,7 +7,7 @@ export default {
   type: "source",
   name: "New Tag Added To Task (Instant)",
   description: "Emit new event for each new tag added to a task.",
-  version: "0.1.7",
+  version: "0.1.8",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/asana/sources/tags-added-to-any-task/tags-added-to-any-task.mjs
+++ b/components/asana/sources/tags-added-to-any-task/tags-added-to-any-task.mjs
@@ -7,7 +7,7 @@ export default {
   type: "source",
   name: "New Tags added to any task (Instant)",
   description: "Emit new event each time a tag is added to any task, optionally filtering by a given set of tags.",
-  version: "0.0.6",
+  version: "0.0.7",
   dedupe: "unique",
   props: {
     ...common.props,
@@ -28,6 +28,9 @@ export default {
       propDefinition: [
         asana,
         "tags",
+        (c) => ({
+          workspace: c.workspace,
+        }),
       ],
     },
   },

--- a/components/asana/sources/task-assigned-in-project/task-assigned-in-project.mjs
+++ b/components/asana/sources/task-assigned-in-project/task-assigned-in-project.mjs
@@ -7,7 +7,7 @@ export default {
   type: "source",
   name: "New Task Assigned in Project (Instant)",
   description: "Emit new event each time a task is assigned, reassigned or unassigned.",
-  version: "0.1.0",
+  version: "0.1.1",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/asana/sources/task-field-updated-in-project/task-field-updated-in-project.mjs
+++ b/components/asana/sources/task-field-updated-in-project/task-field-updated-in-project.mjs
@@ -7,7 +7,7 @@ export default {
   type: "source",
   name: "New Task Field Updated In Project (Instant)",
   description: "Emit new event whenever given task fields are updated.",
-  version: "0.0.6",
+  version: "0.0.7",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/asana/sources/task-updated-in-project/task-updated-in-project.mjs
+++ b/components/asana/sources/task-updated-in-project/task-updated-in-project.mjs
@@ -7,7 +7,7 @@ export default {
   type: "source",
   name: "New Task Updated In Project (Instant)",
   description: "Emit new event for each update to a task.",
-  version: "1.1.6",
+  version: "1.1.7",
   dedupe: "unique",
   props: {
     ...common.props,


### PR DESCRIPTION
The tags prop is returning this error:

```{"errors":[{"message":"Need to specify a workspace to paginate!","help":"For more information on API status codes and how to handle them, read the docs on errors: https://developers.asana.com/docs/errors"}]}```
<img width="942" alt="image" src="https://github.com/user-attachments/assets/f2be98e8-8942-49fb-b09f-9a089282d61c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Updated numerous Asana integration components to their latest maintenance versions for improved stability.
- **New Features**
	- Enhanced tag handling by incorporating workspace context, providing more dynamic task and project interactions.
	- Updated version numbers for various components to reflect the latest changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->