### PR TITLE
Notion 'Retrieve Block' summary fix

### DIFF
--- a/components/notion/actions/retrieve-block/retrieve-block.mjs
+++ b/components/notion/actions/retrieve-block/retrieve-block.mjs
@@ -4,7 +4,7 @@ export default {
   key: "notion-retrieve-block",
   name: "Retrieve Page Content",
   description: "Get page content as block objects or markdown. Blocks can be text, lists, media, a page, among others. [See the documentation](https://developers.notion.com/reference/retrieve-a-block)",
-  version: "0.2.0",
+  version: "0.2.1",
   type: "action",
   props: {
     notion,
@@ -42,14 +42,15 @@ export default {
     const subpagesOnly = retrieveChildren === "Sub-Pages Only";
 
     const block = await this.notion.retrieveBlock(this.blockId);
-    if ([
+    const shouldRetrieveChildren = [
       true,
       "All Children",
       "Sub-Pages Only",
-    ].includes(retrieveChildren)) {
+    ].includes(retrieveChildren);
+    if (shouldRetrieveChildren) {
       block.children = await this.notion.retrieveBlockChildren(block, subpagesOnly);
     }
-    $.export("$summary", `Successfully retrieved block${retrieveChildren
+    $.export("$summary", `Successfully retrieved block${shouldRetrieveChildren
       ? ` with ${block.children.length ?? 0} ${subpagesOnly
         ? "sub-pages"
         : "children"}`

--- a/components/notion/package.json
+++ b/components/notion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/notion",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Pipedream Notion Components",
   "main": "notion.app.mjs",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34555,6 +34555,8 @@ snapshots:
       '@putout/operator-filesystem': 5.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))
       '@putout/operator-json': 2.2.0
       putout: 36.13.1(eslint@8.57.1)(typescript@5.6.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@putout/operator-regexp@1.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))':
     dependencies:


### PR DESCRIPTION
Addresses the issue reported in #16214 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal logic for determining when to retrieve children blocks, resulting in cleaner and more maintainable code.
- **Chores**
  - Updated version numbers for the Notion action and package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->