### PR TITLE
[Bug] google_calendar-update-following-instances duplicates the first instance when rescheduling a recurring event

### DIFF
--- a/components/google_calendar/package.json
+++ b/components/google_calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_calendar",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Pipedream Google_calendar Components",
   "main": "google_calendar.app.mjs",
   "keywords": [


### PR DESCRIPTION
## WHY

Resolves #20056


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update flow for following instances of recurring Google Calendar events: deletion now occurs before recurrence trimming, with added error handling that attempts to restore deleted instances and surfaces clear partial-failure messages when operations partially succeed.

* **Chores**
  * Bumped component and action versions to reflect this update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->