### PR TITLE
[TRIGGER] New SMS in Aircall

### DIFF
--- a/components/aircall/package.json
+++ b/components/aircall/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/aircall",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream Aircall Components",
   "main": "aircall.app.mjs",
   "keywords": [

--- a/components/aircall/sources/common/common-webhook.mjs
+++ b/components/aircall/sources/common/common-webhook.mjs
@@ -21,7 +21,7 @@ export default {
           this.getEventType(),
         ],
       });
-      this._setHookId(webhook.id);
+      this._setHookId(webhook.webhook_id);
     },
     async deactivate() {
       const hookId = this._getHookId();

--- a/components/aircall/sources/new-call-ended/new-call-ended.mjs
+++ b/components/aircall/sources/new-call-ended/new-call-ended.mjs
@@ -5,7 +5,7 @@ export default {
   key: "aircall-new-call-ended",
   name: "New Call Ended",
   description: "Emit new event when a call ends",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/aircall/sources/new-note-added/new-note-added.mjs
+++ b/components/aircall/sources/new-note-added/new-note-added.mjs
@@ -5,7 +5,7 @@ export default {
   key: "aircall-new-note-added",
   name: "New Note Added",
   description: "Emit new event when a new note is added to a call",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/aircall/sources/new-number-created/new-number-created.mjs
+++ b/components/aircall/sources/new-number-created/new-number-created.mjs
@@ -5,7 +5,7 @@ export default {
   key: "aircall-new-number-created",
   name: "New Number Created",
   description: "Emit new event when a number is created",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/aircall/sources/new-sms/new-sms.mjs
+++ b/components/aircall/sources/new-sms/new-sms.mjs
@@ -1,0 +1,27 @@
+import common from "../common/common-webhook.mjs";
+
+export default {
+  ...common,
+  key: "aircall-new-sms",
+  name: "New SMS",
+  description: "Emit new event when a new SMS is received.",
+  version: "0.0.1",
+  type: "source",
+  dedupe: "unique",
+  methods: {
+    ...common.methods,
+    async getHistoricalEvents() {
+      return [];
+    },
+    getEventType() {
+      return "message.received";
+    },
+    generateMeta(data) {
+      return {
+        id: data.id,
+        summary: `New SMS received from ${data.raw_digits} to ${data.number.digits}`,
+        ts: data.created_at,
+      };
+    },
+  },
+};

--- a/components/aircall/sources/new-tag-added/new-tag-added.mjs
+++ b/components/aircall/sources/new-tag-added/new-tag-added.mjs
@@ -5,7 +5,7 @@ export default {
   key: "aircall-new-tag-added",
   name: "New Tag Added",
   description: "Emit new event when a tag is added to a call",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9840,8 +9840,7 @@ importers:
 
   components/paypro: {}
 
-  components/payrexx:
-    specifiers: {}
+  components/payrexx: {}
 
   components/paystack:
     dependencies:
@@ -15876,14 +15875,6 @@ importers:
       dotenv:
         specifier: ^6.0.0
         version: 6.2.0
-
-  modelcontextprotocol/node_modules2/@modelcontextprotocol/sdk/dist/cjs: {}
-
-  modelcontextprotocol/node_modules2/@modelcontextprotocol/sdk/dist/esm: {}
-
-  modelcontextprotocol/node_modules2/zod-to-json-schema/dist/cjs: {}
-
-  modelcontextprotocol/node_modules2/zod-to-json-schema/dist/esm: {}
 
   packages/ai:
     dependencies:
@@ -36627,8 +36618,6 @@ snapshots:
       '@putout/operator-filesystem': 5.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))
       '@putout/operator-json': 2.2.0
       putout: 36.13.1(eslint@8.57.1)(typescript@5.6.3)
-    transitivePeerDependencies:
-      - supports-color
 
   '@putout/operator-regexp@1.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))':
     dependencies:


### PR DESCRIPTION
## WHY

Resolves #17285


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new trigger to emit events when a new SMS is received in Aircall.

* **Bug Fixes**
  * Corrected how webhook IDs are stored for Aircall webhook triggers to ensure proper event tracking.

* **Chores**
  * Updated version numbers for several Aircall triggers and the overall package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->