### PR TITLE
Fix issues with authentication for apps with no auth type

### DIFF
--- a/packages/connect-react/CHANGELOG.md
+++ b/packages/connect-react/CHANGELOG.md
@@ -2,28 +2,39 @@
 
 # Changelog
 
-# [1.3.1] - 2025-06-30
+## [1.3.2] - 2025-07-15
 
-## Changed
+### Changed
+
+- Do not perform prop validation for `app` props with nil auth type. This will
+  allow components to be deployed/executed without users having to authenticate
+  to the app (which would fail given that the app doesn't have a way to
+  authenticate anyways).
+- Use the `getComponents` method from the SDK instead of the deprecated
+  `components` method.
+
+## [1.3.1] - 2025-06-30
+
+### Changed
 
 - Fixed handling of the 'dir' prop type to exclude it from configurable props
 
-# [1.3.0] - 2025-06-10
+## [1.3.0] - 2025-06-10
 
-## Added
+### Added
 
 - Support for `externalUserId` param across all components as the preferred way to identify users
 - Backward compatibility with existing `userId` parameter
 
-## Changed
+### Changed
 
 - All internal SDK calls now use `externalUserId` parameter for consistency with backend SDK
 
-## Deprecated
+### Deprecated
 
 - `userId` parameter in favor of `externalUserId` (existing code continues to work with console warnings)
 
-## Migration
+### Migration
 
 Replace `userId` with `externalUserId` in component props:
 
