### PR TITLE
[FIX] Set restli protocol version header back to 2.0

### DIFF
--- a/components/linkedin_ads/actions/create-report-by-advertiser-account/create-report-by-advertiser-account.mjs
+++ b/components/linkedin_ads/actions/create-report-by-advertiser-account/create-report-by-advertiser-account.mjs
@@ -6,7 +6,7 @@ export default {
   key: "linkedin_ads-create-report-by-advertiser-account",
   name: "Create Report By Advertiser Account",
   description: "Sample query using analytics finder that gets analytics for a particular account for date range starting in a given year. [See the docs here](https://docs.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ads-reporting#sample-request)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/linkedin_ads/actions/create-report-by-campaign/create-report-by-campaign.mjs
+++ b/components/linkedin_ads/actions/create-report-by-campaign/create-report-by-campaign.mjs
@@ -6,7 +6,7 @@ export default {
   key: "linkedin_ads-create-report-by-campaign",
   name: "Query Analytics Finder Campaign Sample",
   description: "Sample query using analytics finder that gets analytics for a particular campaign in a date range starting in a given year. [See the docs here](https://docs.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ads-reporting#analytics-finder)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/linkedin_ads/actions/create-report/create-report.mjs
+++ b/components/linkedin_ads/actions/create-report/create-report.mjs
@@ -6,7 +6,7 @@ export default {
   key: "linkedin_ads-create-report",
   name: "Create A Report",
   description: "Queries the Analytics Finder to get analytics for the specified entity i.e company, account, campaign. [See the docs here](https://docs.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ads-reporting#analytics-finder)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -14,6 +14,12 @@ export default {
   },
   type: "action",
   props: {
+    // eslint-disable-next-line pipedream/props-label, pipedream/props-description
+    infoAlert: {
+      type: "alert",
+      alertType: "info",
+      content: "Please provide at least one facet to get analytics if needed. Eg. **Accounts**.",
+    },
     ...common.props,
     adAccountId: {
       propDefinition: [

--- a/components/linkedin_ads/actions/send-conversion-event/send-conversion-event.mjs
+++ b/components/linkedin_ads/actions/send-conversion-event/send-conversion-event.mjs
@@ -5,7 +5,7 @@ export default {
   key: "linkedin_ads-send-conversion-event",
   name: "Send Conversion Event",
   description: "Sends a conversion event to LinkedIn Ads. [See the documentation](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/conversions-api?view=li-lms-2024-01&tabs=http#streaming-conversion-events)",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/linkedin_ads/common/constants.mjs
+++ b/components/linkedin_ads/common/constants.mjs
@@ -1,0 +1,7 @@
+const VERSION_HEADER = "202509";
+const RESTLI_PROTOCOL_VERSION = "2.0.0";
+
+export default {
+  VERSION_HEADER,
+  RESTLI_PROTOCOL_VERSION,
+};

--- a/components/linkedin_ads/linkedin_ads.app.mjs
+++ b/components/linkedin_ads/linkedin_ads.app.mjs
@@ -1,5 +1,6 @@
 import app from "@pipedream/linkedin";
 import utils from "./common/utils.mjs";
+import constants from "./common/constants.mjs";
 
 export default {
   ...app,
@@ -151,6 +152,14 @@ export default {
   },
   methods: {
     ...app.methods,
+    _getHeaders() {
+      return {
+        "Authorization": `Bearer ${this.$auth.oauth_access_token}`,
+        "Content-Type": "application/json",
+        "Linkedin-Version": constants.VERSION_HEADER,
+        "X-Restli-Protocol-Version": constants.RESTLI_PROTOCOL_VERSION,
+      };
+    },
     getSponsoredAccountUrn(id) {
       return `urn:li:sponsoredAccount:${id}`;
     },

--- a/components/linkedin_ads/package.json
+++ b/components/linkedin_ads/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/linkedin_ads",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Pipedream LinkedIn Ads Components",
   "main": "linkedin_ads.app.mjs",
   "keywords": [
@@ -14,6 +14,6 @@
   },
   "dependencies": {
     "@pipedream/linkedin": "^0.1.1",
-    "@pipedream/platform": "^3.0.3"
+    "@pipedream/platform": "^3.1.0"
   }
 }

--- a/components/linkedin_ads/sources/new-event-registration-form-response/new-event-registration-form-response.mjs
+++ b/components/linkedin_ads/sources/new-event-registration-form-response/new-event-registration-form-response.mjs
@@ -5,7 +5,7 @@ export default {
   key: "linkedin_ads-new-event-registration-form-response",
   name: "New Event Registration Form Response",
   description: "Emit new event when a fresh response is received on the event registration form. User needs to configure the prop of the specific event. [See the documentation](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/organizations/events?view=li-lms-2024-01&tabs=http)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/linkedin_ads/sources/new-lead-gen-form-created/new-lead-gen-form-created.mjs
+++ b/components/linkedin_ads/sources/new-lead-gen-form-created/new-lead-gen-form-created.mjs
@@ -6,7 +6,7 @@ export default {
   key: "linkedin_ads-new-lead-gen-form-created",
   name: "New Lead Gen Form Created",
   description: "Emit new event when a new lead is captured through a form. [See the documentation](https://learn.microsoft.com/en-us/linkedin/marketing/lead-sync/leadsync?view=li-lms-2023-07&tabs=http#find-lead-form-responses-by-owner)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "source",
   dedupe: "unique",
   props: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,7 +104,7 @@ importers:
         version: 4.0.0
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@8.0.0-alpha.13)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@8.0.0-alpha.13))(jest@29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3)))(typescript@5.6.3)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3)))(typescript@5.6.3)
       tsc-esm-fix:
         specifier: ^2.18.0
         version: 2.20.27
@@ -3003,8 +3003,7 @@ importers:
 
   components/codeberg: {}
 
-  components/codefresh:
-    specifiers: {}
+  components/codefresh: {}
 
   components/codegpt: {}
 
@@ -3061,8 +3060,7 @@ importers:
         specifier: ^7.10.6
         version: 7.14.0(@aws-sdk/client-sso-oidc@3.696.0(@aws-sdk/client-sts@3.696.0(aws-crt@1.25.0))(aws-crt@1.25.0))(aws-crt@1.25.0)
 
-  components/coinapi:
-    specifiers: {}
+  components/coinapi: {}
 
   components/coinbase:
     dependencies:
@@ -3120,8 +3118,7 @@ importers:
         specifier: ^0.0.6
         version: 0.0.6
 
-  components/cometapi:
-    specifiers: {}
+  components/cometapi: {}
 
   components/cometly:
     dependencies:
@@ -3307,8 +3304,7 @@ importers:
         specifier: ^1.5.1
         version: 1.6.6
 
-  components/copicake:
-    specifiers: {}
+  components/copicake: {}
 
   components/copper:
     dependencies:
@@ -3396,8 +3392,7 @@ importers:
         specifier: ^1.6.0
         version: 1.6.6
 
-  components/cronly:
-    specifiers: {}
+  components/cronly: {}
 
   components/crove_app:
     dependencies:
@@ -8125,8 +8120,8 @@ importers:
         specifier: ^0.1.1
         version: 0.1.1
       '@pipedream/platform':
-        specifier: ^3.0.3
-        version: 3.0.3
+        specifier: ^3.1.0
+        version: 3.1.0
 
   components/linkish:
     dependencies:
@@ -10925,8 +10920,7 @@ importers:
         specifier: ^1.3.0
         version: 1.6.6
 
-  components/piwik_pro:
-    specifiers: {}
+  components/piwik_pro: {}
 
   components/pixelbin:
     dependencies:
@@ -14782,8 +14776,7 @@ importers:
         specifier: ^0.1.4
         version: 0.1.6
 
-  components/topdesk:
-    specifiers: {}
+  components/topdesk: {}
 
   components/topmessage:
     dependencies:
@@ -16977,7 +16970,7 @@ importers:
         version: 3.1.7
       ts-jest:
         specifier: ^29.2.5
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@20.17.30)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.17.30)(typescript@5.7.2)))(typescript@5.7.2)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(esbuild@0.24.2)(jest@29.7.0(@types/node@20.17.30)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.17.30)(typescript@5.7.2)))(typescript@5.7.2)
       tsup:
         specifier: ^8.3.6
         version: 8.3.6(@microsoft/api-extractor@7.47.12(@types/node@20.17.30))(jiti@2.4.2)(postcss@8.5.6)(tsx@4.19.4)(typescript@5.7.2)(yaml@2.8.0)
