### PR TITLE
Jira - adding pagination to search-issues-with-jql

### DIFF
--- a/components/jira/actions/search-issues-with-jql/search-issues-with-jql.mjs
+++ b/components/jira/actions/search-issues-with-jql/search-issues-with-jql.mjs
@@ -26,6 +26,7 @@ export default {
       optional: true,
       default: 50,
       min: 1,
+      max: 5000,
     },
     fields: {
       type: "string",
@@ -91,7 +92,7 @@ export default {
   },
   methods: {
     getMaxResultsPerPage() {
-      return Math.min(this.maxResults, 500);
+      return Math.min(this.maxResults, 1000);
     },
     async paginate({
       params, maxResults, ...otherArgs

--- a/components/jira/actions/search-issues-with-jql/search-issues-with-jql.mjs
+++ b/components/jira/actions/search-issues-with-jql/search-issues-with-jql.mjs
@@ -17,7 +17,7 @@ export default {
     jql: {
       type: "string",
       label: "JQL Query",
-      description: "The JQL query query to search for issues. [See the documentation for syntax and examples](https://support.atlassian.com/jira-software-cloud/docs/what-is-advanced-search-in-jira-cloud/)",
+      description: "The JQL query to search for issues. [See the documentation for syntax and examples](https://support.atlassian.com/jira-software-cloud/docs/what-is-advanced-search-in-jira-cloud/)",
     },
     maxResults: {
       type: "integer",

--- a/components/jira/actions/search-issues-with-jql/search-issues-with-jql.mjs
+++ b/components/jira/actions/search-issues-with-jql/search-issues-with-jql.mjs
@@ -4,7 +4,7 @@ export default {
   name: "Search Issues with JQL",
   description: "Search for issues using JQL (Jira Query Language). [See the documentation](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/#api-rest-api-3-search-jql-get)",
   key: "jira-search-issues-with-jql",
-  version: "0.0.4",
+  version: "0.1.0",
   type: "action",
   props: {
     jira,
@@ -17,16 +17,15 @@ export default {
     jql: {
       type: "string",
       label: "JQL Query",
-      description: "The [JQL](https://support.atlassian.com/jira-software-cloud/docs/what-is-advanced-search-in-jira-cloud/) query to search for issues",
+      description: "The JQL query query to search for issues. [See the documentation for syntax and examples](https://support.atlassian.com/jira-software-cloud/docs/what-is-advanced-search-in-jira-cloud/)",
     },
     maxResults: {
       type: "integer",
       label: "Max Results",
-      description: "Maximum number of issues to return (default: 50, max: 100)",
+      description: "Maximum number of issues to return (default: 50)",
       optional: true,
       default: 50,
       min: 1,
-      max: 100,
     },
     fields: {
       type: "string",
@@ -90,14 +89,62 @@ export default {
       optional: true,
     },
   },
+  methods: {
+    getMaxResultsPerPage() {
+      return Math.min(this.maxResults, 500);
+    },
+    async paginate({
+      params, maxResults, ...otherArgs
+    }) {
+      const results = [];
+      let nextPageToken;
+      let response;
+
+      do {
+        response = await this.jira.searchIssues({
+          ...otherArgs,
+          params: {
+            ...params,
+            ...(nextPageToken && {
+              nextPageToken,
+            }),
+          },
+        });
+
+        const pageResults = response.issues;
+        const pageLength = pageResults?.length;
+        if (!pageLength) {
+          break;
+        }
+
+        // If maxResults is specified, only add what we need
+        if (maxResults && results.length + pageLength > maxResults) {
+          const remainingSlots = maxResults - results.length;
+          results.push(...pageResults.slice(0, remainingSlots));
+          break;
+        } else {
+          results.push(...pageResults);
+        }
+
+        // Also break if we've reached maxResults exactly
+        if (maxResults && results.length >= maxResults) {
+          break;
+        }
+
+        nextPageToken = response.nextPageToken;
+      } while (nextPageToken && !response.isLast);
+
+      return results;
+    },
+  },
   async run({ $ }) {
     try {
-      const response = await this.jira.searchIssues({
+      const issues = await this.paginate({
         $,
         cloudId: this.cloudId,
         params: {
           jql: this.jql,
-          maxResults: this.maxResults,
+          maxResults: this.getMaxResultsPerPage(),
           fields: this.fields,
           expand: this.expand
             ? this.expand.join(",")
@@ -106,9 +153,12 @@ export default {
           fieldsByKeys: this.fieldsByKeys,
           failFast: this.failFast,
         },
+        maxResults: this.maxResults,
       });
-      $.export("$summary", `Successfully retrieved ${response.issues.length} issues`);
-      return response;
+      $.export("$summary", `Successfully retrieved ${issues.length} issues`);
+      return {
+        issues,
+      };
     } catch (error) {
       throw new Error(`Failed to search issues: ${error.message}`);
     }

--- a/components/jira/package.json
+++ b/components/jira/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/jira",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "Pipedream Jira Components",
   "main": "jira.app.mjs",
   "keywords": [


### PR DESCRIPTION
(reported by a customer)

Component did not have pagination, only max results, limiting the amount of responses that could be retrieved.

I've increased the max page size (1000, or less if `maxResults` is less) and added pagination, raising the max `maxResults` to 5000. While technically we can allow larger values, I think at this point the user should improve their query to narrow down the results, as the execution time can skyrocket.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - JQL search now supports pagination and returns a consolidated issues list.
  - Increased maxResults limit from 100 to 5000 for larger queries.
  - Response shape updated to return { issues } for easier consumption.
  - Pagination helpers exposed to control page size and total results.

- Documentation
  - Clarified descriptions for JQL and maxResults, including updated limits and behavior.

- Chores
  - Version bumps: action API to 0.1.0 and Jira component package to 1.1.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->