### PR TITLE
[Platform] Adding filename parameter support to base64 strings

### DIFF
--- a/platform/package.json
+++ b/platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/platform",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Pipedream platform globals (typing and runtime type checking)",
   "homepage": "https://pipedream.com",
   "main": "dist/index.js",


### PR DESCRIPTION
This supports base64 data URLs with a "name" or "filename" parameter, which is sometimes used by users. This sets the filename metadata, defaulting to "file.{ext}" if it is not present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for extracting and preserving file names from data URLs with explicit name parameters. File names are now properly propagated to metadata when available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->