### PR TITLE
Google Cloud Big Query improvements

### DIFF
--- a/components/google_cloud/package.json
+++ b/components/google_cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_cloud",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Pipedream Google_cloud Components",
   "main": "google_cloud.app.mjs",
   "keywords": [

--- a/components/google_cloud/sources/bigquery-new-row/bigquery-new-row.mjs
+++ b/components/google_cloud/sources/bigquery-new-row/bigquery-new-row.mjs
@@ -9,7 +9,7 @@ export default {
   // eslint-disable-next-line pipedream/source-name
   name: "BigQuery - New Row",
   description: "Emit new events when a new row is added to a table",
-  version: "0.1.7",
+  version: "0.1.8",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/google_cloud/sources/bigquery-query-results/bigquery-query-results.mjs
+++ b/components/google_cloud/sources/bigquery-query-results/bigquery-query-results.mjs
@@ -8,7 +8,7 @@ export default {
   // eslint-disable-next-line pipedream/source-name
   name: "BigQuery - Query Results",
   description: "Emit new events with the results of an arbitrary query",
-  version: "0.1.6",
+  version: "0.1.7",
   dedupe: "unique",
   type: "source",
   props: {
@@ -21,11 +21,7 @@ export default {
     dedupeKey: {
       type: "string",
       label: "De-duplication Key",
-      description: `
-        The name of a column in the table to use for deduplication. See [the
-        docs](https://github.com/PipedreamHQ/pipedream/tree/master/components/google_cloud/sources/bigquery-query-results#technical-details)
-        for more info.
-      `,
+      description: "The name of a column in the table to use for deduplication. See [the docs](https://github.com/PipedreamHQ/pipedream/tree/master/components/google_cloud/sources/bigquery-query-results#technical-details) for more info.",
       optional: true,
     },
   },
@@ -47,10 +43,11 @@ export default {
     },
     generateMetaForCollection(rows, ts) {
       const hash = crypto.createHash("sha1");
-      rows
-        .map((i) => i[this.dedupeKey] || uuidv4())
-        .map((i) => i.toString())
-        .forEach((i) => hash.update(i));
+      // Process rows incrementally to avoid memory accumulation
+      for (const row of rows) {
+        const key = row[this.dedupeKey] || uuidv4();
+        hash.update(key.toString());
+      }
       const id = hash.digest("base64");
       const summary = `New event (ID: ${id})`;
       return {


### PR DESCRIPTION
Resolves #18486 
Resolves #18352 

- Bug fix for error “TypeError: job.getQueryResults is not a function”
- Introduces additional updates to help reduce out-of-memory errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added option to limit the number of BigQuery rows processed per execution.
* **Refactor**
  * Reworked BigQuery processing to page and batch results, reducing memory usage and improving reliability when handling large datasets.
  * Enforced a maximum event size of 1000 for safer processing.
* **Documentation**
  * Clarified the description for the deduplication key in BigQuery query results.
* **Chores**
  * Bumped component versions (google_cloud package and BigQuery sources) with no functional changes beyond those noted above.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->