### PR TITLE
Fix file sync in Sharepoint Download File action

### DIFF
--- a/components/sharepoint/actions/download-file/download-file.mjs
+++ b/components/sharepoint/actions/download-file/download-file.mjs
@@ -5,7 +5,7 @@ export default {
   key: "sharepoint-download-file",
   name: "Download File",
   description: "Download a Microsoft Sharepoint file to the /tmp directory. [See the documentation](https://learn.microsoft.com/en-us/graph/api/driveitem-get-content?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -60,7 +60,10 @@ export default {
 
     const rawcontent = response.toString("base64");
     const buffer = Buffer.from(rawcontent, "base64");
-    const downloadedFilepath = `/tmp/${this.filename}`;
+    // Since the filepath is not returned as one of the standard keys (filePath
+    // or path), save the file to STASH_DIR, if defined, so it is synced at the
+    // end of execution.
+    const downloadedFilepath = `${process.env.STASH_DIR || "/tmp"}/${this.filename}`;
     fs.writeFileSync(downloadedFilepath, buffer);
 
     return {


### PR DESCRIPTION
## WHY

The Sharepoint Download file action was not returning a temporary link to download the file in the `$filestash_uploads` export.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated download file path handling to support environment-based directory configuration with fallback to system temporary directory.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->