### PR TITLE
Adjust hubspot actions reloadProps

### DIFF
--- a/components/hubspot/actions/common/common-create-object.mjs
+++ b/components/hubspot/actions/common/common-create-object.mjs
@@ -1,9 +1,11 @@
 import common from "./common-create.mjs";
+import hubspot from "../../hubspot.app.mjs";
 
 export default {
   ...common,
   props: {
     ...common.props,
+    hubspot,
     // Re-defining propertyGroups so this.getObjectType() can be called from async options
     // eslint-disable-next-line pipedream/props-description
     propertyGroups: {

--- a/components/hubspot/actions/create-company/create-company.mjs
+++ b/components/hubspot/actions/create-company/create-company.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Create Company",
   description:
     "Create a company in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/companies#endpoint?spec=POST-/crm/v3/objects/companies)",
-  version: "0.0.29",
+  version: "0.0.30",
   type: "action",
   methods: {
     ...common.methods,

--- a/components/hubspot/actions/create-custom-object/create-custom-object.mjs
+++ b/components/hubspot/actions/create-custom-object/create-custom-object.mjs
@@ -1,5 +1,8 @@
-import appProp from "../common/common-app-prop.mjs";
 import common from "../common/common-create-object.mjs";
+
+const {
+  hubspot, ...otherProps
+} = common.props;
 
 export default {
   ...common,
@@ -7,17 +10,17 @@ export default {
   name: "Create Custom Object",
   description:
     "Create a new custom object in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/custom-objects#create-a-custom-object)",
-  version: "1.0.11",
+  version: "1.0.12",
   type: "action",
   props: {
-    ...appProp.props,
+    hubspot,
     customObjectType: {
       propDefinition: [
-        appProp.props.hubspot,
+        hubspot,
         "customObjectType",
       ],
     },
-    ...common.props,
+    ...otherProps,
   },
   methods: {
     ...common.methods,

--- a/components/hubspot/actions/create-deal/create-deal.mjs
+++ b/components/hubspot/actions/create-deal/create-deal.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Create Deal",
   description:
     "Create a deal in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/deals#endpoint?spec=POST-/crm/v3/objects/deals)",
-  version: "0.0.29",
+  version: "0.0.30",
   type: "action",
   props: {
     ...common.props,

--- a/components/hubspot/actions/create-lead/create-lead.mjs
+++ b/components/hubspot/actions/create-lead/create-lead.mjs
@@ -1,8 +1,11 @@
 import {
   ASSOCIATION_CATEGORY, OBJECT_TYPE,
 } from "../../common/constants.mjs";
-import appProp from "../common/common-app-prop.mjs";
 import common from "../common/common-create-object.mjs";
+
+const {
+  hubspot, ...otherProps
+} = common.props;
 
 export default {
   ...common,
@@ -10,13 +13,13 @@ export default {
   name: "Create Lead",
   description:
     "Create a lead in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/leads#create-leads)",
-  version: "0.0.17",
+  version: "0.0.18",
   type: "action",
   props: {
-    ...appProp.props,
+    hubspot,
     contactId: {
       propDefinition: [
-        appProp.props.hubspot,
+        hubspot,
         "objectId",
         () => ({
           objectType: "contact",
@@ -25,7 +28,7 @@ export default {
       label: "Contact ID",
       description: "The contact to associate with the lead",
     },
-    ...common.props,
+    ...otherProps,
   },
   methods: {
     ...common.methods,

--- a/components/hubspot/actions/create-or-update-contact/create-or-update-contact.mjs
+++ b/components/hubspot/actions/create-or-update-contact/create-or-update-contact.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Create or Update Contact",
   description:
     "Create or update a contact in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts#endpoint?spec=POST-/crm/v3/objects/contacts)",
-  version: "0.0.27",
+  version: "0.0.28",
   type: "action",
   props: {
     ...common.props,

--- a/components/hubspot/actions/create-ticket/create-ticket.mjs
+++ b/components/hubspot/actions/create-ticket/create-ticket.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Create Ticket",
   description:
     "Create a ticket in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/tickets)",
-  version: "0.0.20",
+  version: "0.0.21",
   type: "action",
   props: {
     ...common.props,

--- a/components/hubspot/actions/update-company/update-company.mjs
+++ b/components/hubspot/actions/update-company/update-company.mjs
@@ -1,5 +1,5 @@
 import { OBJECT_TYPE } from "../../common/constants.mjs";
-import appProp from "../common/common-app-prop.mjs";
+import hubspot from "../../hubspot.app.mjs";
 import common from "../common/common-update-object.mjs";
 
 export default {
@@ -8,7 +8,7 @@ export default {
   name: "Update Company",
   description:
     "Update a company in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/companies)",
-  version: "0.0.25",
+  version: "0.0.26",
   type: "action",
   methods: {
     ...common.methods,
@@ -17,10 +17,10 @@ export default {
     },
   },
   props: {
-    ...appProp.props,
+    hubspot,
     objectId: {
       propDefinition: [
-        appProp.props.hubspot,
+        hubspot,
         "objectId",
         () => ({
           objectType: "company",

--- a/components/hubspot/actions/update-contact/update-contact.mjs
+++ b/components/hubspot/actions/update-contact/update-contact.mjs
@@ -1,5 +1,5 @@
 import { OBJECT_TYPE } from "../../common/constants.mjs";
-import appProp from "../common/common-app-prop.mjs";
+import hubspot from "../../hubspot.app.mjs";
 import common from "../common/common-update-object.mjs";
 
 export default {
@@ -8,7 +8,7 @@ export default {
   name: "Update Contact",
   description:
     "Update a contact in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts#endpoint?spec=POST-/crm/v3/objects/contacts)",
-  version: "0.0.26",
+  version: "0.0.27",
   type: "action",
   methods: {
     ...common.methods,
@@ -17,10 +17,10 @@ export default {
     },
   },
   props: {
-    ...appProp.props,
+    hubspot,
     objectId: {
       propDefinition: [
-        appProp.props.hubspot,
+        hubspot,
         "objectId",
         () => ({
           objectType: "contact",

--- a/components/hubspot/actions/update-custom-object/update-custom-object.mjs
+++ b/components/hubspot/actions/update-custom-object/update-custom-object.mjs
@@ -1,4 +1,4 @@
-import appProp from "../common/common-app-prop.mjs";
+import hubspot from "../../hubspot.app.mjs";
 import common from "../common/common-update-object.mjs";
 
 export default {
@@ -7,7 +7,7 @@ export default {
   name: "Update Custom Object",
   description:
     "Update a custom object in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/custom-objects#update-existing-custom-objects)",
-  version: "1.0.11",
+  version: "1.0.12",
   type: "action",
   methods: {
     ...common.methods,
@@ -16,16 +16,16 @@ export default {
     },
   },
   props: {
-    ...appProp.props,
+    hubspot,
     customObjectType: {
       propDefinition: [
-        appProp.props.hubspot,
+        hubspot,
         "customObjectType",
       ],
     },
     objectId: {
       propDefinition: [
-        appProp.props.hubspot,
+        hubspot,
         "objectId",
         (c) => ({
           objectType: c.customObjectType,

--- a/components/hubspot/actions/update-deal/update-deal.mjs
+++ b/components/hubspot/actions/update-deal/update-deal.mjs
@@ -1,5 +1,5 @@
 import { OBJECT_TYPE } from "../../common/constants.mjs";
-import appProp from "../common/common-app-prop.mjs";
+import hubspot from "../../hubspot.app.mjs";
 import common from "../common/common-update-object.mjs";
 
 export default {
@@ -8,7 +8,7 @@ export default {
   name: "Update Deal",
   description:
     "Update a deal in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/deals#update-deals)",
-  version: "0.0.16",
+  version: "0.0.17",
   type: "action",
   methods: {
     ...common.methods,
@@ -17,10 +17,10 @@ export default {
     },
   },
   props: {
-    ...appProp.props,
+    hubspot,
     objectId: {
       propDefinition: [
-        appProp.props.hubspot,
+        hubspot,
         "objectId",
         () => ({
           objectType: "deal",

--- a/components/hubspot/actions/update-lead/update-lead.mjs
+++ b/components/hubspot/actions/update-lead/update-lead.mjs
@@ -1,5 +1,5 @@
 import { OBJECT_TYPE } from "../../common/constants.mjs";
-import appProp from "../common/common-app-prop.mjs";
+import hubspot from "../../hubspot.app.mjs";
 import common from "../common/common-update-object.mjs";
 
 export default {
@@ -8,7 +8,7 @@ export default {
   name: "Update Lead",
   description:
     "Update a lead in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/leads#update-leads)",
-  version: "0.0.17",
+  version: "0.0.18",
   type: "action",
   methods: {
     ...common.methods,
@@ -17,10 +17,10 @@ export default {
     },
   },
   props: {
-    ...appProp.props,
+    hubspot,
     objectId: {
       propDefinition: [
-        appProp.props.hubspot,
+        hubspot,
         "leadId",
       ],
     },

--- a/components/hubspot/package.json
+++ b/components/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/hubspot",
-  "version": "1.7.10",
+  "version": "1.7.11",
   "description": "Pipedream Hubspot Components",
   "main": "hubspot.app.mjs",
   "keywords": [


### PR DESCRIPTION
These actions only show additional props that were selected in "propertyGroups", so calling reloadProps in the app file (when propertyGroups has not been selected yet) is irrelevant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a helper to retrieve the selected custom object type in the “Create Custom Object” action.

- Refactor
  - Standardized HubSpot app configuration across create/update actions for companies, contacts, deals, leads, tickets, and custom objects, improving consistency and maintainability.

- Chores
  - Bumped versions for multiple HubSpot actions and the HubSpot package to reflect updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->