### PR TITLE
[ACTION] GitHub - Get Issue (#20052)

### DIFF
--- a/components/github/actions/get-issue/get-issue.mjs
+++ b/components/github/actions/get-issue/get-issue.mjs
@@ -1,0 +1,42 @@
+import github from "../../github.app.mjs";
+
+export default {
+  key: "github-get-issue",
+  name: "Get Issue",
+  description: "Get details of an issue in a GitHub repository. [See the documentation](https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#get-an-issue)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  type: "action",
+  props: {
+    github,
+    repoFullname: {
+      propDefinition: [
+        github,
+        "repoFullname",
+      ],
+    },
+    issueNumber: {
+      propDefinition: [
+        github,
+        "issueNumber",
+        (c) => ({
+          repoFullname: c.repoFullname,
+        }),
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.github.getIssue({
+      repoFullname: this.repoFullname,
+      issueNumber: this.issueNumber,
+    });
+
+    $.export("$summary", `Successfully retrieved issue #${this.issueNumber} from ${this.repoFullname}`);
+
+    return response;
+  },
+};


### PR DESCRIPTION
## Summary

- Adds a new **Get Issue** action for the GitHub app that retrieves the full details of an issue by its number
- Uses the existing `getIssue` method from `github.app.mjs`
- Follows the same pattern as `get-repository`, `get-commit`, and other existing "Get" actions

Closes #20052

## How to verify

1. Add the **GitHub - Get Issue** action to a workflow
2. Select a repository and issue number
3. The action should return all properties associated with that issue (title, body, state, labels, assignees, etc.)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Get Issue" GitHub action that retrieves comprehensive issue information from repositories. Users can now programmatically query specific issues by providing the repository name and issue number as parameters, enabling seamless integration with GitHub workflows and enhancing automation capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->