### PR TITLE
feat(quickbooks): Add missing invoice, estimate, and purchase order actions

### DIFF
--- a/components/quickbooks/actions/create-estimate/create-estimate.mjs
+++ b/components/quickbooks/actions/create-estimate/create-estimate.mjs
@@ -1,0 +1,212 @@
+import { ConfigurationError } from "@pipedream/platform";
+import quickbooks from "../../quickbooks.app.mjs";
+import { parseLineItems } from "../../common/utils.mjs";
+
+export default {
+  key: "quickbooks-create-estimate",
+  name: "Create Estimate",
+  description: "Creates an estimate. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/estimate#create-an-estimate)",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    quickbooks,
+    customerRefValue: {
+      propDefinition: [
+        quickbooks,
+        "customer",
+      ],
+    },
+    billEmail: {
+      type: "string",
+      label: "Bill Email",
+      description: "Email address where the estimate should be sent",
+      optional: true,
+    },
+    expirationDate: {
+      type: "string",
+      label: "Expiration Date",
+      description: "Date when the estimate expires (YYYY-MM-DD)",
+      optional: true,
+    },
+    acceptedBy: {
+      type: "string",
+      label: "Accepted By",
+      description: "Name of the customer who accepted the estimate",
+      optional: true,
+    },
+    acceptedDate: {
+      type: "string",
+      label: "Accepted Date",
+      description: "Date when the estimate was accepted (YYYY-MM-DD)",
+      optional: true,
+    },
+    currencyRefValue: {
+      propDefinition: [
+        quickbooks,
+        "currency",
+      ],
+    },
+    docNumber: {
+      type: "string",
+      label: "Document Number",
+      description: "Reference number for the transaction",
+      optional: true,
+    },
+    billAddr: {
+      type: "object",
+      label: "Billing Address",
+      description: "Billing address details",
+      optional: true,
+    },
+    shipAddr: {
+      type: "object",
+      label: "Shipping Address",
+      description: "Shipping address details",
+      optional: true,
+    },
+    privateNote: {
+      type: "string",
+      label: "Private Note",
+      description: "Private note for internal use",
+      optional: true,
+    },
+    customerMemo: {
+      type: "string",
+      label: "Customer Memo",
+      description: "Memo visible to customer",
+      optional: true,
+    },
+    taxCodeId: {
+      propDefinition: [
+        quickbooks,
+        "taxCodeId",
+      ],
+    },
+    lineItemsAsObjects: {
+      propDefinition: [
+        quickbooks,
+        "lineItemsAsObjects",
+      ],
+      reloadProps: true,
+    },
+  },
+  async additionalProps() {
+    const props = {};
+    if (this.lineItemsAsObjects) {
+      props.lineItems = {
+        type: "string[]",
+        label: "Line Items",
+        description: "Line items of an estimate. Set DetailType to `SalesItemLineDetail`, `GroupLineDetail`, or `DescriptionOnly`. Example: `{ \"DetailType\": \"SalesItemLineDetail\", \"Amount\": 100.0, \"SalesItemLineDetail\": { \"ItemRef\": { \"name\": \"Services\", \"value\": \"1\" } } }`",
+      };
+      return props;
+    }
+    props.numLineItems = {
+      type: "integer",
+      label: "Number of Line Items",
+      description: "The number of line items to enter",
+      reloadProps: true,
+    };
+    if (!this.numLineItems) {
+      return props;
+    }
+    for (let i = 1; i <= this.numLineItems; i++) {
+      props[`item_${i}`] = {
+        type: "string",
+        label: `Line ${i} - Item ID`,
+        options: async ({ page }) => {
+          return this.quickbooks.getPropOptions({
+            page,
+            resource: "Item",
+            mapper: ({
+              Id: value, Name: label,
+            }) => ({
+              value,
+              label,
+            }),
+          });
+        },
+      };
+      props[`amount_${i}`] = {
+        type: "string",
+        label: `Line ${i} - Amount`,
+      };
+    }
+    return props;
+  },
+  methods: {
+    buildLineItems() {
+      const lineItems = [];
+      for (let i = 1; i <= this.numLineItems; i++) {
+        lineItems.push({
+          DetailType: "SalesItemLineDetail",
+          Amount: this[`amount_${i}`],
+          SalesItemLineDetail: {
+            ItemRef: {
+              value: this[`item_${i}`],
+            },
+          },
+        });
+      }
+      return lineItems;
+    },
+  },
+  async run({ $ }) {
+    if ((!this.numLineItems && !this.lineItemsAsObjects) || !this.customerRefValue) {
+      throw new ConfigurationError("Must provide lineItems and customerRefValue parameters.");
+    }
+
+    const lines = this.lineItemsAsObjects
+      ? parseLineItems(this.lineItems)
+      : this.buildLineItems();
+
+    lines.forEach((line) => {
+      if (line.DetailType !== "SalesItemLineDetail" && line.DetailType !== "GroupLineDetail" && line.DetailType !== "DescriptionOnly") {
+        throw new ConfigurationError("Line Item DetailType must be `SalesItemLineDetail`, `GroupLineDetail`, or `DescriptionOnly`");
+      }
+    });
+
+    const params = {};
+    const data = {
+      Line: lines,
+      CustomerRef: {
+        value: this.customerRefValue,
+      },
+      ExpirationDate: this.expirationDate,
+      AcceptedBy: this.acceptedBy,
+      AcceptedDate: this.acceptedDate,
+      DocNumber: this.docNumber,
+      BillAddr: this.billAddr,
+      ShipAddr: this.shipAddr,
+      PrivateNote: this.privateNote,
+    };
+
+    if (this.billEmail) {
+      params.include = "estimateLink";
+      data.BillEmail = {
+        Address: this.billEmail,
+      };
+    }
+    if (this.currencyRefValue) {
+      data.CurrencyRef = {
+        value: this.currencyRefValue,
+      };
+    }
+    if (this.customerMemo) {
+      data.CustomerMemo = {
+        value: this.customerMemo,
+      };
+    }
+
+    const response = await this.quickbooks.createEstimate({
+      $,
+      params,
+      data,
+    });
+
+    if (response) {
+      $.export("summary", `Successfully created estimate with ID ${response.Estimate.Id}`);
+    }
+
+    return response;
+  },
+}; 

