### PR TITLE
HubSpot - adding retry to search endpoint 

### DIFF
--- a/components/hubspot/actions/add-contact-to-list/add-contact-to-list.mjs
+++ b/components/hubspot/actions/add-contact-to-list/add-contact-to-list.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-add-contact-to-list",
   name: "Add Contact to List",
   description: "Adds a contact to a specific static list. [See the documentation](https://legacydocs.hubspot.com/docs/methods/lists/add_contact_to_list)",
-  version: "0.0.19",
+  version: "0.0.20",
   type: "action",
   props: {
     hubspot,

--- a/components/hubspot/actions/batch-create-companies/batch-create-companies.mjs
+++ b/components/hubspot/actions/batch-create-companies/batch-create-companies.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-batch-create-companies",
   name: "Batch Create Companies",
   description: "Create a batch of companies in Hubspot. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/objects/companies#post-%2Fcrm%2Fv3%2Fobjects%2Fcompanies%2Fbatch%2Fcreate)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     hubspot,

--- a/components/hubspot/actions/batch-create-or-update-contact/batch-create-or-update-contact.mjs
+++ b/components/hubspot/actions/batch-create-or-update-contact/batch-create-or-update-contact.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-batch-create-or-update-contact",
   name: "Batch Create or Update Contact",
   description: "Create or update a batch of contacts by its ID or email. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts)",
-  version: "0.0.16",
+  version: "0.0.17",
   type: "action",
   props: {
     hubspot,

--- a/components/hubspot/actions/batch-update-companies/batch-update-companies.mjs
+++ b/components/hubspot/actions/batch-update-companies/batch-update-companies.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-batch-update-companies",
   name: "Batch Update Companies",
   description: "Update a batch of companies in Hubspot. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/objects/companies#post-%2Fcrm%2Fv3%2Fobjects%2Fcompanies%2Fbatch%2Fupdate)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     hubspot,

--- a/components/hubspot/actions/batch-upsert-companies/batch-upsert-companies.mjs
+++ b/components/hubspot/actions/batch-upsert-companies/batch-upsert-companies.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-batch-upsert-companies",
   name: "Batch Upsert Companies",
   description: "Upsert a batch of companies in Hubspot. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/objects/companies#post-%2Fcrm%2Fv3%2Fobjects%2Fcompanies%2Fbatch%2Fupsert)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     hubspot,

--- a/components/hubspot/actions/create-associations/create-associations.mjs
+++ b/components/hubspot/actions/create-associations/create-associations.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-create-associations",
   name: "Create Associations",
   description: "Create associations between objects. [See the documentation](https://developers.hubspot.com/docs/api/crm/associations#endpoint?spec=POST-/crm/v3/associations/{fromObjectType}/{toObjectType}/batch/create)",
-  version: "1.0.5",
+  version: "1.0.6",
   type: "action",
   props: {
     hubspot,

--- a/components/hubspot/actions/create-communication/create-communication.mjs
+++ b/components/hubspot/actions/create-communication/create-communication.mjs
@@ -8,7 +8,7 @@ export default {
   key: "hubspot-create-communication",
   name: "Create Communication",
   description: "Create a WhatsApp, LinkedIn, or SMS message. [See the documentation](https://developers.hubspot.com/beta-docs/reference/api/crm/engagements/communications/v3#post-%2Fcrm%2Fv3%2Fobjects%2Fcommunications)",
-  version: "0.0.12",
+  version: "0.0.13",
   type: "action",
   props: {
     ...appProp.props,

--- a/components/hubspot/actions/create-company/create-company.mjs
+++ b/components/hubspot/actions/create-company/create-company.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-create-company",
   name: "Create Company",
   description: "Create a company in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/companies#endpoint?spec=POST-/crm/v3/objects/companies)",
-  version: "0.0.23",
+  version: "0.0.24",
   type: "action",
   methods: {
     ...common.methods,

--- a/components/hubspot/actions/create-custom-object/create-custom-object.mjs
+++ b/components/hubspot/actions/create-custom-object/create-custom-object.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-create-custom-object",
   name: "Create Custom Object",
   description: "Create a new custom object in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/custom-objects#create-a-custom-object)",
-  version: "1.0.5",
+  version: "1.0.6",
   type: "action",
   props: {
     ...appProp.props,

--- a/components/hubspot/actions/create-deal/create-deal.mjs
+++ b/components/hubspot/actions/create-deal/create-deal.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-create-deal",
   name: "Create Deal",
   description: "Create a deal in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/deals#endpoint?spec=POST-/crm/v3/objects/deals)",
-  version: "0.0.23",
+  version: "0.0.24",
   type: "action",
   props: {
     ...common.props,

--- a/components/hubspot/actions/create-engagement/create-engagement.mjs
+++ b/components/hubspot/actions/create-engagement/create-engagement.mjs
@@ -9,7 +9,7 @@ export default {
   key: "hubspot-create-engagement",
   name: "Create Engagement",
   description: "Create a new engagement for a contact. [See the documentation](https://developers.hubspot.com/docs/api/crm/engagements)",
-  version: "0.0.22",
+  version: "0.0.23",
   type: "action",
   props: {
     ...common.props,

--- a/components/hubspot/actions/create-lead/create-lead.mjs
+++ b/components/hubspot/actions/create-lead/create-lead.mjs
@@ -9,7 +9,7 @@ export default {
   key: "hubspot-create-lead",
   name: "Create Lead",
   description: "Create a lead in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/leads#create-leads)",
-  version: "0.0.11",
+  version: "0.0.12",
   type: "action",
   props: {
     ...appProp.props,

--- a/components/hubspot/actions/create-meeting/create-meeting.mjs
+++ b/components/hubspot/actions/create-meeting/create-meeting.mjs
@@ -10,7 +10,7 @@ export default {
   key: "hubspot-create-meeting",
   name: "Create Meeting",
   description: "Creates a new meeting with optional associations to other objects. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/engagements/meetings#post-%2Fcrm%2Fv3%2Fobjects%2Fmeetings)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   props: {
     ...common.props,

--- a/components/hubspot/actions/create-note/create-note.mjs
+++ b/components/hubspot/actions/create-note/create-note.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-create-note",
   name: "Create Note",
   description: "Create a new note. [See the documentation](https://developers.hubspot.com/docs/api/crm/engagements)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   props: {
     ...common.props,

--- a/components/hubspot/actions/create-or-update-contact/create-or-update-contact.mjs
+++ b/components/hubspot/actions/create-or-update-contact/create-or-update-contact.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-create-or-update-contact",
   name: "Create or Update Contact",
   description: "Create or update a contact in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts#endpoint?spec=POST-/crm/v3/objects/contacts)",
-  version: "0.0.21",
+  version: "0.0.22",
   type: "action",
   props: {
     ...common.props,

--- a/components/hubspot/actions/create-task/create-task.mjs
+++ b/components/hubspot/actions/create-task/create-task.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-create-task",
   name: "Create Task",
   description: "Create a new task. [See the documentation](https://developers.hubspot.com/docs/api/crm/engagements)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   props: {
     ...common.props,

--- a/components/hubspot/actions/create-ticket/create-ticket.mjs
+++ b/components/hubspot/actions/create-ticket/create-ticket.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-create-ticket",
   name: "Create Ticket",
   description: "Create a ticket in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/tickets)",
-  version: "0.0.14",
+  version: "0.0.15",
   type: "action",
   props: {
     ...common.props,

--- a/components/hubspot/actions/enroll-contact-into-workflow/enroll-contact-into-workflow.mjs
+++ b/components/hubspot/actions/enroll-contact-into-workflow/enroll-contact-into-workflow.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-enroll-contact-into-workflow",
   name: "Enroll Contact Into Workflow",
   description: "Add a contact to a workflow. Note: The Workflows API currently only supports contact-based workflows and is only available for Marketing Hub Enterprise accounts. [See the documentation](https://legacydocs.hubspot.com/docs/methods/workflows/add_contact)",
-  version: "0.0.19",
+  version: "0.0.20",
   type: "action",
   props: {
     hubspot,

--- a/components/hubspot/actions/get-associated-emails/get-associated-emails.mjs
+++ b/components/hubspot/actions/get-associated-emails/get-associated-emails.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-get-associated-emails",
   name: "Get Associated Emails",
   description: "Retrieves emails associated with a specific object (contact, company, or deal). [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/search)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     hubspot,

--- a/components/hubspot/actions/get-associated-meetings/get-associated-meetings.mjs
+++ b/components/hubspot/actions/get-associated-meetings/get-associated-meetings.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-get-associated-meetings",
   name: "Get Associated Meetings",
   description: "Retrieves meetings associated with a specific object (contact, company, or deal) with optional time filtering. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/associations/association-details#get-%2Fcrm%2Fv4%2Fobjects%2F%7Bobjecttype%7D%2F%7Bobjectid%7D%2Fassociations%2F%7Btoobjecttype%7D)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   props: {
     hubspot,

--- a/components/hubspot/actions/get-company/get-company.mjs
+++ b/components/hubspot/actions/get-company/get-company.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-get-company",
   name: "Get Company",
   description: "Gets a company. [See the documentation](https://developers.hubspot.com/docs/api/crm/companies#endpoint?spec=GET-/crm/v3/objects/companies/{companyId})",
-  version: "0.0.19",
+  version: "0.0.20",
   type: "action",
   props: {
     ...common.props,

--- a/components/hubspot/actions/get-contact/get-contact.mjs
+++ b/components/hubspot/actions/get-contact/get-contact.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-get-contact",
   name: "Get Contact",
   description: "Gets a contact. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts#endpoint?spec=GET-/crm/v3/objects/contacts/{contactId})",
-  version: "0.0.19",
+  version: "0.0.20",
   type: "action",
   props: {
     ...common.props,

--- a/components/hubspot/actions/get-deal/get-deal.mjs
+++ b/components/hubspot/actions/get-deal/get-deal.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-get-deal",
   name: "Get Deal",
   description: "Gets a deal. [See the documentation](https://developers.hubspot.com/docs/api/crm/deals#endpoint?spec=GET-/crm/v3/objects/deals/{dealId})",
-  version: "0.0.19",
+  version: "0.0.20",
   type: "action",
   props: {
     ...common.props,

--- a/components/hubspot/actions/get-file-public-url/get-file-public-url.mjs
+++ b/components/hubspot/actions/get-file-public-url/get-file-public-url.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-get-file-public-url",
   name: "Get File Public URL",
   description: "Get a publicly available URL for a file that was uploaded using a Hubspot form. [See the documentation](https://developers.hubspot.com/docs/api/files/files#endpoint?spec=GET-/files/v3/files/{fileId}/signed-url)",
-  version: "0.0.19",
+  version: "0.0.20",
   type: "action",
   props: {
     hubspot,

--- a/components/hubspot/actions/get-meeting/get-meeting.mjs
+++ b/components/hubspot/actions/get-meeting/get-meeting.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-get-meeting",
   name: "Get Meeting",
   description: "Retrieves a specific meeting by its ID. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/engagements/meetings#get-%2Fcrm%2Fv3%2Fobjects%2Fmeetings%2F%7Bmeetingid%7D)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   props: {
     ...common.props,

--- a/components/hubspot/actions/get-subscription-preferences/get-subscription-preferences.mjs
+++ b/components/hubspot/actions/get-subscription-preferences/get-subscription-preferences.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-get-subscription-preferences",
   name: "Get Subscription Preferences",
   description: "Retrieves the subscription preferences for a contact. [See the documentation](https://developers.hubspot.com/docs/reference/api/marketing/subscriptions#get-%2Fcommunication-preferences%2Fv4%2Fstatuses%2F%7Bsubscriberidstring%7D)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     hubspot,

--- a/components/hubspot/actions/list-blog-posts/list-blog-posts.mjs
+++ b/components/hubspot/actions/list-blog-posts/list-blog-posts.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-list-blog-posts",
   name: "List Blog Posts",
   description: "Retrieves a list of blog posts. [See the documentation](https://developers.hubspot.com/docs/reference/api/cms/blogs/blog-posts)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     hubspot,

--- a/components/hubspot/actions/list-campaigns/list-campaigns.mjs
+++ b/components/hubspot/actions/list-campaigns/list-campaigns.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-list-campaigns",
   name: "List Campaigns",
   description: "Retrieves a list of campaigns. [See the documentation](https://developers.hubspot.com/docs/reference/api/marketing/campaigns#get-%2Fmarketing%2Fv3%2Fcampaigns%2F)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     hubspot,

--- a/components/hubspot/actions/list-forms/list-forms.mjs
+++ b/components/hubspot/actions/list-forms/list-forms.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-list-forms",
   name: "List Forms",
   description: "Retrieves a list of forms. [See the documentation](https://developers.hubspot.com/docs/reference/api/marketing/forms#get-%2Fmarketing%2Fv3%2Fforms%2F)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     hubspot,

--- a/components/hubspot/actions/list-marketing-emails/list-marketing-emails.mjs
+++ b/components/hubspot/actions/list-marketing-emails/list-marketing-emails.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-list-marketing-emails",
   name: "List Marketing Emails",
   description: "Retrieves a list of marketing emails. [See the documentation](https://developers.hubspot.com/docs/reference/api/marketing/emails/marketing-emails#get-%2Fmarketing%2Fv3%2Femails%2F)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     hubspot,

--- a/components/hubspot/actions/list-marketing-events/list-marketing-events.mjs
+++ b/components/hubspot/actions/list-marketing-events/list-marketing-events.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-list-marketing-events",
   name: "List Marketing Events",
   description: "Retrieves a list of marketing events. [See the documentation](https://developers.hubspot.com/docs/reference/api/marketing/marketing-events#get-%2Fmarketing%2Fv3%2Fmarketing-events%2F)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     hubspot,

--- a/components/hubspot/actions/list-pages/list-pages.mjs
+++ b/components/hubspot/actions/list-pages/list-pages.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-list-pages",
   name: "List Pages",
   description: "Retrieves a list of site pages. [See the documentation](https://developers.hubspot.com/docs/reference/api/cms/pages)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     hubspot,

--- a/components/hubspot/actions/list-templates/list-templates.mjs
+++ b/components/hubspot/actions/list-templates/list-templates.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-list-templates",
   name: "List Templates",
   description: "Retrieves a list of templates. [See the documentation](https://developers.hubspot.com/docs/reference/api/cms/templates)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     hubspot,

--- a/components/hubspot/actions/search-crm/search-crm.mjs
+++ b/components/hubspot/actions/search-crm/search-crm.mjs
@@ -17,7 +17,7 @@ export default {
   key: "hubspot-search-crm",
   name: "Search CRM",
   description: "Search companies, contacts, deals, feedback submissions, products, tickets, line-items, quotes, leads, or custom objects. [See the documentation](https://developers.hubspot.com/docs/api/crm/search)",
-  version: "1.0.6",
+  version: "1.0.7",
   type: "action",
   props: {
     hubspot,

--- a/components/hubspot/actions/update-company/update-company.mjs
+++ b/components/hubspot/actions/update-company/update-company.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-update-company",
   name: "Update Company",
   description: "Update a company in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/companies)",
-  version: "0.0.19",
+  version: "0.0.20",
   type: "action",
   methods: {
     ...common.methods,

--- a/components/hubspot/actions/update-contact/update-contact.mjs
+++ b/components/hubspot/actions/update-contact/update-contact.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-update-contact",
   name: "Update Contact",
   description: "Update a contact in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts#endpoint?spec=POST-/crm/v3/objects/contacts)",
-  version: "0.0.20",
+  version: "0.0.21",
   type: "action",
   methods: {
     ...common.methods,

--- a/components/hubspot/actions/update-custom-object/update-custom-object.mjs
+++ b/components/hubspot/actions/update-custom-object/update-custom-object.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-update-custom-object",
   name: "Update Custom Object",
   description: "Update a custom object in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/custom-objects#update-existing-custom-objects)",
-  version: "1.0.5",
+  version: "1.0.6",
   type: "action",
   methods: {
     ...common.methods,

--- a/components/hubspot/actions/update-deal/update-deal.mjs
+++ b/components/hubspot/actions/update-deal/update-deal.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-update-deal",
   name: "Update Deal",
   description: "Update a deal in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/deals#update-deals)",
-  version: "0.0.10",
+  version: "0.0.11",
   type: "action",
   methods: {
     ...common.methods,

--- a/components/hubspot/actions/update-lead/update-lead.mjs
+++ b/components/hubspot/actions/update-lead/update-lead.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-update-lead",
   name: "Update Lead",
   description: "Update a lead in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/leads#update-leads)",
-  version: "0.0.11",
+  version: "0.0.12",
   type: "action",
   methods: {
     ...common.methods,

--- a/components/hubspot/hubspot.app.mjs
+++ b/components/hubspot/hubspot.app.mjs
@@ -15,7 +15,7 @@ import {
 } from "./common/constants.mjs";
 import Bottleneck from "bottleneck";
 const limiter = new Bottleneck({
-  minTime: 250, // 4 requests per second
+  minTime: 500, // 2 requests per second
   maxConcurrent: 1,
 });
 const axiosRateLimiter = limiter.wrap(axios);
@@ -694,15 +694,35 @@ export default {
         value: unit.id,
       })) || [];
     },
-    searchCRM({
+    async searchCRM({
       object, ...opts
     }) {
-      return this.makeRequest({
-        api: API_PATH.CRMV3,
-        method: "POST",
-        endpoint: `/objects/${object}/search`,
-        ...opts,
-      });
+      // Adding retry logic here since the search endpoint specifically has a per-second rate limit
+      const MAX_RETRIES = 5;
+      const BASE_RETRY_DELAY = 500;
+      let success = false;
+      let retries = 0;
+      while (!success) {
+        try {
+          const response = await this.makeRequest({
+            api: API_PATH.CRMV3,
+            method: "POST",
+            endpoint: `/objects/${object}/search`,
+            ...opts,
+          });
+          return response;
+        } catch (error) {
+          if (error.status === 429 && ++retries < MAX_RETRIES) {
+            // Retry delays basically amount to:
+            // 1000-1500 ms, 2000-2500 ms, 4000-4500 ms, 8000-8500 ms
+            const randomDelay = Math.floor(Math.random() * BASE_RETRY_DELAY);
+            const delay = BASE_RETRY_DELAY * (2 ** retries) + randomDelay;
+            await new Promise((resolve) => setTimeout(resolve, delay));
+          } else {
+            throw error;
+          }
+        }
+      }
     },
     getBlogPosts(opts = {}) {
       return this.makeRequest({

--- a/components/hubspot/package.json
+++ b/components/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/hubspot",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Pipedream Hubspot Components",
   "main": "hubspot.app.mjs",
   "keywords": [

--- a/components/hubspot/sources/delete-blog-article/delete-blog-article.mjs
+++ b/components/hubspot/sources/delete-blog-article/delete-blog-article.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-delete-blog-article",
   name: "Deleted Blog Posts",
   description: "Emit new event for each deleted blog post.",
-  version: "0.0.25",
+  version: "0.0.26",
   dedupe: "unique",
   type: "source",
   methods: {

--- a/components/hubspot/sources/new-company-property-change/new-company-property-change.mjs
+++ b/components/hubspot/sources/new-company-property-change/new-company-property-change.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-new-company-property-change",
   name: "New Company Property Change",
   description: "Emit new event when a specified property is provided or updated on a company. [See the documentation](https://developers.hubspot.com/docs/api/crm/companies)",
-  version: "0.0.18",
+  version: "0.0.19",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-contact-property-change/new-contact-property-change.mjs
+++ b/components/hubspot/sources/new-contact-property-change/new-contact-property-change.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-new-contact-property-change",
   name: "New Contact Property Change",
   description: "Emit new event when a specified property is provided or updated on a contact. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts)",
-  version: "0.0.20",
+  version: "0.0.21",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-custom-object-property-change/new-custom-object-property-change.mjs
+++ b/components/hubspot/sources/new-custom-object-property-change/new-custom-object-property-change.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-new-custom-object-property-change",
   name: "New Custom Object Property Change",
   description: "Emit new event when a specified property is provided or updated on a custom object.",
-  version: "0.0.10",
+  version: "0.0.11",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-deal-in-stage/new-deal-in-stage.mjs
+++ b/components/hubspot/sources/new-deal-in-stage/new-deal-in-stage.mjs
@@ -9,7 +9,7 @@ export default {
   key: "hubspot-new-deal-in-stage",
   name: "New Deal In Stage",
   description: "Emit new event for each new deal in a stage.",
-  version: "0.0.31",
+  version: "0.0.32",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-deal-property-change/new-deal-property-change.mjs
+++ b/components/hubspot/sources/new-deal-property-change/new-deal-property-change.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-new-deal-property-change",
   name: "New Deal Property Change",
   description: "Emit new event when a specified property is provided or updated on a deal. [See the documentation](https://developers.hubspot.com/docs/api/crm/deals)",
-  version: "0.0.19",
+  version: "0.0.20",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-email-event/new-email-event.mjs
+++ b/components/hubspot/sources/new-email-event/new-email-event.mjs
@@ -8,7 +8,7 @@ export default {
   key: "hubspot-new-email-event",
   name: "New Email Event",
   description: "Emit new event for each new Hubspot email event.",
-  version: "0.0.28",
+  version: "0.0.29",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-email-subscriptions-timeline/new-email-subscriptions-timeline.mjs
+++ b/components/hubspot/sources/new-email-subscriptions-timeline/new-email-subscriptions-timeline.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-new-email-subscriptions-timeline",
   name: "New Email Subscriptions Timeline",
   description: "Emit new event when a new email timeline subscription is added for the portal.",
-  version: "0.0.25",
+  version: "0.0.26",
   dedupe: "unique",
   type: "source",
   methods: {

--- a/components/hubspot/sources/new-engagement/new-engagement.mjs
+++ b/components/hubspot/sources/new-engagement/new-engagement.mjs
@@ -8,7 +8,7 @@ export default {
   key: "hubspot-new-engagement",
   name: "New Engagement",
   description: "Emit new event for each new engagement created. This action returns a maximum of 5000 records at a time, make sure you set a correct time range so you don't miss any events",
-  version: "0.0.30",
+  version: "0.0.31",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-event/new-event.mjs
+++ b/components/hubspot/sources/new-event/new-event.mjs
@@ -8,7 +8,7 @@ export default {
   key: "hubspot-new-event",
   name: "New Events",
   description: "Emit new event for each new Hubspot event. Note: Only available for Marketing Hub Enterprise, Sales Hub Enterprise, Service Hub Enterprise, or CMS Hub Enterprise accounts",
-  version: "0.0.29",
+  version: "0.0.30",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-form-submission/new-form-submission.mjs
+++ b/components/hubspot/sources/new-form-submission/new-form-submission.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-new-form-submission",
   name: "New Form Submission",
   description: "Emit new event for each new submission of a form.",
-  version: "0.0.30",
+  version: "0.0.31",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-note/new-note.mjs
+++ b/components/hubspot/sources/new-note/new-note.mjs
@@ -8,7 +8,7 @@ export default {
   key: "hubspot-new-note",
   name: "New Note Created",
   description: "Emit new event for each new note created. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/engagements/notes#get-%2Fcrm%2Fv3%2Fobjects%2Fnotes)",
-  version: "1.0.6",
+  version: "1.0.7",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/hubspot/sources/new-or-updated-blog-article/new-or-updated-blog-article.mjs
+++ b/components/hubspot/sources/new-or-updated-blog-article/new-or-updated-blog-article.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-new-or-updated-blog-article",
   name: "New or Updated Blog Post",
   description: "Emit new event for each new or updated blog post in Hubspot.",
-  version: "0.0.12",
+  version: "0.0.13",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-company/new-or-updated-company.mjs
+++ b/components/hubspot/sources/new-or-updated-company/new-or-updated-company.mjs
@@ -9,7 +9,7 @@ export default {
   key: "hubspot-new-or-updated-company",
   name: "New or Updated Company",
   description: "Emit new event for each new or updated company in Hubspot.",
-  version: "0.0.12",
+  version: "0.0.13",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-contact/new-or-updated-contact.mjs
+++ b/components/hubspot/sources/new-or-updated-contact/new-or-updated-contact.mjs
@@ -9,7 +9,7 @@ export default {
   key: "hubspot-new-or-updated-contact",
   name: "New or Updated Contact",
   description: "Emit new event for each new or updated contact in Hubspot.",
-  version: "0.0.12",
+  version: "0.0.13",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-crm-object/new-or-updated-crm-object.mjs
+++ b/components/hubspot/sources/new-or-updated-crm-object/new-or-updated-crm-object.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-new-or-updated-crm-object",
   name: "New or Updated CRM Object",
   description: "Emit new event each time a CRM Object of the specified object type is updated.",
-  version: "0.0.25",
+  version: "0.0.26",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-custom-object/new-or-updated-custom-object.mjs
+++ b/components/hubspot/sources/new-or-updated-custom-object/new-or-updated-custom-object.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-new-or-updated-custom-object",
   name: "New or Updated Custom Object",
   description: "Emit new event each time a Custom Object of the specified schema is updated.",
-  version: "0.0.14",
+  version: "0.0.15",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-deal/new-or-updated-deal.mjs
+++ b/components/hubspot/sources/new-or-updated-deal/new-or-updated-deal.mjs
@@ -9,7 +9,7 @@ export default {
   key: "hubspot-new-or-updated-deal",
   name: "New or Updated Deal",
   description: "Emit new event for each new or updated deal in Hubspot",
-  version: "0.0.12",
+  version: "0.0.13",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-line-item/new-or-updated-line-item.mjs
+++ b/components/hubspot/sources/new-or-updated-line-item/new-or-updated-line-item.mjs
@@ -9,7 +9,7 @@ export default {
   key: "hubspot-new-or-updated-line-item",
   name: "New or Updated Line Item",
   description: "Emit new event for each new line item added or updated in Hubspot.",
-  version: "0.0.12",
+  version: "0.0.13",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-product/new-or-updated-product.mjs
+++ b/components/hubspot/sources/new-or-updated-product/new-or-updated-product.mjs
@@ -9,7 +9,7 @@ export default {
   key: "hubspot-new-or-updated-product",
   name: "New or Updated Product",
   description: "Emit new event for each new or updated product in Hubspot.",
-  version: "0.0.12",
+  version: "0.0.13",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-social-media-message/new-social-media-message.mjs
+++ b/components/hubspot/sources/new-social-media-message/new-social-media-message.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-new-social-media-message",
   name: "New Social Media Message",
   description: "Emit new event when a message is posted from HubSpot to the specified social media channel. Note: Only available for Marketing Hub Enterprise accounts",
-  version: "0.0.25",
+  version: "0.0.26",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/hubspot/sources/new-task/new-task.mjs
+++ b/components/hubspot/sources/new-task/new-task.mjs
@@ -8,7 +8,7 @@ export default {
   key: "hubspot-new-task",
   name: "New Task Created",
   description: "Emit new event for each new task created. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/engagements/tasks#get-%2Fcrm%2Fv3%2Fobjects%2Ftasks)",
-  version: "1.0.6",
+  version: "1.0.7",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/hubspot/sources/new-ticket-property-change/new-ticket-property-change.mjs
+++ b/components/hubspot/sources/new-ticket-property-change/new-ticket-property-change.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-new-ticket-property-change",
   name: "New Ticket Property Change",
   description: "Emit new event when a specified property is provided or updated on a ticket. [See the documentation](https://developers.hubspot.com/docs/api/crm/tickets)",
-  version: "0.0.19",
+  version: "0.0.20",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-ticket/new-ticket.mjs
+++ b/components/hubspot/sources/new-ticket/new-ticket.mjs
@@ -9,7 +9,7 @@ export default {
   key: "hubspot-new-ticket",
   name: "New Ticket",
   description: "Emit new event for each new ticket created.",
-  version: "0.0.25",
+  version: "0.0.26",
   dedupe: "unique",
   type: "source",
   props: {


### PR DESCRIPTION
The issue is the limit of 5 requests per second for the search endpoint specifically. We theoretically already enforce this per component, but each user can be running multiple components simultaneously (many HubSpot actions and sources need to use the search endpoint).

On top of reducing the max requests per second per component from 4 to 2, I'm implementing retrying up to 5 times on a 429 response (specifically for the search endpoint). I've added a bit of exponential backoff, but total delay between requests only goes up to 17 seconds to avoid component runs taking too long.