### PR TITLE
Adding documentation for using Google Ads in the Connect Proxy

### DIFF
--- a/components/google_ads/README.md
+++ b/components/google_ads/README.md
@@ -19,16 +19,16 @@ such as creating and managing campaigns, adding and removing keywords, and
 adjusting bids. You can also use the API to get information about your
 campaigns, such as campaign stats, keyword stats, and ad performance.
 
-## Customizing API requests with the Pipedream proxy
+## Customizing API requests from within the Pipedream workflow builder
 
-The Pipedream components interact with Google Ads API through Pipedream's proxy service, which handles authentication and developer token requirements.
+The Pipedream components interact with Google Ads API through an interal proxy service, which protects Pipedream's developer token.
 
 The component accepts a standard Google Ads API request object with the following structure:
 
 ```javascript
 const googleAdsReq = {
   method: "get|post|put|delete", // HTTP method
-  url: "/v16/...", // Google Ads API endpoint path
+  url: "/v18/...", // Google Ads API endpoint path
   headers: {
     Authorization: `Bearer ${this.googleAds.$auth.oauth_access_token}`,
   },
@@ -58,4 +58,79 @@ const googleAdsReq = {
 };
 ```
 
-The proxy endpoint will remain the same: `https://googleads.m.pipedream.net`
+**The proxy endpoint will remain the same: `https://googleads.m.pipedream.net`**
+
+## Using Google Ads with the Connect API Proxy
+
+To interface with Google Ads via the [Connect API Proxy](https://pipedream.com/docs/connect/api-proxy), you essentially need to nest the request like this:
+
+**Important notes:**
+
+- The upstream URL in this case is Pipedream's proxy service for Google Ads
+- Like in the [above examples](#customizing-api-requests-from-within-the-pipedream-workflow-builder), you'll define the Google Ads URL with the `url` param in the `body`
+- The `method` to the Connect Proxy should always be a `POST`, since it's actually targeting the Google Ads proxy (define the method for the Google Ads request in `options.body.method`)
+
+### Using the Pipedream SDK
+
+```javascript
+const pd = createBackendClient({
+  apiHost: process.env.API_HOST,
+  credentials: {
+    clientId: process.env.CLIENT_ID,
+    clientSecret: process.env.CLIENT_SECRET,
+  },
+  environment: process.env.ENVIRONMENT,
+  projectId: process.env.PROJECT_ID,
+});
+
+const pdGoogleAdsUrl = "https://googleads.m.pipedream.net";
+
+const resp = await pd.makeProxyRequest(
+  {
+    searchParams: {
+      external_user_id: process.env.EXTERNAL_USER_ID,
+      account_id: process.env.ACCOUNT_ID,
+    },
+  },
+  {
+    url: pdGoogleAdsUrl,
+    options: {
+      method: "POST",
+      body: {
+        url: "/v19/customers:listAccessibleCustomers",
+        method: "GET",
+        // data: {} // If you need to send a body with a POST request, define it here
+      },
+    },
+  }
+);
+```
+
+### Using the Connect REST API
+
+```bash
+# First, obtain an OAuth access token to authenticate to the Pipedream API
+
+curl -X POST https://api.pipedream.com/v1/oauth/token \
+  -H "Content-Type: application/json" \
+  -d '{
+    "grant_type": "client_credentials",
+    "client_id": "{your_oauth_client_id}",
+    "client_secret": "{your_oauth_client_secret}"
+  }'
+
+# The response will include an access_token. Use it in the Authorization header below.
+
+# Base64 encode the Pipedream endpoint for Google Ads: https://googleads.m.pipedream.net
+
+curl -X POST "https://api.pipedream.com/v1/connect/{your_project_id}/proxy/{url_safe_base64_encoded_url}?external_user_id={external_user_id}&account_id={apn_xxxxxxx}" \
+  -H "Authorization: Bearer {access_token}" \
+  -H "x-pd-environment: {development | production}" \
+  -d '{
+    "url": "/v19/customers:listAccessibleCustomers",
+    "method": "GET",
+    # "data": {} # If you need to send a body with a POST request, define it here
+  }'
+
+# Parse and return the data you need
+```


### PR DESCRIPTION
## WHY

<!-- author to complete -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified customization instructions for API requests within the Pipedream workflow builder.
  - Updated example requests to use Google Ads API version v18.
  - Revised description of the internal proxy service to highlight its role in protecting the developer token.
  - Added a detailed section on using Google Ads with the Connect API Proxy, including example code and important usage notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->