### PR TITLE
Adding support for the sql prop type in the pipedream sdk

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # Changelog
 
+## [1.6.6] - 2025-06-05
+
+### Added
+
+- Added support for `sql` prop type for `connect-react` package
+
 ## [1.6.5] - 2025-06-02
 
 ### Changed

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pipedream/sdk",
   "type": "module",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "description": "Pipedream SDK",
   "main": "./dist/server.js",
   "module": "./dist/server.js",

--- a/packages/sdk/src/shared/component.ts
+++ b/packages/sdk/src/shared/component.ts
@@ -86,12 +86,17 @@ export type ConfigurablePropStringArray = BaseConfigurableProp & {
   type: "string[]";
   secret?: boolean; // TODO is this supported
 } & Defaultable<string[]>; // TODO
+export type ConfigurablePropSql = BaseConfigurableProp & {
+  type: "sql";
+  auth: {
+    app: string;
+  };
+} & Defaultable<string>;
 // | { type: "$.interface.http" } // source only
 // | { type: "$.interface.timer" } // source only
 // | { type: "$.service.db" }
 // | { type: "data_store" }
 // | { type: "http_request" }
-// | { type: "sql" } -- not in component api docs!
 export type ConfigurableProp =
   | ConfigurablePropAlert
   | ConfigurablePropAny
@@ -101,6 +106,7 @@ export type ConfigurableProp =
   | ConfigurablePropObject
   | ConfigurablePropString
   | ConfigurablePropStringArray
+  | ConfigurablePropSql
   | (BaseConfigurableProp & { type: "$.discord.channel"; });
 
 export type ConfigurableProps = Readonly<ConfigurableProp[]>;
@@ -121,6 +127,8 @@ export type PropValue<T extends ConfigurableProp["type"]> = T extends "alert"
   ? string
   : T extends "string[]"
   ? string[] // XXX support arrays differently?
+  : T extends "sql"
+  ? { app: string; query: string; params: unknown[]; }
   : never;
 
 export type ConfiguredProps<T extends ConfigurableProps> = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15615,6 +15615,14 @@ importers:
         specifier: ^6.0.0
         version: 6.2.0
 
+  modelcontextprotocol/node_modules2/@modelcontextprotocol/sdk/dist/cjs: {}
+
+  modelcontextprotocol/node_modules2/@modelcontextprotocol/sdk/dist/esm: {}
+
+  modelcontextprotocol/node_modules2/zod-to-json-schema/dist/cjs: {}
+
+  modelcontextprotocol/node_modules2/zod-to-json-schema/dist/esm: {}
+
   packages/ai:
     dependencies:
       '@pipedream/sdk':


### PR DESCRIPTION
## WHY

<!-- author to complete -->
