### PR TITLE
Linear - pin sdk version

### DIFF
--- a/components/linear_app/actions/create-issue/create-issue.mjs
+++ b/components/linear_app/actions/create-issue/create-issue.mjs
@@ -5,7 +5,7 @@ export default {
   key: "linear_app-create-issue",
   name: "Create Issue",
   description: "Creates a new issue in Linear. Requires team ID and title. Optional: description, assignee, project, state. Returns response object with success status and issue details. Uses API Key authentication. See Linear docs for additional info [here](https://developers.linear.app/docs/graphql/working-with-the-graphql-api#creating-and-editing-issues).",
-  version: "0.4.10",
+  version: "0.4.11",
   props: {
     linearApp,
     teamId: {

--- a/components/linear_app/actions/get-issue/get-issue.mjs
+++ b/components/linear_app/actions/get-issue/get-issue.mjs
@@ -4,7 +4,7 @@ export default {
   key: "linear_app-get-issue",
   name: "Get Issue",
   description: "Retrieves a Linear issue by its ID. Returns complete issue details including title, description, state, assignee, team, project, labels, and timestamps. Uses API Key authentication. See Linear docs for additional info [here](https://developers.linear.app/docs/graphql/working-with-the-graphql-api).",
-  version: "0.1.10",
+  version: "0.1.11",
   type: "action",
   props: {
     linearApp,

--- a/components/linear_app/actions/get-teams/get-teams.mjs
+++ b/components/linear_app/actions/get-teams/get-teams.mjs
@@ -5,7 +5,7 @@ export default {
   key: "linear_app-get-teams",
   name: "Get Teams",
   description: "Retrieves all teams in your Linear workspace. Returns array of team objects with details like ID, name, and key. Supports pagination with configurable limit. Uses API Key authentication. See Linear docs for additional info [here](https://developers.linear.app/docs/graphql/working-with-the-graphql-api).",
-  version: "0.2.10",
+  version: "0.2.11",
   type: "action",
   props: {
     linearApp,

--- a/components/linear_app/actions/search-issues/search-issues.mjs
+++ b/components/linear_app/actions/search-issues/search-issues.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Search Issues",
   description: "Searches Linear issues by team, project, assignee, labels, state, or text query. Supports pagination, ordering, and archived issues. Returns array of matching issues. Uses API Key authentication. See Linear docs for additional info [here](https://developers.linear.app/docs/graphql/working-with-the-graphql-api).",
   type: "action",
-  version: "0.2.10",
+  version: "0.2.11",
   props: {
     linearApp,
     teamId: {

--- a/components/linear_app/actions/update-issue/update-issue.mjs
+++ b/components/linear_app/actions/update-issue/update-issue.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Update Issue",
   description: "Updates an existing Linear issue. Can modify title, description, assignee, state, project, team, labels, priority, and dates. Returns updated issue details. Uses API Key authentication. See Linear docs for additional info [here](https://developers.linear.app/docs/graphql/working-with-the-graphql-api#creating-and-editing-issues).",
   type: "action",
-  version: "0.1.10",
+  version: "0.1.11",
   props: {
     linearApp,
     teamId: {

--- a/components/linear_app/linear_app.app.mjs
+++ b/components/linear_app/linear_app.app.mjs
@@ -1,4 +1,4 @@
-import { LinearClient } from "@linear/sdk";
+import { LinearClient } from "@linear/sdk@13.0.0";
 import constants from "./common/constants.mjs";
 import utils from "./common/utils.mjs";
 import { axios } from "@pipedream/platform";

--- a/components/linear_app/package.json
+++ b/components/linear_app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/linear_app",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Pipedream Linear_app Components",
   "main": "linear_app.app.mjs",
   "keywords": [

--- a/components/linear_app/sources/comment-created-instant/comment-created-instant.mjs
+++ b/components/linear_app/sources/comment-created-instant/comment-created-instant.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Comment Created (Instant)",
   description: "Triggers instantly when a new comment is added to an issue in Linear. Returns comment details including content, author, issue reference, and timestamps. Supports filtering by team. See Linear docs for additional info [here](https://developers.linear.app/docs/graphql/webhooks).",
   type: "source",
-  version: "0.1.12",
+  version: "0.1.13",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/linear_app/sources/issue-created-instant/issue-created-instant.mjs
+++ b/components/linear_app/sources/issue-created-instant/issue-created-instant.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Issue Created (Instant)",
   description: "Triggers instantly when a new issue is created in Linear. Provides complete issue details including title, description, team, assignee, state, and timestamps. Supports filtering by team and project. See Linear docs for additional info [here](https://developers.linear.app/docs/graphql/webhooks).",
   type: "source",
-  version: "0.3.12",
+  version: "0.3.13",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/linear_app/sources/issue-updated-instant/issue-updated-instant.mjs
+++ b/components/linear_app/sources/issue-updated-instant/issue-updated-instant.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Issue Updated (Instant)",
   description: "Triggers instantly when any issue is updated in Linear. Provides complete issue details with changes. Supports filtering by team and project. Includes all updates except status changes. See Linear docs for additional info [here](https://developers.linear.app/docs/graphql/webhooks).",
   type: "source",
-  version: "0.3.12",
+  version: "0.3.13",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/linear_app/sources/new-issue-status-updated/new-issue-status-updated.mjs
+++ b/components/linear_app/sources/new-issue-status-updated/new-issue-status-updated.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Issue Status Updated (Instant)",
   description: "Triggers instantly when an issue's workflow state changes (e.g., Todo to In Progress). Returns issue with previous and current state info. Can filter by specific target state. See Linear docs for additional info [here](https://developers.linear.app/docs/graphql/webhooks).",
   type: "source",
-  version: "0.1.12",
+  version: "0.1.13",
   dedupe: "unique",
   props: {
     linearApp: common.props.linearApp,

--- a/components/linear_app/sources/new-projectupdate-created/new-projectupdate-created.mjs
+++ b/components/linear_app/sources/new-projectupdate-created/new-projectupdate-created.mjs
@@ -8,7 +8,7 @@ export default {
   name: "New Project Update Written (Instant)",
   description: "Triggers instantly when a project update (status report) is created in Linear. Returns update content, author, project details, and health status. Filters by team and optionally by project. See Linear docs for additional info [here](https://developers.linear.app/docs/graphql/webhooks).",
   type: "source",
-  version: "0.0.4",
+  version: "0.0.5",
   dedupe: "unique",
   props: {
     linearApp,

--- a/components/linear_app/sources/project-updated-instant/project-updated-instant.mjs
+++ b/components/linear_app/sources/project-updated-instant/project-updated-instant.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Project Updated (Instant)",
   description: "Triggers instantly when a project is updated in Linear. Returns project details including name, description, status, dates, and team info. Supports filtering by specific teams. See Linear docs for additional info [here](https://developers.linear.app/docs/graphql/webhooks).",
   type: "source",
-  version: "0.0.5",
+  version: "0.0.6",
   dedupe: "unique",
   props: {
     linearApp,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6045,8 +6045,7 @@ importers:
         specifier: ^3.0.0
         version: 3.0.3
 
-  components/gotify:
-    specifiers: {}
+  components/gotify: {}
 
   components/goto_meeting: {}
 
@@ -8985,8 +8984,7 @@ importers:
 
   components/mozilla_observatory: {}
 
-  components/mqtt:
-    specifiers: {}
+  components/mqtt: {}
 
   components/msg91:
     dependencies:
@@ -9663,8 +9661,7 @@ importers:
         specifier: ^3.0.0
         version: 3.0.3
 
-  components/onesimpleapi:
-    specifiers: {}
+  components/onesimpleapi: {}
 
   components/onethread: {}
 
@@ -40192,6 +40189,8 @@ snapshots:
       '@putout/operator-filesystem': 5.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))
       '@putout/operator-json': 2.2.0
       putout: 36.13.1(eslint@8.57.1)(typescript@5.6.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@putout/operator-regexp@1.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))':
     dependencies:


### PR DESCRIPTION
## WHY

The Linear API key components were getting this error:

SyntaxError
The requested module '@linear/sdk' does not provide an export named 'LinearClient'

<!-- author to complete -->
