### PR TITLE
[ACTION] Add contact search functionality for Outlook Calendar free/busy queries

### DIFF
--- a/components/microsoft_outlook_calendar/actions/create-calendar-event/create-calendar-event.mjs
+++ b/components/microsoft_outlook_calendar/actions/create-calendar-event/create-calendar-event.mjs
@@ -3,7 +3,7 @@ import microsoftOutlook from "../../microsoft_outlook_calendar.app.mjs";
 export default {
   type: "action",
   key: "microsoft_outlook_calendar-create-calendar-event",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/microsoft_outlook_calendar/actions/delete-calendar-event/delete-calendar-event.mjs
+++ b/components/microsoft_outlook_calendar/actions/delete-calendar-event/delete-calendar-event.mjs
@@ -3,7 +3,7 @@ import microsoftOutlook from "../../microsoft_outlook_calendar.app.mjs";
 export default {
   type: "action",
   key: "microsoft_outlook_calendar-delete-calendar-event",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/microsoft_outlook_calendar/actions/delete-recurring-event-instance/delete-recurring-event-instance.mjs
+++ b/components/microsoft_outlook_calendar/actions/delete-recurring-event-instance/delete-recurring-event-instance.mjs
@@ -4,7 +4,7 @@ import { ConfigurationError } from "@pipedream/platform";
 export default {
   type: "action",
   key: "microsoft_outlook_calendar-delete-recurring-event-instance",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/microsoft_outlook_calendar/actions/get-schedule/get-schedule.mjs
+++ b/components/microsoft_outlook_calendar/actions/get-schedule/get-schedule.mjs
@@ -8,7 +8,7 @@ export default {
   key: "microsoft_outlook_calendar-get-schedule",
   name: "Get Free/Busy Schedule",
   description: "Get the free/busy availability information for a collection of users, distributions lists, or resources (rooms or equipment) for a specified time period. [See the documentation](https://learn.microsoft.com/en-us/graph/api/calendar-getschedule)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/microsoft_outlook_calendar/actions/list-events/list-events.mjs
+++ b/components/microsoft_outlook_calendar/actions/list-events/list-events.mjs
@@ -4,7 +4,7 @@ export default {
   key: "microsoft_outlook_calendar-list-events",
   name: "List Events",
   description: "Get a list of event objects in the user's mailbox. [See the documentation](https://learn.microsoft.com/en-us/graph/api/user-list-events)",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/microsoft_outlook_calendar/actions/search-contacts/search-contacts.mjs
+++ b/components/microsoft_outlook_calendar/actions/search-contacts/search-contacts.mjs
@@ -1,0 +1,71 @@
+import microsoftOutlook from "../../microsoft_outlook_calendar.app.mjs";
+
+export default {
+  key: "microsoft_outlook_calendar-search-contacts",
+  name: "Search Contacts",
+  description: "Search for contacts by name from your saved contacts list and retrieve their email addresses. [See the documentation](https://learn.microsoft.com/en-us/graph/api/user-list-contacts)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    microsoftOutlook,
+    search: {
+      type: "string",
+      label: "Search Query",
+      description: "Search for contacts by name (e.g., 'John Doe'). Searches display name, given name, and surname.",
+      optional: true,
+    },
+    filter: {
+      type: "string",
+      label: "Filter",
+      description: "Filter contacts by email address using [OData syntax](https://learn.microsoft.com/en-us/azure/search/search-query-odata-syntax-reference). For example, `emailAddresses/any(a:a/address eq 'john@example.com')`. Note: $filter only works with the `address` sub-property of `emailAddresses`. [See the documentation](https://learn.microsoft.com/en-us/graph/api/user-list-contacts)",
+      optional: true,
+    },
+    expand: {
+      type: "string",
+      label: "Expand",
+      description: "Comma-separated list of relationships to expand and include in the response. See the [relationships table of the contact](https://learn.microsoft.com/en-us/graph/api/resources/contact?view=graph-rest-1.0#relationships) object for supported names.",
+      optional: true,
+    },
+    select: {
+      type: "string",
+      label: "Select",
+      description: "Comma-separated list of [properties](https://learn.microsoft.com/en-us/graph/api/resources/contact?view=graph-rest-1.0#properties) to include in the response.",
+      optional: true,
+    },
+    maxResults: {
+      type: "integer",
+      label: "Max Results",
+      description: "The maximum number of contacts to return",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const {
+      search,
+      filter,
+      expand,
+      select,
+      maxResults,
+    } = this;
+
+    const response = await this.microsoftOutlook.listContacts({
+      $,
+      params: {
+        "$top": maxResults,
+        "$filter": filter,
+        "$search": search,
+        "$expand": expand,
+        "$select": select,
+      },
+    });
+
+    $.export("$summary", `Successfully retrieved \`${response.value.length}\` contact(s)`);
+
+    return response;
+  },
+};

--- a/components/microsoft_outlook_calendar/actions/search-people/search-people.mjs
+++ b/components/microsoft_outlook_calendar/actions/search-people/search-people.mjs
@@ -1,0 +1,81 @@
+import microsoftOutlook from "../../microsoft_outlook_calendar.app.mjs";
+
+export default {
+  key: "microsoft_outlook_calendar-search-people",
+  name: "Search People",
+  description: "Retrieve a collection of person objects ordered by their relevance to the user, based on communication and collaboration patterns and business relationships. [See the documentation](https://learn.microsoft.com/en-us/graph/api/user-list-people)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    microsoftOutlook,
+    search: {
+      type: "string",
+      label: "Search Query",
+      description: "Search for people by name or alias (e.g., 'Jane Smith'). Supports fuzzy matching. Note: Only works for the signed-in user's relevant people.",
+      optional: true,
+    },
+    filter: {
+      type: "string",
+      label: "Filter",
+      description: "Filter people using [OData syntax](https://learn.microsoft.com/en-us/azure/search/search-query-odata-syntax-reference). Limits response to people matching specified criteria. [See the documentation](https://learn.microsoft.com/en-us/graph/api/user-list-people)",
+      optional: true,
+    },
+    orderBy: {
+      type: "string",
+      label: "Order By",
+      description: "Changes the sort order of results. For example, `displayName` or `displayName desc`. Default ordering is by relevance to the user.",
+      optional: true,
+    },
+    select: {
+      type: "string",
+      label: "Select",
+      description: "Comma-separated list of [properties](https://learn.microsoft.com/en-us/graph/api/resources/person?view=graph-rest-1.0#properties) to include in the response. Recommended for performance optimization.",
+      optional: true,
+    },
+    skip: {
+      type: "integer",
+      label: "Skip",
+      description: "Skip the first N results. Note: Not supported with `$search`.",
+      optional: true,
+    },
+    maxResults: {
+      type: "integer",
+      label: "Max Results",
+      description: "The maximum number of people to return per page",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const {
+      search,
+      filter,
+      orderBy,
+      select,
+      skip,
+      maxResults,
+    } = this;
+
+    const response = await this.microsoftOutlook.listPeople({
+      $,
+      params: {
+        "$search": search,
+        "$filter": filter,
+        "$orderby": orderBy,
+        "$select": select,
+        "$skip": skip,
+        "$top": maxResults,
+      },
+    });
+
+    $.export("$summary", `Successfully retrieved \`${response.value.length}\` ${response.value.length === 1
+      ? "person"
+      : "people"}`);
+
+    return response;
+  },
+};

--- a/components/microsoft_outlook_calendar/actions/update-calendar-event/update-calendar-event.mjs
+++ b/components/microsoft_outlook_calendar/actions/update-calendar-event/update-calendar-event.mjs
@@ -3,7 +3,7 @@ import microsoftOutlook from "../../microsoft_outlook_calendar.app.mjs";
 export default {
   type: "action",
   key: "microsoft_outlook_calendar-update-calendar-event",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/microsoft_outlook_calendar/actions/update-recurring-event-instance/update-recurring-event-instance.mjs
+++ b/components/microsoft_outlook_calendar/actions/update-recurring-event-instance/update-recurring-event-instance.mjs
@@ -4,7 +4,7 @@ import { ConfigurationError } from "@pipedream/platform";
 export default {
   type: "action",
   key: "microsoft_outlook_calendar-update-recurring-event-instance",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/microsoft_outlook_calendar/microsoft_outlook_calendar.app.mjs
+++ b/components/microsoft_outlook_calendar/microsoft_outlook_calendar.app.mjs
@@ -236,5 +236,19 @@ export default {
         ...args,
       });
     },
+    async listContacts(args = {}) {
+      return this._makeRequest({
+        method: "GET",
+        path: "/me/contacts",
+        ...args,
+      });
+    },
+    async listPeople(args = {}) {
+      return this._makeRequest({
+        method: "GET",
+        path: "/me/people",
+        ...args,
+      });
+    },
   },
 };

--- a/components/microsoft_outlook_calendar/package.json
+++ b/components/microsoft_outlook_calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/microsoft_outlook_calendar",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Pipedream Microsoft Outlook Calendar Components",
   "main": "microsoft_outlook_calendar.app.mjs",
   "keywords": [

--- a/components/microsoft_outlook_calendar/sources/new-calendar-event/new-calendar-event.mjs
+++ b/components/microsoft_outlook_calendar/sources/new-calendar-event/new-calendar-event.mjs
@@ -5,7 +5,7 @@ export default {
   key: "microsoft_outlook_calendar-new-calendar-event",
   name: "New Calendar Event (Instant)",
   description: "Emit new event when a new Calendar event is created",
-  version: "0.0.9",
+  version: "0.0.10",
   type: "source",
   hooks: {
     ...common.hooks,

--- a/components/microsoft_outlook_calendar/sources/new-upcoming-event-polling/new-upcoming-event-polling.mjs
+++ b/components/microsoft_outlook_calendar/sources/new-upcoming-event-polling/new-upcoming-event-polling.mjs
@@ -5,7 +5,7 @@ export default {
   key: "microsoft_outlook_calendar-new-upcoming-event-polling",
   name: "New Upcoming Calendar Event (Polling)",
   description: "Emit new event based on a time interval before an upcoming calendar event. [See the documentation](https://docs.microsoft.com/en-us/graph/api/user-list-events)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/microsoft_outlook_calendar/sources/new-upcoming-event/new-upcoming-event.mjs
+++ b/components/microsoft_outlook_calendar/sources/new-upcoming-event/new-upcoming-event.mjs
@@ -6,7 +6,7 @@ export default {
   key: "microsoft_outlook_calendar-new-upcoming-event",
   name: "New Upcoming Calendar Event",
   description: "Emit new event when a Calendar event is upcoming, this source is using `reminderMinutesBeforeStart` property of the event to determine the time it should emit.",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   props: {
     ...common.props,

--- a/components/microsoft_outlook_calendar/sources/updated-calendar-event/updated-calendar-event.mjs
+++ b/components/microsoft_outlook_calendar/sources/updated-calendar-event/updated-calendar-event.mjs
@@ -5,7 +5,7 @@ export default {
   key: "microsoft_outlook_calendar-updated-calendar-event",
   name: "New Calendar Event Update (Instant)",
   description: "Emit new event when a Calendar event is updated",
-  version: "0.0.9",
+  version: "0.0.10",
   type: "source",
   hooks: {
     ...common.hooks,


### PR DESCRIPTION
## WHY

Resolves #19742


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Search Contacts action to find and retrieve contacts from Microsoft Outlook Calendar.
  * Added Search People action to search and retrieve people from Microsoft Outlook Calendar with filtering and pagination options.

* **Chores**
  * Updated versions across Microsoft Outlook Calendar actions and sources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->