### PR TITLE
Upgrade to the v2 SDK

### DIFF
--- a/packages/connect-react/package.json
+++ b/packages/connect-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/connect-react",
-  "version": "1.6.0",
+  "version": "2.0.0",
   "description": "Pipedream Connect library for React",
   "files": [
     "dist"
@@ -30,7 +30,7 @@
   "author": "Pipedream Engineering",
   "license": "MIT",
   "dependencies": {
-    "@pipedream/sdk": "^1.8.0",
+    "@pipedream/sdk": "^2.0.9",
     "@tanstack/react-query": "^5.59.16",
     "lodash.isequal": "^4.5.0",
     "react-markdown": "^9.0.1",

--- a/packages/connect-react/src/components/ComponentForm.tsx
+++ b/packages/connect-react/src/components/ComponentForm.tsx
@@ -1,12 +1,14 @@
-import {
-  FormContextProvider, type FormContext,
-} from "../hooks/form-context";
-import { DynamicProps } from "../types";
 import type {
+  Component,
   ConfigurableProps,
   ConfiguredProps,
-  V1Component,
+  DynamicProps,
 } from "@pipedream/sdk";
+
+import {
+  type FormContext,
+  FormContextProvider,
+} from "../hooks/form-context";
 import { InternalComponentForm } from "./InternalComponentForm";
 
 export type ComponentFormProps<T extends ConfigurableProps, U = ConfiguredProps<T>> = {
@@ -18,7 +20,7 @@ export type ComponentFormProps<T extends ConfigurableProps, U = ConfiguredProps<
    * @deprecated Use `externalUserId` instead.
    */
   userId?: string;
-  component: V1Component<T>;
+  component: Component;
   configuredProps?: U; // XXX value?
   disableQueryDisabling?: boolean;
   // dynamicPropsId?: string // XXX need to load this initially when passed

--- a/packages/connect-react/src/components/Control.tsx
+++ b/packages/connect-react/src/components/Control.tsx
@@ -38,7 +38,7 @@ export function Control<T extends ConfigurableProps, U extends ConfigurableProp>
     return <RemoteOptionsContainer queryEnabled={queryDisabledIdx == null || queryDisabledIdx >= idx} />;
   }
 
-  if ("options" in prop && prop.options) {
+  if ("options" in prop && Array.isArray(prop.options) && prop.options.length > 0) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const options: LabelValueOption<any>[] = prop.options.map(sanitizeOption);
     return <ControlSelect options={options} components={{

--- a/packages/connect-react/src/components/ControlAny.tsx
+++ b/packages/connect-react/src/components/ControlAny.tsx
@@ -1,6 +1,13 @@
-import { useFormFieldContext } from "../hooks/form-field-context";
-import { useCustomize } from "../hooks/customization-context";
+import {
+  ConfiguredPropValueInteger,
+  ConfiguredPropValueObject,
+  ConfiguredPropValueString,
+  ConfiguredPropValueStringArray,
+} from "@pipedream/sdk";
 import type { CSSProperties } from "react";
+
+import { useCustomize } from "../hooks/customization-context";
+import { useFormFieldContext } from "../hooks/form-field-context";
 
 export function ControlAny() {
   const formFieldContext = useFormFieldContext();
@@ -18,7 +25,11 @@ export function ControlAny() {
     boxShadow: theme.boxShadow.input,
   };
 
-  let jsonValue = value;
+  let jsonValue = value as
+    | ConfiguredPropValueInteger
+    | ConfiguredPropValueObject
+    | ConfiguredPropValueString
+    | ConfiguredPropValueStringArray;
   if (typeof jsonValue === "object") {
     jsonValue = JSON.stringify(jsonValue);
   }

--- a/packages/connect-react/src/components/ControlApp.tsx
+++ b/packages/connect-react/src/components/ControlApp.tsx
@@ -77,7 +77,7 @@ export function ControlApp({ app }: ControlAppProps) {
   };
   const selectProps = select.getProps("controlAppSelect", baseSelectProps);
 
-  const oauthAppId = oauthAppConfig?.[app.name_slug];
+  const oauthAppId = oauthAppConfig?.[app.nameSlug];
   const {
     isLoading: isLoadingAccounts,
     // TODO error
@@ -86,14 +86,12 @@ export function ControlApp({ app }: ControlAppProps) {
   } = useAccounts(
     {
       external_user_id: externalUserId,
-      app: app.name_slug,
+      app: app.nameSlug,
       oauth_app_id: oauthAppId,
     },
     {
       useQueryOpts: {
         enabled: !!app,
-
-        // @ts-expect-error this seems to work (this overrides enabled so don't just set to true)
         suspense: !!app,
       },
     },
@@ -161,7 +159,7 @@ export function ControlApp({ app }: ControlAppProps) {
             isLoading={isLoadingAccounts}
             isClearable={true}
             isSearchable={true}
-            getOptionLabel={(a) => a.name}
+            getOptionLabel={(a) => a.name ?? ""}
             getOptionValue={(a) => a.id}
             onChange={(a) => {
               if (a) {

--- a/packages/connect-react/src/components/ControlInput.tsx
+++ b/packages/connect-react/src/components/ControlInput.tsx
@@ -1,4 +1,5 @@
 import type { CSSProperties } from "react";
+import type { ConfigurablePropInteger } from "@pipedream/sdk";
 import { useFormFieldContext } from "../hooks/form-field-context";
 import { useCustomize } from "../hooks/customization-context";
 
@@ -46,20 +47,23 @@ export function ControlInput() {
     autoComplete = "new-password"; // in chrome, this is better than "off" here
   }
 
+  const min = prop.type === "integer"
+    ? (prop as ConfigurablePropInteger).min
+    : undefined;
+  const max = prop.type === "integer"
+    ? (prop as ConfigurablePropInteger).max
+    : undefined;
+
   return (
     <input
       id={id}
       type={inputType}
       name={prop.name}
-      value={value ?? ""}
+      value={String(value) ?? ""}
       onChange={(e) => onChange(toOnChangeValue(e.target.value))}
       {...getProps("controlInput", baseStyles, formFieldContextProps)}
-      min={"min" in prop
-        ? prop.min
-        : undefined}
-      max={"max" in prop
-        ? prop.max
-        : undefined}
+      min={min}
+      max={max}
       autoComplete={autoComplete}
       data-lpignore="true"
       data-1p-ignore="true"

--- a/packages/connect-react/src/components/ControlSelect.tsx
+++ b/packages/connect-react/src/components/ControlSelect.tsx
@@ -1,3 +1,4 @@
+import type { PropOptionValue } from "@pipedream/sdk";
 import {
   useEffect,
   useMemo,
@@ -22,7 +23,7 @@ import {
 import { LoadMoreButton } from "./LoadMoreButton";
 
 // XXX T and ConfigurableProp should be related
-type ControlSelectProps<T> = {
+type ControlSelectProps<T extends PropOptionValue> = {
   isCreatable?: boolean;
   options: LabelValueOption<T>[];
   selectProps?: ReactSelectProps<LabelValueOption<T>, boolean>;
@@ -31,7 +32,7 @@ type ControlSelectProps<T> = {
   components?: ReactSelectProps<LabelValueOption<T>, boolean>["components"];
 };
 
-export function ControlSelect<T>({
+export function ControlSelect<T extends PropOptionValue>({
   isCreatable,
   options,
   selectProps,
@@ -83,37 +84,30 @@ export function ControlSelect<T>({
       return null;
     }
 
-    let ret = rawValue;
-    if (Array.isArray(ret)) {
+    if (Array.isArray(rawValue)) {
       // if simple, make lv (XXX combine this with other place this happens)
-      if (!isOptionWithLabel(ret[0])) {
-        return ret.map((o) =>
-          selectOptions.find((item) => item.value === o) || {
-            label: String(o),
-            value: o,
-          });
+      if (!isOptionWithLabel(rawValue[0])) {
+        return rawValue.map((o) =>
+          selectOptions.find((item) => item.value === o) || sanitizeOption(o as T),
+        );
       }
-    } else if (ret && typeof ret === "object" && "__lv" in ret) {
-      // Extract the actual option from __lv wrapper
-      ret = ret.__lv;
-    } else if (!isOptionWithLabel(ret)) {
+    } else if (rawValue && typeof rawValue === "object" && "__lv" in (rawValue as Record<string, unknown>)) {
+      // Extract the actual option from __lv wrapper and sanitize to LV
+      return sanitizeOption(((rawValue as Record<string, unknown>).__lv) as T);
+    } else if (!isOptionWithLabel(rawValue)) {
       const lvOptions = selectOptions?.[0] && isOptionWithLabel(selectOptions[0]);
       if (lvOptions) {
         for (const item of selectOptions) {
           if (item.value === rawValue) {
-            ret = item;
-            break;
+            return item;
           }
         }
       } else {
-        ret = {
-          label: String(rawValue),
-          value: rawValue,
-        }
+        return sanitizeOption(rawValue as T);
       }
     }
 
-    return ret;
+    return null;
   }, [
     rawValue,
     selectOptions,

--- a/packages/connect-react/src/components/Field.tsx
+++ b/packages/connect-react/src/components/Field.tsx
@@ -43,7 +43,7 @@ export function Field<T extends ConfigurableProp>(props: FieldProps<T>) {
   const app = "app" in field.extra
     ? field.extra.app
     : undefined;
-  if (app && !app.auth_type) {
+  if (app && !app.authType) {
     return null;
   }
 
@@ -59,7 +59,7 @@ export function Field<T extends ConfigurableProp>(props: FieldProps<T>) {
   // XXX use similar pattern as app below for boolean and checkboxing DOM re-ordering?
 
   return (
-    <div {...getProps("field", baseStyles, props as FieldProps<ConfigurableProp>)}>
+    <div {...getProps("field", baseStyles, props)}>
       <Label text={labelText} field={field} form={form} />
       <Control field={field} form={form} />
       <Description markdown={prop.description} field={field} form={form} />

--- a/packages/connect-react/src/components/InternalComponentForm.tsx
+++ b/packages/connect-react/src/components/InternalComponentForm.tsx
@@ -56,6 +56,7 @@ export function InternalComponentForm() {
             type: "alert",
             alertType: "error",
             content: `# ${e.name}\n${e.message}`,
+            name: e.name,
           } as ConfigurablePropAlert
         }))
       }
@@ -146,7 +147,7 @@ export function InternalComponentForm() {
             idx,
           ]) => {
             if (prop.type === "alert") {
-              return <Alert key={prop.name} prop={prop} />;
+              return <Alert key={prop.name} prop={prop as ConfigurablePropAlert} />;
             }
             return <InternalField key={prop.name} prop={prop} idx={idx} />;
           })}

--- a/packages/connect-react/src/components/InternalField.tsx
+++ b/packages/connect-react/src/components/InternalField.tsx
@@ -1,4 +1,4 @@
-import type { ConfigurableProp } from "@pipedream/sdk";
+import type { ConfigurableProp, ConfigurablePropApp } from "@pipedream/sdk";
 import { FormFieldContext } from "../hooks/form-field-context";
 import { useFormContext } from "../hooks/form-context";
 import { Field } from "./Field";
@@ -10,6 +10,10 @@ type FieldInternalProps<T extends ConfigurableProp> = {
   idx: number;
 };
 
+function isConfigurablePropApp(prop: ConfigurableProp): prop is ConfigurablePropApp {
+  return prop.type === "app";
+}
+
 export function InternalField<T extends ConfigurableProp>({
   prop, idx,
 }: FieldInternalProps<T>) {
@@ -18,17 +22,16 @@ export function InternalField<T extends ConfigurableProp>({
     id: formId, configuredProps, registerField, setConfiguredProp, errors, enableDebugging,
   } = formCtx;
 
-  const appSlug = prop.type === "app" && "app" in prop
-    ? prop.app
-    : undefined;
+  let appSlug: ConfigurablePropApp["app"] | undefined;
+  if (isConfigurablePropApp(prop)) {
+    appSlug = prop.app;
+  }
   const {
     // TODO error
     app,
   } = useApp(appSlug || "", {
     useQueryOpts: {
       enabled: !!appSlug,
-
-      // @ts-expect-error this seems to work (this overrides enabled so don't just set to true)
       suspense: !!appSlug,
     },
   });

--- a/packages/connect-react/src/components/RemoteOptionsContainer.tsx
+++ b/packages/connect-react/src/components/RemoteOptionsContainer.tsx
@@ -1,4 +1,4 @@
-import type { ConfigureComponentOpts } from "@pipedream/sdk";
+import type { ConfigurePropOpts, PropOptionValue } from "@pipedream/sdk";
 import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 import { useFormContext } from "../hooks/form-context";
@@ -56,8 +56,8 @@ export function RemoteOptionsContainer({ queryEnabled }: RemoteOptionsContainerP
   ] = useState<{
     page: number;
     prevContext: ConfigureComponentContext | undefined;
-    data: RawPropOption<string>[];
-    values: Set<string | number>;
+    data: RawPropOption[];
+    values: Set<PropOptionValue>;
   }>({
     page: 0,
     prevContext: {},
@@ -70,11 +70,11 @@ export function RemoteOptionsContainer({ queryEnabled }: RemoteOptionsContainerP
     const prop = configurableProps[i];
     configuredPropsUpTo[prop.name] = configuredProps[prop.name];
   }
-  const componentConfigureInput: ConfigureComponentOpts = {
+  const componentConfigureInput: ConfigurePropOpts = {
     externalUserId,
     page,
     prevContext: context,
-    componentId: component.key,
+    id: component.key,
     propName: prop.name,
     configuredProps: configuredPropsUpTo,
     dynamicPropsId: dynamicProps?.id,
@@ -112,7 +112,7 @@ export function RemoteOptionsContainer({ queryEnabled }: RemoteOptionsContainerP
     ],
     queryFn: async () => {
       setError(undefined);
-      const res = await client.configureComponent(componentConfigureInput);
+      const res = await client.components.configureProp(componentConfigureInput);
 
       // XXX look at errors in response here too
       const {
@@ -131,7 +131,7 @@ export function RemoteOptionsContainer({ queryEnabled }: RemoteOptionsContainerP
         }
         return [];
       }
-      let _options: RawPropOption<string>[] = []
+      let _options: RawPropOption[] = []
       if (options?.length) {
         _options = options;
       }
@@ -149,7 +149,7 @@ export function RemoteOptionsContainer({ queryEnabled }: RemoteOptionsContainerP
       const newOptions = []
       const allValues = new Set(pageable.values)
       for (const o of _options || []) {
-        let value: string | number;
+        let value: PropOptionValue;
         if (isString(o)) {
           value = o;
         } else if (o && typeof o === "object" && "value" in o && o.value != null) {
@@ -170,7 +170,7 @@ export function RemoteOptionsContainer({ queryEnabled }: RemoteOptionsContainerP
         data = [
           ...pageable.data,
           ...newOptions,
-        ] as RawPropOption<string>[]
+        ] as RawPropOption[]
         setPageable({
           page: page + 1,
           prevContext: res.context,

--- a/packages/connect-react/src/components/SelectApp.tsx
+++ b/packages/connect-react/src/components/SelectApp.tsx
@@ -4,16 +4,17 @@ import {
 import Select, { components } from "react-select";
 import { useApps } from "../hooks/use-apps";
 import type {
-  AppResponse, GetAppsOpts,
+  App,
+  AppsListRequest,
 } from "@pipedream/sdk";
 
 type SelectAppProps = {
-  value?: Partial<AppResponse> & { name_slug: string; };
-  onChange?: (app?: AppResponse) => void;
+  value?: Partial<App> & { nameSlug: string; };
+  onChange?: (app?: App) => void;
   /**
    * Additional options for fetching apps (sorting, filtering, etc.)
    */
-  appsOptions?: Omit<GetAppsOpts, "q">;
+  appsOptions?: Omit<AppsListRequest, "q">;
 };
 
 export function SelectApp({
@@ -54,9 +55,9 @@ export function SelectApp({
     SingleValue,
   } = components;
   // If we have a value prop but it's not in the search results, use the value prop directly
-  const selectedValue = apps?.find((o) => o.name_slug === value?.name_slug)
-    || (value?.name_slug
-      ? value as AppResponse
+  const selectedValue = apps?.find((o: App) => o.nameSlug === value?.nameSlug)
+    || (value?.nameSlug
+      ? value as App
       : null);
   return (
     <Select
@@ -110,10 +111,10 @@ export function SelectApp({
         IndicatorSeparator: () => null,
       }}
       options={apps || []}
-      getOptionLabel={(o) => o.name || o.name_slug} // TODO fetch initial value app so we show name
-      getOptionValue={(o) => o.name_slug}
+      getOptionLabel={(o: App) => o.name || o.nameSlug} // TODO fetch initial value app so we show name
+      getOptionValue={(o: App) => o.nameSlug}
       value={selectedValue}
-      onChange={(o) => onChange?.((o as AppResponse) || undefined)}
+      onChange={(o) => onChange?.((o as App) || undefined)}
       onInputChange={(v, { action }) => {
         // Only update on user input, not on blur/menu-close/etc
         if (action === "input-change") {

--- a/packages/connect-react/src/components/SelectComponent.tsx
+++ b/packages/connect-react/src/components/SelectComponent.tsx
@@ -1,15 +1,16 @@
+import {
+  App,
+  Component,
+} from "@pipedream/sdk";
 import { useId } from "react";
 import Select from "react-select";
 import { useComponents } from "../hooks/use-components";
-import {
-  AppResponse, V1Component,
-} from "@pipedream/sdk";
 
 type SelectComponentProps = {
-  app?: Partial<AppResponse> & { name_slug: string; };
+  app?: Partial<App> & { nameSlug: string; };
   componentType?: "action" | "trigger";
-  value?: Partial<V1Component> & { key: string; };
-  onChange?: (component?: V1Component) => void;
+  value?: Partial<Component> & { key: string; };
+  onChange?: (component?: Component) => void;
 };
 
 export function SelectComponent({
@@ -22,11 +23,11 @@ export function SelectComponent({
   const {
     isLoading, components,
   } = useComponents({
-    app: app?.name_slug,
+    app: app?.nameSlug,
     componentType,
   });
 
-  const selectedValue = components?.find((c) => c.key === value?.key) || null;
+  const selectedValue = components?.find((c: Component) => c.key === value?.key) || null;
 
   return (
     <Select
@@ -37,7 +38,7 @@ export function SelectComponent({
       getOptionLabel={(o) => o.name || o.key}
       getOptionValue={(o) => o.key}
       value={selectedValue}
-      onChange={(o) => onChange?.((o as V1Component) || undefined)}
+      onChange={(o) => onChange?.((o as Component) || undefined)}
       isLoading={isLoading}
       components={{
         IndicatorSeparator: () => null,

--- a/packages/connect-react/src/hooks/customization-context.tsx
+++ b/packages/connect-react/src/hooks/customization-context.tsx
@@ -1,21 +1,26 @@
-import {
-  createContext, useContext, type ReactNode,
-} from "react";
+import type {
+  ConfigurableProp,
+  ConfigurablePropApp,
+  ConfigurablePropBoolean,
+} from "@pipedream/sdk";
 import type {
   ComponentProps, CSSProperties, JSXElementConstructor,
 } from "react";
 import {
-  components as ReactSelectComponents, mergeStyles as mergeReactSelectStyles,
-} from "react-select";
+  createContext, useContext, type ReactNode,
+} from "react";
 import type {
-  ClassNamesConfig as ReactSelectClassNamesConfig,
   GroupBase,
-  Props as ReactSelectCustomizationProps,
+  ClassNamesConfig as ReactSelectClassNamesConfig,
   SelectComponentsConfig as ReactSelectComponentsConfig,
+  Props as ReactSelectCustomizationProps,
   StylesConfig as ReactSelectStylesConfig,
   Theme as ReactSelectTheme,
 } from "react-select";
-import type { ConfigurableProp } from "@pipedream/sdk";
+import {
+  mergeStyles as mergeReactSelectStyles,
+  components as ReactSelectComponents,
+} from "react-select";
 import {
   defaultTheme, getReactSelectTheme, mergeTheme, unstyledTheme, type CustomThemeConfig, type Theme,
 } from "../theme";
@@ -34,9 +39,10 @@ import { ControlSubmit } from "../components/ControlSubmit";
 import { Description } from "../components/Description";
 import { Errors } from "../components/Errors";
 import { Field } from "../components/Field";
+import type { FieldProps } from "../components/Field";
 import { Label } from "../components/Label";
-import { OptionalFieldButton } from "../components/OptionalFieldButton";
 import { LoadMoreButton } from "../components/LoadMoreButton";
+import { OptionalFieldButton } from "../components/OptionalFieldButton";
 
 export const defaultComponents = {
   Description,
@@ -67,11 +73,11 @@ export type CustomizationOpts<P extends ComponentProps<JSXElementConstructor<any
 
 export type CustomizableProps = {
   componentForm: ComponentProps<typeof ComponentForm>;
-  connectButton: ComponentProps<typeof ControlApp> & FormFieldContext<ConfigurableProp>;
+  connectButton: ComponentProps<typeof ControlApp> & FormFieldContext<ConfigurablePropApp>;
   controlAny: ComponentProps<typeof ControlAny> & FormFieldContext<ConfigurableProp>;
-  controlApp: ComponentProps<typeof ControlApp> & FormFieldContext<ConfigurableProp>;
+  controlApp: ComponentProps<typeof ControlApp> & FormFieldContext<ConfigurablePropApp>;
   controlArray: ComponentProps<typeof ControlArray> & FormFieldContext<ConfigurableProp>;
-  controlBoolean: ComponentProps<typeof ControlBoolean> & FormFieldContext<ConfigurableProp>;
+  controlBoolean: ComponentProps<typeof ControlBoolean> & FormFieldContext<ConfigurablePropBoolean>;
   controlInput: ComponentProps<typeof ControlInput> & FormFieldContext<ConfigurableProp>;
   controlObject: ComponentProps<typeof ControlObject> & FormFieldContext<ConfigurableProp>;
   controlSql: ComponentProps<typeof ControlSql> & FormFieldContext<ConfigurableProp>;
@@ -79,7 +85,8 @@ export type CustomizableProps = {
   description: ComponentProps<typeof Description>;
   error: ComponentProps<typeof Errors>;
   errors: ComponentProps<typeof Errors>;
-  field: ComponentProps<typeof Field>;
+  // Accept any field generic to avoid forcing a specific T at call sites
+  field: FieldProps<any>;
   heading: ComponentProps<typeof ComponentForm>;
   label: ComponentProps<typeof Label>;
   optionalFields: ComponentProps<typeof ComponentForm>;
@@ -219,7 +226,8 @@ function createSelectCustomization(): Customization["select"] {
     IsMulti extends boolean = false,
     Group extends GroupBase<Option> = GroupBase<Option>
   >(name: Key, baseStyles?: ReactSelectStylesConfig<Option, IsMulti, Group>): ReactSelectStylesConfig<Option, IsMulti, Group> {
-    return mergeReactSelectStyles(context.styles?.[name] as unknown as ReactSelectStylesConfig<Option, IsMulti, Group> ?? {}, baseStyles ?? {});
+    const override = context.styles?.[name] as ReactSelectStylesConfig<Option, IsMulti, Group> | undefined;
+    return mergeReactSelectStyles(override ?? {}, baseStyles ?? {});
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -299,7 +307,7 @@ export function useCustomize(): Customization {
     if (customStyles) {
       return {
         ...baseStyles,
-        ...customStyles,
+        ...customStyles as CSSProperties,
       } as CSSProperties;
     }
     return baseStyles;

--- a/packages/connect-react/src/hooks/frontend-client-context.tsx
+++ b/packages/connect-react/src/hooks/frontend-client-context.tsx
@@ -4,9 +4,9 @@ import {
 import {
   QueryClient, QueryClientProvider,
 } from "@tanstack/react-query";
-import type { BrowserClient } from "@pipedream/sdk/browser";
+import type { PipedreamClient } from "@pipedream/sdk/browser";
 
-const FrontendClientContext = createContext<BrowserClient | undefined>(
+const FrontendClientContext = createContext<PipedreamClient | undefined>(
   undefined,
 );
 
@@ -20,7 +20,7 @@ export const useFrontendClient = () => {
   return context;
 };
 
-type FrontendClientProviderProps = { children: ReactNode; client: BrowserClient; };
+type FrontendClientProviderProps = { children: ReactNode; client: PipedreamClient; };
 
 export const FrontendClientProvider: FC<FrontendClientProviderProps> = ({
   children,

--- a/packages/connect-react/src/hooks/use-accounts.tsx
+++ b/packages/connect-react/src/hooks/use-accounts.tsx
@@ -1,37 +1,49 @@
 import {
   useQuery,
-  UseQueryOptions,
+  type UseQueryOptions,
 } from "@tanstack/react-query";
 import { useFrontendClient } from "./frontend-client-context";
-import type {
-  GetAccountOpts,
-  GetAccountsResponse,
+import {
+  type AccountsListRequest,
+  type Account,
 } from "@pipedream/sdk";
 
 /**
  * Retrieves the list of accounts associated with the project.
  */
 export const useAccounts = (
-  input: GetAccountOpts,
+  input: {
+    external_user_id?: string;
+    app?: string;
+    oauth_app_id?: string;
+  },
   opts?: {
-    useQueryOpts?: Omit<
-      UseQueryOptions<GetAccountsResponse>,
+    useQueryOpts?: (Omit<
+      UseQueryOptions<Account[]>,
       "queryKey" | "queryFn"
-    >;
+    > & { suspense?: boolean });
   },
 ) => {
   const client = useFrontendClient();
-  const query = useQuery<GetAccountsResponse>({
+  const accountsListRequest: AccountsListRequest = {
+    externalUserId: input.external_user_id,
+    app: input.app,
+    oauthAppId: input.oauth_app_id,
+  };
+  const query = useQuery({
     ...opts?.useQueryOpts,
     queryKey: [
       "accounts",
       input,
     ],
-    queryFn: () => client.getAccounts(input),
+    queryFn: async () => {
+      const response = await client.accounts.list(accountsListRequest);
+      return response.data;
+    },
   });
 
   return {
     ...query,
-    accounts: query.data?.data || [],
+    accounts: query.data || [],
   };
 };

--- a/packages/connect-react/src/hooks/use-app.tsx
+++ b/packages/connect-react/src/hooks/use-app.tsx
@@ -7,14 +7,17 @@ import { useFrontendClient } from "./frontend-client-context";
 /**
  * Get details about an app
  */
-export const useApp = (slug: string, opts?:{ useQueryOpts?: Omit<UseQueryOptions<GetAppResponse>, "queryKey" | "queryFn">;}) => {
+export const useApp = (
+  slug: string,
+  opts?: { useQueryOpts?: (Omit<UseQueryOptions<GetAppResponse>, "queryKey" | "queryFn"> & { suspense?: boolean }) }
+) => {
   const client = useFrontendClient();
   const query = useQuery({
     queryKey: [
       "app",
       slug,
     ],
-    queryFn: () => client.app(slug),
+    queryFn: () => client.apps.retrieve(slug),
     ...opts?.useQueryOpts,
   });
 

--- a/packages/connect-react/src/hooks/use-apps.tsx
+++ b/packages/connect-react/src/hooks/use-apps.tsx
@@ -1,18 +1,23 @@
 import { useQuery } from "@tanstack/react-query";
-import type { GetAppsOpts } from "@pipedream/sdk";
+import type { AppsListRequest, App } from "@pipedream/sdk";
 import { useFrontendClient } from "./frontend-client-context";
 
 /**
  * Get list of apps that can be authenticated
  */
-export const useApps = (input?: GetAppsOpts) => {
+export const useApps = (input?: AppsListRequest): {
+  apps: App[];
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => void;
+} => {
   const client = useFrontendClient();
   const query = useQuery({
     queryKey: [
       "apps",
       input,
     ],
-    queryFn: () => client.apps(input),
+    queryFn: () => client.apps.list(input),
   });
 
   return {

--- a/packages/connect-react/src/hooks/use-component.tsx
+++ b/packages/connect-react/src/hooks/use-component.tsx
@@ -1,7 +1,7 @@
 import {
   useQuery, type UseQueryOptions,
 } from "@tanstack/react-query";
-import type { ComponentRequestResponse } from "@pipedream/sdk";
+import type { GetComponentResponse } from "@pipedream/sdk";
 import { useFrontendClient } from "./frontend-client-context";
 
 /**
@@ -9,7 +9,7 @@ import { useFrontendClient } from "./frontend-client-context";
  */
 export const useComponent = (
   { key }: { key?: string; },
-  opts?: {useQueryOpts?: Omit<UseQueryOptions<ComponentRequestResponse>, "queryKey" | "queryFn">;},
+  opts?: {useQueryOpts?: Omit<UseQueryOptions<GetComponentResponse>, "queryKey" | "queryFn">;},
 ) => {
   const client = useFrontendClient();
   const query = useQuery({
@@ -17,9 +17,7 @@ export const useComponent = (
       "component",
       key,
     ],
-    queryFn: () => client.component({
-      key: key!,
-    }),
+    queryFn: () => client.components.retrieve(key!),
     enabled: !!key,
     ...opts?.useQueryOpts,
   });

--- a/packages/connect-react/src/hooks/use-components.tsx
+++ b/packages/connect-react/src/hooks/use-components.tsx
@@ -1,18 +1,23 @@
-import { useQuery } from "@tanstack/react-query";
-import type { GetComponentsOpts } from "@pipedream/sdk";
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import type { ComponentsListRequest, Component } from "@pipedream/sdk";
 import { useFrontendClient } from "./frontend-client-context";
 
 /**
  * Get list of components
  */
-export const useComponents = (input?: GetComponentsOpts) => {
+export const useComponents = (input?: ComponentsListRequest): {
+  components: Component[];
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => void;
+} => {
   const client = useFrontendClient();
   const query = useQuery({
     queryKey: [
       "components",
       input,
     ],
-    queryFn: () => client.getComponents(input),
+    queryFn: () => client.components.list(input),
   });
 
   return {

--- a/packages/connect-react/src/types.ts
+++ b/packages/connect-react/src/types.ts
@@ -1,6 +1,8 @@
 import type {
-  ConfigureComponentResponse as SdkConfigureComponentResponse,
-  ReloadComponentPropsResponse as SdkReloadComponentPropsResponse,
+  PropOptionValue,
+  PropOption,
+  ConfigurePropResponse as SdkConfigurePropResponse,
+  ReloadPropsResponse as SdkReloadPropsResponse,
 } from "@pipedream/sdk";
 
 export type SdkError = {
@@ -33,28 +35,34 @@ export type Observation = ObservationBase & (
   | ObservationLog
 )
 
-export type LabelValueOption<T> = {
-  label: string;
-  value: T;
+// Redefine to be compatible with SDK's PropOption
+// SDK: export interface PropOption { label: string; value?: PropOptionValue }
+export type LabelValueOption<
+  T extends PropOptionValue = PropOptionValue
+> = Omit<PropOption, "value"> & { value?: T };
+
+export type NestedLabelValueOption<
+  T extends PropOptionValue = PropOptionValue
+> = {
+  __lv: LabelValueOption<T> | LabelValueOption<T>[] | T | T[];
 }
 
-export type NestedLabelValueOption<T> = {
-  __lv: LabelValueOption<T> | T;
-}
-
-export type RawPropOption<T> =
-    | T
-    | NestedLabelValueOption<T>
-    | LabelValueOption<T>
+export type RawPropOption<
+  T extends PropOptionValue = PropOptionValue
+> =
+  | T
+  | NestedLabelValueOption<T>
+  | { lv: LabelValueOption<T> | LabelValueOption<T>[] }
+  | LabelValueOption<T>
 
 export type ConfigureComponentContext = Record<string, unknown>
 
-export type ConfigureComponentResponse = SdkConfigureComponentResponse & {
+export type ConfigureComponentResponse = SdkConfigurePropResponse & {
     observations: Observation[];
 }
 
-export type ReloadComponentPropsResponse = SdkReloadComponentPropsResponse & {
+export type ReloadComponentPropsResponse = SdkReloadPropsResponse & {
     observations: Observation[];
 }
 
-export type DynamicProps = SdkReloadComponentPropsResponse["dynamicProps"]
+export type DynamicProps = SdkReloadPropsResponse["dynamicProps"]

--- a/packages/connect-react/src/utils/component.ts
+++ b/packages/connect-react/src/utils/component.ts
@@ -1,5 +1,13 @@
 import type {
-  App, ConfigurableProp, ConfigurablePropApp, ConfigurablePropBoolean, ConfigurablePropInteger, ConfigurablePropString, ConfigurablePropStringArray, PropValue,
+  App,
+  ConfigurableProp,
+  ConfigurablePropApp,
+  ConfigurablePropBoolean,
+  ConfigurablePropInteger,
+  ConfigurablePropString,
+  ConfigurablePropStringArray,
+  PropOptionValue as SdkPropOptionValue,
+  PropValue,
 } from "@pipedream/sdk";
 import { NestedLabelValueOption } from "../types";
 
@@ -23,7 +31,7 @@ export type PropOptions<T> = {
   selectedOptions: PropOption<T>[]
 }
 
-export function valuesFromOptions<T>(value: unknown | T[] | PropOptions<T>): T[] {
+export function valuesFromOptions<T extends SdkPropOptionValue>(value: unknown | T[] | PropOptions<T>): T[] {
   if (typeof value === "object" && value && "selectedOptions" in value && Array.isArray(value.selectedOptions)) {
     const selectedOptions = value.selectedOptions as PropOption<T>[]
     const results: T[] = []
@@ -125,8 +133,8 @@ type AppPropValueWithCustomFields<T extends AppCustomField[]> = PropValue<"app">
 }
 
 function getCustomFields(app: App): AppCustomField[] {
-  const isOauth = app.auth_type === "oauth"
-  const userDefinedCustomFields = JSON.parse(app.custom_fields_json || "[]")
+  const isOauth = app.authType === "oauth"
+  const userDefinedCustomFields = JSON.parse(app.customFieldsJson || "[]")
   if ("extracted_custom_fields_names" in app && app.extracted_custom_fields_names) {
     const extractedCustomFields = ((app as AppWithExtractedCustomFields).extracted_custom_fields_names || []).map(
       (name) => ({
@@ -153,9 +161,9 @@ export function appPropErrors(opts: ValidationOpts<ConfigurablePropApp>): string
       "app field not registered",
     ]
   }
-  if (!app.auth_type) {
+  if (!app.authType) {
     // These apps don't require authentication since they can't be configured
-    // (i.e. auth_type == "none")
+    // (i.e. authType == "none")
     return
   }
   if (!value) {
@@ -171,10 +179,10 @@ export function appPropErrors(opts: ValidationOpts<ConfigurablePropApp>): string
   const _value = value as PropValue<"app">
   if ("authProvisionId" in _value && !_value.authProvisionId) {
     const errs = []
-    if (app.auth_type === "oauth" && !(_value as OauthAppPropValue).oauth_access_token) {
+    if (app.authType === "oauth" && !(_value as OauthAppPropValue).oauth_access_token) {
       errs.push("missing oauth token")
     }
-    if (app.auth_type === "oauth" || app.auth_type === "keys") {
+    if (app.authType === "oauth" || app.authType === "keys") {
       const customFields = getCustomFields(app)
       const _valueWithCustomFields = _value as AppPropValueWithCustomFields<typeof customFields>
       for (const cf of customFields) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6797,8 +6797,7 @@ importers:
 
   components/humanloop: {}
 
-  components/humantic_ai:
-    specifiers: {}
+  components/humantic_ai: {}
 
   components/humor_api:
     dependencies:
@@ -12646,8 +12645,7 @@ importers:
         specifier: ^4.0.0
         version: 4.0.1
 
-  components/securityscorecard:
-    specifiers: {}
+  components/securityscorecard: {}
 
   components/securitytrails:
     dependencies:
@@ -16825,8 +16823,8 @@ importers:
   packages/connect-react:
     dependencies:
       '@pipedream/sdk':
-        specifier: ^1.8.0
-        version: 1.8.0
+        specifier: ^2.0.9
+        version: 2.0.9
       '@tanstack/react-query':
         specifier: ^5.59.16
         version: 5.61.0(react@18.3.1)
@@ -20339,8 +20337,8 @@ packages:
     resolution: {integrity: sha512-oyWFb2xsm+pRXrm+xiboSRQxA/PcP2tjqc2vQZ4y7TWFUOCBzzxencYFze8Lo+7l/QlWhXy4jbK0UzPMyFr2UQ==}
     engines: {node: '>=18.0.0'}
 
-  '@pipedream/sdk@1.8.0':
-    resolution: {integrity: sha512-nJG6+CsM4QhTD4lgU1tq3ejDieVJmp29DS6COLixdsDHbF8BfSNOxpkHqXKxii91DTm2aZ+WCjbtT5BHTSGcvQ==}
+  '@pipedream/sdk@2.0.9':
+    resolution: {integrity: sha512-yPUTJ7uneKFx6cW5Y63UTCPqX0ExC9ji93PGEAxWDeesQypqEYco+rAdH+7HDcCOSBhlH3+RgKsmXHwuleQJkQ==}
     engines: {node: '>=18.0.0'}
 
   '@pipedream/sftp@0.5.0':
@@ -30986,22 +30984,22 @@ packages:
   superagent@3.8.1:
     resolution: {integrity: sha512-VMBFLYgFuRdfeNQSMLbxGSLfmXL/xc+OO+BZp41Za/NRDBet/BNbkRJrYzCUu0u4GU0i/ml2dtT8b9qgkw9z6Q==}
     engines: {node: '>= 4.0'}
-    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
 
   superagent@4.1.0:
     resolution: {integrity: sha512-FT3QLMasz0YyCd4uIi5HNe+3t/onxMyEho7C3PSqmti3Twgy2rXT4fmkTz6wRL6bTF4uzPcfkUCa8u4JWHw8Ag==}
     engines: {node: '>= 6.0'}
-    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
 
   superagent@5.3.1:
     resolution: {integrity: sha512-wjJ/MoTid2/RuGCOFtlacyGNxN9QLMgcpYLDQlWFIhhdJ93kNscFonGvrpAHSCVjRVj++DGCglocF7Aej1KHvQ==}
     engines: {node: '>= 7.0.0'}
-    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
 
   superagent@7.1.6:
     resolution: {integrity: sha512-gZkVCQR1gy/oUXr+kxJMLDjla434KmSOKbx5iGD30Ql+AkJQ/YlPKECJy2nhqOsHLjGHzoDTXNSjhnvWhzKk7g==}
     engines: {node: '>=6.4.0 <13 || >=14'}
-    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
+    deprecated: Please downgrade to v7.1.5 if you need IE/ActiveXObject support OR upgrade to v8.0.0 as we no longer support IE and published an incorrect patch version (see https://github.com/visionmedia/superagent/issues/1731)
 
   supports-color@10.0.0:
     resolution: {integrity: sha512-HRVVSbCCMbj7/kdWF9Q+bbckjBHLtHMEoJWlkmYzzdwhYMkjkOwubLM6t7NbWKjgKamGDrWL1++KrjUO1t9oAQ==}
@@ -38548,15 +38546,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@pipedream/sdk@1.8.0':
-    dependencies:
-      '@rails/actioncable': 8.0.0
-      commander: 12.1.0
-      oauth4webapi: 3.1.4
-      ws: 8.18.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
+  '@pipedream/sdk@2.0.9': {}
 
   '@pipedream/sftp@0.5.0':
     dependencies:


### PR DESCRIPTION
# Description
Use the new v2 version of the Pipedream SDK in the `connect-react` package. This change involves migrating to the new types mostly, but also runtime changes involving the API calls.

The runtime behaviour should not be affected from a user's perspective, except for consumers of the `connect-react` package itself, since some components (e.g. `FrontendClientProvider`) expect their consumers to inject a client instance of the same SDK version. For this reason, this change bumps the **major** version of this package.
