### PR TITLE
Adding info prop to 'upcoming-event-alert'

### DIFF
--- a/components/google_calendar/package.json
+++ b/components/google_calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_calendar",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Pipedream Google_calendar Components",
   "main": "google_calendar.app.mjs",
   "keywords": [

--- a/components/google_calendar/sources/upcoming-event-alert/upcoming-event-alert.mjs
+++ b/components/google_calendar/sources/upcoming-event-alert/upcoming-event-alert.mjs
@@ -6,12 +6,17 @@ export default {
   key: "google_calendar-upcoming-event-alert",
   name: "New Upcoming Event Alert",
   description: "Emit new event based on a time interval before an upcoming event in the calendar.",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "source",
   props: {
     googleCalendar,
     db: "$.service.db",
     http: "$.interface.http",
+    pollingInfo: {
+      type: "alert",
+      alertType: "info",
+      content: "This source requires a Pipedream API key to provide instant events. Alternatively, you can use the `upcoming-event-alert-polling` source instead, which operates on a timer and does not require a Pipedream API key.",
+    },
     pipedreamApiKey: {
       type: "string",
       label: "Pipedream API Key",


### PR DESCRIPTION
No need for QA, just merge when approved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added informational alert to Google Calendar upcoming event alerts explaining API key requirements and available polling alternatives.

* **Chores**
  * Updated component versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->