### PR TITLE
Configure file sync for Playwright components

### DIFF
--- a/components/playwright/actions/page-pdf/page-pdf.mjs
+++ b/components/playwright/actions/page-pdf/page-pdf.mjs
@@ -4,7 +4,7 @@ export default {
   key: "playwright-page-pdf",
   name: "Page PDF",
   description: "Generates a pdf of the page and store it on /tmp directory. [See the documentation](https://playwright.dev/docs/api/class-page#page-pdf)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -41,6 +41,11 @@ export default {
       label: "Viewport Height",
       description: "The height of viewport. default: `720`",
       optional: true,
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "write",
+      sync: true,
     },
   },
   async run({ $ }) {

--- a/components/playwright/actions/take-screenshot/take-screenshot.mjs
+++ b/components/playwright/actions/take-screenshot/take-screenshot.mjs
@@ -4,7 +4,7 @@ export default {
   key: "playwright-take-screenshot",
   name: "Take Screenshot",
   description: "Store a new screenshot file on /tmp directory. [See the documentation](https://playwright.dev/docs/screenshots)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -52,6 +52,11 @@ export default {
       label: "Viewport Height",
       description: "The height of viewport. default: `720`",
       optional: true,
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "write",
+      sync: true,
     },
   },
   async run({ $ }) {


### PR DESCRIPTION
Adds dir props to Playwright actions:
- Playwright Page PDF
- Playwright Take Screenshot

## WHY

The dir prop indicates that an action works with files, typically read from or written to the ephemeral `/tmp` directory. When [executing actions](https://pipedream.com/docs/connect/components/actions) using the [Connect](https://pipedream.com/docs/connect) service, you can use this [indicator](https://pipedream.com/docs/connect/api-reference/retrieve-component#response-data-stash) to determine when to pass the `stashId` parameter. When `stashId` is passed, files in `/tmp` are synced with [File Stash](https://pipedream.com/docs/connect/components/files#file-stash) at the start or end of execution so they are accessible in other action executions or outside of Pipedream's execution environment entirely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a configurable sync directory option to the PDF export and Screenshot actions, enabling write access and automatic synchronization of generated files to a chosen folder.

- Chores
  - Bumped versions of the PDF export and Screenshot actions to 0.0.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->