### PR TITLE
Add Zendesk Help Center article search and retrieval actions

### DIFF
--- a/components/zendesk/actions/get-article/get-article.mjs
+++ b/components/zendesk/actions/get-article/get-article.mjs
@@ -1,0 +1,79 @@
+import app from "../../zendesk.app.mjs";
+
+export default {
+  key: "zendesk-get-article",
+  name: "Get Article",
+  description: "Retrieves the full content and metadata of a specific help center article by ID. [See the documentation](https://developer.zendesk.com/api-reference/help_center/help-center-api/articles/#show-article).",
+  type: "action",
+  version: "0.1.0",
+  props: {
+    app,
+    articleId: {
+      type: "integer",
+      label: "Article ID",
+      description: "The unique ID of the article to retrieve",
+    },
+    locale: {
+      type: "string",
+      label: "Locale",
+      description: "The locale for the article (e.g., 'en-us')",
+      default: "en-us",
+      optional: true,
+    },
+    includeTranslations: {
+      type: "boolean",
+      label: "Include Translations",
+      description: "Whether to include article translations in the response",
+      default: false,
+      optional: true,
+    },
+    customSubdomain: {
+      propDefinition: [
+        app,
+        "customSubdomain",
+      ],
+    },
+  },
+  methods: {
+    getArticle(args = {}) {
+      const {
+        articleId,
+        customSubdomain,
+        params,
+        ...otherArgs
+      } = args;
+      
+      return this.app.makeRequest({
+        path: `/help_center/articles/${articleId}`,
+        customSubdomain,
+        params,
+        ...otherArgs,
+      });
+    },
+  },
+  async run({ $: step }) {
+    const {
+      articleId,
+      locale,
+      includeTranslations,
+      customSubdomain,
+    } = this;
+
+    const params = {};
+    
+    if (includeTranslations) {
+      params.include = "translations";
+    }
+
+    const response = await this.getArticle({
+      step,
+      articleId,
+      customSubdomain,
+      params,
+    });
+
+    step.export("$summary", `Successfully retrieved article: "${response.article?.title || 'Unknown'}"`);
+    return response;
+  },
+};
+// This code defines a Zendesk action to retrieve a specific help center article by its ID.

--- a/components/zendesk/actions/list-articles-in-section/list-articles-in-section.mjs
+++ b/components/zendesk/actions/list-articles-in-section/list-articles-in-section.mjs
@@ -1,0 +1,100 @@
+import app from "../../zendesk.app.mjs";
+
+export default {
+  key: "zendesk-list-articles-in-section",
+  name: "List Articles in Section",
+  description: "Lists all articles within a specific help center section. Useful after identifying relevant sections. [See the documentation](https://developer.zendesk.com/api-reference/help_center/help-center-api/articles/#list-articles).",
+  type: "action",
+  version: "0.1.0",
+  props: {
+    app,
+    sectionId: {
+      type: "integer",
+      label: "Section ID",
+      description: "The unique ID of the section to list articles from",
+    },
+    locale: {
+      type: "string",
+      label: "Locale",
+      description: "The locale for the articles (e.g., 'en-us')",
+      default: "en-us",
+      optional: true,
+    },
+    sortBy: {
+      type: "string",
+      label: "Sort By",
+      description: "Sort articles by specified field",
+      options: [
+        "position",
+        "title",
+        "created_at",
+        "updated_at",
+        "edited_at",
+      ],
+      default: "position",
+      optional: true,
+    },
+    sortOrder: {
+      type: "string",
+      label: "Sort Order",
+      description: "Order of the results",
+      options: [
+        "asc",
+        "desc",
+      ],
+      default: "asc",
+      optional: true,
+    },
+    customSubdomain: {
+      propDefinition: [
+        app,
+        "customSubdomain",
+      ],
+    },
+  },
+  methods: {
+    listArticlesInSection(args = {}) {
+      const {
+        sectionId,
+        customSubdomain,
+        params,
+        ...otherArgs
+      } = args;
+      
+      return this.app.makeRequest({
+        path: `/help_center/sections/${sectionId}/articles`,
+        customSubdomain,
+        params,
+        ...otherArgs,
+      });
+    },
+  },
+  async run({ $: step }) {
+    const {
+      sectionId,
+      locale,
+      sortBy,
+      sortOrder,
+      customSubdomain,
+    } = this;
+
+    const params = {};
+    
+    if (sortBy) {
+      params.sort_by = sortBy;
+    }
+    if (sortOrder) {
+      params.sort_order = sortOrder;
+    }
+
+    const response = await this.listArticlesInSection({
+      step,
+      sectionId,
+      customSubdomain,
+      params,
+    });
+
+    step.export("$summary", `Successfully retrieved ${response.articles?.length || 0} articles from section ${sectionId}`);
+    return response;
+  },
+};

