### PR TITLE
[FIX] Dedup key in Outlook Shared Email Received causing events to be…

### DIFF
--- a/components/microsoft_outlook/package.json
+++ b/components/microsoft_outlook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/microsoft_outlook",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "Pipedream Microsoft Outlook Components",
   "main": "microsoft_outlook.app.mjs",
   "keywords": [

--- a/components/microsoft_outlook/sources/new-email-in-shared-folder/new-email-in-shared-folder.mjs
+++ b/components/microsoft_outlook/sources/new-email-in-shared-folder/new-email-in-shared-folder.mjs
@@ -6,7 +6,7 @@ export default {
   key: "microsoft_outlook-new-email-in-shared-folder",
   name: "New Email in Shared Folder Event",
   description: "Emit new event when an email is received in specified shared folders.",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "source",
   dedupe: "unique",
   props: {
@@ -47,8 +47,8 @@ export default {
         fn: this.microsoftOutlook.listSharedFolderMessages,
         args: {
           params: {
-            $orderBy: "createdDateTime desc",
-            $filter: `createdDateTime gt ${lastDate}`,
+            $orderBy: "sentDateTime desc",
+            $filter: `sentDateTime gt ${lastDate}`,
           },
           sharedFolderId: this.sharedFolderId,
           userId: this.userId,
@@ -61,15 +61,18 @@ export default {
       for await (const item of items) {
         responseArray.push(item);
       }
-      if (responseArray.length) this._setLastDate(responseArray[0].createdDateTime);
+      if (responseArray.length) {
+        this._setLastDate(responseArray[0].sentDateTime);
+      }
 
       for (const item of responseArray.reverse()) {
+        const ts = Date.parse(item.sentDateTime);
         this.$emit(
           item,
           {
-            id: item.conversationId,
-            summary: `A new email with id: "${item.conversationId}" was received!`,
-            ts: item.createdDateTime,
+            id: item.id,
+            summary: `A new email with subject ${item.subject} was received!`,
+            ts,
           },
         );
       }


### PR DESCRIPTION
… dropped

## WHY

Resolves #18884


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * "New email in shared folder" events now order and filter by sent time, persist sent time for progress tracking, include consistent event timestamps, use the message ID for events, and display email subjects in summaries.

* **Chores**
  * Updated Microsoft Outlook component to v1.7.4 and the "New email in shared folder" source to v0.0.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->