### PR TITLE
Update get-weather-data.mjs to fix querying multiple dates

### DIFF
--- a/components/meteomatics_weather_api/actions/get-weather-data/get-weather-data.mjs
+++ b/components/meteomatics_weather_api/actions/get-weather-data/get-weather-data.mjs
@@ -36,7 +36,7 @@ export default {
   async run({ $ }) {
     const response = await this.app.getWeatherData({
       $,
-      validdatetime: this.validDateTime.join("--"),
+      validdatetime: this.validDateTime.join(","),
       parameters: this.parameters.join(","),
       locations: this.locations,
       format: this.format,


### PR DESCRIPTION
Dates can be described in multiple ways:
Single date:  YYYY-MM-DDTHHZ
Time Period fixed start/end:  YYYY-MM-DDTHHZ--YYYY-MM-DDTHHZ:<step>, where <step> is e.g. PT1H for hourly Time Period fixed start/length: YYYY-MM-DDTHHZP<period>:<step>, where <period> is e.g. P3D for three days.

Multiple dates: YYYY-MM-DDTHHZ,YYYY-MM-DDTHHZ,YYYY-MM-DDTHHZ (comma separated. As e.g. Claude tries to join multiple dates with '--' instead of ',' because of that description. This should fix the behavior to query multiple dates

## WHY

<!-- author to complete -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected date/time formatting in weather data requests to use the expected separator, improving compatibility with the weather API.
  * Resolves occasional failures or incomplete results when querying specific date ranges, ensuring accurate and consistent data retrieval.
  * No action required from users; existing parameters, locations, and formats continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->