### PR TITLE
[FIX] Inconsistent event format between deploy-time and real-time events

### DIFF
--- a/components/salesforce_rest_api/package.json
+++ b/components/salesforce_rest_api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/salesforce_rest_api",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Pipedream Salesforce (REST API) Components",
   "main": "salesforce_rest_api.app.mjs",
   "keywords": [

--- a/components/salesforce_rest_api/sources/common/common-new-record.mjs
+++ b/components/salesforce_rest_api/sources/common/common-new-record.mjs
@@ -15,14 +15,10 @@ export default {
       const { recentItems } = await this.salesforce.listSObjectTypeIds(objectType);
       const ids = recentItems.map((item) => item.Id);
       for (const id of ids.slice(-25)) {
-        const object = await this.salesforce.getSObject(objectType, id);
-        const event = {
-          body: {
-            "New": object,
-            "UserId": id,
-          },
-        };
-        this.processWebhookEvent(event);
+        const body = await this.salesforce.getSObject(objectType, id);
+        this.processWebhookEvent({
+          body,
+        });
       }
     },
     async activate() {
@@ -80,12 +76,11 @@ export default {
     },
     generateWebhookMeta(data) {
       const nameField = this.getNameField();
-      const { New: newObject } = data.body;
       const {
         CreatedDate: createdDate,
         Id: id,
         [nameField]: name,
-      } = newObject;
+      } = data.body;
       const summary = `New ${this.getObjectType()} created: ${name ?? id}`;
       const ts = Date.parse(createdDate);
       return {

--- a/components/salesforce_rest_api/sources/new-case-instant/new-case-instant.mjs
+++ b/components/salesforce_rest_api/sources/new-case-instant/new-case-instant.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Case (Instant, of Selectable Type)",
   key: "salesforce_rest_api-new-case-instant",
   description: "Emit new event when a case is created. [See the documentation](https://sforce.co/3yPSJZy)",
-  version: "0.0.5",
+  version: "0.0.6",
   props: {
     salesforce: common.props.salesforce,
     db: "$.service.db",

--- a/components/salesforce_rest_api/sources/new-email-template-instant/new-email-template-instant.mjs
+++ b/components/salesforce_rest_api/sources/new-email-template-instant/new-email-template-instant.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Email Template (Instant, of Selectable Type)",
   key: "salesforce_rest_api-new-email-template-instant",
   description: "Emit new event when an email template is created. [See the documentation](https://sforce.co/3yPSJZy)",
-  version: "0.0.5",
+  version: "0.0.6",
   props: {
     salesforce: common.props.salesforce,
     db: "$.service.db",

--- a/components/salesforce_rest_api/sources/new-knowledge-article-instant/new-knowledge-article-instant.mjs
+++ b/components/salesforce_rest_api/sources/new-knowledge-article-instant/new-knowledge-article-instant.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Knowledge Article (Instant, of Selectable Type)",
   key: "salesforce_rest_api-new-knowledge-article-instant",
   description: "Emit new event when a knowledge article is created. [See the documentation](https://sforce.co/3yPSJZy)",
-  version: "0.0.5",
+  version: "0.0.6",
   props: {
     salesforce: common.props.salesforce,
     db: "$.service.db",

--- a/components/salesforce_rest_api/sources/new-record-instant/new-record-instant.mjs
+++ b/components/salesforce_rest_api/sources/new-record-instant/new-record-instant.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Record (Instant, of Selectable Type)",
   key: "salesforce_rest_api-new-record-instant",
   description: "Emit new event when a record of the selected object type is created. [See the documentation](https://sforce.co/3yPSJZy)",
-  version: "0.2.5",
+  version: "0.2.6",
   props: {
     ...common.props,
     fieldsToObtain: {


### PR DESCRIPTION
## WHY

Resolves #18929


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Salesforce REST API package version to 1.10.1
  * Bumped versions for multiple Salesforce event source components (new-case, new-email-template, new-knowledge-article, new-record sources)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->