### PR TITLE
[FIX] Airtable webhook sources intermittently emit the raw Airtable payload

### DIFF
--- a/components/airtable_oauth/package.json
+++ b/components/airtable_oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/airtable_oauth",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Pipedream Airtable (OAuth) Components",
   "main": "airtable_oauth.app.mjs",
   "keywords": [
@@ -15,7 +15,9 @@
   "dependencies": {
     "@pipedream/platform": "^3.0.3",
     "airtable": "^0.11.1",
+    "async-retry": "^1.3.3",
     "bottleneck": "^2.19.5",
+    "crypto": "^1.0.1",
     "lodash.chunk": "^4.2.0",
     "lodash.isempty": "^4.4.0",
     "moment": "^2.30.1"

--- a/components/airtable_oauth/sources/common/common-webhook-field.mjs
+++ b/components/airtable_oauth/sources/common/common-webhook-field.mjs
@@ -38,11 +38,6 @@ export default {
         fieldUpdateInfo,
       ] = Object.entries(fieldObj)[0];
 
-      const timestamp = Date.parse(payload.timestamp);
-      if (this.isDuplicateEvent(fieldId, timestamp)) return;
-      this._setLastObjectId(fieldId);
-      this._setLastTimestamp(timestamp);
-
       const updateType = operation === "createdFieldsById"
         ? "created"
         : "updated";

--- a/components/airtable_oauth/sources/new-field/new-field.mjs
+++ b/components/airtable_oauth/sources/new-field/new-field.mjs
@@ -5,11 +5,14 @@ export default {
   name: "New Field Created (Instant)",
   description: "Emit new event when a field is created in the selected table. [See the documentation](https://airtable.com/developers/web/api/get-base-schema)",
   key: "airtable_oauth-new-field",
-  version: "1.0.3",
+  version: "1.0.4",
   type: "source",
   dedupe: "unique",
   methods: {
     ...common.methods,
+    payloadFilter(payload) {
+      return !!payload.changedTablesById;
+    },
     getChangeTypes() {
       return [
         "add",

--- a/components/airtable_oauth/sources/new-modified-or-deleted-records-instant/new-modified-or-deleted-records-instant.mjs
+++ b/components/airtable_oauth/sources/new-modified-or-deleted-records-instant/new-modified-or-deleted-records-instant.mjs
@@ -1,14 +1,13 @@
 import common from "../common/common-webhook-record.mjs";
 import constants from "../common/constants.mjs";
 import sampleEmit from "./test-event.mjs";
-import airtable from "../../airtable_oauth.app.mjs";
 
 export default {
   ...common,
   name: "New Record Created, Updated or Deleted (Instant)",
   description: "Emit new event when a record is added, updated, or deleted in a table or selected view.",
   key: "airtable_oauth-new-modified-or-deleted-records-instant",
-  version: "0.1.3",
+  version: "0.1.4",
   type: "source",
   dedupe: "unique",
   props: {
@@ -27,7 +26,7 @@ export default {
     },
     watchDataInFieldIds: {
       propDefinition: [
-        airtable,
+        common.props.airtable,
         "sortFieldId",
         (c) => ({
           baseId: c.baseId,
@@ -42,6 +41,9 @@ export default {
   },
   methods: {
     ...common.methods,
+    payloadFilter(payload) {
+      return !!payload.changedTablesById;
+    },
     getDataTypes() {
       return [
         "tableData",

--- a/components/airtable_oauth/sources/new-or-modified-field/new-or-modified-field.mjs
+++ b/components/airtable_oauth/sources/new-or-modified-field/new-or-modified-field.mjs
@@ -6,11 +6,14 @@ export default {
   name: "New or Modified Field (Instant)",
   description: "Emit new event when a field is created or updated in the selected table",
   key: "airtable_oauth-new-or-modified-field",
-  version: "1.0.3",
+  version: "1.0.4",
   type: "source",
   dedupe: "unique",
   methods: {
     ...common.methods,
+    payloadFilter(payload) {
+      return !!payload.changedTablesById;
+    },
     getChangeTypes() {
       return [
         "add",

--- a/components/airtable_oauth/sources/new-or-modified-records/new-or-modified-records.mjs
+++ b/components/airtable_oauth/sources/new-or-modified-records/new-or-modified-records.mjs
@@ -1,16 +1,18 @@
 import common from "../common/common-webhook-record.mjs";
-import airtable from "../../airtable_oauth.app.mjs";
 
 export default {
   ...common,
   name: "New or Modified Records (Instant)",
   key: "airtable_oauth-new-or-modified-records",
   description: "Emit new event for each new or modified record in a table or view",
-  version: "1.0.3",
+  version: "1.0.4",
   type: "source",
   dedupe: "unique",
   methods: {
     ...common.methods,
+    payloadFilter(payload) {
+      return !!payload.changedTablesById;
+    },
     getChangeTypes() {
       return [
         "add",
@@ -22,7 +24,7 @@ export default {
     ...common.props,
     watchDataInFieldIds: {
       propDefinition: [
-        airtable,
+        common.props.airtable,
         "sortFieldId",
         (c) => ({
           baseId: c.baseId,

--- a/components/airtable_oauth/sources/new-records/new-records.mjs
+++ b/components/airtable_oauth/sources/new-records/new-records.mjs
@@ -5,11 +5,14 @@ export default {
   name: "New Record(s) Created (Instant)",
   description: "Emit new event for each new record in a table",
   key: "airtable_oauth-new-records",
-  version: "1.0.3",
+  version: "1.0.4",
   type: "source",
   dedupe: "unique",
   methods: {
     ...common.methods,
+    payloadFilter(payload) {
+      return !!payload.changedTablesById;
+    },
     getChangeTypes() {
       return [
         "add",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -606,9 +606,15 @@ importers:
       airtable:
         specifier: ^0.11.1
         version: 0.11.6
+      async-retry:
+        specifier: ^1.3.3
+        version: 1.3.3
       bottleneck:
         specifier: ^2.19.5
         version: 2.19.5
+      crypto:
+        specifier: ^1.0.1
+        version: 1.0.1
       lodash.chunk:
         specifier: ^4.2.0
         version: 4.2.0


### PR DESCRIPTION
## WHY

Resolves 18220


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Webhook requests now verified with HMAC signatures.
  - Record fetches automatically retried for improved reliability.
  - Added payload filtering to process only relevant Airtable webhook events.
- Bug Fixes
  - Reduced duplicate events via cursor-based processing.
- Refactor
  - Shifted from timestamp/object ID tracking to cursor-based flow.
  - Adjusted default event payload to wrap the original payload.
- Chores
  - Bumped versions of multiple sources.
  - Added dependencies for retry and crypto utilities.
  - Aligned prop definitions to shared properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->