### PR TITLE
[18884] Update new-email-in-shared-folder.mjs

### DIFF
--- a/components/microsoft_outlook/package.json
+++ b/components/microsoft_outlook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/microsoft_outlook",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "description": "Pipedream Microsoft Outlook Components",
   "main": "microsoft_outlook.app.mjs",
   "keywords": [

--- a/components/microsoft_outlook/sources/new-email-in-shared-folder/new-email-in-shared-folder.mjs
+++ b/components/microsoft_outlook/sources/new-email-in-shared-folder/new-email-in-shared-folder.mjs
@@ -7,7 +7,7 @@ export default {
   key: "microsoft_outlook-new-email-in-shared-folder",
   name: "New Email in Shared Folder Event",
   description: "Emit new event when an email is received in specified shared folders.",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "source",
   dedupe: "unique",
   props: {


### PR DESCRIPTION
## WHY
This source is currently broken and not emitting new events. Should actually fix https://github.com/PipedreamHQ/pipedream/issues/18884

Repro:
1. Deploy trigger to a shared inbox trigger
2. Ensure the user.id is of a shared inbox that the logged in user has access to and not of the logged in user
3. Select "inbox" as the shared folder
4. Deploy source
5. Observe only 1 test event emitted
6. After deployed, send an email to the shared inbox
7. Observe no event emitted  

## Explanation 
https://github.com/PipedreamHQ/pipedream/blob/master/components/microsoft_outlook/sources/new-email/new-email.mjs#L47
In new email, the ID is hashed b/c >64 characters. Maybe pipedream cache doesn't work over 64 characters? and/or the microsoft one is the same for first for 64 characters
[5:02](https://pipedream-users.slack.com/archives/CMZG4EBJ9/p1763168569303459?thread_ts=1761672754.560479&cid=CMZG4EBJ9)
[https://github.com/PipedreamHQ/pipedream/blob/master/components/microsoft_outlook/[…]urces/new-email-in-shared-folder/new-email-in-shared-folder.mjs](https://github.com/PipedreamHQ/pipedream/blob/master/components/microsoft_outlook/sources/new-email-in-shared-folder/new-email-in-shared-folder.mjs#L73)
shared folder is just raw ID, no hash

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email identification for shared-folder monitoring to reduce duplicate events and make detection more reliable.

* **Chores**
  * Package and connector versions bumped to the latest release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->