### PR TITLE
fix(confluence): handle relative paths when extracting cursor from link

### DIFF
--- a/components/confluence/confluence.app.mjs
+++ b/components/confluence/confluence.app.mjs
@@ -146,7 +146,15 @@ export default {
     _extractCursorFromLink(link) {
       if (!link) return null;
       try {
-        const url = new URL(link);
+        // Handle cases where link might be just a path or relative URL
+        let url;
+        if (link.startsWith("http")) {
+          url = new URL(link);
+        } else {
+          // If it's a path or relative URL, construct a full URL
+          const baseUrl = "https://api.atlassian.com";
+          url = new URL(link, baseUrl);
+        }
         return url.searchParams.get("cursor");
       } catch (e) {
         console.log("Error extracting cursor from link:", e);


### PR DESCRIPTION
## WHY

Seeing errors like this:

```
"observations" => [{"k" => "console.log", "msg" => "Error extracting cursor from link: {
  code: 'ERR_INVALID_URL',
  input: '/wiki/api/v2/spaces?cursor=123...'
}]"
```

API reference: https://developer.atlassian.com/cloud/confluence/rest/v2/api-group-space/#api-group-space