### PR TITLE
Adding app sort and filter opts, discord async options

### DIFF
--- a/packages/connect-react/CHANGELOG.md
+++ b/packages/connect-react/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 # Changelog
 
+## [1.5.0] - 2025-08-18
+
+### Fixed
+
+- Added special handling to support `$.discord.channel[]` prop type
+
+### Added
+
+- Support for app sorting and filtering in `SelectApp` component and `useApps` hook
+- Added `appsOptions` prop to `SelectApp` for controlling sort order and filtering
+- Apps can now be sorted by `name`, `featured_weight`, or `name_slug`
+- Support for filtering apps by whether they have actions, triggers, or components
+
 ## [1.4.0] - 2025-08-01
 
 ### Added

--- a/packages/connect-react/README.md
+++ b/packages/connect-react/README.md
@@ -183,6 +183,34 @@ This allows you to use your own OAuth applications for specific integrations, pr
 
 **Note**: OAuth app IDs are not sensitive, and are safe to expose in the client.
 
+### App Sorting and Filtering
+
+When using the `SelectApp` component or `useApps` hook, you can control how apps are sorted and filtered:
+
+```tsx
+<SelectApp
+  value={selectedApp}
+  onChange={setSelectedApp}
+  appsOptions={{
+    sortKey: "featured_weight", // Sort by: "name" | "featured_weight" | "name_slug"
+    sortDirection: "desc", // "asc" | "desc"
+    hasActions: true, // Only show apps with actions
+    hasTriggers: false, // Exclude apps with triggers
+  }}
+/>
+```
+
+The `useApps` hook accepts the same options:
+
+```tsx
+const { apps, isLoading } = useApps({
+  q: "slack", // Search query
+  sortKey: "featured_weight",
+  sortDirection: "desc",
+  hasActions: true,
+});
+```
+
 ## Customization
 
 Style individual components using the `CustomizeProvider` and a `CustomizationConfig`.
@@ -454,7 +482,7 @@ customization options available.
 - `useFrontendClient` — _allows use of provided Pipedream frontendClient_
 - `useAccounts` — _react-query wrapper to list Pipedream connect accounts (for app, external user, etc.)_
 - `useApp` — _react-query wrapper to retrieve a Pipedream app_
-- `useApps` — _react-query wrapper to list Pipedream apps_
+- `useApps` — _react-query wrapper to list Pipedream apps with support for sorting and filtering_
 - `useComponent` — _react-query wrapper to retrieve a Pipedream component (action or trigger)_
 - `useComponents` — _react-query wrapper to list Pipedream components (actions or triggers)_
 

