### PR TITLE
Hubspot update search-crm

### DIFF
--- a/components/hubspot/actions/search-crm/search-crm.mjs
+++ b/components/hubspot/actions/search-crm/search-crm.mjs
@@ -8,6 +8,7 @@ import {
   DEFAULT_PRODUCT_PROPERTIES,
   DEFAULT_LINE_ITEM_PROPERTIES,
   DEFAULT_LEAD_PROPERTIES,
+  DEFAULT_LIMIT,
 } from "../../common/constants.mjs";
 import common from "../common/common-create.mjs";
 import { ConfigurationError } from "@pipedream/platform";
@@ -16,7 +17,7 @@ export default {
   key: "hubspot-search-crm",
   name: "Search CRM",
   description: "Search companies, contacts, deals, feedback submissions, products, tickets, line-items, quotes, leads, or custom objects. [See the documentation](https://developers.hubspot.com/docs/api/crm/search)",
-  version: "1.0.3",
+  version: "1.0.4",
   type: "action",
   props: {
     hubspot,
@@ -32,6 +33,13 @@ export default {
         },
       ],
       reloadProps: true,
+    },
+    exactMatch: {
+      type: "boolean",
+      label: "Exact Match",
+      description: "Set to `true` to search for an exact match of the search value. If `false`, partial matches will be returned. Default: `true`",
+      default: true,
+      optional: true,
     },
     createIfNotFound: {
       type: "boolean",
@@ -97,7 +105,7 @@ export default {
     props.searchValue = {
       type: "string",
       label: "Search Value",
-      description: "Search for objects where the specified search field/property contains an exact match of the search value",
+      description: "Search for objects where the specified search field/property contains a match of the search value",
     };
     const defaultProperties = this.getDefaultProperties();
     if (defaultProperties?.length) {
@@ -201,6 +209,23 @@ export default {
         label: labels.plural,
       })) || [];
     },
+    async paginate(params) {
+      let results;
+      const items = [];
+      while (!results || params.after) {
+        results = await this.hubspot.searchCRM(params);
+        if (results.paging) {
+          params.after = results.paging.next.after;
+        } else {
+          delete params.after;
+        }
+        results = results.results;
+        for (const result of results) {
+          items.push(result);
+        }
+      }
+      return items;
+    },
   },
   async run({ $ }) {
     const {
@@ -210,6 +235,7 @@ export default {
       additionalProperties = [],
       searchProperty,
       searchValue,
+      exactMatch,
       /* eslint-disable no-unused-vars */
       info,
       createIfNotFound,
@@ -242,19 +268,29 @@ export default {
         ...defaultProperties,
         ...additionalProperties,
       ],
-      filters: [
+    };
+    if (exactMatch) {
+      data.filters = [
         {
           propertyName: searchProperty,
           operator: "EQ",
           value: searchValue,
         },
-      ],
-    };
-    const { results } = await hubspot.searchCRM({
+      ];
+    } else {
+      data.limit = DEFAULT_LIMIT;
+    }
+
+    let results = await this.paginate({
       object: actualObjectType,
       data,
-      $,
     });
+
+    if (!exactMatch) {
+      results = results.filter((result) =>
+        result.properties[searchProperty]
+        && result.properties[searchProperty].toLowerCase().includes(searchValue.toLowerCase()));
+    }
 
     if (!results?.length && createIfNotFound) {
       const response = await hubspot.createObject({

--- a/components/hubspot/package.json
+++ b/components/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/hubspot",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Pipedream Hubspot Components",
   "main": "hubspot.app.mjs",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13279,8 +13279,7 @@ importers:
 
   components/test_apps_for_switching_appslug_009: {}
 
-  components/testlocally:
-    specifiers: {}
+  components/testlocally: {}
 
   components/testmo:
     dependencies:
@@ -15543,14 +15542,6 @@ importers:
       dotenv:
         specifier: ^6.0.0
         version: 6.2.0
-
-  modelcontextprotocol/node_modules2/@modelcontextprotocol/sdk/dist/cjs: {}
-
-  modelcontextprotocol/node_modules2/@modelcontextprotocol/sdk/dist/esm: {}
-
-  modelcontextprotocol/node_modules2/zod-to-json-schema/dist/cjs: {}
-
-  modelcontextprotocol/node_modules2/zod-to-json-schema/dist/esm: {}
 
   packages/ai:
     dependencies:


### PR DESCRIPTION
Resolves #16888 

- Updated search-crm.mjs to support partial matches
- I was unable to reproduce the issue of exact matches not returning any results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to choose between exact match and partial match when searching CRM records.
  - Enhanced search functionality to support both server-side exact matching and client-side partial matching, with automatic handling of paginated results.

- **Chores**
  - Updated the component and package version numbers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->