### PR TITLE
Add file attachment support to Zendesk update-ticket action

### DIFF
--- a/components/zendesk/package.json
+++ b/components/zendesk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/zendesk",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Pipedream Zendesk Components",
   "main": "zendesk.app.mjs",
   "keywords": [


### PR DESCRIPTION
## Summary
- Add file attachment support to the Zendesk `update-ticket` action
- Support for multiple file uploads with automatic MIME type detection
- Proper integration with Zendesk's uploads API workflow

## Changes
- Added `attachments` prop definition to `zendesk.app.mjs` for multiple file uploads
- Added `uploadFile()` and `uploadFiles()` helper methods with MIME type detection for common file types
- Modified `update-ticket` action to upload files and attach them via upload tokens
- Updated action version to 0.2.0 and package version to 0.7.2
- Enhanced success message to show attachment count

## Test plan
- [ ] Test update-ticket action with single file attachment
- [ ] Test update-ticket action with multiple file attachments
- [ ] Test update-ticket action without attachments (existing functionality)
- [ ] Verify proper error handling for failed uploads
- [ ] Test with various file types (PDF, images, documents, etc.)