### PR TITLE
Expensify - new action list-policies

### DIFF
--- a/components/expensify/actions/list-policies/list-policies.ts
+++ b/components/expensify/actions/list-policies/list-policies.ts
@@ -1,0 +1,36 @@
+import { defineAction } from "@pipedream/types";
+import expensify from "../../app/expensify.app";
+
+export default defineAction({
+  key: "expensify-list-policies",
+  name: "List Policies",
+  description: "Retrieves a list of policies. [See the documentation](https://integrations.expensify.com/Integration-Server/doc/#policy-list-getter)",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    expensify,
+    adminOnly: {
+      type: "boolean",
+      label: "Admin Only",
+      description: "Whether or not to only get policies for which the user is an admin",
+      optional: true,
+    },
+    userEmail: {
+      type: "string",
+      label: "User Email",
+      description: "Specifies the user to gather the policy list for. You must have been granted third-party access by that user/company domain beforehand.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const response = await this.expensify.getPolicyList({
+      $,
+      userEmail: this.userEmail,
+      adminOnly: this.adminOnly,
+    });
+
+    $.export("$summary", `Successfully retrieved ${response?.policyList?.length || 0} policies`);
+
+    return response?.policyList || [];
+  },
+})

--- a/components/expensify/package.json
+++ b/components/expensify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/expensify",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Expensify Components",
   "main": "dist/app/expensify.app.mjs",
   "keywords": [


### PR DESCRIPTION
Resolves #18421 

- Implements new action `list-policies`
- Expensify API does not provide an endpoint for listing report IDs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an Expensify “List Policies” action to retrieve policies from your account.
  - Supports optional filters: admin-only policies and by user email.
  - Provides a summary of the number of policies retrieved and returns the policy list.

- Chores
  - Bumped Expensify component package version to 0.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->