### PR TITLE
MongoDB - update to new-document source

### DIFF
--- a/components/mongodb/package.json
+++ b/components/mongodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/mongodb",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Pipedream MongoDB Components",
   "main": "mongodb.app.mjs",
   "keywords": [

--- a/components/mongodb/sources/new-document/new-document.mjs
+++ b/components/mongodb/sources/new-document/new-document.mjs
@@ -6,7 +6,7 @@ export default {
   key: "mongodb-new-document",
   name: "New Document",
   description: "Emit new an event when a new document is added to a collection",
-  version: "0.0.10",
+  version: "0.0.11",
   type: "source",
   dedupe: "unique",
   props: {
@@ -29,7 +29,16 @@ export default {
     timestampField: {
       type: "string",
       label: "Timestamp Field",
-      description: "The key of a timestamp field, such as 'created_at' that is set to the current timestamp when a document is created. Must be of type Timestamp.",
+      description: "The key of a timestamp field, such as 'created_at' that is set to the current timestamp when a document is created.",
+    },
+    timestampFieldType: {
+      type: "string",
+      label: "Timestamp Field Type",
+      description: "The type of the timestamp field",
+      options: [
+        "Timestamp",
+        "Integer",
+      ],
     },
   },
   hooks: {
@@ -49,6 +58,9 @@ export default {
     },
     getTs(doc) {
       const tsValue = doc[this.timestampField];
+      if (this.timestampFieldType === "Integer") {
+        return tsValue;
+      }
       if (typeof tsValue === "string") {
         return new Date(tsValue).getTime();
       }
@@ -77,14 +89,16 @@ export default {
       };
       const query = {
         [this.timestampField]: {
-          $gt: this.convertToTimestamp(lastTs),
+          $gt: this.timestampFieldType === "Integer"
+            ? lastTs
+            : this.convertToTimestamp(lastTs),
         },
       };
       const documents = await collection.find(query).sort(sort)
-        .toArray();
+        .toArray(); console.log(documents);
       const docs = [];
       for (const doc of documents) {
-        const ts = this.getTs(doc);
+        const ts = this.getTs(doc); console.log(ts);
         if (!(ts > lastTs) || (max && count >= max)) {
           break;
         }

--- a/components/mongodb/sources/new-document/new-document.mjs
+++ b/components/mongodb/sources/new-document/new-document.mjs
@@ -35,6 +35,7 @@ export default {
       type: "string",
       label: "Timestamp Field Type",
       description: "The type of the timestamp field",
+      default: "Timestamp",
       options: [
         "Timestamp",
         "Integer",

--- a/components/mongodb/sources/new-document/new-document.mjs
+++ b/components/mongodb/sources/new-document/new-document.mjs
@@ -95,10 +95,10 @@ export default {
         },
       };
       const documents = await collection.find(query).sort(sort)
-        .toArray(); console.log(documents);
+        .toArray();
       const docs = [];
       for (const doc of documents) {
-        const ts = this.getTs(doc); console.log(ts);
+        const ts = this.getTs(doc);
         if (!(ts > lastTs) || (max && count >= max)) {
           break;
         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15484,14 +15484,6 @@ importers:
         specifier: ^6.0.0
         version: 6.2.0
 
-  modelcontextprotocol/node_modules2/@modelcontextprotocol/sdk/dist/cjs: {}
-
-  modelcontextprotocol/node_modules2/@modelcontextprotocol/sdk/dist/esm: {}
-
-  modelcontextprotocol/node_modules2/zod-to-json-schema/dist/cjs: {}
-
-  modelcontextprotocol/node_modules2/zod-to-json-schema/dist/esm: {}
-
   packages/ai:
     dependencies:
       '@pipedream/sdk':


### PR DESCRIPTION
Resolves #16805 

It looks like it's only not emitting events if the "Timestamp Field" entered isn't of type Timestamp, so I added the option to use a timestamp field of type Integer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for integer-based timestamp fields alongside MongoDB Timestamp objects.
  - Introduced an option to specify the timestamp field type for better flexibility.
- **Bug Fixes**
  - Enhanced document querying and timestamp handling based on the selected timestamp field type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->