### PR TITLE
Modified delete-note action component to show both types of notes

### DIFF
--- a/components/salesforce_rest_api/actions/delete-note/delete-note.mjs
+++ b/components/salesforce_rest_api/actions/delete-note/delete-note.mjs
@@ -3,9 +3,9 @@ import { ConfigurationError } from "@pipedream/platform";
 
 export default {
   key: "salesforce_rest_api-delete-note",
-  name: "Delete Note",
-  description: "Delete a note from a Salesforce record. [See the documentation](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_sobject_retrieve_delete.htm)",
-  version: "0.0.1",
+  name: "Delete Note Or Content Note",
+  description: "Delete a note or content note from a Salesforce record. [See the documentation](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_sobject_retrieve_delete.htm)",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: true,
@@ -27,8 +27,8 @@ export default {
     },
     recordId: {
       type: "string",
-      label: "Note ID",
-      description: "The ID of the note to delete",
+      label: "Note ID Or Content Note ID",
+      description: "The ID of the note or content note to delete",
       async options() {
         try {
           return await this.salesforce.listRecordOptions({

--- a/components/salesforce_rest_api/package.json
+++ b/components/salesforce_rest_api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/salesforce_rest_api",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Pipedream Salesforce (REST API) Components",
   "main": "salesforce_rest_api.app.mjs",
   "keywords": [


### PR DESCRIPTION
## WHY

Modified delete-note action component to show both types of notes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The delete note action now supports deleting both Note and ContentNote types from Salesforce records.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->