### PR TITLE
Configure file stash sync for Zoho CRM components

### DIFF
--- a/components/zoho_crm/actions/download-attachment/download-attachment.mjs
+++ b/components/zoho_crm/actions/download-attachment/download-attachment.mjs
@@ -5,7 +5,7 @@ export default {
   key: "zoho_crm-download-attachment",
   name: "Download Attachment",
   description: "Downloads an attachment file from Zoho CRM, saves it in the temporary file system and exports the file path for use in a future step.",
-  version: "0.2.1",
+  version: "0.2.2",
   type: "action",
   props: {
     zohoCrm,
@@ -34,6 +34,15 @@ export default {
         }),
       ],
     },
+    // This prop indicates that the otherwise ephemeral /tmp directory is automatically synced to a
+    // remote directory (if configured for the execution context), making files written by this
+    // action accessible for future executions.  Only files located in STASH_DIR or, for legacy
+    // action support, whose /tmp file paths are explicitly returned by `run` will be synced.
+    syncDir: {
+      type: "dir",
+      accessMode: "write",
+      sync: true,
+    },
   },
   async run({ $ }) {
     const file = await this.zohoCrm.downloadAttachment(
@@ -43,7 +52,7 @@ export default {
       $,
     );
 
-    const filePath = "/tmp/" + this.attachmentId;
+    const filePath = (process.env.STASH_DIR || "/tmp") + "/" + this.attachmentId;
     fs.writeFileSync(filePath, file);
 
     $.export("$summary", "Successfully downloaded attachment");

--- a/components/zoho_crm/actions/upload-attachment/upload-attachment.mjs
+++ b/components/zoho_crm/actions/upload-attachment/upload-attachment.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoho_crm-upload-attachment",
   name: "Upload Attachment",
   description: "Uploads an attachment file to Zoho CRM from a URL or file path. [See the documentation](https://www.zoho.com/crm/developer/docs/api/v3/upload-attachment.html)",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "action",
   props: {
     zohoCrm,
@@ -29,6 +29,15 @@ export default {
       type: "string",
       label: "File Path or URL",
       description: "The file to upload. Provide either a file URL or a path to a file in the `/tmp` directory (for example, `/tmp/myFile.txt`)",
+    },
+    // This prop indicates that a remote directory (if configured for the execution context) is
+    // automatically synced to the /tmp directory before the action runs, making files in that
+    // directory accessible for use in this action via the file system.
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
     },
   },
   async run({ $ }) {

--- a/components/zoho_crm/package.json
+++ b/components/zoho_crm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/zoho_crm",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Pipedream Zoho CRM Components",
   "main": "zoho_crm.app.mjs",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29316,22 +29316,22 @@ packages:
   superagent@3.8.1:
     resolution: {integrity: sha512-VMBFLYgFuRdfeNQSMLbxGSLfmXL/xc+OO+BZp41Za/NRDBet/BNbkRJrYzCUu0u4GU0i/ml2dtT8b9qgkw9z6Q==}
     engines: {node: '>= 4.0'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
 
   superagent@4.1.0:
     resolution: {integrity: sha512-FT3QLMasz0YyCd4uIi5HNe+3t/onxMyEho7C3PSqmti3Twgy2rXT4fmkTz6wRL6bTF4uzPcfkUCa8u4JWHw8Ag==}
     engines: {node: '>= 6.0'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
 
   superagent@5.3.1:
     resolution: {integrity: sha512-wjJ/MoTid2/RuGCOFtlacyGNxN9QLMgcpYLDQlWFIhhdJ93kNscFonGvrpAHSCVjRVj++DGCglocF7Aej1KHvQ==}
     engines: {node: '>= 7.0.0'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
 
   superagent@7.1.6:
     resolution: {integrity: sha512-gZkVCQR1gy/oUXr+kxJMLDjla434KmSOKbx5iGD30Ql+AkJQ/YlPKECJy2nhqOsHLjGHzoDTXNSjhnvWhzKk7g==}
     engines: {node: '>=6.4.0 <13 || >=14'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please downgrade to v7.1.5 if you need IE/ActiveXObject support OR upgrade to v8.0.0 as we no longer support IE and published an incorrect patch version (see https://github.com/visionmedia/superagent/issues/1731)
 
   supports-color@2.0.0:
     resolution: {integrity: sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==}


### PR DESCRIPTION
## WHY

Adding dir props to the Zoho CRM Download Attachment and Upload Attachment actions indicates that a stash ID should be passed when running these actions via the Connect API. This allows files written to the ephemeral /tmp directory in one action to be read by another, separately executed action since both can sync /tmp with the same File Stash directory.
