### PR TITLE
Asana "Create Project" fix

### DIFF
--- a/components/asana/actions/create-project/create-project.mjs
+++ b/components/asana/actions/create-project/create-project.mjs
@@ -28,9 +28,7 @@ export default {
         asana,
         "teams",
         ({ workspace }) => ({
-          workspaces: [
-            workspace,
-          ],
+          workspace,
         }),
       ],
       type: "string",

--- a/components/asana/asana.app.mjs
+++ b/components/asana/asana.app.mjs
@@ -49,8 +49,8 @@ export default {
       label: "Teams",
       description: "List of teams. This field uses the team GID.",
       type: "string[]",
-      async options({ workspaces }) {
-        const teams = await this.getTeams(workspaces);
+      async options({ workspace }) {
+        const teams = await this.getTeams(workspace);
         return teams?.map((team) => ({
           label: team.name,
           value: team.gid,

--- a/components/asana/package.json
+++ b/components/asana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/asana",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Pipedream Asana Components",
   "main": "asana.app.mjs",
   "keywords": [


### PR DESCRIPTION
Closes #18809 

The `teamId` prop is specifically having issues in Pipedream MCP, and I believe it is due to the format (sending an array in the propDefinition's third arg).

Since this format is very unusual and there is no need for it at all (`getTeams` already wraps the incoming value in an array if it is not one), I'm changing it to the standard format widely used across components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Simplified team/workspace parameter handling in the Create Project action for streamlined configuration.

* **Chores**
  * Bumped component version to 0.8.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->