### PR TITLE
Quickbooks Create Purchase Order Updates

### DIFF
--- a/components/quickbooks/actions/create-ap-aging-report/create-ap-aging-report.mjs
+++ b/components/quickbooks/actions/create-ap-aging-report/create-ap-aging-report.mjs
@@ -5,7 +5,7 @@ export default {
   key: "quickbooks-create-ap-aging-report",
   name: "Create AP Aging Detail Report",
   description: "Creates an AP aging report in Quickbooks Online. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/apagingdetail#query-a-report)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/create-bill/create-bill.mjs
+++ b/components/quickbooks/actions/create-bill/create-bill.mjs
@@ -6,7 +6,7 @@ export default {
   key: "quickbooks-create-bill",
   name: "Create Bill",
   description: "Creates a bill. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/bill#create-a-bill)",
-  version: "0.1.9",
+  version: "0.1.10",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/create-customer/create-customer.mjs
+++ b/components/quickbooks/actions/create-customer/create-customer.mjs
@@ -5,7 +5,7 @@ export default {
   key: "quickbooks-create-customer",
   name: "Create Customer",
   description: "Creates a customer. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/customer#create-a-customer)",
-  version: "0.1.9",
+  version: "0.1.10",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/create-estimate/create-estimate.mjs
+++ b/components/quickbooks/actions/create-estimate/create-estimate.mjs
@@ -9,7 +9,7 @@ export default {
   key: "quickbooks-create-estimate",
   name: "Create Estimate",
   description: "Creates an estimate. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/estimate#create-an-estimate)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/create-invoice/create-invoice.mjs
+++ b/components/quickbooks/actions/create-invoice/create-invoice.mjs
@@ -6,7 +6,7 @@ export default {
   key: "quickbooks-create-invoice",
   name: "Create Invoice",
   description: "Creates an invoice. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/invoice#create-an-invoice)",
-  version: "0.2.3",
+  version: "0.2.4",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/create-payment/create-payment.mjs
+++ b/components/quickbooks/actions/create-payment/create-payment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "quickbooks-create-payment",
   name: "Create Payment",
   description: "Creates a payment. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/payment#create-a-payment)",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/create-pl-report/create-pl-report.mjs
+++ b/components/quickbooks/actions/create-pl-report/create-pl-report.mjs
@@ -7,7 +7,7 @@ export default {
   key: "quickbooks-create-pl-report",
   name: "Create Profit and Loss Detail Report",
   description: "Creates a profit and loss report in Quickbooks Online. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/profitandloss#query-a-report)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/create-purchase-order/create-purchase-order.mjs
+++ b/components/quickbooks/actions/create-purchase-order/create-purchase-order.mjs
@@ -9,7 +9,7 @@ export default {
   key: "quickbooks-create-purchase-order",
   name: "Create Purchase Order",
   description: "Creates a purchase order. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/purchaseorder#create-a-purchaseorder)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/create-purchase-order/create-purchase-order.mjs
+++ b/components/quickbooks/actions/create-purchase-order/create-purchase-order.mjs
@@ -14,13 +14,22 @@ export default {
   props: {
     quickbooks,
     accountId: {
-      propDefinition: [
-        quickbooks,
-        "accountIds",
-      ],
       type: "string",
       label: "Account ID",
       description: "The ID of the account to use for the purchase order",
+      async options() {
+        const { QueryResponse: queryResponse } = await this.quickbooks.query({
+          params: {
+            query: "select * from Account where Classification = 'Liability' AND AccountSubType = 'AccountsPayable'",
+          },
+        });
+        return queryResponse.Account.map(({
+          Id, Name,
+        }) => ({
+          value: Id,
+          label: Name,
+        }));
+      },
     },
     vendorRefValue: {
       propDefinition: [
@@ -102,7 +111,7 @@ export default {
       props.lineItems = {
         type: "string[]",
         label: "Line Items",
-        description: "Line items of a purchase order. Set DetailType to `ItemBasedExpenseLineDetail` or `AccountBasedExpenseLineDetail`. Example: `{ \"DetailType\": \"ItemBasedExpenseLineDetail\", \"Amount\": 100.0, \"ItemBasedExpenseLineDetail\": { \"ItemRef\": { \"name\": \"Services\", \"value\": \"1\" } } }` [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/purchaseorder#create-a-purchaseorder) for more information.",
+        description: "Line items of a purchase order. DetailType is `ItemBasedExpenseLineDetail`. Example: `{ \"DetailType\": \"ItemBasedExpenseLineDetail\", \"Amount\": 100.0, \"ItemBasedExpenseLineDetail\": { \"ItemRef\": { \"name\": \"Services\", \"value\": \"1\" } } }` [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/purchaseorder#create-a-purchaseorder) for more information.",
       };
       return props;
     }
@@ -116,35 +125,26 @@ export default {
       return props;
     }
     for (let i = 1; i <= this.numLineItems; i++) {
-      props[`detailType_${i}`] = {
-        type: "string",
-        label: `Line ${i} - Detail Type`,
-        options: [
-          {
-            label: "Item Based Expense",
-            value: "ItemBasedExpenseLineDetail",
-          },
-          {
-            label: "Account Based Expense",
-            value: "AccountBasedExpenseLineDetail",
-          },
-        ],
-        default: "ItemBasedExpenseLineDetail",
-      };
       props[`item_${i}`] = {
         type: "string",
         label: `Line ${i} - Item/Account ID`,
         options: async ({ page }) => {
-          return this.quickbooks.getPropOptions({
+          const options = await this.quickbooks.getPropOptions({
             page,
             resource: "Item",
             mapper: ({
-              Id: value, Name: label,
-            }) => ({
-              value,
-              label,
-            }),
+              Id: value, Name: label, ExpenseAccountRef,
+            }) => {
+              if (ExpenseAccountRef) {
+                return {
+                  value,
+                  label,
+                };
+              }
+              return null;
+            },
           });
+          return options.filter((option) => option !== null);
         },
       };
       props[`amount_${i}`] = {
@@ -179,12 +179,6 @@ export default {
     if (!lines || lines.length === 0) {
       throw new ConfigurationError("No valid line items were provided.");
     }
-
-    lines.forEach((line, index) => {
-      if (line.DetailType !== "ItemBasedExpenseLineDetail" && line.DetailType !== "AccountBasedExpenseLineDetail") {
-        throw new ConfigurationError(`Line Item at index ${index + 1} has invalid DetailType '${line.DetailType}'. Must be 'ItemBasedExpenseLineDetail' or 'AccountBasedExpenseLineDetail'`);
-      }
-    });
 
     const hasShippingAddress = this.shippingStreetAddress
       || this.shippingCity

--- a/components/quickbooks/actions/create-purchase/create-purchase.mjs
+++ b/components/quickbooks/actions/create-purchase/create-purchase.mjs
@@ -6,7 +6,7 @@ export default {
   key: "quickbooks-create-purchase",
   name: "Create Purchase",
   description: "Creates a new purchase. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/purchase#create-a-purchase)",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/create-sales-receipt/create-sales-receipt.mjs
+++ b/components/quickbooks/actions/create-sales-receipt/create-sales-receipt.mjs
@@ -6,7 +6,7 @@ export default {
   key: "quickbooks-create-sales-receipt",
   name: "Create Sales Receipt",
   description: "Creates a sales receipt. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/salesreceipt#create-a-salesreceipt)",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/delete-purchase/delete-purchase.mjs
+++ b/components/quickbooks/actions/delete-purchase/delete-purchase.mjs
@@ -4,7 +4,7 @@ export default {
   key: "quickbooks-delete-purchase",
   name: "Delete Purchase",
   description: "Delete a specific purchase. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/purchase#delete-a-purchase)",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/get-bill/get-bill.mjs
+++ b/components/quickbooks/actions/get-bill/get-bill.mjs
@@ -5,7 +5,7 @@ export default {
   key: "quickbooks-get-bill",
   name: "Get Bill",
   description: "Returns info about a bill. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/bill#read-a-bill)",
-  version: "0.1.9",
+  version: "0.1.10",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/get-customer/get-customer.mjs
+++ b/components/quickbooks/actions/get-customer/get-customer.mjs
@@ -5,7 +5,7 @@ export default {
   key: "quickbooks-get-customer",
   name: "Get Customer",
   description: "Returns info about a customer. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/most-commonly-used/customer#read-a-customer)",
-  version: "0.3.9",
+  version: "0.3.10",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/get-invoice/get-invoice.mjs
+++ b/components/quickbooks/actions/get-invoice/get-invoice.mjs
@@ -5,7 +5,7 @@ export default {
   key: "quickbooks-get-invoice",
   name: "Get Invoice",
   description: "Returns info about an invoice. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/invoice#read-an-invoice)",
-  version: "0.2.10",
+  version: "0.2.11",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/get-my-company/get-my-company.mjs
+++ b/components/quickbooks/actions/get-my-company/get-my-company.mjs
@@ -4,7 +4,7 @@ export default {
   key: "quickbooks-get-my-company",
   name: "Get My Company",
   description: "Gets info about a company. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/companyinfo)",
-  version: "0.1.9",
+  version: "0.1.10",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/get-payment/get-payment.mjs
+++ b/components/quickbooks/actions/get-payment/get-payment.mjs
@@ -5,7 +5,7 @@ export default {
   key: "quickbooks-get-payment",
   name: "Get Payment",
   description: "Returns info about a payment. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/payment#read-a-payment)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/get-purchase-order/get-purchase-order.mjs
+++ b/components/quickbooks/actions/get-purchase-order/get-purchase-order.mjs
@@ -5,7 +5,7 @@ export default {
   key: "quickbooks-get-purchase-order",
   name: "Get Purchase Order",
   description: "Returns details about a purchase order. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/purchaseorder#read-a-purchase-order)",
-  version: "0.1.9",
+  version: "0.1.10",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/get-purchase/get-purchase.mjs
+++ b/components/quickbooks/actions/get-purchase/get-purchase.mjs
@@ -5,7 +5,7 @@ export default {
   key: "quickbooks-get-purchase",
   name: "Get Purchase",
   description: "Returns info about a purchase. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/purchase#read-a-purchase)",
-  version: "0.1.9",
+  version: "0.1.10",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/get-sales-receipt/get-sales-receipt.mjs
+++ b/components/quickbooks/actions/get-sales-receipt/get-sales-receipt.mjs
@@ -5,7 +5,7 @@ export default {
   key: "quickbooks-get-sales-receipt",
   name: "Get Sales Receipt",
   description: "Returns details about a sales receipt. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/salesreceipt#read-a-salesreceipt)",
-  version: "0.1.9",
+  version: "0.1.10",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/get-time-activity/get-time-activity.mjs
+++ b/components/quickbooks/actions/get-time-activity/get-time-activity.mjs
@@ -5,7 +5,7 @@ export default {
   key: "quickbooks-get-time-activity",
   name: "Get Time Activity",
   description: "Returns info about an activity. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/timeactivity#read-a-timeactivity-object)",
-  version: "0.1.9",
+  version: "0.1.10",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/search-accounts/search-accounts.mjs
+++ b/components/quickbooks/actions/search-accounts/search-accounts.mjs
@@ -5,7 +5,7 @@ export default {
   key: "quickbooks-search-accounts",
   name: "Search Accounts",
   description: "Search for accounts. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/account#query-an-account)",
-  version: "0.2.9",
+  version: "0.2.10",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/search-customers/search-customers.mjs
+++ b/components/quickbooks/actions/search-customers/search-customers.mjs
@@ -5,7 +5,7 @@ export default {
   key: "quickbooks-search-customers",
   name: "Search Customers",
   description: "Searches for customers. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/customer#query-a-customer)",
-  version: "0.1.9",
+  version: "0.1.10",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/search-invoices/search-invoices.mjs
+++ b/components/quickbooks/actions/search-invoices/search-invoices.mjs
@@ -5,7 +5,7 @@ export default {
   key: "quickbooks-search-invoices",
   name: "Search Invoices",
   description: "Searches for invoices. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/invoice#query-an-invoice)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/search-items/search-items.mjs
+++ b/components/quickbooks/actions/search-items/search-items.mjs
@@ -5,7 +5,7 @@ export default {
   key: "quickbooks-search-items",
   name: "Search Items",
   description: "Searches for items. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/item#query-an-item)",
-  version: "0.1.9",
+  version: "0.1.10",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/search-products/search-products.mjs
+++ b/components/quickbooks/actions/search-products/search-products.mjs
@@ -5,7 +5,7 @@ export default {
   key: "quickbooks-search-products",
   name: "Search Products",
   description: "Search for products. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/item#query-an-item)",
-  version: "0.1.9",
+  version: "0.1.10",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/search-purchases/search-purchases.mjs
+++ b/components/quickbooks/actions/search-purchases/search-purchases.mjs
@@ -4,7 +4,7 @@ export default {
   key: "quickbooks-search-purchases",
   name: "Search Purchases",
   description: "Searches for purchases. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/purchase#query-a-purchase)",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/search-query/search-query.mjs
+++ b/components/quickbooks/actions/search-query/search-query.mjs
@@ -5,7 +5,7 @@ export default {
   key: "quickbooks-search-query",
   name: "Search Query",
   description: "Performs a search query against a Quickbooks entity. [See the documentation](https://developer.intuit.com/app/develophttps://developer.intuit.com/app/developer/qbo/docs/develop/explore-the-quickbooks-online-api/data-queries)",
-  version: "0.1.9",
+  version: "0.1.10",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/search-services/search-services.mjs
+++ b/components/quickbooks/actions/search-services/search-services.mjs
@@ -5,7 +5,7 @@ export default {
   key: "quickbooks-search-services",
   name: "Search Services",
   description: "Search for services. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/item#query-an-item)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/search-time-activities/search-time-activities.mjs
+++ b/components/quickbooks/actions/search-time-activities/search-time-activities.mjs
@@ -5,7 +5,7 @@ export default {
   key: "quickbooks-search-time-activities",
   name: "Search Time Activities",
   description: "Searches for time activities. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/timeactivity#query-a-timeactivity-object)",
-  version: "0.1.9",
+  version: "0.1.10",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/search-vendors/search-vendors.mjs
+++ b/components/quickbooks/actions/search-vendors/search-vendors.mjs
@@ -5,7 +5,7 @@ export default {
   key: "quickbooks-search-vendors",
   name: "Search Vendors",
   description: "Searches for vendors. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/vendor#query-a-vendor)",
-  version: "0.1.9",
+  version: "0.1.10",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/send-estimate/send-estimate.mjs
+++ b/components/quickbooks/actions/send-estimate/send-estimate.mjs
@@ -4,7 +4,7 @@ export default {
   key: "quickbooks-send-estimate",
   name: "Send Estimate",
   description: "Sends an estimate by email. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/estimate#send-an-estimate)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/send-invoice/send-invoice.mjs
+++ b/components/quickbooks/actions/send-invoice/send-invoice.mjs
@@ -4,7 +4,7 @@ export default {
   key: "quickbooks-send-invoice",
   name: "Send Invoice",
   description: "Sends an invoice by email. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/invoice#send-an-invoice)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/sparse-update-invoice/sparse-update-invoice.mjs
+++ b/components/quickbooks/actions/sparse-update-invoice/sparse-update-invoice.mjs
@@ -6,7 +6,7 @@ export default {
   key: "quickbooks-sparse-update-invoice",
   name: "Sparse Update Invoice",
   description: "Sparse updating provides the ability to update a subset of properties for a given object; only elements specified in the request are updated. Missing elements are left untouched. The ID of the object to update is specified in the request body.​ [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/invoice#sparse-update-an-invoice)",
-  version: "0.1.7",
+  version: "0.1.8",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/update-customer/update-customer.mjs
+++ b/components/quickbooks/actions/update-customer/update-customer.mjs
@@ -5,7 +5,7 @@ export default {
   key: "quickbooks-update-customer",
   name: "Update Customer",
   description: "Updates a customer. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/customer#full-update-a-customer)",
-  version: "0.1.9",
+  version: "0.1.10",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/update-estimate/update-estimate.mjs
+++ b/components/quickbooks/actions/update-estimate/update-estimate.mjs
@@ -9,7 +9,7 @@ export default {
   key: "quickbooks-update-estimate",
   name: "Update Estimate",
   description: "Updates an estimate. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/estimate#update-an-estimate)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/update-invoice/update-invoice.mjs
+++ b/components/quickbooks/actions/update-invoice/update-invoice.mjs
@@ -9,7 +9,7 @@ export default {
   key: "quickbooks-update-invoice",
   name: "Update Invoice",
   description: "Updates an invoice. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/invoice#update-an-invoice)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/update-item/update-item.mjs
+++ b/components/quickbooks/actions/update-item/update-item.mjs
@@ -5,7 +5,7 @@ export default {
   key: "quickbooks-update-item",
   name: "Update Item",
   description: "Updates an item. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/item#full-update-an-item)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/actions/void-invoice/void-invoice.mjs
+++ b/components/quickbooks/actions/void-invoice/void-invoice.mjs
@@ -5,7 +5,7 @@ export default {
   key: "quickbooks-void-invoice",
   name: "Void Invoice",
   description: "Voids an invoice. [See the documentation](https://developer.intuit.com/app/developer/qbo/docs/api/accounting/all-entities/invoice#void-an-invoice)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     quickbooks,

--- a/components/quickbooks/common/utils.mjs
+++ b/components/quickbooks/common/utils.mjs
@@ -171,26 +171,9 @@ export function buildPurchaseLineItems(numLineItems, context) {
     throw new ConfigurationError(`Invalid amount values for: ${invalidAmounts.join(", ")}. Amounts must be valid numbers.`);
   }
 
-  // Validate detailType values if provided
-  const validDetailTypes = [
-    "ItemBasedExpenseLineDetail",
-    "AccountBasedExpenseLineDetail",
-  ];
-  const invalidDetailTypes = [];
-  for (let i = 1; i <= numLineItems; i++) {
-    const detailType = context[`detailType_${i}`];
-    if (detailType && !validDetailTypes.includes(detailType)) {
-      invalidDetailTypes.push(`detailType_${i}: ${detailType}`);
-    }
-  }
-
-  if (invalidDetailTypes.length > 0) {
-    throw new ConfigurationError(`Invalid detailType values for: ${invalidDetailTypes.join(", ")}. Valid types are: ${validDetailTypes.join(", ")}`);
-  }
-
   const lineItems = [];
   for (let i = 1; i <= numLineItems; i++) {
-    const detailType = context[`detailType_${i}`] || "ItemBasedExpenseLineDetail";
+    const detailType = "ItemBasedExpenseLineDetail";
 
     // Extract conditional logic into clear variables
     const isItemBased = detailType === "ItemBasedExpenseLineDetail";

--- a/components/quickbooks/package.json
+++ b/components/quickbooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/quickbooks",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Pipedream Quickbooks Components",
   "main": "quickbooks.app.mjs",
   "keywords": [

--- a/components/quickbooks/sources/new-customer-created/new-customer-created.mjs
+++ b/components/quickbooks/sources/new-customer-created/new-customer-created.mjs
@@ -6,7 +6,7 @@ export default {
   key: "quickbooks-new-customer-created",
   name: "New Customer Created",
   description: "Emit new event when a new customer is created.",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/quickbooks/sources/new-customer-updated/new-customer-updated.mjs
+++ b/components/quickbooks/sources/new-customer-updated/new-customer-updated.mjs
@@ -6,7 +6,7 @@ export default {
   key: "quickbooks-new-customer-updated",
   name: "New Customer Updated",
   description: "Emit new event when a customer is updated.",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/quickbooks/sources/new-employee-created/new-employee-created.mjs
+++ b/components/quickbooks/sources/new-employee-created/new-employee-created.mjs
@@ -6,7 +6,7 @@ export default {
   key: "quickbooks-new-employee-created",
   name: "New Employee Created",
   description: "Emit new event when a new employee is created.",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/quickbooks/sources/new-employee-updated/new-employee-updated.mjs
+++ b/components/quickbooks/sources/new-employee-updated/new-employee-updated.mjs
@@ -6,7 +6,7 @@ export default {
   key: "quickbooks-new-employee-updated",
   name: "New Employee Updated",
   description: "Emit new event when an employee is updated.",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/quickbooks/sources/new-invoice-created/new-invoice-created.mjs
+++ b/components/quickbooks/sources/new-invoice-created/new-invoice-created.mjs
@@ -6,7 +6,7 @@ export default {
   key: "quickbooks-new-invoice-created",
   name: "New Invoice Created",
   description: "Emit new event when a new invoice is created.",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/quickbooks/sources/new-invoice-updated/new-invoice-updated.mjs
+++ b/components/quickbooks/sources/new-invoice-updated/new-invoice-updated.mjs
@@ -6,7 +6,7 @@ export default {
   key: "quickbooks-new-invoice-updated",
   name: "New Invoice Updated",
   description: "Emit new event when an invoice is updated.",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/quickbooks/sources/new-item-created/new-item-created.mjs
+++ b/components/quickbooks/sources/new-item-created/new-item-created.mjs
@@ -6,7 +6,7 @@ export default {
   key: "quickbooks-new-item-created",
   name: "New Item Created",
   description: "Emit new event when a new item is created.",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/quickbooks/sources/new-item-updated/new-item-updated.mjs
+++ b/components/quickbooks/sources/new-item-updated/new-item-updated.mjs
@@ -6,7 +6,7 @@ export default {
   key: "quickbooks-new-item-updated",
   name: "New Item Updated",
   description: "Emit new event when an item is updated.",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "source",
   dedupe: "unique",
   methods: {


### PR DESCRIPTION
QA requested updates for (https://github.com/PipedreamHQ/pipedream/pull/17078) that were missed in the original issue (https://github.com/PipedreamHQ/pipedream/issues/16906).

Once this is tested and published, I'll continue with the Quickbooks Sandbox followup PR (https://github.com/PipedreamHQ/pipedream/pull/17078).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved the purchase order creation process by simplifying account selection and restricting line items to a single detail type, making configuration easier and more intuitive.
  - Enhanced item selection for purchase order line items to only show items with expense accounts.

- **Other Changes**
  - Updated version numbers for multiple QuickBooks actions and sources to reflect the latest updates and improvements. No functional changes for most components.
  - Removed validation of purchase line item detail types and standardized detail type to improve consistency in purchase processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->