### PR TITLE
Slack Bot - update channeld prop in New Message In Channel trigger

### DIFF
--- a/components/slack_bot/package.json
+++ b/components/slack_bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/slack_bot",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "Pipedream Slack_bot Components",
   "main": "slack_bot.app.mjs",
   "keywords": [

--- a/components/slack_bot/sources/new-message-in-channel/new-message-in-channel.mjs
+++ b/components/slack_bot/sources/new-message-in-channel/new-message-in-channel.mjs
@@ -6,7 +6,7 @@ export default {
   ...common,
   key: "slack_bot-new-message-in-channel",
   name: "New Message In Channel",
-  version: "0.0.5",
+  version: "0.0.6",
   description: "Emit new event when a new message is posted to a public, private or group channel (Bot)",
   type: "source",
   dedupe: "unique",
@@ -15,7 +15,7 @@ export default {
     channelId: {
       propDefinition: [
         common.props.app,
-        "channelId",
+        "conversation",
         () => ({
           types: [
             constants.CHANNEL_TYPE.PUBLIC,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12247,7 +12247,11 @@ importers:
         specifier: ^3.0.0
         version: 3.0.3
 
-  components/rosette_text_analytics: {}
+  components/rosette_text_analytics:
+    dependencies:
+      '@pipedream/platform':
+        specifier: ^3.1.0
+        version: 3.1.0
 
   components/route4me: {}
 


### PR DESCRIPTION
Updates the `channelId` prop to use the `conversations` propDefinition. [Slack context](https://pipedream-users.slack.com/archives/CPTJYRY5A/p1758821714016149)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Renamed the Slack channel selection field to “Conversation” in the New Message in Channel source.

- Chores
  - Bumped Slack Bot package version to 0.5.7.
  - Updated New Message in Channel source version to 0.0.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->