### PR TITLE
[Component] Pipedrive - add note prop to add deal action

### DIFF
--- a/components/pipedrive/actions/add-activity/add-activity.mjs
+++ b/components/pipedrive/actions/add-activity/add-activity.mjs
@@ -7,7 +7,7 @@ export default {
   key: "pipedrive-add-activity",
   name: "Add Activity",
   description: "Adds a new activity. Includes `more_activities_scheduled_in_context` property in response's `additional_data` which indicates whether there are more undone activities scheduled with the same deal, person or organization (depending on the supplied data). See the Pipedrive API docs for Activities [here](https://developers.pipedrive.com/docs/api/v1/#!/Activities). For info on [adding an activity in Pipedrive](https://developers.pipedrive.com/docs/api/v1/Activities#addActivity)",
-  version: "0.1.13",
+  version: "0.1.14",
   type: "action",
   props: {
     pipedriveApp,

--- a/components/pipedrive/actions/add-deal/add-deal.mjs
+++ b/components/pipedrive/actions/add-deal/add-deal.mjs
@@ -1,110 +1,212 @@
 import { ConfigurationError } from "@pipedream/platform";
-import pipedriveApp from "../../pipedrive.app.mjs";
+import app from "../../pipedrive.app.mjs";
+import { parseObject } from "../../common/utils.mjs";
 
 export default {
   key: "pipedrive-add-deal",
   name: "Add Deal",
   description: "Adds a new deal. See the Pipedrive API docs for Deals [here](https://developers.pipedrive.com/docs/api/v1/Deals#addDeal)",
-  version: "0.1.13",
+  version: "0.1.14",
   type: "action",
   props: {
-    pipedriveApp,
+    app,
     title: {
       propDefinition: [
-        pipedriveApp,
+        app,
         "dealTitle",
       ],
     },
     ownerId: {
       propDefinition: [
-        pipedriveApp,
+        app,
         "userId",
       ],
     },
     personId: {
       propDefinition: [
-        pipedriveApp,
+        app,
         "personId",
       ],
     },
     orgId: {
       propDefinition: [
-        pipedriveApp,
+        app,
         "organizationId",
       ],
     },
     pipelineId: {
       propDefinition: [
-        pipedriveApp,
+        app,
         "pipelineId",
       ],
       optional: true,
     },
     stageId: {
       propDefinition: [
-        pipedriveApp,
+        app,
         "stageId",
       ],
     },
     value: {
       propDefinition: [
-        pipedriveApp,
+        app,
         "dealValue",
       ],
     },
     currency: {
       propDefinition: [
-        pipedriveApp,
+        app,
         "dealCurrency",
       ],
     },
     status: {
       propDefinition: [
-        pipedriveApp,
+        app,
         "status",
       ],
     },
     probability: {
       propDefinition: [
-        pipedriveApp,
+        app,
         "probability",
       ],
     },
     lostReason: {
       propDefinition: [
-        pipedriveApp,
+        app,
         "lostReason",
       ],
     },
     visibleTo: {
       propDefinition: [
-        pipedriveApp,
+        app,
         "visibleTo",
       ],
     },
+    isDeleted: {
+      propDefinition: [
+        app,
+        "isDeleted",
+      ],
+    },
+    isArchived: {
+      propDefinition: [
+        app,
+        "isArchived",
+      ],
+    },
+    archiveTime: {
+      propDefinition: [
+        app,
+        "archiveTime",
+      ],
+    },
+    closeTime: {
+      propDefinition: [
+        app,
+        "closeTime",
+      ],
+    },
+    wonTime: {
+      propDefinition: [
+        app,
+        "wonTime",
+      ],
+    },
+    lostTime: {
+      propDefinition: [
+        app,
+        "lostTime",
+      ],
+    },
+    expectedCloseDate: {
+      propDefinition: [
+        app,
+        "expectedCloseDate",
+      ],
+    },
+    labelIds: {
+      propDefinition: [
+        app,
+        "labelIds",
+      ],
+    },
+    customFields: {
+      propDefinition: [
+        app,
+        "customFields",
+      ],
+    },
+    note: {
+      type: "string",
+      label: "Note",
+      description: "The content of a note to be attached to the deal. The note will be created after the deal is successfully added.",
+      optional: true,
+    },
   },
   async run({ $ }) {
+    const {
+      app,
+      title,
+      ownerId,
+      personId,
+      orgId,
+      pipelineId,
+      stageId,
+      value,
+      currency,
+      status,
+      probability,
+      lostReason,
+      visibleTo,
+      isDeleted,
+      isArchived,
+      archiveTime,
+      closeTime,
+      wonTime,
+      lostTime,
+      expectedCloseDate,
+      labelIds,
+      customFields,
+      note,
+    } = this;
+
     try {
-      const resp =
-        await this.pipedriveApp.addDeal({
-          title: this.title,
-          owner_id: this.ownerId,
-          person_id: this.personId,
-          org_id: this.orgId,
-          pipeline_id: this.pipelineId,
-          stage_id: this.stageId,
-          value: this.value,
-          currency: this.currency,
-          status: this.status,
-          probability: this.probability,
-          lost_reason: this.lostReason,
-          visible_to: this.visibleTo,
+      const resp = await app.addDeal({
+        title,
+        owner_id: ownerId,
+        person_id: personId,
+        org_id: orgId,
+        pipeline_id: pipelineId,
+        stage_id: stageId,
+        value,
+        currency,
+        status,
+        probability,
+        lost_reason: lostReason,
+        visible_to: visibleTo,
+        is_deleted: isDeleted,
+        is_archived: isArchived,
+        archive_time: archiveTime,
+        close_time: closeTime,
+        won_time: wonTime,
+        lost_time: lostTime,
+        expected_close_date: expectedCloseDate,
+        label_ids: parseObject(labelIds),
+        custom_fields: parseObject(customFields),
+      });
+
+      if (note) {
+        await app.addNote({
+          content: note,
+          deal_id: resp.data?.id,
         });
+      }
 
       $.export("$summary", "Successfully added deal");
 
       return resp;
-    }  catch ({ error }) {
+    } catch ({ error }) {
       throw new ConfigurationError(error);
     }
   },

--- a/components/pipedrive/actions/add-lead/add-lead.mjs
+++ b/components/pipedrive/actions/add-lead/add-lead.mjs
@@ -6,7 +6,7 @@ export default {
   key: "pipedrive-add-lead",
   name: "Add Lead",
   description: "Create a new lead in Pipedrive. [See the documentation](https://developers.pipedrive.com/docs/api/v1/Leads#addLead)",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   props: {
     pipedrive,

--- a/components/pipedrive/actions/add-note/add-note.mjs
+++ b/components/pipedrive/actions/add-note/add-note.mjs
@@ -5,7 +5,7 @@ export default {
   key: "pipedrive-add-note",
   name: "Add Note",
   description: "Adds a new note. For info on [adding an note in Pipedrive](https://developers.pipedrive.com/docs/api/v1/Notes#addNote)",
-  version: "0.0.11",
+  version: "0.0.12",
   type: "action",
   props: {
     pipedriveApp,

--- a/components/pipedrive/actions/add-organization/add-organization.mjs
+++ b/components/pipedrive/actions/add-organization/add-organization.mjs
@@ -5,7 +5,7 @@ export default {
   key: "pipedrive-add-organization",
   name: "Add Organization",
   description: "Adds a new organization. See the Pipedrive API docs for Organizations [here](https://developers.pipedrive.com/docs/api/v1/Organizations#addOrganization)",
-  version: "0.1.13",
+  version: "0.1.14",
   type: "action",
   props: {
     pipedriveApp,

--- a/components/pipedrive/actions/add-person/add-person.mjs
+++ b/components/pipedrive/actions/add-person/add-person.mjs
@@ -6,7 +6,7 @@ export default {
   key: "pipedrive-add-person",
   name: "Add Person",
   description: "Adds a new person. See the Pipedrive API docs for People [here](https://developers.pipedrive.com/docs/api/v1/Persons#addPerson)",
-  version: "0.1.13",
+  version: "0.1.14",
   type: "action",
   props: {
     pipedriveApp,

--- a/components/pipedrive/actions/get-lead-by-id/get-lead-by-id.mjs
+++ b/components/pipedrive/actions/get-lead-by-id/get-lead-by-id.mjs
@@ -4,7 +4,7 @@ export default {
   key: "pipedrive-get-lead-by-id",
   name: "Get Lead by ID",
   description: "Get a lead by its ID. [See the documentation](https://developers.pipedrive.com/docs/api/v1/Leads#getLead)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     pipedriveApp,

--- a/components/pipedrive/actions/get-person-details/get-person-details.mjs
+++ b/components/pipedrive/actions/get-person-details/get-person-details.mjs
@@ -5,7 +5,7 @@ export default {
   key: "pipedrive-get-person-details",
   name: "Get person details",
   description: "Get details of a person by their ID. [See the documentation](https://developers.pipedrive.com/docs/api/v1/Persons#getPerson)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     pipedriveApp,

--- a/components/pipedrive/actions/merge-deals/merge-deals.mjs
+++ b/components/pipedrive/actions/merge-deals/merge-deals.mjs
@@ -4,7 +4,7 @@ export default {
   key: "pipedrive-merge-deals",
   name: "Merge Deals",
   description: "Merge two deals in Pipedrive. [See the documentation](https://developers.pipedrive.com/docs/api/v1/Deals#mergeDeals)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     pipedriveApp,

--- a/components/pipedrive/actions/merge-persons/merge-persons.mjs
+++ b/components/pipedrive/actions/merge-persons/merge-persons.mjs
@@ -4,7 +4,7 @@ export default {
   key: "pipedrive-merge-persons",
   name: "Merge Persons",
   description: "Merge two persons in Pipedrive. [See the documentation](https://developers.pipedrive.com/docs/api/v1/Persons#mergePersons)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     pipedriveApp,

--- a/components/pipedrive/actions/remove-duplicate-notes/remove-duplicate-notes.mjs
+++ b/components/pipedrive/actions/remove-duplicate-notes/remove-duplicate-notes.mjs
@@ -5,7 +5,7 @@ export default {
   key: "pipedrive-remove-duplicate-notes",
   name: "Remove Duplicate Notes",
   description: "Remove duplicate notes from an object in Pipedrive. See the documentation for [getting notes](https://developers.pipedrive.com/docs/api/v1/Notes#getNotes) and [deleting notes](https://developers.pipedrive.com/docs/api/v1/Notes#deleteNote)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   props: {
     pipedriveApp,

--- a/components/pipedrive/actions/search-leads/search-leads.mjs
+++ b/components/pipedrive/actions/search-leads/search-leads.mjs
@@ -5,7 +5,7 @@ export default {
   key: "pipedrive-search-leads",
   name: "Search Leads",
   description: "Search for leads by name or email. [See the documentation](https://developers.pipedrive.com/docs/api/v1/Leads#searchLeads)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   props: {
     pipedriveApp,

--- a/components/pipedrive/actions/search-notes/search-notes.mjs
+++ b/components/pipedrive/actions/search-notes/search-notes.mjs
@@ -4,7 +4,7 @@ export default {
   key: "pipedrive-search-notes",
   name: "Search Notes",
   description: "Search for notes in Pipedrive. [See the documentation](https://developers.pipedrive.com/docs/api/v1/Notes#getNotes)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   props: {
     pipedriveApp,

--- a/components/pipedrive/actions/search-persons/search-persons.mjs
+++ b/components/pipedrive/actions/search-persons/search-persons.mjs
@@ -7,7 +7,7 @@ export default {
   key: "pipedrive-search-persons",
   name: "Search persons",
   description: "Searches all Persons by `name`, `email`, `phone`, `notes` and/or custom fields. This endpoint is a wrapper of `/v1/itemSearch` with a narrower OAuth scope. Found Persons can be filtered by Organization ID. See the Pipedrive API docs [here](https://developers.pipedrive.com/docs/api/v1/Persons#searchPersons)",
-  version: "0.1.13",
+  version: "0.1.14",
   type: "action",
   props: {
     pipedriveApp,

--- a/components/pipedrive/actions/update-deal/update-deal.mjs
+++ b/components/pipedrive/actions/update-deal/update-deal.mjs
@@ -5,7 +5,7 @@ export default {
   key: "pipedrive-update-deal",
   name: "Update Deal",
   description: "Updates the properties of a deal. See the Pipedrive API docs for Deals [here](https://developers.pipedrive.com/docs/api/v1/Deals#updateDeal)",
-  version: "0.1.15",
+  version: "0.1.16",
   type: "action",
   props: {
     pipedriveApp,

--- a/components/pipedrive/actions/update-person/update-person.mjs
+++ b/components/pipedrive/actions/update-person/update-person.mjs
@@ -6,7 +6,7 @@ export default {
   key: "pipedrive-update-person",
   name: "Update Person",
   description: "Updates an existing person in Pipedrive. [See the documentation](https://developers.pipedrive.com/docs/api/v1/Persons#updatePerson)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   props: {
     pipedriveApp,

--- a/components/pipedrive/package.json
+++ b/components/pipedrive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/pipedrive",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Pipedream Pipedrive Components",
   "main": "pipedrive.app.mjs",
   "keywords": [

--- a/components/pipedrive/pipedrive.app.mjs
+++ b/components/pipedrive/pipedrive.app.mjs
@@ -306,6 +306,70 @@ export default {
       description: "Phone numbers (one or more) associated with the person, presented in the same manner as received by GET request of a person. **Example: {\"value\":\"12345\", \"primary\":true, \"label\":\"work\"}**",
       optional: true,
     },
+    isDeleted: {
+      type: "boolean",
+      label: "Is Deleted",
+      description: "Whether the deal is deleted or not",
+      optional: true,
+    },
+    isArchived: {
+      type: "boolean",
+      label: "Is Archived",
+      description: "Whether the deal is archived or not",
+      optional: true,
+    },
+    archiveTime: {
+      type: "string",
+      label: "Archive Time",
+      description: "The optional date and time of archiving the deal in UTC. Format: `YYYY-MM-DD HH:MM:SS`. If omitted and **Is Archived** is `true`, it will be set to the current date and time.",
+      optional: true,
+    },
+    closeTime: {
+      type: "string",
+      label: "Close Time",
+      description: "The date and time of closing the deal. Can only be set if deal status is won or lost. Format: `YYYY-MM-DD HH:MM:SS`",
+      optional: true,
+    },
+    wonTime: {
+      type: "string",
+      label: "Won Time",
+      description: "The date and time of changing the deal status as won. Can only be set if deal status is won. Format: `YYYY-MM-DD HH:MM:SS`",
+      optional: true,
+    },
+    lostTime: {
+      type: "string",
+      label: "Lost Time",
+      description: "The date and time of changing the deal status as lost. Can only be set if deal status is lost. Format: `YYYY-MM-DD HH:MM:SS`",
+      optional: true,
+    },
+    expectedCloseDate: {
+      type: "string",
+      label: "Expected Close Date",
+      description: "The expected close date of the deal. Format: `YYYY-MM-DD`",
+      optional: true,
+    },
+    customFields: {
+      type: "object",
+      label: "Custom Fields",
+      description: "An object where each key represents a custom field. All custom fields are referenced as randomly generated 40-character hashes",
+      optional: true,
+    },
+    labelIds: {
+      type: "integer[]",
+      label: "Label IDs",
+      description: "The IDs of labels assigned to the deal",
+      optional: true,
+      async options() {
+        const { data } = await this.getDealCustomFields();
+        const labelField = data.find(({ key }) => key === "label");
+        return labelField?.options?.map(({
+          id: value, label,
+        }) => ({
+          label,
+          value,
+        })) || [];
+      },
+    },
   },
   methods: {
     api(model, version = "v1") {

--- a/components/pipedrive/sources/new-deal-instant/new-deal-instant.mjs
+++ b/components/pipedrive/sources/new-deal-instant/new-deal-instant.mjs
@@ -6,7 +6,7 @@ export default {
   key: "pipedrive-new-deal-instant",
   name: "New Deal (Instant)",
   description: "Emit new event when a new deal is created.",
-  version: "0.0.10",
+  version: "0.0.11",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/pipedrive/sources/new-event-instant/new-event-instant.mjs
+++ b/components/pipedrive/sources/new-event-instant/new-event-instant.mjs
@@ -5,7 +5,7 @@ export default {
   key: "pipedrive-new-event-instant",
   name: "New Event (Instant)",
   description: "Emit new event when a new webhook event is received. [See the documentation](https://developers.pipedrive.com/docs/api/v1/Webhooks#addWebhook)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/pipedrive/sources/new-person-instant/new-person-instant.mjs
+++ b/components/pipedrive/sources/new-person-instant/new-person-instant.mjs
@@ -6,7 +6,7 @@ export default {
   key: "pipedrive-new-person-instant",
   name: "New Person (Instant)",
   description: "Emit new event when a new person is created.",
-  version: "0.0.10",
+  version: "0.0.11",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/pipedrive/sources/updated-deal-instant/updated-deal-instant.mjs
+++ b/components/pipedrive/sources/updated-deal-instant/updated-deal-instant.mjs
@@ -7,7 +7,7 @@ export default {
   key: "pipedrive-updated-deal-instant",
   name: "Deal Updated (Instant)",
   description: "Emit new event when a deal is updated.",
-  version: "0.1.3",
+  version: "0.1.4",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/pipedrive/sources/updated-lead-instant/updated-lead-instant.mjs
+++ b/components/pipedrive/sources/updated-lead-instant/updated-lead-instant.mjs
@@ -7,7 +7,7 @@ export default {
   key: "pipedrive-updated-lead-instant",
   name: "Lead Updated (Instant)",
   description: "Emit new event when a lead is updated.",
-  version: "0.1.3",
+  version: "0.1.4",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/pipedrive/sources/updated-person-instant/updated-person-instant.mjs
+++ b/components/pipedrive/sources/updated-person-instant/updated-person-instant.mjs
@@ -7,7 +7,7 @@ export default {
   key: "pipedrive-updated-person-instant",
   name: "Person Updated (Instant)",
   description: "Emit new event when a person is updated.",
-  version: "0.1.3",
+  version: "0.1.4",
   type: "source",
   dedupe: "unique",
   methods: {


### PR DESCRIPTION
## WHY

Resolves #18235


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Add Deal now supports additional deal fields (status timestamps, expected close date, archived/deleted flags, labels, custom fields).
  - Optionally attach a note automatically to a newly created deal.
  - Improved label selection with dynamic options.

- Chores
  - Patch version updates across multiple Pipedrive actions and instant sources (e.g., Add Activity, Add Lead, Add Note, Add Organization, Add Person, Update Deal/Person, search/merge utilities, and event sources).
  - Package version bumped to 0.10.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->