### PR TITLE
HubSpot 'new deal in stage' - fixing initial event emission

### DIFF
--- a/components/hubspot/package.json
+++ b/components/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/hubspot",
-  "version": "1.7.9",
+  "version": "1.7.10",
   "description": "Pipedream Hubspot Components",
   "main": "hubspot.app.mjs",
   "keywords": [

--- a/components/hubspot/sources/new-deal-in-stage/new-deal-in-stage.mjs
+++ b/components/hubspot/sources/new-deal-in-stage/new-deal-in-stage.mjs
@@ -11,7 +11,7 @@ export default {
   key: "hubspot-new-deal-in-stage",
   name: "New Deal In Stage",
   description: "Emit new event for each new deal in a stage.",
-  version: "0.0.40",
+  version: "0.0.41",
   dedupe: "unique",
   type: "source",
   props: {
@@ -100,7 +100,7 @@ export default {
 
         for (const deal of results.results) {
           const ts = await this.getTs(deal);
-          if (this.isRelevant(ts, after)) {
+          if (!after || this.isRelevant(ts, after)) {
             if (deal.properties.hubspot_owner_id) {
               deal.properties.owner = await this.getOwner(
                 deal.properties.hubspot_owner_id,
@@ -112,6 +112,11 @@ export default {
               this._setAfter(ts);
             }
           }
+        }
+
+        // first run, get only first page
+        if (!after) {
+          return;
         }
       } while (params.after);
     },


### PR DESCRIPTION
Closes #18416 

Follow-up to #18438 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the “New Deal in Stage” source on first run by refining relevance checks, reducing the chance of missed or extra events.
  * Limited initial execution to the first page of results to avoid lengthy syncs and potential timeouts, improving setup experience.

* **Chores**
  * Bumped component and source versions for release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->