### PR TITLE
Add Screenshotbase app and Take actions (GET /v1/take)

### DIFF
--- a/components/screenshotbase/actions/capture/capture.mjs
+++ b/components/screenshotbase/actions/capture/capture.mjs
@@ -1,0 +1,73 @@
+import screenshotbase from "../../screenshotbase.app.mjs";
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "screenshotbase-take",
+  name: "Take Screenshot",
+  description: "Render a website screenshot or PDF via Screenshotbase.",
+  version: "0.1.1",
+  type: "action",
+  props: {
+    screenshotbase,
+    url: {
+      label: "URL",
+      type: "string",
+      description: "Website to render",
+      optional: false,
+    },
+    width: {
+      type: "integer",
+      label: "Width",
+      optional: true,
+      default: 1280,
+    },
+    height: {
+      type: "integer",
+      label: "Height",
+      optional: true,
+      default: 800,
+    },
+    format: {
+      type: "string",
+      label: "Format",
+      description: "png | jpeg | pdf",
+      optional: true,
+      options: ["png", "jpeg", "pdf"],
+    },
+    fullPage: {
+      type: "boolean",
+      label: "Full Page",
+      optional: true,
+    },
+    waitForSelector: {
+      type: "string",
+      label: "Wait for CSS Selector",
+      optional: true,
+    },
+    omitBackground: {
+      type: "boolean",
+      label: "Transparent Background",
+      optional: true,
+    },
+  },
+  async run({ steps, $ }) {
+    const base = this.screenshotbase.baseUrl();
+    const params = {
+      url: this.url,
+      viewport_width: this.width,
+      viewport_height: this.height,
+      format: this.format,
+      full_page: this.fullPage ? 1 : undefined,
+    };
+    const res = await axios($, {
+      method: "GET",
+      url: `${base}/v1/take`,
+      headers: { apikey: this.screenshotbase.$auth.api_key },
+      params,
+    });
+    $.export("result", res);
+    return res;
+  },
+};
+
+

--- a/components/screenshotbase/actions/take_advanced/take_advanced.mjs
+++ b/components/screenshotbase/actions/take_advanced/take_advanced.mjs
@@ -1,0 +1,40 @@
+import screenshotbase from "../../screenshotbase.app.mjs";
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "screenshotbase-take-advanced",
+  name: "Take Screenshot (Advanced)",
+  description: "Render a website with full set of parameters (format, quality, full_page, viewport)",
+  version: "0.1.0",
+  type: "action",
+  props: {
+    screenshotbase,
+    url: { label: "URL", type: "string", optional: false },
+    format: { label: "Format", type: "string", optional: true, options: ["jpg", "jpeg", "png", "gif"] },
+    quality: { label: "Quality (jpg/jpeg only)", type: "integer", optional: true },
+    full_page: { label: "Full Page", type: "boolean", optional: true },
+    viewport_width: { label: "Viewport Width", type: "integer", optional: true, default: 1280 },
+    viewport_height: { label: "Viewport Height", type: "integer", optional: true, default: 800 },
+  },
+  async run({ $ }) {
+    const base = this.screenshotbase.baseUrl();
+    const params = {
+      url: this.url,
+      format: this.format,
+      quality: this.quality,
+      full_page: this.full_page ? 1 : undefined,
+      viewport_width: this.viewport_width,
+      viewport_height: this.viewport_height,
+    };
+    const res = await axios($, {
+      method: "GET",
+      url: `${base}/v1/take`,
+      headers: { apikey: this.screenshotbase.$auth.api_key },
+      params,
+    });
+    $.export("result", res);
+    return res;
+  },
+};
+
+

--- a/components/screenshotbase/actions/take_html/take_html.mjs
+++ b/components/screenshotbase/actions/take_html/take_html.mjs
@@ -1,0 +1,36 @@
+import screenshotbase from "../../screenshotbase.app.mjs";
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "screenshotbase-take-html",
+  name: "Take from HTML",
+  description: "Render a screenshot from raw HTML (served by Screenshotbase)",
+  version: "0.1.0",
+  type: "action",
+  props: {
+    screenshotbase,
+    html: { label: "HTML", type: "string", optional: false },
+    viewport_width: { label: "Viewport Width", type: "integer", optional: true, default: 800 },
+    viewport_height: { label: "Viewport Height", type: "integer", optional: true, default: 400 },
+    format: { label: "Format", type: "string", optional: true, options: ["jpg", "jpeg", "png", "gif"] },
+  },
+  async run({ $ }) {
+    const base = this.screenshotbase.baseUrl();
+    const params = {
+      html: this.html,
+      format: this.format,
+      viewport_width: this.viewport_width,
+      viewport_height: this.viewport_height,
+    };
+    const res = await axios($, {
+      method: "GET",
+      url: `${base}/v1/take`,
+      headers: { apikey: this.screenshotbase.$auth.api_key },
+      params,
+    });
+    $.export("result", res);
+    return res;
+  },
+};
+
+

