### PR TITLE
Linear App - bump versions to republish

### DIFF
--- a/components/linear_app/actions/create-comment/create-comment.mjs
+++ b/components/linear_app/actions/create-comment/create-comment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "linear_app-create-comment",
   name: "Create Comment",
   description: "Create a comment in Linear. [See the documentation](https://studio.apollographql.com/public/Linear-API/variant/current/schema/reference/objects/Mutation?query=comment)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/linear_app/actions/create-initiative/create-initiative.mjs
+++ b/components/linear_app/actions/create-initiative/create-initiative.mjs
@@ -4,7 +4,7 @@ export default {
   key: "linear_app-create-initiative",
   name: "Create Initiative",
   description: "Create an initiative in Linear. [See the documentation](https://studio.apollographql.com/public/Linear-API/variant/current/schema/reference/objects/Mutation?query=initiativeCreate)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/linear_app/actions/create-issue/create-issue.mjs
+++ b/components/linear_app/actions/create-issue/create-issue.mjs
@@ -5,7 +5,7 @@ export default {
   key: "linear_app-create-issue",
   name: "Create Issue",
   description: "Creates a new issue in Linear. Requires team ID and title. Optional: description, assignee, project, state. Returns response object with success status and issue details. Uses API Key authentication. [See the documentation](https://linear.app/developers/graphql#creating-and-editing-issues).",
-  version: "0.4.18",
+  version: "0.4.19",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/linear_app/actions/create-project/create-project.mjs
+++ b/components/linear_app/actions/create-project/create-project.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Create Project",
   description: "Create a project in Linear. [See the documentation](https://studio.apollographql.com/public/Linear-API/variant/current/schema/reference/inputs/ProjectCreateInput).",
   type: "action",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/linear_app/actions/get-issue/get-issue.mjs
+++ b/components/linear_app/actions/get-issue/get-issue.mjs
@@ -5,7 +5,7 @@ export default {
   key: "linear_app-get-issue",
   name: "Get Issue",
   description: "Retrieves a Linear issue by its ID or identifier. Returns complete issue details including title, description, state, assignee, team, project, labels, and timestamps. Uses API Key authentication. [See the documentation](https://linear.app/developers/graphql).",
-  version: "0.1.18",
+  version: "0.1.19",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/linear_app/actions/get-teams/get-teams.mjs
+++ b/components/linear_app/actions/get-teams/get-teams.mjs
@@ -5,7 +5,7 @@ export default {
   key: "linear_app-get-teams",
   name: "Get Teams",
   description: "Retrieves all teams in your Linear workspace. Returns array of team objects with details like ID, name, and key. Supports pagination with configurable limit. Uses API Key authentication. See Linear docs for additional info [here](https://linear.app/developers/graphql).",
-  version: "0.2.18",
+  version: "0.2.19",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/linear_app/actions/get-view-issues/get-view-issues.mjs
+++ b/components/linear_app/actions/get-view-issues/get-view-issues.mjs
@@ -4,7 +4,7 @@ export default {
   key: "linear_app-get-view-issues",
   name: "Get View Issues",
   description: "Get issues from a custom view in Linear. [See the documentation](https://studio.apollographql.com/public/Linear-API/variant/current/schema/reference/objects/Query?query=customView)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/linear_app/actions/list-comments/list-comments.mjs
+++ b/components/linear_app/actions/list-comments/list-comments.mjs
@@ -4,7 +4,7 @@ export default {
   key: "linear_app-list-comments",
   name: "List Comments",
   description: "List comments in Linear. [See the documentation](https://studio.apollographql.com/public/Linear-API/variant/current/schema/reference/objects/Query?query=comments)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/linear_app/actions/list-initiatives/list-initiatives.mjs
+++ b/components/linear_app/actions/list-initiatives/list-initiatives.mjs
@@ -4,7 +4,7 @@ export default {
   key: "linear_app-list-initiatives",
   name: "List Initiatives",
   description: "List initiatives in Linear. [See the documentation](https://studio.apollographql.com/public/Linear-API/variant/current/schema/reference/objects/Query?query=initiatives)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/linear_app/actions/list-projects/list-projects.mjs
+++ b/components/linear_app/actions/list-projects/list-projects.mjs
@@ -6,7 +6,7 @@ export default {
   name: "List Projects",
   description: "List projects in Linear. [See the documentation](https://studio.apollographql.com/public/Linear-API/variant/current/schema/reference/objects/ProjectConnection?query=projects).",
   type: "action",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/linear_app/actions/list-views/list-views.mjs
+++ b/components/linear_app/actions/list-views/list-views.mjs
@@ -4,7 +4,7 @@ export default {
   key: "linear_app-list-views",
   name: "List Views",
   description: "List views in Linear. [See the documentation](https://studio.apollographql.com/public/Linear-API/variant/current/schema/reference/objects/Query?query=views)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/linear_app/actions/remove-label-from-issue/remove-label-from-issue.mjs
+++ b/components/linear_app/actions/remove-label-from-issue/remove-label-from-issue.mjs
@@ -4,7 +4,7 @@ export default {
   key: "linear_app-remove-label-from-issue",
   name: "Remove Label from Issue",
   description: "Remove a label from an issue in Linear. [See the documentation](https://studio.apollographql.com/public/Linear-API/variant/current/schema/reference/objects/Mutation?query=issueremovelabel)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: true,

--- a/components/linear_app/actions/search-issues/search-issues.mjs
+++ b/components/linear_app/actions/search-issues/search-issues.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Search Issues",
   description: "Searches Linear issues by team, project, assignee, labels, state, or text query. Supports pagination, ordering, and archived issues. Returns array of matching issues. Uses API Key authentication. See Linear docs for additional info [here](https://linear.app/developers/graphql).",
   type: "action",
-  version: "0.2.18",
+  version: "0.2.19",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/linear_app/actions/update-initiative/update-initiative.mjs
+++ b/components/linear_app/actions/update-initiative/update-initiative.mjs
@@ -4,7 +4,7 @@ export default {
   key: "linear_app-update-initiative",
   name: "Update Initiative",
   description: "Update an initiative in Linear. [See the documentation](https://studio.apollographql.com/public/Linear-API/variant/current/schema/reference/objects/Mutation?query=initiativeupdate)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: true,

--- a/components/linear_app/actions/update-issue/update-issue.mjs
+++ b/components/linear_app/actions/update-issue/update-issue.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Update Issue",
   description: "Updates an existing Linear issue. Can modify title, description, assignee, state, project, team, labels, priority, and dates. Returns updated issue details. Uses API Key authentication. [See the documentation](https://linear.app/developers/graphql#creating-and-editing-issues).",
   type: "action",
-  version: "0.1.18",
+  version: "0.1.19",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/linear_app/package.json
+++ b/components/linear_app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/linear_app",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Pipedream Linear_app Components",
   "main": "linear_app.app.mjs",
   "keywords": [

--- a/components/linear_app/sources/comment-created-instant/comment-created-instant.mjs
+++ b/components/linear_app/sources/comment-created-instant/comment-created-instant.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Comment Created (Instant)",
   description: "Triggers instantly when a new comment is added to an issue in Linear. Returns comment details including content, author, issue reference, and timestamps. Supports filtering by team. See Linear docs for additional info [here](https://linear.app/developers/webhooks).",
   type: "source",
-  version: "0.1.19",
+  version: "0.1.20",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/linear_app/sources/issue-created-instant/issue-created-instant.mjs
+++ b/components/linear_app/sources/issue-created-instant/issue-created-instant.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Issue Created (Instant)",
   description: "Triggers instantly when a new issue is created in Linear. Provides complete issue details including title, description, team, assignee, state, and timestamps. Supports filtering by team and project. See Linear docs for additional info [here](https://linear.app/developers/webhooks).",
   type: "source",
-  version: "0.3.19",
+  version: "0.3.20",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/linear_app/sources/issue-updated-instant/issue-updated-instant.mjs
+++ b/components/linear_app/sources/issue-updated-instant/issue-updated-instant.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Issue Updated (Instant)",
   description: "Triggers instantly when any issue is updated in Linear. Provides complete issue details with changes. Supports filtering by team and project. Includes all updates except status changes. See Linear docs for additional info [here](https://linear.app/developers/webhooks).",
   type: "source",
-  version: "0.3.19",
+  version: "0.3.20",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/linear_app/sources/new-issue-status-updated/new-issue-status-updated.mjs
+++ b/components/linear_app/sources/new-issue-status-updated/new-issue-status-updated.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Issue Status Updated (Instant)",
   description: "Triggers instantly when an issue's workflow state changes (e.g., Todo to In Progress). Returns issue with previous and current state info. Can filter by specific target state. See Linear docs for additional info [here](https://linear.app/developers/webhooks).",
   type: "source",
-  version: "0.1.19",
+  version: "0.1.20",
   dedupe: "unique",
   props: {
     linearApp: common.props.linearApp,

--- a/components/linear_app/sources/new-projectupdate-created/new-projectupdate-created.mjs
+++ b/components/linear_app/sources/new-projectupdate-created/new-projectupdate-created.mjs
@@ -8,7 +8,7 @@ export default {
   name: "New Project Update Written (Instant)",
   description: "Triggers instantly when a project update (status report) is created in Linear. Returns update content, author, project details, and health status. Filters by team and optionally by project. See Linear docs for additional info [here](https://linear.app/developers/webhooks).",
   type: "source",
-  version: "0.0.11",
+  version: "0.0.12",
   dedupe: "unique",
   props: {
     linearApp,

--- a/components/linear_app/sources/project-updated-instant/project-updated-instant.mjs
+++ b/components/linear_app/sources/project-updated-instant/project-updated-instant.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Project Updated (Instant)",
   description: "Triggers instantly when a project is updated in Linear. Returns project details including name, description, status, dates, and team info. Supports filtering by specific teams. See Linear docs for additional info [here](https://linear.app/developers/webhooks).",
   type: "source",
-  version: "0.0.12",
+  version: "0.0.13",
   dedupe: "unique",
   props: {
     linearApp,


### PR DESCRIPTION
Previous [PR](https://github.com/PipedreamHQ/pipedream/pull/20236) failed to publish to the registry.
https://github.com/PipedreamHQ/pipedream/actions/runs/22971563021/job/66689344600

This PR bumps component and `package.json` versions to attempt to republish.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Linear app component versions across multiple actions and event sources, including create operations, list operations, get operations, update operations, and instant event triggers. Package version bumped to 0.9.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->