### PR TITLE
Fix Linear get-teams action missing limit prop

### DIFF
--- a/components/linear/actions/get-teams/get-teams.mjs
+++ b/components/linear/actions/get-teams/get-teams.mjs
@@ -1,5 +1,5 @@
-import linearApp from "../../linear.app.mjs";
 import getTeams from "@pipedream/linear_app/actions/get-teams/get-teams.mjs";
+import utils from "../../common/utils.mjs";
 
 /* eslint-disable pipedream/required-properties-type */
 /* eslint-disable pipedream/required-properties-name */
@@ -7,11 +7,9 @@ import getTeams from "@pipedream/linear_app/actions/get-teams/get-teams.mjs";
 
 export default {
   ...getTeams,
+  ...utils.getAppProps(getTeams),
   key: "linear-get-teams",
   description: "Retrieves all teams in your Linear workspace. Returns array of team objects with details like ID, name, and key. Supports pagination with configurable limit. Uses OAuth authentication. See Linear docs for additional info [here](https://developers.linear.app/docs/graphql/working-with-the-graphql-api).",
-  version: "0.2.10",
-  props: {
-    linearApp,
-  },
+  version: "0.2.11",
 };
 

--- a/components/linear/package.json
+++ b/components/linear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/linear",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Pipedream Linear Components",
   "main": "linear.app.mjs",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5891,8 +5891,7 @@ importers:
 
   components/greenhouse_job_board_api: {}
 
-  components/greenspark:
-    specifiers: {}
+  components/greenspark: {}
 
   components/greptile:
     dependencies:


### PR DESCRIPTION
## Summary
- Fixed the get-teams action in the Linear component to properly inherit props from the parent linear_app component
- Added `utils.getAppProps()` to ensure all props (including `limit`) are correctly imported
- Bumped versions: get-teams action to 0.2.11 and linear package to 0.7.3

## Test plan
- [ ] Publish the linear get-teams action
- [ ] Verify that the `limit` prop appears in the action configuration
- [ ] Test that the limit prop works correctly when set

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies and version numbers for improved consistency and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->