--- a/components/quickbooks/actions/create-purchase-order/create-purchase-order.mjs
+++ b/components/quickbooks/actions/create-purchase-order/create-purchase-order.mjs
@@ -1,0 +1,160 @@
+import { ConfigurationError } from "@pipedream/platform";
+import quickbooks from "../../quickbooks.app.mjs";
+import { parseLineItems } from "../../common/utils.mjs";
+
+export default {
+  key: "quickbooks-create-purchase-order",
+  name: "Create Purchase Order",
+  description: "Creates a purchase order. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/purchaseorder#create-a-purchaseorder)",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    quickbooks,
+    vendorRefValue: {
+      propDefinition: [
+        quickbooks,
+        "vendor",
+      ],
+    },
+    dueDate: {
+      type: "string",
+      label: "Due Date",
+      description: "Date when the purchase order is due (YYYY-MM-DD)",
+      optional: true,
+    },
+    currencyRefValue: {
+      propDefinition: [
+        quickbooks,
+        "currency",
+      ],
+    },
+    docNumber: {
+      type: "string",
+      label: "Document Number",
+      description: "Reference number for the transaction",
+      optional: true,
+    },
+    shipAddr: {
+      type: "object",
+      label: "Shipping Address",
+      description: "Shipping address details",
+      optional: true,
+    },
+    memo: {
+      type: "string",
+      label: "Memo",
+      description: "Memo or note for the purchase order",
+      optional: true,
+    },
+    lineItemsAsObjects: {
+      propDefinition: [
+        quickbooks,
+        "lineItemsAsObjects",
+      ],
+      reloadProps: true,
+    },
+  },
+  async additionalProps() {
+    const props = {};
+    if (this.lineItemsAsObjects) {
+      props.lineItems = {
+        type: "string[]",
+        label: "Line Items",
+        description: "Line items of a purchase order. Set DetailType to `ItemBasedExpenseLineDetail` or `AccountBasedExpenseLineDetail`. Example: `{ \"DetailType\": \"ItemBasedExpenseLineDetail\", \"Amount\": 100.0, \"ItemBasedExpenseLineDetail\": { \"ItemRef\": { \"name\": \"Services\", \"value\": \"1\" } } }`",
+      };
+      return props;
+    }
+    props.numLineItems = {
+      type: "integer",
+      label: "Number of Line Items",
+      description: "The number of line items to enter",
+      reloadProps: true,
+    };
+    if (!this.numLineItems) {
+      return props;
+    }
+    for (let i = 1; i <= this.numLineItems; i++) {
+      props[`item_${i}`] = {
+        type: "string",
+        label: `Line ${i} - Item ID`,
+        options: async ({ page }) => {
+          return this.quickbooks.getPropOptions({
+            page,
+            resource: "Item",
+            mapper: ({
+              Id: value, Name: label,
+            }) => ({
+              value,
+              label,
+            }),
+          });
+        },
+      };
+      props[`amount_${i}`] = {
+        type: "string",
+        label: `Line ${i} - Amount`,
+      };
+    }
+    return props;
+  },
+  methods: {
+    buildLineItems() {
+      const lineItems = [];
+      for (let i = 1; i <= this.numLineItems; i++) {
+        lineItems.push({
+          DetailType: "ItemBasedExpenseLineDetail",
+          Amount: this[`amount_${i}`],
+          ItemBasedExpenseLineDetail: {
+            ItemRef: {
+              value: this[`item_${i}`],
+            },
+          },
+        });
+      }
+      return lineItems;
+    },
+  },
+  async run({ $ }) {
+    if ((!this.numLineItems && !this.lineItemsAsObjects) || !this.vendorRefValue) {
+      throw new ConfigurationError("Must provide lineItems and vendorRefValue parameters.");
+    }
+
+    const lines = this.lineItemsAsObjects
+      ? parseLineItems(this.lineItems)
+      : this.buildLineItems();
+
+    lines.forEach((line) => {
+      if (line.DetailType !== "ItemBasedExpenseLineDetail" && line.DetailType !== "AccountBasedExpenseLineDetail") {
+        throw new ConfigurationError("Line Item DetailType must be `ItemBasedExpenseLineDetail` or `AccountBasedExpenseLineDetail`");
+      }
+    });
+
+    const data = {
+      Line: lines,
+      VendorRef: {
+        value: this.vendorRefValue,
+      },
+      DueDate: this.dueDate,
+      DocNumber: this.docNumber,
+      ShipAddr: this.shipAddr,
+      Memo: this.memo,
+    };
+
+    if (this.currencyRefValue) {
+      data.CurrencyRef = {
+        value: this.currencyRefValue,
+      };
+    }
+
+    const response = await this.quickbooks.createPurchaseOrder({
+      $,
+      data,
+    });
+
+    if (response) {
+      $.export("summary", `Successfully created purchase order with ID ${response.PurchaseOrder.Id}`);
+    }
+
+    return response;
+  },
+}; 