@@ -35813,7 +35806,7 @@ snapshots:
       '@babel/traverse': 7.25.9
       '@babel/types': 7.26.0
       convert-source-map: 2.0.0
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -36084,44 +36077,20 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@8.0.0-alpha.13)':
-    dependencies:
-      '@babel/core': 8.0.0-alpha.13
-      '@babel/helper-plugin-utils': 7.25.9
-    optional: true
-
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
-
-  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@8.0.0-alpha.13)':
-    dependencies:
-      '@babel/core': 8.0.0-alpha.13
-      '@babel/helper-plugin-utils': 7.25.9
-    optional: true
 
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@8.0.0-alpha.13)':
-    dependencies:
-      '@babel/core': 8.0.0-alpha.13
-      '@babel/helper-plugin-utils': 7.25.9
-    optional: true
-
   '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
-
-  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@8.0.0-alpha.13)':
-    dependencies:
-      '@babel/core': 8.0.0-alpha.13
-      '@babel/helper-plugin-utils': 7.25.9
-    optional: true
 
   '@babel/plugin-syntax-import-assertions@7.26.0(@babel/core@7.26.0)':
     dependencies:
@@ -36133,33 +36102,15 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-import-attributes@7.26.0(@babel/core@8.0.0-alpha.13)':
-    dependencies:
-      '@babel/core': 8.0.0-alpha.13
-      '@babel/helper-plugin-utils': 7.25.9
-    optional: true
-
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@8.0.0-alpha.13)':
-    dependencies:
-      '@babel/core': 8.0.0-alpha.13
-      '@babel/helper-plugin-utils': 7.25.9
-    optional: true
-
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
-
-  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@8.0.0-alpha.13)':
-    dependencies:
-      '@babel/core': 8.0.0-alpha.13
-      '@babel/helper-plugin-utils': 7.25.9
-    optional: true
 
   '@babel/plugin-syntax-jsx@7.25.9(@babel/core@7.26.0)':
     dependencies:
