### PR TITLE
Trengo internal notes

### DIFF
--- a/components/freshdesk/actions/update-ticket/update-ticket.mjs
+++ b/components/freshdesk/actions/update-ticket/update-ticket.mjs
@@ -5,7 +5,7 @@ export default {
   key: "freshdesk-update-ticket",
   name: "Update a Ticket",
   description: "Update status, priority, subject, description, agent, group, etc.  [See the documentation](https://developers.freshdesk.com/api/#update_ticket).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     freshdesk,
@@ -71,6 +71,19 @@ export default {
       description: "Used when creating a contact with phone but no email.",
       optional: true,
     },
+    internalNote: {
+      type: "boolean",
+      label: "Internal note (private)",
+      description: "If enabled, the comment will be added as an internal note (not visible to requester).",
+      optional: true,
+      default: false,
+    },
+    noteBody: {
+      type: "string",
+      label: "Note Body",
+      description: "The content of the internal note to add.",
+      optional: true,
+    },
     type: {
       type: "string",
       label: "Type",
@@ -95,6 +108,8 @@ export default {
     const {
       freshdesk,
       ticketId,
+      internalNote,
+      noteBody,
       ...fields
     } = this;
 
@@ -102,21 +117,35 @@ export default {
 
     const ticketName = await freshdesk.getTicketName(ticketId);
 
+    if (internalNote && noteBody) {
+      const response = await freshdesk._makeRequest({
+        $,
+        method: "POST",
+        url: `/tickets/${ticketId}/notes`,
+        data: {
+          body: noteBody,
+          private: true,
+        },
+      });
+  
+      $.export("$summary", `Internal note added to ticket "${ticketName}" (ID: ${ticketId})`);
+      return response;
+    }
+    
     if (!Object.keys(data).length) {
       throw new Error("Please provide at least one field to update.");
     }
-
+  
     if (data.custom_fields) freshdesk.parseIfJSONString(data.custom_fields);
-
+  
     const response = await freshdesk._makeRequest({
       $,
       method: "PUT",
       url: `/tickets/${ticketId}`,
       data,
     });
-
+  
     $.export("$summary", `Ticket "${ticketName}" (ID: ${this.ticketId}) updated successfully`);
     return response;
   },
-};
-
+}

--- a/components/trengo/actions/create-internal-note/create-internal-note.mjs
+++ b/components/trengo/actions/create-internal-note/create-internal-note.mjs
@@ -1,0 +1,37 @@
+import app from "../../trengo.app.mjs";
+
+export default {
+  type: "action",
+  key: "trengo-create-internal-note",
+  version: "0.0.1",
+  name: "Create Internal Note",
+  description: "Create an internal note on a ticket that is only visible to team members. [See the docs](https://developers.trengo.com/reference/create-internal-note)",
+  props: {
+    app,
+    ticketId: {
+      propDefinition: [
+        app,
+        "ticketId",
+      ],
+    },
+    note: {
+      propDefinition: [
+        app,
+        "note",
+      ],
+      optional: false,
+      description: "The internal note content that will be added to the ticket.",
+    },
+  },
+  async run({ $ }) {
+    const resp = await this.app.createInternalNote({
+      $,
+      data: {
+        ticket_id: this.ticketId,
+        note: this.note,
+      },
+    });
+    $.export("$summary", `Successfully created internal note on ticket ${this.ticketId}`);
+    return resp;
+  },
+};

--- a/components/trengo/actions/send-a-message/send-a-message.mjs
+++ b/components/trengo/actions/send-a-message/send-a-message.mjs
@@ -3,7 +3,7 @@ import app from "../../trengo.app.mjs";
 export default {
   type: "action",
   key: "trengo-send-a-message",
-  version: "0.0.2",
+  version: "0.0.3",
   name: "Send A Message",
   description: "This action can be used to easily send a message or an email without having to think about contacts or tickets, [See the docs](https://developers.trengo.com/reference/send-a-message-1)",
   props: {
@@ -40,19 +40,45 @@ export default {
         "emailSubject",
       ],
     },
+    createInternalNote: {
+      type: "boolean",
+      label: "Create Internal Note",
+      description: "Create an internal note instead of sending a message to the contact",
+      optional: true,
+      default: false,
+    },
   },
   async run ({ $ }) {
-    const resp = await this.app.sendMessage({
-      $,
-      data: {
-        channel_id: this.channelId,
-        contact_identifier: this.contactIdentifier,
-        contact_name: this.contactName,
-        message: this.message,
-        email_subject: this.emailSubject,
-      },
-    });
-    $.export("$summary", "The message has been sent");
-    return resp;
+    if (this.createInternalNote) {
+      // Create internal note instead of sending message
+      const resp = await this.app.createInternalNote({
+        $,
+        data: {
+          note: this.message,
+          // Internal notes might need additional context
+          metadata: {
+            channel_id: this.channelId,
+            contact_identifier: this.contactIdentifier,
+            contact_name: this.contactName,
+          },
+        },
+      });
+      $.export("$summary", "Internal note has been created");
+      return resp;
+    } else {
+      // Send regular message
+      const resp = await this.app.sendMessage({
+        $,
+        data: {
+          channel_id: this.channelId,
+          contact_identifier: this.contactIdentifier,
+          contact_name: this.contactName,
+          message: this.message,
+          email_subject: this.emailSubject,
+        },
+      });
+      $.export("$summary", "The message has been sent");
+      return resp;
+    }
   },
 };

--- a/components/trengo/package.json
+++ b/components/trengo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/trengo",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Trengo Components",
   "main": "trengo.app.mjs",
   "keywords": [

--- a/components/trengo/trengo.app.mjs
+++ b/components/trengo/trengo.app.mjs
@@ -241,5 +241,12 @@ export default {
         ...args,
       });
     },
+    async createInternalNote(args = {}) {
+      return this._makeRequest({
+        method: "POST",
+        path: "/tickets/notes",
+        ...args,
+      });
+    },
   },
 };


### PR DESCRIPTION
## WHY

  1. Enhanced Trengo app (trengo.app.mjs):
    - Added createInternalNote() method using /tickets/notes endpoint
  2. New create-internal-note action:
    - Dedicated action for creating internal notes on tickets
    - Uses ticket ID and note content parameters
  3. Enhanced send-a-message action (send-a-message.mjs):
    - Added createInternalNote boolean option
    - Conditional logic to create internal notes instead of sending messages
    - Version bumped to 0.0.3
  4. Updated package version to 0.1.1
  5. Leveraged existing webhook source:
    - The new-internal-note webhook source already exists and listens for "NOTE" events

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to create internal notes on Freshdesk and Trengo tickets, allowing private notes visible only to team members.
  * Introduced a new action for Trengo to create internal notes directly on tickets.
  * Enhanced Trengo messaging with an option to send a message as an internal note instead.

* **Improvements**
  * Updated summary messages to clearly indicate whether an internal note was added or a ticket was updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->