### PR TITLE
Google Calendar - new-or-updated-event-instant update

### DIFF
--- a/components/google_calendar/package.json
+++ b/components/google_calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_calendar",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "description": "Pipedream Google_calendar Components",
   "main": "google_calendar.app.mjs",
   "keywords": [

--- a/components/google_calendar/sources/new-or-updated-event-instant/new-or-updated-event-instant.mjs
+++ b/components/google_calendar/sources/new-or-updated-event-instant/new-or-updated-event-instant.mjs
@@ -8,7 +8,7 @@ export default {
   type: "source",
   name: "New Created or Updated Event (Instant)",
   description: "Emit new event when a Google Calendar events is created or updated (does not emit cancelled events)",
-  version: "0.1.15",
+  version: "0.1.16",
   dedupe: "unique",
   props: {
     googleCalendar,
@@ -48,6 +48,7 @@ export default {
       const params = {
         maxResults: 25,
         orderBy: "updated",
+        timeMin: new Date(new Date().setMonth(new Date().getMonth() - 1)).toISOString(), // 1 month ago
       };
       for (const calendarId of this.calendarIds) {
         params.calendarId = calendarId;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1123,8 +1123,7 @@ importers:
         specifier: ^1.5.1
         version: 1.6.6
 
-  components/attentive:
-    specifiers: {}
+  components/attentive: {}
 
   components/attio:
     dependencies:
@@ -2968,8 +2967,7 @@ importers:
 
   components/coinbase_commerce: {}
 
-  components/coingecko:
-    specifiers: {}
+  components/coingecko: {}
 
   components/coinlore:
     dependencies:
@@ -8401,8 +8399,7 @@ importers:
         specifier: ^1.2.1
         version: 1.7.7
 
-  components/matrix:
-    specifiers: {}
+  components/matrix: {}
 
   components/mattermost:
     dependencies:
@@ -12708,8 +12705,7 @@ importers:
         specifier: ^1.6.2
         version: 1.6.6
 
-  components/sherpa:
-    specifiers: {}
+  components/sherpa: {}
 
   components/shift4:
     dependencies:


### PR DESCRIPTION
Limits historical events emitted in the `deploy` hook to events from withing the previous month.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Google Calendar “New or Updated Event (Instant)” now limits initial seed to the past month, reducing noise and speeding up first-time setup while preserving normal runtime behavior.
- Chores
  - Bumped Google Calendar component version to 0.5.10.
  - Updated “New or Updated Event (Instant)” source version to 0.1.16.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->