### PR TITLE
Configure file stash sync: Ragie-Zoho WorkDrive

### DIFF
--- a/components/ragie/actions/create-document/create-document.mjs
+++ b/components/ragie/actions/create-document/create-document.mjs
@@ -6,7 +6,7 @@ export default {
   key: "ragie-create-document",
   name: "Create Document",
   description: "Creates a new document in Ragie. [See the documentation](https://docs.ragie.ai/reference/createdocument)",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "action",
   props: {
     ragie,
@@ -46,6 +46,12 @@ export default {
         ragie,
         "partition",
       ],
+      optional: true,
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
       optional: true,
     },
   },

--- a/components/ragie/actions/update-document-file/update-document-file.mjs
+++ b/components/ragie/actions/update-document-file/update-document-file.mjs
@@ -6,7 +6,7 @@ export default {
   key: "ragie-update-document-file",
   name: "Update Document File",
   description: "Updates an existing document file in Ragie. [See the documentation](https://docs.ragie.ai/reference/updatedocumentfile).",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "action",
   props: {
     ragie,
@@ -28,6 +28,12 @@ export default {
         ragie,
         "documentFile",
       ],
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
     },
   },
   async run({ $ }) {

--- a/components/ragie/package.json
+++ b/components/ragie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/ragie",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Ragie Components",
   "main": "ragie.app.mjs",
   "keywords": [

--- a/components/raindrop/actions/parse-bookmark-file/parse-bookmark-file.mjs
+++ b/components/raindrop/actions/parse-bookmark-file/parse-bookmark-file.mjs
@@ -6,7 +6,7 @@ export default {
   key: "raindrop-parse-bookmark-file",
   name: "Parse HTML Bookmark File",
   description: "Convert an HTML bookmark file to JSON. Supports Nestcape, Pocket and Instapaper file formats. [See the documentation](https://developer.raindrop.io/v1/import#parse-html-import-file)",
-  version: "1.0.0",
+  version: "1.0.1",
   type: "action",
   props: {
     raindrop,
@@ -14,6 +14,12 @@ export default {
       type: "string",
       label: "File Path or URL",
       description: "The file to parse. Provide either a file URL or a path to a file in the `/tmp` directory (for example, `/tmp/bookmarks.html`)",
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
     },
   },
   async run({ $ }) {

--- a/components/raindrop/package.json
+++ b/components/raindrop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/raindrop",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Pipedream Raindrop.io Components",
   "main": "raindrop.app.mjs",
   "keywords": [

--- a/components/ramp/actions/upload-receipt/upload-receipt.mjs
+++ b/components/ramp/actions/upload-receipt/upload-receipt.mjs
@@ -6,7 +6,7 @@ export default {
   key: "ramp-upload-receipt",
   name: "Upload Receipt",
   description: "Uploads a receipt for a given transaction and user. [See the documentation](https://docs.ramp.com/developer-api/v1/reference/rest/receipts#post-developer-v1-receipts)",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "action",
   props: {
     ramp,
@@ -26,6 +26,12 @@ export default {
       type: "string",
       label: "File Path or URL",
       description: "The file to upload. Provide either a file URL or a path to a file in the `/tmp` directory (for example, `/tmp/myFile.txt`)",
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
     },
   },
   async run({ $ }) {

--- a/components/ramp/package.json
+++ b/components/ramp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/ramp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Ramp Components",
   "main": "ramp.app.mjs",
   "keywords": [

--- a/components/ramp_sandbox/actions/upload-receipt/upload-receipt.mjs
+++ b/components/ramp_sandbox/actions/upload-receipt/upload-receipt.mjs
@@ -6,7 +6,7 @@ export default {
   key: "ramp_sandbox-upload-receipt",
   name: "Upload Receipt",
   description: "Uploads a receipt for a given transaction and user. [See the documentation](https://docs.ramp.com/developer-api/v1/reference/rest/receipts#post-developer-v1-receipts)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     ramp,
@@ -26,6 +26,12 @@ export default {
       type: "string",
       label: "File Path",
       description: "The path to a file in the `/tmp` directory. [See the documentation on working with files](https://pipedream.com/docs/code/nodejs/working-with-files/#writing-a-file-to-tmp)",
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
     },
   },
 };

--- a/components/ramp_sandbox/package.json
+++ b/components/ramp_sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/ramp_sandbox",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Pipedream Ramp (Sandbox) Components",
   "main": "ramp_sandbox.app.mjs",
   "keywords": [

--- a/components/rapid_url_indexer/actions/download-project-report/download-project-report.mjs
+++ b/components/rapid_url_indexer/actions/download-project-report/download-project-report.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Download Project Report",
   description: "Download the report for a specific project. [See the documentation](https://rapidurlindexer.com/indexing-api/).",
   type: "action",
-  version: "0.0.1",
+  version: "0.0.2",
   props: {
     rapidUrlIndexer,
     projectId: {
@@ -19,6 +19,11 @@ export default {
       type: "string",
       label: "Filename",
       description: "A filename to save the report as in the `/tmp` directory. Include the `.csv` extension",
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "write",
+      sync: true,
     },
   },
   async run({ $ }) {

--- a/components/rapid_url_indexer/package.json
+++ b/components/rapid_url_indexer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/rapid_url_indexer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Rapid URL Indexer Components",
   "main": "rapid_url_indexer.app.mjs",
   "keywords": [

--- a/components/reform/actions/extract-data-from-document/extract-data-from-document.mjs
+++ b/components/reform/actions/extract-data-from-document/extract-data-from-document.mjs
@@ -7,7 +7,7 @@ export default {
   key: "reform-extract-data-from-document",
   name: "Extract Data From Document",
   description: "Extract structured data from a document. [See the documentation](https://docs.reformhq.com/synchronous-data-processing/extract)",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "action",
   props: {
     reform,
@@ -22,6 +22,12 @@ export default {
         reform,
         "fields",
       ],
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
     },
   },
   async run({ $ }) {

--- a/components/reform/package.json
+++ b/components/reform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/reform",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Reform Components",
   "main": "reform.app.mjs",
   "keywords": [

--- a/components/rendi/actions/run-ffmpeg-command/run-ffmpeg-command.mjs
+++ b/components/rendi/actions/run-ffmpeg-command/run-ffmpeg-command.mjs
@@ -8,7 +8,7 @@ export default {
   key: "rendi-run-ffmpeg-command",
   name: "Run FFmpeg Command",
   description: "Submit an FFmpeg command for processing with input and output file specifications. [See the documentation](https://docs.rendi.dev/api-reference/endpoint/run-ffmpeg-command)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     rendi,
@@ -39,6 +39,11 @@ export default {
       description: "Set to `true` to poll the API in 3-second intervals until the command is completed",
       optional: true,
       reloadProps: true,
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "write",
+      sync: true,
     },
   },
   additionalProps() {
@@ -93,7 +98,8 @@ export default {
             responseType: "arraybuffer",
           });
           const filename = value.storage_url.split("/").pop();
-          const downloadedFilepath = `/tmp/${filename}`;
+          const downloadedFilepath =
+            `${process.env.STASH_DIR || "/tmp"}/${filename}`;
           fs.writeFileSync(downloadedFilepath, resp);
 
           response.tmpFiles.push({

--- a/components/rendi/package.json
+++ b/components/rendi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/rendi",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Rendi Components",
   "main": "rendi.app.mjs",
   "keywords": [

--- a/components/ringcentral/actions/download-recording/download-recording.mjs
+++ b/components/ringcentral/actions/download-recording/download-recording.mjs
@@ -5,7 +5,7 @@ export default {
   key: "ringcentral-download-recording",
   name: "Download Recording",
   description: "Gets a recording and downloads it to the /tmp directory. [See the documentation](https://developers.ringcentral.com/api-reference/Call-Recordings/readCallRecordingContent)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     ringcentral,
@@ -45,6 +45,11 @@ export default {
       type: "string",
       label: "Filename",
       description: "Filename for the new file in the /tmp directory",
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "write",
+      sync: true,
     },
   },
   methods: {

--- a/components/ringcentral/package.json
+++ b/components/ringcentral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/ringcentral",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Pipedream Ringcentral Components",
   "main": "ringcentral.app.mjs",
   "keywords": [

--- a/components/roboflow/actions/classify-image/classify-image.mjs
+++ b/components/roboflow/actions/classify-image/classify-image.mjs
@@ -5,7 +5,7 @@ export default {
   key: "roboflow-classify-image",
   name: "Classify Image",
   description: "Run inference on classification models hosted on Roboflow. [See the documentation](https://docs.roboflow.com/deploy/hosted-api/classification).",
-  version: "1.0.0",
+  version: "1.0.1",
   type: "action",
   props: {
     roboflow,
@@ -29,6 +29,12 @@ export default {
         roboflow,
         "filePath",
       ],
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
     },
   },
   async run({ $ }) {

--- a/components/roboflow/actions/detect-object-from-image/detect-object-from-image.mjs
+++ b/components/roboflow/actions/detect-object-from-image/detect-object-from-image.mjs
@@ -5,7 +5,7 @@ export default {
   key: "roboflow-detect-object-from-image",
   name: "Detect Object From Image",
   description: "Run inference on your object detection models hosted on Roboflow. [See the documentation](https://docs.roboflow.com/deploy/hosted-api/object-detection).",
-  version: "1.0.0",
+  version: "1.0.1",
   type: "action",
   props: {
     roboflow,
@@ -29,6 +29,12 @@ export default {
         roboflow,
         "filePath",
       ],
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
     },
   },
   async run({ $ }) {

--- a/components/roboflow/actions/upload-image/upload-image.mjs
+++ b/components/roboflow/actions/upload-image/upload-image.mjs
@@ -7,7 +7,7 @@ export default {
   key: "roboflow-upload-image",
   name: "Upload Image",
   description: "Upload an image to a project on the Roboflow platform. [See the documentation](https://docs.roboflow.com/datasets/adding-data/upload-api).",
-  version: "1.0.0",
+  version: "1.0.1",
   type: "action",
   props: {
     roboflow,
@@ -27,6 +27,12 @@ export default {
       type: "string",
       label: "Name",
       description: "Name of the uploaded file",
+      optional: true,
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
       optional: true,
     },
   },

--- a/components/roboflow/package.json
+++ b/components/roboflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/roboflow",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Pipedream Roboflow  Components",
   "main": "roboflow.app.mjs",
   "keywords": [

--- a/components/salesforce_rest_api/actions/create-attachment/create-attachment.mjs
+++ b/components/salesforce_rest_api/actions/create-attachment/create-attachment.mjs
@@ -18,7 +18,7 @@ export default {
   key: "salesforce_rest_api-create-attachment",
   name: "Create Attachment",
   description: `Creates an Attachment on a parent object. [See the documentation](${docsLink})`,
-  version: "0.5.0",
+  version: "0.5.1",
   type: "action",
   props,
   async run({ $ }) {

--- a/components/salesforce_rest_api/package.json
+++ b/components/salesforce_rest_api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/salesforce_rest_api",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Pipedream Salesforce (REST API) Components",
   "main": "salesforce_rest_api.app.mjs",
   "keywords": [

--- a/components/scoredetect/actions/create-timestamp-file/create-timestamp-file.mjs
+++ b/components/scoredetect/actions/create-timestamp-file/create-timestamp-file.mjs
@@ -5,7 +5,7 @@ export default {
   key: "scoredetect-create-timestamp-file",
   name: "Create Certificate from File",
   description: "Creates a timestamped blockchain certificate using a provided file (local or URL). [See the documentation](https://api.scoredetect.com/docs/routes#create-certificate)",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "action",
   props: {
     scoreDetect,
@@ -14,6 +14,12 @@ export default {
         scoreDetect,
         "fileOrUrl",
       ],
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
     },
   },
   async run({ $ }) {

--- a/components/scoredetect/package.json
+++ b/components/scoredetect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/scoredetect",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream ScoreDetect Components",
   "main": "scoredetect.app.mjs",
   "keywords": [

--- a/components/scrapfly/actions/ai-data-extraction/ai-data-extraction.mjs
+++ b/components/scrapfly/actions/ai-data-extraction/ai-data-extraction.mjs
@@ -6,7 +6,7 @@ export default {
   key: "scrapfly-ai-data-extraction",
   name: "AI Data Extraction",
   description: "Automate content extraction from any text-based source using AI, LLM, and custom parsing. [See the documentation](https://scrapfly.io/docs/extraction-api/getting-started)",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "action",
   props: {
     scrapfly,
@@ -57,6 +57,12 @@ export default {
       type: "string",
       label: "Webhook Name",
       description: "Queue you scrape request and redirect API response to a provided webhook endpoint. You can create a webhook endpoint from your `dashboard`, it takes the name of the webhook. Webhooks are scoped to the given project/env.",
+      optional: true,
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
       optional: true,
     },
   },

--- a/components/scrapfly/package.json
+++ b/components/scrapfly/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/scrapfly",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Scrapfly Components",
   "main": "scrapfly.app.mjs",
   "keywords": [
@@ -16,4 +16,3 @@
     "@pipedream/platform": "^3.1.0"
   }
 }
-

--- a/components/sendgrid/actions/send-email-multiple-recipients/send-email-multiple-recipients.mjs
+++ b/components/sendgrid/actions/send-email-multiple-recipients/send-email-multiple-recipients.mjs
@@ -10,7 +10,7 @@ export default {
   key: "sendgrid-send-email-multiple-recipients",
   name: "Send Email Multiple Recipients",
   description: "This action sends a personalized e-mail to multiple specified recipients. [See the docs here](https://docs.sendgrid.com/api-reference/mail-send/mail-send)",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "action",
   props: {
     ...common.props,
@@ -142,6 +142,12 @@ export default {
         common.props.sendgrid,
         "numberOfAttachments",
       ],
+      optional: true,
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
       optional: true,
     },
   },

--- a/components/sendgrid/actions/send-email-single-recipient/send-email-single-recipient.mjs
+++ b/components/sendgrid/actions/send-email-single-recipient/send-email-single-recipient.mjs
@@ -8,7 +8,7 @@ export default {
   key: "sendgrid-send-email-single-recipient",
   name: "Send Email Single Recipient",
   description: "This action sends a personalized e-mail to the specified recipient. [See the docs here](https://docs.sendgrid.com/api-reference/mail-send/mail-send)",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "action",
   props: {
     ...common.props,
@@ -163,6 +163,12 @@ export default {
         common.props.sendgrid,
         "numberOfAttachments",
       ],
+      optional: true,
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
       optional: true,
     },
   },

--- a/components/sendgrid/package.json
+++ b/components/sendgrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/sendgrid",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Pipedream Sendgrid Components",
   "main": "sendgrid.app.mjs",
   "keywords": [

--- a/components/sftp/actions/upload-file/upload-file.mjs
+++ b/components/sftp/actions/upload-file/upload-file.mjs
@@ -7,7 +7,7 @@ export default {
   key: "sftp-upload-file",
   name: "Upload File",
   description: "Uploads a file or string in UTF-8 format to the SFTP server. [See the documentation](https://github.com/theophilusx/ssh2-sftp-client#org99d1b64)",
-  version: "0.4.0",
+  version: "0.4.1",
   type: "action",
   props: {
     app,
@@ -27,6 +27,12 @@ export default {
       type: "string",
       label: "Remote Path",
       description: "The path on the sftp server for store the data. e.g. `./uploads/my-file.txt`",
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
     },
   },
   async run({ $ }) {

--- a/components/sftp/package.json
+++ b/components/sftp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/sftp",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Pipedream SFTP Components",
   "main": "sftp.app.mjs",
   "keywords": [

--- a/components/sharepoint/actions/download-file/download-file.mjs
+++ b/components/sharepoint/actions/download-file/download-file.mjs
@@ -5,7 +5,7 @@ export default {
   key: "sharepoint-download-file",
   name: "Download File",
   description: "Download a Microsoft Sharepoint file to the /tmp directory. [See the documentation](https://learn.microsoft.com/en-us/graph/api/driveitem-get-content?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     sharepoint,
@@ -38,6 +38,11 @@ export default {
       type: "string",
       label: "Filename",
       description: "The filename to save the downloaded file as in the `/tmp` directory",
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "write",
+      sync: true,
     },
   },
   async run({ $ }) {

--- a/components/sharepoint/package.json
+++ b/components/sharepoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/sharepoint",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Pipedream Microsoft Sharepoint Online Components",
   "main": "sharepoint.app.mjs",
   "keywords": [

--- a/components/shopify/actions/bulk-import/bulk-import.mjs
+++ b/components/shopify/actions/bulk-import/bulk-import.mjs
@@ -7,7 +7,7 @@ export default {
   key: "shopify-bulk-import",
   name: "Bulk Import",
   description: "Execute bulk mutations by uploading a JSONL file containing mutation variables. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/bulkoperationrunmutation)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     shopify,
@@ -30,6 +30,12 @@ export default {
       type: "string",
       label: "Client Identifier",
       description: "An optional identifier which may be used for querying",
+      optional: true,
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
       optional: true,
     },
   },

--- a/components/shopify/package.json
+++ b/components/shopify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/shopify",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Pipedream Shopify Components",
   "main": "shopify.app.mjs",
   "keywords": [

--- a/components/shortpixel/actions/optimize-image/optimize-image.mjs
+++ b/components/shortpixel/actions/optimize-image/optimize-image.mjs
@@ -6,7 +6,7 @@ export default {
   key: "shortpixel-optimize-image",
   name: "Optimize Image",
   description: "Optimize and/or adjust an image using ShortPixel. [See the documentation](https://shortpixel.com/knowledge-base/article/shortpixel-adaptive-images-api-parameters/)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     shortpixel,
@@ -56,6 +56,12 @@ export default {
       type: "string",
       label: "Filename",
       description: "Optionally, enter a filename that will be used to save the image in /tmp",
+      optional: true,
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "write",
+      sync: true,
       optional: true,
     },
   },

--- a/components/shortpixel/package.json
+++ b/components/shortpixel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/shortpixel",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream ShortPixel Components",
   "main": "shortpixel.app.mjs",
   "keywords": [

--- a/components/signaturit/actions/create-certified-email/create-certified-email.mjs
+++ b/components/signaturit/actions/create-certified-email/create-certified-email.mjs
@@ -8,7 +8,7 @@ export default {
   key: "signaturit-create-certified-email",
   name: "Create Certified Email",
   description: "Initiates the creation of a certified email. [See the documentation](https://docs.signaturit.com/api/latest#emails_create_email)",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "action",
   props: {
     signaturit,
@@ -65,6 +65,12 @@ export default {
         signaturit,
         "subject",
       ],
+      optional: true,
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
       optional: true,
     },
   },

--- a/components/signaturit/actions/create-signature-request-from-template/create-signature-request-from-template.mjs
+++ b/components/signaturit/actions/create-signature-request-from-template/create-signature-request-from-template.mjs
@@ -12,7 +12,7 @@ export default {
   key: "signaturit-create-signature-request-from-template",
   name: "Create Signature Request from Template",
   description: "Creates a signature request using a pre-existing template. [See the documentation](https://docs.signaturit.com/api/latest#signatures_create_signature)",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "action",
   props: {
     signaturit,
@@ -129,6 +129,12 @@ export default {
       label: "Type",
       description: "The type of the signature.",
       options: SIGNATURE_TYPE_OPTIONS,
+      optional: true,
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
       optional: true,
     },
   },

--- a/components/signaturit/package.json
+++ b/components/signaturit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/signaturit",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Signaturit Components",
   "main": "signaturit.app.mjs",
   "keywords": [

--- a/components/signerx/actions/upload-package/upload-package.mjs
+++ b/components/signerx/actions/upload-package/upload-package.mjs
@@ -6,7 +6,7 @@ export default {
   key: "signerx-upload-package",
   name: "Upload Package",
   description: "Quickly create a draft for a new package/document by uploading a file or providing a file_url to a PDF document. [See the documentation](https://documenter.getpostman.com/view/13877745/2sa3xv9kni)",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "action",
   props: {
     signerx,
@@ -19,6 +19,12 @@ export default {
       type: "string",
       label: "Name",
       description: "The name of the package/document",
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
     },
   },
   async run({ $ }) {

--- a/components/signerx/package.json
+++ b/components/signerx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/signerx",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream SignerX Components",
   "main": "signerx.app.mjs",
   "keywords": [

--- a/components/signnow/actions/upload-document-with-tags/upload-document-with-tags.mjs
+++ b/components/signnow/actions/upload-document-with-tags/upload-document-with-tags.mjs
@@ -6,7 +6,7 @@ export default {
   key: "signnow-upload-document-with-tags",
   name: "Upload Document With Tags",
   description: "Uploads a file that contains SignNow text tags. [See the documentation](https://docs.signnow.com/docs/signnow/document/operations/create-a-document-fieldextract)",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "action",
   props: {
     app,
@@ -14,6 +14,12 @@ export default {
       type: "string",
       label: "File Path or URL",
       description: "The file to upload. Provide either a file URL or a path to a file in the `/tmp` directory (for example, `/tmp/myFile.txt`).",
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
     },
   },
   methods: {

--- a/components/signnow/package.json
+++ b/components/signnow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/signnow",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream signNow Components",
   "main": "signnow.app.mjs",
   "keywords": [

--- a/components/slack/actions/upload-file/upload-file.mjs
+++ b/components/slack/actions/upload-file/upload-file.mjs
@@ -8,7 +8,7 @@ export default {
   key: "slack-upload-file",
   name: "Upload File",
   description: "Upload a file. [See the documentation](https://api.slack.com/messaging/files#uploading_files)",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "action",
   props: {
     slack,
@@ -30,6 +30,12 @@ export default {
         slack,
         "initial_comment",
       ],
+      optional: true,
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
       optional: true,
     },
   },

--- a/components/slack/package.json
+++ b/components/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/slack",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Pipedream Slack Components",
   "main": "slack.app.mjs",
   "keywords": [

--- a/components/smugmug/actions/upload-image/upload-image.mjs
+++ b/components/smugmug/actions/upload-image/upload-image.mjs
@@ -6,7 +6,7 @@ export default {
   key: "smugmug-upload-image",
   name: "Upload Image",
   description: "Uploads an image to a SmugMug album. [See the docs here](https://api.smugmug.com/services/api/?method=upload)",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "action",
   props: {
     smugmug,
@@ -21,6 +21,12 @@ export default {
       type: "string",
       label: "File Path or URL",
       description: "The file to upload. Provide either a file URL or a path to a file in the `/tmp` directory (for example, `/tmp/myFile.txt`).",
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
     },
   },
   async run({ $ }) {

--- a/components/smugmug/package.json
+++ b/components/smugmug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/smugmug",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Smugmug Components",
   "main": "smugmug.app.mjs",
   "keywords": [

--- a/components/sonix/actions/upload-media/upload-media.mjs
+++ b/components/sonix/actions/upload-media/upload-media.mjs
@@ -7,7 +7,7 @@ export default {
   key: "sonix-upload-media",
   name: "Upload Media",
   description: "Submits new media for processing. [See the documentation](https://sonix.ai/docs/api#new_media)",
-  version: "1.0.0",
+  version: "1.0.1",
   type: "action",
   props: {
     sonix,
@@ -57,6 +57,12 @@ export default {
       type: "string",
       label: "Callback URL",
       description: "URL for Sonix to make a POST request notifying of a change in transcript status (either failed or completed). The POST will include the media status JSON.",
+      optional: true,
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
       optional: true,
     },
   },

--- a/components/sonix/package.json
+++ b/components/sonix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/sonix",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Pipedream Sonix Components",
   "main": "sonix.app.mjs",
   "keywords": [

--- a/components/speechace/actions/score-scripted-recording/score-scripted-recording.mjs
+++ b/components/speechace/actions/score-scripted-recording/score-scripted-recording.mjs
@@ -8,7 +8,7 @@ export default {
   key: "speechace-score-scripted-recording",
   name: "Score Scripted Recording",
   description: "Scores a scripted recording based on fluency and pronunciation. [See the documentation](https://docs.speechace.com/#c34b11dd-8172-441a-bc27-223339d48d8e)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     speechace,
@@ -40,6 +40,12 @@ export default {
         speechace,
         "userId",
       ],
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
     },
   },
   async run({ $ }) {

--- a/components/speechace/actions/transcribe-and-score-recording/transcribe-and-score-recording.mjs
+++ b/components/speechace/actions/transcribe-and-score-recording/transcribe-and-score-recording.mjs
@@ -8,7 +8,7 @@ export default {
   key: "speechace-transcribe-and-score-recording",
   name: "Transcribe and Score Recording",
   description: "Transcribes and scores a provided speech recording. [See the documentation](https://docs.speechace.com/#76089b5d-7e25-4744-8d32-f6c230acf217)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     speechace,
@@ -35,6 +35,12 @@ export default {
         speechace,
         "userId",
       ],
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
     },
   },
   async run({ $ }) {

--- a/components/speechace/package.json
+++ b/components/speechace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/speechace",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream Speechace Components",
   "main": "speechace.app.mjs",
   "keywords": [

--- a/components/spotlightr/actions/create-video/create-video.mjs
+++ b/components/spotlightr/actions/create-video/create-video.mjs
@@ -5,7 +5,7 @@ import spotlightr from "../../spotlightr.app.mjs";
 export default {
   key: "spotlightr-create-video",
   name: "Create Video",
-  version: "1.0.0",
+  version: "1.0.1",
   description: "Create a video in an application. [See the documentation](https://app.spotlightr.com/docs/api/#create-video)",
   type: "action",
   props: {
@@ -69,6 +69,12 @@ export default {
       type: "object",
       label: "Player Settings",
       description: "Video ID for coping playerSettings (decoded base64)",
+      optional: true,
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
       optional: true,
     },
   },

--- a/components/spotlightr/package.json
+++ b/components/spotlightr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/spotlightr",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Pipedream Spotlightr Components",
   "main": "spotlightr.app.mjs",
   "keywords": [

--- a/components/stannp/actions/create-campaign/create-campaign.mjs
+++ b/components/stannp/actions/create-campaign/create-campaign.mjs
@@ -9,7 +9,7 @@ export default {
   key: "stannp-create-campaign",
   name: "Create a New Campaign",
   description: "Create a new campaign in Stannp. [See the documentation](https://www.stannp.com/us/direct-mail-api/campaigns)",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "action",
   props: {
     stannp,
@@ -76,6 +76,12 @@ export default {
       description: "A PDF or JPG file to use as the back image. Provide either a file URL or a path to a file in the `/tmp` directory (for example, `/tmp/myFile.jpg`)",
       optional: true,
       reloadProps: true,
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
     },
   },
   async additionalProps() {

--- a/components/stannp/package.json
+++ b/components/stannp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/stannp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Stannp Components",
   "main": "stannp.app.mjs",
   "keywords": [

--- a/components/supabase/actions/batch-insert-rows/batch-insert-rows.mjs
+++ b/components/supabase/actions/batch-insert-rows/batch-insert-rows.mjs
@@ -6,7 +6,7 @@ export default {
   key: "supabase-batch-insert-rows",
   name: "Batch Insert Rows",
   description: "Inserts new rows into a database. [See the documentation](https://supabase.com/docs/reference/javascript/insert)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   props: {
     supabase,
@@ -26,6 +26,12 @@ export default {
         "CSV File",
       ],
       reloadProps: true,
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
     },
   },
   async additionalProps() {

--- a/components/supabase/package.json
+++ b/components/supabase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/supabase",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Pipedream Supabase Components",
   "main": "supabase.app.mjs",
   "keywords": [

--- a/components/syncmate_by_assitro/actions/send-bulk-messages/send-bulk-messages.mjs
+++ b/components/syncmate_by_assitro/actions/send-bulk-messages/send-bulk-messages.mjs
@@ -8,7 +8,7 @@ export default {
   key: "syncmate_by_assitro-send-bulk-messages",
   name: "Send Bulk Messages",
   description: "Send multiple WhatsApp messages in bulk. [See the documentation](https://assistro.co/user-guide/bulk-messaging-at-a-scheduled-time-using-syncmate-2/)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     syncmateByAssitro,
@@ -17,6 +17,12 @@ export default {
       label: "Messages Number",
       description: "The quantity of messages you want to send.",
       reloadProps: true,
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
     },
   },
   async additionalProps() {

--- a/components/syncmate_by_assitro/actions/send-message/send-message.mjs
+++ b/components/syncmate_by_assitro/actions/send-message/send-message.mjs
@@ -8,7 +8,7 @@ export default {
   key: "syncmate_by_assitro-send-message",
   name: "Send WhatsApp Message",
   description: "Send a single WhatsApp message using SyncMate by Assistro. [See the documentation](https://assistro.co/user-guide/connect-your-custom-app-with-syncmate/)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     syncmateByAssitro,
@@ -32,6 +32,12 @@ export default {
       type: "string",
       label: "File Name",
       description: "The name of the file.",
+      optional: true,
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
       optional: true,
     },
   },

--- a/components/syncmate_by_assitro/package.json
+++ b/components/syncmate_by_assitro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/syncmate_by_assitro",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream SyncMate by Assitro Components",
   "main": "syncmate_by_assitro.app.mjs",
   "keywords": [

--- a/components/testmonitor/actions/create-test-result/create-test-result.mjs
+++ b/components/testmonitor/actions/create-test-result/create-test-result.mjs
@@ -9,7 +9,7 @@ export default {
   key: "testmonitor-create-test-result",
   name: "Create Test Result",
   description: "Create a new test result. [See the documentation](https://docs.testmonitor.com/#tag/Test-Results/operation/PostTestResult)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     testmonitor,
@@ -67,6 +67,12 @@ export default {
       type: "string",
       label: "Description",
       description: "The description of the test result.",
+      optional: true,
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
       optional: true,
     },
   },

--- a/components/testmonitor/package.json
+++ b/components/testmonitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/testmonitor",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream Testmonitor Components",
   "main": "testmonitor.app.mjs",
   "keywords": [

--- a/components/the_bookie/actions/create-sales-invoice/create-sales-invoice.mjs
+++ b/components/the_bookie/actions/create-sales-invoice/create-sales-invoice.mjs
@@ -8,7 +8,7 @@ export default {
   key: "the_bookie-create-sales-invoice",
   name: "Create Sales Invoice",
   description: "Creates a new sales invoice. [See the documentation](https://app.thebookie.nl/nl/help/article/api-documentatie/#salesentry_create)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     theBookie,
@@ -67,6 +67,12 @@ export default {
       type: "string",
       label: "Attachment",
       description: "Provide either a file URL or a path to a file in the /tmp directory (for example, /tmp/myFile.pdf).",
+      optional: true,
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
       optional: true,
     },
   },

--- a/components/the_bookie/package.json
+++ b/components/the_bookie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/the_bookie",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream The Bookie Components",
   "main": "the_bookie.app.mjs",
   "keywords": [

--- a/components/tinypng/actions/compress-image/compress-image.mjs
+++ b/components/tinypng/actions/compress-image/compress-image.mjs
@@ -5,7 +5,7 @@ export default {
   key: "tinypng-compress-image",
   name: "Compress Image",
   description: "Compress a WebP, JPEG, or PNG image using the TinyPNG API. [See the documentation](https://tinypng.com/developers/reference#compressing-images)",
-  version: "1.0.0",
+  version: "1.0.1",
   type: "action",
   props: {
     tinypng,
@@ -14,6 +14,12 @@ export default {
         tinypng,
         "file",
       ],
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
     },
   },
   async run({ $ }) {

--- a/components/tinypng/actions/convert-image/convert-image.mjs
+++ b/components/tinypng/actions/convert-image/convert-image.mjs
@@ -8,7 +8,7 @@ export default {
   key: "tinypng-convert-image",
   name: "Convert Image",
   description: "Convert your images to your desired image type using TinyPNG. [See the documentation](https://tinypng.com/developers/reference#converting-images)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     tinypng,
@@ -29,6 +29,11 @@ export default {
       label: "Transform Background",
       description: "The background color to use when converting images with transparency to a format that does not support transparency (like JPEG). Use a hex value (e.g., '#FFFFFF') or 'white'/'black'.",
       optional: true,
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "write",
+      sync: true,
     },
   },
   async run({ $ }) {

--- a/components/tinypng/actions/resize-image/resize-image.mjs
+++ b/components/tinypng/actions/resize-image/resize-image.mjs
@@ -8,7 +8,7 @@ export default {
   key: "tinypng-resize-image",
   name: "Resize Image",
   description: "Create resized versions of your uploaded image. [See the documentation](https://tinypng.com/developers/reference#resizing-images)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     tinypng,
@@ -24,6 +24,11 @@ export default {
         "method",
       ],
       reloadProps: true,
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "write",
+      sync: true,
     },
   },
   async additionalProps() {

--- a/components/tinypng/package.json
+++ b/components/tinypng/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/tinypng",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream TinyPNG AI Components",
   "main": "tinypng.app.mjs",
   "keywords": [

--- a/components/todoist/actions/export-tasks/export-tasks.mjs
+++ b/components/todoist/actions/export-tasks/export-tasks.mjs
@@ -7,7 +7,7 @@ export default {
   key: "todoist-export-tasks",
   name: "Export Tasks",
   description: "Export project task names as comma separated file. Returns path to new file. [See Docs](https://developer.todoist.com/rest/v2/#get-active-tasks)",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "action",
   props: {
     todoist,
@@ -16,6 +16,11 @@ export default {
         todoist,
         "project",
       ],
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "write",
+      sync: true,
     },
   },
   async run ({ $ }) {

--- a/components/todoist/actions/import-tasks/import-tasks.mjs
+++ b/components/todoist/actions/import-tasks/import-tasks.mjs
@@ -6,7 +6,7 @@ export default {
   key: "todoist-import-tasks",
   name: "Import Tasks",
   description: "Import tasks into a selected project. [See Docs](https://developer.todoist.com/sync/v9/#add-an-item)",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "action",
   props: {
     todoist,
@@ -22,6 +22,12 @@ export default {
         "project",
       ],
       description: "Project to import tasks into",
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
     },
   },
   methods: {

--- a/components/todoist/package.json
+++ b/components/todoist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/todoist",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Todoist Components",
   "main": "todoist.app.mjs",
   "keywords": [

--- a/components/transifex/actions/download-file/download-file.mjs
+++ b/components/transifex/actions/download-file/download-file.mjs
@@ -5,7 +5,7 @@ export default {
   key: "transifex-download-file",
   name: "Download File",
   description: "Downloads a user-specified file from the Transifex platform. [See the documentation](https://developers.transifex.com/reference/get_resource-strings-async-downloads-resource-strings-async-download-id)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     transifex,
@@ -14,6 +14,11 @@ export default {
         transifex,
         "asyncDownloadId",
       ],
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "write",
+      sync: true,
     },
   },
   methods: {

--- a/components/transifex/actions/upload-file/upload-file.mjs
+++ b/components/transifex/actions/upload-file/upload-file.mjs
@@ -5,7 +5,7 @@ export default {
   key: "transifex-upload-file",
   name: "Upload File to Transifex",
   description: "Uploads a given file to the Transifex platform. [See the documentation](https://developers.transifex.com/reference/post_resource-strings-async-uploads)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     transifex,
@@ -56,6 +56,12 @@ export default {
           projectId,
         }),
       ],
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
     },
   },
   methods: {

--- a/components/transifex/package.json
+++ b/components/transifex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/transifex",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream Transifex Components",
   "main": "transifex.app.mjs",
   "keywords": [

--- a/components/trello/actions/add-attachment-to-card/add-attachment-to-card.mjs
+++ b/components/trello/actions/add-attachment-to-card/add-attachment-to-card.mjs
@@ -6,7 +6,7 @@ export default {
   key: "trello-add-attachment-to-card",
   name: "Add Attachment To Card",
   description: "Adds a file attachment on a card. [See the documentation](https://developer.atlassian.com/cloud/trello/rest/api-group-cards/#api-cards-id-attachments-post)",
-  version: "1.0.0",
+  version: "1.0.1",
   type: "action",
   props: {
     app,
@@ -51,6 +51,12 @@ export default {
       label: "Set Cover?",
       description: "Determines whether to use the new attachment as a cover for the Card",
       default: false,
+      optional: true,
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
       optional: true,
     },
   },

--- a/components/trello/actions/create-card/create-card.mjs
+++ b/components/trello/actions/create-card/create-card.mjs
@@ -7,7 +7,7 @@ export default {
   key: "trello-create-card",
   name: "Create Card",
   description: "Creates a new card. [See the documentation](https://developer.atlassian.com/cloud/trello/rest/api-group-cards/#api-cards-post).",
-  version: "1.0.0",
+  version: "1.0.1",
   type: "action",
   props: {
     app,
@@ -150,6 +150,12 @@ export default {
         }),
       ],
       reloadProps: true,
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
     },
   },
   async additionalProps(existingProps) {

--- a/components/trello/package.json
+++ b/components/trello/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/trello",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Pipedream Trello Components",
   "main": "trello.app.mjs",
   "keywords": [

--- a/components/trust/actions/upload-video/upload-video.mjs
+++ b/components/trust/actions/upload-video/upload-video.mjs
@@ -6,7 +6,7 @@ export default {
   key: "trust-upload-video",
   name: "Upload Video",
   description: "Upload a video to the Trust platform. [See the documentation](https://api-docs.usetrust.io/uploads-a-video-to-be-used-for-testimonials).",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     app,
@@ -20,6 +20,12 @@ export default {
       type: "string",
       label: "File Path or URL",
       description: "Provide either a file URL or a path to a file in the /tmp directory (for example, /tmp/myFile.pdf).",
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
     },
   },
   methods: {

--- a/components/trust/package.json
+++ b/components/trust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/trust",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream Trust Components",
   "main": "trust.app.mjs",
   "keywords": [

--- a/components/twilio/actions/download-recording-media/download-recording-media.mjs
+++ b/components/twilio/actions/download-recording-media/download-recording-media.mjs
@@ -8,7 +8,7 @@ export default {
   key: "twilio-download-recording-media",
   name: "Download Recording Media",
   description: "Download a recording media file. [See the documentation](https://www.twilio.com/docs/voice/api/recording#fetch-a-recording-media-file)",
-  version: "0.1.6",
+  version: "0.1.7",
   type: "action",
   props: {
     twilio,
@@ -28,6 +28,11 @@ export default {
       type: "string",
       label: "File Path",
       description: "The destination path in [`/tmp`](https://pipedream.com/docs/workflows/steps/code/nodejs/working-with-files/#the-tmp-directory) for the downloaded the file (e.g., `/tmp/myFile.mp3`). Make sure to include the file extension.",
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "write",
+      sync: true,
     },
   },
   methods: {
@@ -58,13 +63,16 @@ export default {
       downloadUrl,
     });
     const pipeline = promisify(stream.pipeline);
-    const resp = await pipeline(
+    const filePath = this.filePath.startsWith("/tmp")
+      ? this.filePath
+      : `/tmp/${this.filePath}`;
+    await pipeline(
       fileStream,
-      fs.createWriteStream(this.filePath.includes("/tmp")
-        ? this.filePath
-        : `/tmp/${this.filePath}`),
+      fs.createWriteStream(filePath),
     );
-    $.export("$summary", `Successfully downloaded the recording media file to "${this.filePath}"`);
-    return resp;
+    $.export("$summary", `Successfully downloaded the recording media file to "${filePath}"`);
+    return {
+      filePath,
+    };
   },
 };

--- a/components/twilio/package.json
+++ b/components/twilio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/twilio",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Pipedream Twilio Components",
   "main": "twilio.app.mjs",
   "keywords": [

--- a/components/vapi/actions/upload-file/upload-file.mjs
+++ b/components/vapi/actions/upload-file/upload-file.mjs
@@ -6,7 +6,7 @@ export default {
   key: "vapi-upload-file",
   name: "Upload File",
   description: "Uploads a new file. [See the documentation](https://docs.vapi.ai/api-reference)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     vapi,
@@ -14,6 +14,12 @@ export default {
       type: "string",
       label: "File Path or URL",
       description: "Provide either a file URL or a path to a file in the /tmp directory (for example, /tmp/myFile.pdf).",
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
     },
   },
   async run({ $ }) {

--- a/components/vapi/package.json
+++ b/components/vapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/vapi",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream Vapi Components",
   "main": "vapi.app.mjs",
   "keywords": [

--- a/components/what_are_those/actions/find-sneakers-by-sku/find-sneakers-by-sku.mjs
+++ b/components/what_are_those/actions/find-sneakers-by-sku/find-sneakers-by-sku.mjs
@@ -6,7 +6,7 @@ export default {
   key: "what_are_those-find-sneakers-by-sku",
   name: "Find Sneakers by SKU",
   description: "Identifies sneakers from a size tag photo and returns sneaker name and details. [See the documentation](https://documenter.getpostman.com/view/3847098/2sAY4rDQDs#4f6a49f9-3393-42cd-8474-3856a79888af)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     app,
@@ -14,6 +14,12 @@ export default {
       type: "string",
       label: "Size Tag Image",
       description: "The image to upload. Provide either a file URL or a path to a file in the /tmp directory (for example, /tmp/myFile.jpg).",
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
     },
   },
   async run({ $ }) {

--- a/components/what_are_those/actions/grade-sneakers-condition/grade-sneakers-condition.mjs
+++ b/components/what_are_those/actions/grade-sneakers-condition/grade-sneakers-condition.mjs
@@ -6,7 +6,7 @@ export default {
   key: "what_are_those-grade-sneakers-condition",
   name: "Grade and Authenticate Sneakers",
   description: "Grades and authenticates sneakers using provided images. [See the documentation](https://documenter.getpostman.com/view/3847098/2sAY4rDQDs#13d527e8-5d8f-4511-857c-b40b8dd921b8)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     app,
@@ -48,6 +48,12 @@ export default {
         "grading",
         "authentication",
       ],
+      optional: true,
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
       optional: true,
     },
   },

--- a/components/what_are_those/actions/identify-sneakers-from-photo/identify-sneakers-from-photo.mjs
+++ b/components/what_are_those/actions/identify-sneakers-from-photo/identify-sneakers-from-photo.mjs
@@ -6,7 +6,7 @@ export default {
   key: "what_are_those-identify-sneakers-from-photo",
   name: "Identify Sneakers from Photo",
   description: "Identifies sneakers from an uploaded image and returns details such as name, links, images, prices, and confidence scores. [See the documentation](https://documenter.getpostman.com/view/3847098/2sAY4rDQDs#957c900c-501f-4c8f-9b8b-71655a8cfb5d).",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     app,
@@ -14,6 +14,12 @@ export default {
       type: "string",
       label: "Image",
       description: "The image to upload. Provide either a file URL or a path to a file in the /tmp directory (for example, /tmp/myFile.jpg).",
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
     },
   },
   async run({ $ }) {

--- a/components/what_are_those/package.json
+++ b/components/what_are_those/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/what_are_those",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream What Are Those Components",
   "main": "what_are_those.app.mjs",
   "keywords": [

--- a/components/whatsapp_business/actions/send-voice-message/send-voice-message.mjs
+++ b/components/whatsapp_business/actions/send-voice-message/send-voice-message.mjs
@@ -6,7 +6,7 @@ export default {
   key: "whatsapp_business-send-voice-message",
   name: "Send Voice Message",
   description: "Sends a voice message. [See the documentation](https://developers.facebook.com/docs/whatsapp/cloud-api/messages/audio-messages)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     whatsapp,
@@ -39,6 +39,12 @@ export default {
         "audio/ogg",
         "audio/opus",
       ],
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
     },
   },
   async run({ $ }) {

--- a/components/whatsapp_business/package.json
+++ b/components/whatsapp_business/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/whatsapp_business",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Pipedream WhatsApp Business Components",
   "main": "whatsapp_business.app.mjs",
   "keywords": [

--- a/components/wordpress_org/actions/upload-media/upload-media.mjs
+++ b/components/wordpress_org/actions/upload-media/upload-media.mjs
@@ -6,7 +6,7 @@ export default {
   key: "wordpress_org-upload-media",
   name: "Upload Media",
   description: "Upload a media item to your WordPress media library. Returns a media ID to be used in creating or updating posts.[See the documentation](https://www.npmjs.com/package/wpapi#uploading-media)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     wordpress,
@@ -35,6 +35,12 @@ export default {
         "description",
       ],
       description: "Description of the media item",
+      optional: true,
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
       optional: true,
     },
   },

--- a/components/wordpress_org/package.json
+++ b/components/wordpress_org/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/wordpress_org",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Pipedream Wordpress.org Components",
   "main": "wordpress_org.app.mjs",
   "keywords": [

--- a/components/xero_accounting_api/actions/download-invoice/download-invoice.mjs
+++ b/components/xero_accounting_api/actions/download-invoice/download-invoice.mjs
@@ -6,7 +6,7 @@ export default {
   key: "xero_accounting_api-download-invoice",
   name: "Download Invoice",
   description: "Downloads an invoice as pdf file. File will be placed at the action's associated workflow temporary folder.",
-  version: "0.2.0",
+  version: "0.2.1",
   type: "action",
   props: {
     xero_accounting_api: {
@@ -20,6 +20,11 @@ export default {
     invoice_id: {
       type: "string",
       description: "Xero generated unique identifier for the invoice to download.",
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "write",
+      sync: true,
     },
   },
   async run({ $ }) {
@@ -47,5 +52,8 @@ export default {
     $.export("invoice_path", invoicePath); //This is where the invoice is saved at the workflow's temporary files.
     fs.writeFileSync(invoicePath, buffer);
     console.log(`Invoice saved at: ${invoicePath}`);
+    return {
+      filePath: invoicePath,
+    };
   },
 };

--- a/components/xero_accounting_api/actions/upload-file/upload-file.mjs
+++ b/components/xero_accounting_api/actions/upload-file/upload-file.mjs
@@ -9,7 +9,7 @@ export default {
   key: "xero_accounting_api-upload-file",
   name: "Upload File",
   description: "Uploads a file to the specified document. [See the documentation](https://developer.xero.com/documentation/api/accounting/invoices#upload-attachment)",
-  version: "1.0.0",
+  version: "1.0.1",
   type: "action",
   props: {
     xeroAccountingApi,
@@ -44,6 +44,12 @@ export default {
       label: "Document ID",
       type: "string",
       description: "Xero identifier of the document where the attachment will be sent to.",
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
     },
   },
   async run({ $ }) {

--- a/components/xero_accounting_api/package.json
+++ b/components/xero_accounting_api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/xero_accounting_api",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Pipedream Xero Components",
   "main": "xero_accounting_api.app.mjs",
   "keywords": [

--- a/components/youtube_data_api/actions/upload-channel-banner/upload-channel-banner.mjs
+++ b/components/youtube_data_api/actions/upload-channel-banner/upload-channel-banner.mjs
@@ -6,7 +6,7 @@ export default {
   key: "youtube_data_api-upload-channel-banner",
   name: "Upload Channel Banner",
   description: "Uploads a channel banner image to YouTube. [See the documentation](https://developers.google.com/youtube/v3/docs/channelBanners/insert) for more information",
-  version: "1.0.0",
+  version: "1.0.1",
   type: "action",
   props: {
     youtubeDataApi,
@@ -27,5 +27,11 @@ export default {
       ],
     },
     ...common.props,
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
+    },
   },
 };

--- a/components/youtube_data_api/actions/upload-thumbnail/upload-thumbnail.mjs
+++ b/components/youtube_data_api/actions/upload-thumbnail/upload-thumbnail.mjs
@@ -6,7 +6,7 @@ export default {
   key: "youtube_data_api-upload-thumbnail",
   name: "Upload Thumbnail",
   description: "Uploads a custom video thumbnail to YouTube and sets it for a video. Note: Account must be [verified](https://www.youtube.com/verify). [See the documentation](https://developers.google.com/youtube/v3/docs/thumbnails/set) for more information",
-  version: "1.0.0",
+  version: "1.0.1",
   type: "action",
   props: {
     youtubeDataApi,
@@ -33,5 +33,11 @@ export default {
       ],
     },
     ...common.props,
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
+    },
   },
 };

--- a/components/youtube_data_api/actions/upload-video/upload-video.mjs
+++ b/components/youtube_data_api/actions/upload-video/upload-video.mjs
@@ -6,7 +6,7 @@ export default {
   key: "youtube_data_api-upload-video",
   name: "Upload Video",
   description: "Post a video to your channel. [See the documentation](https://developers.google.com/youtube/v3/docs/videos/insert) for more information",
-  version: "1.0.0",
+  version: "1.0.1",
   type: "action",
   props: {
     youtubeDataApi,
@@ -52,5 +52,11 @@ export default {
       ],
     },
     ...common.props,
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
+    },
   },
 };

--- a/components/youtube_data_api/package.json
+++ b/components/youtube_data_api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/youtube_data_api",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Pipedream Youtube Components",
   "main": "youtube_data_api.app.mjs",
   "keywords": [

--- a/components/youtube_data_api_custom_app/actions/upload-channel-banner/upload-channel-banner.mjs
+++ b/components/youtube_data_api_custom_app/actions/upload-channel-banner/upload-channel-banner.mjs
@@ -6,7 +6,7 @@ export default {
   key: "youtube_data_api_custom_app-upload-channel-banner",
   name: "Upload Channel Banner",
   description: "Uploads a channel banner image to YouTube. [See the docs](https://developers.google.com/youtube/v3/docs/channelBanners/insert) for more information",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     youtubeDataApi,
@@ -31,5 +31,11 @@ export default {
       ],
     },
     ...common.props,
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
+    },
   },
 };

--- a/components/youtube_data_api_custom_app/actions/upload-thumbnail/upload-thumbnail.mjs
+++ b/components/youtube_data_api_custom_app/actions/upload-thumbnail/upload-thumbnail.mjs
@@ -6,7 +6,7 @@ export default {
   key: "youtube_data_api_custom_app-upload-thumbnail",
   name: "Upload Thumbnail",
   description: "Uploads a custom video thumbnail to YouTube and sets it for a video. [See the docs](https://developers.google.com/youtube/v3/docs/thumbnails/set) for more information",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     youtubeDataApi,
@@ -37,5 +37,11 @@ export default {
       ],
     },
     ...common.props,
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
+    },
   },
 };

--- a/components/youtube_data_api_custom_app/actions/upload-video/upload-video.mjs
+++ b/components/youtube_data_api_custom_app/actions/upload-video/upload-video.mjs
@@ -6,7 +6,7 @@ export default {
   key: "youtube_data_api_custom_app-upload-video",
   name: "Upload Video",
   description: "Post a video to your channel. [See the docs](https://developers.google.com/youtube/v3/docs/videos/insert) for more information",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   dedupe: "unique",
   props: {
@@ -60,5 +60,11 @@ export default {
       ],
     },
     ...common.props,
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
+    },
   },
 };

--- a/components/youtube_data_api_custom_app/package.json
+++ b/components/youtube_data_api_custom_app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/youtube_data_api_custom_app",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Pipedream Youtube Custom App Components",
   "main": "youtube_data_api_custom_app.app.mjs",
   "keywords": [

--- a/components/zerobounce/actions/file-validation/file-validation.mjs
+++ b/components/zerobounce/actions/file-validation/file-validation.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zerobounce-file-validation",
   name: "Validate Emails in File",
   description: "Performs email validation on all the addresses contained in a provided file. [See the documentation](https://www.zerobounce.net/docs/email-validation-api-quickstart/)",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "action",
   props: {
     zerobounce,
@@ -60,6 +60,12 @@ export default {
       type: "boolean",
       label: "Callback With Rerun",
       description: "Use the `$.flow.rerun` Node.js helper to rerun the step when the validation is completed. Overrides the `rerunUrl` prop. This will increase execution time and credit usage as a result. [See the documentation](https://pipedream.com/docs/code/nodejs/rerun/#flow-rerun)",
+      optional: true,
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
       optional: true,
     },
   },

--- a/components/zerobounce/actions/get-validation-results-file/get-validation-results-file.mjs
+++ b/components/zerobounce/actions/get-validation-results-file/get-validation-results-file.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zerobounce-get-validation-results-file",
   name: "Get Validation Results File",
   description: "Downloads the validation results for a file submitted using sendfile API. [See the documentation](https://www.zerobounce.net/docs/email-validation-api-quickstart/#get_file__v2__)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     zerobounce,
@@ -19,6 +19,11 @@ export default {
       type: "string",
       label: "File Name",
       description: "The filename to save the file as in the \"/tmp\" directory",
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "write",
+      sync: true,
     },
   },
   methods: {

--- a/components/zerobounce/package.json
+++ b/components/zerobounce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/zerobounce",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream ZeroBounce Components",
   "main": "zerobounce.app.mjs",
   "keywords": [

--- a/components/zip_archive_api/actions/compress-files/compress-files.mjs
+++ b/components/zip_archive_api/actions/compress-files/compress-files.mjs
@@ -7,7 +7,7 @@ export default {
   key: "zip_archive_api-compress-files",
   name: "Compress Files",
   description: "Compress files provided through URLs into a zip folder. [See the documentation](https://archiveapi.com/rest-api/file-compression/)",
-  version: "1.0.0",
+  version: "1.0.1",
   type: "action",
   props: {
     app,
@@ -34,6 +34,12 @@ export default {
         app,
         "files",
       ],
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read-write",
+      sync: true,
+      optional: true,
     },
   },
   async run({ $ }) {

--- a/components/zip_archive_api/package.json
+++ b/components/zip_archive_api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/zip_archive_api",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Zip Archive API Components",
   "main": "zip_archive_api.app.mjs",
   "keywords": [

--- a/components/zoho_bugtracker/actions/create-bug/create-bug.mjs
+++ b/components/zoho_bugtracker/actions/create-bug/create-bug.mjs
@@ -6,7 +6,7 @@ import zohoBugtracker from "../../zoho_bugtracker.app.mjs";
 export default {
   key: "zoho_bugtracker-create-bug",
   name: "Create Bug",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Create a new bug [See the documentation](https://www.zoho.com/projects/help/rest-api/bugtracker-bugs-api.html#alink3)",
   type: "action",
   props: {
@@ -162,6 +162,12 @@ export default {
         zohoBugtracker,
         "uploaddoc",
       ],
+      optional: true,
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
       optional: true,
     },
   },

--- a/components/zoho_bugtracker/actions/update-bug/update-bug.mjs
+++ b/components/zoho_bugtracker/actions/update-bug/update-bug.mjs
@@ -6,7 +6,7 @@ import zohoBugtracker from "../../zoho_bugtracker.app.mjs";
 export default {
   key: "zoho_bugtracker-update-bug",
   name: "Update Bug",
-  version: "0.1.0",
+  version: "0.1.1",
   description: "Update a specific bug [See the documentation](https://www.zoho.com/projects/help/rest-api/bugtracker-bugs-api.html#alink4)",
   type: "action",
   props: {
@@ -180,6 +180,12 @@ export default {
         zohoBugtracker,
         "uploaddoc",
       ],
+      optional: true,
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
       optional: true,
     },
   },

--- a/components/zoho_bugtracker/package.json
+++ b/components/zoho_bugtracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/zoho_bugtracker",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Zoho BugTracker Components",
   "main": "zoho_bugtracker.app.mjs",
   "keywords": [

--- a/components/zoho_desk/actions/add-ticket-attachment/add-ticket-attachment.mjs
+++ b/components/zoho_desk/actions/add-ticket-attachment/add-ticket-attachment.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Add Ticket Attachment",
   description: "Attaches a file to a ticket. [See the docs here](https://desk.zoho.com/DeskAPIDocument#TicketAttachments#TicketAttachments_CreateTicketattachment)",
   type: "action",
-  version: "0.1.0",
+  version: "0.1.1",
   props: {
     zohoDesk,
     orgId: {
@@ -35,6 +35,12 @@ export default {
       type: "string",
       label: "File Path or URL",
       description: "The file to attach. Provide either a file URL or a path to a file in the `/tmp` directory (for example, `/tmp/myFile.txt`)",
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
     },
   },
   async run({ $ }) {

--- a/components/zoho_desk/package.json
+++ b/components/zoho_desk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/zoho_desk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Zoho_desk Components",
   "main": "zoho_desk.app.mjs",
   "keywords": [

--- a/components/zoho_workdrive/actions/download-file/download-file.mjs
+++ b/components/zoho_workdrive/actions/download-file/download-file.mjs
@@ -7,7 +7,7 @@ export default {
   key: "zoho_workdrive-download-file",
   name: "Download File to Tmp Direcory",
   description: "Download a file to the /tmp directory. [See the documentation](https://workdrive.zoho.com/apidocs/v1/filesfolders/downloadserverfile)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   props: {
     app,
@@ -64,6 +64,11 @@ export default {
       label: "Filename",
       description: "What to name the new file saved to /tmp directory",
       optional: true,
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "write",
+      sync: true,
     },
   },
   methods: {

--- a/components/zoho_workdrive/actions/upload-file/upload-file.mjs
+++ b/components/zoho_workdrive/actions/upload-file/upload-file.mjs
@@ -5,7 +5,7 @@ import app from "../../zoho_workdrive.app.mjs";
 export default {
   key: "zoho_workdrive-upload-file",
   name: "Upload File",
-  version: "0.0.5",
+  version: "0.0.6",
   description: "Upload a new file to your WorkDrive account. [See the documentation](https://workdrive.zoho.com/apidocs/v1/chunkupload/chunkuploadcreatesession)",
   type: "action",
   props: {
@@ -50,6 +50,12 @@ export default {
       type: "string",
       label: "File Path or URL",
       description: "Provide either a file URL or a path to a file in the /tmp directory (for example, /tmp/myFile.pdf).",
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
     },
   },
   async run({ $ }) {

--- a/components/zoho_workdrive/package.json
+++ b/components/zoho_workdrive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/zoho_workdrive",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Pipedream Zoho WorkDrive Components",
   "main": "zoho_workdrive.app.mjs",
   "keywords": [


### PR DESCRIPTION
Adds dir props to relevant components for apps starting with 'R' to 'Z'.

## WHY

The 'dir' prop indicates that a stash ID should be passed when running these actions via the Connect API. This allows files written to the ephemeral /tmp directory in one action to be read by another, separately executed action since both can sync /tmp with the same File Stash directory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new optional `syncDir` property to numerous actions, allowing users to specify a directory for file synchronization with configurable read or write access.
  * Updated several actions to use the `syncDir` property for improved file handling and synchronization.
  * Some actions now return file path information after file operations.

* **Chores**
  * Incremented version numbers across multiple components and actions for consistency and tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->