### PR TITLE
Shopify & Shopify Developer App - add reverse prop to search-orders

### DIFF
--- a/components/shopify/actions/search-orders/search-orders.mjs
+++ b/components/shopify/actions/search-orders/search-orders.mjs
@@ -5,7 +5,7 @@ export default {
   key: "shopify-search-orders",
   name: "Search for Orders",
   description: "Search for an order or a list of orders. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/queries/orders)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -33,6 +33,12 @@ export default {
       optional: true,
       options: constants.ORDER_SORT_KEY,
     },
+    reverse: {
+      type: "boolean",
+      label: "Sort Descending",
+      description: "Sort the results in descending order. Defaults to ascending",
+      optional: true,
+    },
     max: {
       type: "integer",
       label: "Max Records",
@@ -49,6 +55,7 @@ export default {
       variables: {
         query: this.query,
         sortKey: this.sortKey,
+        reverse: this.reverse,
       },
       max: this.max,
     });

--- a/components/shopify/package.json
+++ b/components/shopify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/shopify",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Pipedream Shopify Components",
   "main": "shopify.app.mjs",
   "keywords": [

--- a/components/shopify_developer_app/actions/search-orders/search-orders.mjs
+++ b/components/shopify_developer_app/actions/search-orders/search-orders.mjs
@@ -5,7 +5,7 @@ export default {
   key: "shopify_developer_app-search-orders",
   name: "Search for Orders",
   description: "Search for an order or a list of orders. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/queries/orders)",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -27,6 +27,12 @@ export default {
       optional: true,
       options: constants.ORDER_SORT_KEY,
     },
+    reverse: {
+      type: "boolean",
+      label: "Sort Descending",
+      description: "Sort the results in descending order. Defaults to ascending",
+      optional: true,
+    },
     max: {
       type: "integer",
       label: "Max Records",
@@ -43,6 +49,7 @@ export default {
       variables: {
         query: this.query,
         sortKey: this.sortKey,
+        reverse: this.reverse,
       },
       max: this.max,
     });

--- a/components/shopify_developer_app/package.json
+++ b/components/shopify_developer_app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/shopify_developer_app",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Pipedream Shopify (Developer App) Components",
   "main": "shopify_developer_app.app.mjs",
   "keywords": [


### PR DESCRIPTION
Resolves #19731 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional "Sort Descending" configuration to the Search Orders action, enabling descending order sorting of results (defaults to ascending).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->