### PR TITLE
feat(wics): add WICS app integration with API connector

### DIFF
--- a/components/wics/wics.app.mjs
+++ b/components/wics/wics.app.mjs
@@ -1,0 +1,58 @@
+import { axios } from "@pipedream/platform";
+
+export default {
+  type: "app",
+  app: "wics",
+  propDefinitions: {
+    api_key: {
+      type: "string",
+      secret: true,
+      label: "API Key",
+      description: "WICS API Key",
+    },
+    base_url: {
+      type: "string",
+      label: "Base URL",
+      description: "WICS Base URL",
+      default: "https://api.wics.nl",
+    },
+  },
+  methods: {
+    _baseUrl() {
+      return this.$auth.base_url || "https://api.wics.nl";
+    },
+    async _makeRequest({ $ = this, path, ...opts }) {
+      return axios($, {
+        url: `${this._baseUrl()}${path}`,
+        headers: {
+          Authorization: `Bearer ${this.$auth.api_key}`,
+          "Content-Type": "application/json",
+        },
+        ...opts,
+      });
+    },
+    async getOrder(order_id) {
+      return this._makeRequest({
+        path: `/orders/${order_id}`,
+      });
+    },
+    async listOrders(params = {}) {
+      return this._makeRequest({
+        path: "/orders",
+        params,
+      });
+    },
+    async createOrder(data) {
+      return this._makeRequest({
+        method: "POST",
+        path: "/orders",
+        data,
+      });
+    },
+  },
+  async auth() {
+    return this._makeRequest({
+      path: "/auth/verify",
+    });
+  },
+};


### PR DESCRIPTION
- Implements WICS (for people) API integration for Pipedream
- Added authentication support with API key and base URL configuration
- Implemented core API methods:
  * getOrder(order_id): Retrieve a specific order from WICS
  * listOrders(params): Retrieve all orders with optional filtering
  * createOrder(data): Create new orders through WICS API
- Added automatic request handling with proper headers and authorization
- Resolves issue #19207 - Add WICS app integration

This implementation follows Pipedream's app component conventions and supports the WICS API endpoint documented at https://docs.wics.nl/#orders-get-order

## WHY

<!-- author to complete -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WICS integration now available. Securely connect your WICS account using an API key to seamlessly manage your orders. Features include retrieving detailed order information, browsing your complete order history, creating new orders, and customizing your connection settings for optimal integration with your WICS setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->