### PR TITLE
Clarifying OAuth client usage for accounts API

### DIFF
--- a/docs-v2/pages/connect/api.mdx
+++ b/docs-v2/pages/connect/api.mdx
@@ -428,7 +428,7 @@ Never return user credentials to the client
 </Callout>
 
 <Callout type="info">
-To retrieve the credentials for any account in `production` for OAuth apps (Slack, Google Sheets, etc), the connected account must be using [your own OAuth client](/connect/managed-auth/oauth-clients/#using-a-custom-oauth-client). You can only retrieve end user credentials for accounts that are using Pipedream's OAuth clients in `development`. [Learn more here](/connect/managed-auth/oauth-clients/#using-pipedream-oauth).
+To retrieve credentials for a connected account for **OAuth** apps (Slack, Google Sheets, etc), the connected account must be using [your own OAuth client](/connect/managed-auth/oauth-clients/#using-a-custom-oauth-client).
 </Callout>
 
 ##### Examples
@@ -681,7 +681,7 @@ Never return user credentials to the client
 </Callout>
 
 <Callout type="info">
-To retrieve the credentials for any account in `production` for OAuth apps (Slack, Google Sheets, etc), the connected account must be using [your own OAuth client](/connect/managed-auth/oauth-clients/#using-a-custom-oauth-client). You can only retrieve end user credentials for accounts that are using Pipedream's OAuth clients in `development`. [Learn more here](/connect/managed-auth/oauth-clients/#using-pipedream-oauth).
+To retrieve credentials for a connected account for **OAuth** apps (Slack, Google Sheets, etc), the connected account must be using [your own OAuth client](/connect/managed-auth/oauth-clients/#using-a-custom-oauth-client).
 </Callout>
 
 ##### Examples

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3176,8 +3176,7 @@ importers:
 
   components/danny_test_app: {}
 
-  components/dappier:
-    specifiers: {}
+  components/dappier: {}
 
   components/darksky_api:
     dependencies:


### PR DESCRIPTION
## WHY

<!-- author to complete -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Simplified and clarified the explanation for retrieving credentials of connected accounts for OAuth apps, removing environment-specific details and focusing on the requirement for custom OAuth clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->