### PR TITLE
Remove empty "crypto" package

### DIFF
--- a/components/brex_staging/package.json
+++ b/components/brex_staging/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "@pipedream/brex": "^0.1.0",
     "axios": "^0.25.0",
-    "crypto": "^1.0.1",
     "uuid": "^8.3.2"
   }
 }

--- a/components/cats/package.json
+++ b/components/cats/package.json
@@ -13,7 +13,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@pipedream/platform": "^3.0.3",
-    "crypto": "^1.0.1"
+    "@pipedream/platform": "^3.0.3"
   }
 }

--- a/components/cisco_webex/package.json
+++ b/components/cisco_webex/package.json
@@ -11,7 +11,6 @@
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "dependencies": {
     "@pipedream/platform": "^1.4.0",
-    "crypto": "^1.0.1",
     "uuid": "^8.3.2"
   },
   "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",

--- a/components/clickup/package.json
+++ b/components/clickup/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "@pipedream/platform": "^3.1.0",
-    "crypto": "^1.0.1",
     "lodash": "^4.17.21"
   }
 }

--- a/components/clio/package.json
+++ b/components/clio/package.json
@@ -10,8 +10,7 @@
   "homepage": "https://pipedream.com/apps/clio",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "dependencies": {
-    "@pipedream/platform": "^1.6.4",
-    "crypto": "^1.0.1"
+    "@pipedream/platform": "^1.6.4"
   },
   "publishConfig": {
     "access": "public"

--- a/components/companycam/package.json
+++ b/components/companycam/package.json
@@ -11,7 +11,6 @@
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "dependencies": {
     "@pipedream/platform": "^1.3.0",
-    "crypto": "^1.0.1",
     "uuid": "^9.0.0"
   },
   "publishConfig": {

--- a/components/eversign/package.json
+++ b/components/eversign/package.json
@@ -14,7 +14,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@pipedream/platform": "^1.1.1",
-    "crypto": "^1.0.1"
+    "@pipedream/platform": "^1.1.1"
   }
 }

--- a/components/fidel_api/package.json
+++ b/components/fidel_api/package.json
@@ -13,7 +13,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@pipedream/platform": "^1.5.1",
-    "crypto": "^1.0.1"
+    "@pipedream/platform": "^1.5.1"
   }
 }

--- a/components/google_ads/package.json
+++ b/components/google_ads/package.json
@@ -13,7 +13,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@pipedream/platform": "^3.0.3",
-    "crypto": "^1.0.1"
+    "@pipedream/platform": "^3.0.3"
   }
 }

--- a/components/google_cloud/package.json
+++ b/components/google_cloud/package.json
@@ -21,7 +21,6 @@
     "@google-cloud/pubsub": "^3.0.1",
     "@google-cloud/storage": "^6.0.1",
     "@pipedream/platform": "^3.1.0",
-    "crypto": "^1.0.1",
     "lodash-es": "^4.17.21",
     "uuid": "^8.3.2"
   }

--- a/components/help_scout/package.json
+++ b/components/help_scout/package.json
@@ -13,7 +13,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@pipedream/platform": "^3.1.0",
-    "crypto": "^1.0.1"
+    "@pipedream/platform": "^3.1.0"
   }
 }

--- a/components/intercom/package.json
+++ b/components/intercom/package.json
@@ -14,7 +14,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@pipedream/platform": "^3.0.3",
-    "crypto": "^1.0.1"
+    "@pipedream/platform": "^3.0.3"
   }
 }

--- a/components/jotform/package.json
+++ b/components/jotform/package.json
@@ -11,7 +11,6 @@
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "dependencies": {
     "@pipedream/platform": "^1.5.1",
-    "crypto": "^1.0.1",
     "query-string": "^8.1.0"
   },
   "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",

--- a/components/kontent_ai/package.json
+++ b/components/kontent_ai/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "@kontent-ai/delivery-sdk": "^14.4.0",
     "@kontent-ai/management-sdk": "^5.2.0",