--- a/components/quickbooks/actions/send-estimate/send-estimate.mjs
+++ b/components/quickbooks/actions/send-estimate/send-estimate.mjs
@@ -1,0 +1,43 @@
+import quickbooks from "../../quickbooks.app.mjs";
+
+export default {
+  key: "quickbooks-send-estimate",
+  name: "Send Estimate",
+  description: "Sends an estimate by email. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/estimate#send-an-estimate)",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    quickbooks,
+    estimateId: {
+      propDefinition: [
+        quickbooks,
+        "estimateId",
+      ],
+    },
+    email: {
+      type: "string",
+      label: "Email Address",
+      description: "Email address to send the estimate to (optional - if not provided, uses the customer's email address)",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const data = {};
+    
+    if (this.email) {
+      data.email = this.email;
+    }
+
+    const response = await this.quickbooks.sendEstimate({
+      $,
+      estimateId: this.estimateId,
+      data,
+    });
+
+    if (response) {
+      $.export("summary", `Successfully sent estimate with ID ${this.estimateId}`);
+    }
+
+    return response;
+  },
+}; 

--- a/components/quickbooks/actions/send-invoice/send-invoice.mjs
+++ b/components/quickbooks/actions/send-invoice/send-invoice.mjs
@@ -1,0 +1,43 @@
+import quickbooks from "../../quickbooks.app.mjs";
+
+export default {
+  key: "quickbooks-send-invoice",
+  name: "Send Invoice",
+  description: "Sends an invoice by email. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/invoice#send-an-invoice)",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    quickbooks,
+    invoiceId: {
+      propDefinition: [
+        quickbooks,
+        "invoiceId",
+      ],
+    },
+    email: {
+      type: "string",
+      label: "Email Address",
+      description: "Email address to send the invoice to (optional - if not provided, uses the customer's email address)",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const data = {};
+    
+    if (this.email) {
+      data.email = this.email;
+    }
+
+    const response = await this.quickbooks.sendInvoice({
+      $,
+      invoiceId: this.invoiceId,
+      data,
+    });
+
+    if (response) {
+      $.export("summary", `Successfully sent invoice with ID ${this.invoiceId}`);
+    }
+
+    return response;
+  },
+}; 

