### PR TITLE
Discord Bot - "Ignore Bot Messages" Flag in New Message Triggers

### DIFF
--- a/components/discord_bot/package.json
+++ b/components/discord_bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/discord_bot",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Pipedream Discord_bot Components",
   "main": "discord_bot.app.mjs",
   "keywords": [

--- a/components/discord_bot/sources/common/common.mjs
+++ b/components/discord_bot/sources/common/common.mjs
@@ -1,5 +1,5 @@
-import common from "../common.mjs";
-import constants from "../common/constants.mjs";
+import common from "../../common.mjs";
+import constants from "../../common/constants.mjs";
 
 export default {
   ...common,
@@ -16,6 +16,17 @@ export default {
     },
     _setLastMemberID(memberID) {
       this.db.set(constants.LAST_MEMBER_ID, memberID);
+    },
+    _getBotId() {
+      return this.db.get("botId");
+    },
+    _setBotId(botId) {
+      this.db.set("botId", botId);
+    },
+    getBotProfile() {
+      return this.discord._makeRequest({
+        path: "/users/@me",
+      });
     },
   },
 };

--- a/components/discord_bot/sources/new-guild-member/new-guild-member.mjs
+++ b/components/discord_bot/sources/new-guild-member/new-guild-member.mjs
@@ -1,5 +1,5 @@
 import { DEFAULT_POLLING_SOURCE_TIMER_INTERVAL } from "@pipedream/platform";
