### PR TITLE
Slack list-channels bugfix

### DIFF
--- a/components/slack_v2/actions/list-channels/list-channels.mjs
+++ b/components/slack_v2/actions/list-channels/list-channels.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-list-channels",
   name: "List Channels",
   description: "Return a list of all channels in a workspace. [See the documentation](https://api.slack.com/methods/conversations.list)",
-  version: "0.1.0",
+  version: "0.1.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -49,9 +49,12 @@ export default {
   },
   async run({ $ }) {
     const allChannels = [];
+    const types = Array.isArray(this.channelTypes)
+      ? this.channelTypes.join(",")
+      : this.channelTypes;
     const params = {
       limit: this.pageSize,
-      types: this.channelTypes,
+      types,
     };
     let page = 0;
 

--- a/components/slack_v2/package.json
+++ b/components/slack_v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/slack_v2",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream Slack_v2 Components",
   "main": "slack_v2.app.mjs",
   "keywords": [


### PR DESCRIPTION
The array was being serialized to JSON (`JSON.stringify([1, 2]) // [1,2] not 1,2` by the Slack client so the prop was not working as intended

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced channel type handling to accept both string and array formats for improved flexibility in channel filtering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->