### PR TITLE
[BUG] Implemented a backward-compatible solution to fix the breaking change in the Google Sheets New Row Added source

### DIFF
--- a/components/google_sheets/package.json
+++ b/components/google_sheets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_sheets",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "Pipedream Google_sheets Components",
   "main": "google_sheets.app.mjs",
   "keywords": [

--- a/components/google_sheets/sources/new-row-added-polling/new-row-added-polling.mjs
+++ b/components/google_sheets/sources/new-row-added-polling/new-row-added-polling.mjs
@@ -8,7 +8,7 @@ export default {
   key: "google_sheets-new-row-added-polling",
   name: "New Row Added",
   description: "Emit new event each time a row or rows are added to the bottom of a spreadsheet.",
-  version: "0.0.7",
+  version: "0.0.8",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/google_sheets/sources/new-row-added/new-row-added.mjs
+++ b/components/google_sheets/sources/new-row-added/new-row-added.mjs
@@ -8,7 +8,7 @@ export default {
   key: "google_sheets-new-row-added",
   name: "New Row Added (Instant)",
   description: "Emit new event each time a row or rows are added to the bottom of a spreadsheet.",
-  version: "0.1.15",
+  version: "0.1.16",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/google_sheets/sources/new-row-added/test-event.mjs
+++ b/components/google_sheets/sources/new-row-added/test-event.mjs
@@ -1,5 +1,10 @@
 export default {
-  "newRow": {
+  "newRow": [
+    "John Doe",
+    "john@example.com",
+    "30"
+  ],
+  "rowAsObject": {
     "Name": "John Doe",
     "Email": "john@example.com",
     "Age": "30"


### PR DESCRIPTION
## WHY

Resolves #18338


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * New Row Added events now include an optional rowAsObject when headers are enabled, while retaining the original newRow array for compatibility.
* Documentation
  * Clarified Has Headers and Header Row descriptions with clearer guidance and examples.
* Tests
  * Updated test event to mirror the new payload structure, showing both newRow (array) and rowAsObject.
* Chores
  * Bumped component versions to reflect changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->