### PR TITLE
Gmail - add info alert to new-attachment-received

### DIFF
--- a/components/gmail/package.json
+++ b/components/gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/gmail",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Pipedream Gmail Components",
   "main": "gmail.app.mjs",
   "keywords": [

--- a/components/gmail/sources/new-attachment-received/new-attachment-received.mjs
+++ b/components/gmail/sources/new-attachment-received/new-attachment-received.mjs
@@ -8,11 +8,16 @@ export default {
   key: "gmail-new-attachment-received",
   name: "New Attachment Received",
   description: "Emit new event for each attachment in a message received. This source is capped at 100 max new messages per run.",
-  version: "0.2.0",
+  version: "0.2.1",
   type: "source",
   dedupe: "unique",
   props: {
     gmail,
+    info: {
+      type: "alert",
+      alertType: "info",
+      content: "Note: May not emit events for attachments sent via a Gmail alias. [See issue](https://github.com/PipedreamHQ/pipedream/issues/15309) for more information.",
+    },
     ...common.props,
     q: {
       propDefinition: [


### PR DESCRIPTION
Resolves #15309 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an informational alert to the Gmail “New Attachment Received” source, guiding users about handling attachments from Gmail aliases and providing a helpful issue link.

* **Chores**
  * Bumped the Gmail component package version from 1.3.1 to 1.3.2.
  * Updated the “New Attachment Received” source version from 0.2.0 to 0.2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->