### PR TITLE
Google Sheets - watch drive instead of file

### DIFF
--- a/components/google_sheets/package.json
+++ b/components/google_sheets/package.json
@@ -11,7 +11,7 @@
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "dependencies": {
     "@googleapis/sheets": "^0.3.0",
-    "@pipedream/google_drive": "^1.1.0",
+    "@pipedream/google_drive": "^1.1.1",
     "@pipedream/platform": "^3.1.0",
     "lodash": "^4.17.21",
     "uuidv4": "^6.2.6",

--- a/components/google_sheets/package.json
+++ b/components/google_sheets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_sheets",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Pipedream Google_sheets Components",
   "main": "google_sheets.app.mjs",
   "keywords": [

--- a/components/google_sheets/sources/common/http-based/base.mjs
+++ b/components/google_sheets/sources/common/http-based/base.mjs
@@ -31,7 +31,10 @@ export default {
   props: {
     googleSheets,
     db: "$.service.db",
-    http: "$.interface.http",
+    http: {
+      type: "$.interface.http",
+      customResponse: true,
+    },
     timer: {
       label: "Push notification renewal schedule",
       description:

--- a/components/google_sheets/sources/common/http-based/drive.mjs
+++ b/components/google_sheets/sources/common/http-based/drive.mjs
@@ -135,6 +135,10 @@ export default {
       return;
     }
 
+    this.http.respond({
+      status: 200,
+    });
+
     const spreadsheet = await this.getSpreadsheetToProcess(event);
 
     if (!spreadsheet) {

--- a/components/google_sheets/sources/common/http-based/sheet.mjs
+++ b/components/google_sheets/sources/common/http-based/sheet.mjs
@@ -54,10 +54,19 @@ export default {
     async isSheetRelevant() {
       const pageToken = this._getChangeToken() || this._getPageToken();
       const drive = this.googleSheets.drive();
-      const { data } = await drive.changes.list({
+      const params = {
         pageToken,
-        driveId: this.googleSheets.getDriveId(this.watchedDrive),
-      });
+      };
+      const driveId = this.getDriveId(this.watchedDrive);
+      if (driveId) {
+        Object.assign(params, {
+          driveId,
+          supportsAllDrives: true,
+          includeItemsFromAllDrives: true,
+          corpora: "drive",
+        });
+      }
+      const { data } = await drive.changes.list(params);
       const {
         changes, newStartPageToken,
       } = data;

--- a/components/google_sheets/sources/common/http-based/sheet.mjs
+++ b/components/google_sheets/sources/common/http-based/sheet.mjs
@@ -5,6 +5,7 @@
 import { v4 as uuid } from "uuid";
 
 import base from "./base.mjs";
+import drive from "./drive.mjs";
 
 /**
  * This source watches for changes to a specific spreadsheet in the user's Google Drive.
@@ -12,12 +13,13 @@ import base from "./base.mjs";
 export default {
   ...base,
   methods: {
+    ...drive.methods,
     ...base.methods,
     async activateHook(channelID) {
-      return this.googleSheets.activateFileHook(
+      return this.googleSheets.activateHook(
         channelID,
         this.http.endpoint,
-        this.getSheetId(),
+        this.googleSheets.getDriveId(this.watchedDrive),
       );
     },
     async getAllWorksheetIds(sheetID) {

--- a/components/google_sheets/sources/common/http-based/sheet.mjs
+++ b/components/google_sheets/sources/common/http-based/sheet.mjs
@@ -12,14 +12,36 @@ import drive from "./drive.mjs";
  */
 export default {
   ...base,
+  props: {
+    ...base.props,
+    watchDrive: {
+      type: "boolean",
+      label: "Watch Drive",
+      description: "Set to `true` to watch the drive for changes. May reduce rate limiting.",
+      optional: true,
+    },
+  },
   methods: {
     ...drive.methods,
     ...base.methods,
+    _getChangeToken() {
+      return this.db.get("changeToken");
+    },
+    _setChangeToken(changeToken) {
+      this.db.set("changeToken", changeToken);
+    },
     async activateHook(channelID) {
-      return this.googleSheets.activateHook(
+      if (this.watchDrive) {
+        return this.googleSheets.activateHook(
+          channelID,
+          this.http.endpoint,
+          this.googleSheets.getDriveId(this.watchedDrive),
+        );
+      }
+      return this.googleSheets.activateFileHook(
         channelID,
         this.http.endpoint,
-        this.googleSheets.getDriveId(this.watchedDrive),
+        this.getSheetId(),
       );
     },
     async getAllWorksheetIds(sheetID) {
@@ -28,6 +50,19 @@ export default {
         .map(({ properties }) => properties)
         .filter(({ sheetType }) => sheetType === "GRID")
         .map(({ sheetId }) => (sheetId.toString()));
+    },
+    async isSheetRelevant() {
+      const pageToken = this._getChangeToken() || this._getPageToken();
+      const drive = this.googleSheets.drive();
+      const { data } = await drive.changes.list({
+        pageToken,
+        driveId: this.googleSheets.getDriveId(this.watchedDrive),
+      });
+      const {
+        changes, newStartPageToken,
+      } = data;
+      this._setChangeToken(newStartPageToken);
+      return changes.some((change) => change.file.id === this.getSheetId());
     },
     async renewSubscription() {
       // Assume subscription & channelID may all be undefined at
@@ -53,15 +88,51 @@ export default {
       });
       this._setChannelID(newChannelID);
     },
+    async renewDriveSubscription() {
+      const subscription = this._getSubscription();
+      const channelID = this._getChannelID() || uuid();
+
+      const {
+        expiration,
+        resourceId,
+        newChannelID,
+        newPageToken,
+      } = await this.googleSheets.renewSubscription(
+        this.watchedDrive,
+        subscription,
+        this.http.endpoint,
+        channelID,
+        this._getPageToken(),
+      );
+
+      this._setSubscription({
+        expiration,
+        resourceId,
+      });
+      this._setChannelID(newChannelID);
+      this._setPageToken(newPageToken);
+    },
   },
   async run(event) {
     if (event.timestamp) {
       // Component was invoked by timer
+      if (this.watchDrive) {
+        return this.renewDriveSubscription();
+      }
       return this.renewSubscription();
     }
 
     if (!this.isEventRelevant(event)) {
       console.log("Sync notification, exiting early");
+      return;
+    }
+
+    this.http.respond({
+      status: 200,
+    });
+
+    if (this.watchDrive && !(await this.isSheetRelevant(event))) {
+      console.log("Change to unwatched file, exiting early");
       return;
     }
 

--- a/components/google_sheets/sources/new-comment/new-comment.mjs
+++ b/components/google_sheets/sources/new-comment/new-comment.mjs
@@ -6,7 +6,7 @@ export default {
   key: "google_sheets-new-comment",
   name: "New Comment (Instant)",
   description: "Emit new event each time a comment is added to a spreadsheet.",
-  version: "0.1.1",
+  version: "0.1.2",
   dedupe: "unique",
   type: "source",
   methods: {

--- a/components/google_sheets/sources/new-row-added-polling/new-row-added-polling.mjs
+++ b/components/google_sheets/sources/new-row-added-polling/new-row-added-polling.mjs
@@ -8,7 +8,7 @@ export default {
   key: "google_sheets-new-row-added-polling",
   name: "New Row Added",
   description: "Emit new event each time a row or rows are added to the bottom of a spreadsheet.",
-  version: "0.1.1",
+  version: "0.1.2",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/google_sheets/sources/new-row-added/new-row-added.mjs
+++ b/components/google_sheets/sources/new-row-added/new-row-added.mjs
@@ -8,7 +8,7 @@ export default {
   key: "google_sheets-new-row-added",
   name: "New Row Added (Instant)",
   description: "Emit new event each time a row or rows are added to the bottom of a spreadsheet.",
-  version: "0.2.1",
+  version: "0.2.2",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/google_sheets/sources/new-updates/new-updates.mjs
+++ b/components/google_sheets/sources/new-updates/new-updates.mjs
@@ -9,7 +9,7 @@ export default {
   type: "source",
   name: "New Updates (Instant)",
   description: "Emit new event each time a row or cell is updated in a spreadsheet.",
-  version: "0.3.1",
+  version: "0.3.2",
   dedupe: "unique",
   props: {
     ...httpBase.props,

--- a/components/google_sheets/sources/new-worksheet/new-worksheet.mjs
+++ b/components/google_sheets/sources/new-worksheet/new-worksheet.mjs
@@ -9,7 +9,7 @@ export default {
   type: "source",
   name: "New Worksheet (Instant)",
   description: "Emit new event each time a new worksheet is created in a spreadsheet.",
-  version: "0.2.1",
+  version: "0.2.2",
   dedupe: "unique",
   hooks: {
     ...httpBase.hooks,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -623,8 +623,7 @@ importers:
         specifier: ^2.30.1
         version: 2.30.1
 
-  components/airtop:
-    specifiers: {}
+  components/airtop: {}
 
   components/aitable_ai:
     dependencies:
@@ -6099,8 +6098,8 @@ importers:
         specifier: ^0.3.0
         version: 0.3.0
       '@pipedream/google_drive':
-        specifier: ^1.1.0
-        version: 1.1.0
+        specifier: ^1.1.1
+        version: 1.1.1
       '@pipedream/platform':
         specifier: ^3.1.0
         version: 3.1.0
@@ -7684,8 +7683,7 @@ importers:
         specifier: ^3.1.0
         version: 3.1.0
 
-  components/kudosity:
-    specifiers: {}
+  components/kudosity: {}
 
   components/kustomer:
     dependencies:
@@ -13287,8 +13285,7 @@ importers:
         specifier: ^3.0.0
         version: 3.0.3
 
-  components/sinch:
-    specifiers: {}
+  components/sinch: {}
 
   components/sinch_messagemedia: {}
 
@@ -20415,8 +20412,8 @@ packages:
   '@pipedream/google_drive@1.0.3':
     resolution: {integrity: sha512-E7MF0E3f/RRyL5PsLaoL51IZtdoyWKNpUIT7RIpQDJ2wh00H0hrISfgugfKAVdv7Tl//BvJezu1FecSLTxhroQ==}
 
-  '@pipedream/google_drive@1.1.0':
-    resolution: {integrity: sha512-ZiLlhIrJc7iUK7jLaQaRj4sf/9VUi6ZyZAGhYd2CfoZ8J7ys1KA9Rxi7oUFZvdKsH0AyJIHTIokCZbcuubS0Pw==}
+  '@pipedream/google_drive@1.1.1':
+    resolution: {integrity: sha512-amUo+NYuBMnXlJoIAIjw8vuVhGF4AB8LuLn5G2oq4lgU1Xt0Fqot8WGIh1Ahwx16q1RqKq+4DDdV9jROjm9rSA==}
 
   '@pipedream/helper_functions@0.3.13':
     resolution: {integrity: sha512-67zXT5rMccSYEeQCEKjO0g/U2Wnc3q1ErRWt0sivqJEF/KYqAb3tWmznDYGACbC8L6ML0WWSWRy7nEGt5Vyuaw==}
@@ -39129,7 +39126,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@pipedream/google_drive@1.1.0':
+  '@pipedream/google_drive@1.1.1':
     dependencies:
       '@googleapis/drive': 2.4.0
       '@pipedream/platform': 3.1.0


### PR DESCRIPTION
Updates Google Sheets sources to watch the drive instead of the selected file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * Bumped Google Sheets package to 0.9.1 and updated Google Drive integration dependency.
  * Incremented versions for Google Sheets sources: New Comment (0.1.2), New Row Added (0.2.2 / polling 0.1.2), New Updates (Instant) (0.3.2), New Worksheet (Instant) (0.2.2).

* New Features
  * Added optional "Watch Drive" mode to Sheets instant sources to monitor Drive-level changes and renew subscriptions.
  * HTTP handlers now support custom responses (early 200 OK) for relevant events.

* Refactor
  * Updated activation and subscription flows for Drive-based behavior in Sheets instant sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->