### PR TITLE
feat(platform): add file-stream utility

### DIFF
--- a/platform/__tests__/file-stream.js
+++ b/platform/__tests__/file-stream.js
@@ -1,0 +1,196 @@
+const {
+  getFileStream, getFileStreamAndMetadata,
+} = require("../dist");
+const fs = require("fs");
+const path = require("path");
+const http = require("http");
+const os = require("os");
+
+// Helper function to read content from a readable stream
+async function readStreamContent(stream) {
+  let content = "";
+  stream.on("data", (chunk) => {
+    content += chunk.toString();
+  });
+
+  await new Promise((resolve) => {
+    stream.on("end", resolve);
+  });
+
+  return content;
+}
+
+// Helper function to wait for stream cleanup by listening to close event
+async function waitForStreamCleanup(stream) {
+  return new Promise((resolve) => {
+    stream.on("close", resolve);
+  });
+}
+
+describe("file-stream", () => {
+  let testFilePath;
+  let server;
+  const testPort = 3892;
+
+  beforeAll(() => {
+    // Create a test file
+    testFilePath = path.join(__dirname, "test-file.txt");
+    fs.writeFileSync(testFilePath, "test content for file stream");
+
+    // Create a simple HTTP server for testing remote files
+    server = http.createServer((req, res) => {
+      if (req.url === "/test-file.txt") {
+        res.writeHead(200, {
+          "Content-Type": "text/plain",
+          "Content-Length": "28",
+          "Last-Modified": new Date().toUTCString(),
+          "ETag": "\"test-etag\"",
+        });
+        res.end("test content for file stream");
+      } else if (req.url === "/no-content-length") {
+        res.writeHead(200, {
+          "Content-Type": "application/json",
+          "Last-Modified": new Date().toUTCString(),
+        });
+        res.end("{\"test\": \"data\"}");
+      } else if (req.url === "/error") {
+        res.writeHead(404, "Not Found");
+        res.end();
+      } else {
+        res.writeHead(404, "Not Found");
+        res.end();
+      }
+    });
+
+    return new Promise((resolve) =>
+      server.listen(testPort, resolve));
+  });
+
+  afterAll(() => {
+    // Clean up test file
+    if (fs.existsSync(testFilePath)) {
+      fs.unlinkSync(testFilePath);
+    }
+
+    if (server) {
+      return new Promise((resolve) =>
+        server.close(resolve));
+    }
+  });
+
+  describe("getFileStream", () => {
+    it("should return readable stream for local file", async () => {
+      const stream = await getFileStream(testFilePath);
+      expect(stream).toBeDefined();
+      expect(typeof stream.read).toBe("function");
+
+      const content = await readStreamContent(stream);
+      expect(content).toBe("test content for file stream");
+    });
+
+    it("should return readable stream for remote URL", async () => {
+      const stream = await getFileStream(`http://localhost:${testPort}/test-file.txt`);
+      expect(stream).toBeDefined();
+      expect(typeof stream.read).toBe("function");
+
+      const content = await readStreamContent(stream);
+      expect(content).toBe("test content for file stream");
+    });
+
+    it("should throw error for invalid URL", async () => {
+      await expect(getFileStream(`http://localhost:${testPort}/error`))
+        .rejects.toThrow("Failed to fetch");
+    });
+
+    it("should throw error for non-existent local file", async () => {
+      await expect(getFileStream("/non/existent/file.txt"))
+        .rejects.toThrow();
+    });
+  });
+
+  describe("getFileStreamAndMetadata", () => {
+    it("should return stream and metadata for local file", async () => {
+      const result = await getFileStreamAndMetadata(testFilePath);
+
+      expect(result.stream).toBeDefined();
+      expect(typeof result.stream.read).toBe("function");
+      expect(result.metadata).toMatchObject({
+        size: 28,
+        name: "test-file.txt",
+      });
+      expect(result.metadata.lastModified.constructor.name).toBe("Date");
+      const content = await readStreamContent(result.stream);
+      expect(content).toBe("test content for file stream");
+    });
+
+    it("should return stream and metadata for remote file with content-length", async () => {
+      const result = await getFileStreamAndMetadata(`http://localhost:${testPort}/test-file.txt`);
+
+      expect(result.stream).toBeDefined();
+      expect(typeof result.stream.read).toBe("function");
+      expect(result.metadata).toMatchObject({
+        size: 28,
+        contentType: "text/plain",
+        name: "test-file.txt",
+        etag: "\"test-etag\"",
+      });
+      expect(result.metadata.lastModified).toBeInstanceOf(Date);
+      const content = await readStreamContent(result.stream);
+      expect(content).toBe("test content for file stream");
+    });
+
+    it("should handle remote file without content-length", async () => {
+      const result = await getFileStreamAndMetadata(`http://localhost:${testPort}/no-content-length`);
+
+      expect(result.stream).toBeDefined();
+      expect(typeof result.stream.read).toBe("function");
+
+      expect(result.metadata).toMatchObject({
+        size: 16, // Size determined after download
+        contentType: "application/json",
+      });
+      expect(result.metadata.lastModified).toBeInstanceOf(Date);
+
+      const content = await readStreamContent(result.stream);
+      expect(content).toBe("{\"test\": \"data\"}");
+    });
+
+    it("should throw error for invalid remote URL", async () => {
+      await expect(getFileStreamAndMetadata(`http://localhost:${testPort}/error`))
+        .rejects.toThrow("Failed to fetch");
+    });
+  });
+
+  describe("temporary file cleanup", () => {
+    it("should clean up temporary files after stream ends", async () => {
+      const tmpDir = os.tmpdir();
+      const tempFilesBefore = fs.readdirSync(tmpDir);
+      const result = await getFileStreamAndMetadata(`http://localhost:${testPort}/no-content-length`);
+
+      const content = await readStreamContent(result.stream);
+      // Wait for cleanup to complete by listening to close event
+      await waitForStreamCleanup(result.stream);
+
+      // Check that temp files were cleaned up
+      const tempFilesAfter = fs.readdirSync(tmpDir);
+      expect(tempFilesAfter.length).toEqual(tempFilesBefore.length);
+      expect(content).toBe("{\"test\": \"data\"}");
+    });
+
+    it("should clean up temporary files on stream error", async () => {
+      // Check temp files before
+      const tmpDir = os.tmpdir();
+      const tempFilesBefore = fs.readdirSync(tmpDir);
+
+      const result = await getFileStreamAndMetadata(`http://localhost:${testPort}/no-content-length`);
+
+      // Trigger an error and wait for cleanup
+      result.stream.destroy(new Error("Test error"));
+      await waitForStreamCleanup(result.stream);
+
+      // Check that temp files were cleaned up
+      const tempFilesAfter = fs.readdirSync(tmpDir);
+      expect(tempFilesAfter.length).toEqual(tempFilesBefore.length);
+    });
+  });
+});

