### PR TITLE
Fix: support invoice creation without line items. Stripe.

### DIFF
--- a/components/stripe/actions/cancel-or-reverse-payout/cancel-or-reverse-payout.mjs
+++ b/components/stripe/actions/cancel-or-reverse-payout/cancel-or-reverse-payout.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-cancel-or-reverse-payout",
   name: "Cancel Or Reverse a Payout",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Cancel or reverse a [payout](https://stripe.com/docs/payouts). " +
     "A payout can be canceled only if it has not yet been paid out. A payout can be reversed " +
     "only if it has already been paid out. Funds will be refunded to your available balance. [See" +

--- a/components/stripe/actions/cancel-payment-intent/cancel-payment-intent.mjs
+++ b/components/stripe/actions/cancel-payment-intent/cancel-payment-intent.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-cancel-payment-intent",
   name: "Cancel a Payment Intent",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Cancel a [payment intent](https://stripe.com/docs/payments/payment-intents). " +
     "Once canceled, no additional charges will be made by the payment intent and any operations " +
     "on the payment intent will fail with an error. For payment intents with status=" +

--- a/components/stripe/actions/capture-payment-intent/capture-payment-intent.mjs
+++ b/components/stripe/actions/capture-payment-intent/capture-payment-intent.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-capture-payment-intent",
   name: "Capture a Payment Intent",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Capture the funds of an existing uncaptured payment intent. [See the " +
   "docs](https://stripe.com/docs/api/payment_intents/capture) for more information",
   props: {

--- a/components/stripe/actions/confirm-payment-intent/confirm-payment-intent.mjs
+++ b/components/stripe/actions/confirm-payment-intent/confirm-payment-intent.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-confirm-payment-intent",
   name: "Confirm a Payment Intent",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Confirm that your customer intends to pay with current or provided payment " +
     "method. Upon confirmation, Stripe will attempt to initiate a payment. [See the " +
     "docs](https://stripe.com/docs/api/payment_intents/confirm) for more information",

--- a/components/stripe/actions/create-customer/create-customer.mjs
+++ b/components/stripe/actions/create-customer/create-customer.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-create-customer",
   name: "Create a Customer",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Create a customer. [See the docs](https://stripe.com/docs/api/customers/create) " +
     "for more information",
   props: {

--- a/components/stripe/actions/create-invoice-item/create-invoice-item.mjs
+++ b/components/stripe/actions/create-invoice-item/create-invoice-item.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-create-invoice-item",
   name: "Create Invoice Line Item",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Add a line item to an invoice. [See the " +
     "docs](https://stripe.com/docs/api/invoiceitems/create) for more information",
   props: {

--- a/components/stripe/actions/create-invoice/create-invoice.mjs
+++ b/components/stripe/actions/create-invoice/create-invoice.mjs
@@ -81,7 +81,7 @@ export default {
     },
   },
   async run({ $ }) {
-    const resp = await this.app.sdk().invoices.create({
+    const resp = await this.app.sdk("2022-11-15").invoices.create({
       ...pick(this, [
         "customer",
         "subscription",

--- a/components/stripe/actions/create-invoice/create-invoice.mjs
+++ b/components/stripe/actions/create-invoice/create-invoice.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-create-invoice",
   name: "Create Invoice",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Create an invoice. [See the docs](https://stripe.com/docs/api/invoices/create) " +
     "for more information",
   props: {

--- a/components/stripe/actions/create-payment-intent/create-payment-intent.mjs
+++ b/components/stripe/actions/create-payment-intent/create-payment-intent.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-create-payment-intent",
   name: "Create a Payment Intent",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Create a [payment intent](https://stripe.com/docs/payments/payment-intents). [See" +
     "the docs](https://stripe.com/docs/api/payment_intents/create) for more information",
   props: {

--- a/components/stripe/actions/create-payout/create-payout.mjs
+++ b/components/stripe/actions/create-payout/create-payout.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-create-payout",
   name: "Create a Payout",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Send funds to your own bank account. Your Stripe balance must be able to cover " +
     "the payout amount, or you'll receive an 'Insufficient Funds' error. [See the " +
     "docs](https://stripe.com/docs/api/payouts/create) for more information",

--- a/components/stripe/actions/create-price/create-price.mjs
+++ b/components/stripe/actions/create-price/create-price.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-create-price",
   name: "Create Price",
   description: "Creates a new price for an existing product. The price can be recurring or one-time. [See the documentation](https://stripe.com/docs/api/prices/create)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     app,

--- a/components/stripe/actions/create-product/create-product.mjs
+++ b/components/stripe/actions/create-product/create-product.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-create-product",
   name: "Create Product",
   description: "Creates a new product object in Stripe. [See the documentation](https://stripe.com/docs/api/products/create)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     app,

--- a/components/stripe/actions/create-refund/create-refund.mjs
+++ b/components/stripe/actions/create-refund/create-refund.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-create-refund",
   name: "Create a Refund",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Creating a new refund will refund a charge that has previously been created but " +
     "not yet refunded. Funds will be refunded to the credit or debit card that was originally " +
     "charged. You can optionally refund only part of a charge. You can do so multiple times, " +

--- a/components/stripe/actions/create-subscription/create-subscription.mjs
+++ b/components/stripe/actions/create-subscription/create-subscription.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-create-subscription",
   name: "Create Subscription",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Create a subscription. [See docs here](https://stripe.com/docs/api/subscriptions/create)",
   props: {
     stripe,

--- a/components/stripe/actions/create-usage-record/create-usage-record.mjs
+++ b/components/stripe/actions/create-usage-record/create-usage-record.mjs
@@ -6,7 +6,7 @@ export default {
   key: "stripe-create-usage-record",
   name: "Create a Usage Record",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "With metered billing, you charge your customers based on their consumption of " +
     "your service during the billing cycle, instead of explicitly setting quantities. Use this " +
     " action to create a usage record for metered billing. [See the " +

--- a/components/stripe/actions/delete-customer/delete-customer.mjs
+++ b/components/stripe/actions/delete-customer/delete-customer.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-delete-customer",
   name: "Delete a Customer",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Delete a customer. [See the docs](https://stripe.com/docs/api/customers/delete) " +
     "for more information",
   props: {

--- a/components/stripe/actions/delete-invoice-item/delete-invoice-item.mjs
+++ b/components/stripe/actions/delete-invoice-item/delete-invoice-item.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-delete-invoice-item",
   name: "Delete Invoice Line Item",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Delete a line item from an invoice. [See the " +
     "docs](https://stripe.com/docs/api/invoiceitems/delete) for more information",
   props: {

--- a/components/stripe/actions/delete-or-void-invoice/delete-or-void-invoice.mjs
+++ b/components/stripe/actions/delete-or-void-invoice/delete-or-void-invoice.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-delete-or-void-invoice",
   name: "Delete Or Void Invoice",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Delete a draft invoice, or void a non-draft or subscription invoice. [See the " +
     "docs](https://stripe.com/docs/api/invoiceitems/delete) for more information",
   props: {

--- a/components/stripe/actions/finalize-invoice/finalize-invoice.mjs
+++ b/components/stripe/actions/finalize-invoice/finalize-invoice.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-finalize-invoice",
   name: "Finalize Draft Invoice",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Finalize a draft invoice. [See the " +
     "docs](https://stripe.com/docs/api/invoices/finalize) for more information",
   props: {

--- a/components/stripe/actions/list-balance-history/list-balance-history.mjs
+++ b/components/stripe/actions/list-balance-history/list-balance-history.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-list-balance-history",
   name: "List Balance History",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Returns the last 100 transactions that have contributed to the Stripe account " +
     "balance (e.g., charges, transfers, and so forth). The transactions are returned in " +
     "sorted order, with the most recent transactions appearing first. [See the " +

--- a/components/stripe/actions/list-customers/list-customers.mjs
+++ b/components/stripe/actions/list-customers/list-customers.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-list-customers",
   name: "List Customers",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Find or list customers. [See the " +
     "docs](https://stripe.com/docs/api/customers/list) for more information",
   props: {

--- a/components/stripe/actions/list-invoices/list-invoices.mjs
+++ b/components/stripe/actions/list-invoices/list-invoices.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-list-invoices",
   name: "List Invoices",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Find or list invoices. [See the docs](https://stripe.com/docs/api/invoices/list) " +
     "for more information",
   props: {

--- a/components/stripe/actions/list-payment-intents/list-payment-intents.mjs
+++ b/components/stripe/actions/list-payment-intents/list-payment-intents.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-list-payment-intents",
   name: "List Payment Intents",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Retrieves a list of " +
     "[payment intent](https://stripe.com/docs/payments/payment-intents) that were previously " +
     "created. [See the docs](https://stripe.com/docs/api/payment_intents/list) for more " +

--- a/components/stripe/actions/list-payouts/list-payouts.mjs
+++ b/components/stripe/actions/list-payouts/list-payouts.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-list-payouts",
   name: "List Payouts",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Find or list payouts. [See the docs](https://stripe.com/docs/api/payouts/list) " +
     "for more information",
   props: {

--- a/components/stripe/actions/list-refunds/list-refunds.mjs
+++ b/components/stripe/actions/list-refunds/list-refunds.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-list-refunds",
   name: "List Refunds",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Find or list refunds. [See the docs](https://stripe.com/docs/api/refunds/list) " +
     "for more information",
   props: {

--- a/components/stripe/actions/retrieve-balance/retrieve-balance.mjs
+++ b/components/stripe/actions/retrieve-balance/retrieve-balance.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-retrieve-balance",
   name: "Retrieve the Current Balance",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Retrieves the current account balance, based on the authentication that was used " +
     "to make the request. [See the docs](https://stripe.com/docs/api/balance/balance_retrieve) " +
     "for more information",

--- a/components/stripe/actions/retrieve-checkout-session-line-items/retrieve-checkout-session-line-items.mjs
+++ b/components/stripe/actions/retrieve-checkout-session-line-items/retrieve-checkout-session-line-items.mjs
@@ -4,7 +4,7 @@ export default {
   name: "Retrieve Checkout Session Line Items",
   description: "Given a checkout session ID, retrieve the line items. [See the docs](https://stripe.com/docs/api/checkout/sessions/line_items)",
   key: "stripe-retrieve-checkout-session-line-items",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "action",
   props: {
     app,

--- a/components/stripe/actions/retrieve-checkout-session/retrieve-checkout-session.mjs
+++ b/components/stripe/actions/retrieve-checkout-session/retrieve-checkout-session.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-retrieve-checkout-session",
   name: "Retrieve a Checkout Session",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "A Checkout Session represents your customer's session as they pay for one-time " +
     "purchases or subscriptions through Stripe Checkout. [See the " +
     "docs](https://stripe.com/docs/api/checkout/sessions/retrieve) for more information",

--- a/components/stripe/actions/retrieve-customer/retrieve-customer.mjs
+++ b/components/stripe/actions/retrieve-customer/retrieve-customer.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-retrieve-customer",
   name: "Retrieve a Customer",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Retrieves the details of an existing customer. [See the " +
     "docs](https://stripe.com/docs/api/customers/retrieve) for more information",
   props: {

--- a/components/stripe/actions/retrieve-invoice-item/retrieve-invoice-item.mjs
+++ b/components/stripe/actions/retrieve-invoice-item/retrieve-invoice-item.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-retrieve-invoice-item",
   name: "Retrieve Invoice Line Item",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Retrieve a single line item on an invoice. [See the " +
     "docs](https://stripe.com/docs/api/invoiceitems/retrieve) for more information",
   props: {

--- a/components/stripe/actions/retrieve-invoice/retrieve-invoice.mjs
+++ b/components/stripe/actions/retrieve-invoice/retrieve-invoice.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-retrieve-invoice",
   name: "Retrieve an Invoice",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Retrieves the details of an existing invoice. [See the " +
     "docs](https://stripe.com/docs/api/invoices/retrieve) for more information",
   props: {

--- a/components/stripe/actions/retrieve-payment-intent/retrieve-payment-intent.mjs
+++ b/components/stripe/actions/retrieve-payment-intent/retrieve-payment-intent.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-retrieve-payment-intent",
   name: "Retrieve a Payment Intent",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Retrieves the details of a " +
     "[payment intent](https://stripe.com/docs/payments/payment-intents) that was previously " +
     "created. [See the docs](https://stripe.com/docs/api/payment_intents/retrieve) for more " +

--- a/components/stripe/actions/retrieve-payout/retrieve-payout.mjs
+++ b/components/stripe/actions/retrieve-payout/retrieve-payout.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-retrieve-payout",
   name: "Retrieve a Payout",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Retrieves the details of an existing payout. [See the " +
     "docs](https://stripe.com/docs/api/payouts/retrieve) for more information",
   props: {

--- a/components/stripe/actions/retrieve-price/retrieve-price.mjs
+++ b/components/stripe/actions/retrieve-price/retrieve-price.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-retrieve-price",
   name: "Retrieve a Price",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Retrieves the details of an existing product price. [See the " +
     "docs](https://stripe.com/docs/api/prices/retrieve) for more information",
   props: {

--- a/components/stripe/actions/retrieve-product/retrieve-product.mjs
+++ b/components/stripe/actions/retrieve-product/retrieve-product.mjs
@@ -4,7 +4,7 @@ export default {
   name: "Retrieve Product",
   description: "Retrieve a product by ID. [See the docs](https://stripe.com/docs/api/products/retrieve)",
   key: "stripe-retrieve-product",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "action",
   props: {
     app,

--- a/components/stripe/actions/retrieve-refund/retrieve-refund.mjs
+++ b/components/stripe/actions/retrieve-refund/retrieve-refund.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-retrieve-refund",
   name: "Retrieve a Refund",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Retrieves the details of an existing refund. [See the " +
     "docs](https://stripe.com/docs/api/refunds/retrieve) for more information",
   props: {

--- a/components/stripe/actions/send-invoice/send-invoice.mjs
+++ b/components/stripe/actions/send-invoice/send-invoice.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-send-invoice",
   name: "Send Invoice",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Manually send an invoice to your customer out of the normal schedule for payment " +
     "(note that no emails are actually sent in test mode). [See the " +
     "docs](https://stripe.com/docs/api/invoices/send) for more information",

--- a/components/stripe/actions/update-customer/update-customer.mjs
+++ b/components/stripe/actions/update-customer/update-customer.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-update-customer",
   name: "Update a Customer",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Update a customer. [See the docs](https://stripe.com/docs/api/customers/update) " +
     "for more information",
   props: {

--- a/components/stripe/actions/update-invoice-item/update-invoice-item.mjs
+++ b/components/stripe/actions/update-invoice-item/update-invoice-item.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-update-invoice-item",
   name: "Update Invoice Line Item",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Update an invoice line item. [See the " +
     "docs](https://stripe.com/docs/api/invoiceitems/update) for more information",
   props: {

--- a/components/stripe/actions/update-invoice/update-invoice.mjs
+++ b/components/stripe/actions/update-invoice/update-invoice.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-update-invoice",
   name: "Update Invoice",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Update an invoice. [See the docs](https://stripe.com/docs/api/invoices/update) " +
     "for more information",
   props: {

--- a/components/stripe/actions/update-payment-intent/update-payment-intent.mjs
+++ b/components/stripe/actions/update-payment-intent/update-payment-intent.mjs
@@ -6,7 +6,7 @@ export default {
   key: "stripe-update-payment-intent",
   name: "Update a Payment Intent",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Update a [payment intent](https://stripe.com/docs/payments/payment-intents). [See" +
     " the docs](https://stripe.com/docs/api/payment_intents/update) for more information",
   props: {

--- a/components/stripe/actions/update-payout/update-payout.mjs
+++ b/components/stripe/actions/update-payout/update-payout.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-update-payout",
   name: "Update a Payout",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Update the metadata on a payout. [See the " +
     "docs](https://stripe.com/docs/api/payouts/update) for more information",
   props: {

--- a/components/stripe/actions/update-refund/update-refund.mjs
+++ b/components/stripe/actions/update-refund/update-refund.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-update-refund",
   name: "Update a Refund",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Update the metadata on a refund. [See the " +
     "docs](https://stripe.com/docs/api/refunds/update) for more information",
   props: {

--- a/components/stripe/actions/void-invoice/void-invoice.mjs
+++ b/components/stripe/actions/void-invoice/void-invoice.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-void-invoice",
   name: "Void Invoice",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Void an invoice. [See the docs](https://stripe.com/docs/api/invoices/void) for " +
     "more information",
   props: {

--- a/components/stripe/actions/write-off-invoice/write-off-invoice.mjs
+++ b/components/stripe/actions/write-off-invoice/write-off-invoice.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-write-off-invoice",
   name: "Write Off Invoice",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Mark an invoice as uncollectible. [See the " +
     "docs](https://stripe.com/docs/api/invoices/mark_uncollectible) for more information",
   props: {

--- a/components/stripe/package.json
+++ b/components/stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/stripe",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Pipedream Stripe Components",
   "main": "stripe.app.mjs",
   "keywords": [

--- a/components/stripe/sources/abandoned-cart/abandoned-cart.mjs
+++ b/components/stripe/sources/abandoned-cart/abandoned-cart.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-abandoned-cart",
   name: "New Abandoned Cart",
   type: "source",
-  version: "0.1.1",
+  version: "0.1.2",
   description: "Emit new event when a customer abandons their cart.",
   methods: {
     ...common.methods,

--- a/components/stripe/sources/canceled-subscription/canceled-subscription.mjs
+++ b/components/stripe/sources/canceled-subscription/canceled-subscription.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-canceled-subscription",
   name: "Canceled Subscription",
   type: "source",
-  version: "0.1.1",
+  version: "0.1.2",
   description: "Emit new event for each new canceled subscription",
   methods: {
     ...common.methods,

--- a/components/stripe/sources/custom-webhook-events/custom-webhook-events.mjs
+++ b/components/stripe/sources/custom-webhook-events/custom-webhook-events.mjs
@@ -7,7 +7,7 @@ export default {
   key: "stripe-custom-webhook-events",
   name: "New Custom Webhook Events",
   type: "source",
-  version: "0.1.1",
+  version: "0.1.2",
   description: "Emit new event on each webhook event",
   props: {
     ...common.props,

--- a/components/stripe/sources/new-customer/new-customer.mjs
+++ b/components/stripe/sources/new-customer/new-customer.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-new-customer",
   name: "New Customer",
   type: "source",
-  version: "0.1.1",
+  version: "0.1.2",
   description: "Emit new event for each new customer",
   methods: {
     ...common.methods,

--- a/components/stripe/sources/new-dispute/new-dispute.mjs
+++ b/components/stripe/sources/new-dispute/new-dispute.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-new-dispute",
   name: "New Dispute",
   type: "source",
-  version: "0.1.1",
+  version: "0.1.2",
   description: "Emit new event for each new dispute",
   methods: {
     ...common.methods,

--- a/components/stripe/sources/new-failed-invoice-payment/new-failed-invoice-payment.mjs
+++ b/components/stripe/sources/new-failed-invoice-payment/new-failed-invoice-payment.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-new-failed-invoice-payment",
   name: "New Failed Invoice Payment",
   type: "source",
-  version: "0.1.1",
+  version: "0.1.2",
   description: "Emit new event for each new failed invoice payment",
   methods: {
     ...common.methods,

--- a/components/stripe/sources/new-failed-payment/new-failed-payment.mjs
+++ b/components/stripe/sources/new-failed-payment/new-failed-payment.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-new-failed-payment",
   name: "New Failed Payment",
   type: "source",
-  version: "0.1.1",
+  version: "0.1.2",
   description: "Emit new event for each new failed payment",
   methods: {
     ...common.methods,

--- a/components/stripe/sources/new-invoice/new-invoice.mjs
+++ b/components/stripe/sources/new-invoice/new-invoice.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-new-invoice",
   name: "New Invoice",
   type: "source",
-  version: "0.1.1",
+  version: "0.1.2",
   description: "Emit new event for each new invoice",
   methods: {
     ...common.methods,

--- a/components/stripe/sources/new-payment/new-payment.mjs
+++ b/components/stripe/sources/new-payment/new-payment.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-new-payment",
   name: "New Payment",
   type: "source",
-  version: "0.1.2",
+  version: "0.1.3",
   description: "Emit new event for each new payment",
   methods: {
     ...common.methods,

--- a/components/stripe/sources/new-subscription/new-subscription.mjs
+++ b/components/stripe/sources/new-subscription/new-subscription.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-new-subscription",
   name: "New Subscription",
   type: "source",
-  version: "0.1.1",
+  version: "0.1.2",
   description: "Emit new event for each new subscription",
   methods: {
     ...common.methods,

--- a/components/stripe/sources/subscription-updated/subscription-updated.mjs
+++ b/components/stripe/sources/subscription-updated/subscription-updated.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-subscription-updated",
   name: "Subscription Updated",
   type: "source",
-  version: "0.1.1",
+  version: "0.1.2",
   description: "Emit new event on a new subscription is updated",
   methods: {
     ...common.methods,

--- a/components/stripe/stripe.app.mjs
+++ b/components/stripe/stripe.app.mjs
@@ -658,7 +658,7 @@ export default {
     },
     sdk() {
       return stripe(this._apiKey(), {
-        apiVersion: "2020-03-02",
+        apiVersion: "2022-11-15",
         maxNetworkRetries: 2,
       });
     },

--- a/components/stripe/stripe.app.mjs
+++ b/components/stripe/stripe.app.mjs
@@ -656,9 +656,9 @@ export default {
     _apiKey() {
       return this.$auth.api_key;
     },
-    sdk() {
+    sdk(apiVersion = "2020-03-02") {
       return stripe(this._apiKey(), {
-        apiVersion: "2022-11-15",
+        apiVersion,
         maxNetworkRetries: 2,
       });
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2864,8 +2864,7 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
 
-  components/consulta_unica:
-    specifiers: {}
+  components/consulta_unica: {}
 
   components/contact_enhance:
     dependencies:


### PR DESCRIPTION
Fixes #16354 
## What’s Fixed

This PR allows Stripe invoices to be created **without line items**, using:

- `collection_method: "send_invoice"`
- `due_date` or `days_until_due`

This works as expected in newer Stripe API versions, but **fails in the old one (2020-03-02)** with:
> "Nothing to invoice for customer"

## What Changed

- Updated the `apiVersion` used inside `this.stripe.sdk()` from `"2020-03-02"` → `"2022-11-15"`

## ⚠️⚠️⚠️ WARNING – Potential Breaking Change ⚠️⚠️⚠️

This PR **does not touch any other action logic**, but **upgrades the Stripe API version globally** inside `this.stripe.sdk()`.

That means:
- Any other Stripe action relying on older behavior might break silently or throw unexpected errors.
- Stripe's API is **version-sensitive**, and even minor field differences could trigger issues downstream.

## Suggested Next Steps

- Thoroughly test key actions (e.g. `create-payment-intent`, `create-customer`, etc.).
- Consider making this version update opt-in (e.g. `sdkNew()`).
- If merging globally, update changelog and notify integration users.

## Why It Matters

This bug was open for 5+ days and is blocking users from creating draft invoices correctly — a required flow for many billing pipelines.

---

Let me know if you’d like help writing regression tests or scoping this into a safer "v2" variant!



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated Stripe integration to allow dynamic specification of API versions for enhanced flexibility.
	- Incremented version numbers across multiple Stripe actions and source components for consistency and maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->