### PR TITLE
Hubspot New Deal in Stage - limit initial events

### DIFF
--- a/components/hubspot/package.json
+++ b/components/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/hubspot",
-  "version": "1.7.10",
+  "version": "1.7.11",
   "description": "Pipedream Hubspot Components",
   "main": "hubspot.app.mjs",
   "keywords": [

--- a/components/hubspot/sources/new-deal-in-stage/new-deal-in-stage.mjs
+++ b/components/hubspot/sources/new-deal-in-stage/new-deal-in-stage.mjs
@@ -11,7 +11,7 @@ export default {
   key: "hubspot-new-deal-in-stage",
   name: "New Deal In Stage",
   description: "Emit new event for each new deal in a stage.",
-  version: "0.0.41",
+  version: "0.0.42",
   dedupe: "unique",
   type: "source",
   props: {
@@ -89,6 +89,8 @@ export default {
     },
     async processDeals(params, after) {
       let maxTs = after || 0;
+      let initialEventsEmitted = 0;
+      const maxInitialEvents = 25;
 
       do {
         const results = await this.hubspot.searchCRM(params);
@@ -110,6 +112,9 @@ export default {
             if (ts > maxTs) {
               maxTs = ts;
               this._setAfter(ts);
+            }
+            if (!after && ++initialEventsEmitted >= maxInitialEvents) {
+              return;
             }
           }
         }


### PR DESCRIPTION
This limits the events emitted when `ts` is falsy, i.e. on initial event emission.