--- a/components/quickbooks/actions/update-estimate/update-estimate.mjs
+++ b/components/quickbooks/actions/update-estimate/update-estimate.mjs
@@ -1,0 +1,230 @@
+import { ConfigurationError } from "@pipedream/platform";
+import quickbooks from "../../quickbooks.app.mjs";
+import { parseLineItems } from "../../common/utils.mjs";
+
+export default {
+  key: "quickbooks-update-estimate",
+  name: "Update Estimate",
+  description: "Updates an estimate. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/estimate#update-an-estimate)",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    quickbooks,
+    estimateId: {
+      propDefinition: [
+        quickbooks,
+        "estimateId",
+      ],
+    },
+    customerRefValue: {
+      propDefinition: [
+        quickbooks,
+        "customer",
+      ],
+      optional: true,
+    },
+    billEmail: {
+      type: "string",
+      label: "Bill Email",
+      description: "Email address where the estimate should be sent",
+      optional: true,
+    },
+    expirationDate: {
+      type: "string",
+      label: "Expiration Date",
+      description: "Date when the estimate expires (YYYY-MM-DD)",
+      optional: true,
+    },
+    acceptedBy: {
+      type: "string",
+      label: "Accepted By",
+      description: "Name of the customer who accepted the estimate",
+      optional: true,
+    },
+    acceptedDate: {
+      type: "string",
+      label: "Accepted Date",
+      description: "Date when the estimate was accepted (YYYY-MM-DD)",
+      optional: true,
+    },
+    currencyRefValue: {
+      propDefinition: [
+        quickbooks,
+        "currency",
+      ],
+    },
+    docNumber: {
+      type: "string",
+      label: "Document Number",
+      description: "Reference number for the transaction",
+      optional: true,
+    },
+    billAddr: {
+      type: "object",
+      label: "Billing Address",
+      description: "Billing address details",
+      optional: true,
+    },
+    shipAddr: {
+      type: "object",
+      label: "Shipping Address",
+      description: "Shipping address details",
+      optional: true,
+    },
+    privateNote: {
+      type: "string",
+      label: "Private Note",
+      description: "Private note for internal use",
+      optional: true,
+    },
+    customerMemo: {
+      type: "string",
+      label: "Customer Memo",
+      description: "Memo visible to customer",
+      optional: true,
+    },
+    taxCodeId: {
+      propDefinition: [
+        quickbooks,
+        "taxCodeId",
+      ],
+    },
+    lineItemsAsObjects: {
+      propDefinition: [
+        quickbooks,
+        "lineItemsAsObjects",
+      ],
+      reloadProps: true,
+    },
+  },
+  async additionalProps() {
+    const props = {};
+    if (this.lineItemsAsObjects) {
+      props.lineItems = {
+        type: "string[]",
+        label: "Line Items",
+        description: "Line items of an estimate. Set DetailType to `SalesItemLineDetail`, `GroupLineDetail`, or `DescriptionOnly`. Example: `{ \"DetailType\": \"SalesItemLineDetail\", \"Amount\": 100.0, \"SalesItemLineDetail\": { \"ItemRef\": { \"name\": \"Services\", \"value\": \"1\" } } }`",
+      };
+      return props;
+    }
+    props.numLineItems = {
+      type: "integer",
+      label: "Number of Line Items",
+      description: "The number of line items to enter",
+      reloadProps: true,
+    };
+    if (!this.numLineItems) {
+      return props;
+    }
+    for (let i = 1; i <= this.numLineItems; i++) {
+      props[`item_${i}`] = {
+        type: "string",
+        label: `Line ${i} - Item ID`,
+        options: async ({ page }) => {
+          return this.quickbooks.getPropOptions({
+            page,
+            resource: "Item",
+            mapper: ({
+              Id: value, Name: label,
+            }) => ({
+              value,
+              label,
+            }),
+          });
+        },
+      };
+      props[`amount_${i}`] = {
+        type: "string",
+        label: `Line ${i} - Amount`,
+      };
+    }
+    return props;
+  },
+  methods: {
+    buildLineItems() {
+      const lineItems = [];
+      for (let i = 1; i <= this.numLineItems; i++) {
+        lineItems.push({
+          DetailType: "SalesItemLineDetail",
+          Amount: this[`amount_${i}`],
+          SalesItemLineDetail: {
+            ItemRef: {
+              value: this[`item_${i}`],
+            },
+          },
+        });
+      }
+      return lineItems;
+    },
+  },
+  async run({ $ }) {
+    // Get the current estimate to obtain SyncToken
+    const { Estimate: estimate } = await this.quickbooks.getEstimate({
+      $,
+      estimateId: this.estimateId,
+    });
+
+    const data = {
+      Id: this.estimateId,
+      SyncToken: estimate.SyncToken,
+    };
+
+    // Only update fields that are provided
+    if (this.customerRefValue) {
+      data.CustomerRef = {
+        value: this.customerRefValue,
+      };
+    }
+
+    if (this.lineItemsAsObjects || this.numLineItems) {
+      const lines = this.lineItemsAsObjects
+        ? parseLineItems(this.lineItems)
+        : this.buildLineItems();
+
+      lines.forEach((line) => {
+        if (line.DetailType !== "SalesItemLineDetail" && line.DetailType !== "GroupLineDetail" && line.DetailType !== "DescriptionOnly") {
+          throw new ConfigurationError("Line Item DetailType must be `SalesItemLineDetail`, `GroupLineDetail`, or `DescriptionOnly`");
+        }
+      });
+
+      data.Line = lines;
+    }
+
+    if (this.expirationDate) data.ExpirationDate = this.expirationDate;
+    if (this.acceptedBy) data.AcceptedBy = this.acceptedBy;
+    if (this.acceptedDate) data.AcceptedDate = this.acceptedDate;
+    if (this.docNumber) data.DocNumber = this.docNumber;
+    if (this.billAddr) data.BillAddr = this.billAddr;
+    if (this.shipAddr) data.ShipAddr = this.shipAddr;
+    if (this.privateNote) data.PrivateNote = this.privateNote;
+
+    if (this.billEmail) {
+      data.BillEmail = {
+        Address: this.billEmail,
+      };
+    }
+
+    if (this.currencyRefValue) {
+      data.CurrencyRef = {
+        value: this.currencyRefValue,
+      };
+    }
+
+    if (this.customerMemo) {
+      data.CustomerMemo = {
+        value: this.customerMemo,
+      };
+    }
+
+    const response = await this.quickbooks.updateEstimate({
+      $,
+      data,
+    });
+
+    if (response) {
+      $.export("summary", `Successfully updated estimate with ID ${response.Estimate.Id}`);
+    }
+
+    return response;
+  },
+}; 

