### PR TITLE
[ACTION] Google Sheets Insert new Row at X

### DIFF
--- a/components/google_sheets/package.json
+++ b/components/google_sheets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_sheets",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Pipedream Google_sheets Components",
   "main": "google_sheets.app.mjs",
   "keywords": [


### PR DESCRIPTION
## WHY

Resolves #12803


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Row Index input to Google Sheets add-row action, enabling insertion at specific positions instead of appending to the end.
  * Added validation to prevent inserting at row 1 when headers exist.

* **Version Updates**
  * Google Sheets component version bumped to 2.2.0 and package version to 0.13.1.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->