### PR TITLE
added 'paptrading' header to support demo_environment custom field

### DIFF
--- a/components/bitget/bitget.app.mjs
+++ b/components/bitget/bitget.app.mjs
@@ -365,8 +365,9 @@ export default {
         secret_key: secretKey,
         api_key: apiKey,
         secret_passphrase: secretPassphrase,
+        demo_environment: demoEnvironment
       } = this.$auth;
-
+      
       const timestamp = Date.now();
 
       const message = this.preHash({
@@ -376,14 +377,16 @@ export default {
       console.log("message!!!", message);
 
       const signature = this.sign(message, secretKey);
+      const paptrading = demoEnvironment ? "1" : "0"; 
 
       return {
         "ACCESS-KEY": apiKey,
         "ACCESS-PASSPHRASE": secretPassphrase,
         "ACCESS-TIMESTAMP": timestamp,
         "ACCESS-SIGN": signature,
+				paptrading,        
         "locale": "en-US",
-        "Content-Type": "application/json",
+        "Content-Type": "application/json",          
       };
     },
     makeRequest({


### PR DESCRIPTION
Modified `getHeaders` in `bitget.app.mjs `to support demo/live environments for Bitget API access. Leverages `demo_environment` from app auth custom fields