### PR TITLE
Add Set Custom Ticket Fields action for Zendesk

### DIFF
--- a/components/zendesk/actions/set-custom-ticket-fields/set-custom-ticket-fields.mjs
+++ b/components/zendesk/actions/set-custom-ticket-fields/set-custom-ticket-fields.mjs
@@ -1,0 +1,82 @@
+import app from "../../zendesk.app.mjs";
+
+export default {
+  key: "zendesk-set-custom-ticket-fields",
+  name: "Set Custom Ticket Fields",
+  description: "Sets one or more custom field values on a ticket. [See the documentation](https://developer.zendesk.com/api-reference/ticketing/tickets/tickets/#update-ticket).",
+  type: "action",
+  version: "0.0.1",
+  props: {
+    app,
+    ticketId: {
+      propDefinition: [
+        app,
+        "ticketId",
+      ],
+    },
+    customFields: {
+      type: "string[]",
+      label: "Custom Fields",
+      description: "Array of custom field objects. Each item should be formatted as `{\"id\": \"field_id\", \"value\": \"field_value\"}`. Example: `{\"id\": \"23129751115165\", \"value\": \"ABCDE\"}`",
+    },
+    customSubdomain: {
+      propDefinition: [
+        app,
+        "customSubdomain",
+      ],
+    },
+  },
+  methods: {
+    updateTicket({
+      ticketId, ...args
+    } = {}) {
+      return this.app.update({
+        path: `/tickets/${ticketId}`,
+        ...args,
+      });
+    },
+  },
+  async run({ $: step }) {
+    const {
+      ticketId,
+      customFields,
+      customSubdomain,
+    } = this;
+
+    // Parse custom fields from string array to objects
+    const parsedCustomFields = customFields.map((field) => {
+      try {
+        return typeof field === "string"
+          ? JSON.parse(field)
+          : field;
+      } catch (error) {
+        throw new Error(`Failed to parse custom field: ${field}. Each field must be valid JSON with "id" and "value" properties.`);
+      }
+    });
+
+    // Validate custom fields structure
+    parsedCustomFields.forEach((field, index) => {
+      if (!field.id) {
+        throw new Error(`Custom field at index ${index} is missing required "id" property`);
+      }
+      if (field.value === undefined) {
+        throw new Error(`Custom field at index ${index} is missing required "value" property`);
+      }
+    });
+
+    const response = await this.updateTicket({
+      step,
+      ticketId,
+      customSubdomain,
+      data: {
+        ticket: {
+          custom_fields: parsedCustomFields,
+        },
+      },
+    });
+
+    step.export("$summary", `Successfully updated ${parsedCustomFields.length} custom field(s) on ticket ${response.ticket.id}`);
+
+    return response;
+  },
+};


### PR DESCRIPTION
## Summary
Added new action to set one or more custom field values on a Zendesk ticket using the Zendesk API.

## Features
- Supports setting multiple custom fields in a single action
- Accepts array of custom field objects with `id` and `value` properties
- Includes validation for required properties
- Supports custom subdomain for enterprise accounts

## Test plan
- [x] Published action to Pipedream (component ID: `sc_JDi80Zjp`)
- [x] Action successfully packages with dependencies (`zendesk.app.mjs`, `common/constants.mjs`)
- [ ] Manual testing in Pipedream workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)