### PR TITLE
[Components] zoom_admin - fix to get-meeting-recordings

### DIFF
--- a/components/zoom_admin/actions/get-meeting-recordings/get-meeting-recordings.mjs
+++ b/components/zoom_admin/actions/get-meeting-recordings/get-meeting-recordings.mjs
@@ -7,7 +7,7 @@ export default {
   description:
     "Get all recordings of a meeting. [See the documentation](https://developers.zoom.us/docs/api/meetings/#tag/cloud-recording/GET/meetings/{meetingId}/recordings)",
   key: "zoom_admin-get-meeting-recordings",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     zoomAdmin,

--- a/components/zoom_admin/actions/get-meeting-recordings/get-meeting-recordings.mjs
+++ b/components/zoom_admin/actions/get-meeting-recordings/get-meeting-recordings.mjs
@@ -42,12 +42,7 @@ export default {
       }
     }
 
-    const res = await paginate(
-      this.zoomAdmin.listMeetingRecordings,
-      "recording_files",
-      get(this.meeting, "value", this.meeting),
-      params,
-    );
+    const res = await this.zoomAdmin.listMeetingRecordings(get(this.meeting, "value", this.meeting), params);
 
     $.export("$summary", `"${get(this.meeting, "label", this.meeting)}" meeting recordings successfully fetched`);
 

--- a/components/zoom_admin/actions/get-meeting-recordings/get-meeting-recordings.mjs
+++ b/components/zoom_admin/actions/get-meeting-recordings/get-meeting-recordings.mjs
@@ -23,15 +23,30 @@ export default {
       description: "Whether to include the download access token in the response",
       optional: true,
     },
+    ttl: {
+      type: "integer",
+      label: "TTL (seconds)",
+      description: "Time to live (TTL) of the download_access_token in seconds. Range: 0-604800 (7 days). Only valid when Download Access Token is enabled.",
+      optional: true,
+      min: 0,
+      max: 604800,
+    },
   },
   async run({ $ }) {
+    const params = {};
+
+    if (this.downloadAccessToken) {
+      params.include_fields = "download_access_token";
+      if (this.ttl !== undefined) {
+        params.ttl = this.ttl;
+      }
+    }
+
     const res = await paginate(
       this.zoomAdmin.listMeetingRecordings,
-      "recordings",
+      "recording_files",
       get(this.meeting, "value", this.meeting),
-      {
-        download_access_token: this.downloadAccessToken,
-      },
+      params,
     );
 
     $.export("$summary", `"${get(this.meeting, "label", this.meeting)}" meeting recordings successfully fetched`);

--- a/components/zoom_admin/actions/get-meeting-recordings/get-meeting-recordings.mjs
+++ b/components/zoom_admin/actions/get-meeting-recordings/get-meeting-recordings.mjs
@@ -1,5 +1,4 @@
 import get from "lodash/get.js";
-import { paginate } from "../../common/pagination.mjs";
 import zoomAdmin from "../../zoom_admin.app.mjs";
 
 export default {

--- a/components/zoom_admin/package.json
+++ b/components/zoom_admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/zoom_admin",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Pipedream Zoom_admin Components",
   "main": "zoom_admin.app.mjs",
   "keywords": [


### PR DESCRIPTION
## WHY

Correct downloadAccessToken -> string not a boolean
Add TTL for the token
Removed pagination on recordings -> wrong prop and don't need this or won't show other important props
Tested custom version on workflow to check it's working as intended
![Screenshot 2025-06-03 at 11 36 11](https://github.com/user-attachments/assets/2f7f8cc9-160d-44f6-b8e9-93922a60ad99)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional setting to specify how long the download access token for meeting recordings remains valid (up to 7 days).

- **Refactor**
  - Improved how meeting recording downloads are handled for greater flexibility and control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->