### PR TITLE
Gmail 'Create Draft' improvement

### DIFF
--- a/components/gmail/actions/create-draft/create-draft.mjs
+++ b/components/gmail/actions/create-draft/create-draft.mjs
@@ -6,7 +6,7 @@ export default {
   key: "gmail-create-draft",
   name: "Create Draft",
   description: "Create a draft from your Google Workspace email account. [See the documentation](https://developers.google.com/gmail/api/reference/rest/v1/users.drafts/create)",
-  version: "0.0.5",
+  version: "0.1.0",
   type: "action",
   props: {
     gmail,

--- a/components/gmail/actions/create-draft/create-draft.mjs
+++ b/components/gmail/actions/create-draft/create-draft.mjs
@@ -73,6 +73,18 @@ export default {
         "mimeType",
       ],
     },
+    fromEmail: {
+      propDefinition: [
+        gmail,
+        "fromEmail",
+      ],
+    },
+    signature: {
+      propDefinition: [
+        gmail,
+        "signature",
+      ],
+    },
   },
   async run({ $ }) {
     this.attachmentFilenames = utils.parseArray(this.attachmentFilenames);

--- a/components/gmail/gmail.app.mjs
+++ b/components/gmail/gmail.app.mjs
@@ -318,11 +318,11 @@ export default {
         }
       }
 
-      if (props.signature) {
-        props.body += props.signature;
-      }
-
       if (props.bodyType === constants.BODY_TYPES.HTML) {
+        if (props.signature) {
+          props.body += props.signature;
+        }
+
         opts.html = props.body;
       } else {
         opts.text = props.body;

--- a/components/gmail/gmail.app.mjs
+++ b/components/gmail/gmail.app.mjs
@@ -318,6 +318,10 @@ export default {
         }
       }
 
+      if (props.signature) {
+        props.body += props.signature;
+      }
+
       if (props.bodyType === constants.BODY_TYPES.HTML) {
         opts.html = props.body;
       } else {

--- a/components/gmail/gmail.app.mjs
+++ b/components/gmail/gmail.app.mjs
@@ -118,7 +118,7 @@ export default {
     signature: {
       type: "string",
       label: "Signature",
-      description: "An HTML signature composed in the Gmail Web UI that will be included in the message",
+      description: "An HTML signature composed in the Gmail Web UI that will be included in the message. Only works with the `HTML` body type.",
       optional: true,
       async options() {
         const { sendAs } = await this.listSignatures();

--- a/components/gmail/package.json
+++ b/components/gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/gmail",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Pipedream Gmail Components",
   "main": "gmail.app.mjs",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3176,8 +3176,7 @@ importers:
 
   components/danny_test_app: {}
 
-  components/dappier:
-    specifiers: {}
+  components/dappier: {}
 
   components/darksky_api:
     dependencies:


### PR DESCRIPTION
Closes #15556 

Note: only signatures that are explicitly set as the sender email's signature can be selected (those that are not, are not returned by Gmail's API, but a custom value can still be used)

Regarding PR checks, only updating the version of 1 component since no others use the signature property which was added in the app file's method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added options to specify the sender's email address and include an email signature when creating Gmail drafts.

- **Improvements**
  - Enhanced signature handling so that HTML signatures are automatically appended to the email body when using HTML format.
  - Clarified the description for the signature property to indicate it applies only to HTML email bodies.

- **Chores**
  - Updated package version numbers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->