### PR TITLE
Notion API Key - update @pipedream/notion version

### DIFF
--- a/components/notion_api_key/actions/append-block/append-block.mjs
+++ b/components/notion_api_key/actions/append-block/append-block.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-append-block",
-  version: "0.0.2",
+  version: "0.0.3",
   name,
   description,
   type,

--- a/components/notion_api_key/actions/create-comment/create-comment.mjs
+++ b/components/notion_api_key/actions/create-comment/create-comment.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-create-comment",
-  version: "0.0.2",
+  version: "0.0.3",
   name,
   description,
   type,

--- a/components/notion_api_key/actions/create-page-from-database/create-page-from-database.mjs
+++ b/components/notion_api_key/actions/create-page-from-database/create-page-from-database.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-create-page-from-database",
-  version: "0.0.2",
+  version: "0.0.3",
   name,
   description,
   type,

--- a/components/notion_api_key/actions/create-page/create-page.mjs
+++ b/components/notion_api_key/actions/create-page/create-page.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-create-page",
-  version: "0.0.2",
+  version: "0.0.3",
   name,
   description,
   type,

--- a/components/notion_api_key/actions/duplicate-page/duplicate-page.mjs
+++ b/components/notion_api_key/actions/duplicate-page/duplicate-page.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-duplicate-page",
-  version: "0.0.2",
+  version: "0.0.3",
   name,
   description,
   type,

--- a/components/notion_api_key/actions/query-database/query-database.mjs
+++ b/components/notion_api_key/actions/query-database/query-database.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-query-database",
-  version: "0.0.2",
+  version: "0.0.3",
   name,
   description,
   type,

--- a/components/notion_api_key/actions/retrieve-block/retrieve-block.mjs
+++ b/components/notion_api_key/actions/retrieve-block/retrieve-block.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-retrieve-block",
-  version: "0.0.2",
+  version: "0.0.3",
   name,
   description,
   type,

--- a/components/notion_api_key/actions/retrieve-database-content/retrieve-database-content.mjs
+++ b/components/notion_api_key/actions/retrieve-database-content/retrieve-database-content.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-retrieve-database-content",
-  version: "0.0.2",
+  version: "0.0.3",
   name,
   description,
   type,

--- a/components/notion_api_key/actions/retrieve-database-schema/retrieve-database-schema.mjs
+++ b/components/notion_api_key/actions/retrieve-database-schema/retrieve-database-schema.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-retrieve-database-schema",
-  version: "0.0.2",
+  version: "0.0.3",
   name,
   description,
   type,

--- a/components/notion_api_key/actions/retrieve-page-property-item/retrieve-page-property-item.mjs
+++ b/components/notion_api_key/actions/retrieve-page-property-item/retrieve-page-property-item.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-retrieve-page-property-item",
-  version: "0.0.2",
+  version: "0.0.3",
   name,
   description,
   type,

--- a/components/notion_api_key/actions/retrieve-page/retrieve-page.mjs
+++ b/components/notion_api_key/actions/retrieve-page/retrieve-page.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-retrieve-page",
-  version: "0.0.2",
+  version: "0.0.3",
   name,
   description,
   type,

--- a/components/notion_api_key/actions/search/search.mjs
+++ b/components/notion_api_key/actions/search/search.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-search",
-  version: "0.0.2",
+  version: "0.0.3",
   name,
   description,
   type,

--- a/components/notion_api_key/actions/update-page/update-page.mjs
+++ b/components/notion_api_key/actions/update-page/update-page.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-update-page",
-  version: "0.0.2",
+  version: "0.0.3",
   name,
   description,
   type,

--- a/components/notion_api_key/package.json
+++ b/components/notion_api_key/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/notion_api_key",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Pipedream Notion (API Key) Components",
   "main": "notion_api_key.app.mjs",
   "keywords": [
@@ -14,6 +14,6 @@
   },
   "dependencies": {
     "@notionhq/client": "4.0.2",
-    "@pipedream/notion": "^0.10.1"
+    "@pipedream/notion": "^1.0.2"
   }
 }