@@ -36171,88 +36122,40 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@8.0.0-alpha.13)':
-    dependencies:
-      '@babel/core': 8.0.0-alpha.13
-      '@babel/helper-plugin-utils': 7.25.9
-    optional: true
-
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
-
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@8.0.0-alpha.13)':
-    dependencies:
-      '@babel/core': 8.0.0-alpha.13
-      '@babel/helper-plugin-utils': 7.25.9
-    optional: true
 
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@8.0.0-alpha.13)':
-    dependencies:
-      '@babel/core': 8.0.0-alpha.13
-      '@babel/helper-plugin-utils': 7.25.9
-    optional: true
-
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
-
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@8.0.0-alpha.13)':
-    dependencies:
-      '@babel/core': 8.0.0-alpha.13
-      '@babel/helper-plugin-utils': 7.25.9
-    optional: true
 
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@8.0.0-alpha.13)':
-    dependencies:
-      '@babel/core': 8.0.0-alpha.13
-      '@babel/helper-plugin-utils': 7.25.9
-    optional: true
-
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
-
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@8.0.0-alpha.13)':
-    dependencies:
-      '@babel/core': 8.0.0-alpha.13
-      '@babel/helper-plugin-utils': 7.25.9
-    optional: true
 
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
 
-  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@8.0.0-alpha.13)':
-    dependencies:
-      '@babel/core': 8.0.0-alpha.13
-      '@babel/helper-plugin-utils': 7.25.9
-    optional: true
-
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.25.9
-
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@8.0.0-alpha.13)':
-    dependencies:
-      '@babel/core': 8.0.0-alpha.13
-      '@babel/helper-plugin-utils': 7.25.9
-    optional: true
 
   '@babel/plugin-syntax-typescript@7.25.9(@babel/core@7.26.0)':
     dependencies:
@@ -37316,7 +37219,7 @@ snapshots:
   '@eslint/eslintrc@3.2.0':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       espree: 10.3.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -39822,8 +39725,6 @@ snapshots:
       '@putout/operator-filesystem': 5.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))
       '@putout/operator-json': 2.2.0
       putout: 36.13.1(eslint@8.57.1)(typescript@5.6.3)
-    transitivePeerDependencies:
-      - supports-color
 
   '@putout/operator-regexp@1.0.0(putout@36.13.1(eslint@8.57.1)(typescript@5.6.3))':
     dependencies:
@@ -42384,7 +42285,7 @@ snapshots:
       '@typescript-eslint/types': 8.15.0
       '@typescript-eslint/typescript-estree': 8.15.0(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 8.15.0
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       eslint: 8.57.1
     optionalDependencies:
       typescript: 5.6.3
@@ -43278,20 +43179,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-jest@29.7.0(@babel/core@8.0.0-alpha.13):
-    dependencies:
-      '@babel/core': 8.0.0-alpha.13
-      '@jest/transform': 29.7.0
-      '@types/babel__core': 7.20.5
-      babel-plugin-istanbul: 6.1.1
-      babel-preset-jest: 29.6.3(@babel/core@8.0.0-alpha.13)
-      chalk: 4.1.2
-      graceful-fs: 4.2.11
-      slash: 3.0.0
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   babel-plugin-istanbul@6.1.1:
     dependencies:
       '@babel/helper-plugin-utils': 7.25.9
@@ -43358,38 +43245,11 @@ snapshots:
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.26.0)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.26.0)
 
