### PR TITLE
Fix: pass returnFieldsByFieldId to getRecord for Airtable actions

### DIFF
--- a/components/airtable_oauth/actions/create-comment/create-comment.mjs
+++ b/components/airtable_oauth/actions/create-comment/create-comment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "airtable_oauth-create-comment",
   name: "Create Comment",
   description: "Create a comment on a selected record. [See the documentation](https://airtable.com/developers/web/api/create-comment)",
-  version: "0.0.10",
+  version: "0.0.11",
   type: "action",
   props: {
     ...common.props,

--- a/components/airtable_oauth/actions/create-field/create-field.mjs
+++ b/components/airtable_oauth/actions/create-field/create-field.mjs
@@ -5,7 +5,7 @@ export default {
   key: "airtable_oauth-create-field",
   name: "Create Field",
   description: "Create a new field in a table. [See the documentation](https://airtable.com/developers/web/api/create-field)",
-  version: "0.1.2",
+  version: "0.1.3",
   type: "action",
   props: {
     ...common.props,

--- a/components/airtable_oauth/actions/create-multiple-records/create-multiple-records.mjs
+++ b/components/airtable_oauth/actions/create-multiple-records/create-multiple-records.mjs
@@ -9,7 +9,7 @@ export default {
   key: "airtable_oauth-create-multiple-records",
   name: "Create Multiple Records",
   description: "Create one or more records in a table in a single operation with an array. [See the documentation](https://airtable.com/developers/web/api/create-records)",
-  version: "0.0.10",
+  version: "0.0.11",
   type: "action",
   props: {
     ...common.props,

--- a/components/airtable_oauth/actions/create-or-update-record/create-or-update-record.mjs
+++ b/components/airtable_oauth/actions/create-or-update-record/create-or-update-record.mjs
@@ -6,7 +6,7 @@ export default {
   key: "airtable_oauth-create-or-update-record",
   name: "Create or Update Record",
   description: "Create a new record or update an existing one. [See the documentation](https://airtable.com/developers/web/api/create-records)",
-  version: "0.1.2",
+  version: "0.1.3",
   type: "action",
   props: {
     ...common.props,

--- a/components/airtable_oauth/actions/create-single-record/create-single-record.mjs
+++ b/components/airtable_oauth/actions/create-single-record/create-single-record.mjs
@@ -6,7 +6,7 @@ export default {
   key: "airtable_oauth-create-single-record",
   name: "Create Single Record",
   description: "Adds a record to a table.",
-  version: "0.0.11",
+  version: "0.0.12",
   type: "action",
   props: {
     ...common.props,

--- a/components/airtable_oauth/actions/create-table/create-table.mjs
+++ b/components/airtable_oauth/actions/create-table/create-table.mjs
@@ -4,7 +4,7 @@ export default {
   key: "airtable_oauth-create-table",
   name: "Create Table",
   description: "Create a new table. [See the documentation](https://airtable.com/developers/web/api/create-table)",
-  version: "0.0.10",
+  version: "0.0.11",
   type: "action",
   props: {
     airtable,

--- a/components/airtable_oauth/actions/delete-record/delete-record.mjs
+++ b/components/airtable_oauth/actions/delete-record/delete-record.mjs
@@ -5,7 +5,7 @@ export default {
   key: "airtable_oauth-delete-record",
   name: "Delete Record",
   description: "Delete a selected record from a table. [See the documentation](https://airtable.com/developers/web/api/delete-record)",
-  version: "0.0.10",
+  version: "0.0.11",
   type: "action",
   props: {
     ...common.props,

--- a/components/airtable_oauth/actions/get-record-or-create/get-record-or-create.mjs
+++ b/components/airtable_oauth/actions/get-record-or-create/get-record-or-create.mjs
@@ -6,7 +6,7 @@ export default {
   key: "airtable_oauth-get-record-or-create",
   name: "Get Record Or Create",
   description: "Get a specific record, or create one if it doesn't exist. [See the documentation](https://airtable.com/developers/web/api/create-records)",
-  version: "0.0.12",
+  version: "0.0.13",
   type: "action",
   props: {
     ...common.props,

--- a/components/airtable_oauth/actions/get-record/get-record.mjs
+++ b/components/airtable_oauth/actions/get-record/get-record.mjs
@@ -6,7 +6,7 @@ export default {
   key: "airtable_oauth-get-record",
   name: "Get Record",
   description: "Get data of a selected record from a table. [See the documentation](https://airtable.com/developers/web/api/get-record)",
-  version: "0.0.17",
+  version: "0.0.12",
   type: "action",
   props: {
     ...common.props,

--- a/components/airtable_oauth/actions/get-record/get-record.mjs
+++ b/components/airtable_oauth/actions/get-record/get-record.mjs
@@ -6,10 +6,16 @@ export default {
   key: "airtable_oauth-get-record",
   name: "Get Record",
   description: "Get data of a selected record from a table. [See the documentation](https://airtable.com/developers/web/api/get-record)",
-  version: "0.0.11",
+  version: "0.0.17",
   type: "action",
   props: {
     ...common.props,
+    returnFieldsByFieldId: {
+      propDefinition: [
+        airtable,
+        "returnFieldsByFieldId",
+      ],
+    },
     recordId: {
       propDefinition: [
         airtable,

--- a/components/airtable_oauth/actions/list-bases/list-bases.mjs
+++ b/components/airtable_oauth/actions/list-bases/list-bases.mjs
@@ -6,7 +6,7 @@ export default {
   description:
     "Get the list of bases that can be accessed. [See the documentation](https://airtable.com/developers/web/api/list-bases)",
   type: "action",
-  version: "0.0.1",
+  version: "0.0.2",
   props: {
     airtable,
   },

--- a/components/airtable_oauth/actions/list-records-in-view/list-records-in-view.mjs
+++ b/components/airtable_oauth/actions/list-records-in-view/list-records-in-view.mjs
@@ -6,7 +6,7 @@ export default {
   name: "List Records in View",
   description: "Retrieve records from a view, optionally sorting and filtering results. [See the documentation](https://airtable.com/developers/web/api/list-views)",
   type: "action",
-  version: "0.0.10",
+  version: "0.0.11",
   ...commonList,
   props: {
     accountTierAlert: {

--- a/components/airtable_oauth/actions/list-records/list-records.mjs
+++ b/components/airtable_oauth/actions/list-records/list-records.mjs
@@ -6,7 +6,7 @@ export default {
   name: "List Records",
   description: "Retrieve records from a table, optionally sorting and filtering results. [See the documentation](https://airtable.com/developers/web/api/list-records)",
   type: "action",
-  version: "0.0.10",
+  version: "0.0.11",
   ...commonList,
   props: {
     ...common.props,

--- a/components/airtable_oauth/actions/list-tables/list-tables.mjs
+++ b/components/airtable_oauth/actions/list-tables/list-tables.mjs
@@ -6,7 +6,7 @@ export default {
   description:
     "Get a list of tables in the selected base. [See the documentation](https://airtable.com/developers/web/api/get-base-schema)",
   type: "action",
-  version: "0.0.1",
+  version: "0.0.2",
   props: {
     airtable,
     baseId: {

--- a/components/airtable_oauth/actions/search-records/search-records.mjs
+++ b/components/airtable_oauth/actions/search-records/search-records.mjs
@@ -5,7 +5,7 @@ export default {
   key: "airtable_oauth-search-records",
   name: "Search Records",
   description: "Search for a record by formula or by field value. [See the documentation](https://airtable.com/developers/web/api/list-records)",
-  version: "0.0.12",
+  version: "0.0.13",
   type: "action",
   props: {
     ...common.props,

--- a/components/airtable_oauth/actions/update-comment/update-comment.mjs
+++ b/components/airtable_oauth/actions/update-comment/update-comment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "airtable_oauth-update-comment",
   name: "Update Comment",
   description: "Update an existing comment on a selected record. [See the documentation](https://airtable.com/developers/web/api/update-comment)",
-  version: "0.0.10",
+  version: "0.0.11",
   type: "action",
   props: {
     ...common.props,

--- a/components/airtable_oauth/actions/update-field/update-field.mjs
+++ b/components/airtable_oauth/actions/update-field/update-field.mjs
@@ -5,7 +5,7 @@ export default {
   key: "airtable_oauth-update-field",
   name: "Update Field",
   description: "Update an existing field in a table. [See the documentation](https://airtable.com/developers/web/api/update-field)",
-  version: "0.0.10",
+  version: "0.0.11",
   type: "action",
   props: {
     ...common.props,

--- a/components/airtable_oauth/actions/update-record/update-record.mjs
+++ b/components/airtable_oauth/actions/update-record/update-record.mjs
@@ -6,7 +6,7 @@ export default {
   key: "airtable_oauth-update-record",
   name: "Update Record",
   description: "Update a single record in a table by Record ID. [See the documentation](https://airtable.com/developers/web/api/update-record)",
-  version: "0.0.11",
+  version: "0.0.12",
   type: "action",
   props: {
     ...common.props,

--- a/components/airtable_oauth/actions/update-table/update-table.mjs
+++ b/components/airtable_oauth/actions/update-table/update-table.mjs
@@ -4,7 +4,7 @@ export default {
   key: "airtable_oauth-update-table",
   name: "Update Table",
   description: "Update an existing table. [See the documentation](https://airtable.com/developers/web/api/update-table)",
-  version: "0.0.10",
+  version: "0.0.11",
   type: "action",
   props: {
     ...common.props,

--- a/components/airtable_oauth/airtable_oauth.app.mjs
+++ b/components/airtable_oauth/airtable_oauth.app.mjs
@@ -258,10 +258,16 @@ You can also reference an object exported by a previous step, e.g. \`{{steps.foo
         : axios($, config);
     },
     getRecord({
-      baseId, tableId, recordId,
+      baseId,
+      tableId,
+      recordId,
+      opts = {},
     }) {
-      const base = this.base(baseId);
-      return base(tableId).find(recordId);
+      return this._makeRequest({
+        method: "GET",
+        path: `/${baseId}/${tableId}/${recordId}`,
+        params: opts,
+      });
     },
     listBases(args = {}) {
       return this._makeRequest({

--- a/components/airtable_oauth/common/actions.mjs
+++ b/components/airtable_oauth/common/actions.mjs
@@ -92,6 +92,11 @@ export default {
       baseId,
       tableId,
       recordId,
+      // Added 2025-04-22: Ensure returnFieldsByFieldId is passed to the API.
+      // Previously, this option was defined in the action but not forwarded to the API call.
+      opts: {
+        returnFieldsByFieldId: ctx.returnFieldsByFieldId,
+      },
     });
 
     $.export("$summary", `Fetched record "${recordId}" from ${ctx.baseId?.label || baseId}: [${ctx.tableId?.label || tableId}](https://airtable.com/${baseId}/${tableId})`);

--- a/components/airtable_oauth/package.json
+++ b/components/airtable_oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/airtable_oauth",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Pipedream Airtable (OAuth) Components",
   "main": "airtable_oauth.app.mjs",
   "keywords": [

--- a/components/airtable_oauth/sources/new-field/new-field.mjs
+++ b/components/airtable_oauth/sources/new-field/new-field.mjs
@@ -5,7 +5,7 @@ export default {
   name: "New Field Created (Instant)",
   description: "Emit new event when a field is created in the selected table. [See the documentation](https://airtable.com/developers/web/api/get-base-schema)",
   key: "airtable_oauth-new-field",
-  version: "1.0.2",
+  version: "1.0.3",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/airtable_oauth/sources/new-modified-or-deleted-records-instant/new-modified-or-deleted-records-instant.mjs
+++ b/components/airtable_oauth/sources/new-modified-or-deleted-records-instant/new-modified-or-deleted-records-instant.mjs
@@ -8,7 +8,7 @@ export default {
   name: "New Record Created, Updated or Deleted (Instant)",
   description: "Emit new event when a record is added, updated, or deleted in a table or selected view.",
   key: "airtable_oauth-new-modified-or-deleted-records-instant",
-  version: "0.1.2",
+  version: "0.1.3",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/airtable_oauth/sources/new-modified-or-deleted-records/new-modified-or-deleted-records.mjs
+++ b/components/airtable_oauth/sources/new-modified-or-deleted-records/new-modified-or-deleted-records.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New, Modified or Deleted Records",
   description: "Emit new event each time a record is added, updated, or deleted in an Airtable table. Supports tables up to 10,000 records",
   key: "airtable_oauth-new-modified-or-deleted-records",
-  version: "0.0.11",
+  version: "0.0.12",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/airtable_oauth/sources/new-or-modified-field/new-or-modified-field.mjs
+++ b/components/airtable_oauth/sources/new-or-modified-field/new-or-modified-field.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New or Modified Field (Instant)",
   description: "Emit new event when a field is created or updated in the selected table",
   key: "airtable_oauth-new-or-modified-field",
-  version: "1.0.2",
+  version: "1.0.3",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/airtable_oauth/sources/new-or-modified-records-in-view/new-or-modified-records-in-view.mjs
+++ b/components/airtable_oauth/sources/new-or-modified-records-in-view/new-or-modified-records-in-view.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New or Modified Records in View",
   description: "Emit new event for each new or modified record in a view",
   key: "airtable_oauth-new-or-modified-records-in-view",
-  version: "0.0.12",
+  version: "0.0.13",
   type: "source",
   props: {
     ...base.props,

--- a/components/airtable_oauth/sources/new-or-modified-records/new-or-modified-records.mjs
+++ b/components/airtable_oauth/sources/new-or-modified-records/new-or-modified-records.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New or Modified Records (Instant)",
   key: "airtable_oauth-new-or-modified-records",
   description: "Emit new event for each new or modified record in a table or view",
-  version: "1.0.2",
+  version: "1.0.3",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/airtable_oauth/sources/new-records-in-view/new-records-in-view.mjs
+++ b/components/airtable_oauth/sources/new-records-in-view/new-records-in-view.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Records in View",
   description: "Emit new event for each new record in a view",
   key: "airtable_oauth-new-records-in-view",
-  version: "0.0.11",
+  version: "0.0.12",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/airtable_oauth/sources/new-records/new-records.mjs
+++ b/components/airtable_oauth/sources/new-records/new-records.mjs
@@ -5,7 +5,7 @@ export default {
   name: "New Record(s) Created (Instant)",
   description: "Emit new event for each new record in a table",
   key: "airtable_oauth-new-records",
-  version: "1.0.2",
+  version: "1.0.3",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3176,8 +3176,7 @@ importers:
 
   components/danny_test_app: {}
 
-  components/dappier:
-    specifiers: {}
+  components/dappier: {}
 
   components/darksky_api:
     dependencies:


### PR DESCRIPTION
Fixes #16317 


I opened both actions:

    get-record.mjs

    get-record-or-create.mjs

Both use the shared getRecord() method from commonActions.mjs.

I noticed that returnFieldsByFieldId was not being passed to the API when fetching a record — unlike updateRecord(), which correctly includes it via the opts parameter:
```js
updateRecord({
  baseId,
  tableId,
  recordId,
  data: record,
  opts: {
    returnFieldsByFieldId: ctx.returnFieldsByFieldId,
  },
});
```


I inspected getRecord() and found the issue:

```js
getRecord({
  baseId,
  tableId,
  recordId,
}) {
  const base = this.base(baseId);
  return base(tableId).find(recordId); // ❌ No support for opts
}
```

I suspected .find() might not support query parameters, so I checked the Airtable SDK (table.ts) and confirmed:

```js
this.find = callbackToPromise(this._findRecordById, this);
this.update = callbackToPromise(this._updateRecords.bind(this, false), this);
```

These wrap two different functions:

```js
    .update() wraps _updateRecords(..., opts, callback) ✅

    .find() wraps _findRecordById(recordId, callback) ❌
```

Since _findRecordById does not accept opts, and .find() simply wraps it, there's no way to pass returnFieldsByFieldId using the SDK method.


**What I did to fix it**


 I rewrote the internal getRecord() method inside the Airtable app (airtable_oauth.app.mjs) 
to use this._makeRequest() instead of .find(), giving us full control over query parameters:

```js
    getRecord({
  baseId,
  tableId,
  recordId,
  opts = {},
}) {
  return this._makeRequest({
    method: "GET",
    path: `/${baseId}/${tableId}/${recordId}`,
    params: opts,
  });
}

```
Then I updated commonActions.getRecord(...) to pass the returnFieldsByFieldId flag properly:

```js
const response = await ctx.airtable.getRecord({
  baseId,
  tableId,
  recordId,
  opts: {
    returnFieldsByFieldId: ctx.returnFieldsByFieldId, // ✅
  },
});

```

I also updated get-record.mjs to explicitly expose the returnFieldsByFieldId option to the user by adding it as a prop.

I did not need to modify get-record-or-create.mjs, as it already defined the returnFieldsByFieldId prop and passed this to commonActions.getRecord(...).

 **Result**

When testing the updated actions, I confirmed that:

    With returnFieldsByFieldId: true, the response returned field IDs in the fields object

    With it disabled, it returned field names as expected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying which fields to return when retrieving a record from Airtable, allowing more control over the data returned.

- **Refactor**
  - Improved internal handling of Airtable API requests for better consistency and maintainability.

- **Chores**
  - Updated version numbers across multiple actions and sources to ensure component currency and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->