### PR TITLE
[Upgrade] Migrate Tellent HR to new Authentication

### DIFF
--- a/components/kiwihr/actions/create-employee/create-employee.mjs
+++ b/components/kiwihr/actions/create-employee/create-employee.mjs
@@ -6,7 +6,7 @@ export default {
   key: "kiwihr-create-employee",
   name: "Create Employee",
   description: "Add a new employee to kiwiHR. [See the documentation](https://api.kiwihr.com/api/docs/mutation.doc.html)",
-  version: "0.0.2",
+  version: "1.0.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/kiwihr/actions/update-employee-record/update-employee-record.mjs
+++ b/components/kiwihr/actions/update-employee-record/update-employee-record.mjs
@@ -6,7 +6,7 @@ export default {
   key: "kiwihr-update-employee-record",
   name: "Update Employee Record",
   description: "Update an existing employee's record in kiwiHR. [See the documentation](https://api.kiwihr.it/api/docs/mutation.doc.html)",
-  version: "0.0.2",
+  version: "1.0.0",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/kiwihr/kiwihr.app.mjs
+++ b/components/kiwihr/kiwihr.app.mjs
@@ -194,11 +194,11 @@ export default {
   },
   methods: {
     _baseUrl() {
-      return `${this.$auth.api_url}/api/graphql`;
+      return `https://${this.$auth.subdomain}.kiwihr.com/api/graphql`;
     },
     _headers() {
       return {
-        "X-Api-Key": `${this.$auth.api_key}`,
+        "x-api-key": `${this.$auth.api_key}`,
       };
     },
     getClient() {

--- a/components/kiwihr/package.json
+++ b/components/kiwihr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/kiwihr",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "description": "Pipedream kiwiHR Components",
   "main": "kiwihr.app.mjs",
   "keywords": [

--- a/components/kiwihr/sources/new-employee/new-employee.mjs
+++ b/components/kiwihr/sources/new-employee/new-employee.mjs
@@ -6,7 +6,7 @@ export default {
   key: "kiwihr-new-employee",
   name: "New Employee",
   description: "Emit new event when a new employee is added to KiwiHR.",
-  version: "0.0.1",
+  version: "1.0.0",
   type: "source",
   dedupe: "unique",
   methods: {


### PR DESCRIPTION
## WHY

Resolves #18904


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GraphQL endpoint now uses subdomain-based URLs for more reliable API calls.
  * API authentication header standardized to a lowercase key for consistent requests.

* **Chores**
  * Bumped package and component version numbers across the KiwiHR integration for release management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->