--- a/platform/dist/file-stream.d.ts
+++ b/platform/dist/file-stream.d.ts
@@ -1,0 +1,22 @@
+/// <reference types="node" />
+import { Readable } from "stream";
+export interface FileMetadata {
+    size?: number;
+    contentType?: string;
+    lastModified?: Date;
+    name?: string;
+    etag?: string;
+}
+/**
+ * @param pathOrUrl - a file path or a URL
+ * @returns a Readable stream of the file content
+ */
+export declare function getFileStream(pathOrUrl: string): Promise<Readable>;
+/**
+ * @param pathOrUrl - a file path or a URL
+ * @returns a Readable stream of the file content and its metadata
+ */
+export declare function getFileStreamAndMetadata(pathOrUrl: string): Promise<{
+    stream: Readable;
+    metadata: FileMetadata;
+}>;

--- a/platform/dist/file-stream.d.ts
+++ b/platform/dist/file-stream.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="node" />
 import { Readable } from "stream";
 export interface FileMetadata {
-    size?: number;
+    size: number;
     contentType?: string;
     lastModified?: Date;
     name?: string;

--- a/platform/dist/file-stream.js
+++ b/platform/dist/file-stream.js
@@ -1,0 +1,132 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getFileStreamAndMetadata = exports.getFileStream = void 0;
+const stream_1 = require("stream");
+const fs_1 = require("fs");
+const os_1 = require("os");
+const path_1 = require("path");
+const fs_2 = require("fs");
+const promises_1 = require("stream/promises");
+/**
+ * @param pathOrUrl - a file path or a URL
+ * @returns a Readable stream of the file content
+ */
+async function getFileStream(pathOrUrl) {
+    if (isUrl(pathOrUrl)) {
+        const response = await fetch(pathOrUrl);
+        if (!response.ok) {
+            throw new Error(`Failed to fetch ${pathOrUrl}: ${response.status} ${response.statusText}`);
+        }
+        return stream_1.Readable.fromWeb(response.body);
+    }
+    else {
+        // Check if file exists first (this will throw if file doesn't exist)
+        await fs_1.promises.stat(pathOrUrl);
+        return fs_1.createReadStream(pathOrUrl);
+    }
+}
+exports.getFileStream = getFileStream;
+/**
+ * @param pathOrUrl - a file path or a URL
+ * @returns a Readable stream of the file content and its metadata
+ */
+async function getFileStreamAndMetadata(pathOrUrl) {
+    if (isUrl(pathOrUrl)) {
+        return await getRemoteFileStreamAndMetadata(pathOrUrl);
+    }
+    else {
+        return await getLocalFileStreamAndMetadata(pathOrUrl);
+    }
+}
+exports.getFileStreamAndMetadata = getFileStreamAndMetadata;
+function isUrl(pathOrUrl) {
+    try {
+        new URL(pathOrUrl);
+        return true;
+    }
+    catch (_a) {
+        return false;
+    }
+}
+async function getLocalFileStreamAndMetadata(filePath) {
+    const stats = await fs_1.promises.stat(filePath);
+    const metadata = {
+        size: stats.size,
+        lastModified: stats.mtime,
+        name: filePath.split("/").pop() || filePath.split("\\").pop(),
+    };
+    const stream = fs_1.createReadStream(filePath);
+    return {
+        stream,
+        metadata,
+    };
+}
+async function getRemoteFileStreamAndMetadata(url) {
+    const response = await fetch(url);
+    if (!response.ok) {
+        throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
+    }
+    const headers = response.headers;
+    const contentLength = headers.get("content-length");
+    const contentType = headers.get("content-type") || undefined;
+    const lastModified = headers.get("last-modified")
+        ? new Date(headers.get("last-modified"))
+        : undefined;
+    const etag = headers.get("etag") || undefined;
+    const urlObj = new URL(url);
+    const name = urlObj.pathname.split("/").pop() || undefined;
+    const baseMetadata = {
+        contentType,
+        lastModified,
+        name,
+        etag,
+    };
+    // If we have content-length, we can stream directly
+    if (contentLength) {
+        const metadata = {
+            ...baseMetadata,
+            size: parseInt(contentLength, 10),
+        };
+        const stream = stream_1.Readable.fromWeb(response.body);
+        return {
+            stream,
+            metadata,
+        };
+    }
+    // No content-length header - need to download to temporary file to get size
+    return await downloadToTemporaryFile(response, baseMetadata);
+}
+async function downloadToTemporaryFile(response, baseMetadata) {
+    // Generate unique temporary file path
+    const tempFileName = `file-stream-${Date.now()}-${Math.random().toString(36)
+        .substring(2)}`;
+    const tempFilePath = path_1.join(os_1.tmpdir(), tempFileName);
+    // Download to temporary file
+    const fileStream = fs_2.createWriteStream(tempFilePath);
+    const webStream = stream_1.Readable.fromWeb(response.body);
+    await promises_1.pipeline(webStream, fileStream);
+    // Get file stats
+    const stats = await fs_1.promises.stat(tempFilePath);
+    const metadata = {
+        ...baseMetadata,
+        size: stats.size,
+    };
+    // Create a readable stream that cleans up the temp file when done
+    const stream = fs_1.createReadStream(tempFilePath);
+    // Clean up temp file when stream is closed or ends
+    const cleanup = async () => {
+        try {
+            await fs_1.promises.unlink(tempFilePath);
+        }
+        catch (_a) {
+            // Ignore cleanup errors (file might already be deleted)
+        }
+    };
+    stream.on("close", cleanup);
+    stream.on("end", cleanup);
+    stream.on("error", cleanup);
+    return {
+        stream,
+        metadata,
+    };
+}

--- a/platform/dist/file-stream.js
+++ b/platform/dist/file-stream.js
@@ -129,9 +129,9 @@ async function downloadToTemporaryFile(response, baseMetadata) {
                 // Ignore cleanup errors
             }
         };
