### PR TITLE
[TRIGGER] Add shared drive prop to relevant Onedrive triggers

### DIFF
--- a/components/microsoft_onedrive/actions/create-folder/create-folder.mjs
+++ b/components/microsoft_onedrive/actions/create-folder/create-folder.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Create Folder",
   description: "Create a new folder in a drive. [See the documentation](https://learn.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_post_children?view=odsp-graph-online)",
   key: "microsoft_onedrive-create-folder",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
   props: {
     onedrive,

--- a/components/microsoft_onedrive/actions/create-link/create-link.mjs
+++ b/components/microsoft_onedrive/actions/create-link/create-link.mjs
@@ -3,7 +3,7 @@ import constants from "../../common/constants.mjs";
 
 export default {
   name: "Create Link",
-  version: "0.0.2",
+  version: "0.0.3",
   key: "microsoft_onedrive-create-link",
   type: "action",
   description: "Create a sharing link for a DriveItem. [See the documentation](https://docs.microsoft.com/en-us/graph/api/driveitem-createlink?view=graph-rest-1.0&tabs=http)",

--- a/components/microsoft_onedrive/actions/download-file/download-file.mjs
+++ b/components/microsoft_onedrive/actions/download-file/download-file.mjs
@@ -9,7 +9,7 @@ export default {
   name: "Download File",
   description: "Download a file stored in OneDrive. [See the documentation](https://learn.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_get_content?view=odsp-graph-online)",
   key: "microsoft_onedrive-download-file",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   props: {
     onedrive,

--- a/components/microsoft_onedrive/actions/find-file-by-name/find-file-by-name.mjs
+++ b/components/microsoft_onedrive/actions/find-file-by-name/find-file-by-name.mjs
@@ -5,7 +5,7 @@ export default {
   key: "microsoft_onedrive-find-file-by-name",
   name: "Find File by Name",
   description: "Search for a file or folder by name. [See the documentation](https://learn.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_search)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     onedrive,

--- a/components/microsoft_onedrive/actions/get-excel-table/get-excel-table.mjs
+++ b/components/microsoft_onedrive/actions/get-excel-table/get-excel-table.mjs
@@ -4,7 +4,7 @@ export default {
   name: "Get Table",
   description: "Retrieve a table from an Excel spreadsheet stored in OneDrive [See the documentation](https://learn.microsoft.com/en-us/graph/api/table-range?view=graph-rest-1.0&tabs=http)",
   key: "microsoft_onedrive-get-excel-table",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   props: {
     onedrive,

--- a/components/microsoft_onedrive/actions/get-file-by-id/get-file-by-id.mjs
+++ b/components/microsoft_onedrive/actions/get-file-by-id/get-file-by-id.mjs
@@ -4,7 +4,7 @@ export default {
   key: "microsoft_onedrive-get-file-by-id",
   name: "Get File by ID",
   description: "Retrieves a file by ID. [See the documentation](https://learn.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_get)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     onedrive,

--- a/components/microsoft_onedrive/actions/list-files-in-folder/list-files-in-folder.mjs
+++ b/components/microsoft_onedrive/actions/list-files-in-folder/list-files-in-folder.mjs
@@ -5,7 +5,7 @@ export default {
   key: "microsoft_onedrive-list-files-in-folder",
   name: "List Files in Folder",
   description: "Retrieves a list of the files and/or folders directly within a folder. [See the documentation](https://learn.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_list_children)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     onedrive,

--- a/components/microsoft_onedrive/actions/upload-file/upload-file.mjs
+++ b/components/microsoft_onedrive/actions/upload-file/upload-file.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Upload File",
   description: "Upload a file to OneDrive. [See the documentation](https://learn.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_put_content?view=odsp-graph-online)",
   key: "microsoft_onedrive-upload-file",
-  version: "0.2.1",
+  version: "0.2.2",
   type: "action",
   props: {
     onedrive,

--- a/components/microsoft_onedrive/package.json
+++ b/components/microsoft_onedrive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/microsoft_onedrive",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Pipedream Microsoft OneDrive components",
   "main": "microsoft_onedrive.app.mjs",
   "homepage": "https://pipedream.com/apps/microsoft-onedrive",

--- a/components/microsoft_onedrive/sources/common/base.mjs
+++ b/components/microsoft_onedrive/sources/common/base.mjs
@@ -84,8 +84,10 @@ const methods = {
     return new Date(nowTimestamp + expirationTimestampDelta);
   },
   async _createNewSubscription() {
+    const deltaLinkParams = this.getDeltaLinkParams();
     const hookOpts = {
       expirationDateTime: this._getNextExpirationDateTime(),
+      driveId: deltaLinkParams.driveId,
     };
     const hookId = await this.onedrive.createHook(this.http.endpoint, hookOpts);
     this._setHookId(hookId);

--- a/components/microsoft_onedrive/sources/new-file-created/new-file-created.mjs
+++ b/components/microsoft_onedrive/sources/new-file-created/new-file-created.mjs
@@ -8,14 +8,25 @@ export default {
   key: "microsoft_onedrive-new-file-created",
   name: "New File Created (Instant)",
   description: "Emit new event when a new file is created in a OneDrive drive",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
   props: {
     ...base.props,
+    drive: {
+      propDefinition: [
+        onedrive,
+        "drive",
+      ],
+      description: "The drive to monitor for new files. If not specified, the personal OneDrive will be monitored.",
+      optional: true,
+    },
     folder: {
       propDefinition: [
         onedrive,
         "folder",
+        ({ drive }) => ({
+          driveId: drive,
+        }),
       ],
       description: "The OneDrive folder to watch for new files (leave empty to watch the entire drive). Use the \"Load More\" button to load subfolders.",
       optional: true,
@@ -30,11 +41,14 @@ export default {
   methods: {
     ...base.methods,
     getDeltaLinkParams() {
-      return this.folder
-        ? {
-          folderId: this.folder,
-        }
-        : {};
+      const params = {};
+      if (this.drive) {
+        params.driveId = this.drive;
+      }
+      if (this.folder) {
+        params.folderId = this.folder;
+      }
+      return params;
     },
     isItemTypeRelevant(driveItem) {
       const fileType = driveItem?.file?.mimeType;

--- a/components/microsoft_onedrive/sources/new-folder-created/new-folder-created.mjs
+++ b/components/microsoft_onedrive/sources/new-folder-created/new-folder-created.mjs
@@ -8,14 +8,25 @@ export default {
   key: "microsoft_onedrive-new-folder-created",
   name: "New Folder Created (Instant)",
   description: "Emit new event when a new folder is created in a OneDrive drive",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
   props: {
     ...base.props,
+    drive: {
+      propDefinition: [
+        onedrive,
+        "drive",
+      ],
+      description: "The drive to monitor for new folders. If not specified, the personal OneDrive will be monitored.",
+      optional: true,
+    },
     folder: {
       propDefinition: [
         onedrive,
         "folder",
+        ({ drive }) => ({
+          driveId: drive,
+        }),
       ],
       optional: true,
     },
@@ -23,11 +34,14 @@ export default {
   methods: {
     ...base.methods,
     getDeltaLinkParams() {
-      return this.folder
-        ? {
-          folderId: this.folder,
-        }
-        : {};
+      const params = {};
+      if (this.drive) {
+        params.driveId = this.drive;
+      }
+      if (this.folder) {
+        params.folderId = this.folder;
+      }
+      return params;
     },
     isItemRelevant(driveItem) {
       return !!(driveItem.folder);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29979,22 +29979,22 @@ packages:
   superagent@3.8.1:
     resolution: {integrity: sha512-VMBFLYgFuRdfeNQSMLbxGSLfmXL/xc+OO+BZp41Za/NRDBet/BNbkRJrYzCUu0u4GU0i/ml2dtT8b9qgkw9z6Q==}
     engines: {node: '>= 4.0'}
-    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
 
   superagent@4.1.0:
     resolution: {integrity: sha512-FT3QLMasz0YyCd4uIi5HNe+3t/onxMyEho7C3PSqmti3Twgy2rXT4fmkTz6wRL6bTF4uzPcfkUCa8u4JWHw8Ag==}
     engines: {node: '>= 6.0'}
-    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
 
   superagent@5.3.1:
     resolution: {integrity: sha512-wjJ/MoTid2/RuGCOFtlacyGNxN9QLMgcpYLDQlWFIhhdJ93kNscFonGvrpAHSCVjRVj++DGCglocF7Aej1KHvQ==}
     engines: {node: '>= 7.0.0'}
-    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
 
   superagent@7.1.6:
     resolution: {integrity: sha512-gZkVCQR1gy/oUXr+kxJMLDjla434KmSOKbx5iGD30Ql+AkJQ/YlPKECJy2nhqOsHLjGHzoDTXNSjhnvWhzKk7g==}
     engines: {node: '>=6.4.0 <13 || >=14'}
-    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
 
   supports-color@2.0.0:
     resolution: {integrity: sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==}
@@ -37304,8 +37304,6 @@ snapshots:
       '@putout/operator-filesystem': 5.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))
       '@putout/operator-json': 2.2.0
       putout: 36.13.1(eslint@8.57.1)(typescript@5.6.3)
-    transitivePeerDependencies:
-      - supports-color
 
   '@putout/operator-regexp@1.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))':
     dependencies:


### PR DESCRIPTION
## WHY

Resolves #17335


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting and monitoring specific drives (including shared drives) when detecting new files or folders in OneDrive.
  * Enhanced folder selection to be scoped by the selected drive for more precise monitoring.

* **Improvements**
  * Improved error handling for folder and drive selection operations to prevent unhandled exceptions.
  * Updated internal logic to support drive-aware event filtering for file and folder creation triggers.

* **Chores**
  * Incremented version numbers for several OneDrive actions and the overall component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->