### PR TITLE
[Enhancement] - Add Support for Fetching All HubSpot Contact Properties

### DIFF
--- a/components/hubspot/hubspot.app.mjs
+++ b/components/hubspot/hubspot.app.mjs
@@ -1614,5 +1614,37 @@ export default {
         ...opts,
       });
     },
+    async getContactWithAllProperties({
+      contactId, ...opts
+    }) {
+      const properties = await this.getContactProperties();
+      const allPropertyNames = properties.map((prop) => prop.name);
+
+      return this.makeRequest({
+        api: API_PATH.CRMV3,
+        endpoint: `/objects/contacts/${contactId}`,
+        params: {
+          properties: allPropertyNames.join(","),
+        },
+        ...opts,
+      });
+    },
+    async batchGetContactsWithAllProperties({
+      contactIds, ...opts
+    }) {
+      const properties = await this.getContactProperties();
+      const allPropertyNames = properties.map((prop) => prop.name);
+
+      return this.batchGetObjects({
+        objectType: "contacts",
+        data: {
+          inputs: contactIds.map((id) => ({
+            id,
+          })),
+          properties: allPropertyNames,
+        },
+        ...opts,
+      });
+    },
   },
 };

--- a/components/hubspot/package.json
+++ b/components/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/hubspot",
-  "version": "1.7.12",
+  "version": "1.7.14",
   "description": "Pipedream Hubspot Components",
   "main": "hubspot.app.mjs",
   "keywords": [

--- a/components/hubspot/sources/delete-blog-article/delete-blog-article.mjs
+++ b/components/hubspot/sources/delete-blog-article/delete-blog-article.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-delete-blog-article",
   name: "Deleted Blog Posts",
   description: "Emit new event for each deleted blog post.",
-  version: "0.0.34",
+  version: "0.0.35",
   dedupe: "unique",
   type: "source",
   methods: {

--- a/components/hubspot/sources/new-company-property-change/new-company-property-change.mjs
+++ b/components/hubspot/sources/new-company-property-change/new-company-property-change.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-new-company-property-change",
   name: "New Company Property Change",
   description: "Emit new event when a specified property is provided or updated on a company. [See the documentation](https://developers.hubspot.com/docs/api/crm/companies)",
-  version: "0.0.27",
+  version: "0.0.28",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-contact-added-to-list/new-contact-added-to-list.mjs
+++ b/components/hubspot/sources/new-contact-added-to-list/new-contact-added-to-list.mjs
@@ -12,7 +12,7 @@ export default {
   name: "New Contact Added to List",
   description:
     "Emit new event when a contact is added to a HubSpot list. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/lists#get-%2Fcrm%2Fv3%2Flists%2F%7Blistid%7D%2Fmemberships%2Fjoin-order)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/hubspot/sources/new-contact-added-to-list/new-contact-added-to-list.mjs
+++ b/components/hubspot/sources/new-contact-added-to-list/new-contact-added-to-list.mjs
@@ -55,6 +55,14 @@ export default {
       label: "Additional contact properties to retrieve",
       optional: true,
     },
+    fetchAllProperties: {
+      type: "boolean",
+      label: "Fetch all contact properties",
+      description:
+        "When enabled, fetches all available contact properties instead of just default and selected properties. This provides complete contact data but may increase API usage.",
+      optional: true,
+      default: false,
+    },
   },
   methods: {
     ...common.methods,
@@ -94,6 +102,40 @@ export default {
     },
     async getContactDetails(contactIds) {
       if (!contactIds.length) return {};
+
+      if (this.fetchAllProperties) {
+        const chunks = [];
+        const chunkSize = 100;
+        for (let i = 0; i < contactIds.length; i += chunkSize) {
+          chunks.push(contactIds.slice(i, i + chunkSize));
+        }
+
+        const contactMap = {};
+
+        try {
+          for (const chunk of chunks) {
+            try {
+              const { results } = await this.hubspot.batchGetContactsWithAllProperties({
+                contactIds: chunk,
+              });
+
+              results.forEach((contact) => {
+                contactMap[contact.id] = contact;
+              });
+            } catch (error) {
+              console.warn(
+                `Error fetching contact details for chunk of ${chunk.length} contacts:`,
+                error,
+              );
+            }
+          }
+
+          return contactMap;
+        } catch (error) {
+          console.warn("Error processing contact details:", error);
+          return {};
+        }
+      }
 
       const { properties = [] } = this;
       const allProperties = [

--- a/components/hubspot/sources/new-contact-property-change/new-contact-property-change.mjs
+++ b/components/hubspot/sources/new-contact-property-change/new-contact-property-change.mjs
@@ -8,7 +8,7 @@ export default {
   name: "New Contact Property Change",
   description:
     "Emit new event when a specified property is provided or updated on a contact. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts)",
-  version: "0.0.30",
+  version: "0.0.31",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-custom-object-property-change/new-custom-object-property-change.mjs
+++ b/components/hubspot/sources/new-custom-object-property-change/new-custom-object-property-change.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Custom Object Property Change",
   description:
     "Emit new event when a specified property is provided or updated on a custom object.",
-  version: "0.0.19",
+  version: "0.0.20",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-deal-in-stage/new-deal-in-stage.mjs
+++ b/components/hubspot/sources/new-deal-in-stage/new-deal-in-stage.mjs
@@ -13,7 +13,7 @@ export default {
   key: "hubspot-new-deal-in-stage",
   name: "New Deal In Stage",
   description: "Emit new event for each new deal in a stage.",
-  version: "0.1.0",
+  version: "0.1.1",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-deal-property-change/new-deal-property-change.mjs
+++ b/components/hubspot/sources/new-deal-property-change/new-deal-property-change.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-new-deal-property-change",
   name: "New Deal Property Change",
   description: "Emit new event when a specified property is provided or updated on a deal. [See the documentation](https://developers.hubspot.com/docs/api/crm/deals)",
-  version: "0.0.28",
+  version: "0.0.30",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-email-event/new-email-event.mjs
+++ b/components/hubspot/sources/new-email-event/new-email-event.mjs
@@ -8,7 +8,7 @@ export default {
   key: "hubspot-new-email-event",
   name: "New Email Event",
   description: "Emit new event for each new Hubspot email event.",
-  version: "0.0.37",
+  version: "0.0.38",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-email-subscriptions-timeline/new-email-subscriptions-timeline.mjs
+++ b/components/hubspot/sources/new-email-subscriptions-timeline/new-email-subscriptions-timeline.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-new-email-subscriptions-timeline",
   name: "New Email Subscriptions Timeline",
   description: "Emit new event when a new email timeline subscription is added for the portal.",
-  version: "0.0.34",
+  version: "0.0.35",
   dedupe: "unique",
   type: "source",
   methods: {

--- a/components/hubspot/sources/new-engagement/new-engagement.mjs
+++ b/components/hubspot/sources/new-engagement/new-engagement.mjs
@@ -8,7 +8,7 @@ export default {
   key: "hubspot-new-engagement",
   name: "New Engagement",
   description: "Emit new event for each new engagement created. This action returns a maximum of 5000 records at a time, make sure you set a correct time range so you don't miss any events",
-  version: "0.0.39",
+  version: "0.0.40",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-event/new-event.mjs
+++ b/components/hubspot/sources/new-event/new-event.mjs
@@ -8,7 +8,7 @@ export default {
   key: "hubspot-new-event",
   name: "New Events",
   description: "Emit new event for each new Hubspot event. Note: Only available for Marketing Hub Enterprise, Sales Hub Enterprise, Service Hub Enterprise, or CMS Hub Enterprise accounts",
-  version: "0.0.38",
+  version: "0.0.39",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-form-submission/new-form-submission.mjs
+++ b/components/hubspot/sources/new-form-submission/new-form-submission.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-new-form-submission",
   name: "New Form Submission",
   description: "Emit new event for each new submission of a form.",
-  version: "0.0.39",
+  version: "0.0.40",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-note/new-note.mjs
+++ b/components/hubspot/sources/new-note/new-note.mjs
@@ -8,7 +8,7 @@ export default {
   key: "hubspot-new-note",
   name: "New Note Created",
   description: "Emit new event for each new note created. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/engagements/notes#get-%2Fcrm%2Fv3%2Fobjects%2Fnotes)",
-  version: "1.0.15",
+  version: "1.0.16",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/hubspot/sources/new-or-updated-blog-article/new-or-updated-blog-article.mjs
+++ b/components/hubspot/sources/new-or-updated-blog-article/new-or-updated-blog-article.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-new-or-updated-blog-article",
   name: "New or Updated Blog Post",
   description: "Emit new event for each new or updated blog post in Hubspot.",
-  version: "0.0.21",
+  version: "0.0.22",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-company/new-or-updated-company.mjs
+++ b/components/hubspot/sources/new-or-updated-company/new-or-updated-company.mjs
@@ -10,7 +10,7 @@ export default {
   key: "hubspot-new-or-updated-company",
   name: "New or Updated Company",
   description: "Emit new event for each new or updated company in Hubspot.",
-  version: "0.0.21",
+  version: "0.0.22",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-contact/new-or-updated-contact.mjs
+++ b/components/hubspot/sources/new-or-updated-contact/new-or-updated-contact.mjs
@@ -10,7 +10,7 @@ export default {
   key: "hubspot-new-or-updated-contact",
   name: "New or Updated Contact",
   description: "Emit new event for each new or updated contact in Hubspot.",
-  version: "0.0.22",
+  version: "0.0.23",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-crm-object/new-or-updated-crm-object.mjs
+++ b/components/hubspot/sources/new-or-updated-crm-object/new-or-updated-crm-object.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-new-or-updated-crm-object",
   name: "New or Updated CRM Object",
   description: "Emit new event each time a CRM Object of the specified object type is updated.",
-  version: "0.0.34",
+  version: "0.0.35",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-custom-object/new-or-updated-custom-object.mjs
+++ b/components/hubspot/sources/new-or-updated-custom-object/new-or-updated-custom-object.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-new-or-updated-custom-object",
   name: "New or Updated Custom Object",
   description: "Emit new event each time a Custom Object of the specified schema is updated.",
-  version: "0.0.23",
+  version: "0.0.24",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-deal/new-or-updated-deal.mjs
+++ b/components/hubspot/sources/new-or-updated-deal/new-or-updated-deal.mjs
@@ -10,7 +10,7 @@ export default {
   key: "hubspot-new-or-updated-deal",
   name: "New or Updated Deal",
   description: "Emit new event for each new or updated deal in Hubspot",
-  version: "0.0.21",
+  version: "0.0.22",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-line-item/new-or-updated-line-item.mjs
+++ b/components/hubspot/sources/new-or-updated-line-item/new-or-updated-line-item.mjs
@@ -10,7 +10,7 @@ export default {
   key: "hubspot-new-or-updated-line-item",
   name: "New or Updated Line Item",
   description: "Emit new event for each new line item added or updated in Hubspot.",
-  version: "0.0.21",
+  version: "0.0.22",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-product/new-or-updated-product.mjs
+++ b/components/hubspot/sources/new-or-updated-product/new-or-updated-product.mjs
@@ -10,7 +10,7 @@ export default {
   key: "hubspot-new-or-updated-product",
   name: "New or Updated Product",
   description: "Emit new event for each new or updated product in Hubspot.",
-  version: "0.0.21",
+  version: "0.0.22",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-social-media-message/new-social-media-message.mjs
+++ b/components/hubspot/sources/new-social-media-message/new-social-media-message.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Social Media Message",
   description:
     "Emit new event when a message is posted from HubSpot to the specified social media channel. Note: Only available for Marketing Hub Enterprise accounts",
-  version: "0.0.34",
+  version: "0.0.35",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/hubspot/sources/new-task/new-task.mjs
+++ b/components/hubspot/sources/new-task/new-task.mjs
@@ -9,7 +9,7 @@ export default {
   name: "New Task Created",
   description:
     "Emit new event for each new task created. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/engagements/tasks#get-%2Fcrm%2Fv3%2Fobjects%2Ftasks)",
-  version: "1.0.15",
+  version: "1.0.16",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/hubspot/sources/new-ticket-property-change/new-ticket-property-change.mjs
+++ b/components/hubspot/sources/new-ticket-property-change/new-ticket-property-change.mjs
@@ -8,7 +8,7 @@ export default {
   name: "New Ticket Property Change",
   description:
     "Emit new event when a specified property is provided or updated on a ticket. [See the documentation](https://developers.hubspot.com/docs/api/crm/tickets)",
-  version: "0.0.28",
+  version: "0.0.29",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-ticket/new-ticket.mjs
+++ b/components/hubspot/sources/new-ticket/new-ticket.mjs
@@ -10,7 +10,7 @@ export default {
   key: "hubspot-new-ticket",
   name: "New Ticket",
   description: "Emit new event for each new ticket created.",
-  version: "0.0.34",
+  version: "0.0.35",
   dedupe: "unique",
   type: "source",
   props: {


### PR DESCRIPTION
  ## Summary
  Added optional `fetchAllProperties` prop to `new-contact-property-change` and `new-contact-added-to-list` sources. When enabled, fetches all available contact properties instead of just
  default/selected ones.

  ## Changes
  - Added `getContactWithAllProperties()` and `batchGetContactsWithAllProperties()` methods to `hubspot.app.mjs`
  - Added `fetchAllProperties` boolean prop (default: `false`) to both sources
  - No breaking changes - feature is opt-in

  ## Use Case
  Enables syncing complete contact records (including custom properties) without manual configuration, useful for external system integrations and workflows requiring dynamic fields.