### PR TITLE
Pipedream Axios - hide debug export for axios errors

### DIFF
--- a/platform/lib/axios.ts
+++ b/platform/lib/axios.ts
@@ -128,7 +128,7 @@ async function callAxios(step: PipedreamStep | undefined, config: AxiosRequestCo
     config.headers.Authorization = oauthSignature;
   }
 
-  try {
+  /*try {
     if (config.debug) {
       stepExport(step, config, "debug_config");
     }
@@ -147,7 +147,19 @@ async function callAxios(step: PipedreamStep | undefined, config: AxiosRequestCo
       stepExport(step, axiosErr.response, "debug");
     }
     throw err;
+  }*/
+
+  if (config.debug) {
+    stepExport(step, config, "debug_config");
   }
+  const response = await axios(config);
+  if (config.debug) {
+    stepExport(step, response.data, "debug_response");
+  }
+
+  return config.returnFullResponse
+    ? response
+    : response.data;
 }
 
 function stepExport(step: PipedreamStep | undefined, message: unknown, key: string) {
@@ -164,7 +176,7 @@ function stepExport(step: PipedreamStep | undefined, message: unknown, key: stri
   console.log(`export: ${key} - ${JSON.stringify(message, null, 2)}`);
 }
 
-function convertAxiosError(err: AxiosError) {
+/*function convertAxiosError(err: AxiosError) {
   if (err.response) {
     delete err.response.request;
     err.name = `${err.name} - ${err.message}`;
@@ -177,7 +189,7 @@ function convertAxiosError(err: AxiosError) {
     }
   }
   return err;
-}
+}*/
 
 function create(config?: AxiosRequestConfig, signConfig?: OAuth1SignConfig) {
   const axiosInstance = axios.create(config);
@@ -214,10 +226,10 @@ function create(config?: AxiosRequestConfig, signConfig?: OAuth1SignConfig) {
       ? response
       : response.data;
   }, (error: AxiosError) => {
-    if (error.response) {
+    /*if (error.response) {
       convertAxiosError(error);
       stepExport(undefined, error.response, "debug");
-    }
+    }*/
 
     throw error;
   });

--- a/platform/package.json
+++ b/platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/platform",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Pipedream platform globals (typing and runtime type checking)",
   "homepage": "https://pipedream.com",
   "main": "dist/index.js",
@@ -10,7 +10,6 @@
     "test": "npm run build && jest"
   },
   "author": "Pipedream Team",
-  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/PipedreamHQ/platform.git"


### PR DESCRIPTION
This is to temporarily remove the `debug` section of errors thrown by Pipedream axios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Platform version updated to 3.2.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->