### PR TITLE
google_drive: fix crash in new-or-modified-folders instant source when folder has no parents

### DIFF
--- a/components/google_drive/package.json
+++ b/components/google_drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_drive",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Pipedream Google_drive Components",
   "main": "google_drive.app.mjs",
   "keywords": [

--- a/components/google_drive/sources/new-or-modified-folders/new-or-modified-folders.mjs
+++ b/components/google_drive/sources/new-or-modified-folders/new-or-modified-folders.mjs
@@ -20,7 +20,7 @@ export default {
   key: "google_drive-new-or-modified-folders",
   name: "New or Modified Folders (Instant)",
   description: "Emit new event when a folder is created or modified in the selected Drive",
-  version: "0.2.7",
+  version: "0.2.8",
   type: "source",
   // Dedupe events based on the "x-goog-message-number" header for the target channel:
   // https://developers.google.com/drive/api/v3/push#making-watch-requests
@@ -143,7 +143,7 @@ export default {
         const allParents = [];
         if (this.includeSubfolders) {
           allParents.push(...(await this.getAllParents(file.id)));
-        } else {
+        } else if (fileInfo.parents) {
           allParents.push(fileInfo.parents[0]);
         }
 


### PR DESCRIPTION
Guard against undefined `parents` field before accessing `[0]`, matching the same logic already used in the polling version (new-or-modified-folders-polling).

## WHY

"Instant" version of the same "polling" trigger doesn't use same logic to resolve parents causing crashes for folders that don't have visible parents, like:
```
{"err":null,"error":"observation error","observations":[{"h":"deploy","k":"hook","ts":1767881885575},{"err":{"message":"Cannot read properties of undefined (reading '0')","name":"TypeError","stack":"TypeError: Cannot read properties of undefined (reading '0')\n at Object.processChanges (file:///tmp/__pdg__/dist/code/596e0a3d958db92535e4ebdffed494547e64b69a232b98d6bd1eb3e90762908d/code/sources/new-or-modified-folders/new-or-modified-folders.mjs:147:43)\n at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n at async Object.deploy (file:///tmp/__pdg__/dist/code/596e0a3d958db92535e4ebdffed494547e64b69a232b98d6bd1eb3e90762908d/code/sources/new-or-modified-folders/new-or-modified-folders.mjs:62:7)\n at async callComponentHooks (/var/task/node_modules/@lambda-v2/component-runtime/src/callComponentHooks.js:31:7)\n at async /var/task/node_modules/@lambda-v2/component-runtime/src/deployedComponentMain.js:73:7\n at async captureObservations (/var/task/node_modules/@lambda-v2/component-runtime/src/captureObservations.js:28:5)\n at async deployedComponentMain (/var/task/node_modules/@lambda-v2/component-runtime/src/deployedComponentMain.js:46:20)\n at async file:///var/task/component_maker.mjs:203:11"},"k":"error","ts":1767881908397}]}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Google Drive folder monitoring to avoid errors when folder entries lack parent information.

* **Chores**
  * Updated Google Drive component version to 1.5.4 and internal package version to 0.2.8.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->