-    "@kontent-ai/webhook-helper": "^2.1.0",
-    "crypto": "^1.0.1"
+    "@kontent-ai/webhook-helper": "^2.1.0"
   }
 }

--- a/components/mailersend/package.json
+++ b/components/mailersend/package.json
@@ -14,7 +14,6 @@
     "access": "public"
   },
   "dependencies": {
-    "mailersend": "^2.0.5",
-    "crypto": "^1.0.1"
+    "mailersend": "^2.0.5"
   }
 }

--- a/components/memberful/package.json
+++ b/components/memberful/package.json
@@ -13,7 +13,6 @@
     "access": "public"
   },
   "dependencies": {
-    "crypto": "^1.0.1",
     "uuid": "^9.0.0"
   }
 }

--- a/components/paradym/package.json
+++ b/components/paradym/package.json
@@ -13,7 +13,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@pipedream/platform": "^3.0.0",
-    "crypto": "^1.0.1"
+    "@pipedream/platform": "^3.0.0"
   }
 }

--- a/components/paymo/package.json
+++ b/components/paymo/package.json
@@ -11,7 +11,6 @@
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "dependencies": {
     "@pipedream/platform": "^1.3.0",
-    "crypto": "^1.0.1",
     "uuid": "^9.0.0"
   },
   "publishConfig": {

--- a/components/printify/package.json
+++ b/components/printify/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "@pipedream/platform": "^3.1.0",
-    "crypto": "^1.0.1",
     "fs": "^0.0.1-security"
   }
 }

--- a/components/productive_io/package.json
+++ b/components/productive_io/package.json
@@ -13,7 +13,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@pipedream/platform": "^1.5.1",
-    "crypto": "^1.0.1"
+    "@pipedream/platform": "^1.5.1"
   }
 }

--- a/components/savvycal/package.json
+++ b/components/savvycal/package.json
@@ -11,8 +11,5 @@
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "publishConfig": {
     "access": "public"
-  },
-  "dependencies": {
-    "crypto": "^1.0.1"
   }
 }

--- a/components/signnow/package.json
+++ b/components/signnow/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "@pipedream/platform": "^3.1.0",
-    "crypto": "^1.0.1",
     "form-data": "^4.0.0",
     "uuid": "^10.0.0"
   }

--- a/components/superdocu/package.json
+++ b/components/superdocu/package.json
@@ -11,8 +11,5 @@
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "publishConfig": {
     "access": "public"
-  },
-  "dependencies": {
-    "crypto": "^1.0.1"
   }
 }

--- a/components/ticket_tailor/package.json
+++ b/components/ticket_tailor/package.json
@@ -13,7 +13,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@pipedream/platform": "^1.2.0",
-    "crypto": "^1.0.1"
+    "@pipedream/platform": "^1.2.0"
   }
 }

--- a/components/trello/package.json
+++ b/components/trello/package.json
@@ -11,7 +11,6 @@
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "dependencies": {
     "@pipedream/platform": "^3.1.0",
-    "crypto": "^1.0.1",
     "form-data": "^4.0.0",
     "lodash-es": "^4.17.21",
     "mime": "^4.0.4",

--- a/components/twitch/package.json
+++ b/components/twitch/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "@pipedream/platform": "^1.4.0",
-    "crypto": "^1.0.1",
     "qs": "^6.10.5",
     "uuid": "^8.3.2"
   }

--- a/components/vercel_token_auth/package.json
+++ b/components/vercel_token_auth/package.json
@@ -13,7 +13,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@pipedream/platform": "^3.0.3",
-    "crypto": "^1.0.1"
+    "@pipedream/platform": "^3.0.3"
   }
 }

--- a/components/woocommerce/package.json
+++ b/components/woocommerce/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "@pipedream/platform": "^0.10.0",
     "@woocommerce/woocommerce-rest-api": "^1.0.1",
