### PR TITLE
Bug Fix - OpenRouter MCP Server Schema Validation Erro

### DIFF
--- a/components/openrouter/actions/send-chat-completion-request/send-chat-completion-request.mjs
+++ b/components/openrouter/actions/send-chat-completion-request/send-chat-completion-request.mjs
@@ -5,7 +5,7 @@ import openrouter from "../../openrouter.app.mjs";
 export default {
   key: "openrouter-send-chat-completion-request",
   name: "Send Chat Completion Request",
-  version: "0.0.1",
+  version: "0.0.2",
   description: "Send a chat completion request to a selected model. [See the documentation](https://openrouter.ai/docs/api-reference/chat-completion)",
   type: "action",
   props: {
@@ -106,7 +106,8 @@ export default {
       ],
       type: "string[]",
       label: "Models",
-      description: "Alternate list of models for routing overrides.",
+      description: "Alternate list of models for routing overrides",
+      optional: true,
     },
     sort: {
       propDefinition: [

--- a/components/openrouter/actions/send-completion-request/send-completion-request.mjs
+++ b/components/openrouter/actions/send-completion-request/send-completion-request.mjs
@@ -4,7 +4,7 @@ import openrouter from "../../openrouter.app.mjs";
 export default {
   key: "openrouter-send-completion-request",
   name: "Send Completion Request",
-  version: "0.0.1",
+  version: "0.0.2",
   description: "Send a completion request to a selected model (text-only format) [See the documentation](https://openrouter.ai/docs/api-reference/completions)",
   type: "action",
   props: {
@@ -105,7 +105,8 @@ export default {
       ],
       type: "string[]",
       label: "Models",
-      description: "Alternate list of models for routing overrides.",
+      description: "Alternate list of models for routing overrides",
+      optional: true,
     },
     sort: {
       propDefinition: [

--- a/components/openrouter/package.json
+++ b/components/openrouter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/openrouter",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream OpenRouter Components",
   "main": "openrouter.app.mjs",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2850,8 +2850,7 @@ importers:
 
   components/common_paper: {}
 
-  components/commonninja:
-    specifiers: {}
+  components/commonninja: {}
 
   components/commpeak:
     dependencies:
@@ -9307,8 +9306,7 @@ importers:
         specifier: ^17.0.45
         version: 17.0.45
 
-  components/openai_passthrough:
-    specifiers: {}
+  components/openai_passthrough: {}
 
   components/opencage:
     dependencies:
@@ -9907,8 +9905,7 @@ importers:
         specifier: ^1.5.1
         version: 1.6.6
 
-  components/phonely:
-    specifiers: {}
+  components/phonely: {}
 
   components/php_point_of_sale:
     dependencies:
@@ -10397,8 +10394,7 @@ importers:
 
   components/predictleads: {}
 
-  components/predis_ai:
-    specifiers: {}
+  components/predis_ai: {}
 
   components/prepr_graphql: {}
 
@@ -13424,8 +13420,7 @@ importers:
 
   components/test_apps_for_switching_appslug_009: {}
 
-  components/test_apps_for_switching_appslug_025:
-    specifiers: {}
+  components/test_apps_for_switching_appslug_025: {}
 
   components/testlocally:
     dependencies:


### PR DESCRIPTION
Resolves #17097 

The documentation shows that `model` is required, and `models` is optional. I think the problem was that we had both `model` and `models` props required.