### PR TITLE
Microsoft Outlook Calendar - Fix regex check for end date in create event action

### DIFF
--- a/components/microsoft_outlook_calendar/actions/create-calendar-event/create-calendar-event.mjs
+++ b/components/microsoft_outlook_calendar/actions/create-calendar-event/create-calendar-event.mjs
@@ -73,7 +73,7 @@ export default {
   async run({ $ }) {
     //RegExp to check time strings(yyyy-MM-ddThh:mm:ss)
     const re = /^(\d{4})-(\d\d)-(\d\d)T(\d\d):(\d\d):(\d\d)$/;
-    if (!re.test(this.start) || !re.test(this.start)) {
+    if (!re.test(this.start) || !re.test(this.end)) {
       throw new Error("Please provide both start and end props in 'yyyy-MM-ddThh:mm:ss'");
     }
     const data = {


### PR DESCRIPTION
## WHY

Before it was checking that the start date exists twice instead of checking the end date

Fixes #18115 