-  babel-preset-current-node-syntax@1.1.0(@babel/core@8.0.0-alpha.13):
-    dependencies:
-      '@babel/core': 8.0.0-alpha.13
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@8.0.0-alpha.13)
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@8.0.0-alpha.13)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@8.0.0-alpha.13)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@8.0.0-alpha.13)
-      '@babel/plugin-syntax-import-attributes': 7.26.0(@babel/core@8.0.0-alpha.13)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@8.0.0-alpha.13)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@8.0.0-alpha.13)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@8.0.0-alpha.13)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@8.0.0-alpha.13)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@8.0.0-alpha.13)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@8.0.0-alpha.13)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@8.0.0-alpha.13)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@8.0.0-alpha.13)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@8.0.0-alpha.13)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@8.0.0-alpha.13)
-    optional: true
-
   babel-preset-jest@29.6.3(@babel/core@7.26.0):
     dependencies:
       '@babel/core': 7.26.0
       babel-plugin-jest-hoist: 29.6.3
       babel-preset-current-node-syntax: 1.1.0(@babel/core@7.26.0)
-
-  babel-preset-jest@29.6.3(@babel/core@8.0.0-alpha.13):
-    dependencies:
-      '@babel/core': 8.0.0-alpha.13
-      babel-plugin-jest-hoist: 29.6.3
-      babel-preset-current-node-syntax: 1.1.0(@babel/core@8.0.0-alpha.13)
-    optional: true
 
   backoff@2.5.0:
     dependencies:
@@ -45599,7 +45459,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -47460,7 +47320,7 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -50041,7 +49901,7 @@ snapshots:
     dependencies:
       '@tediousjs/connection-string': 0.5.0
       commander: 11.1.0
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       rfdc: 1.4.1
       tarn: 3.0.2
       tedious: 16.7.1
@@ -51790,7 +51650,7 @@ snapshots:
       ajv: 8.17.1
       chalk: 5.3.0
       ci-info: 4.1.0
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       deepmerge: 4.3.1
       escalade: 3.2.0
       fast-glob: 3.3.2
@@ -53926,7 +53786,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@20.17.30)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.17.30)(typescript@5.7.2)))(typescript@5.7.2):
+  ts-jest@29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(esbuild@0.24.2)(jest@29.7.0(@types/node@20.17.30)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.17.30)(typescript@5.7.2)))(typescript@5.7.2):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
@@ -53944,8 +53804,9 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.26.0)
+      esbuild: 0.24.2
 
-  ts-jest@29.2.5(@babel/core@8.0.0-alpha.13)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@8.0.0-alpha.13))(jest@29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3)))(typescript@5.6.3):
+  ts-jest@29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@20.17.6)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3)))(typescript@5.6.3):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
@@ -53959,10 +53820,10 @@ snapshots:
       typescript: 5.6.3
       yargs-parser: 21.1.1
     optionalDependencies:
-      '@babel/core': 8.0.0-alpha.13
+      '@babel/core': 7.26.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@8.0.0-alpha.13)
+      babel-jest: 29.7.0(@babel/core@7.26.0)
 
   ts-node@10.9.2(@types/node@20.17.30)(typescript@5.7.2):
     dependencies:
@@ -54134,7 +53995,7 @@ snapshots:
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.0
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       esbuild: 0.24.2
       joycon: 3.1.1
       picocolors: 1.1.1
@@ -54162,7 +54023,7 @@ snapshots:
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.0
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       esbuild: 0.24.2
       joycon: 3.1.1
       picocolors: 1.1.1
@@ -54786,7 +54647,7 @@ snapshots:
       '@volar/typescript': 2.4.10
       '@vue/language-core': 2.1.6(typescript@5.9.2)
       compare-versions: 6.1.1
-      debug: 4.3.7(supports-color@9.4.0)
+      debug: 4.3.7(supports-color@5.5.0)
       kolorist: 1.8.0
       local-pkg: 0.5.1
       magic-string: 0.30.13


### PR DESCRIPTION
## WHY

Resolves  #18686


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds an informational alert in the report creation UI prompting users to select at least one facet.
  * Improved request header support for LinkedIn API compatibility and protocol handling.

* **Chores**
  * Updated core platform dependency to a newer compatible release.
  * Incremented component and action versions across LinkedIn Ads sources and actions for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->