### PR TITLE
Add the email property to the create customer component of quickbooks

### DIFF
--- a/components/quickbooks/actions/create-customer/create-customer.mjs
+++ b/components/quickbooks/actions/create-customer/create-customer.mjs
@@ -5,7 +5,7 @@ export default {
   key: "quickbooks-create-customer",
   name: "Create Customer",
   description: "Creates a customer. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/customer#create-a-customer)",
-  version: "0.1.8",
+  version: "0.1.9",
   type: "action",
   props: {
     quickbooks,
@@ -45,6 +45,12 @@ export default {
         "suffix",
       ],
     },
+    primaryEmailAddr: { 
+      propDefinition: [
+        quickbooks,
+        "primaryEmailAddr",
+      ],
+    },
   },
   async run({ $ }) {
     if (
@@ -63,6 +69,7 @@ export default {
         MiddleName: this.middleName,
         FamilyName: this.familyName,
         GivenName: this.givenName,
+        PrimaryEmailAddr: {Address: this.primaryEmailAddr},
       },
     });
 

--- a/components/quickbooks/quickbooks.app.mjs
+++ b/components/quickbooks/quickbooks.app.mjs
@@ -421,6 +421,12 @@ export default {
       description: "Suffix of the name. For example, `Jr`. The `DisplayName` attribute or at least one of `Title`, `GivenName`, `MiddleName`, `FamilyName`, or `Suffix` attributes is required for object create.",
       optional: true,
     },
+    primaryEmailAddr: {
+      label: "Email",
+      type: "string",
+      description: "Primary email address of the person or organization.",
+      optional: true,
+    },
     accountingMethod: {
       type: "string",
       label: "Accounting Method",


### PR DESCRIPTION
## WHY
The current implementation of the QuickBooks "Create Customer" action lacks a feature: the ability to set a customer's email address during creation.

The QuickBooks API fully supports setting email addresses during customer creation, so this change simply exposes existing API capabilities that were previously unavailable in the Pipedream component.
<!-- author to complete -->