--- a/components/quickbooks/actions/update-invoice/update-invoice.mjs
+++ b/components/quickbooks/actions/update-invoice/update-invoice.mjs
@@ -1,0 +1,237 @@
+import { ConfigurationError } from "@pipedream/platform";
+import quickbooks from "../../quickbooks.app.mjs";
+import { parseLineItems } from "../../common/utils.mjs";
+
+export default {
+  key: "quickbooks-update-invoice",
+  name: "Update Invoice",
+  description: "Updates an invoice. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/invoice#update-an-invoice)",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    quickbooks,
+    invoiceId: {
+      propDefinition: [
+        quickbooks,
+        "invoiceId",
+      ],
+    },
+    customerRefValue: {
+      propDefinition: [
+        quickbooks,
+        "customer",
+      ],
+      optional: true,
+    },
+    billEmail: {
+      type: "string",
+      label: "Bill Email",
+      description: "Email address where the invoice should be sent",
+      optional: true,
+    },
+    dueDate: {
+      type: "string",
+      label: "Due Date",
+      description: "Date when the payment of the transaction is due (YYYY-MM-DD)",
+      optional: true,
+    },
+    allowOnlineCreditCardPayment: {
+      type: "boolean",
+      label: "Allow Online Credit Card Payment",
+      description: "Allow online credit card payment",
+      optional: true,
+    },
+    allowOnlineACHPayment: {
+      type: "boolean",
+      label: "Allow Online Bank Transfer Payment",
+      description: "Allow online bank transfer payment",
+      optional: true,
+    },
+    currencyRefValue: {
+      propDefinition: [
+        quickbooks,
+        "currency",
+      ],
+    },
+    docNumber: {
+      type: "string",
+      label: "Document Number",
+      description: "Reference number for the transaction",
+      optional: true,
+    },
+    billAddr: {
+      type: "object",
+      label: "Billing Address",
+      description: "Billing address details",
+      optional: true,
+    },
+    shipAddr: {
+      type: "object",
+      label: "Shipping Address",
+      description: "Shipping address details",
+      optional: true,
+    },
+    trackingNum: {
+      type: "string",
+      label: "Tracking Number",
+      description: "Shipping tracking number",
+      optional: true,
+    },
+    privateNote: {
+      type: "string",
+      label: "Private Note",
+      description: "Private note for internal use",
+      optional: true,
+    },
+    customerMemo: {
+      type: "string",
+      label: "Customer Memo",
+      description: "Memo visible to customer",
+      optional: true,
+    },
+    taxCodeId: {
+      propDefinition: [
+        quickbooks,
+        "taxCodeId",
+      ],
+    },
+    lineItemsAsObjects: {
+      propDefinition: [
+        quickbooks,
+        "lineItemsAsObjects",
+      ],
+      reloadProps: true,
+    },
+  },
+  async additionalProps() {
+    const props = {};
+    if (this.lineItemsAsObjects) {
+      props.lineItems = {
+        type: "string[]",
+        label: "Line Items",
+        description: "Line items of an invoice. Set DetailType to `SalesItemLineDetail`, `GroupLineDetail`, or `DescriptionOnly`. Example: `{ \"DetailType\": \"SalesItemLineDetail\", \"Amount\": 100.0, \"SalesItemLineDetail\": { \"ItemRef\": { \"name\": \"Services\", \"value\": \"1\" } } }`",
+      };
+      return props;
+    }
+    props.numLineItems = {
+      type: "integer",
+      label: "Number of Line Items",
+      description: "The number of line items to enter",
+      reloadProps: true,
+    };
+    if (!this.numLineItems) {
+      return props;
+    }
+    for (let i = 1; i <= this.numLineItems; i++) {
+      props[`item_${i}`] = {
+        type: "string",
+        label: `Line ${i} - Item ID`,
+        options: async ({ page }) => {
+          return this.quickbooks.getPropOptions({
+            page,
+            resource: "Item",
+            mapper: ({
+              Id: value, Name: label,
+            }) => ({
+              value,
+              label,
+            }),
+          });
+        },
+      };
+      props[`amount_${i}`] = {
+        type: "string",
+        label: `Line ${i} - Amount`,
+      };
+    }
+    return props;
+  },
+  methods: {
+    buildLineItems() {
+      const lineItems = [];
+      for (let i = 1; i <= this.numLineItems; i++) {
+        lineItems.push({
+          DetailType: "SalesItemLineDetail",
+          Amount: this[`amount_${i}`],
+          SalesItemLineDetail: {
+            ItemRef: {
+              value: this[`item_${i}`],
+            },
+          },
+        });
+      }
+      return lineItems;
+    },
+  },
+  async run({ $ }) {
+    // Get the current invoice to obtain SyncToken
+    const { Invoice: invoice } = await this.quickbooks.getInvoice({
+      $,
+      invoiceId: this.invoiceId,
+    });
+
+    const data = {
+      Id: this.invoiceId,
+      SyncToken: invoice.SyncToken,
+    };
+
+    // Only update fields that are provided
+    if (this.customerRefValue) {
+      data.CustomerRef = {
+        value: this.customerRefValue,
+      };
+    }
+
+    if (this.lineItemsAsObjects || this.numLineItems) {
+      const lines = this.lineItemsAsObjects
+        ? parseLineItems(this.lineItems)
+        : this.buildLineItems();
+
+      lines.forEach((line) => {
+        if (line.DetailType !== "SalesItemLineDetail" && line.DetailType !== "GroupLineDetail" && line.DetailType !== "DescriptionOnly") {
+          throw new ConfigurationError("Line Item DetailType must be `SalesItemLineDetail`, `GroupLineDetail`, or `DescriptionOnly`");
+        }
+      });
+
+      data.Line = lines;
+    }
+
+    if (this.dueDate) data.DueDate = this.dueDate;
+    if (typeof this.allowOnlineCreditCardPayment === "boolean") data.AllowOnlineCreditCardPayment = this.allowOnlineCreditCardPayment;
+    if (typeof this.allowOnlineACHPayment === "boolean") data.AllowOnlineACHPayment = this.allowOnlineACHPayment;
+    if (this.docNumber) data.DocNumber = this.docNumber;
+    if (this.billAddr) data.BillAddr = this.billAddr;
+    if (this.shipAddr) data.ShipAddr = this.shipAddr;
+    if (this.trackingNum) data.TrackingNum = this.trackingNum;
+    if (this.privateNote) data.PrivateNote = this.privateNote;
+
+    if (this.billEmail) {
+      data.BillEmail = {
+        Address: this.billEmail,
+      };
+    }
+
+    if (this.currencyRefValue) {
+      data.CurrencyRef = {
+        value: this.currencyRefValue,
+      };
+    }
+
+    if (this.customerMemo) {
+      data.CustomerMemo = {
+        value: this.customerMemo,
+      };
+    }
+
+    const response = await this.quickbooks.updateInvoice({
+      $,
+      data,
+    });
+
+    if (response) {
+      $.export("summary", `Successfully updated invoice with ID ${response.Invoice.Id}`);
+    }
+
+    return response;
+  },
+}; 

