### PR TITLE
Google Docs - add support for tabs content to get-document

### DIFF
--- a/components/google_docs/actions/append-image/append-image.mjs
+++ b/components/google_docs/actions/append-image/append-image.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-append-image",
   name: "Append Image to Document",
   description: "Appends an image to the end of a document. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#InsertInlineImageRequest)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   props: {
     googleDocs,

--- a/components/google_docs/actions/append-text/append-text.mjs
+++ b/components/google_docs/actions/append-text/append-text.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-append-text",
   name: "Append Text",
   description: "Append text to an existing document. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#InsertTextRequest)",
-  version: "0.1.5",
+  version: "0.1.6",
   type: "action",
   props: {
     googleDocs,

--- a/components/google_docs/actions/create-document-from-template/create-document-from-template.mjs
+++ b/components/google_docs/actions/create-document-from-template/create-document-from-template.mjs
@@ -13,7 +13,7 @@ export default {
   ...others,
   key: "google_docs-create-document-from-template",
   name: "Create New Document From Template",
-  version: "0.0.1",
+  version: "0.0.2",
   description,
   type,
   props: {

--- a/components/google_docs/actions/create-document/create-document.mjs
+++ b/components/google_docs/actions/create-document/create-document.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-create-document",
   name: "Create a New Document",
   description: "Create a new document. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/create)",
-  version: "0.1.5",
+  version: "0.1.6",
   type: "action",
   props: {
     googleDocs,

--- a/components/google_docs/actions/find-document/find-document.mjs
+++ b/components/google_docs/actions/find-document/find-document.mjs
@@ -14,7 +14,7 @@ export default {
   ...others,
   key: "google_docs-find-document",
   name: "Find Document",
-  version: "0.0.1",
+  version: "0.0.2",
   description,
   type,
   props: {

--- a/components/google_docs/actions/get-document/get-document.mjs
+++ b/components/google_docs/actions/get-document/get-document.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-get-document",
   name: "Get Document",
   description: "Get the contents of the latest version of a document. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/get)",
-  version: "0.1.4",
+  version: "0.1.5",
   type: "action",
   props: {
     googleDocs,
@@ -14,9 +14,15 @@ export default {
         "docId",
       ],
     },
+    includeTabsContent: {
+      type: "boolean",
+      label: "Include Tabs Content",
+      description: "Whether to populate the `Document.tabs` field instead of the text content fields like `body` and `documentStyle` on `Document`",
+      default: false,
+    },
   },
   async run({ $ }) {
-    const response = await this.googleDocs.getDocument(this.docId);
+    const response = await this.googleDocs.getDocument(this.docId, this.includeTabsContent);
 
     $.export("$summary", `Successfully retrieved document with ID: ${this.docId}`);
 

--- a/components/google_docs/actions/get-document/get-document.mjs
+++ b/components/google_docs/actions/get-document/get-document.mjs
@@ -18,6 +18,7 @@ export default {
       type: "boolean",
       label: "Include Tabs Content",
       description: "Whether to populate the `Document.tabs` field instead of the text content fields like `body` and `documentStyle` on `Document`",
+      optional: true,
       default: false,
     },
   },

--- a/components/google_docs/actions/replace-image/replace-image.mjs
+++ b/components/google_docs/actions/replace-image/replace-image.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-replace-image",
   name: "Replace Image",
   description: "Replace image in a existing document. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#ReplaceImageRequest)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   props: {
     googleDocs,

--- a/components/google_docs/actions/replace-text/replace-text.mjs
+++ b/components/google_docs/actions/replace-text/replace-text.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-replace-text",
   name: "Replace Text",
   description: "Replace all instances of matched text in an existing document. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#ReplaceAllTextRequest)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   props: {
     googleDocs,

--- a/components/google_docs/google_docs.app.mjs
+++ b/components/google_docs/google_docs.app.mjs
@@ -102,11 +102,14 @@ export default {
         },
       });
     },
-    async getDocument(documentId) {
+    async getDocument(documentId, includeTabsContent = false) {
       const { data } = await this.docs().documents.get({
         documentId,
+        includeTabsContent,
       });
-      const doc = utils.addTextContentToDocument(data);
+      const doc = includeTabsContent
+        ? data
+        : utils.addTextContentToDocument(data);
       return doc;
     },
     async createEmptyDoc(title) {

--- a/components/google_docs/package.json
+++ b/components/google_docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_docs",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Pipedream Google_docs Components",
   "main": "google_docs.app.mjs",
   "keywords": [

--- a/components/google_docs/sources/new-document-created/new-document-created.mjs
+++ b/components/google_docs/sources/new-document-created/new-document-created.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_docs-new-document-created",
   name: "New Document Created (Instant)",
   description: "Emit new event when a new document is created in Google Docs. [See the documentation](https://developers.google.com/drive/api/reference/rest/v3/changes/watch)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/google_docs/sources/new-or-updated-document/new-or-updated-document.mjs
+++ b/components/google_docs/sources/new-or-updated-document/new-or-updated-document.mjs
@@ -9,7 +9,7 @@ export default {
   key: "google_docs-new-or-updated-document",
   name: "New or Updated Document (Instant)",
   description: "Emit new event when a document is created or updated in Google Docs. [See the documentation](https://developers.google.com/drive/api/reference/rest/v3/changes/watch)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15832,14 +15832,6 @@ importers:
         specifier: ^6.0.0
         version: 6.2.0
 
-  modelcontextprotocol/node_modules2/@modelcontextprotocol/sdk/dist/cjs: {}
-
-  modelcontextprotocol/node_modules2/@modelcontextprotocol/sdk/dist/esm: {}
-
-  modelcontextprotocol/node_modules2/zod-to-json-schema/dist/cjs: {}
-
-  modelcontextprotocol/node_modules2/zod-to-json-schema/dist/esm: {}
-
   packages/ai:
     dependencies:
       '@pipedream/sdk':


### PR DESCRIPTION
Adds the `includeTabsContent` prop to allow retrieving tabs content.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to retrieve raw tab content when getting a Google Doc, allowing more flexible document data access.

* **Chores**
  * Updated version numbers for multiple Google Docs actions and sources to reflect the latest changes.
  * Incremented the package version for the Google Docs integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->