### PR TITLE
Google Docs - add tabIds prop to get-document

### DIFF
--- a/components/google_docs/actions/get-document/get-document.mjs
+++ b/components/google_docs/actions/get-document/get-document.mjs
@@ -1,10 +1,11 @@
 import googleDocs from "../../google_docs.app.mjs";
+import { ConfigurationError } from "@pipedream/platform";
 
 export default {
   key: "google_docs-get-document",
   name: "Get Document",
   description: "Get the contents of the latest version of a document. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/get)",
-  version: "0.1.5",
+  version: "0.1.6",
   type: "action",
   props: {
     googleDocs,
@@ -21,9 +22,31 @@ export default {
       optional: true,
       default: false,
     },
+    tabIds: {
+      type: "string[]",
+      label: "Tab IDs",
+      description: "Only return content for the specified tabs",
+      optional: true,
+      async options() {
+        const { tabs } = await this.googleDocs.getDocument(this.docId, this.includeTabsContent);
+        if (!tabs?.length) return [];
+        return tabs.map((tab) => ({
+          label: tab.tabProperties.title,
+          value: tab.tabProperties.tabId,
+        }));
+      },
+    },
   },
   async run({ $ }) {
+    if (this.tabIds?.length && !this.includeTabsContent) {
+      throw new ConfigurationError("Include Tabs Content must be true if tabIds are provided");
+    }
+
     const response = await this.googleDocs.getDocument(this.docId, this.includeTabsContent);
+
+    if (this.tabIds?.length) {
+      response.tabs = response.tabs.filter((tab) => this.tabIds.includes(tab.tabProperties.tabId));
+    }
 
     $.export("$summary", `Successfully retrieved document with ID: ${this.docId}`);
 

--- a/components/google_docs/package.json
+++ b/components/google_docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_docs",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Pipedream Google_docs Components",
   "main": "google_docs.app.mjs",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14568,8 +14568,7 @@ importers:
         specifier: ^1.2.5
         version: 1.2.7
 
-  components/viewdns_info:
-    specifiers: {}
+  components/viewdns_info: {}
 
   components/vimeo:
     dependencies:
@@ -37177,6 +37176,8 @@ snapshots:
       '@putout/operator-filesystem': 5.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))
       '@putout/operator-json': 2.2.0
       putout: 36.13.1(eslint@8.57.1)(typescript@5.6.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@putout/operator-regexp@1.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))':
     dependencies:


### PR DESCRIPTION
Adds a `tabIds` prop to support returning only the content of the specified tabs.
[Requested by user](https://github.com/PipedreamHQ/pipedream/issues/17374#issuecomment-3051379063)