### PR TITLE
Type improvements for configurable props

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 # Changelog
 
+## [1.6.9] - 2025-06-10
+
+### Added
+
+- Added types for the missing configurable props
+
+## Changed
+
+- Fixed the `Defaultable` type to correctly handle arrays
+- Fixed the `ConfigurablePropTimer` type to define cron expressions and
+  time intervals
+- Marked the `auth` field in the SQL prop type as optional
+
 ## [1.6.8] - 2025-06-07
 
 ### Added

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pipedream/sdk",
   "type": "module",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "description": "Pipedream SDK",
   "main": "./dist/server.js",
   "module": "./dist/server.js",

--- a/packages/sdk/src/shared/component.ts
+++ b/packages/sdk/src/shared/component.ts
@@ -55,59 +55,150 @@ type BaseConfigurableProp = {
 };
 
 // XXX fix duplicating mapping to value type here and with PropValue
-type Defaultable<T> = { default?: T; options?: T[]; };
+
+type LabelValueOption<T> = {
+  label: string;
+  value: T;
+};
+
+type Defaultable<T, SingleT = T> = {
+  default?: T
+  options?: SingleT[] | Array<LabelValueOption<SingleT>>;
+}
 
 export type ConfigurablePropAlert = BaseConfigurableProp & {
   type: "alert";
   alertType: "info" | "neutral" | "warning" | "error"; // TODO check the types
   content: string;
 };
+
 export type ConfigurablePropAny = BaseConfigurableProp & {
   type: "any";
 } & Defaultable<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+
 export type ConfigurablePropApp = BaseConfigurableProp & {
   type: "app";
   app: string;
 };
-export type ConfigurablePropBoolean = BaseConfigurableProp & { type: "boolean"; };
+
+export type ConfigurablePropBoolean = BaseConfigurableProp & {
+  type: "boolean";
+} & Defaultable<boolean>;
+
 export type ConfigurablePropInteger = BaseConfigurableProp & {
   type: "integer";
   min?: number;
   max?: number;
 } & Defaultable<number>;
+
 export type ConfigurablePropObject = BaseConfigurableProp & {
   type: "object";
 } & Defaultable<object>;
+
 export type ConfigurablePropString = BaseConfigurableProp & {
   type: "string";
   secret?: boolean;
 } & Defaultable<string>;
+
 export type ConfigurablePropStringArray = BaseConfigurableProp & {
   type: "string[]";
   secret?: boolean; // TODO is this supported
-} & Defaultable<string[]>; // TODO
+} & Defaultable<string[], string>;
+
+export type TimerInterval = {
+  intervalSeconds: number;
+}
+
+export type TimerCron = {
+  cron: string;
+}
+
+export type ConfigurablePropTimer = BaseConfigurableProp & {
+  type: "$.interface.timer";
+  static?: TimerInterval | TimerCron;
+} & Defaultable<TimerInterval | TimerCron>;
+
+export type ConfigurablePropApphook = BaseConfigurableProp & {
+  type: "$.interface.apphook";
+  appProp: string;
+  eventNames?: Array<string>;
+  remote?: boolean;
+  static?: Array<unknown>;
+}
+
+export type ConfigurablePropIntegerArray = BaseConfigurableProp & {
+  type: "integer[]";
+  min?: number;
+  max?: number;
+} & Defaultable<number[], number>
+
+export type ConfigurablePropHttp = BaseConfigurableProp & {
+  type: "$.interface.http";
+  customResponse?: boolean;
+}
+
+export type ConfigurablePropDb = BaseConfigurableProp & {
+  type: "$.service.db";
+}
+
 export type ConfigurablePropSql = BaseConfigurableProp & {
   type: "sql";
-  auth: {
+  auth?: {
     app: string;
   };
 } & Defaultable<string>;
-// | { type: "$.interface.http" } // source only
-// | { type: "$.interface.timer" } // source only
-// | { type: "$.service.db" }
-// | { type: "data_store" }
-// | { type: "http_request" }
+
+export type ConfigurablePropAirtableBaseId = BaseConfigurableProp & {
+  type: "$.airtable.baseId";
+  appProp: string;
+}
+
+export type ConfigurablePropAirtableTableId = BaseConfigurableProp & {
+  type: "$.airtable.tableId";
+  baseIdProp: string;
+}
+
+export type ConfigurablePropAirtableViewId = BaseConfigurableProp & {
+  type: "$.airtable.viewId";
+  tableIdProp: string;
+}
+
+export type ConfigurablePropAirtableFieldId = BaseConfigurableProp & {
+  type: "$.airtable.fieldId";
+  tableIdProp: string;
+}
+
+export type ConfigurablePropDiscordChannel = BaseConfigurableProp & {
+  type: "$.discord.channel";
+  appProp: string;
+}
+
+export type ConfigurablePropDiscordChannelArray = BaseConfigurableProp & {
+  type: "$.discord.channel[]";
+  appProp: string;
+}
+
 export type ConfigurableProp =
+  | ConfigurablePropAirtableBaseId
+  | ConfigurablePropAirtableFieldId
+  | ConfigurablePropAirtableTableId
+  | ConfigurablePropAirtableViewId
   | ConfigurablePropAlert
   | ConfigurablePropAny
   | ConfigurablePropApp
+  | ConfigurablePropApphook
   | ConfigurablePropBoolean
+  | ConfigurablePropDb
+  | ConfigurablePropDiscordChannel
+  | ConfigurablePropDiscordChannelArray
+  | ConfigurablePropHttp
   | ConfigurablePropInteger
+  | ConfigurablePropIntegerArray
   | ConfigurablePropObject
+  | ConfigurablePropSql
   | ConfigurablePropString
   | ConfigurablePropStringArray
-  | ConfigurablePropSql
-  | (BaseConfigurableProp & { type: "$.discord.channel"; });
+  | ConfigurablePropTimer
 
 export type ConfigurableProps = Readonly<ConfigurableProp[]>;
 


### PR DESCRIPTION
# Changelog
* Add types for the missing configurable props
* Fix the `Defaultable` type to correctly handle arrays
* Fixed the `ConfigurablePropTimer` type to define cron expressions and time intervals
* Mark the `auth` field in the SQL prop type as optional