### PR TITLE
Notion api key client version

### DIFF
--- a/components/notion_api_key/actions/append-block/append-block.mjs
+++ b/components/notion_api_key/actions/append-block/append-block.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-append-block",
-  version: "0.0.1",
+  version: "0.0.2",
   name,
   description,
   type,

--- a/components/notion_api_key/actions/create-comment/create-comment.mjs
+++ b/components/notion_api_key/actions/create-comment/create-comment.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-create-comment",
-  version: "0.0.1",
+  version: "0.0.2",
   name,
   description,
   type,

--- a/components/notion_api_key/actions/create-page-from-database/create-page-from-database.mjs
+++ b/components/notion_api_key/actions/create-page-from-database/create-page-from-database.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-create-page-from-database",
-  version: "0.0.1",
+  version: "0.0.2",
   name,
   description,
   type,

--- a/components/notion_api_key/actions/create-page/create-page.mjs
+++ b/components/notion_api_key/actions/create-page/create-page.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-create-page",
-  version: "0.0.1",
+  version: "0.0.2",
   name,
   description,
   type,

--- a/components/notion_api_key/actions/duplicate-page/duplicate-page.mjs
+++ b/components/notion_api_key/actions/duplicate-page/duplicate-page.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-duplicate-page",
-  version: "0.0.1",
+  version: "0.0.2",
   name,
   description,
   type,

--- a/components/notion_api_key/actions/query-database/query-database.mjs
+++ b/components/notion_api_key/actions/query-database/query-database.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-query-database",
-  version: "0.0.1",
+  version: "0.0.2",
   name,
   description,
   type,

--- a/components/notion_api_key/actions/retrieve-block/retrieve-block.mjs
+++ b/components/notion_api_key/actions/retrieve-block/retrieve-block.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-retrieve-block",
-  version: "0.0.1",
+  version: "0.0.2",
   name,
   description,
   type,

--- a/components/notion_api_key/actions/retrieve-database-content/retrieve-database-content.mjs
+++ b/components/notion_api_key/actions/retrieve-database-content/retrieve-database-content.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-retrieve-database-content",
-  version: "0.0.1",
+  version: "0.0.2",
   name,
   description,
   type,

--- a/components/notion_api_key/actions/retrieve-database-schema/retrieve-database-schema.mjs
+++ b/components/notion_api_key/actions/retrieve-database-schema/retrieve-database-schema.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-retrieve-database-schema",
-  version: "0.0.1",
+  version: "0.0.2",
   name,
   description,
   type,

--- a/components/notion_api_key/actions/retrieve-page-property-item/retrieve-page-property-item.mjs
+++ b/components/notion_api_key/actions/retrieve-page-property-item/retrieve-page-property-item.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-retrieve-page-property-item",
-  version: "0.0.1",
+  version: "0.0.2",
   name,
   description,
   type,

--- a/components/notion_api_key/actions/retrieve-page/retrieve-page.mjs
+++ b/components/notion_api_key/actions/retrieve-page/retrieve-page.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-retrieve-page",
-  version: "0.0.1",
+  version: "0.0.2",
   name,
   description,
   type,

--- a/components/notion_api_key/actions/search/search.mjs
+++ b/components/notion_api_key/actions/search/search.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-search",
-  version: "0.0.1",
+  version: "0.0.2",
   name,
   description,
   type,

--- a/components/notion_api_key/actions/update-page/update-page.mjs
+++ b/components/notion_api_key/actions/update-page/update-page.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-update-page",
-  version: "0.0.1",
+  version: "0.0.2",
   name,
   description,
   type,

--- a/components/notion_api_key/package.json
+++ b/components/notion_api_key/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/notion_api_key",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Pipedream Notion (API Key) Components",
   "main": "notion_api_key.app.mjs",
   "keywords": [
@@ -13,7 +13,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@notionhq/client": "^2.3.0",
-    "@pipedream/notion": "^0.6.2"
+    "@notionhq/client": "4.0.2",
+    "@pipedream/notion": "^0.10.1"
   }
 }

--- a/components/notion_api_key/sources/new-comment-created/new-comment-created.mjs
+++ b/components/notion_api_key/sources/new-comment-created/new-comment-created.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-new-comment-created",
-  version: "0.0.1",
+  version: "0.0.2",
   name,
   description,
   type,

--- a/components/notion_api_key/sources/new-database/new-database.mjs
+++ b/components/notion_api_key/sources/new-database/new-database.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-new-database",
-  version: "0.0.1",
+  version: "0.0.2",
   name,
   description,
   type,

--- a/components/notion_api_key/sources/new-page/new-page.mjs
+++ b/components/notion_api_key/sources/new-page/new-page.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-new-page",
-  version: "0.0.1",
+  version: "0.0.2",
   name,
   description,
   type,

