### PR TITLE
Zendesk - Added the ability to set tags on a ticket when updating

### DIFF
--- a/components/zendesk/actions/update-ticket/update-ticket.mjs
+++ b/components/zendesk/actions/update-ticket/update-ticket.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Update Ticket",
   description: "Updates a ticket. [See the documentation](https://developer.zendesk.com/api-reference/ticketing/tickets/tickets/#update-ticket).",
   type: "action",
-  version: "0.1.3",
+  version: "0.2.0",
   props: {
     app,
     ticketId: {
@@ -38,6 +38,12 @@ export default {
         "ticketStatus",
       ],
     },
+    tags: {
+      propDefinition: [
+        app,
+        "tags",
+      ],
+    },
     customSubdomain: {
       propDefinition: [
         app,
@@ -62,6 +68,7 @@ export default {
       ticketPriority,
       ticketSubject,
       ticketStatus,
+      tags,
       customSubdomain,
     } = this;
 
@@ -77,6 +84,7 @@ export default {
           priority: ticketPriority,
           subject: ticketSubject,
           status: ticketStatus,
+          tags: tags,
         },
       },
     });

--- a/components/zendesk/zendesk.app.mjs
+++ b/components/zendesk/zendesk.app.mjs
@@ -144,6 +144,12 @@ export default {
       optional: true,
       options: Object.values(constants.TICKET_STATUS_OPTIONS),
     },
+    tags: {
+      type: "string[]",
+      label: "Tags",
+      description: "Tags to apply to the ticket. You can specify multiple tags.",
+      optional: true,
+    },
     sortBy: {
       type: "string",
       label: "Sort By",


### PR DESCRIPTION
This is a minor update which adds the ability to specify the `tags` to apply to a Zendesk ticket when performing an update operation on that ticket. I have added it to the existing `updateTicket` method, per their documentation: [https://developer.zendesk.com/api-reference/ticketing/tickets/tickets/#update-ticket](https://developer.zendesk.com/api-reference/ticketing/tickets/tickets/#update-ticket)
