### PR TITLE
Add to Calendar - fix subscriptionCalUrl prop

### DIFF
--- a/components/add_to_calendar_pro/actions/update-event-group/update-event-group.mjs
+++ b/components/add_to_calendar_pro/actions/update-event-group/update-event-group.mjs
@@ -4,7 +4,7 @@ export default {
   key: "add_to_calendar_pro-update-event-group",
   name: "Update Event Group",
   description: "Update an event group. [See the documentation](https://docs.add-to-calendar-pro.com/api/groups#update-a-group)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     addToCalendarPro,
@@ -27,10 +27,10 @@ export default {
         "internalNote",
       ],
     },
-    subscriptionCallUrl: {
+    subscriptionCalUrl: {
       propDefinition: [
         addToCalendarPro,
-        "subscriptionCallUrl",
+        "subscriptionCalUrl",
       ],
       description: "URL to an external calendar. Needs to start with \"http\"! Usually ends with \".ics\". Note: You can only change the subscription setting as long as there are no events linked to the group",
     },
@@ -61,10 +61,10 @@ export default {
       data: {
         name: this.eventGroupName,
         internal_note: this.internalNote,
-        subscription: this.subscriptionCallUrl
+        subscription: this.subscriptionCalUrl
           ? "external"
           : "no",
-        subscription_call_url: this.subscriptionCallUrl,
+        subscription_cal_url: this.subscriptionCalUrl,
         cta: this.cta,
         layout: this.styleId,
         landingpage: this.landingPageTemplateId,

--- a/components/add_to_calendar_pro/package.json
+++ b/components/add_to_calendar_pro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/add_to_calendar_pro",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Add to Calendar PRO Components",
   "main": "add_to_calendar_pro.app.mjs",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29624,22 +29624,22 @@ packages:
   superagent@3.8.1:
     resolution: {integrity: sha512-VMBFLYgFuRdfeNQSMLbxGSLfmXL/xc+OO+BZp41Za/NRDBet/BNbkRJrYzCUu0u4GU0i/ml2dtT8b9qgkw9z6Q==}
     engines: {node: '>= 4.0'}
-    deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
+    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
 
   superagent@4.1.0:
     resolution: {integrity: sha512-FT3QLMasz0YyCd4uIi5HNe+3t/onxMyEho7C3PSqmti3Twgy2rXT4fmkTz6wRL6bTF4uzPcfkUCa8u4JWHw8Ag==}
     engines: {node: '>= 6.0'}
-    deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
+    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
 
   superagent@5.3.1:
     resolution: {integrity: sha512-wjJ/MoTid2/RuGCOFtlacyGNxN9QLMgcpYLDQlWFIhhdJ93kNscFonGvrpAHSCVjRVj++DGCglocF7Aej1KHvQ==}
     engines: {node: '>= 7.0.0'}
-    deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
+    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
 
   superagent@7.1.6:
     resolution: {integrity: sha512-gZkVCQR1gy/oUXr+kxJMLDjla434KmSOKbx5iGD30Ql+AkJQ/YlPKECJy2nhqOsHLjGHzoDTXNSjhnvWhzKk7g==}
     engines: {node: '>=6.4.0 <13 || >=14'}
-    deprecated: Please downgrade to v7.1.5 if you need IE/ActiveXObject support OR upgrade to v8.0.0 as we no longer support IE and published an incorrect patch version (see https://github.com/visionmedia/superagent/issues/1731)
+    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
 
   supports-color@2.0.0:
     resolution: {integrity: sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==}


### PR DESCRIPTION
Fixes `subscriptionCalUrl` prop in `update-event-group`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the version of the Add to Calendar Pro integration.
  * Renamed a property related to external calendar URLs for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->