--- a/components/notion_api_key/sources/page-or-subpage-updated/page-or-subpage-updated.mjs
+++ b/components/notion_api_key/sources/page-or-subpage-updated/page-or-subpage-updated.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-page-or-subpage-updated",
-  version: "0.0.1",
+  version: "0.0.2",
   name,
   description,
   type,

--- a/components/notion_api_key/sources/updated-page-id/updated-page-id.mjs
+++ b/components/notion_api_key/sources/updated-page-id/updated-page-id.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-updated-page-id",
-  version: "0.0.1",
+  version: "0.0.2",
   name,
   description,
   type,

--- a/components/notion_api_key/sources/updated-page/updated-page.mjs
+++ b/components/notion_api_key/sources/updated-page/updated-page.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-updated-page",
-  version: "0.0.1",
+  version: "0.0.2",
   name,
   description,
   type,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9536,11 +9536,11 @@ importers:
   components/notion_api_key:
     dependencies:
       '@notionhq/client':
-        specifier: ^2.3.0
-        version: 2.3.0
+        specifier: 4.0.2
+        version: 4.0.2
       '@pipedream/notion':
-        specifier: ^0.6.2
-        version: 0.6.2
+        specifier: ^0.10.1
+        version: 0.10.1
 
   components/nozbe_teams: {}
 
@@ -19709,10 +19709,6 @@ packages:
     resolution: {integrity: sha512-m7zZ5l3RUktayf1lRBV1XMb8HSKsmWTv/LZPqP7UGC1NMzOlc+bbTOPNQ4CP/c1P4cP61VWLb/zBq7a3c0nMaw==}
     engines: {node: '>=12'}
 
-  '@notionhq/client@2.3.0':
-    resolution: {integrity: sha512-l7WqTCpQqC+HibkB9chghONQTYcxNQT0/rOJemBfmuKQRTu2vuV8B3yA395iKaUdDo7HI+0KvQaz9687Xskzkw==}
-    engines: {node: '>=12'}
-
   '@notionhq/client@4.0.2':
     resolution: {integrity: sha512-4pk3dm4umhjsRI0umCnJ8lCZh0TMiaMdkY0rz6FV4OqVuTsmYFV3pk+YTR5S8792ZY2Rm4lJHlLj05HQVKDuIg==}
     engines: {node: '>=18'}
@@ -20068,8 +20064,8 @@ packages:
   '@pipedream/notiff_io@0.1.0':
     resolution: {integrity: sha512-jgt5JJGxI9SM6chDeQpxbaS/NSuUUxhe/PeAXRdZKx28Gp0QCxW7egIImC3pqQ9aMSubaeygRyR0ELhKhmbtPg==}
 
-  '@pipedream/notion@0.6.2':
-    resolution: {integrity: sha512-xA2oh2eVwUrQ/pvAAtlLjWaWJsYaDhNQ00W3xkv5RcAMYKA0EbUQzSjL6ljSWlWiye3CftoFxK/L56Mld38iOQ==}
+  '@pipedream/notion@0.10.1':
+    resolution: {integrity: sha512-3P3zvFMIHur5BaoFAkAo3t5hPoblDNxYrSWw1UdicTGtWMne43Oo9+qOm7NAeQDEN5I1sHDLprKv2aMM2beB7w==}
 
   '@pipedream/platform@0.10.0':
     resolution: {integrity: sha512-N3F/xVfBZQXc9wl+2/4E8U9Zma1rxpvylK6Gtw8Ofmiwjnmnvs+2SNjEpIXBPUeL+wxEkofSGOq7bkqt1hqwDg==}
@@ -37495,13 +37491,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@notionhq/client@2.3.0':
-    dependencies:
-      '@types/node-fetch': 2.6.12
-      node-fetch: 2.7.0
-    transitivePeerDependencies:
-      - encoding
-
   '@notionhq/client@4.0.2': {}
 
   '@octokit/auth-token@2.5.0':
@@ -37984,9 +37973,9 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@pipedream/notion@0.6.2':
+  '@pipedream/notion@0.10.1':
     dependencies:
-      '@notionhq/client': 2.3.0
+      '@notionhq/client': 4.0.2
       '@pipedream/platform': 3.1.0
       '@tryfabric/martian': 1.2.4
       lodash-es: 4.17.21


### PR DESCRIPTION
Follow-up to #18292 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated Notion client dependencies to newer versions for improved compatibility and stability.
  - Bumped patch versions across Notion actions: append block, create comment, create page (including from database), duplicate page, query database, retrieve block/database content/schema/page/page property, search, update page.
  - Bumped patch versions across Notion event sources: new comment, new database, new page, page or subpage updated, updated page, updated page ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->