### PR TITLE
[ACTION] Get Voices with Descriptions from ElevenLabs

### DIFF
--- a/components/elevenlabs/actions/get-voices-with-descriptions/get-voices-with-descriptions.mjs
+++ b/components/elevenlabs/actions/get-voices-with-descriptions/get-voices-with-descriptions.mjs
@@ -1,0 +1,19 @@
+import elevenlabs from "../../elevenlabs.app.mjs";
+
+export default {
+  key: "get-voices-with-descriptions",
+  name: "Get Voices with Descriptions",
+  version: "0.0.1",
+  description: "Fetches all available voices from ElevenLabs, including metadata like name, gender, accent, and category. [API Docs](https://docs.elevenlabs.io/api-reference/voices/list)",
+  type: "action",
+  props: {
+    elevenlabs,
+  },
+  async run({ $ }) {
+    const { voices } = await this.elevenlabs.listVoices({ $ });
+
+    $.export("$summary", `Fetched ${voices.length} voices`);
+
+    return voices;
+  },
+};


### PR DESCRIPTION
#16371 
This action returns a list of all available voices with metadata.
I initially considered adding filters (e.g., by gender or accent), but realized most developers would prefer to handle that logic on their side — so I kept the action simple.

If needed, I can easily add filtering support later.
