### PR TITLE
Add missing fields in SDK types

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 # Changelog
 
+## [1.6.8] - 2025-06-07
+
+### Added
+
+- Added `endpoint_url` field to the component metadata, providing the URL to the
+  HTTP interface of the component.
+- Added missing pagination fields to the `GetComponentsResponse`  and
+  `GetAccountsResponse` types.
+
 ## [1.6.7] - 2025-06-06
 
 ### Added

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pipedream/sdk",
   "type": "module",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "description": "Pipedream SDK",
   "main": "./dist/server.js",
   "module": "./dist/server.js",

--- a/packages/sdk/src/shared/component.ts
+++ b/packages/sdk/src/shared/component.ts
@@ -157,6 +157,11 @@ export type V1DeployedComponent<T extends ConfigurableProps = any> = { // eslint
   name: string;
   name_slug: string;
   callback_observations?: unknown;
+
+  /**
+   * The URL to the HTTP interface of this component, if it has one.
+   */
+  endpoint_url?: string;
 };
 
 export type V1EmittedEvent = {

--- a/packages/sdk/src/shared/index.ts
+++ b/packages/sdk/src/shared/index.ts
@@ -497,7 +497,9 @@ export type ConnectTokenResponse = {
 /**
  * The response received when retrieving a list of accounts.
  */
-export type GetAccountsResponse = { data: Account[]; };
+export type GetAccountsResponse = PaginationResponse & {
+  data: Account[];
+};
 
 /**
  * @deprecated Use `GetAccountsResponse` instead.
@@ -527,7 +529,7 @@ export type AppRequestResponse = GetAppResponse;
 /**
  * The response received when retrieving a list of components.
  */
-export type GetComponentsResponse = {
+export type GetComponentsResponse = PaginationResponse & {
   data: V1Component[];
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2742,8 +2742,7 @@ importers:
 
   components/codeq_natural_language_processing_api: {}
 
-  components/codeqr:
-    specifiers: {}
+  components/codeqr: {}
 
   components/codereadr:
     dependencies:
@@ -4595,8 +4594,7 @@ importers:
 
   components/finage: {}
 
-  components/finalscout:
-    specifiers: {}
+  components/finalscout: {}
 
   components/findymail:
     dependencies:
@@ -10335,8 +10333,7 @@ importers:
         specifier: ^1.5.1
         version: 1.6.6
 
-  components/predictleads:
-    specifiers: {}
+  components/predictleads: {}
 
   components/prepr_graphql: {}
 


### PR DESCRIPTION
# Changelog
* Add `endpoint_url` field to the component metadata, providing the URL to the HTTP interface of the component.
* Add missing pagination fields to the `GetComponentsResponse` and `GetAccountsResponse` types.