### PR TITLE
Feature: Add SharePoint File Search with Metadata/Custom Column Filtering #19772

### DIFF
--- a/components/sharepoint/actions/create-folder/create-folder.mjs
+++ b/components/sharepoint/actions/create-folder/create-folder.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sharepoint-create-folder",
   name: "Create Folder",
   description: "Create a new folder in SharePoint. [See the documentation](https://learn.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_post_children?view=odsp-graph-online)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/create-item/create-item.mjs
+++ b/components/sharepoint/actions/create-item/create-item.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sharepoint-create-item",
   name: "Create Item",
   description: "Create a new item in Microsoft Sharepoint. [See the documentation](https://learn.microsoft.com/en-us/graph/api/listitem-create?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/sharepoint/actions/create-link/create-link.mjs
+++ b/components/sharepoint/actions/create-link/create-link.mjs
@@ -5,7 +5,7 @@ export default {
   key: "sharepoint-create-link",
   name: "Create Link",
   description: "Create a sharing link for a DriveItem. [See the documentation](https://docs.microsoft.com/en-us/graph/api/driveitem-createlink?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/create-list/create-list.mjs
+++ b/components/sharepoint/actions/create-list/create-list.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sharepoint-create-list",
   name: "Create List",
   description: "Create a new list in Microsoft Sharepoint. [See the documentation](https://learn.microsoft.com/en-us/graph/api/list-create?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/sharepoint/actions/download-file/download-file.mjs
+++ b/components/sharepoint/actions/download-file/download-file.mjs
@@ -5,7 +5,7 @@ export default {
   key: "sharepoint-download-file",
   name: "Download File",
   description: "Download a Microsoft Sharepoint file to the /tmp directory. [See the documentation](https://learn.microsoft.com/en-us/graph/api/driveitem-get-content?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/sharepoint/actions/find-file-by-name/find-file-by-name.mjs
+++ b/components/sharepoint/actions/find-file-by-name/find-file-by-name.mjs
@@ -6,7 +6,7 @@ export default {
   key: "sharepoint-find-file-by-name",
   name: "Find File by Name",
   description: "Search for a file or folder by name. [See the documentation](https://learn.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_search)",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/find-files-with-metadata/find-files-with-metadata.mjs
+++ b/components/sharepoint/actions/find-files-with-metadata/find-files-with-metadata.mjs
@@ -1,0 +1,132 @@
+import sharepoint from "../../sharepoint.app.mjs";
+
+export default {
+  key: "sharepoint-find-files-with-metadata",
+  name: "Find Files in List with Metadata",
+  description:
+    "Search and filter items in a SharePoint list based on metadata and custom columns. [See docs here](https://learn.microsoft.com/en-us/graph/api/listitem-list)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    sharepoint,
+    siteId: {
+      propDefinition: [
+        sharepoint,
+        "siteId",
+      ],
+      description: "Select the SharePoint site.",
+    },
+    listId: {
+      propDefinition: [
+        sharepoint,
+        "listId",
+        (c) => ({
+          siteId: c.siteId,
+        }),
+      ],
+      description: "Select the list or document library to search within.",
+    },
+    returnFields: {
+      propDefinition: [
+        sharepoint,
+        "columnNames",
+        (c) => ({
+          siteId: c.siteId,
+          listId: c.listId,
+          mapper: ({
+            name, displayName,
+          }) => ({
+            label: displayName,
+            value: name,
+          }),
+        }),
+      ],
+      label: "Fields to Return",
+      description:
+        "Select which custom fields to return. If left empty, all custom fields are returned.",
+      optional: true,
+    },
+    filter: {
+      type: "string",
+      label: "Filter Query",
+      description:
+        "OData filter query. To filter by a custom column, use the format `fields/InternalName eq 'Value'`. The field picker for 'Fields to Return' shows the `InternalName` in parentheses.",
+      optional: true,
+    },
+    orderby: {
+      type: "string",
+      label: "Order By",
+      description:
+        "OData order by query (e.g., `lastModifiedDateTime desc`). To sort by a custom field, use `fields/InternalName asc`.",
+      optional: true,
+    },
+    select: {
+      type: "string[]",
+      label: "Top-level Properties",
+      description:
+        "Select which top-level item properties to return. If not specified, a default set is returned. `id` and `webUrl` are always returned.",
+      optional: true,
+      options: [
+        "id",
+        "name",
+        "createdDateTime",
+        "lastModifiedDateTime",
+        "webUrl",
+        "size",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const {
+      siteId, listId, returnFields, filter, orderby, select,
+    } = this;
+
+    const params = {
+      $filter: filter,
+      $orderby: orderby,
+    };
+
+    let expandValue = "fields";
+    if (returnFields?.length > 0) {
+      expandValue = `fields($select=${returnFields.join(",")})`;
+    }
+
+    if (select?.length > 0) {
+      const selectSet = new Set(select);
+      selectSet.add("id");
+      selectSet.add("webUrl");
+      params.$select = Array.from(selectSet).join(",");
+    }
+
+    params.$expand = expandValue;
+
+    const results = [];
+    const iterator = this.sharepoint.paginate({
+      fn: this.sharepoint.listItems,
+      args: {
+        siteId,
+        listId,
+        params,
+      },
+    });
+
+    for await (const item of iterator) {
+      results.push(item);
+    }
+
+    $.export(
+      "$summary",
+      `Successfully found ${results.length} item${
+        results.length === 1
+          ? ""
+          : "s"
+      }.`,
+    );
+    return results;
+  },
+};

--- a/components/sharepoint/actions/get-excel-table/get-excel-table.mjs
+++ b/components/sharepoint/actions/get-excel-table/get-excel-table.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sharepoint-get-excel-table",
   name: "Get Excel Table",
   description: "Retrieve a table from an Excel spreadsheet stored in Sharepoint [See the documentation](https://learn.microsoft.com/en-us/graph/api/table-range?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -16,6 +16,8 @@ export default {
     alert: {
       type: "alert",
       alertType: "info",
+      label: "Excel Table Information",
+      description: "Information about selecting Excel tables",
       content: `Note: The table must exist within the Excel spreadsheet.
         \nSee Microsoft's documentation on how to [Create and Format a Table](https://support.microsoft.com/en-us/office/create-and-format-tables-e81aa349-b006-4f8a-9806-5af9df0ac664)
       `,

--- a/components/sharepoint/actions/get-file-by-id/get-file-by-id.mjs
+++ b/components/sharepoint/actions/get-file-by-id/get-file-by-id.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sharepoint-get-file-by-id",
   name: "Get File by ID",
   description: "Retrieves a file by ID. [See the documentation](https://learn.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_get)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/get-site/get-site.mjs
+++ b/components/sharepoint/actions/get-site/get-site.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sharepoint-get-site",
   name: "Get Site",
   description: "Get a site in Microsoft Sharepoint. [See the documentation](https://learn.microsoft.com/en-us/graph/api/site-get?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/list-files-in-folder/list-files-in-folder.mjs
+++ b/components/sharepoint/actions/list-files-in-folder/list-files-in-folder.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sharepoint-list-files-in-folder",
   name: "List Files in Folder",
   description: "Retrieves a list of the files and/or folders directly within a folder. [See the documentation](https://learn.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_list_children)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/list-sites/list-sites.mjs
+++ b/components/sharepoint/actions/list-sites/list-sites.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sharepoint-list-sites",
   name: "List Sites",
   description: "List all sites in Microsoft Sharepoint. [See the documentation](https://learn.microsoft.com/en-us/graph/api/site-list?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/search-and-filter-files/search-and-filter-files.mjs
+++ b/components/sharepoint/actions/search-and-filter-files/search-and-filter-files.mjs
@@ -1,0 +1,155 @@
+import sharepoint from "../../sharepoint.app.mjs";
+import utils from "../../common/utils.mjs";
+
+export default {
+  key: "sharepoint-search-and-filter-files",
+  name: "Search and Filter Files",
+  description:
+    "Search and filter SharePoint files based on metadata and custom columns. This action allows you to query files using SharePoint's custom properties, managed metadata, and other column values. [See the documentation](https://learn.microsoft.com/en-us/graph/api/listitem-list)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    sharepoint,
+    siteId: {
+      propDefinition: [
+        sharepoint,
+        "siteId",
+      ],
+    },
+    listId: {
+      propDefinition: [
+        sharepoint,
+        "listId",
+        (c) => ({
+          siteId: c.siteId,
+        }),
+      ],
+      label: "List / Document Library",
+      description: "Select the document library or list to search in",
+    },
+    filter: {
+      type: "string",
+      label: "Filter",
+      description:
+        "Filter items using OData syntax. To filter by custom columns, use `fields/ColumnInternalName`. Example: `fields/Title eq 'My File'` or `fields/Status eq 'Approved'`. [See OData filter documentation](https://learn.microsoft.com/en-us/graph/query-parameters#filter-parameter)",
+      optional: true,
+    },
+    select: {
+      propDefinition: [
+        sharepoint,
+        "columnNames",
+        (c) => ({
+          siteId: c.siteId,
+          listId: c.listId,
+          mapper: ({
+            name, displayName,
+          }) => ({
+            label: displayName,
+            value: name,
+          }),
+        }),
+      ],
+      label: "Select Fields",
+      description:
+        "Select the specific metadata fields to return in the response. If none are selected, all fields will be returned.",
+      optional: true,
+    },
+    orderBy: {
+      type: "string",
+      label: "Order By",
+      description:
+        "Specify the sort order of the results using OData syntax. Example: `fields/Created desc` or `fields/Title asc`.",
+      optional: true,
+    },
+    expandFields: {
+      type: "boolean",
+      label: "Expand Fields?",
+      description:
+        "Set to `true` to retrieve custom metadata and column values. Defaults to `true`.",
+      optional: true,
+      default: true,
+    },
+    maxResults: {
+      type: "integer",
+      label: "Max Results",
+      description: "The maximum number of results to return. Defaults to 100.",
+      optional: true,
+      default: 100,
+      min: 1,
+    },
+  },
+  async run({ $ }) {
+    const {
+      siteId,
+      listId,
+      filter,
+      select,
+      orderBy,
+      expandFields,
+      maxResults,
+    } = this;
+
+    const expand = expandFields
+      ? "fields"
+      : undefined;
+
+    // Construct select parameter
+    // If fields are selected, we need to select them within the expanded fields
+    // Graph API supports $expand=fields($select=Title,Color)
+    let expandParam = expand;
+    if (expandFields && select?.length > 0) {
+      expandParam = `fields($select=${select.join(",")})`;
+    }
+
+    const params = utils.cleanObject({
+      $filter: filter,
+      $expand: expandParam,
+      $orderby: orderBy,
+      $top: Math.max(1, maxResults),
+    });
+
+    const items = [];
+    const iterator = this.sharepoint.paginate({
+      fn: this.sharepoint.listItems,
+      args: {
+        $,
+        siteId,
+        listId,
+        params,
+      },
+    });
+
+    for await (const item of iterator) {
+      items.push({
+        id: item.id,
+        name:
+          item.fields?.FileLeafRef ||
+          item.fields?.Title ||
+          item.name ||
+          item.displayName,
+        fileType: item.fields?.File_x0020_Type,
+        createdDateTime: item.createdDateTime,
+        lastModifiedDateTime: item.lastModifiedDateTime,
+        webUrl: item.webUrl,
+        fields: item.fields,
+      });
+
+      if (items.length >= maxResults) {
+        break;
+      }
+    }
+
+    $.export(
+      "$summary",
+      `Found ${items.length} matching item${items.length === 1
+        ? ""
+        : "s"}`,
+    );
+    return items;
+  },
+};

--- a/components/sharepoint/actions/search-files/search-files.mjs
+++ b/components/sharepoint/actions/search-files/search-files.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sharepoint-search-files",
   name: "Search Files",
   description: "Search for files in Microsoft Sharepoint. [See the documentation](https://learn.microsoft.com/en-us/graph/api/search-query?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/search-sites/search-sites.mjs
+++ b/components/sharepoint/actions/search-sites/search-sites.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sharepoint-search-sites",
   name: "Search Sites",
   description: "Search for sites in Microsoft Sharepoint. [See the documentation](https://learn.microsoft.com/en-us/graph/api/site-search?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/select-files/select-files.mjs
+++ b/components/sharepoint/actions/select-files/select-files.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sharepoint-select-files",
   name: "Select Files",
   description: "A file picker action that allows browsing and selecting one or more files from SharePoint. Returns the selected files' metadata including pre-authenticated download URLs. [See the documentation](https://learn.microsoft.com/en-us/graph/api/driveitem-get)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/update-item/update-item.mjs
+++ b/components/sharepoint/actions/update-item/update-item.mjs
@@ -5,7 +5,7 @@ export default {
   key: "sharepoint-update-item",
   name: "Update Item",
   description: "Updates an existing item in Microsoft Sharepoint. [See the documentation](https://learn.microsoft.com/en-us/graph/api/listitem-update?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/sharepoint/actions/upload-file/upload-file.mjs
+++ b/components/sharepoint/actions/upload-file/upload-file.mjs
@@ -5,7 +5,7 @@ export default {
   key: "sharepoint-upload-file",
   name: "Upload File",
   description: "Upload a file to OneDrive. [See the documentation](https://learn.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_put_content?view=odsp-graph-online)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/package.json
+++ b/components/sharepoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/sharepoint",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Pipedream Microsoft Sharepoint Online Components",
   "main": "sharepoint.app.mjs",
   "keywords": [

--- a/components/sharepoint/sources/new-file-created/new-file-created.mjs
+++ b/components/sharepoint/sources/new-file-created/new-file-created.mjs
@@ -5,7 +5,7 @@ export default {
   key: "sharepoint-new-file-created",
   name: "New File Created",
   description: "Emit new event when a new file is created in Microsoft Sharepoint.",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/sharepoint/sources/new-folder-created/new-folder-created.mjs
+++ b/components/sharepoint/sources/new-folder-created/new-folder-created.mjs
@@ -5,7 +5,7 @@ export default {
   key: "sharepoint-new-folder-created",
   name: "New Folder Created",
   description: "Emit new event when a new folder is created in Microsoft Sharepoint.",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/sharepoint/sources/new-list-item/new-list-item.mjs
+++ b/components/sharepoint/sources/new-list-item/new-list-item.mjs
@@ -5,7 +5,7 @@ export default {
   key: "sharepoint-new-list-item",
   name: "New List Item",
   description: "Emit new event when a new list item is created in Microsoft Sharepoint.",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/sharepoint/sources/updated-list-item/updated-list-item.mjs
+++ b/components/sharepoint/sources/updated-list-item/updated-list-item.mjs
@@ -5,7 +5,7 @@ export default {
   key: "sharepoint-updated-list-item",
   name: "Updated List Item",
   description: "Emit new event when a list item is updated in Microsoft Sharepoint.",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "source",
   dedupe: "unique",
   props: {


### PR DESCRIPTION
Resolved merge conflict in sharepoint.app.mjs and added support for metadata-based file search in SharePoint. Includes $filter, $expand=fields, $select, and $orderby for querying custom columns, returning enriched file metadata with discoverable custom fields.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Search and Filter Files" and "Find Files in List with Metadata" actions for querying SharePoint items by metadata and custom columns.

* **Improvements**
  * Enhanced SharePoint API: better column mapping, drive browsing, pre-resolution of identifiers and a new getListItem method.
  * Validation tightened: item selection now requires both site and list.
  * Improved labels/descriptions for Excel Table selection.

* **Chores**
  * Routine version bumps across many SharePoint actions, sources, and package.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->