### PR TITLE
Mastodon - add pagination props to Get Accounts Following

### DIFF
--- a/components/mastodon/package.json
+++ b/components/mastodon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/mastodon",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Pipedream Mastodon Components",
   "main": "mastodon.app.mjs",
   "keywords": [


### PR DESCRIPTION
Adds prop `maxId`, `minId`, and `sinceId` to help support pagination of large data sets.

Followup to https://github.com/PipedreamHQ/pipedream/issues/19014

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pagination support for account following lists with optional pagination identifiers (Max ID, Min ID, Since ID).
  * Enhanced pagination handling to expose link information for navigating through result sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->