### PR TITLE
add rawAccessToken() to BackendClient

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # Changelog
 
+## [1.6.3] - 2025-05-20b
+
+### Added
+
+- Added `rawAccessToken` getter to `BackendClient`
+
 ## [1.6.2] - 2025-05-20a
 
 ### Added

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pipedream/sdk",
   "type": "module",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Pipedream SDK",
   "main": "./dist/server.js",
   "module": "./dist/server.js",

--- a/packages/sdk/src/server/index.ts
+++ b/packages/sdk/src/server/index.ts
@@ -251,6 +251,12 @@ export class BackendClient extends BaseClient {
     }
   }
 
+  /**
+   * Returns the raw access token string or a promise resolving to it.
+   * This can be used when you need the token directly without Authorization header formatting.
+   *
+   * @returns A string or promise resolving to the access token.
+   */
   public rawAccessToken(): string | Promise<string> {
     if (this.staticAccessToken) {
       return this.staticAccessToken;

--- a/packages/sdk/src/server/index.ts
+++ b/packages/sdk/src/server/index.ts
@@ -251,6 +251,13 @@ export class BackendClient extends BaseClient {
     }
   }
 
+  public rawAccessToken(): string | Promise<string> {
+    if (this.staticAccessToken) {
+      return this.staticAccessToken;
+    }
+    return this.ensureValidOauthAccessToken();
+  }
+
   protected authHeaders(): string | Promise<string> {
     if (this.staticAccessToken) {
       return `Bearer ${this.staticAccessToken}`;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8669,8 +8669,7 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
 
-  components/nextlead:
-    specifiers: {}
+  components/nextlead: {}
 
   components/nexudus: {}
 
@@ -13980,8 +13979,7 @@ importers:
 
   components/usps: {}
 
-  components/utopian_labs:
-    specifiers: {}
+  components/utopian_labs: {}
 
   components/utradea: {}
 


### PR DESCRIPTION
## WHY

<!-- author to complete -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new method to retrieve the raw access token directly from the BackendClient.

- **Documentation**
  - Updated the changelog to reflect the new version and feature addition.

- **Chores**
  - Bumped the SDK package version to 1.6.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->