### PR TITLE
[Feature] Add Markdown-Aware Text Replacement for Google Docs Action

### DIFF
--- a/components/google_docs/actions/append-image/append-image.mjs
+++ b/components/google_docs/actions/append-image/append-image.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-append-image",
   name: "Append Image to Document",
   description: "Appends an image to the end of a document. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#InsertInlineImageRequest)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/append-text/append-text.mjs
+++ b/components/google_docs/actions/append-text/append-text.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-append-text",
   name: "Append Text",
   description: "Append text to an existing document. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#InsertTextRequest)",
-  version: "0.1.9",
+  version: "0.1.10",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/create-document-from-template/create-document-from-template.mjs
+++ b/components/google_docs/actions/create-document-from-template/create-document-from-template.mjs
@@ -13,7 +13,7 @@ export default {
   ...others,
   key: "google_docs-create-document-from-template",
   name: "Create New Document From Template",
-  version: "0.0.5",
+  version: "0.0.6",
   description,
   type,
   props: {

--- a/components/google_docs/actions/create-document/create-document.mjs
+++ b/components/google_docs/actions/create-document/create-document.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-create-document",
   name: "Create a New Document",
   description: "Create a new document. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/create)",
-  version: "0.2.0",
+  version: "0.2.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/find-document/find-document.mjs
+++ b/components/google_docs/actions/find-document/find-document.mjs
@@ -14,7 +14,7 @@ export default {
   ...others,
   key: "google_docs-find-document",
   name: "Find Document",
-  version: "0.0.4",
+  version: "0.0.5",
   description,
   type,
   props: {

--- a/components/google_docs/actions/get-document/get-document.mjs
+++ b/components/google_docs/actions/get-document/get-document.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_docs-get-document",
   name: "Get Document",
   description: "Get the contents of the latest version of a document. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/get)",
-  version: "0.1.9",
+  version: "0.1.10",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/get-tab-content/get-tab-content.mjs
+++ b/components/google_docs/actions/get-tab-content/get-tab-content.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-get-tab-content",
   name: "Get Tab Content",
   description: "Get the content of a tab in a document. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/get)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/insert-page-break/insert-page-break.mjs
+++ b/components/google_docs/actions/insert-page-break/insert-page-break.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-insert-page-break",
   name: "Insert Page Break",
   description: "Insert a page break into a document. [See the documentation](https://developers.google.com/workspace/docs/api/reference/rest/v1/documents/request#insertpagebreakrequest)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/insert-table/insert-table.mjs
+++ b/components/google_docs/actions/insert-table/insert-table.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-insert-table",
   name: "Insert Table",
   description: "Insert a table into a document. [See the documentation](https://developers.google.com/workspace/docs/api/reference/rest/v1/documents/request#inserttablerequest)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/insert-text/insert-text.mjs
+++ b/components/google_docs/actions/insert-text/insert-text.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-insert-text",
   name: "Insert Text",
   description: "Insert text into a document. [See the documentation](https://developers.google.com/workspace/docs/api/reference/rest/v1/documents/request#inserttextrequest)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/replace-image/replace-image.mjs
+++ b/components/google_docs/actions/replace-image/replace-image.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-replace-image",
   name: "Replace Image",
   description: "Replace image in a existing document. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#ReplaceImageRequest)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_docs/actions/replace-text/replace-text.mjs
+++ b/components/google_docs/actions/replace-text/replace-text.mjs
@@ -3,8 +3,8 @@ import googleDocs from "../../google_docs.app.mjs";
 export default {
   key: "google_docs-replace-text",
   name: "Replace Text",
-  description: "Replace all instances of matched text in an existing document. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#ReplaceAllTextRequest)",
-  version: "0.0.10",
+  description: "Replace all instances of matched text in an existing document. Supports Markdown formatting in the replacement text. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#ReplaceAllTextRequest)",
+  version: "0.0.11",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
@@ -33,6 +33,14 @@ export default {
         "text",
       ],
       label: "New Text",
+      description: "The replacement text. Can include Markdown formatting (bold, italic, code, links, headings, lists, etc.).",
+    },
+    enableMarkdown: {
+      type: "boolean",
+      label: "Parse as Markdown",
+      description: "Enable Markdown parsing for the replacement text. When enabled, Markdown syntax (e.g., **bold**, *italic*, [links](url), `code`) will be converted to Google Docs formatting.",
+      default: false,
+      optional: true,
     },
     matchCase: {
       propDefinition: [
@@ -55,21 +63,43 @@ export default {
     },
   },
   async run({ $ }) {
-    const text = {
-      replaceText: this.text,
-      containsText: {
-        text: this.replaced,
-        matchCase: this.matchCase,
-      },
-      tabsCriteria: this.tabIds
-        ? {
-          tabIds: this.tabIds,
-        }
-        : undefined,
-    };
-    await this.googleDocs.replaceText(this.docId, text);
-    const doc = this.googleDocs.getDocument(this.docId);
-    $.export("$summary", `Successfully replaced text in doc with ID: ${this.docId}`);
+    const {
+      googleDocs,
+      docId,
+      replaced,
+      text,
+      enableMarkdown,
+      matchCase,
+      tabIds,
+    } = this;
+
+    if (enableMarkdown) {
+      // Use Markdown-aware replacement
+      await googleDocs.replaceTextWithMarkdown({
+        documentId: docId,
+        textToReplace: replaced,
+        markdownReplacement: text,
+        matchCase,
+        tabIds,
+      });
+    } else {
+      // Use plain text replacement (original behavior)
+      const textObject = {
+        replaceText: text,
+        containsText: {
+          text: replaced,
+          matchCase,
+        },
+        tabsCriteria: tabIds
+          ? {
+            tabIds,
+          }
+          : undefined,
+      };
+      await googleDocs.replaceText(docId, textObject);
+    }
+    const doc = await googleDocs.getDocument(docId);
+    $.export("$summary", `Successfully replaced text in doc with ID: ${docId}`);
     return doc;
   },
 };

--- a/components/google_docs/common/markdown-parser.mjs
+++ b/components/google_docs/common/markdown-parser.mjs
@@ -70,14 +70,13 @@ function parseMarkdown(markdown) {
     } else if (token.type === "list_item_open") {
       listItemStartIndex = currentIndex;
     } else if (token.type === "inline" && (inBulletList || inOrderedList)) {
-      const text = token.content;
+      // Process inline formatting within list items (bold, italic, code, links, etc.)
+      const result = processInlineToken(token, textContent, formattingRequests, currentIndex);
+      currentIndex = result;
 
-      textContent.push(text);
-      currentIndex += text.length;
-
-      // Apply bullet formatting
+      // Apply bullet formatting to the entire list item paragraph
       const bulletPreset = inOrderedList
-        ? "NUMBER_ASCENDING"
+        ? "NUMBERED_DECIMAL_ALPHA_ROMAN"
         : "BULLET_DISC_CIRCLE_SQUARE";
       formattingRequests.push({
         type: "createParagraphBullets",
@@ -133,6 +132,8 @@ function processInlineToken(token, textContent, formattingRequests, startIndex) 
   let isBold = false;
   let isItalic = false;
   let isCode = false;
+  let linkUrl = null;
+  let linkStartIndex = -1;
 
   token.children.forEach((child) => {
     if (child.type === "text") {
@@ -174,6 +175,19 @@ function processInlineToken(token, textContent, formattingRequests, startIndex) 
           formatting,
         });
       }
+
+      // Apply link formatting if inside a link
+      if (linkUrl) {
+        formattingRequests.push({
+          type: "updateLink",
+          textRange: {
+            startIndex: linkStartIndex,
+            endIndex: currentIndex,
+          },
+          url: linkUrl,
+        });
+        linkUrl = null;
+      }
     } else if (child.type === "strong_open") {
       isBold = true;
     } else if (child.type === "strong_close") {
@@ -213,6 +227,12 @@ function processInlineToken(token, textContent, formattingRequests, startIndex) 
           },
         },
       });
+    } else if (child.type === "link_open") {
+      linkUrl = child.attrGet("href");
+      linkStartIndex = currentIndex;
+    } else if (child.type === "link_close") {
+      // Link closing handled by the next text node
+      // This flag will be reset after applying the formatting
     } else if (child.type === "softbreak" || child.type === "hardbreak") {
       textContent.push("\n");
       currentIndex += 1;
@@ -313,13 +333,23 @@ function buildFormattingRequest(req) {
   }
 
   case "createParagraphBullets":
+    // Bullet formatting is not supported for replacement text
+    // It only works on paragraph-level, not on text ranges
+    return null;
+
+  case "updateLink":
     return {
-      createParagraphBullets: {
+      updateTextStyle: {
         range: {
           startIndex: req.textRange.startIndex,
           endIndex: req.textRange.endIndex,
         },
-        bulletPreset: req.bulletPreset || "BULLET_DISC_CIRCLE_SQUARE",
+        textStyle: {
+          link: {
+            url: req.url,
+          },
+        },
+        fields: "link",
       },
     };
 
@@ -328,7 +358,333 @@ function buildFormattingRequest(req) {
   }
 }
 
+/**
+ * Collect all text from the document into a single array
+ * Also builds an index map to track original document positions
+ */
+function collectAllDocumentText(elements, allText, indexMap, state) {
+  if (!elements || !Array.isArray(elements)) {
+    return;
+  }
+
+  elements.forEach((element) => {
+    if (element.paragraph) {
+      if (element.paragraph.elements && Array.isArray(element.paragraph.elements)) {
+        element.paragraph.elements.forEach((el) => {
+          if (el.textRun && el.textRun.content) {
+            const text = el.textRun.content;
+            const startOfText = state.allTextIndex;
+
+            allText.push(text);
+
+            // Record the document index for this position in allText
+            for (let i = 0; i < text.length; i++) {
+              indexMap[startOfText + i] = state.currentIndex + i;
+            }
+
+            state.allTextIndex += text.length;
+            state.currentIndex += text.length;
+          } else if (el.inlineObject) {
+            indexMap[state.allTextIndex] = state.currentIndex;
+            state.allTextIndex += 1;
+            state.currentIndex += 1;
+          } else if (
+            el.pageBreak
+            || el.columnBreak
+            || el.footnoteReference
+            || el.endnoteReference
+          ) {
+            indexMap[state.allTextIndex] = state.currentIndex;
+            state.allTextIndex += 1;
+            state.currentIndex += 1;
+          }
+        });
+      }
+    } else if (element.table) {
+      collectTableText(element.table, allText, indexMap, state);
+    }
+  });
+}
+
+/**
+ * Collect text from a table recursively
+ */
+function collectTableText(table, allText, indexMap, state) {
+  if (!table.tableRows || !Array.isArray(table.tableRows)) {
+    return;
+  }
+
+  table.tableRows.forEach((row) => {
+    if (row.tableCells && Array.isArray(row.tableCells)) {
+      row.tableCells.forEach((cell) => {
+        collectAllDocumentText(cell.content, allText, indexMap, state);
+      });
+    }
+  });
+}
+
+/**
+ * Build formatting requests for replaced text with recursive document scanning
+ * Scans the entire document including nested structures (tables, lists) and finds
+ * all occurrences of replacementText, applying formatting to each match.
+ */
+function buildFormattingRequestsForReplacement(markdownFormatting, doc, replacementText) {
+  const requests = [];
+  const bodyContent = doc?.body?.content || [];
+
+  // First, collect all text from the document and build an index map
+  const allText = [];
+  const indexMap = []; // Maps position in allText to position in document
+  const state = {
+    currentIndex: 1,
+    allTextIndex: 0,
+  };
+
+  // Collect all text
+  collectAllDocumentText(bodyContent, allText, indexMap, state);
+
+  const fullText = allText.join("");
+
+  // Now search for the replacement text in the full text
+  const matches = [];
+  let searchPos = 0;
+  let matchPos = fullText.indexOf(replacementText, searchPos);
+
+  while (matchPos !== -1) {
+    const docIndex = indexMap[matchPos] || (state.currentIndex + matchPos);
+    matches.push({
+      startIndex: docIndex,
+      endIndex: docIndex + replacementText.length,
+    });
+    searchPos = matchPos + 1;
+    matchPos = fullText.indexOf(replacementText, searchPos);
+  }
+
+  // Collect all bullet formatting requests separately
+  const bulletRequests = [];
+
+  // For each match found, generate formatting requests
+  matches.forEach((match) => {
+    markdownFormatting.forEach((req) => {
+      // Handle bullet list formatting separately
+      if (req.type === "createParagraphBullets") {
+        bulletRequests.push({
+          match,
+          req,
+        });
+        return;
+      }
+
+      const adjustedReq = JSON.parse(JSON.stringify(req));
+      // Adjust indices: the formatting is relative to start of replacement text (index 1)
+      // We need to offset it to the actual match position in the document
+      // match.startIndex is 1-based, so we add (match.startIndex - 1) to shift the formatting range
+      const offset = match.startIndex - 1;
+      adjustedReq.textRange.startIndex += offset;
+      adjustedReq.textRange.endIndex += offset;
+
+      // Validate that the range is not empty and within bounds
+      if (adjustedReq.textRange.startIndex >= adjustedReq.textRange.endIndex) {
+        return;
+      }
+
+      const formattingRequest = buildFormattingRequest(adjustedReq);
+      if (formattingRequest) {
+        requests.push(formattingRequest);
+      }
+    });
+  });
+
+  // Process bullet requests - apply bullets to the exact ranges from markdown parsing
+  bulletRequests.forEach(({
+    match,
+    req,
+  }) => {
+    // Adjust the text range to the actual match position in the document
+    // req.textRange is relative to the replacement text (starting at index 1)
+    // match.startIndex is where the replacement text starts in the document
+    const offset = match.startIndex - 1;
+
+    // Find the paragraph that contains this specific range
+    const rangeStart = req.textRange.startIndex + offset;
+    const rangeEnd = req.textRange.endIndex + offset;
+
+    // For bullet formatting, we only want to include the list item's own paragraph
+    // Not any preceding text from a previous paragraph
+    // Start from the beginning of the list item itself or the line start
+    let paragraphStart = rangeStart;
+
+    // Check if the character before rangeStart is a newline
+    // If yes, paragraphStart is already correct (start of current line)
+    // If no, scan backwards only one line to find the start of current paragraph
+    if (rangeStart > 1 && fullText[rangeStart - 2] !== "\n") {
+      // Scan backwards to find the newline that starts this paragraph
+      for (let i = rangeStart - 1; i >= 1; i--) {
+        if (fullText[i - 1] === "\n") {
+          paragraphStart = i;
+          break;
+        }
+        if (i === 1) {
+          paragraphStart = 1;
+          break;
+        }
+      }
+    }
+
+    // Scan forwards to find paragraph end (look for newline or document end)
+    let paragraphEnd = rangeEnd;
+    for (let i = rangeEnd; i < fullText.length; i++) {
+      if (fullText[i] === "\n") {
+        paragraphEnd = i;
+        break;
+      }
+      if (i === fullText.length - 1) {
+        paragraphEnd = fullText.length;
+        break;
+      }
+    }
+
+    // Determine bullet preset - use req.bulletPreset if available, otherwise default
+    const defaultBulletPreset = req.bulletPreset || "BULLET_DISC_CIRCLE_SQUARE";
+
+    const bulletRequest = {
+      createParagraphBullets: {
+        range: {
+          startIndex: paragraphStart,
+          endIndex: paragraphEnd,
+        },
+        bulletPreset: defaultBulletPreset,
+      },
+    };
+    requests.push(bulletRequest);
+  });
+
+  return requests;
+}
+
+/**
+ * Recursively scan document content for all text matches
+ * Handles paragraphs, tables, lists, and all nested elements
+ * Accumulates character index across all elements
+ */
+function scanDocumentContent(elements, replacementText, state, matches) {
+  if (!elements || !Array.isArray(elements)) {
+    return;
+  }
+
+  elements.forEach((element) => {
+    if (element.paragraph) {
+      scanParagraph(element.paragraph, replacementText, state, matches);
+    } else if (element.table) {
+      scanTable(element.table, replacementText, state, matches);
+    } else if (element.sectionBreak) {
+      // Sections don't contain text, just update structure
+    } else if (element.pageBreak) {
+      // Page breaks don't contain searchable text
+    } else if (element.tableOfContents) {
+      // Table of contents is auto-generated, skip
+    }
+  });
+}
+
+/**
+ * Scan a paragraph element for text matches
+ */
+function scanParagraph(paragraph, replacementText, state, matches) {
+  if (!paragraph.elements || !Array.isArray(paragraph.elements)) {
+    return;
+  }
+
+  paragraph.elements.forEach((element) => {
+    if (element.textRun && element.textRun.content) {
+      const runText = element.textRun.content;
+      const runStartIndex = state.currentIndex;
+
+      // Find all occurrences of replacementText in this text run
+      findAllMatches(runText, replacementText, runStartIndex, matches);
+
+      state.currentIndex += runText.length;
+    } else if (element.inlineObject) {
+      // Inline objects (images, etc.) take up 1 character in index
+      state.currentIndex += 1;
+    } else if (element.pageBreak) {
+      state.currentIndex += 1;
+    } else if (element.columnBreak) {
+      state.currentIndex += 1;
+    } else if (element.footnoteReference) {
+      state.currentIndex += 1;
+    } else if (element.endnoteReference) {
+      state.currentIndex += 1;
+    }
+  });
+}
+
+/**
+ * Scan a table element recursively
+ * Tables contain rows which contain cells which contain content blocks
+ */
+function scanTable(table, replacementText, state, matches) {
+  if (!table.tableRows || !Array.isArray(table.tableRows)) {
+    return;
+  }
+
+  table.tableRows.forEach((row) => {
+    scanTableRow(row, replacementText, state, matches);
+  });
+}
+
+/**
+ * Scan a table row element
+ */
+function scanTableRow(row, replacementText, state, matches) {
+  if (!row.tableCells || !Array.isArray(row.tableCells)) {
+    return;
+  }
+
+  row.tableCells.forEach((cell) => {
+    scanTableCell(cell, replacementText, state, matches);
+  });
+}
+
+/**
+ * Scan a table cell element
+ * Cells contain content blocks similar to document body
+ */
+function scanTableCell(cell, replacementText, state, matches) {
+  if (!cell.content || !Array.isArray(cell.content)) {
+    return;
+  }
+
+  // Recursively scan cell content (paragraphs, tables, lists, etc.)
+  scanDocumentContent(cell.content, replacementText, state, matches);
+}
+
+/**
+ * Find all occurrences of searchText within a given string
+ * Add match objects with exact startIndex and endIndex
+ */
+function findAllMatches(haystack, needle, baseIndex, matches) {
+  if (!haystack || !needle || haystack.length === 0 || needle.length === 0) {
+    return;
+  }
+
+  let searchStartPos = 0;
+  let matchPos = haystack.indexOf(needle, searchStartPos);
+
+  while (matchPos !== -1) {
+    matches.push({
+      startIndex: baseIndex + matchPos,
+      endIndex: baseIndex + matchPos + needle.length,
+    });
+
+    // Continue searching for next occurrence
+    searchStartPos = matchPos + 1;
+    matchPos = haystack.indexOf(needle, searchStartPos);
+  }
+}
+
 export default {
   parseMarkdown,
   convertToGoogleDocsRequests,
+  buildFormattingRequestsForReplacement,
 };

--- a/components/google_docs/google_docs.app.mjs
+++ b/components/google_docs/google_docs.app.mjs
@@ -200,5 +200,86 @@ export default {
         throw new Error(`Failed to insert markdown text: ${error.message}`);
       }
     },
+    async replaceTextWithMarkdown({
+      documentId,
+      textToReplace,
+      markdownReplacement,
+      matchCase = false,
+      tabIds = null,
+    }) {
+      try {
+        // Parse the markdown replacement text
+        const parseResult = markdownParser.parseMarkdown(markdownReplacement);
+        const {
+          text: replacementText,
+          formattingRequests: markdownFormatting,
+        } = parseResult;
+
+        // Build the initial replace request
+        const requests = [
+          {
+            replaceAllText: {
+              containsText: {
+                text: textToReplace,
+                matchCase: matchCase || false,
+              },
+              replaceText: replacementText,
+              tabsCriteria: tabIds
+                ? {
+                  tabIds,
+                }
+                : undefined,
+            },
+          },
+        ];
+
+        if (markdownFormatting.length === 0) {
+          // No formatting needed, just do the plain text replacement
+          return this.docs().documents.batchUpdate({
+            documentId,
+            requestBody: {
+              requests,
+            },
+          });
+        }
+
+        // For markdown with formatting, we need to find where the text will be replaced
+        // and then apply formatting to it
+        // First, do the replacement
+        await this.docs().documents.batchUpdate({
+          documentId,
+          requestBody: {
+            requests,
+          },
+        });
+
+        // Get the document AFTER replacement
+        const { data: updatedDocData } = await this.docs().documents.get({
+          documentId,
+        });
+
+        // Find all occurrences of the replacement text in the updated document
+        const formattingRequests = markdownParser.buildFormattingRequestsForReplacement(
+          markdownFormatting,
+          updatedDocData,
+          replacementText,
+        );
+
+        // Apply formatting if any matches were found
+        if (formattingRequests.length > 0) {
+          return this.docs().documents.batchUpdate({
+            documentId,
+            requestBody: {
+              requests: formattingRequests,
+            },
+          });
+        }
+
+        // Return updated document even if no formatting was applied
+        return updatedDocData;
+      } catch (error) {
+        throw new Error(`Failed to replace text with markdown: ${error.message}`);
+      }
+    },
   },
 };

