### PR TITLE
fix(types): `PropOptions` don't need to be writable.

### DIFF
--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -221,7 +221,7 @@ export interface BasePropInterface {
   description?: string;
 }
 
-export type PropOptions = any[] | Array<{ [key: string]: string; }>;
+export type PropOptions = Readonly<any[] | Array<{ [key: string]: string; }>>;
 
 // https://pipedream.com/docs/components/api/#user-input-props
 export interface UserProp extends BasePropInterface {


### PR DESCRIPTION
This should be allowed:

```ts
const EventTypes = ["default", "focusTime", "outOfOffice", "workingLocation"] as const;

// ...
    eventTypes: {
      type: "string[]",
      default: ["default"],
      label: "Event Types",
      description: "Filter events by event type",
      optional: true,
      options: EventTypes,
    },
// ...
```

## WHY

<!-- author to complete -->