--- a/components/zendesk/actions/list-help-center-sections/list-help-center-sections.mjs
+++ b/components/zendesk/actions/list-help-center-sections/list-help-center-sections.mjs
@@ -1,0 +1,91 @@
+import app from "../../zendesk.app.mjs";
+
+export default {
+  key: "zendesk-list-help-center-sections",
+  name: "List Help Center Sections",
+  description: "Lists all sections in the help center to understand content organization. Useful for browsing articles by topic area. [See the documentation](https://developer.zendesk.com/api-reference/help_center/help-center-api/sections/#list-sections).",
+  type: "action",
+  version: "0.1.0",
+  props: {
+    app,
+    locale: {
+      type: "string",
+      label: "Locale",
+      description: "The locale for the sections (e.g., 'en-us')",
+      default: "en-us",
+      optional: true,
+    },
+    sortBy: {
+      type: "string",
+      label: "Sort By",
+      description: "Sort sections by specified field",
+      options: [
+        "position",
+        "name",
+        "created_at",
+        "updated_at",
+      ],
+      default: "position",
+      optional: true,
+    },
+    sortOrder: {
+      type: "string",
+      label: "Sort Order",
+      description: "Order of the results",
+      options: [
+        "asc",
+        "desc",
+      ],
+      default: "asc",
+      optional: true,
+    },
+    customSubdomain: {
+      propDefinition: [
+        app,
+        "customSubdomain",
+      ],
+    },
+  },
+  methods: {
+    listSections(args = {}) {
+      const {
+        customSubdomain,
+        params,
+        ...otherArgs
+      } = args;
+      
+      return this.app.makeRequest({
+        path: `/help_center/sections`,
+        customSubdomain,
+        params,
+        ...otherArgs,
+      });
+    },
+  },
+  async run({ $: step }) {
+    const {
+      locale,
+      sortBy,
+      sortOrder,
+      customSubdomain,
+    } = this;
+
+    const params = {};
+    
+    if (sortBy) {
+      params.sort_by = sortBy;
+    }
+    if (sortOrder) {
+      params.sort_order = sortOrder;
+    }
+
+    const response = await this.listSections({
+      step,
+      customSubdomain,
+      params,
+    });
+
+    step.export("$summary", `Successfully retrieved ${response.sections?.length || 0} help center sections`);
+    return response;
+  },
+};

--- a/components/zendesk/actions/search-articles/search-articles.mjs
+++ b/components/zendesk/actions/search-articles/search-articles.mjs
@@ -1,0 +1,110 @@
+import app from "../../zendesk.app.mjs";
+
+export default {
+  key: "zendesk-search-articles",
+  name: "Search Articles",
+  description: "Searches for help center knowledge base articles using Zendesk's Help Center API. Can search by keywords, filter by labels, and sort results. [See the documentation](https://developer.zendesk.com/api-reference/help_center/help-center-api/articles/#list-articles).",
+  type: "action",
+  version: "0.1.0",
+  props: {
+    app,
+    searchQuery: {
+      type: "string",
+      label: "Search Query",
+      description: "Keywords to search for in article titles and content",
+      optional: true,
+    },
+    labelNames: {
+      type: "string",
+      label: "Label Names",
+      description: "Comma-separated list of label names to filter by (e.g., 'photos,camera')",
+      optional: true,
+    },
+    sortBy: {
+      type: "string",
+      label: "Sort By",
+      description: "Sort articles by specified field",
+      options: [
+        "position",
+        "title", 
+        "created_at",
+        "updated_at",
+        "edited_at",
+      ],
+      default: "position",
+      optional: true,
+    },
+    sortOrder: {
+      type: "string",
+      label: "Sort Order",
+      description: "Order of the results",
+      options: [
+        "asc",
+        "desc",
+      ],
+      default: "asc",
+      optional: true,
+    },
+    locale: {
+      type: "string",
+      label: "Locale",
+      description: "The locale for the articles (e.g., 'en-us')",
+      default: "en-us",
+      optional: true,
+    },
+    customSubdomain: {
+      propDefinition: [
+        app,
+        "customSubdomain",
+      ],
+    },
+  },
+  methods: {
+    searchArticles(args = {}) {
+      const {
+        customSubdomain,
+        params,
+        ...otherArgs
+      } = args;
+      
+      return this.app.makeRequest({
+        path: `/help_center/articles`,
+        customSubdomain,
+        params,
+        ...otherArgs,
+      });
+    },
+  },
+  async run({ $: step }) {
+    const {
+      searchQuery,
+      labelNames,
+      sortBy,
+      sortOrder,
+      locale,
+      customSubdomain,
+    } = this;
+
+    const params = {};
+    
+    if (labelNames) {
+      params.label_names = labelNames;
+    }
+    if (sortBy) {
+      params.sort_by = sortBy;
+    }
+    if (sortOrder) {
+      params.sort_order = sortOrder;
+    }
+
+    const response = await this.searchArticles({
+      step,
+      customSubdomain,
+      params,
+    });
+
+    step.export("$summary", `Successfully found ${response.articles?.length || 0} articles`);
+    return response;
+  },
+};
+// This code defines a Pipedream action that allows users to search for articles in Zendesk's Help Center.


### PR DESCRIPTION
Adds four actions based off of the Zendesk API docs, following the format of the existing actions. The current actions are for tickets only, these are for knowledge articles.

- search-articles: Search help center articles by keywords and labels
- get-article: Retrieve full article content by ID
- list-help-center-sections: List all help center sections
- list-articles-in-section: List articles within a specific section

These actions enable access to Zendesk's Help Center knowledge base for knowledge workflows.

## WHY

I want to leverage Zendesk article content in my workflows. The current integration only considers tickets. 

These API docs were used to develop: 

https://developer.zendesk.com/api-reference/help_center/help-center-api/articles/#show-article
https://developer.zendesk.com/api-reference/help_center/help-center-api/articles/#list-articles
