### PR TITLE
Create BackenClient with static access token

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # Changelog
 
+## [1.6.2] - 2025-05-20a
+
+### Added
+
+- Added ability to create a `BackendClient` with just an `AccessToken`
+
 ## [1.6.1] - 2025-05-20
 
 ### Added

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pipedream/sdk",
   "type": "module",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Pipedream SDK",
   "main": "./dist/server.js",
   "module": "./dist/server.js",


### PR DESCRIPTION
## WHY

<!-- author to complete -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - You can now create a BackendClient instance using only an access token, without requiring OAuth credentials.

- **Documentation**
  - Updated the changelog to reflect the new access token authentication feature.

- **Chores**
  - Bumped the SDK package version to 1.6.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->