### PR TITLE
Reverting ServiceNow auth change

### DIFF
--- a/components/servicenow/actions/create-table-record/create-table-record.mjs
+++ b/components/servicenow/actions/create-table-record/create-table-record.mjs
@@ -5,7 +5,7 @@ export default {
   key: "servicenow-create-table-record",
   name: "Create Table Record",
   description: "Inserts one record in the specified table. [See the documentation](https://www.servicenow.com/docs/bundle/zurich-api-reference/page/integrate/inbound-rest/concept/c_TableAPI.html#title_table-POST)",
-  version: "1.0.1",
+  version: "1.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/servicenow/actions/delete-table-record/delete-table-record.mjs
+++ b/components/servicenow/actions/delete-table-record/delete-table-record.mjs
@@ -4,7 +4,7 @@ export default {
   key: "servicenow-delete-table-record",
   name: "Delete Table Record",
   description: "Deletes the specified record from a table. [See the documentation](https://www.servicenow.com/docs/bundle/zurich-api-reference/page/integrate/inbound-rest/concept/c_TableAPI.html#title_table-DELETE)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/servicenow/actions/get-record-counts-by-field/get-record-counts-by-field.mjs
+++ b/components/servicenow/actions/get-record-counts-by-field/get-record-counts-by-field.mjs
@@ -5,7 +5,7 @@ export default {
   key: "servicenow-get-record-counts-by-field",
   name: "Get Record Counts by Field",
   description: "Retrieves the count of records grouped by a specified field from a ServiceNow table. [See the documentation](https://www.servicenow.com/docs/bundle/zurich-api-reference/page/integrate/inbound-rest/concept/c_AggregateAPI.html#title_aggregate-GET-stats)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/servicenow/actions/get-table-record-by-id/get-table-record-by-id.mjs
+++ b/components/servicenow/actions/get-table-record-by-id/get-table-record-by-id.mjs
@@ -4,7 +4,7 @@ export default {
   key: "servicenow-get-table-record-by-id",
   name: "Get Table Record by ID",
   description: "Retrieves a single record from a table by its ID. [See the documentation](https://www.servicenow.com/docs/bundle/zurich-api-reference/page/integrate/inbound-rest/concept/c_TableAPI.html#title_table-GET-id)",
-  version: "1.0.1",
+  version: "1.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/servicenow/actions/get-table-records/get-table-records.mjs
+++ b/components/servicenow/actions/get-table-records/get-table-records.mjs
@@ -5,7 +5,7 @@ export default {
   key: "servicenow-get-table-records",
   name: "Get Table Records",
   description: "Retrieves multiple records for the specified table. [See the documentation](https://www.servicenow.com/docs/bundle/zurich-api-reference/page/integrate/inbound-rest/concept/c_TableAPI.html#title_table-GET)",
-  version: "1.0.1",
+  version: "1.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/servicenow/actions/update-table-record/update-table-record.mjs
+++ b/components/servicenow/actions/update-table-record/update-table-record.mjs
@@ -5,7 +5,7 @@ export default {
   key: "servicenow-update-table-record",
   name: "Update Table Record",
   description: "Updates the specified record with the name-value pairs included in the request body. [See the documentation](https://www.servicenow.com/docs/bundle/zurich-api-reference/page/integrate/inbound-rest/concept/c_TableAPI.html#title_table-PATCH)",
-  version: "1.0.1",
+  version: "1.0.2",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/servicenow/package.json
+++ b/components/servicenow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/servicenow",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Pipedream ServiceNow Components",
   "main": "servicenow.app.mjs",
   "keywords": [

--- a/components/servicenow/servicenow.app.mjs
+++ b/components/servicenow/servicenow.app.mjs
@@ -100,10 +100,7 @@ export default {
         baseURL: `https://${this.$auth.instance_name}.service-now.com/api/now`,
         headers: {
           ...headers,
-          auth: {
-            username: `${this.$auth.username}`,
-            password: `${this.$auth.password}`,
-          },
+          "Authorization": `Bearer ${this.$auth.oauth_access_token}`,
         },
         ...args,
       });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ServiceNow action component versions (create-table-record, delete-table-record, get-record-counts-by-field, get-table-record-by-id, get-table-records, and update-table-record).
  * Bumped ServiceNow package version to 0.8.2.

* **Updates**
  * Modified ServiceNow API authentication to use OAuth Bearer tokens instead of basic authentication.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->