### PR TITLE
[FIX] Notion: New or Updated Page in Database is not emitting events

### DIFF
--- a/components/notion/package.json
+++ b/components/notion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/notion",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Pipedream Notion Components",
   "main": "notion.app.mjs",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10067,8 +10067,7 @@ importers:
         specifier: ^1.5.1
         version: 1.6.6
 
-  components/paazl:
-    specifiers: {}
+  components/paazl: {}
 
   components/paddle: {}
 
@@ -40366,8 +40365,6 @@ snapshots:
       '@putout/operator-filesystem': 5.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))
       '@putout/operator-json': 2.2.0
       putout: 36.13.1(eslint@8.57.1)(typescript@5.6.3)
-    transitivePeerDependencies:
-      - supports-color
 
   '@putout/operator-regexp@1.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))':
     dependencies:


### PR DESCRIPTION
## WHY

Resolves #18102


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Respects settings to include or exclude new pages when emitting change events.

* **Bug Fixes**
  * More reliable detection of property changes for existing pages.
  * Consistent tracking of property values for all pages, eliminating inconsistent handling of new pages.

* **Chores**
  * Bumped Notion component version to 0.9.1.
  * Incremented Updated Page module version to 0.1.11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->