### PR TITLE
FrontApp source improvements

### DIFF
--- a/components/frontapp/package.json
+++ b/components/frontapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/frontapp",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Pipedream Frontapp Components",
   "main": "frontapp.app.mjs",
   "keywords": [

--- a/components/frontapp/sources/common/base.mjs
+++ b/components/frontapp/sources/common/base.mjs
@@ -14,7 +14,7 @@ export default {
   },
   methods: {
     _getLastTs() {
-      return this.db.get("lastTs") ?? 1000000000;
+      return this.db.get("lastTs") ?? 0;
     },
     _setLastTs(lastTs) {
       this.db.set("lastTs", lastTs);
@@ -36,6 +36,8 @@ export default {
         // If filterFn is provided, use it to filter items, otherwise add all items
         if (!filterFn || filterFn(item, lastTs)) {
           responseArray.push(item);
+        } else {
+          break; // done paginating
         }
       }
 

--- a/components/frontapp/sources/new-conversation-created/new-conversation-created.mjs
+++ b/components/frontapp/sources/new-conversation-created/new-conversation-created.mjs
@@ -6,7 +6,7 @@ export default {
   key: "frontapp-new-conversation-created",
   name: "New Conversation Created",
   description: "Emit new event when a conversation is created. [See the documentation](https://dev.frontapp.com/reference/list-conversations)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/frontapp/sources/new-conversation-state-change/new-conversation-state-change.mjs
+++ b/components/frontapp/sources/new-conversation-state-change/new-conversation-state-change.mjs
@@ -6,8 +6,8 @@ export default {
   ...common,
   key: "frontapp-new-conversation-state-change",
   name: "New Conversation State Change",
-  description: "Emit new event when a conversation reaches a specific state. [See the documentation](https://dev.frontapp.com/reference/list-conversations)",
-  version: "0.0.4",
+  description: "Emit new event when a conversation reaches a specific state. [See the documentation](https://dev.frontapp.com/reference/list-events)",
+  version: "0.0.5",
   type: "source",
   dedupe: "unique",
   props: {
@@ -28,6 +28,8 @@ export default {
       return {
         "q[after]": lastTs,
         "q[types]": this.types,
+        "sort_by": "created_at",
+        "sort_order": "desc",
       };
     },
     _getEmit(item) {

--- a/components/frontapp/sources/new-conversation-tag/new-conversation-tag.mjs
+++ b/components/frontapp/sources/new-conversation-tag/new-conversation-tag.mjs
@@ -6,7 +6,7 @@ export default {
   key: "frontapp-new-conversation-tag",
   name: "New Conversation Tag",
   description: "Emit new event when a conversation is tagged with a specific tag or any tag. [See the documentation](https://dev.frontapp.com/reference/events)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "source",
   dedupe: "unique",
   props: {
@@ -30,6 +30,8 @@ export default {
         "q[types]": [
           "tag",
         ],
+        "sort_by": "created_at",
+        "sort_order": "desc",
       };
     },
     _getEmit(item) {

--- a/components/frontapp/sources/new-message-template-created/new-message-template-created.mjs
+++ b/components/frontapp/sources/new-message-template-created/new-message-template-created.mjs
@@ -6,7 +6,7 @@ export default {
   key: "frontapp-new-message-template-created",
   name: "New Message Template Created",
   description: "Emit new event when a message template is created. [See the documentation](https://dev.frontapp.com/reference/list-message-templates)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "source",
   dedupe: "unique",
   methods: {


### PR DESCRIPTION
Resolves #18465 

The query object prop in the [`list-conversations`](https://dev.frontapp.com/reference/list-conversations) endpoint only supports filtering by "statuses". However, we can limit pagination by exiting the loop when we get to a timestamp older than `lastTs`.
