### PR TITLE
Notion markdown followup

### DIFF
--- a/components/notion/actions/append-block/append-block.mjs
+++ b/components/notion/actions/append-block/append-block.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Append Block to Parent",
   description:
     "Append new and/or existing blocks to the specified parent. [See the documentation](https://developers.notion.com/reference/patch-block-children)",
-  version: "0.3.1",
+  version: "0.3.2",
   type: "action",
   props: {
     notion,

--- a/components/notion/actions/duplicate-page/duplicate-page.mjs
+++ b/components/notion/actions/duplicate-page/duplicate-page.mjs
@@ -7,7 +7,7 @@ export default {
   key: "notion-duplicate-page",
   name: "Duplicate Page",
   description: "Create a new page copied from an existing page block. [See the documentation](https://developers.notion.com/reference/post-page)",
-  version: "0.0.11",
+  version: "0.0.12",
   type: "action",
   props: {
     notion,

--- a/components/notion/notion.app.mjs
+++ b/components/notion/notion.app.mjs
@@ -325,7 +325,8 @@ export default {
         block_id: blockId,
       });
     },
-    async retrieveBlockChildren(block, params = {}) {
+    async retrieveBlockChildren(block, subpagesOnly = false) {
+      const params = {};
       const children = [];
       if (!block.has_children) return children;
 
@@ -335,11 +336,11 @@ export default {
           next_cursor: nextCursor,
         } = await this.listBlockChildren(block.id, params);
 
-        children.push(...results);
+        children.push(...(results.filter((child) => !subpagesOnly || child.type === "child_page")));
         params.next_cursor = nextCursor;
       } while (params.next_cursor);
 
-      (await Promise.all(children.map((child) => this.retrieveBlockChildren(child))))
+      (await Promise.all(children.map((child) => this.retrieveBlockChildren(child, subpagesOnly))))
         .forEach((c, i) => {
           children[i].children = c;
         });

--- a/components/notion/package.json
+++ b/components/notion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/notion",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Pipedream Notion Components",
   "main": "notion.app.mjs",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2147,8 +2147,7 @@ importers:
 
   components/changenow: {}
 
-  components/changes_page:
-    specifiers: {}
+  components/changes_page: {}
 
   components/channeladvisor:
     dependencies:
@@ -11106,8 +11105,7 @@ importers:
 
   components/saucelabs: {}
 
-  components/savvy_folders:
-    specifiers: {}
+  components/savvy_folders: {}
 
   components/savvycal:
     dependencies:


### PR DESCRIPTION
The `Retrieve Content` prop was renamed back to `Retrieve Children` and changed to a three-option prop instead of a boolean (still optional).

- 'All Children' works the same as before, recursively retrieving all child blocks.
- 'Sub-Pages Only' filters these children to include only sub-pages.
- 'None' (same as default of not choosing anything, will only retrieve the page block itself).

I've special-cased this to check for a boolean value in the code and keep the same behavior (true = 'all children', false = 'none') in case users update the action and don't change the prop's value, so it'll function exactly as it did before.

Finally, the markdown is now returned as well as the blocks, such that enabling the 'Retrieve as Markdown' prop returns this:
```
{
  markdown: 'my content'
  block: {
    id: 'block_id',
    children: [ ... ],
    // ...
  }
}
```

while not enabling it keeps the same behavior as before it existed.
```
{
  id: 'block_id',
  children: [ ... ],
  // ...
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced content retrieval now offers flexible filtering options, allowing you to select between retrieving all content, sub-pages only, or none.
	- Added support for optionally returning page content as markdown alongside standard details.
- **Improvements**
	- Streamlined retrieval configurations provide a more intuitive and consistent experience when managing nested content.
- **Version Updates**
	- Updated version numbers reflect the latest enhancements and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->