--- a/components/quickbooks/actions/void-invoice/void-invoice.mjs
+++ b/components/quickbooks/actions/void-invoice/void-invoice.mjs
@@ -1,0 +1,41 @@
+import quickbooks from "../../quickbooks.app.mjs";
+
+export default {
+  key: "quickbooks-void-invoice",
+  name: "Void Invoice",
+  description: "Voids an invoice. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/invoice#void-an-invoice)",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    quickbooks,
+    invoiceId: {
+      propDefinition: [
+        quickbooks,
+        "invoiceId",
+      ],
+    },
+  },
+  async run({ $ }) {
+    // Get the current invoice to obtain SyncToken
+    const { Invoice: invoice } = await this.quickbooks.getInvoice({
+      $,
+      invoiceId: this.invoiceId,
+    });
+
+    const data = {
+      Id: this.invoiceId,
+      SyncToken: invoice.SyncToken,
+    };
+
+    const response = await this.quickbooks.voidInvoice({
+      $,
+      data,
+    });
+
+    if (response) {
+      $.export("summary", `Successfully voided invoice with ID ${response.Invoice.Id}`);
+    }
+
+    return response;
+  },
+}; 

--- a/components/quickbooks/quickbooks.app.mjs
+++ b/components/quickbooks/quickbooks.app.mjs
@@ -116,6 +116,40 @@ export default {
         });
       },
     },
