### PR TITLE
Fix SDK bug in the `deployTrigger` method

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # Changelog
 
+## [1.6.5] - 2025-06-02
+
+### Changed
+
+- Fix the `deployTrigger` method so that it sends the workflow ID to the API
+
 ## [1.6.4] - 2025-05-30
 
 ### Added

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pipedream/sdk",
   "type": "module",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "Pipedream SDK",
   "main": "./dist/server.js",
   "module": "./dist/server.js",

--- a/packages/sdk/src/shared/index.ts
+++ b/packages/sdk/src/shared/index.ts
@@ -1481,6 +1481,7 @@ export abstract class BaseClient {
       id,
       configured_props: opts.configuredProps,
       dynamic_props_id: opts.dynamicPropsId,
+      workflow_id: opts.workflowId,
       webhook_url: opts.webhookUrl,
     };
     return this.makeConnectRequest<DeployTriggerResponse>("/triggers/deploy", {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -367,8 +367,7 @@ importers:
         specifier: ^1.2.1
         version: 1.6.6
 
-  components/adtraction:
-    specifiers: {}
+  components/adtraction: {}
 
   components/adversus:
     dependencies:
@@ -3739,8 +3738,7 @@ importers:
 
   components/dokan: {}
 
-  components/dolibarr:
-    specifiers: {}
+  components/dolibarr: {}
 
   components/domain_group:
     dependencies:
@@ -7377,8 +7375,7 @@ importers:
         specifier: ^3.0.0
         version: 3.0.3
 
-  components/limoexpress:
-    specifiers: {}
+  components/limoexpress: {}
 
   components/line:
     dependencies:
@@ -9892,8 +9889,7 @@ importers:
         specifier: ^1.5.1
         version: 1.6.6
 
-  components/pinghome:
-    specifiers: {}
+  components/pinghome: {}
 
   components/pingone: {}
 
@@ -10388,8 +10384,7 @@ importers:
 
   components/procore_sandbox: {}
 
-  components/prodatakey:
-    specifiers: {}
+  components/prodatakey: {}
 
   components/prodpad:
     dependencies:
@@ -15062,8 +15057,7 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
 
-  components/zenedu:
-    specifiers: {}
+  components/zenedu: {}
 
   components/zenkit:
     dependencies:
@@ -29100,22 +29094,22 @@ packages:
   superagent@3.8.1:
     resolution: {integrity: sha512-VMBFLYgFuRdfeNQSMLbxGSLfmXL/xc+OO+BZp41Za/NRDBet/BNbkRJrYzCUu0u4GU0i/ml2dtT8b9qgkw9z6Q==}
     engines: {node: '>= 4.0'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
 
   superagent@4.1.0:
     resolution: {integrity: sha512-FT3QLMasz0YyCd4uIi5HNe+3t/onxMyEho7C3PSqmti3Twgy2rXT4fmkTz6wRL6bTF4uzPcfkUCa8u4JWHw8Ag==}
     engines: {node: '>= 6.0'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
 
   superagent@5.3.1:
     resolution: {integrity: sha512-wjJ/MoTid2/RuGCOFtlacyGNxN9QLMgcpYLDQlWFIhhdJ93kNscFonGvrpAHSCVjRVj++DGCglocF7Aej1KHvQ==}
     engines: {node: '>= 7.0.0'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
 
   superagent@7.1.6:
     resolution: {integrity: sha512-gZkVCQR1gy/oUXr+kxJMLDjla434KmSOKbx5iGD30Ql+AkJQ/YlPKECJy2nhqOsHLjGHzoDTXNSjhnvWhzKk7g==}
     engines: {node: '>=6.4.0 <13 || >=14'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please downgrade to v7.1.5 if you need IE/ActiveXObject support OR upgrade to v8.0.0 as we no longer support IE and published an incorrect patch version (see https://github.com/visionmedia/superagent/issues/1731)
 
   supports-color@2.0.0:
     resolution: {integrity: sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==}


### PR DESCRIPTION
## WHY

The `deployTrigger` method was ignoring the `workflowId` argument when calling the API, which prevented the new trigger from emitting events to the target workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where the workflow ID was not being sent when deploying a trigger.

- **Chores**
  - Updated documentation to reflect the latest changes.
  - Bumped the SDK version to 1.6.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->