-        stream.on("close", cleanup);
-        stream.on("end", cleanup);
-        stream.on("error", cleanup);
+        stream.once("close", cleanup);
+        stream.once("end", cleanup);
+        stream.once("error", cleanup);
         return {
             stream,
             metadata,

--- a/platform/dist/file-stream.js
+++ b/platform/dist/file-stream.js
@@ -78,13 +78,13 @@ async function getRemoteFileStreamAndMetadata(url) {
     }
     const headers = response.headers;
     const contentLength = headers.get("content-length");
-    const contentType = headers.get("content-type") || undefined;
     const lastModified = headers.get("last-modified")
         ? new Date(headers.get("last-modified"))
         : undefined;
     const etag = headers.get("etag") || undefined;
     const urlObj = new URL(url);
-    const name = urlObj.pathname.split("/").pop() || undefined;
+    const name = path_1.basename(urlObj.pathname);
+    const contentType = headers.get("content-type") || mime.lookup(urlObj.pathname) || undefined;
     const baseMetadata = {
         contentType,
         lastModified,

--- a/platform/dist/index.d.ts
+++ b/platform/dist/index.d.ts
@@ -3,6 +3,8 @@ import axios, { transformConfigForOauth } from "./axios";
 import { AxiosRequestConfig as AxiosConfig } from "axios";
 export { axios, transformConfigForOauth, };
 export { cloneSafe, jsonStringifySafe, } from "./utils";
+export { getFileStreamAndMetadata, getFileStream, } from "./file-stream";
+export type { FileMetadata, } from "./file-stream";
 export { ConfigurationError, } from "./errors";
 export { default as sqlProp, } from "./sql-prop";
 export type { ColumnSchema, DbInfo, TableInfo, TableMetadata, TableSchema, } from "./sql-prop";

--- a/platform/dist/index.js
+++ b/platform/dist/index.js
@@ -8,6 +8,9 @@ Object.defineProperty(exports, "transformConfigForOauth", { enumerable: true, ge
 var utils_1 = require("./utils");
 Object.defineProperty(exports, "cloneSafe", { enumerable: true, get: function () { return utils_1.cloneSafe; } });
 Object.defineProperty(exports, "jsonStringifySafe", { enumerable: true, get: function () { return utils_1.jsonStringifySafe; } });
+var file_stream_1 = require("./file-stream");
+Object.defineProperty(exports, "getFileStreamAndMetadata", { enumerable: true, get: function () { return file_stream_1.getFileStreamAndMetadata; } });
+Object.defineProperty(exports, "getFileStream", { enumerable: true, get: function () { return file_stream_1.getFileStream; } });
 var errors_1 = require("./errors");
 Object.defineProperty(exports, "ConfigurationError", { enumerable: true, get: function () { return errors_1.ConfigurationError; } });
 var sql_prop_1 = require("./sql-prop");

--- a/platform/lib/file-stream.ts
+++ b/platform/lib/file-stream.ts
@@ -1,0 +1,148 @@
+import { Readable } from "stream";
+import { ReadableStream } from "stream/web";
+import {
+  createReadStream, promises as fs,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createWriteStream } from "fs";
+import { pipeline } from "stream/promises";
+
+export interface FileMetadata {
+  size?: number;
+  contentType?: string;
+  lastModified?: Date;
+  name?: string;
+  etag?: string;
+}
+
+/**
+ * @param pathOrUrl - a file path or a URL
+ * @returns a Readable stream of the file content
+ */
+export async function getFileStream(pathOrUrl: string): Promise<Readable> {
+  if (isUrl(pathOrUrl)) {
+    const response = await fetch(pathOrUrl);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch ${pathOrUrl}: ${response.status} ${response.statusText}`);
+    }
+    return Readable.fromWeb(response.body as ReadableStream<Uint8Array>);
+  } else {
+    // Check if file exists first (this will throw if file doesn't exist)
+    await fs.stat(pathOrUrl);
+    return createReadStream(pathOrUrl);
+  }
+}
+
+/**
+ * @param pathOrUrl - a file path or a URL
+ * @returns a Readable stream of the file content and its metadata
+ */
+export async function getFileStreamAndMetadata(pathOrUrl: string): Promise<{ stream: Readable; metadata: FileMetadata }> {
+  if (isUrl(pathOrUrl)) {
+    return await getRemoteFileStreamAndMetadata(pathOrUrl);
+  } else {
+    return await getLocalFileStreamAndMetadata(pathOrUrl);
+  }
+}
+
+function isUrl(pathOrUrl: string): boolean {
+  try {
+    new URL(pathOrUrl);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function getLocalFileStreamAndMetadata(filePath: string): Promise<{ stream: Readable; metadata: FileMetadata }> {
+  const stats = await fs.stat(filePath);
+  const metadata: FileMetadata = {
+    size: stats.size,
+    lastModified: stats.mtime,
+    name: filePath.split("/").pop() || filePath.split("\\").pop(),
+  };
+  const stream = createReadStream(filePath);
+  return {
+    stream,
+    metadata,
+  };
+}
+
+async function getRemoteFileStreamAndMetadata(url: string): Promise<{ stream: Readable; metadata: FileMetadata }> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
+  }
+
+  const headers = response.headers;
+  const contentLength = headers.get("content-length");
+  const contentType = headers.get("content-type") || undefined;
+  const lastModified = headers.get("last-modified")
+    ? new Date(headers.get("last-modified")!)
+    : undefined;
+  const etag = headers.get("etag") || undefined;
+  const urlObj = new URL(url);
+  const name = urlObj.pathname.split("/").pop() || undefined;
+
+  const baseMetadata: FileMetadata = {
+    contentType,
+    lastModified,
+    name,
+    etag,
+  };
+
+  // If we have content-length, we can stream directly
+  if (contentLength) {
+    const metadata: FileMetadata = {
+      ...baseMetadata,
+      size: parseInt(contentLength, 10),
+    };
+    const stream = Readable.fromWeb(response.body as ReadableStream<Uint8Array>);
+    return {
+      stream,
+      metadata,
+    };
+  }
+
+  // No content-length header - need to download to temporary file to get size
+  return await downloadToTemporaryFile(response, baseMetadata);
+}
+
+async function downloadToTemporaryFile(response: Response, baseMetadata: FileMetadata): Promise<{ stream: Readable; metadata: FileMetadata }> {
+  // Generate unique temporary file path
+  const tempFileName = `file-stream-${Date.now()}-${Math.random().toString(36)
+    .substring(2)}`;
+  const tempFilePath = join(tmpdir(), tempFileName);
+  // Download to temporary file
+  const fileStream = createWriteStream(tempFilePath);
+  const webStream = Readable.fromWeb(response.body as ReadableStream<Uint8Array>);
+  await pipeline(webStream, fileStream);
+  // Get file stats
+  const stats = await fs.stat(tempFilePath);
+  const metadata: FileMetadata = {
+    ...baseMetadata,
+    size: stats.size,
+  };
+
+  // Create a readable stream that cleans up the temp file when done
+  const stream = createReadStream(tempFilePath);
+
+  // Clean up temp file when stream is closed or ends
+  const cleanup = async () => {
+    try {
+      await fs.unlink(tempFilePath);
+    } catch {
+      // Ignore cleanup errors (file might already be deleted)
+    }
+  };
+
+  stream.on("close", cleanup);
+  stream.on("end", cleanup);
+  stream.on("error", cleanup);
+
+  return {
+    stream,
+    metadata,
+  };
+}

--- a/platform/lib/file-stream.ts
+++ b/platform/lib/file-stream.ts
@@ -12,7 +12,7 @@ import { v4 as uuidv4 } from "uuid";
 import * as mime from "mime-types";
 
 export interface FileMetadata {
-  size?: number;
+  size: number;
   contentType?: string;
   lastModified?: Date;
   name?: string;
@@ -91,15 +91,15 @@ async function getRemoteFileStreamAndMetadata(url: string): Promise<{ stream: Re
 
   const headers = response.headers;
   const contentLength = headers.get("content-length");
-  const contentType = headers.get("content-type") || undefined;
   const lastModified = headers.get("last-modified")
     ? new Date(headers.get("last-modified")!)
     : undefined;
   const etag = headers.get("etag") || undefined;
   const urlObj = new URL(url);
-  const name = urlObj.pathname.split("/").pop() || undefined;
+  const name = basename(urlObj.pathname);
+  const contentType = headers.get("content-type") || mime.lookup(urlObj.pathname) || undefined;
 
-  const baseMetadata: FileMetadata = {
+  const baseMetadata = {
     contentType,
     lastModified,
     name,
@@ -123,7 +123,7 @@ async function getRemoteFileStreamAndMetadata(url: string): Promise<{ stream: Re
   return await downloadToTemporaryFile(response, baseMetadata);
 }
 
-async function downloadToTemporaryFile(response: Response, baseMetadata: FileMetadata): Promise<{ stream: Readable; metadata: FileMetadata }> {
+async function downloadToTemporaryFile(response: Response, baseMetadata: Partial<FileMetadata>): Promise<{ stream: Readable; metadata: FileMetadata }> {
   // Generate unique temporary file path
   const tempFileName = `file-stream-${uuidv4()}`;
   const tempFilePath = join(tmpdir(), tempFileName);

--- a/platform/lib/file-stream.ts
+++ b/platform/lib/file-stream.ts
@@ -147,9 +147,9 @@ async function downloadToTemporaryFile(response: Response, baseMetadata: Partial
       }
     };
 
-    stream.on("close", cleanup);
-    stream.on("end", cleanup);
-    stream.on("error", cleanup);
+    stream.once("close", cleanup);
+    stream.once("end", cleanup);
+    stream.once("error", cleanup);
 
     return {
       stream,

--- a/platform/lib/index.ts
+++ b/platform/lib/index.ts
@@ -11,6 +11,14 @@ export {
 } from "./utils";
 
 export {
+  getFileStreamAndMetadata,
+  getFileStream,
+} from "./file-stream";
+export type {
+  FileMetadata,
+} from "./file-stream";
+
+export {
   ConfigurationError,
 } from "./errors";
 

--- a/platform/lib/index.ts
+++ b/platform/lib/index.ts
@@ -167,6 +167,7 @@ export const sendTypeMap = {
 };
 
 // Event object that persists throughout worfklow with observability after each step.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export let $event: any;
 
 export const END_NEEDLE = "__pd_end";
@@ -215,6 +216,7 @@ export const $sendConfigRuntimeTypeChecker = (function () {
 
 export interface AxiosRequestConfig extends AxiosConfig {
   debug?: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   body?: any;
   returnFullResponse?: boolean;
 }

--- a/platform/package-lock.json
+++ b/platform/package-lock.json
@@ -12,7 +12,9 @@
         "axios": "^1.7.4",
         "fp-ts": "^2.0.2",
         "io-ts": "^2.0.0",
-        "querystring": "^0.2.1"
+        "mime-types": "^3.0.1",
+        "querystring": "^0.2.1",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@octokit/core": "^3.6.0",
@@ -2320,6 +2322,25 @@
         "node": ">= 6"
       }
     },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/fp-ts": {
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.12.1.tgz",
@@ -4603,19 +4624,19 @@
       }
     },
     "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
       "dependencies": {
-        "mime-db": "1.52.0"
+        "mime-db": "^1.54.0"
       },
       "engines": {
         "node": ">= 0.6"
@@ -5514,6 +5535,18 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {
@@ -7488,6 +7521,21 @@
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.52.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+          "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+        },
+        "mime-types": {
+          "version": "2.1.35",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+          "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+          "requires": {
+            "mime-db": "1.52.0"
+          }
+        }
       }
     },
     "fp-ts": {
@@ -9180,16 +9228,16 @@
       }
     },
     "mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="
     },
     "mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
       "requires": {
-        "mime-db": "1.52.0"
+        "mime-db": "^1.54.0"
       }
     },
     "mimic-fn": {
@@ -9858,6 +9906,11 @@
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"
       }
+    },
+    "uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="
     },
     "v8-to-istanbul": {
       "version": "9.0.1",

--- a/platform/package-lock.json
+++ b/platform/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pipedream/platform",
-  "version": "3.0.1",
+  "version": "3.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pipedream/platform",
-      "version": "3.0.1",
+      "version": "3.0.3",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.4",

--- a/platform/package-lock.json
+++ b/platform/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pipedream/platform",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pipedream/platform",
-      "version": "3.0.3",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.4",

--- a/platform/package.json
+++ b/platform/package.json
@@ -20,13 +20,15 @@
     "axios": "^1.7.4",
     "fp-ts": "^2.0.2",
     "io-ts": "^2.0.0",
-    "querystring": "^0.2.1"
+    "mime-types": "^3.0.1",
+    "querystring": "^0.2.1",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
+    "@octokit/core": "^3.6.0",
     "husky": "^3.0.0",
     "jest": "^29.1.2",
     "type-fest": "^4.15.0",
-    "@octokit/core": "^3.6.0",
     "typescript": "^3.5.3"
   }
 }

--- a/platform/package.json
+++ b/platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/platform",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "description": "Pipedream platform globals (typing and runtime type checking)",
   "homepage": "https://pipedream.com",
   "main": "dist/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32644,7 +32644,7 @@ snapshots:
       '@babel/helper-validator-option': 8.0.0-alpha.13
       browserslist: 4.24.2
       lru-cache: 7.18.3
-      semver: 7.7.1
+      semver: 7.7.2
 
   '@babel/helper-create-class-features-plugin@7.25.9(@babel/core@7.26.0)':
     dependencies:
@@ -35984,6 +35984,8 @@ snapshots:
       '@putout/operator-filesystem': 5.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))
       '@putout/operator-json': 2.2.0
       putout: 36.13.1(eslint@8.57.1)(typescript@5.6.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@putout/operator-regexp@1.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))':
     dependencies:
@@ -43260,7 +43262,7 @@ snapshots:
 
   is-bun-module@1.2.1:
     dependencies:
-      semver: 7.7.1
+      semver: 7.7.2
 
   is-callable@1.2.7: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15765,9 +15765,15 @@ importers:
       io-ts:
         specifier: ^2.0.0
         version: 2.2.21(fp-ts@2.16.9)
+      mime-types:
+        specifier: ^3.0.1
+        version: 3.0.1
       querystring:
         specifier: ^0.2.1
         version: 0.2.1
+      uuid:
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@octokit/core':
         specifier: ^3.6.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29125,22 +29125,22 @@ packages:
   superagent@3.8.1:
     resolution: {integrity: sha512-VMBFLYgFuRdfeNQSMLbxGSLfmXL/xc+OO+BZp41Za/NRDBet/BNbkRJrYzCUu0u4GU0i/ml2dtT8b9qgkw9z6Q==}
     engines: {node: '>= 4.0'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
 
   superagent@4.1.0:
     resolution: {integrity: sha512-FT3QLMasz0YyCd4uIi5HNe+3t/onxMyEho7C3PSqmti3Twgy2rXT4fmkTz6wRL6bTF4uzPcfkUCa8u4JWHw8Ag==}
     engines: {node: '>= 6.0'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
 
   superagent@5.3.1:
     resolution: {integrity: sha512-wjJ/MoTid2/RuGCOFtlacyGNxN9QLMgcpYLDQlWFIhhdJ93kNscFonGvrpAHSCVjRVj++DGCglocF7Aej1KHvQ==}
     engines: {node: '>= 7.0.0'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
 
   superagent@7.1.6:
     resolution: {integrity: sha512-gZkVCQR1gy/oUXr+kxJMLDjla434KmSOKbx5iGD30Ql+AkJQ/YlPKECJy2nhqOsHLjGHzoDTXNSjhnvWhzKk7g==}
     engines: {node: '>=6.4.0 <13 || >=14'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please downgrade to v7.1.5 if you need IE/ActiveXObject support OR upgrade to v8.0.0 as we no longer support IE and published an incorrect patch version (see https://github.com/visionmedia/superagent/issues/1731)
 
   supports-color@2.0.0:
     resolution: {integrity: sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==}


### PR DESCRIPTION
## WHY

Components that take a file as input accept a file path (e.g., `/tmp/my-file.csv`), a remove URL (e.g. `https://example.com/file.txt`), or both. For convenience, ideally every component that accepts only a file path would also accept a remote file URL. Those components can be updated to use the helper, added in this PR, to get a readable stream and file metadata by passing either a local file path or remote file URL.

For example:
```js
import { getFileStreamAndMetadata } from "@pipedream/platform";

export default {
  type: "action",
  props: {
    file: {
      type: "string",
      label: "File",
      description: "The URL or local path to the file (e.g. \`/tmp/myFile.csv\`)",
      optional: true,
    },
  },
  async run({ $ }) {
    const { file: filePathOrUrl } = this;
    const { stream, metadata } = await getFileStreamAndMetadata(filePathOrUrl);
    // Do something with the file stream and metadata
  },
};

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to stream files from both local paths and remote URLs, with support for retrieving file metadata such as size, content type, last modified date, name, and ETag.
- **Tests**
  - Introduced comprehensive tests to ensure correct file streaming and metadata extraction, as well as proper cleanup of temporary files.
- **Chores**
  - Updated the package version to 3.1.0 and added new dependencies for MIME type handling and UUID generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->