### PR TITLE
Salesforce - Return browser URL to the relevant object in search-string

### DIFF
--- a/components/salesforce_rest_api/actions/search-string/search-string.mjs
+++ b/components/salesforce_rest_api/actions/search-string/search-string.mjs
@@ -4,7 +4,7 @@ export default {
   key: "salesforce_rest_api-search-string",
   name: "Search Object Records",
   description: "Searches for records in an object using a parameterized search. [See the documentation](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_search_parameterized_get.htm)",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -40,6 +40,13 @@ export default {
       ],
     },
   },
+  methods: {
+    // constructs a url that users can copy into a browser to view the record in Salesforce
+    createBrowserUrl(baseUrl, url) {
+      return `${baseUrl.replace(".my.salesforce.com", ".lightning.force.com")}/lightning/r/${url.match(/sobjects\/([^/]+)\/([^/]+)/).slice(1)
+        .join("/")}/view`;
+    },
+  },
   async run({ $ }) {
     const {
       sobjectType,
@@ -56,6 +63,7 @@ export default {
       },
     });
     const resultsFound = response.searchRecords.length;
+    const baseUrl = this.salesforce._baseApiUrl();
     response.searchRecords = response.searchRecords.map((record) => {
       const url = record?.attributes?.url;
       if (!url) return record;
@@ -63,7 +71,8 @@ export default {
         ...record,
         attributes: {
           ...record.attributes,
-          url: `${this.salesforce._baseApiUrl()}${url}`,
+          url: `${baseUrl}${url}`, // api url
+          browserUrl: this.createBrowserUrl(baseUrl, url),
         },
       };
     });

--- a/components/salesforce_rest_api/package.json
+++ b/components/salesforce_rest_api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/salesforce_rest_api",
-  "version": "1.11.4",
+  "version": "1.11.5",
   "description": "Pipedream Salesforce (REST API) Components",
   "main": "salesforce_rest_api.app.mjs",
   "keywords": [


### PR DESCRIPTION
Followup to #20023 

The previous PR updated `search-string` to return the full api URL for an object. This PR updates the action to also return a `browserUrl` that can be pasted in a browser to view the object in Salesforce.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added browser URL support to Salesforce search results, allowing users to construct direct links to records in the Salesforce interface.
  * Enhanced search results now include both API and browser URL information for each record.

* **Updates**
  * Improved URL handling for Salesforce search functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->