--- a/components/screenshotbase/actions/take_pdf/take_pdf.mjs
+++ b/components/screenshotbase/actions/take_pdf/take_pdf.mjs
@@ -1,0 +1,35 @@
+import screenshotbase from "../../screenshotbase.app.mjs";
+import { axios } from "@pipedream/platform";
+
+export default {
+  key: "screenshotbase-take-pdf",
+  name: "Take PDF",
+  description: "Render a PDF from a website URL",
+  version: "0.1.0",
+  type: "action",
+  props: {
+    screenshotbase,
+    url: { label: "URL", type: "string", optional: false },
+    viewport_width: { label: "Viewport Width", type: "integer", optional: true, default: 1280 },
+    viewport_height: { label: "Viewport Height", type: "integer", optional: true, default: 800 },
+  },
+  async run({ $ }) {
+    const base = this.screenshotbase.baseUrl();
+    const params = {
+      url: this.url,
+      format: "pdf",
+      viewport_width: this.viewport_width,
+      viewport_height: this.viewport_height,
+    };
+    const res = await axios($, {
+      method: "GET",
+      url: `${base}/v1/take`,
+      headers: { apikey: this.screenshotbase.$auth.api_key },
+      params,
+    });
+    $.export("result", res);
+    return res;
+  },
+};
+
+

--- a/components/screenshotbase/screenshotbase.app.mjs
+++ b/components/screenshotbase/screenshotbase.app.mjs
@@ -1,0 +1,38 @@
+export default {
+  type: "app",
+  app: "screenshotbase",
+  name: "Screenshotbase",
+  propDefinitions: {},
+  auth: {
+    type: "custom",
+    fields: {
+      api_key: {
+        label: "API Key",
+        description: "Get your key from the Screenshotbase dashboard.",
+        type: "string",
+      },
+      base_url: {
+        label: "Base URL (optional)",
+        type: "string",
+        optional: true,
+        description: "Override API base, defaults to https://api.screenshotbase.com",
+      },
+    },
+    test: {
+      request: {
+        url: "https://api.screenshotbase.com/status",
+        headers: {
+          apikey: "{{auth.api_key}}",
+        },
+      },
+    },
+    connectionLabel: "Screenshotbase",
+  },
+  methods: {
+    baseUrl() {
+      return this.$auth.base_url?.trim() || "https://api.screenshotbase.com";
+    },
+  },
+};
+
+


### PR DESCRIPTION
# Summary
Adds a new **Screenshotbase** integration with one app and four actions powered by the **Take** endpoint.

**Website:** https://screenshotbase.com  
**Docs:** https://screenshotbase.com/docs/take

---

## What’s included
- **App:** `screenshotbase`
- **Auth:** API Key via `apikey` header
- **Test:** `GET https://api.screenshotbase.com/status`
- **Actions** (all call `GET /v1/take`)
  - **Take Screenshot (basic)**
  - **Take PDF** (`format=pdf`)
  - **Take from HTML** (render from raw HTML)
  - **Take Screenshot (Advanced)** – `format`, `quality`, `full_page`, `viewport_width`, `viewport_height`

---

## Files added
- `components/screenshotbase/screenshotbase.app.mjs`
- `components/screenshotbase/actions/capture/capture.mjs` *(Take Screenshot)*
- `components/screenshotbase/actions/take_pdf/take_pdf.mjs` *(Take PDF)*
- `components/screenshotbase/actions/take_html/take_html.mjs` *(Take from HTML)*
- `components/screenshotbase/actions/take_advanced/take_advanced.mjs` *(Advanced)*

---

## Endpoint usage (Take)
- **Required:**
  - `url`
- **Optional:**
  - `viewport_width` (default `1280`)
  - `viewport_height` (default `800`)
  - `full_page` (`0`/`1`)
  - `format` (`jpg`, `jpeg`, `png`, `gif`)
  - `quality` (for `jpg`/`jpeg` only)
- **Response:** JSON with a URL to the rendered asset

---

## Testing instructions
1) Connect **Screenshotbase** app (provide API key).  
2) Run **“Take Screenshot”** with e.g.:  
   `url=https://example.com, viewport_width=1280, viewport_height=800, full_page=1, format=png`  
3) Verify JSON output includes an asset URL.

**Example (Pipedream Code step):**
```javascript
import { axios } from "@pipedream/platform";
export default defineComponent({
  props: { api_key: { type: "string" }, url: { type: "string", default: "https://example.com" } },
  async run({ $ }) {
    const res = await axios($, {
      method: "GET",
      url: "https://api.screenshotbase.com/v1/take",
      headers: { apikey: this.api_key },
      params: { url: this.url, viewport_width: 1280, viewport_height: 800, full_page: 1, format: "png" },
    });
    $.export("result", res);
  },
});
```

---

## Notes for reviewers
- Uses `axios` from `@pipedream/platform` and query params to match docs.
- Auth via `apikey` header; app test uses `/status`.
- Advanced action exposes the full parameter set; others provide simplified UX.

---

## Checklist
- [x] App auth + passing test  
- [x] Actions validate required input and map to documented params  
- [x] Uses `axios($)` and handles JSON responses  
- [x] Links to site and docs  
- [x] Manually tested in a Pipedream workflow  

---

## Attribution
**Author:** Everapi (office@everapi.com)  
**Committer:** martechdev

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Screenshotbase integration with API key connection.
  - Introduced actions: Take Screenshot, Take Screenshot (Advanced), Take Screenshot from HTML, and Take PDF.
  - Configurable options: URL or HTML input, format (image/PDF), viewport width/height, full-page capture, quality, wait-for-selector, and transparent background.
  - Action outputs include the captured file in the workflow step result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->