--- a/components/google_docs/package.json
+++ b/components/google_docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_docs",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Pipedream Google_docs Components",
   "main": "google_docs.app.mjs",
   "keywords": [

--- a/components/google_docs/sources/new-document-created/new-document-created.mjs
+++ b/components/google_docs/sources/new-document-created/new-document-created.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_docs-new-document-created",
   name: "New Document Created (Instant)",
   description: "Emit new event when a new document is created in Google Docs. [See the documentation](https://developers.google.com/drive/api/reference/rest/v3/changes/watch)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/google_docs/sources/new-or-updated-document/new-or-updated-document.mjs
+++ b/components/google_docs/sources/new-or-updated-document/new-or-updated-document.mjs
@@ -9,7 +9,7 @@ export default {
   key: "google_docs-new-or-updated-document",
   name: "New or Updated Document (Instant)",
   description: "Emit new event when a document is created or updated in Google Docs. [See the documentation](https://developers.google.com/drive/api/reference/rest/v3/changes/watch)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "source",
   dedupe: "unique",
   methods: {


### PR DESCRIPTION
## WHY

Resolves #19007


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Markdown-based replace for Google Docs (toggleable), applying inline formatting, links, lists and table-aware formatting.
  * New two-phase replacement flow to more accurately apply Markdown-derived formatting to matched text.

* **Chores**
  * Routine version bumps across Google Docs actions, sources, and package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->