### PR TITLE
servers: Don't use an auth token that expires within 1 second.

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # Changelog
 
+## [1.5.4] - 2025-04-25
+
+### Added
+
+- Changed server-side authorized requests to refresh its auth token if it expires within 1 second.
+
 ## [1.5.3] - 2025-04-18
 
 ### Added

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 ### Added
 
-- Changed server-side authorized requests to refresh its auth token if it expires within 1 second.
-
+- Changed server-side authorized requests to refresh its auth token if it expires 
+  within 1 second.
 ## [1.5.3] - 2025-04-18
 
 ### Added

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -6,8 +6,9 @@
 
 ### Added
 
-- Changed server-side authorized requests to refresh its auth token if it expires 
+- Changed server-side authorized requests to refresh its auth token if it expires
   within 1 second.
+
 ## [1.5.3] - 2025-04-18
 
 ### Added

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pipedream/sdk",
   "type": "module",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Pipedream SDK",
   "main": "./dist/server.js",
   "module": "./dist/server.js",

--- a/packages/sdk/src/server/index.ts
+++ b/packages/sdk/src/server/index.ts
@@ -258,7 +258,7 @@ export class BackendClient extends BaseClient {
     let attempts = 0;
     const maxAttempts = 2;
 
-    while (!this.oauthAccessToken || this.oauthAccessToken.expiresAt - Date.now() <= 0) {
+    while (!this.oauthAccessToken || this.oauthAccessToken.expiresAt - Date.now() < 1000) {
       if (attempts > maxAttempts) {
         throw new Error("ran out of attempts trying to retrieve oauth access token");
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -550,8 +550,7 @@ importers:
         specifier: ^4.0.0
         version: 4.0.1
 
-  components/airpinpoint:
-    specifiers: {}
+  components/airpinpoint: {}
 
   components/airplane:
     dependencies:
@@ -14006,8 +14005,7 @@ importers:
 
   components/vk: {}
 
-  components/vlm_run:
-    specifiers: {}
+  components/vlm_run: {}
 
   components/voice: {}
 


### PR DESCRIPTION
## WHY

<!-- author to complete -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of server-side authorized requests by refreshing authentication tokens up to 1 second before expiration.

- **Documentation**
  - Updated changelog to reflect changes in version 1.5.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->