### PR TITLE
Supabase: Select Row sometimes returns errors

### DIFF
--- a/components/supabase/actions/select-row/select-row.mjs
+++ b/components/supabase/actions/select-row/select-row.mjs
@@ -5,7 +5,7 @@ export default {
   key: "supabase-select-row",
   name: "Select Row",
   type: "action",
-  version: "0.1.2",
+  version: "0.1.3",
   description: "Selects row(s) in a database. [See the docs here](https://supabase.com/docs/reference/javascript/select)",
   props: {
     supabase,
@@ -81,7 +81,7 @@ export default {
       sortOrder,
       max,
     });
-    $.export("$summary", `Successfully retrieved ${response.length} rows from table ${table}`);
+    $.export("$summary", `Successfully retrieved ${response.data?.length || 0} row(s) from table ${table}`);
     return response;
   },
 };

--- a/components/supabase/package.json
+++ b/components/supabase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/supabase",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Pipedream Supabase Components",
   "main": "supabase.app.mjs",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36078,6 +36078,8 @@ snapshots:
       '@putout/operator-filesystem': 5.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))
       '@putout/operator-json': 2.2.0
       putout: 36.13.1(eslint@8.57.1)(typescript@5.6.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@putout/operator-regexp@1.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))':
     dependencies:


### PR DESCRIPTION
Resolves #17043 

I was able to reproduce the error, but I discovered that it was because my Project had been paused due to inactivity. Once reactivated, the error went away. 

However, I found several online comments about similar sporadic errors, and that the "fetch failed" error can stem from various issues, including network problems. So I added a `retryWithExponentialBackoff` method to help reduce errors.