### PR TITLE
add ProxyResponse type, change DEBUG location

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 # Changelog
 
+## [1.5.3] - 2025-04-18
+
+### Added
+
+- Added `ProxyResponse` type for makeProxyRequest
+- changed the location of connect DEBUG calls so they'll still show in the error case.
+
 ## [1.5.2] - 2025-04-15
 
 ### Added

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -7,8 +7,9 @@
 ### Added
 
 - Added `ProxyResponse` type for makeProxyRequest
-- changed the location of connect DEBUG calls so they'll still show in the 
-    error case.
+- changed the location of connect DEBUG calls so they'll still show in the
+  error case.
+
 ## [1.5.2] - 2025-04-15
 
 ### Added

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -7,8 +7,8 @@
 ### Added
 
 - Added `ProxyResponse` type for makeProxyRequest
-- changed the location of connect DEBUG calls so they'll still show in the error case.
-
+- changed the location of connect DEBUG calls so they'll still show in the 
+    error case.
 ## [1.5.2] - 2025-04-15
 
 ### Added

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pipedream/sdk",
   "type": "module",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Pipedream SDK",
   "main": "./dist/server.js",
   "module": "./dist/server.js",

--- a/packages/sdk/src/server/index.ts
+++ b/packages/sdk/src/server/index.ts
@@ -155,7 +155,7 @@ export type ProxyTargetApiRequest = {
  * If the response has a Content-Type of application/json, the body will be parsed
  * and returned as an object. Otherwise the type will be a string.
  */
-export type ProxyResponse = Record<string, any> | string;
+export type ProxyResponse = Record<string, unknown> | string;
 
 /**
  * Creates a new instance of BackendClient with the provided options.

--- a/packages/sdk/src/server/index.ts
+++ b/packages/sdk/src/server/index.ts
@@ -150,6 +150,14 @@ export type ProxyTargetApiRequest = {
 };
 
 /**
+ * The parsed response body from a proxied API request.
+ *
+ * If the response has a Content-Type of application/json, the body will be parsed
+ * and returned as an object. Otherwise the type will be a string.
+ */
+export type ProxyResponse = Record<string, any> | string;
+
+/**
  * Creates a new instance of BackendClient with the provided options.
  *
  * @example
@@ -422,7 +430,7 @@ export class BackendClient extends BaseClient {
    *
    * @returns A promise resolving to the response from the downstream service
    */
-  public makeProxyRequest(proxyOptions: ProxyApiOpts, targetRequest: ProxyTargetApiRequest): Promise<string> {
+  public makeProxyRequest(proxyOptions: ProxyApiOpts, targetRequest: ProxyTargetApiRequest): Promise<ProxyResponse> {
     const url64 = btoa(targetRequest.url).replace(/\+/g, "-")
       .replace(/\//g, "_")
       .replace(/=+$/, "");

--- a/packages/sdk/src/shared/index.ts
+++ b/packages/sdk/src/shared/index.ts
@@ -1021,11 +1021,15 @@ export abstract class BaseClient {
 
     const rawBody = await response.text();
 
+    DEBUG("status: ", response.status)
+    DEBUG("url: ", url.toString())
+    DEBUG("requestOptions: ", requestOptions)
+    DEBUG("rawBody: ", rawBody)
+
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}, body: ${rawBody}`);
     }
 
-    DEBUG(response.status, url.toString(), requestOptions, rawBody)
     const contentType = response.headers.get("Content-Type");
     if (contentType && contentType.includes("application/json")) {
       try {


### PR DESCRIPTION
## WHY

<!-- author to complete -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a changelog entry for version 1.5.3, highlighting recent updates.

- **New Features**
  - Introduced a new response type for proxy requests, allowing responses to be either a JSON object or a string.

- **Style**
  - Enhanced debug logging for connection attempts to ensure messages remain visible even when errors occur.

- **Chores**
  - Updated the package version to 1.5.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->