-    "crypto": "^1.0.1",
     "lodash.pick": "^4.4.0",
     "lodash.pickby": "^4.6.0",
     "query-string": "^7.1.1"

--- a/components/zendesk/package.json
+++ b/components/zendesk/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "@pipedream/platform": "^3.1.0",
-    "crypto": "^1.0.1",
     "path": "^0.12.7"
   }
 }

--- a/components/zoho_crm/package.json
+++ b/components/zoho_crm/package.json
@@ -11,7 +11,6 @@
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "dependencies": {
     "@pipedream/platform": "^3.1.0",
-    "crypto": "^1.0.1",
     "lodash.sortby": "^4.7.0"
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "@pipedream/platform": "^1.5.1",
     "@sentry/node": "^7.7.0",
     "@types/node": "^20.17.6",
-    "crypto": "^1.0.1",
     "linkup-sdk": "^1.0.3",
     "uuid": "^8.3.2",
     "vue": "^2.6.14"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       '@types/node':
         specifier: ^20.17.6
         version: 20.17.6
-      crypto:
-        specifier: ^1.0.1
-        version: 1.0.1
       linkup-sdk:
         specifier: ^1.0.3
         version: 1.0.3
@@ -1970,9 +1967,6 @@ importers:
       axios:
         specifier: ^0.25.0
         version: 0.25.0
-      crypto:
-        specifier: ^1.0.1
-        version: 1.0.1
       uuid:
         specifier: ^8.3.2
         version: 8.3.2
@@ -2342,9 +2336,6 @@ importers:
       '@pipedream/platform':
         specifier: ^3.0.3
         version: 3.0.3
-      crypto:
-        specifier: ^1.0.1
-        version: 1.0.1
 
   components/cdc_national_environmental_public_health_tracking: {}
 
@@ -2624,9 +2615,6 @@ importers:
       '@pipedream/platform':
         specifier: ^1.4.0
         version: 1.6.6
-      crypto:
-        specifier: ^1.0.1
-        version: 1.0.1
       uuid:
         specifier: ^8.3.2
         version: 8.3.2
@@ -2748,9 +2736,6 @@ importers:
       '@pipedream/platform':
         specifier: ^3.1.0
         version: 3.1.0
-      crypto:
-        specifier: ^1.0.1
-        version: 1.0.1
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -2800,9 +2785,6 @@ importers:
       '@pipedream/platform':
         specifier: ^1.6.4
         version: 1.6.6
-      crypto:
-        specifier: ^1.0.1
-        version: 1.0.1
 
   components/clio_australia:
     dependencies:
@@ -3115,9 +3097,6 @@ importers:
       '@pipedream/platform':
         specifier: ^1.3.0
         version: 1.6.6
-      crypto:
-        specifier: ^1.0.1
-        version: 1.0.1
       uuid:
         specifier: ^9.0.0
         version: 9.0.1
@@ -4704,9 +4683,6 @@ importers:
       '@pipedream/platform':
         specifier: ^1.1.1
         version: 1.6.6
-      crypto:
-        specifier: ^1.0.1
-        version: 1.0.1
 
   components/everwebinar:
     dependencies:
@@ -4920,9 +4896,6 @@ importers:
       '@pipedream/platform':
         specifier: ^1.5.1
         version: 1.6.6
-      crypto:
-        specifier: ^1.0.1
-        version: 1.0.1
 
   components/figma:
     dependencies:
@@ -5831,9 +5804,6 @@ importers:
       '@pipedream/platform':
         specifier: ^3.0.3
         version: 3.0.3
-      crypto:
-        specifier: ^1.0.1
-        version: 1.0.1
 
   components/google_analytics:
     dependencies:
@@ -5911,9 +5881,6 @@ importers:
       '@pipedream/platform':
         specifier: ^3.1.0
         version: 3.1.0
-      crypto:
-        specifier: ^1.0.1
-        version: 1.0.1
       lodash-es:
         specifier: ^4.17.21
         version: 4.17.21
@@ -6487,9 +6454,6 @@ importers:
       '@pipedream/platform':
         specifier: ^3.1.0
         version: 3.1.0
-      crypto:
-        specifier: ^1.0.1
-        version: 1.0.1
 
   components/helpcrunch:
     dependencies:
@@ -7156,9 +7120,6 @@ importers:
       '@pipedream/platform':
         specifier: ^3.0.3
         version: 3.0.3
-      crypto:
-        specifier: ^1.0.1
-        version: 1.0.1
 
   components/interseller:
     dependencies:
@@ -7388,9 +7349,6 @@ importers:
       '@pipedream/platform':
         specifier: ^1.5.1
         version: 1.6.6
-      crypto:
-        specifier: ^1.0.1
-        version: 1.0.1
       query-string:
         specifier: ^8.1.0
         version: 8.2.0
@@ -7659,9 +7617,6 @@ importers:
       '@kontent-ai/webhook-helper':
         specifier: ^2.1.0
         version: 2.1.0
-      crypto:
-        specifier: ^1.0.1
-        version: 1.0.1
 
   components/kordiam: {}
 
@@ -7681,8 +7636,7 @@ importers:
         specifier: ^3.1.0
         version: 3.1.0
 
-  components/kudosity:
-    specifiers: {}
+  components/kudosity: {}
 
   components/kustomer:
     dependencies:
@@ -8434,9 +8388,6 @@ importers:
 
   components/mailersend:
     dependencies:
-      crypto:
-        specifier: ^1.0.1
-        version: 1.0.1
       mailersend:
         specifier: ^2.0.5
         version: 2.3.0
@@ -8693,9 +8644,6 @@ importers:
 
   components/memberful:
     dependencies:
-      crypto:
-        specifier: ^1.0.1
-        version: 1.0.1
       uuid:
         specifier: ^9.0.0
         version: 9.0.1
@@ -10306,9 +10254,6 @@ importers:
       '@pipedream/platform':
         specifier: ^3.0.0
         version: 3.0.3
-      crypto:
-        specifier: ^1.0.1
-        version: 1.0.1
 
   components/parallel: {}
 
@@ -10409,9 +10354,6 @@ importers:
       '@pipedream/platform':
         specifier: ^1.3.0
         version: 1.6.6
-      crypto:
-        specifier: ^1.0.1
-        version: 1.0.1
       uuid:
         specifier: ^9.0.0
         version: 9.0.1
@@ -11215,9 +11157,6 @@ importers:
       '@pipedream/platform':
         specifier: ^3.1.0
         version: 3.1.0
-      crypto:
-        specifier: ^1.0.1
-        version: 1.0.1
       fs:
         specifier: ^0.0.1-security
         version: 0.0.1-security
@@ -11309,9 +11248,6 @@ importers:
       '@pipedream/platform':
         specifier: ^1.5.1
         version: 1.6.6
-      crypto:
-        specifier: ^1.0.1
-        version: 1.0.1
 
   components/productlane:
     dependencies:
@@ -12504,11 +12440,7 @@ importers:
 
   components/savvy_folders: {}
 
-  components/savvycal:
-    dependencies:
-      crypto:
-        specifier: ^1.0.1
-        version: 1.0.1
+  components/savvycal: {}
 
   components/scale_ai:
     dependencies:
@@ -13216,9 +13148,6 @@ importers:
       '@pipedream/platform':
         specifier: ^3.1.0
         version: 3.1.0
-      crypto:
-        specifier: ^1.0.1
-        version: 1.0.1
       form-data:
         specifier: ^4.0.0
         version: 4.0.1
@@ -13280,8 +13209,7 @@ importers:
         specifier: ^3.0.0
         version: 3.0.3
 
-  components/sinch:
-    specifiers: {}
+  components/sinch: {}
 
   components/sinch_messagemedia: {}
 
@@ -13987,11 +13915,7 @@ importers:
         specifier: ^1.6.0
         version: 1.6.6
 
-  components/superdocu:
-    dependencies:
-      crypto:
-        specifier: ^1.0.1
-        version: 1.0.1
+  components/superdocu: {}
 
   components/supernotes:
     dependencies:
@@ -14532,9 +14456,6 @@ importers:
       '@pipedream/platform':
         specifier: ^1.2.0
         version: 1.6.6
-      crypto:
-        specifier: ^1.0.1
-        version: 1.0.1
 
   components/ticketsauce: {}
 
@@ -14810,9 +14731,6 @@ importers:
       '@pipedream/platform':
         specifier: ^3.1.0
         version: 3.1.0
-      crypto:
-        specifier: ^1.0.1
-        version: 1.0.1
       form-data:
         specifier: ^4.0.0
         version: 4.0.1
@@ -14981,9 +14899,6 @@ importers:
       '@pipedream/platform':
         specifier: ^1.4.0
         version: 1.6.6
-      crypto:
-        specifier: ^1.0.1
-        version: 1.0.1
       qs:
         specifier: ^6.10.5
         version: 6.13.1
@@ -15373,9 +15288,6 @@ importers:
       '@pipedream/platform':
         specifier: ^3.0.3
         version: 3.0.3
-      crypto:
-        specifier: ^1.0.1
-        version: 1.0.1
 
   components/verdict_as_a_service:
     dependencies:
@@ -15943,9 +15855,6 @@ importers:
       '@woocommerce/woocommerce-rest-api':
         specifier: ^1.0.1
         version: 1.0.1
-      crypto:
-        specifier: ^1.0.1
-        version: 1.0.1
       lodash.pick:
         specifier: ^4.4.0
         version: 4.4.0
@@ -16322,9 +16231,6 @@ importers:
       '@pipedream/platform':
         specifier: ^3.1.0
         version: 3.1.0
-      crypto:
-        specifier: ^1.0.1
-        version: 1.0.1
       path:
         specifier: ^0.12.7
         version: 0.12.7
@@ -16526,9 +16432,6 @@ importers:
       '@pipedream/platform':
         specifier: ^3.1.0
         version: 3.1.0
-      crypto:
-        specifier: ^1.0.1
-        version: 1.0.1
       lodash.sortby:
         specifier: ^4.7.0
         version: 4.7.0
@@ -31347,22 +31250,22 @@ packages:
   superagent@3.8.1:
     resolution: {integrity: sha512-VMBFLYgFuRdfeNQSMLbxGSLfmXL/xc+OO+BZp41Za/NRDBet/BNbkRJrYzCUu0u4GU0i/ml2dtT8b9qgkw9z6Q==}
     engines: {node: '>= 4.0'}
-    deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
+    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
 
   superagent@4.1.0:
     resolution: {integrity: sha512-FT3QLMasz0YyCd4uIi5HNe+3t/onxMyEho7C3PSqmti3Twgy2rXT4fmkTz6wRL6bTF4uzPcfkUCa8u4JWHw8Ag==}
     engines: {node: '>= 6.0'}
-    deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
+    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
 
   superagent@5.3.1:
     resolution: {integrity: sha512-wjJ/MoTid2/RuGCOFtlacyGNxN9QLMgcpYLDQlWFIhhdJ93kNscFonGvrpAHSCVjRVj++DGCglocF7Aej1KHvQ==}
     engines: {node: '>= 7.0.0'}
-    deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
+    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
 
   superagent@7.1.6:
     resolution: {integrity: sha512-gZkVCQR1gy/oUXr+kxJMLDjla434KmSOKbx5iGD30Ql+AkJQ/YlPKECJy2nhqOsHLjGHzoDTXNSjhnvWhzKk7g==}
     engines: {node: '>=6.4.0 <13 || >=14'}
-    deprecated: Please downgrade to v7.1.5 if you need IE/ActiveXObject support OR upgrade to v8.0.0 as we no longer support IE and published an incorrect patch version (see https://github.com/visionmedia/superagent/issues/1731)
+    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
 
   supports-color@10.0.0:
     resolution: {integrity: sha512-HRVVSbCCMbj7/kdWF9Q+bbckjBHLtHMEoJWlkmYzzdwhYMkjkOwubLM6t7NbWKjgKamGDrWL1++KrjUO1t9oAQ==}
@@ -39792,8 +39695,6 @@ snapshots:
       '@putout/operator-filesystem': 5.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))
       '@putout/operator-json': 2.2.0
       putout: 36.13.1(eslint@8.57.1)(typescript@5.6.3)