--- a/components/notion_api_key/sources/new-comment-created/new-comment-created.mjs
+++ b/components/notion_api_key/sources/new-comment-created/new-comment-created.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-new-comment-created",
-  version: "0.0.2",
+  version: "0.0.3",
   name,
   description,
   type,

--- a/components/notion_api_key/sources/new-database/new-database.mjs
+++ b/components/notion_api_key/sources/new-database/new-database.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-new-database",
-  version: "0.0.2",
+  version: "0.0.3",
   name,
   description,
   type,

--- a/components/notion_api_key/sources/new-page/new-page.mjs
+++ b/components/notion_api_key/sources/new-page/new-page.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-new-page",
-  version: "0.0.2",
+  version: "0.0.3",
   name,
   description,
   type,

--- a/components/notion_api_key/sources/page-or-subpage-updated/page-or-subpage-updated.mjs
+++ b/components/notion_api_key/sources/page-or-subpage-updated/page-or-subpage-updated.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-page-or-subpage-updated",
-  version: "0.0.2",
+  version: "0.0.3",
   name,
   description,
   type,

--- a/components/notion_api_key/sources/updated-page-id/updated-page-id.mjs
+++ b/components/notion_api_key/sources/updated-page-id/updated-page-id.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-updated-page-id",
-  version: "0.0.2",
+  version: "0.0.3",
   name,
   description,
   type,

--- a/components/notion_api_key/sources/updated-page/updated-page.mjs
+++ b/components/notion_api_key/sources/updated-page/updated-page.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "notion_api_key-updated-page",
-  version: "0.0.2",
+  version: "0.0.3",
   name,
   description,
   type,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4628,8 +4628,7 @@ importers:
 
   components/ethereum: {}
 
-  components/etrusted:
-    specifiers: {}
+  components/etrusted: {}
 
   components/etsy:
     dependencies:
@@ -7105,8 +7104,7 @@ importers:
         specifier: ^1.5.1
         version: 1.6.6
 
-  components/intelliflo_office:
-    specifiers: {}
+  components/intelliflo_office: {}
 
   components/intellihr:
     dependencies:
@@ -7626,8 +7624,7 @@ importers:
         specifier: ^1.0.1
         version: 1.0.1
 
-  components/kordiam:
-    specifiers: {}
+  components/kordiam: {}
 
   components/koyeb: {}
 
@@ -9605,8 +9602,8 @@ importers:
         specifier: 4.0.2
         version: 4.0.2
       '@pipedream/notion':
-        specifier: ^0.10.1
-        version: 0.10.1
+        specifier: ^1.0.2
+        version: 1.0.2
 
   components/nozbe_teams: {}
 
@@ -10481,8 +10478,7 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
 
-  components/peekalink:
-    specifiers: {}
+  components/peekalink: {}
 
   components/peerdom:
     dependencies:
@@ -12281,8 +12277,7 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
 
-  components/rundeck:
-    specifiers: {}
+  components/rundeck: {}
 
   components/runpod: {}
 
@@ -14432,8 +14427,7 @@ importers:
         specifier: ^1.6.5
         version: 1.6.6
 
-  components/thoughtspot:
-    specifiers: {}
+  components/thoughtspot: {}
 
   components/threads:
     dependencies:
@@ -14466,8 +14460,7 @@ importers:
         specifier: ^1.0.1
         version: 1.0.1
 
-  components/ticketsauce:
-    specifiers: {}
+  components/ticketsauce: {}
 
   components/ticktick:
     dependencies:
@@ -20214,8 +20207,8 @@ packages:
   '@pipedream/notiff_io@0.1.0':
     resolution: {integrity: sha512-jgt5JJGxI9SM6chDeQpxbaS/NSuUUxhe/PeAXRdZKx28Gp0QCxW7egIImC3pqQ9aMSubaeygRyR0ELhKhmbtPg==}
 
