### PR TITLE
Zoho Workdrive - optional folder id prop to bypass rate limiting

### DIFF
--- a/components/zoho_workdrive/package.json
+++ b/components/zoho_workdrive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/zoho_workdrive",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Pipedream Zoho WorkDrive Components",
   "main": "zoho_workdrive.app.mjs",
   "keywords": [

--- a/components/zoho_workdrive/sources/new-file-in-folder/new-file-in-folder.mjs
+++ b/components/zoho_workdrive/sources/new-file-in-folder/new-file-in-folder.mjs
@@ -1,4 +1,7 @@
-import { DEFAULT_POLLING_SOURCE_TIMER_INTERVAL } from "@pipedream/platform";
+import {
+  ConfigurationError,
+  DEFAULT_POLLING_SOURCE_TIMER_INTERVAL,
+} from "@pipedream/platform";
 import app from "../../zoho_workdrive.app.mjs";
 import { Readable } from "stream";
 import { fileTypeFromBuffer } from "file-type";
@@ -7,7 +10,7 @@ import sampleEmit from "./test-event.mjs";
 export default {
   key: "zoho_workdrive-new-file-in-folder",
   name: "New File In Folder",
-  version: "0.1.0",
+  version: "0.2.0",
   description: "Emit new event when a new file is created in a specific folder.",
   type: "source",
   dedupe: "unique",
@@ -46,7 +49,14 @@ export default {
         }),
       ],
       label: "Folder Id",
-      description: "The unique ID of the folder.",
+      description: "Select the unique ID of the folder.",
+      optional: true,
+    },
+    typedFolderId: {
+      type: "string",
+      label: "Typed Folder Id",
+      description: "Type in the unique ID of the folder. Use this if you hit rate limits on the `Folder Id` prop.",
+      optional: true,
     },
     includeLink: {
       label: "Include Link",
@@ -88,7 +98,12 @@ export default {
       const {
         app,
         folderId,
+        typedFolderId,
       } = this;
+
+      if (!folderId && !typedFolderId) {
+        throw new ConfigurationError("Please select a Folder Id or type in a Typed Folder Id.");
+      }
 
       const lastDate = this._getLastDate();
       let maxDate = lastDate;
@@ -97,7 +112,7 @@ export default {
         maxResults,
         filter: "allfiles",
         sort: "created_time",
-        folderId,
+        folderId: folderId || typedFolderId,
       });
 
       let responseArray = [];

--- a/components/zoho_workdrive/sources/new-folder/new-folder.mjs
+++ b/components/zoho_workdrive/sources/new-folder/new-folder.mjs
@@ -1,11 +1,13 @@
-import { DEFAULT_POLLING_SOURCE_TIMER_INTERVAL } from "@pipedream/platform";
-import app from "../../zoho_workdrive.app.mjs";
+import {
+  ConfigurationError,
+  DEFAULT_POLLING_SOURCE_TIMER_INTERVAL,
+} from "@pipedream/platform";import app from "../../zoho_workdrive.app.mjs";
 import sampleEmit from "./test-event.mjs";
 
 export default {
   key: "zoho_workdrive-new-folder",
   name: "New Folder",
-  version: "0.0.4",
+  version: "0.1.0",
   description: "Emit new event when a new folder is created in a specific folder.",
   type: "source",
   dedupe: "unique",
@@ -45,6 +47,13 @@ export default {
       ],
       label: "Folder Id",
       description: "The unique ID of the folder.",
+      optional: true,
+    },
+    typedFolderId: {
+      type: "string",
+      label: "Typed Folder Id",
+      description: "Type in the unique ID of the folder. Use this if you hit rate limits on the `Folder Id` prop.",
+      optional: true,
     },
   },
   methods: {
@@ -58,7 +67,12 @@ export default {
       const {
         app,
         folderId,
+        typedFolderId,
       } = this;
+
+      if (!folderId && !typedFolderId) {
+        throw new ConfigurationError("Please select a Folder Id or type in a Typed Folder Id.");
+      }
 
       const lastDate = this._getLastDate();
       let maxDate = lastDate;
@@ -67,7 +81,7 @@ export default {
         maxResults,
         filter: "folder",
         sort: "created_time",
-        folderId,
+        folderId: folderId || typedFolderId,
       });
 
       let responseArray = [];


### PR DESCRIPTION
## WHY

<!-- author to complete -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Zoho WorkDrive “New File in Folder” and “New Folder” now support a typed Folder ID as an alternative to selecting a folder.
  - Folder selection is more flexible: use either a selected Folder ID or a typed Folder ID, with clear validation if neither is provided.

- Chores
  - Version bumps for the Zoho WorkDrive component and related sources to reflect the new capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->