### PR TITLE
Apollo search contacts bug fix

### DIFF
--- a/components/apollo_io/actions/add-contacts-to-sequence/add-contacts-to-sequence.mjs
+++ b/components/apollo_io/actions/add-contacts-to-sequence/add-contacts-to-sequence.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Add Contacts to Sequence",
   description: "Adds one or more contacts to a sequence in Apollo.io. [See the documentation](https://apolloio.github.io/apollo-api-docs/?shell#add-contacts-to-sequence)",
   type: "action",
-  version: "0.0.5",
+  version: "0.0.6",
   props: {
     app,
     sequenceId: {

--- a/components/apollo_io/actions/create-account/create-account.mjs
+++ b/components/apollo_io/actions/create-account/create-account.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Create Account",
   description: "Creates a new account in Apollo.io. [See the documentation](https://apolloio.github.io/apollo-api-docs/?shell#create-an-account)",
   type: "action",
-  version: "0.0.5",
+  version: "0.0.6",
   props: {
     app,
     name: {

--- a/components/apollo_io/actions/create-contact/create-contact.mjs
+++ b/components/apollo_io/actions/create-contact/create-contact.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Create Contact",
   description: "Creates a new contact in Apollo.io. [See the documentation](https://apolloio.github.io/apollo-api-docs/?shell#create-a-contact)",
   type: "action",
-  version: "0.0.6",
+  version: "0.0.7",
   props: {
     app,
     email: {

--- a/components/apollo_io/actions/create-opportunity/create-opportunity.mjs
+++ b/components/apollo_io/actions/create-opportunity/create-opportunity.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Create Opportunity",
   description: "Creates a new opportunity in Apollo.io. [See the documentation](https://apolloio.github.io/apollo-api-docs/?shell#create-opportunity)",
   type: "action",
-  version: "0.0.4",
+  version: "0.0.5",
   props: {
     app,
     ownerId: {

--- a/components/apollo_io/actions/create-update-contact/create-update-contact.mjs
+++ b/components/apollo_io/actions/create-update-contact/create-update-contact.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Create Or Update Contact",
   description: "Creates or updates a specific contact. If the contact email already exists, it's updated. Otherwise, a new contact is created. [See the documentation](https://apolloio.github.io/apollo-api-docs/?shell#create-a-contact)",
   type: "action",
-  version: "0.0.3",
+  version: "0.0.4",
   props: {
     app,
     email: {

--- a/components/apollo_io/actions/get-opportunity/get-opportunity.mjs
+++ b/components/apollo_io/actions/get-opportunity/get-opportunity.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Get Opportunity",
   description: "Gets a specific opportunity in Apollo.io. [See the documentation](https://apolloio.github.io/apollo-api-docs/?shell#view-opportunity)",
   type: "action",
-  version: "0.0.4",
+  version: "0.0.5",
   props: {
     app,
     opportunityId: {

--- a/components/apollo_io/actions/people-enrichment/people-enrichment.mjs
+++ b/components/apollo_io/actions/people-enrichment/people-enrichment.mjs
@@ -5,7 +5,7 @@ export default {
   name: "People Enrichment",
   description: "Enriches a person's information, the more information you pass in, the more likely we can find a match. [See the documentation](https://apolloio.github.io/apollo-api-docs/?shell#people-enrichment)",
   type: "action",
-  version: "0.0.7",
+  version: "0.0.8",
   props: {
     app,
     firstName: {

--- a/components/apollo_io/actions/search-accounts/search-accounts.mjs
+++ b/components/apollo_io/actions/search-accounts/search-accounts.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Search For Accounts",
   description: "Search for accounts in Apollo.io. [See the documentation](https://apolloio.github.io/apollo-api-docs/?shell#search-for-accounts)",
   type: "action",
-  version: "0.0.4",
+  version: "0.0.5",
   props: {
     app,
     search: {

--- a/components/apollo_io/actions/search-contacts/search-contacts.mjs
+++ b/components/apollo_io/actions/search-contacts/search-contacts.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Search For Contacts",
   description: "Search for contacts in Apollo.io. [See the documentation](https://apolloio.github.io/apollo-api-docs/?shell#search-for-contacts)",
   type: "action",
-  version: "0.0.6", 
+  version: "0.0.6",
   props: {
     app,
     search: {

--- a/components/apollo_io/actions/search-contacts/search-contacts.mjs
+++ b/components/apollo_io/actions/search-contacts/search-contacts.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Search For Contacts",
   description: "Search for contacts in Apollo.io. [See the documentation](https://apolloio.github.io/apollo-api-docs/?shell#search-for-contacts)",
   type: "action",
-  version: "0.0.4",
+  version: "0.0.6", //4
   props: {
     app,
     search: {
@@ -43,7 +43,7 @@ export default {
     },
   },
   async run({ $ }) {
-    const resourcesStream = this.app.getResourcesStream({
+    const resourcesStream = this.app.getIterations({
       resourceFn: this.app.searchContacts,
       resourceFnArgs: {
         params: {
@@ -56,7 +56,7 @@ export default {
       resourceName: "contacts",
     });
 
-    const contacts = await utils.streamIterator(resourcesStream);
+    const contacts = await utils.iterate(resourcesStream);
 
     $.export("$summary", `Successfully fetched ${contacts.length} contacts.`);
 

--- a/components/apollo_io/actions/search-contacts/search-contacts.mjs
+++ b/components/apollo_io/actions/search-contacts/search-contacts.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Search For Contacts",
   description: "Search for contacts in Apollo.io. [See the documentation](https://apolloio.github.io/apollo-api-docs/?shell#search-for-contacts)",
   type: "action",
-  version: "0.0.6", //4
+  version: "0.0.6", 
   props: {
     app,
     search: {

--- a/components/apollo_io/actions/search-sequences/search-sequences.mjs
+++ b/components/apollo_io/actions/search-sequences/search-sequences.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Search For Sequences",
   description: "Search for sequences in Apollo.io. [See the documentation](https://apolloio.github.io/apollo-api-docs/?shell#search-for-sequences)",
   type: "action",
-  version: "0.0.4",
+  version: "0.0.5",
   props: {
     app,
     search: {

--- a/components/apollo_io/actions/search-sequences/search-sequences.mjs
+++ b/components/apollo_io/actions/search-sequences/search-sequences.mjs
@@ -16,7 +16,7 @@ export default {
     },
   },
   async run({ $ }) {
-    const resourcesStream = this.app.getResourcesStream({
+    const resourcesStream = this.app.getIterations({
       resourceFn: this.app.listSequences,
       resourceFnArgs: {
         params: {
@@ -26,7 +26,7 @@ export default {
       resourceName: "emailer_campaigns",
     });
 
-    const sequences = await utils.streamIterator(resourcesStream);
+    const sequences = await utils.iterate(resourcesStream);
 
     $.export("$summary", `Successfully fetched ${sequences.length} sequences.`);
 

--- a/components/apollo_io/actions/search-sequences/search-sequences.mjs
+++ b/components/apollo_io/actions/search-sequences/search-sequences.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Search For Sequences",
   description: "Search for sequences in Apollo.io. [See the documentation](https://apolloio.github.io/apollo-api-docs/?shell#search-for-sequences)",
   type: "action",
-  version: "0.0.5",
+  version: "0.0.6",
   props: {
     app,
     search: {

--- a/components/apollo_io/actions/update-account-stage/update-account-stage.mjs
+++ b/components/apollo_io/actions/update-account-stage/update-account-stage.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Update Account Stage",
   description: "Updates the stage of one or more accounts in Apollo.io. [See the documentation](https://apolloio.github.io/apollo-api-docs/?shell#update-account-stage)",
   type: "action",
-  version: "0.0.5",
+  version: "0.0.6",
   props: {
     app,
     accountIds: {

--- a/components/apollo_io/actions/update-account/update-account.mjs
+++ b/components/apollo_io/actions/update-account/update-account.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Update Account",
   description: "Updates an existing account in Apollo.io. [See the documentation](https://apolloio.github.io/apollo-api-docs/?shell#update-an-account)",
   type: "action",
-  version: "0.0.5",
+  version: "0.0.6",
   props: {
     app,
     accountId: {

--- a/components/apollo_io/actions/update-contact-stage/update-contact-stage.mjs
+++ b/components/apollo_io/actions/update-contact-stage/update-contact-stage.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Update Contact Stage",
   description: "Updates the stage of one or more contacts in Apollo.io. [See the documentation](https://apolloio.github.io/apollo-api-docs/?shell#update-contact-stage)",
   type: "action",
-  version: "0.0.5",
+  version: "0.0.6",
   props: {
     app,
     contactIds: {

--- a/components/apollo_io/actions/update-contact/update-contact.mjs
+++ b/components/apollo_io/actions/update-contact/update-contact.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Update Contact",
   description: "Updates an existing contact in Apollo.io. [See the documentation](https://apolloio.github.io/apollo-api-docs/?shell#update-a-contact)",
   type: "action",
-  version: "0.0.6",
+  version: "0.0.7",
   props: {
     app,
     contactId: {

--- a/components/apollo_io/actions/update-opportunity/update-opportunity.mjs
+++ b/components/apollo_io/actions/update-opportunity/update-opportunity.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Update Opportunity",
   description: "Updates a new opportunity in Apollo.io. [See the documentation](https://apolloio.github.io/apollo-api-docs/?shell#update-opportunity)",
   type: "action",
-  version: "0.0.4",
+  version: "0.0.5",
   props: {
     app,
     opportunityId: {

--- a/components/apollo_io/apollo_io.app.mjs
+++ b/components/apollo_io/apollo_io.app.mjs
@@ -216,7 +216,7 @@ export default {
       return {
         "Content-Type": "application/json",
         "Cache-Control": "no-cache",
-        "X-Api-Key": this.$auth.api_key, // ✅ this is correct
+        "X-Api-Key": this.$auth.api_key,
         ...headers,
       };
     },

--- a/components/apollo_io/apollo_io.app.mjs
+++ b/components/apollo_io/apollo_io.app.mjs
@@ -216,12 +216,12 @@ export default {
       return {
         "Content-Type": "application/json",
         "Cache-Control": "no-cache",
+        "X-Api-Key": this.$auth.api_key, // ✅ this is correct
         ...headers,
       };
     },
     getParams(params) {
       return {
-        api_key: this.$auth.api_key,
         ...params,
       };
     },

--- a/components/apollo_io/package.json
+++ b/components/apollo_io/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/apollo_io",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Pipedream Apollo.io Components",
   "main": "apollo_io.app.mjs",
   "keywords": [

--- a/components/apollo_io/sources/account-created/account-created.mjs
+++ b/components/apollo_io/sources/account-created/account-created.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Account Created",
   description: "Emit new event when an account is created. [See the documentation](https://apolloio.github.io/apollo-api-docs/?shell#search-for-accounts)",
   type: "source",
-  version: "0.0.5",
+  version: "0.0.6",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/apollo_io/sources/account-updated/account-updated.mjs
+++ b/components/apollo_io/sources/account-updated/account-updated.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Account Updated",
   description: "Emit new event when an account is updated. [See the documentation](https://apolloio.github.io/apollo-api-docs/?shell#search-for-contacts)",
   type: "source",
-  version: "0.0.5",
+  version: "0.0.6",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/apollo_io/sources/contact-created/contact-created.mjs
+++ b/components/apollo_io/sources/contact-created/contact-created.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Contact Created",
   description: "Emit new event when a contact is created. [See the documentation](https://apolloio.github.io/apollo-api-docs/?shell#search-for-contacts)",
   type: "source",
-  version: "0.0.7",
+  version: "0.0.8",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/apollo_io/sources/contact-updated/contact-updated.mjs
+++ b/components/apollo_io/sources/contact-updated/contact-updated.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Contact Updated",
   description: "Emit new event when a contact is updated. [See the documentation](https://apolloio.github.io/apollo-api-docs/?shell#search-for-contacts)",
   type: "source",
-  version: "0.0.7",
+  version: "0.0.8",
   dedupe: "unique",
   methods: {
     ...common.methods,


### PR DESCRIPTION
Fixes #16421 

While testing the Apollo integration, I noticed a few things that needed fixing:

getResourcesStream wasn’t defined, but elsewhere in the code getIterations was being used 
for the same purpose — so I switched to that

There was a small mismatch — utils.streamIterator didn’t exist, but utils.iterate does, so I fixed that

Apollo’s API expected the key in the X-Api-Key header instead of the query params, so I updated the headers accordingly.
Should be fine — but just in case something explodes, you’ve been gently warned 😅

Tested everything using a free Apollo.io account. Auth works, pagination works, and the action runs successfully (even if it returns 0 contacts for now).
 Forgive me in advance if I missed something — happy to adjust anything if needed! 🙂

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The method for sending API keys has been updated to use a secure HTTP header instead of a query parameter.

- **Bug Fixes**
	- Improved reliability and consistency when retrieving paginated contact and sequence data.

- **Chores**
	- Updated version numbers for multiple actions and sources to reflect recent changes and improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->