### PR TITLE
Pipedrive - pipelineId integer

### DIFF
--- a/components/pipedrive/actions/add-activity/add-activity.mjs
+++ b/components/pipedrive/actions/add-activity/add-activity.mjs
@@ -7,7 +7,7 @@ export default {
   key: "pipedrive-add-activity",
   name: "Add Activity",
   description: "Adds a new activity. Includes `more_activities_scheduled_in_context` property in response's `additional_data` which indicates whether there are more undone activities scheduled with the same deal, person or organization (depending on the supplied data). See the Pipedrive API docs for Activities [here](https://developers.pipedrive.com/docs/api/v1/#!/Activities). For info on [adding an activity in Pipedrive](https://developers.pipedrive.com/docs/api/v1/Activities#addActivity)",
-  version: "0.1.14",
+  version: "0.1.15",
   type: "action",
   props: {
     pipedriveApp,

--- a/components/pipedrive/actions/add-deal/add-deal.mjs
+++ b/components/pipedrive/actions/add-deal/add-deal.mjs
@@ -6,7 +6,7 @@ export default {
   key: "pipedrive-add-deal",
   name: "Add Deal",
   description: "Adds a new deal. See the Pipedrive API docs for Deals [here](https://developers.pipedrive.com/docs/api/v1/Deals#addDeal)",
-  version: "0.1.15",
+  version: "0.1.16",
   type: "action",
   props: {
     pipedriveApp,

--- a/components/pipedrive/actions/add-lead/add-lead.mjs
+++ b/components/pipedrive/actions/add-lead/add-lead.mjs
@@ -6,7 +6,7 @@ export default {
   key: "pipedrive-add-lead",
   name: "Add Lead",
   description: "Create a new lead in Pipedrive. [See the documentation](https://developers.pipedrive.com/docs/api/v1/Leads#addLead)",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "action",
   props: {
     pipedrive,

--- a/components/pipedrive/actions/add-note/add-note.mjs
+++ b/components/pipedrive/actions/add-note/add-note.mjs
@@ -5,7 +5,7 @@ export default {
   key: "pipedrive-add-note",
   name: "Add Note",
   description: "Adds a new note. For info on [adding an note in Pipedrive](https://developers.pipedrive.com/docs/api/v1/Notes#addNote)",
-  version: "0.0.12",
+  version: "0.0.13",
   type: "action",
   props: {
     pipedriveApp,

--- a/components/pipedrive/actions/add-organization/add-organization.mjs
+++ b/components/pipedrive/actions/add-organization/add-organization.mjs
@@ -5,7 +5,7 @@ export default {
   key: "pipedrive-add-organization",
   name: "Add Organization",
   description: "Adds a new organization. See the Pipedrive API docs for Organizations [here](https://developers.pipedrive.com/docs/api/v1/Organizations#addOrganization)",
-  version: "0.1.14",
+  version: "0.1.15",
   type: "action",
   props: {
     pipedriveApp,

--- a/components/pipedrive/actions/add-person/add-person.mjs
+++ b/components/pipedrive/actions/add-person/add-person.mjs
@@ -6,7 +6,7 @@ export default {
   key: "pipedrive-add-person",
   name: "Add Person",
   description: "Adds a new person. See the Pipedrive API docs for People [here](https://developers.pipedrive.com/docs/api/v1/Persons#addPerson)",
-  version: "0.1.14",
+  version: "0.1.15",
   type: "action",
   props: {
     pipedriveApp,

--- a/components/pipedrive/actions/get-lead-by-id/get-lead-by-id.mjs
+++ b/components/pipedrive/actions/get-lead-by-id/get-lead-by-id.mjs
@@ -4,7 +4,7 @@ export default {
   key: "pipedrive-get-lead-by-id",
   name: "Get Lead by ID",
   description: "Get a lead by its ID. [See the documentation](https://developers.pipedrive.com/docs/api/v1/Leads#getLead)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     pipedriveApp,

--- a/components/pipedrive/actions/get-person-details/get-person-details.mjs
+++ b/components/pipedrive/actions/get-person-details/get-person-details.mjs
@@ -5,7 +5,7 @@ export default {
   key: "pipedrive-get-person-details",
   name: "Get person details",
   description: "Get details of a person by their ID. [See the documentation](https://developers.pipedrive.com/docs/api/v1/Persons#getPerson)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   props: {
     pipedriveApp,

--- a/components/pipedrive/actions/merge-deals/merge-deals.mjs
+++ b/components/pipedrive/actions/merge-deals/merge-deals.mjs
@@ -4,7 +4,7 @@ export default {
   key: "pipedrive-merge-deals",
   name: "Merge Deals",
   description: "Merge two deals in Pipedrive. [See the documentation](https://developers.pipedrive.com/docs/api/v1/Deals#mergeDeals)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     pipedriveApp,

--- a/components/pipedrive/actions/merge-persons/merge-persons.mjs
+++ b/components/pipedrive/actions/merge-persons/merge-persons.mjs
@@ -4,7 +4,7 @@ export default {
   key: "pipedrive-merge-persons",
   name: "Merge Persons",
   description: "Merge two persons in Pipedrive. [See the documentation](https://developers.pipedrive.com/docs/api/v1/Persons#mergePersons)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     pipedriveApp,

--- a/components/pipedrive/actions/remove-duplicate-notes/remove-duplicate-notes.mjs
+++ b/components/pipedrive/actions/remove-duplicate-notes/remove-duplicate-notes.mjs
@@ -5,7 +5,7 @@ export default {
   key: "pipedrive-remove-duplicate-notes",
   name: "Remove Duplicate Notes",
   description: "Remove duplicate notes from an object in Pipedrive. See the documentation for [getting notes](https://developers.pipedrive.com/docs/api/v1/Notes#getNotes) and [deleting notes](https://developers.pipedrive.com/docs/api/v1/Notes#deleteNote)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   props: {
     pipedriveApp,

--- a/components/pipedrive/actions/search-leads/search-leads.mjs
+++ b/components/pipedrive/actions/search-leads/search-leads.mjs
@@ -5,7 +5,7 @@ export default {
   key: "pipedrive-search-leads",
   name: "Search Leads",
   description: "Search for leads by name or email. [See the documentation](https://developers.pipedrive.com/docs/api/v1/Leads#searchLeads)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     pipedriveApp,

--- a/components/pipedrive/actions/search-notes/search-notes.mjs
+++ b/components/pipedrive/actions/search-notes/search-notes.mjs
@@ -4,7 +4,7 @@ export default {
   key: "pipedrive-search-notes",
   name: "Search Notes",
   description: "Search for notes in Pipedrive. [See the documentation](https://developers.pipedrive.com/docs/api/v1/Notes#getNotes)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   props: {
     pipedriveApp,

--- a/components/pipedrive/actions/search-persons/search-persons.mjs
+++ b/components/pipedrive/actions/search-persons/search-persons.mjs
@@ -7,7 +7,7 @@ export default {
   key: "pipedrive-search-persons",
   name: "Search persons",
   description: "Searches all Persons by `name`, `email`, `phone`, `notes` and/or custom fields. This endpoint is a wrapper of `/v1/itemSearch` with a narrower OAuth scope. Found Persons can be filtered by Organization ID. See the Pipedrive API docs [here](https://developers.pipedrive.com/docs/api/v1/Persons#searchPersons)",
-  version: "0.1.14",
+  version: "0.1.15",
   type: "action",
   props: {
     pipedriveApp,

--- a/components/pipedrive/actions/update-deal/update-deal.mjs
+++ b/components/pipedrive/actions/update-deal/update-deal.mjs
@@ -5,7 +5,7 @@ export default {
   key: "pipedrive-update-deal",
   name: "Update Deal",
   description: "Updates the properties of a deal. See the Pipedrive API docs for Deals [here](https://developers.pipedrive.com/docs/api/v1/Deals#updateDeal)",
-  version: "0.1.16",
+  version: "0.1.17",
   type: "action",
   props: {
     pipedriveApp,

--- a/components/pipedrive/actions/update-person/update-person.mjs
+++ b/components/pipedrive/actions/update-person/update-person.mjs
@@ -6,7 +6,7 @@ export default {
   key: "pipedrive-update-person",
   name: "Update Person",
   description: "Updates an existing person in Pipedrive. [See the documentation](https://developers.pipedrive.com/docs/api/v1/Persons#updatePerson)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   props: {
     pipedriveApp,

--- a/components/pipedrive/package.json
+++ b/components/pipedrive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/pipedrive",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Pipedream Pipedrive Components",
   "main": "pipedrive.app.mjs",
   "keywords": [

--- a/components/pipedrive/pipedrive.app.mjs
+++ b/components/pipedrive/pipedrive.app.mjs
@@ -189,7 +189,7 @@ export default {
       },
     },
     pipelineId: {
-      type: "string",
+      type: "integer",
       label: "Pipeline ID",
       description: "ID of the pipeline this activity will be associated with",
       optional: true,

--- a/components/pipedrive/sources/new-deal-instant/new-deal-instant.mjs
+++ b/components/pipedrive/sources/new-deal-instant/new-deal-instant.mjs
@@ -6,7 +6,7 @@ export default {
   key: "pipedrive-new-deal-instant",
   name: "New Deal (Instant)",
   description: "Emit new event when a new deal is created.",
-  version: "0.0.11",
+  version: "0.0.12",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/pipedrive/sources/new-event-instant/new-event-instant.mjs
+++ b/components/pipedrive/sources/new-event-instant/new-event-instant.mjs
@@ -5,7 +5,7 @@ export default {
   key: "pipedrive-new-event-instant",
   name: "New Event (Instant)",
   description: "Emit new event when a new webhook event is received. [See the documentation](https://developers.pipedrive.com/docs/api/v1/Webhooks#addWebhook)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/pipedrive/sources/new-person-instant/new-person-instant.mjs
+++ b/components/pipedrive/sources/new-person-instant/new-person-instant.mjs
@@ -6,7 +6,7 @@ export default {
   key: "pipedrive-new-person-instant",
   name: "New Person (Instant)",
   description: "Emit new event when a new person is created.",
-  version: "0.0.11",
+  version: "0.0.12",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/pipedrive/sources/updated-deal-instant/updated-deal-instant.mjs
+++ b/components/pipedrive/sources/updated-deal-instant/updated-deal-instant.mjs
@@ -7,7 +7,7 @@ export default {
   key: "pipedrive-updated-deal-instant",
   name: "Deal Updated (Instant)",
   description: "Emit new event when a deal is updated.",
-  version: "0.1.4",
+  version: "0.1.5",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/pipedrive/sources/updated-lead-instant/updated-lead-instant.mjs
+++ b/components/pipedrive/sources/updated-lead-instant/updated-lead-instant.mjs
@@ -7,7 +7,7 @@ export default {
   key: "pipedrive-updated-lead-instant",
   name: "Lead Updated (Instant)",
   description: "Emit new event when a lead is updated.",
-  version: "0.1.4",
+  version: "0.1.5",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/pipedrive/sources/updated-person-instant/updated-person-instant.mjs
+++ b/components/pipedrive/sources/updated-person-instant/updated-person-instant.mjs
@@ -7,7 +7,7 @@ export default {
   key: "pipedrive-updated-person-instant",
   name: "Person Updated (Instant)",
   description: "Emit new event when a person is updated.",
-  version: "0.1.4",
+  version: "0.1.5",
   type: "source",
   dedupe: "unique",
   methods: {


### PR DESCRIPTION
## WHY

<!-- author to complete -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Pipeline ID field to require a numeric value, matching the service’s expected format. This improves validation during setup, reduces runtime errors from invalid IDs, and ensures smoother pipeline selection. Existing configurations that used a string may need updating to the numeric ID. Users will see clearer input validation when configuring or editing steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->