@@ -35,137 +46,137 @@ Replace `userId` with `externalUserId` in component props:
 <ComponentFormContainer externalUserId={userId} />
 ```
 
-# [1.2.1] - 2025-06-07
+## [1.2.1] - 2025-06-07
 
 - Fixing the SelectApp component to properly handle controlled values when not found in search results
 - Fixing infinite re-render issue in ComponentFormContainer by memoizing configurableProps
 
-# [1.2.0] - 2025-06-05
+## [1.2.0] - 2025-06-05
 
 - Adding basic support for 'sql' prop types
 
-# [1.1.0] - 2025-06-04
+## [1.1.0] - 2025-06-04
 
 - Adding support for 'object' prop types
 - Modifying string and string[] inputs to hide the dropdown in the case of no options
 - Added basic styling to hyperlinks in prop descriptions
 
-# [1.0.2] - 2025-04-24
+## [1.0.2] - 2025-04-24
 
 - Updating README to remove note about this package being in early preview
 
-# [1.0.1] - 2025-04-16
+## [1.0.1] - 2025-04-16
 
 - remove bad polyfill (would break checking `document`)
 - handle bad `decode-named-character-reference` browser import via vite resolve.alias
 - stop accidentally bundling `lodash` (-80KB for es build)
 
-# [1.0.0-preview.30] - 2025-02-19
+## [1.0.0-preview.30] - 2025-02-19
 
 - SelectApp and SelectComponent Improvements
 
-# [1.0.0-preview.29] - 2025-02-10
+## [1.0.0-preview.29] - 2025-02-10
 
 - Fix enableDebugging state update bug
 
-# [1.0.0-preview.28] - 2025-02-05
+## [1.0.0-preview.28] - 2025-02-05
 
 - Surface SDK errors in the form
 
-# [1.0.0-preview.27] - 2025-01-30
+## [1.0.0-preview.27] - 2025-01-30
 
 - Add styling to alerts
 
-# [1.0.0-preview.26] - 2025-01-29
+## [1.0.0-preview.26] - 2025-01-29
 
 - No change
 
-# [1.0.0-preview.25] - 2025-01-28
+## [1.0.0-preview.25] - 2025-01-28
 
 - Show prop labels instead of values after selecting dynamic props
 - Fix the bug where a remote option would not be reloaded when the form component is re-rendered
 
-# [1.0.0-preview.24] - 2025-01-24
+## [1.0.0-preview.24] - 2025-01-24
 
 - Fix the bug where inputting multiple strings into an array prop would merge the strings into one
 - Fix custom string input for remote options
 - Fix the reloading of a previously selected remote option when re-rendering the form component
 
-# [1.0.0-preview.23] - 2025-01-22
+## [1.0.0-preview.23] - 2025-01-22
 
 - Show the prop label instead of the value after selecting from a dropdown for string array props
 
-# [1.0.0-preview.22] - 2025-01-21
+## [1.0.0-preview.22] - 2025-01-21
 
 - Allow custom string input for remote options
 
-# [1.0.0-preview.21] - 2025-01-17
+## [1.0.0-preview.21] - 2025-01-17
 
 - Fix a bug in async prop value validation when the prop is a string
 
-# [1.0.0-preview.20] - 2025-01-16
+## [1.0.0-preview.20] - 2025-01-16
 
 - Check if a string prop is set instead of inspecting the contents of the string
 
-# [1.0.0-preview.15] - 2024-12-18
+## [1.0.0-preview.15] - 2024-12-18
 
 - Emit dynamic props via `onUpdateDynamicProps`
 
-# [1.0.0-preview.14] - 2024-12-17
+## [1.0.0-preview.14] - 2024-12-17
 
 - Fixed one case of "maximum update depth exceeded" (useEffect component dependency)
 
-# [1.0.0-preview.13] - 2024-12-17
+## [1.0.0-preview.13] - 2024-12-17
 
 - Added skippable prop types to support triggers
 
-# [1.0.0-preview.12] - 2024-12-13
+## [1.0.0-preview.12] - 2024-12-13
 
 - Don't throw when validating unexpected values from the api
 
-# [1.0.0-preview.11] - 2024-12-13
+## [1.0.0-preview.11] - 2024-12-13
 
 - Make prop validation more consistent with app behavior
 - Relax validation of string props when value is not a string
 
-# [1.0.0-preview.10] - 2024-12-12
+## [1.0.0-preview.10] - 2024-12-12
 
 - Enforce string length limits
 
-# [1.0.0-preview.9] - 2024-12-10
+## [1.0.0-preview.9] - 2024-12-10
 
 - Disabled submit button when form is incomplete
 
-# [1.0.0-preview.8] - 2024-12-09
+## [1.0.0-preview.8] - 2024-12-09
 
 - Fix dynamic props in the Connect demo app
 
-# [1.0.0-preview.7] - 2024-12-05
+## [1.0.0-preview.7] - 2024-12-05
 
 - Use proper casing for `stringOptions` now that configure prop is properly async
 
-# [1.0.0-preview.6] - 2024-12-05
+## [1.0.0-preview.6] - 2024-12-05
 
 - Handle configurable prop `withLabel` (eg. fixes config of Airtable `tableId`)
 
-# [1.0.0-preview.5] - 2024-12-02
+## [1.0.0-preview.5] - 2024-12-02
 
 - Change colors of "Connect App" button
 
-# [1.0.0-preview.4] - 2024-11-27
+## [1.0.0-preview.4] - 2024-11-27
 
 - Fix accidental use of useSuspenseQuery
 - Fix setState during render due to userId useEffect
 
-# [1.0.0-preview.3] - 2024-11-27
+## [1.0.0-preview.3] - 2024-11-27
 
 - Previous version broken, lack of build before publish (not sure how preview.1 shipped)
 
-# [1.0.0-preview.2] - 2024-11-27
+## [1.0.0-preview.2] - 2024-11-27
 
 - Externalize @emotion/react
 - Minor type improvements
 
-# [1.0.0-preview.1] - 2024-11-22
+## [1.0.0-preview.1] - 2024-11-22
 
 Initial release

--- a/packages/connect-react/package.json
+++ b/packages/connect-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/connect-react",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Pipedream Connect library for React",
   "files": [
     "dist"

--- a/packages/connect-react/src/hooks/use-components.tsx
+++ b/packages/connect-react/src/hooks/use-components.tsx
@@ -1,18 +1,18 @@
 import { useQuery } from "@tanstack/react-query";
-import type { GetComponentOpts } from "@pipedream/sdk";
+import type { GetComponentsOpts } from "@pipedream/sdk";
 import { useFrontendClient } from "./frontend-client-context";
 
 /**
  * Get list of components
  */
-export const useComponents = (input?: GetComponentOpts) => {
+export const useComponents = (input?: GetComponentsOpts) => {
   const client = useFrontendClient();
   const query = useQuery({
     queryKey: [
       "components",
       input,
     ],
-    queryFn: () => client.components(input),
+    queryFn: () => client.getComponents(input),
   });
 
   return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1872,8 +1872,7 @@ importers:
         specifier: ^3.0.0
         version: 3.0.3
 
-  components/bright_data:
-    specifiers: {}
+  components/bright_data: {}
 
   components/brilliant_directories:
     dependencies:
@@ -2646,14 +2645,11 @@ importers:
         specifier: ^1.0.1
         version: 1.0.1
 
-  components/clio_australia:
-    specifiers: {}
+  components/clio_australia: {}
 
-  components/clio_canada:
-    specifiers: {}
+  components/clio_canada: {}
 
-  components/clio_eu:
-    specifiers: {}
+  components/clio_eu: {}
 
   components/clockify:
     dependencies:
@@ -11470,8 +11466,7 @@ importers:
         specifier: ^1.5.1
         version: 1.6.6
 
-  components/rhombus:
-    specifiers: {}
+  components/rhombus: {}
 
   components/richpanel:
     dependencies:
@@ -29900,22 +29895,22 @@ packages:
   superagent@3.8.1:
     resolution: {integrity: sha512-VMBFLYgFuRdfeNQSMLbxGSLfmXL/xc+OO+BZp41Za/NRDBet/BNbkRJrYzCUu0u4GU0i/ml2dtT8b9qgkw9z6Q==}
     engines: {node: '>= 4.0'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
 
   superagent@4.1.0:
     resolution: {integrity: sha512-FT3QLMasz0YyCd4uIi5HNe+3t/onxMyEho7C3PSqmti3Twgy2rXT4fmkTz6wRL6bTF4uzPcfkUCa8u4JWHw8Ag==}
     engines: {node: '>= 6.0'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
 
   superagent@5.3.1:
     resolution: {integrity: sha512-wjJ/MoTid2/RuGCOFtlacyGNxN9QLMgcpYLDQlWFIhhdJ93kNscFonGvrpAHSCVjRVj++DGCglocF7Aej1KHvQ==}
     engines: {node: '>= 7.0.0'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
 
   superagent@7.1.6:
     resolution: {integrity: sha512-gZkVCQR1gy/oUXr+kxJMLDjla434KmSOKbx5iGD30Ql+AkJQ/YlPKECJy2nhqOsHLjGHzoDTXNSjhnvWhzKk7g==}
     engines: {node: '>=6.4.0 <13 || >=14'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please downgrade to v7.1.5 if you need IE/ActiveXObject support OR upgrade to v8.0.0 as we no longer support IE and published an incorrect patch version (see https://github.com/visionmedia/superagent/issues/1731)
 
   supports-color@2.0.0:
     resolution: {integrity: sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==}


### PR DESCRIPTION
# Changelog
* Ignore the prop configuration and validation for apps with no authentication type (i.e. they do not require authentication, nor have a way to do so).
* Replace usage of deprecated `components` method from the SDK with `getComponents`
* Fix linter errors in `CHANGELOG.md`

## WHY

This will allow components to be deployed/executed without users having to
authenticate to the app (which would fail given that the app doesn't have a way
to authenticate anyways).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled prop validation for app props when authentication is not required, allowing components to run without user authentication.
  * Updated internal logic to use the correct method for fetching components, ensuring compatibility with the latest SDK.

* **Documentation**
  * Updated the changelog with a new version entry and standardized formatting for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->