### PR TITLE
[ACTIONS] Notion - notion-retrieve-block - Fix timeouts when fetching only page content when markdown is true

### DIFF
--- a/components/notion/actions/append-block/append-block.mjs
+++ b/components/notion/actions/append-block/append-block.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Append Block to Parent",
   description:
     "Append new and/or existing blocks to the specified parent. [See the documentation](https://developers.notion.com/reference/patch-block-children)",
-  version: "0.3.4",
+  version: "0.3.5",
   type: "action",
   props: {
     notion,

--- a/components/notion/actions/create-comment/create-comment.mjs
+++ b/components/notion/actions/create-comment/create-comment.mjs
@@ -5,7 +5,7 @@ export default {
   key: "notion-create-comment",
   name: "Create Comment",
   description: "Create a comment in a page or existing discussion thread. [See the documentation](https://developers.notion.com/reference/create-a-comment)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   props: {
     notion,

--- a/components/notion/actions/create-page-from-database/create-page-from-database.mjs
+++ b/components/notion/actions/create-page-from-database/create-page-from-database.mjs
@@ -8,7 +8,7 @@ export default {
   key: "notion-create-page-from-database",
   name: "Create Page from Database",
   description: "Create a page from a database. [See the documentation](https://developers.notion.com/reference/post-page)",
-  version: "0.2.1",
+  version: "0.2.2",
   type: "action",
   props: {
     notion,

--- a/components/notion/actions/create-page/create-page.mjs
+++ b/components/notion/actions/create-page/create-page.mjs
@@ -7,7 +7,7 @@ export default {
   key: "notion-create-page",
   name: "Create Page",
   description: "Create a page from a parent page. [See the documentation](https://developers.notion.com/reference/post-page)",
-  version: "0.2.17",
+  version: "0.2.18",
   type: "action",
   props: {
     notion,

--- a/components/notion/actions/duplicate-page/duplicate-page.mjs
+++ b/components/notion/actions/duplicate-page/duplicate-page.mjs
@@ -7,7 +7,7 @@ export default {
   key: "notion-duplicate-page",
   name: "Duplicate Page",
   description: "Create a new page copied from an existing page block. [See the documentation](https://developers.notion.com/reference/post-page)",
-  version: "0.0.14",
+  version: "0.0.15",
   type: "action",
   props: {
     notion,

--- a/components/notion/actions/query-database/query-database.mjs
+++ b/components/notion/actions/query-database/query-database.mjs
@@ -5,7 +5,7 @@ export default {
   key: "notion-query-database",
   name: "Query Database",
   description: "Query a database with a specified filter. [See the documentation](https://developers.notion.com/reference/post-database-query)",
-  version: "0.0.12",
+  version: "0.0.13",
   type: "action",
   props: {
     notion,

--- a/components/notion/actions/retrieve-block/retrieve-block.mjs
+++ b/components/notion/actions/retrieve-block/retrieve-block.mjs
@@ -4,7 +4,7 @@ export default {
   key: "notion-retrieve-block",
   name: "Retrieve Page Content",
   description: "Get page content as block objects or markdown. Blocks can be text, lists, media, a page, among others. [See the documentation](https://developers.notion.com/reference/retrieve-a-block)",
-  version: "0.2.2",
+  version: "0.2.3",
   type: "action",
   props: {
     notion,

--- a/components/notion/actions/retrieve-database-content/retrieve-database-content.mjs
+++ b/components/notion/actions/retrieve-database-content/retrieve-database-content.mjs
@@ -4,7 +4,7 @@ export default {
   key: "notion-retrieve-database-content",
   name: "Retrieve Database Content",
   description: "Get all content of a database. [See the documentation](https://developers.notion.com/reference/post-database-query)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   props: {
     notion,

--- a/components/notion/actions/retrieve-database-schema/retrieve-database-schema.mjs
+++ b/components/notion/actions/retrieve-database-schema/retrieve-database-schema.mjs
@@ -4,7 +4,7 @@ export default {
   key: "notion-retrieve-database-schema",
   name: "Retrieve Database Schema",
   description: "Get the property schema of a database in Notion. [See the documentation](https://developers.notion.com/reference/retrieve-a-database)",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "action",
   props: {
     notion,

--- a/components/notion/actions/retrieve-page-property-item/retrieve-page-property-item.mjs
+++ b/components/notion/actions/retrieve-page-property-item/retrieve-page-property-item.mjs
@@ -4,7 +4,7 @@ export default {
   key: "notion-retrieve-page-property-item",
   name: "Retrieve Page Property Item",
   description: "Get a Property Item object for a selected page and property. [See the documentation](https://developers.notion.com/reference/retrieve-a-page-property)",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   props: {
     notion,

--- a/components/notion/actions/retrieve-page/retrieve-page.mjs
+++ b/components/notion/actions/retrieve-page/retrieve-page.mjs
@@ -4,7 +4,7 @@ export default {
   key: "notion-retrieve-page",
   name: "Retrieve Page Metadata",
   description: "Get details of a page. [See the documentation](https://developers.notion.com/reference/retrieve-a-page)",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "action",
   props: {
     notion,

--- a/components/notion/actions/search/search.mjs
+++ b/components/notion/actions/search/search.mjs
@@ -5,7 +5,7 @@ export default {
   key: "notion-search",
   name: "Find Pages or Databases",
   description: "Searches for a page or database. [See the documentation](https://developers.notion.com/reference/post-search)",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   props: {
     ...common.props,

--- a/components/notion/actions/update-page/update-page.mjs
+++ b/components/notion/actions/update-page/update-page.mjs
@@ -7,7 +7,7 @@ export default {
   key: "notion-update-page",
   name: "Update Page",
   description: "Update a page's property values. To append page content, use the *Append Block* action instead. [See the documentation](https://developers.notion.com/reference/patch-page)",
-  version: "1.1.7",
+  version: "1.1.8",
   type: "action",
   props: {
     notion,

--- a/components/notion/notion.app.mjs
+++ b/components/notion/notion.app.mjs
@@ -364,6 +364,9 @@ export default {
         notionClient: notion,
         config: {
           separateChildPage: true,
+          ...!shouldRetrieveChildren && {
+            parseChildPages:false
+          }
         },
       });
       const blocks = await n2m.pageToMarkdown(pageId);

--- a/components/notion/notion.app.mjs
+++ b/components/notion/notion.app.mjs
@@ -364,9 +364,7 @@ export default {
         notionClient: notion,
         config: {
           separateChildPage: true,
-          ...!shouldRetrieveChildren && {
-            parseChildPages:false
-          }
+          parseChildPages: shouldRetrieveChildren,
         },
       });
       const blocks = await n2m.pageToMarkdown(pageId);

--- a/components/notion/package.json
+++ b/components/notion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/notion",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Pipedream Notion Components",
   "main": "notion.app.mjs",
   "keywords": [

--- a/components/notion/sources/new-comment-created/new-comment-created.mjs
+++ b/components/notion/sources/new-comment-created/new-comment-created.mjs
@@ -5,7 +5,7 @@ export default {
   key: "notion-new-comment-created",
   name: "New Comment Created",
   description: "Emit new event when a new comment is created in a page or block. [See the documentation](https://developers.notion.com/reference/retrieve-a-comment)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/notion/sources/new-database/new-database.mjs
+++ b/components/notion/sources/new-database/new-database.mjs
@@ -7,7 +7,7 @@ export default {
   key: "notion-new-database",
   name: "New Database Created",
   description: "Emit new event when a database is created. [See the documentation](https://developers.notion.com/reference/database)",
-  version: "0.0.11",
+  version: "0.0.12",
   type: "source",
   props: {
     ...base.props,

--- a/components/notion/sources/new-page/new-page.mjs
+++ b/components/notion/sources/new-page/new-page.mjs
@@ -8,7 +8,7 @@ export default {
   key: "notion-new-page",
   name: "New Page in Database",
   description: "Emit new event when a page is created in the selected database. [See the documentation](https://developers.notion.com/reference/page)",
-  version: "0.0.13",
+  version: "0.0.14",
   type: "source",
   props: {
     ...base.props,

--- a/components/notion/sources/page-or-subpage-updated/page-or-subpage-updated.mjs
+++ b/components/notion/sources/page-or-subpage-updated/page-or-subpage-updated.mjs
@@ -7,7 +7,7 @@ export default {
   key: "notion-page-or-subpage-updated",
   name: "Page or Subpage Updated", /* eslint-disable-line pipedream/source-name */
   description: "Emit new event when the selected page or one of its sub-pages is updated. [See the documentation](https://developers.notion.com/reference/page)",
-  version: "0.0.9",
+  version: "0.0.10",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/notion/sources/updated-page-by-timestamp/updated-page-by-timestamp.mjs
+++ b/components/notion/sources/updated-page-by-timestamp/updated-page-by-timestamp.mjs
@@ -8,7 +8,7 @@ export default {
   key: "notion-updated-page-by-timestamp",
   name: "New or Updated Page in Database (By Timestamp)",
   description: "Emit new event when a page is created or updated in the selected database. [See the documentation](https://developers.notion.com/reference/page)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/notion/sources/updated-page-id/updated-page-id.mjs
+++ b/components/notion/sources/updated-page-id/updated-page-id.mjs
@@ -7,7 +7,7 @@ export default {
   key: "notion-updated-page-id",
   name: "Page Updated", /* eslint-disable-line pipedream/source-name */
   description: "Emit new event when a selected page is updated. [See the documentation](https://developers.notion.com/reference/page)",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/notion/sources/updated-page/updated-page.mjs
+++ b/components/notion/sources/updated-page/updated-page.mjs
@@ -9,7 +9,7 @@ export default {
   key: "notion-updated-page",
   name: "New or Updated Page in Database (By Property)",
   description: "Emit new event when a page is created or updated in the selected database. [See the documentation](https://developers.notion.com/reference/page)",
-  version: "0.1.8",
+  version: "0.1.9",
   type: "source",
   dedupe: "unique",
   props: {


### PR DESCRIPTION
## WHY
When retrieveMarkdown is true, this will convert the pages content into markdown, including child page as those are included in the child-blocks of a page. If the page has many child pages, this will cause the request to timeout and/or hit rate-limits as it recursively fetches the content for all child pages. 

This change makes it so that child pages are skipped when shouldRetrieveChildren is false to avoid this lengthy operation, as it isn't required and removed in the output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to enable or disable parsing of child pages during Markdown export, reducing work and improving performance when disabled.
* **Chores**
  * Bumped release metadata across Notion actions, sources, and package; no changes to public APIs or runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->