+    estimateId: {
+      label: "Estimate ID",
+      type: "string",
+      description: "ID of the estimate to get details of",
+      async options({ page }) {
+        return this.getPropOptions({
+          page,
+          resource: "Estimate",
+          mapper: ({
+            Id: value, DocNumber: docNumber, CustomerRef: customerRef,
+          }) => ({
+            label: `(${docNumber}) ${customerRef.name}`,
+            value,
+          }),
+        });
+      },
+    },
+    vendor: {
+      label: "Vendor Reference",
+      type: "string",
+      description: "Reference to a vendor",
+      async options({ page }) {
+        return this.getPropOptions({
+          page,
+          resource: "Vendor",
+          mapper: ({
+            Id: id, DisplayName: label,
+          }) => ({
+            label,
+            value: id,
+          }),
+        });
+      },
+    },
     termIds: {
       type: "string[]",
       label: "Term IDs",
@@ -516,6 +550,76 @@ export default {
       return this._makeRequest({
         path: `company/${this._companyId()}/invoice`,
         method: "post",
+        ...opts,
+      });
+    },
+    sendInvoice({
+      invoiceId, ...opts
+    }) {
+      return this._makeRequest({
+        path: `company/${this._companyId()}/invoice/${invoiceId}/send`,
+        method: "post",
+        ...opts,
+      });
+    },
+    updateInvoice(opts = {}) {
+      return this._makeRequest({
+        path: `company/${this._companyId()}/invoice`,
+        method: "post",
+        params: {
+          operation: "update",
+        },
+        ...opts,
+      });
+    },
+    voidInvoice(opts = {}) {
+      return this._makeRequest({
+        path: `company/${this._companyId()}/invoice`,
+        method: "post",
+        params: {
+          operation: "void",
+        },
+        ...opts,
+      });
+    },
+    createPurchaseOrder(opts = {}) {
+      return this._makeRequest({
+        path: `company/${this._companyId()}/purchaseorder`,
+        method: "post",
+        ...opts,
+      });
+    },
+    createEstimate(opts = {}) {
+      return this._makeRequest({
+        path: `company/${this._companyId()}/estimate`,
+        method: "post",
+        ...opts,
+      });
+    },
+    sendEstimate({
+      estimateId, ...opts
+    }) {
+      return this._makeRequest({
+        path: `company/${this._companyId()}/estimate/${estimateId}/send`,
+        method: "post",
+        ...opts,
+      });
+    },
+    updateEstimate(opts = {}) {
+      return this._makeRequest({
+        path: `company/${this._companyId()}/estimate`,
+        method: "post",
+        params: {
+          operation: "update",
+        },
+        ...opts,
+      });
+    },
+    getEstimate({
+      estimateId, ...opts
+    }) {
+      return this._makeRequest({
+        path: `company/${this._companyId()}/estimate/${estimateId}`,
         ...opts,
       });
     },


### PR DESCRIPTION
This PR addresses [GitHub issue #16906](https://github.com/PipedreamHQ/pipedream/issues/16906) by implementing missing QuickBooks Online API endpoints that are available in Zapier but were missing from Pipedream. This brings the Pipedream QuickBooks integration to feature parity with Zapier for invoice, estimate, and purchase order operations.

### 🔧 **New API Methods Added to `quickbooks.app.mjs`:**
- `sendInvoice()` - Send invoice via email
- `updateInvoice()` - Update existing invoice 
- `voidInvoice()` - Void an invoice
- `createPurchaseOrder()` - Create purchase orders
- `createEstimate()` - Create estimates/quotes
- `sendEstimate()` - Send estimate via email
- `updateEstimate()` - Update existing estimate
- `getEstimate()` - Retrieve estimate by ID

### 📋 **New Prop Definitions:**
- `estimateId` - For selecting estimates with customer context
- `vendor` - For selecting vendors for purchase orders



Fixes #16906