### PR TITLE
Exposing webUrl and desc for sharepoint file selection

### DIFF
--- a/components/sharepoint/sharepoint.app.mjs
+++ b/components/sharepoint/sharepoint.app.mjs
@@ -360,7 +360,7 @@ export default {
             driveId: resolvedDriveId,
           });
         return response.value?.map(({
-          id, name, folder, size, lastModifiedDateTime,
+          id, name, folder, size, lastModifiedDateTime, webUrl, description,
         }) => ({
           value: JSON.stringify({
             id,
@@ -369,6 +369,8 @@ export default {
             size,
             childCount: folder?.childCount,
             lastModifiedDateTime,
+            webUrl,
+            description,
           }),
           label: folder
             ? `📁 ${name}`

--- a/components/sharepoint_admin/actions/retrieve-file-metadata/retrieve-file-metadata.mjs
+++ b/components/sharepoint_admin/actions/retrieve-file-metadata/retrieve-file-metadata.mjs
@@ -8,7 +8,7 @@ export default {
   name: retrieveFileMetadata.name,
   description: retrieveFileMetadata.description,
   type: retrieveFileMetadata.type,
-  version: "0.0.1",
+  version: "0.0.2",
   methods: {
     ...retrieveFileMetadata.methods,
   },

--- a/components/sharepoint_admin/package.json
+++ b/components/sharepoint_admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/sharepoint_admin",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream SharePoint Admin Components",
   "main": "sharepoint_admin.app.mjs",
   "keywords": [

--- a/packages/connect-react/CHANGELOG.md
+++ b/packages/connect-react/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # Changelog
 
+## [2.7.2] - 2026-02-20
+
+### Added
+- Added `webUrl` and `description` fields to `FilePickerItem` interface
+- Parse `webUrl` and `description` from JSON option values in file picker
+
 ## [2.7.1] - 2026-02-19
 
 ### Added

--- a/packages/connect-react/CLAUDE.md
+++ b/packages/connect-react/CLAUDE.md
@@ -1,0 +1,19 @@
+# @pipedream/connect-react
+
+## Versioning & Changelog
+
+**Every change to this package must include:**
+
+1. **Version bump** in `package.json` — follow semver:
+   - Patch (x.x.N): bug fixes, adding optional fields to existing interfaces
+   - Minor (x.N.0): new features, new components, new props
+   - Major (N.0.0): breaking changes to public API or component props
+2. **CHANGELOG.md entry** — add a new section at the top following the existing format:
+   ```markdown
+   ## [x.y.z] - YYYY-MM-DD
+
+   ### Added / Changed / Fixed
+   - Description of changes
+   ```
+
+Do not merge or consider a change complete without both the version bump and changelog entry.

--- a/packages/connect-react/package.json
+++ b/packages/connect-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/connect-react",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "Pipedream Connect library for React",
   "files": [
     "dist"

--- a/packages/connect-react/src/components/ConfigureFilePicker/index.tsx
+++ b/packages/connect-react/src/components/ConfigureFilePicker/index.tsx
@@ -18,6 +18,8 @@ export interface FilePickerItem {
   size?: number;
   childCount?: number;
   lastModifiedDateTime?: string;
+  webUrl?: string;
+  description?: string;
   raw?: unknown;
 }
 
@@ -486,7 +488,7 @@ export const ConfigureFilePicker: FC<ConfigureFilePickerProps> = ({
           : item;
         if (parsed && typeof parsed === "object") {
           const {
-            id, name, isFolder, size, childCount, lastModifiedDateTime,
+            id, name, isFolder, size, childCount, lastModifiedDateTime, webUrl, description,
           } = parsed as Record<string, unknown>;
           items.push({
             id: String(id ?? ""),
@@ -501,6 +503,12 @@ export const ConfigureFilePicker: FC<ConfigureFilePickerProps> = ({
               : undefined,
             lastModifiedDateTime: typeof lastModifiedDateTime === "string"
               ? lastModifiedDateTime
+              : undefined,
+            webUrl: typeof webUrl === "string"
+              ? webUrl
+              : undefined,
+            description: typeof description === "string"
+              ? description
               : undefined,
           });
         }
@@ -623,6 +631,8 @@ export const ConfigureFilePicker: FC<ConfigureFilePickerProps> = ({
     let size: number | undefined;
     let childCount: number | undefined;
     let lastModifiedDateTime: string | undefined;
+    let webUrl: string | undefined;
+    let description: string | undefined;
     let parsedValue: unknown = rawValue;
 
     try {
@@ -635,6 +645,8 @@ export const ConfigureFilePicker: FC<ConfigureFilePickerProps> = ({
         size = parsed.size;
         childCount = parsed.childCount;
         lastModifiedDateTime = parsed.lastModifiedDateTime;
+        webUrl = parsed.webUrl;
+        description = parsed.description;
       }
     } catch {
       // Not JSON, check label for folder indicators
@@ -649,6 +661,8 @@ export const ConfigureFilePicker: FC<ConfigureFilePickerProps> = ({
       size,
       childCount,
       lastModifiedDateTime,
+      webUrl,
+      description,
       raw: opt,
     };
   });


### PR DESCRIPTION
## WHY

<!-- author to complete -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * File picker now includes additional metadata: web URL and description fields for selected files and folders, providing richer context when browsing SharePoint items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->