### PR TITLE
Gorgias internal notes

### DIFF
--- a/components/freshdesk/actions/update-ticket/update-ticket.mjs
+++ b/components/freshdesk/actions/update-ticket/update-ticket.mjs
@@ -5,7 +5,7 @@ export default {
   key: "freshdesk-update-ticket",
   name: "Update a Ticket",
   description: "Update status, priority, subject, description, agent, group, etc.  [See the documentation](https://developers.freshdesk.com/api/#update_ticket).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     freshdesk,
@@ -71,6 +71,19 @@ export default {
       description: "Used when creating a contact with phone but no email.",
       optional: true,
     },
+    internalNote: {
+      type: "boolean",
+      label: "Internal note (private)",
+      description: "If enabled, the comment will be added as an internal note (not visible to requester).",
+      optional: true,
+      default: false,
+    },
+    noteBody: {
+      type: "string",
+      label: "Note Body",
+      description: "The content of the internal note to add.",
+      optional: true,
+    },
     type: {
       type: "string",
       label: "Type",
@@ -95,6 +108,8 @@ export default {
     const {
       freshdesk,
       ticketId,
+      internalNote,
+      noteBody,
       ...fields
     } = this;
 
@@ -102,21 +117,35 @@ export default {
 
     const ticketName = await freshdesk.getTicketName(ticketId);
 
+    if (internalNote && noteBody) {
+      const response = await freshdesk._makeRequest({
+        $,
+        method: "POST",
+        url: `/tickets/${ticketId}/notes`,
+        data: {
+          body: noteBody,
+          private: true,
+        },
+      });
+  
+      $.export("$summary", `Internal note added to ticket "${ticketName}" (ID: ${ticketId})`);
+      return response;
+    }
+    
     if (!Object.keys(data).length) {
       throw new Error("Please provide at least one field to update.");
     }
-
+  
     if (data.custom_fields) freshdesk.parseIfJSONString(data.custom_fields);
-
+  
     const response = await freshdesk._makeRequest({
       $,
       method: "PUT",
       url: `/tickets/${ticketId}`,
       data,
     });
-
+  
     $.export("$summary", `Ticket "${ticketName}" (ID: ${this.ticketId}) updated successfully`);
     return response;
   },
-};
-
+}

--- a/components/gorgias_oauth/package.json
+++ b/components/gorgias_oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/gorgias_oauth",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Pipedream Gorgias OAuth Components",
   "main": "gorgias_oauth.app.mjs",
   "keywords": [

--- a/components/gorgias_oauth/sources/internal-note-created/internal-note-created.mjs
+++ b/components/gorgias_oauth/sources/internal-note-created/internal-note-created.mjs
@@ -1,0 +1,51 @@
+import constants from "../../common/constants.mjs";
+import base from "../common/base.mjs";
+import eventTypes from "../common/event-types.mjs";
+import sampleEmit from "./test-event.mjs";
+
+export default {
+  ...base,
+  key: "gorgias_oauth-internal-note-created",
+  name: "New Internal Note",
+  description: "Emit new event when an internal note is created on a ticket. [See the documentation](https://developers.gorgias.com/reference/the-event-object)",
+  version: "0.0.1",
+  type: "source",
+  props: {
+    ...base.props,
+    ticketId: {
+      propDefinition: [
+        base.props.gorgias_oauth,
+        "ticketId",
+      ],
+      optional: true,
+    },
+    sender: {
+      type: "string",
+      label: "Sender Email",
+      description: "Email address of the sender",
+      optional: true,
+    },
+  },
+  hooks: {
+    ...base.hooks,
+    deploy() {},
+  },
+  methods: {
+    ...base.methods,
+    getEventType() {
+      return eventTypes.TICKET_MESSAGE_CREATED;
+    },
+    isRelevant(message) {
+      return message.channel === "internal-note"
+        && (!this.ticketId || message.ticket_id === this.ticketId)
+        && (!this.sender || message.sender.email === this.sender);
+    },
+    async processEvent(event) {
+      const { message } = event;
+      if (this.isRelevant(message)) {
+        this.emitEvent(message);
+      }
+    },
+  },
+  sampleEmit,
+};

--- a/components/gorgias_oauth/sources/internal-note-created/test-event.mjs
+++ b/components/gorgias_oauth/sources/internal-note-created/test-event.mjs
@@ -1,0 +1,43 @@
+export default {
+  id: 123456789,
+  created_datetime: "2024-01-15T10:30:00Z",
+  updated_datetime: "2024-01-15T10:30:00Z",
+  ticket_id: 98765,
+  channel: "internal-note",
+  via: "internal-note",
+  source: {
+    type: "internal-note",
+    from: {
+      address: "agent@company.com",
+      name: "Support Agent"
+    },
+    to: []
+  },
+  sender: {
+    id: 456,
+    email: "agent@company.com",
+    name: "Support Agent"
+  },
+  receiver: null,
+  body_html: "<p>This is an internal note about the customer's issue.</p>",
+  body_text: "This is an internal note about the customer's issue.",
+  subject: "Internal Note",
+  from_agent: true,
+  sent_datetime: "2024-01-15T10:30:00Z",
+  attachments: [],
+  public: false,
+  stripped_html: "<p>This is an internal note about the customer's issue.</p>",
+  stripped_text: "This is an internal note about the customer's issue.",
+  stripped_signature: "",
+  message_id: "internal-note-123456789",
+  actions: [],
+  rule_id: null,
+  external_id: null,
+  tags: [],
+  integration_id: null,
+  last_sending_error: null,
+  opened_datetime: null,
+  clicked_datetime: null,
+  failed_datetime: null,
+  errors: []
+};


### PR DESCRIPTION
## WHY

 1. Enhanced create-ticket-message action (create-ticket-message.mjs):
    - Added channel prop with support for "internal-note"
    - Hide from/to fields when internal notes are selected (since they don't need recipients)
    - Modified validation to skip sender/receiver checks for internal notes
    - Updated message creation logic to handle internal notes properly
  2. New internal-note-created webhook source:
    - Created dedicated webhook source for internal note events
    - Filters specifically for channel === "internal-note"
    - Includes test event sample
  3. Updated package version to 0.5.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to create and add internal notes to Freshdesk tickets.
  * Introduced a new "New Internal Note" event source for Gorgias, allowing detection of internal note creation on tickets.
  * Added support for sending internal notes or ticket messages in Gorgias, with a new channel selection option.

* **Bug Fixes**
  * Improved visibility logic for user and customer fields when creating Gorgias ticket messages, ensuring proper hiding for internal notes.

* **Chores**
  * Updated version numbers for Freshdesk and Gorgias integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->