### PR TITLE
Fix Pipedream Connect managed auth link on Connect Docs

### DIFF
--- a/docs-v2/pages/connect/components.mdx
+++ b/docs-v2/pages/connect/components.mdx
@@ -830,7 +830,7 @@ Refer to the [full Connect API reference](/connect/api/#deploy-trigger) to list,
 
 ### App-based event sources
 - Listen for events that occur in other systems: for example, when [a new file is added to Google Drive](https://pipedream.com/apps/google-drive/triggers/new-files-instant) or when [a new contact is created in HubSpot](https://pipedream.com/apps/hubspot/triggers/new-or-updated-contact)
-- Deploying these triggers requires that your customers first connect their account using [Pipedream Connect Managed Auth](/managed-auth/quickstart), since the triggers are deployed on their behalf using account
+- Deploying these triggers requires that your customers first connect their account using [Pipedream Connect Managed Auth](/connect/managed-auth/quickstart), since the triggers are deployed on their behalf using account
 - Refer to the [quickstart above](#deploying-a-source) to get started 
 
 #### Handling test events


### PR DESCRIPTION
## WHY

This PR fix the broken Managed Auth link in the connect doc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Fixed the documentation link for "Pipedream Connect Managed Auth" under the "App-based event sources" section to point to the correct location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->