### PR TITLE
Google sheets type fix

### DIFF
--- a/components/google_sheets/actions/add-column/add-column.mjs
+++ b/components/google_sheets/actions/add-column/add-column.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_sheets-add-column",
   name: "Create Column",
   description: "Create a new column in a spreadsheet. [See the documentation](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/batchUpdate)",
-  version: "0.1.10",
+  version: "0.1.11",
   type: "action",
   props: {
     googleSheets,

--- a/components/google_sheets/actions/add-multiple-rows/add-multiple-rows.mjs
+++ b/components/google_sheets/actions/add-multiple-rows/add-multiple-rows.mjs
@@ -11,7 +11,7 @@ export default {
   key: "google_sheets-add-multiple-rows",
   name: "Add Multiple Rows",
   description: "Add multiple rows of data to a Google Sheet. [See the documentation](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/append)",
-  version: "0.2.13",
+  version: "0.2.14",
   type: "action",
   props: {
     googleSheets,

--- a/components/google_sheets/actions/add-single-row/add-single-row.mjs
+++ b/components/google_sheets/actions/add-single-row/add-single-row.mjs
@@ -10,7 +10,7 @@ export default {
   key: "google_sheets-add-single-row",
   name: "Add Single Row",
   description: "Add a single row of data to Google Sheets. [See the documentation](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/append)",
-  version: "2.1.15",
+  version: "2.1.16",
   type: "action",
   props: {
     googleSheets,

--- a/components/google_sheets/actions/clear-cell/clear-cell.mjs
+++ b/components/google_sheets/actions/clear-cell/clear-cell.mjs
@@ -7,7 +7,7 @@ export default {
   key: "google_sheets-clear-cell",
   name: "Clear Cell",
   description: "Delete the content of a specific cell in a spreadsheet. [See the documentation](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/clear)",
-  version: "0.1.14",
+  version: "0.1.15",
   type: "action",
   props: {
     googleSheets,

--- a/components/google_sheets/actions/clear-rows/clear-rows.mjs
+++ b/components/google_sheets/actions/clear-rows/clear-rows.mjs
@@ -7,7 +7,7 @@ export default {
   key: "google_sheets-clear-rows",
   name: "Clear Rows",
   description: "Delete the content of a row or rows in a spreadsheet. Deleted rows will appear as blank rows. [See the documentation](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/clear)",
-  version: "0.1.12",
+  version: "0.1.13",
   type: "action",
   props: {
     googleSheets,

--- a/components/google_sheets/actions/copy-worksheet/copy-worksheet.mjs
+++ b/components/google_sheets/actions/copy-worksheet/copy-worksheet.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_sheets-copy-worksheet",
   name: "Copy Worksheet",
   description: "Copy an existing worksheet to another Google Sheets file. [See the documentation](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.sheets/copyTo)",
-  version: "0.1.10",
+  version: "0.1.11",
   type: "action",
   props: {
     googleSheets,

--- a/components/google_sheets/actions/create-spreadsheet/create-spreadsheet.mjs
+++ b/components/google_sheets/actions/create-spreadsheet/create-spreadsheet.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_sheets-create-spreadsheet",
   name: "Create Spreadsheet",
   description: "Create a blank spreadsheet or duplicate an existing spreadsheet. [See the documentation](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/create)",
-  version: "0.1.12",
+  version: "0.1.13",
   type: "action",
   props: {
     googleSheets,

--- a/components/google_sheets/actions/create-worksheet/create-worksheet.mjs
+++ b/components/google_sheets/actions/create-worksheet/create-worksheet.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_sheets-create-worksheet",
   name: "Create Worksheet",
   description: "Create a blank worksheet with a title. [See the documentation](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/batchUpdate)",
-  version: "0.1.10",
+  version: "0.1.11",
   type: "action",
   props: {
     googleSheets,

--- a/components/google_sheets/actions/delete-rows/delete-rows.mjs
+++ b/components/google_sheets/actions/delete-rows/delete-rows.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_sheets-delete-rows",
   name: "Delete Rows",
   description: "Deletes the specified rows from a spreadsheet. [See the documentation](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/request#deletedimensionrequest)",
-  version: "0.0.10",
+  version: "0.0.11",
   type: "action",
   props: {
     googleSheets,

--- a/components/google_sheets/actions/delete-worksheet/delete-worksheet.mjs
+++ b/components/google_sheets/actions/delete-worksheet/delete-worksheet.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_sheets-delete-worksheet",
   name: "Delete Worksheet",
   description: "Delete a specific worksheet. [See the documentation](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/batchUpdate)",
-  version: "0.1.10",
+  version: "0.1.11",
   type: "action",
   props: {
     googleSheets,

--- a/components/google_sheets/actions/find-row/find-row.mjs
+++ b/components/google_sheets/actions/find-row/find-row.mjs
@@ -7,7 +7,7 @@ export default {
   key: "google_sheets-find-row",
   name: "Find Row",
   description: "Find one or more rows by a column and value. [See the documentation](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/get)",
-  version: "0.2.13",
+  version: "0.2.14",
   type: "action",
   props: {
     googleSheets,

--- a/components/google_sheets/actions/get-cell/get-cell.mjs
+++ b/components/google_sheets/actions/get-cell/get-cell.mjs
@@ -7,7 +7,7 @@ export default {
   key: "google_sheets-get-cell",
   name: "Get Cell",
   description: "Fetch the contents of a specific cell in a spreadsheet. [See the documentation](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/get)",
-  version: "0.1.12",
+  version: "0.1.13",
   type: "action",
   props: {
     googleSheets,

--- a/components/google_sheets/actions/get-spreadsheet-by-id/get-spreadsheet-by-id.mjs
+++ b/components/google_sheets/actions/get-spreadsheet-by-id/get-spreadsheet-by-id.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_sheets-get-spreadsheet-by-id",
   name: "Get Spreadsheet by ID",
   description: "Returns the spreadsheet at the given ID. [See the documentation](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/get) for more information",
-  version: "0.1.11",
+  version: "0.1.12",
   type: "action",
   props: {
     googleSheets,

--- a/components/google_sheets/actions/get-values-in-range/get-values-in-range.mjs
+++ b/components/google_sheets/actions/get-values-in-range/get-values-in-range.mjs
@@ -7,7 +7,7 @@ export default {
   key: "google_sheets-get-values-in-range",
   name: "Get Values in Range",
   description: "Get all values or values from a range of cells using A1 notation. [See the documentation](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/get)",
-  version: "0.1.12",
+  version: "0.1.13",
   type: "action",
   props: {
     googleSheets,

--- a/components/google_sheets/actions/insert-anchored-note/insert-anchored-note.mjs
+++ b/components/google_sheets/actions/insert-anchored-note/insert-anchored-note.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_sheets-insert-anchored-note",
   name: "Insert an Anchored Note",
   description: "Insert a note on a spreadsheet cell. [See the documentation](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/batchUpdate)",
-  version: "0.1.10",
+  version: "0.1.11",
   type: "action",
   props: {
     app,

--- a/components/google_sheets/actions/insert-comment/insert-comment.mjs
+++ b/components/google_sheets/actions/insert-comment/insert-comment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_sheets-insert-comment",
   name: "Insert Comment",
   description: "Insert a comment into a spreadsheet. [See the documentation](https://developers.google.com/drive/api/v3/reference/comments/create)",
-  version: "0.1.11",
+  version: "0.1.12",
   type: "action",
   props: {
     app,

--- a/components/google_sheets/actions/list-worksheets/list-worksheets.mjs
+++ b/components/google_sheets/actions/list-worksheets/list-worksheets.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_sheets-list-worksheets",
   name: "List Worksheets",
   description: "Get a list of all worksheets in a spreadsheet. [See the documentation](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/get)",
-  version: "0.1.10",
+  version: "0.1.11",
   type: "action",
   props: {
     googleSheets,

--- a/components/google_sheets/actions/update-cell/update-cell.mjs
+++ b/components/google_sheets/actions/update-cell/update-cell.mjs
@@ -7,7 +7,7 @@ export default {
   key: "google_sheets-update-cell",
   name: "Update Cell",
   description: "Update a cell in a spreadsheet. [See the documentation](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/update)",
-  version: "0.1.12",
+  version: "0.1.13",
   type: "action",
   props: {
     googleSheets,

--- a/components/google_sheets/actions/update-multiple-rows/update-multiple-rows.mjs
+++ b/components/google_sheets/actions/update-multiple-rows/update-multiple-rows.mjs
@@ -9,7 +9,7 @@ export default {
   key: "google_sheets-update-multiple-rows",
   name: "Update Multiple Rows",
   description: "Update multiple rows in a spreadsheet defined by a range. [See the documentation](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/update)",
-  version: "0.1.12",
+  version: "0.1.13",
   type: "action",
   props: {
     googleSheets,

--- a/components/google_sheets/actions/update-row/update-row.mjs
+++ b/components/google_sheets/actions/update-row/update-row.mjs
@@ -10,7 +10,7 @@ export default {
   key: "google_sheets-update-row",
   name: "Update Row",
   description: "Update a row in a spreadsheet. [See the documentation](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/update)",
-  version: "0.1.14",
+  version: "0.1.15",
   type: "action",
   props: {
     googleSheets,

--- a/components/google_sheets/actions/upsert-row/upsert-row.mjs
+++ b/components/google_sheets/actions/upsert-row/upsert-row.mjs
@@ -24,7 +24,7 @@ export default {
   key: "google_sheets-upsert-row",
   name: "Upsert Row",
   description: "Upsert a row of data in a Google Sheet. [See the documentation](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/append)",
-  version: "0.1.14",
+  version: "0.1.15",
   type: "action",
   props: {
     googleSheets,

--- a/components/google_sheets/google_sheets.app.mjs
+++ b/components/google_sheets/google_sheets.app.mjs
@@ -71,7 +71,7 @@ export default {
       },
     },
     worksheetIDs: {
-      type: "string",
+      type: "integer",
       label: "Worksheet ID",
       description: "Select a worksheet or provide a worksheet ID",
       async options({ sheetId }) {

--- a/components/google_sheets/package.json
+++ b/components/google_sheets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_sheets",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "description": "Pipedream Google_sheets Components",
   "main": "google_sheets.app.mjs",
   "keywords": [

--- a/components/google_sheets/sources/common/new-row-added.mjs
+++ b/components/google_sheets/sources/common/new-row-added.mjs
@@ -16,7 +16,7 @@ export default {
           sheetId: c.sheetID,
         }),
       ],
-      type: "string[]",
+      type: "integer[]",
       label: "Worksheet ID(s)",
       description: "Select one or more worksheet(s), or provide an array of worksheet IDs.",
     },

--- a/components/google_sheets/sources/common/new-updates.mjs
+++ b/components/google_sheets/sources/common/new-updates.mjs
@@ -16,7 +16,7 @@ export default {
           sheetId: c.sheetID,
         }),
       ],
-      type: "string[]",
+      type: "integer[]",
       label: "Worksheet ID(s)",
       description: "Select one or more worksheet(s), or provide an array of worksheet IDs.",
     },

--- a/components/google_sheets/sources/new-comment/new-comment.mjs
+++ b/components/google_sheets/sources/new-comment/new-comment.mjs
@@ -6,7 +6,7 @@ export default {
   key: "google_sheets-new-comment",
   name: "New Comment (Instant)",
   description: "Emit new event each time a comment is added to a spreadsheet.",
-  version: "0.0.9",
+  version: "0.0.10",
   dedupe: "unique",
   type: "source",
   methods: {

--- a/components/google_sheets/sources/new-row-added-polling/new-row-added-polling.mjs
+++ b/components/google_sheets/sources/new-row-added-polling/new-row-added-polling.mjs
@@ -8,7 +8,7 @@ export default {
   key: "google_sheets-new-row-added-polling",
   name: "New Row Added",
   description: "Emit new event each time a row or rows are added to the bottom of a spreadsheet.",
-  version: "0.0.8",
+  version: "0.0.9",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/google_sheets/sources/new-row-added/new-row-added.mjs
+++ b/components/google_sheets/sources/new-row-added/new-row-added.mjs
@@ -8,7 +8,7 @@ export default {
   key: "google_sheets-new-row-added",
   name: "New Row Added (Instant)",
   description: "Emit new event each time a row or rows are added to the bottom of a spreadsheet.",
-  version: "0.1.16",
+  version: "0.1.17",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/google_sheets/sources/new-updates/new-updates.mjs
+++ b/components/google_sheets/sources/new-updates/new-updates.mjs
@@ -9,7 +9,7 @@ export default {
   type: "source",
   name: "New Updates (Instant)",
   description: "Emit new event each time a row or cell is updated in a spreadsheet.",
-  version: "0.2.11",
+  version: "0.2.12",
   dedupe: "unique",
   props: {
     ...httpBase.props,

--- a/components/google_sheets/sources/new-worksheet/new-worksheet.mjs
+++ b/components/google_sheets/sources/new-worksheet/new-worksheet.mjs
@@ -9,7 +9,7 @@ export default {
   type: "source",
   name: "New Worksheet (Instant)",
   description: "Emit new event each time a new worksheet is created in a spreadsheet.",
-  version: "0.1.14",
+  version: "0.1.15",
   dedupe: "unique",
   hooks: {
     ...httpBase.hooks,


### PR DESCRIPTION
The worksheetId prop is an integer, but was typed as a string.

This did not result in any bugs due to the property not being manipulated before being sent to the API, but it was reported by a user and may cause issues when validating values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Updated Worksheet ID inputs to accept numeric IDs across the Google Sheets app and related event sources, improving consistency with sheet IDs and input validation.

- Chores
  - Incremented versions for multiple Google Sheets actions and sources with no behavioral changes.
  - Updated the Google Sheets package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->