### PR TITLE
Slack - adding channel type prop to list channels

### DIFF
--- a/components/slack_v2/actions/list-channels/list-channels.mjs
+++ b/components/slack_v2/actions/list-channels/list-channels.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-list-channels",
   name: "List Channels",
   description: "Return a list of all channels in a workspace. [See the documentation](https://api.slack.com/methods/conversations.list)",
-  version: "0.0.25",
+  version: "0.1.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -13,6 +13,27 @@ export default {
   type: "action",
   props: {
     slack,
+    channelTypes: {
+      type: "string",
+      label: "Channel Types",
+      description: "The types of channels to list. Select `public` for public channels only, `private` for private channels only, or `all` for both public and private channels.",
+      options: [
+        {
+          label: "Public Channels",
+          value: "public_channel",
+        },
+        {
+          label: "Private Channels",
+          value: "private_channel",
+        },
+        {
+          label: "All (Public + Private)",
+          value: "public_channel,private_channel",
+        },
+      ],
+      default: "public_channel",
+      optional: true,
+    },
     pageSize: {
       propDefinition: [
         slack,
@@ -30,6 +51,7 @@ export default {
     const allChannels = [];
     const params = {
       limit: this.pageSize,
+      types: this.channelTypes,
     };
     let page = 0;
 

--- a/components/slack_v2/package.json
+++ b/components/slack_v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/slack_v2",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Slack_v2 Components",
   "main": "slack_v2.app.mjs",
   "keywords": [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional channel type filtering to the Slack List Channels action, allowing users to filter channels by specific types when retrieving results.

* **Chores**
  * Version updates for enhanced functionality and stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->