### PR TITLE
[DEPLOYMENT] Fixed prop automaticTaxLiabilityAccount in action create-subscription

### DIFF
--- a/components/stripe/actions/create-subscription/create-subscription.mjs
+++ b/components/stripe/actions/create-subscription/create-subscription.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-create-subscription",
   name: "Create Subscription",
   type: "action",
-  version: "0.1.3",
+  version: "0.1.4",
   description: "Create a subscription. [See the documentation](https://stripe.com/docs/api/subscriptions/create).",
   props: {
     app,
@@ -106,6 +106,7 @@ export default {
       ],
     },
     automaticTaxLiabilityAccount: {
+      type: "string",
       label: "Automatic Tax - Liability - Account",
       description: "The connected account being referenced when **Automatic Tax - Liability - Type** is account.",
       optional: true,

--- a/components/stripe/package.json
+++ b/components/stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/stripe",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Pipedream Stripe Components",
   "main": "stripe.app.mjs",
   "keywords": [


### PR DESCRIPTION
## WHY

fixes deployment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the version of the Create Subscription action and the Stripe component package.
- **Refactor**
  - Clarified the type of the automatic tax liability account property in the Create Subscription action settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->