--- a/packages/connect-react/package.json
+++ b/packages/connect-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/connect-react",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Pipedream Connect library for React",
   "files": [
     "dist"

--- a/packages/connect-react/src/components/Control.tsx
+++ b/packages/connect-react/src/components/Control.tsx
@@ -32,8 +32,7 @@ export function Control<T extends ConfigurableProps, U extends ConfigurableProp>
   const app = "app" in field.extra
     ? field.extra.app
     : undefined;
-
-  if (prop.remoteOptions || prop.type === "$.discord.channel") {
+  if (prop.remoteOptions || prop.type === "$.discord.channel" || prop.type === "$.discord.channel[]") {
     return <RemoteOptionsContainer queryEnabled={queryDisabledIdx == null || queryDisabledIdx >= idx} />;
   }
 

--- a/packages/connect-react/src/components/SelectApp.tsx
+++ b/packages/connect-react/src/components/SelectApp.tsx
@@ -3,7 +3,7 @@ import {
 } from "react";
 import Select, { components } from "react-select";
 import { useApps } from "../hooks/use-apps";
-import {
+import type {
   AppResponse, GetAppsOpts,
 } from "@pipedream/sdk";
 

--- a/packages/connect-react/src/components/SelectApp.tsx
+++ b/packages/connect-react/src/components/SelectApp.tsx
@@ -3,7 +3,9 @@ import {
 } from "react";
 import Select, { components } from "react-select";
 import { useApps } from "../hooks/use-apps";
-import { AppResponse, GetAppsOpts } from "@pipedream/sdk";
+import {
+  AppResponse, GetAppsOpts,
+} from "@pipedream/sdk";
 
 type SelectAppProps = {
   value?: Partial<AppResponse> & { name_slug: string; };
@@ -11,7 +13,7 @@ type SelectAppProps = {
   /**
    * Additional options for fetching apps (sorting, filtering, etc.)
    */
-  appsOptions?: Omit<GetAppsOpts, 'q'>;
+  appsOptions?: Omit<GetAppsOpts, "q">;
 };
 
 export function SelectApp({

--- a/packages/connect-react/src/components/SelectApp.tsx
+++ b/packages/connect-react/src/components/SelectApp.tsx
@@ -3,15 +3,19 @@ import {
 } from "react";
 import Select, { components } from "react-select";
 import { useApps } from "../hooks/use-apps";
-import { AppResponse } from "@pipedream/sdk";
+import { AppResponse, GetAppsOpts } from "@pipedream/sdk";
 
 type SelectAppProps = {
   value?: Partial<AppResponse> & { name_slug: string; };
   onChange?: (app?: AppResponse) => void;
+  /**
+   * Additional options for fetching apps (sorting, filtering, etc.)
+   */
+  appsOptions?: Omit<GetAppsOpts, 'q'>;
 };
 
 export function SelectApp({
-  value, onChange,
+  value, onChange, appsOptions,
 }: SelectAppProps) {
   const [
     inputValue,
@@ -41,6 +45,7 @@ export function SelectApp({
     apps,
   } = useApps({
     q,
+    ...appsOptions,
   });
   const {
     Option,

--- a/packages/connect-react/src/components/SelectApp.tsx
+++ b/packages/connect-react/src/components/SelectApp.tsx
@@ -46,8 +46,8 @@ export function SelectApp({
     // TODO error
     apps,
   } = useApps({
+    ...appsOptions ?? {},
     q,
-    ...appsOptions,
   });
   const {
     Option,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3699,8 +3699,7 @@ importers:
         specifier: ^1.5.1
         version: 1.6.6
 
-  components/dhl:
-    specifiers: {}
+  components/dhl: {}
 
   components/diabatix_coldstream:
     dependencies:
@@ -12216,8 +12215,7 @@ importers:
         specifier: ^3.0.0
         version: 3.0.3
 
-  components/sanity:
-    specifiers: {}
+  components/sanity: {}
 
   components/sap_s_4hana_cloud: {}
 
@@ -14438,8 +14436,7 @@ importers:
         specifier: ^0.1.4
         version: 0.1.6
 
-  components/topmessage:
-    specifiers: {}
+  components/topmessage: {}
 
   components/totango:
     dependencies:
@@ -16530,6 +16527,14 @@ importers:
       dotenv:
         specifier: ^6.0.0
         version: 6.2.0
+
+  modelcontextprotocol/node_modules2/@modelcontextprotocol/sdk/dist/cjs: {}
+
+  modelcontextprotocol/node_modules2/@modelcontextprotocol/sdk/dist/esm: {}
+
+  modelcontextprotocol/node_modules2/zod-to-json-schema/dist/cjs: {}
+
+  modelcontextprotocol/node_modules2/zod-to-json-schema/dist/esm: {}
 
   packages/ai:
     dependencies:
@@ -32031,22 +32036,22 @@ packages:
   superagent@3.8.1:
     resolution: {integrity: sha512-VMBFLYgFuRdfeNQSMLbxGSLfmXL/xc+OO+BZp41Za/NRDBet/BNbkRJrYzCUu0u4GU0i/ml2dtT8b9qgkw9z6Q==}
     engines: {node: '>= 4.0'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
 
   superagent@4.1.0:
     resolution: {integrity: sha512-FT3QLMasz0YyCd4uIi5HNe+3t/onxMyEho7C3PSqmti3Twgy2rXT4fmkTz6wRL6bTF4uzPcfkUCa8u4JWHw8Ag==}
     engines: {node: '>= 6.0'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
 
   superagent@5.3.1:
     resolution: {integrity: sha512-wjJ/MoTid2/RuGCOFtlacyGNxN9QLMgcpYLDQlWFIhhdJ93kNscFonGvrpAHSCVjRVj++DGCglocF7Aej1KHvQ==}
     engines: {node: '>= 7.0.0'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
 
   superagent@7.1.6:
     resolution: {integrity: sha512-gZkVCQR1gy/oUXr+kxJMLDjla434KmSOKbx5iGD30Ql+AkJQ/YlPKECJy2nhqOsHLjGHzoDTXNSjhnvWhzKk7g==}
     engines: {node: '>=6.4.0 <13 || >=14'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
 
   supports-color@10.0.0:
     resolution: {integrity: sha512-HRVVSbCCMbj7/kdWF9Q+bbckjBHLtHMEoJWlkmYzzdwhYMkjkOwubLM6t7NbWKjgKamGDrWL1++KrjUO1t9oAQ==}
@@ -40364,6 +40369,8 @@ snapshots:
       '@putout/operator-filesystem': 5.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))
       '@putout/operator-json': 2.2.0
       putout: 36.13.1(eslint@8.57.1)(typescript@5.6.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@putout/operator-regexp@1.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))':
     dependencies:


### PR DESCRIPTION
## WHY

<!-- author to complete -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SelectApp supports app sorting and filtering via a new appsOptions prop (sort by name, featured weight, or slug; filter by actions/triggers).
  * useApps hook now supports query, sorting, and filtering options.

* **Bug Fixes**
  * Improved handling of Discord channel array fields so options render correctly.

* **Documentation**
  * Added guidance on app sorting and filtering for SelectApp and useApps.

* **Chores**
  * Bumped package version to 1.5.0 and updated changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->