### PR TITLE
fix(connect-react): exclude 'dir' from configurable props

### DIFF
--- a/packages/connect-react/CHANGELOG.md
+++ b/packages/connect-react/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # Changelog
 
+# [1.3.1] - 2025-06-30
+
+## Changed
+
+- Fixed handling of the 'dir' prop type to exclude it from configurable props
+
 # [1.3.0] - 2025-06-10
 
 ## Added

--- a/packages/connect-react/package.json
+++ b/packages/connect-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/connect-react",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Pipedream Connect library for React",
   "files": [
     "dist"

--- a/packages/connect-react/src/hooks/form-context.tsx
+++ b/packages/connect-react/src/hooks/form-context.tsx
@@ -51,6 +51,7 @@ export const skippablePropTypes = [
   "$.interface.http",
   "$.interface.apphook",
   "$.interface.timer", // TODO add support for this (cron string and timers)
+  "dir",
 ]
 
 export const FormContext = createContext<FormContext<any /* XXX fix */> | undefined>(undefined); // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4428,8 +4428,7 @@ importers:
         specifier: ^6.11.0
         version: 6.13.1
 
-  components/explorium:
-    specifiers: {}
+  components/explorium: {}
 
   components/expofp:
     dependencies:
@@ -6907,8 +6906,7 @@ importers:
         specifier: ^1.5.1
         version: 1.6.6
 
-  components/joggai:
-    specifiers: {}
+  components/joggai: {}
 
   components/join: {}
 
@@ -12362,8 +12360,7 @@ importers:
         specifier: 1.6.5
         version: 1.6.5
 
-  components/sign_plus:
-    specifiers: {}
+  components/sign_plus: {}
 
   components/signable: {}
 
@@ -29615,22 +29612,22 @@ packages:
   superagent@3.8.1:
     resolution: {integrity: sha512-VMBFLYgFuRdfeNQSMLbxGSLfmXL/xc+OO+BZp41Za/NRDBet/BNbkRJrYzCUu0u4GU0i/ml2dtT8b9qgkw9z6Q==}
     engines: {node: '>= 4.0'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
 
   superagent@4.1.0:
     resolution: {integrity: sha512-FT3QLMasz0YyCd4uIi5HNe+3t/onxMyEho7C3PSqmti3Twgy2rXT4fmkTz6wRL6bTF4uzPcfkUCa8u4JWHw8Ag==}
     engines: {node: '>= 6.0'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
 
   superagent@5.3.1:
     resolution: {integrity: sha512-wjJ/MoTid2/RuGCOFtlacyGNxN9QLMgcpYLDQlWFIhhdJ93kNscFonGvrpAHSCVjRVj++DGCglocF7Aej1KHvQ==}
     engines: {node: '>= 7.0.0'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
 
   superagent@7.1.6:
     resolution: {integrity: sha512-gZkVCQR1gy/oUXr+kxJMLDjla434KmSOKbx5iGD30Ql+AkJQ/YlPKECJy2nhqOsHLjGHzoDTXNSjhnvWhzKk7g==}
     engines: {node: '>=6.4.0 <13 || >=14'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please downgrade to v7.1.5 if you need IE/ActiveXObject support OR upgrade to v8.0.0 as we no longer support IE and published an incorrect patch version (see https://github.com/visionmedia/superagent/issues/1731)
 
   supports-color@2.0.0:
     resolution: {integrity: sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==}


### PR DESCRIPTION
## WHY

The 'dir' prop is not configurable and should not be shown in the prop form.

Example ([Connect demo](https://pipedream.com/connect/demo?app=zoho_crm&component=zoho_crm-download-attachment)):


https://github.com/user-attachments/assets/1d1228d4-91c7-4472-a685-00d53d4063ff




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of the 'dir' property to ensure it is no longer treated as a configurable prop.

* **Chores**
  * Updated the package version to 1.3.1 and documented the change in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->