-import common from "../common.mjs";
+import common from "../common/common.mjs";
 
 export default {
   ...common,
@@ -8,7 +8,7 @@ export default {
   description: "Emit new event for every member added to a guild. [See docs here](https://discord.com/developers/docs/resources/guild#list-guild-members)",
   type: "source",
   dedupe: "unique",
-  version: "0.1.4",
+  version: "0.1.5",
   props: {
     ...common.props,
     db: "$.service.db",

--- a/components/discord_bot/sources/new-message-in-channel/new-message-in-channel.mjs
+++ b/components/discord_bot/sources/new-message-in-channel/new-message-in-channel.mjs
@@ -1,6 +1,6 @@
 import { DEFAULT_POLLING_SOURCE_TIMER_INTERVAL } from "@pipedream/platform";
 import maxBy from "lodash.maxby";
-import common from "../common.mjs";
+import common from "../common/common.mjs";
 import sampleEmit from "./test-event.mjs";
 
 const { discord } = common.props;
@@ -11,8 +11,7 @@ export default {
   name: "New Message in Channel",
   description: "Emit new event for each message posted to one or more channels",
   type: "source",
-  version: "0.0.18",
-
+  version: "0.0.19",
   dedupe: "unique", // Dedupe events based on the Discord message ID
   props: {
     ...common.props,
@@ -37,6 +36,12 @@ export default {
       optional: true,
       default: false,
     },
+    ignoreBotMessages: {
+      type: "boolean",
+      label: "Ignore Bot Messages",
+      description: "Set to `true` to only emit messages NOT from the configured Discord bot",
+      optional: true,
+    },
     timer: {
       type: "$.interface.timer",
       default: {
@@ -44,9 +49,20 @@ export default {
       },
     },
   },
+  hooks: {
+    async deploy() {
+      if (this.ignoreBotMessages) {
+        const { id } = await this.getBotProfile();
+        this._setBotId(id);
+      }
+    },
+  },
   async run({ $ }) {
     // We store a cursor to the last message ID
     let lastMessageIDs = this._getLastMessageIDs();
+    const botId = this.ignoreBotMessages
+      ? this._getBotId()
+      : null;
 
     // If this is our first time running this source,
     // get the last N messages, emit them, and checkpoint
@@ -95,6 +111,10 @@ export default {
       if (!messages.length) {
         console.log(`No new messages in channel ${channelId}`);
         return;
+      }
+
+      if (botId) {
+        messages = messages.filter((message) => message.author.id !== botId);
       }
 
       console.log(`${messages.length} new messages in channel ${channelId}`);

--- a/components/discord_bot/sources/new-tag-added-to-thread/new-tag-added-to-thread.mjs
+++ b/components/discord_bot/sources/new-tag-added-to-thread/new-tag-added-to-thread.mjs
@@ -1,5 +1,5 @@
 import { DEFAULT_POLLING_SOURCE_TIMER_INTERVAL } from "@pipedream/platform";
-import common from "../common.mjs";
+import common from "../common/common.mjs";
 import sampleEmit from "./test-event.mjs";
 
 export default {
@@ -8,7 +8,7 @@ export default {
   name: "New Tag Added to Forum Thread",
   description: "Emit new event when a new tag is added to a thread",
   type: "source",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/discord_bot/sources/new-thread-message/new-thread-message.mjs
+++ b/components/discord_bot/sources/new-thread-message/new-thread-message.mjs
@@ -1,6 +1,6 @@
 import { DEFAULT_POLLING_SOURCE_TIMER_INTERVAL } from "@pipedream/platform";
 import maxBy from "lodash.maxby";
-import common from "../common.mjs";
+import common from "../common/common.mjs";
 import sampleEmit from "./test-event.mjs";
 
 export default {
@@ -9,7 +9,7 @@ export default {
   name: "New Thread Message",
   description: "Emit new event for each thread message posted.",
   type: "source",
-  version: "0.0.5",
+  version: "0.0.6",
   dedupe: "unique", // Dedupe events based on the Discord message ID
   props: {
     ...common.props,
@@ -20,10 +20,27 @@ export default {
         intervalSeconds: DEFAULT_POLLING_SOURCE_TIMER_INTERVAL,
       },
     },
+    ignoreBotMessages: {
+      type: "boolean",
+      label: "Ignore Bot Messages",
+      description: "Set to `true` to only emit messages NOT from the configured Discord bot",
+      optional: true,
+    },
+  },
+  hooks: {
+    async deploy() {
+      if (this.ignoreBotMessages) {
+        const { id } = await this.getBotProfile();
+        this._setBotId(id);
+      }
+    },
   },
   async run({ $ }) {
     // We store a cursor to the last message ID
     let lastMessageIDs = this._getLastMessageIDs();
+    const botId = this.ignoreBotMessages
+      ? this._getBotId()
+      : null;
 
     const { threads } = await this.discord.listThreads({
       $,
@@ -79,6 +96,10 @@ export default {
       if (!messages.length) {
         console.log(`No new messages in thread ${channelId}`);
         continue;
+      }
+
+      if (botId) {
+        messages = messages.filter((message) => message.author.id !== botId);
       }
 
       console.log(`${messages.length} new messages in thread ${channelId}`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5396,8 +5396,7 @@ importers:
 
   components/godial: {}
 
-  components/goformz:
-    specifiers: {}
+  components/goformz: {}
 
   components/gohighlevel:
     dependencies:
@@ -7288,8 +7287,7 @@ importers:
         specifier: ^3.0.0
         version: 3.0.3
 
-  components/lark:
-    specifiers: {}
+  components/lark: {}
 
   components/lastpass:
     dependencies:
@@ -8494,8 +8492,7 @@ importers:
 
   components/mollie: {}
 
-  components/momentum_ams:
-    specifiers: {}
+  components/momentum_ams: {}
 
   components/monday:
     dependencies:
@@ -9478,8 +9475,7 @@ importers:
 
   components/order_sender: {}
 
-  components/orderspace:
-    specifiers: {}
+  components/orderspace: {}
 
   components/originality_ai:
     dependencies:
@@ -11556,8 +11552,7 @@ importers:
 
   components/ryver: {}
 
-  components/sage_accounting:
-    specifiers: {}
+  components/sage_accounting: {}
 
   components/sage_intacct: {}
 
@@ -12974,8 +12969,7 @@ importers:
 
   components/stealthseminar: {}
 
-  components/stiply:
-    specifiers: {}
+  components/stiply: {}
 
   components/storeganise:
     dependencies:


### PR DESCRIPTION
Resolves #17200 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to ignore messages sent by the bot itself in new message, thread message, and forum thread message event sources.
  - Users can now enable or disable filtering of bot-authored messages via a new setting.

- **Bug Fixes**
  - Corrected import paths for improved reliability across several Discord Bot components.

- **Chores**
  - Updated version numbers for multiple Discord Bot components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->