### PR TITLE
Microsoft Teams - Stop triggers from unnecessarily emitting every event every run

### DIFF
--- a/components/microsoft_teams/sources/common/base.mjs
+++ b/components/microsoft_teams/sources/common/base.mjs
@@ -56,7 +56,7 @@ export default {
     },
   },
   async run() {
-    let lastCreated = Date.parse(this._getLastCreated());
+    let lastCreated = this._getLastCreated();
 
     const resources = await this.getResources(lastCreated);
     for (const resource of resources) {


### PR DESCRIPTION
## WHY

On line 65, the value saved with `_setLastCreated` is already parsed as a unix timestamp. Thus when getting the value, there's no reason to call `Date.parse` again. It's already in the correct format.

In fact, this actually breaks it and returns NaN. This then causes every event to be emitted unnecessarily. I believe the only reason this still actually works is because of the `dedupe: "unique"`, but that's just a guess - I'm not too sure.