### PR TITLE
Google Drive - create-file-from-template - make folderId prop optional

### DIFF
--- a/components/google_drive/actions/create-file-from-template/create-file-from-template.mjs
+++ b/components/google_drive/actions/create-file-from-template/create-file-from-template.mjs
@@ -8,7 +8,7 @@ export default {
   key: "google_drive-create-file-from-template",
   name: "Create New File From Template",
   description: "Create a new Google Docs file from a template. Optionally include placeholders in the template document that will get replaced from this action. [See documentation](https://www.npmjs.com/package/google-docs-mustaches)",
-  version: "0.1.14",
+  version: "0.1.15",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
@@ -32,6 +32,7 @@ export default {
       ],
       description:
         "Select the folder of the newly created Google Doc and/or PDF, or use a custom expression to reference a folder ID from a previous step.",
+      optional: true,
     },
     name: {
       propDefinition: [

--- a/components/google_drive/package.json
+++ b/components/google_drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_drive",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Pipedream Google_drive Components",
   "main": "google_drive.app.mjs",
   "keywords": [


### PR DESCRIPTION
Resolves #18590 

Will create follow-up PR to update Google Docs create-document-from-template which imports from Google Drive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Creating a Google Drive file from a template no longer requires selecting a destination folder; the folder field is now optional.

* **Chores**
  * Incremented action and package versions for the Google Drive integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->