-  '@pipedream/notion@0.10.1':
-    resolution: {integrity: sha512-3P3zvFMIHur5BaoFAkAo3t5hPoblDNxYrSWw1UdicTGtWMne43Oo9+qOm7NAeQDEN5I1sHDLprKv2aMM2beB7w==}
+  '@pipedream/notion@1.0.2':
+    resolution: {integrity: sha512-qVMpoUOus3E4oYtrPoHq0jciipxY4Y9bOxqaiv6uyUbxOKC5QaVvOIRgge5E++uR7Bf46NepwwTcW7wujktUrw==}
 
   '@pipedream/platform@0.10.0':
     resolution: {integrity: sha512-N3F/xVfBZQXc9wl+2/4E8U9Zma1rxpvylK6Gtw8Ofmiwjnmnvs+2SNjEpIXBPUeL+wxEkofSGOq7bkqt1hqwDg==}
@@ -30940,22 +30933,22 @@ packages:
   superagent@3.8.1:
     resolution: {integrity: sha512-VMBFLYgFuRdfeNQSMLbxGSLfmXL/xc+OO+BZp41Za/NRDBet/BNbkRJrYzCUu0u4GU0i/ml2dtT8b9qgkw9z6Q==}
     engines: {node: '>= 4.0'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
 
   superagent@4.1.0:
     resolution: {integrity: sha512-FT3QLMasz0YyCd4uIi5HNe+3t/onxMyEho7C3PSqmti3Twgy2rXT4fmkTz6wRL6bTF4uzPcfkUCa8u4JWHw8Ag==}
     engines: {node: '>= 6.0'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
 
   superagent@5.3.1:
     resolution: {integrity: sha512-wjJ/MoTid2/RuGCOFtlacyGNxN9QLMgcpYLDQlWFIhhdJ93kNscFonGvrpAHSCVjRVj++DGCglocF7Aej1KHvQ==}
     engines: {node: '>= 7.0.0'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
 
   superagent@7.1.6:
     resolution: {integrity: sha512-gZkVCQR1gy/oUXr+kxJMLDjla434KmSOKbx5iGD30Ql+AkJQ/YlPKECJy2nhqOsHLjGHzoDTXNSjhnvWhzKk7g==}
     engines: {node: '>=6.4.0 <13 || >=14'}
-    deprecated: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
 
   supports-color@10.0.0:
     resolution: {integrity: sha512-HRVVSbCCMbj7/kdWF9Q+bbckjBHLtHMEoJWlkmYzzdwhYMkjkOwubLM6t7NbWKjgKamGDrWL1++KrjUO1t9oAQ==}
@@ -38331,9 +38324,9 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@pipedream/notion@0.10.1':
+  '@pipedream/notion@1.0.2':
     dependencies:
-      '@notionhq/client': 4.0.2
+      '@notionhq/client': 5.0.0
       '@pipedream/platform': 3.1.0
       '@tryfabric/martian': 1.2.4
       lodash-es: 4.17.21


### PR DESCRIPTION
Updates `notion_api_key` app to import changes from https://github.com/PipedreamHQ/pipedream/issues/18212 and https://github.com/PipedreamHQ/pipedream/issues/18349

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped Notion API Key package version to 0.1.3.
  * Updated Notion SDK dependency to ^1.0.2.
  * Aligned version metadata to 0.0.3 across all Notion actions and sources, including: Append Block, Create Comment, Create Page, Create Page from Database, Duplicate Page, Query Database, Retrieve Block, Retrieve Database Content, Retrieve Database Schema, Retrieve Page, Retrieve Page Property Item, Search, Update Page, and sources for New Comment Created, New Database, New Page, Page or Subpage Updated, Updated Page ID, and Updated Page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->