-    transitivePeerDependencies:
-      - supports-color
 
   '@putout/operator-regexp@1.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -620,6 +620,12 @@ importers:
         specifier: ^2.30.1
         version: 2.30.1
 
+  components/airtop:
+    dependencies:
+      '@pipedream/platform':
+        specifier: ^3.1.0
+        version: 3.1.0
+
   components/aitable_ai:
     dependencies:
       '@pipedream/platform':
@@ -7999,8 +8005,8 @@ importers:
         specifier: ^55.1.0
         version: 55.1.0
       '@pipedream/platform':
-        specifier: ^3.0.3
-        version: 3.0.3
+        specifier: ^3.1.0
+        version: 3.1.0
 
   components/linearb:
     dependencies:
@@ -8930,7 +8936,14 @@ importers:
 
   components/minio: {}
 
-  components/mintlify: {}
+  components/mintlify:
+    dependencies:
+      '@pipedream/platform':
+        specifier: ^3.1.0
+        version: 3.1.0
+      uuid:
+        specifier: ^13.0.0
+        version: 13.0.0
 
   components/miro_custom_app:
     dependencies:
@@ -10366,7 +10379,11 @@ importers:
 
   components/paypro: {}
 
-  components/payrexx: {}
+  components/payrexx:
+    dependencies:
+      '@pipedream/platform':
+        specifier: ^3.1.0
+        version: 3.1.0
 
   components/paystack:
     dependencies:
@@ -13209,7 +13226,14 @@ importers:
         specifier: ^3.0.0
         version: 3.0.3
 
-  components/sinch: {}
+  components/sinch:
+    dependencies:
+      '@pipedream/platform':
+        specifier: ^3.1.0
+        version: 3.1.0
+      form-data:
+        specifier: ^4.0.4
+        version: 4.0.4
 
   components/sinch_messagemedia: {}
 
@@ -13733,6 +13757,8 @@ importers:
         version: 4.17.21
 
   components/stack_overflow_for_teams: {}
+
+  components/stackby: {}
 
   components/stackshare_api: {}
 
@@ -32161,6 +32187,10 @@ packages:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
 
+  uuid@13.0.0:
+    resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
+    hasBin: true
+
   uuid@3.3.2:
     resolution: {integrity: sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==}
     deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
@@ -39695,6 +39725,8 @@ snapshots:
       '@putout/operator-filesystem': 5.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))
       '@putout/operator-json': 2.2.0
       putout: 36.13.1(eslint@8.57.1)(typescript@5.6.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@putout/operator-regexp@1.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))':
     dependencies:
@@ -54552,6 +54584,8 @@ snapshots:
   uuid@11.0.5: {}
 
   uuid@11.1.0: {}
+
+  uuid@13.0.0: {}
 
   uuid@3.3.2: {}
 


### PR DESCRIPTION
https://www.npmjs.com/package/crypto is an empty module because

```js
import crypto from "crypto";
// or more explicitly
import crypto from "node:crypto";
```

actually imports Node's [builtin Crypto module](https://nodejs.org/api/crypto.html), so there's no reason to install it.

On Node 19+ you don't even have to import it, `crypto` is already a global variable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed an unnecessary "crypto" dependency across many integrations and the root package to streamline installations.
  * Reduced dependency surface and package footprint for improved reliability and security posture.
  * No user-facing behavior changes, API modifications, or functional changes were introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->