### PR TITLE
[ACTION] Zendesk - Help Center Search endpoints

### DIFF
--- a/components/zendesk/actions/add-ticket-tags/add-ticket-tags.mjs
+++ b/components/zendesk/actions/add-ticket-tags/add-ticket-tags.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Add Ticket Tags",
   description: "Add tags to a ticket (appends to existing tags). [See the documentation](https://developer.zendesk.com/api-reference/ticketing/ticket-management/tags/#add-tags).",
   type: "action",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zendesk/actions/create-ticket/create-ticket.mjs
+++ b/components/zendesk/actions/create-ticket/create-ticket.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Create Ticket",
   description: "Creates a ticket. [See the documentation](https://developer.zendesk.com/api-reference/ticketing/tickets/tickets/#create-ticket).",
   type: "action",
-  version: "0.1.12",
+  version: "0.1.13",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zendesk/actions/delete-ticket/delete-ticket.mjs
+++ b/components/zendesk/actions/delete-ticket/delete-ticket.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Delete Ticket",
   description: "Deletes a ticket. [See the documentation](https://developer.zendesk.com/api-reference/ticketing/tickets/tickets/#delete-ticket).",
   type: "action",
-  version: "0.1.12",
+  version: "0.1.13",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/zendesk/actions/get-article/get-article.mjs
+++ b/components/zendesk/actions/get-article/get-article.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Get Article",
   description: "Retrieves an article by its ID. [See the documentation](https://developer.zendesk.com/api-reference/help_center/help-center-api/articles/#show-article).",
   type: "action",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zendesk/actions/get-macro/get-macro.mjs
+++ b/components/zendesk/actions/get-macro/get-macro.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Get Macro",
   description: "Retrieves a macro by its ID. [See the documentation](https://developer.zendesk.com/api-reference/ticketing/business-rules/macros/#show-macro).",
   type: "action",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zendesk/actions/get-ticket-info/get-ticket-info.mjs
+++ b/components/zendesk/actions/get-ticket-info/get-ticket-info.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Get Ticket Info",
   description: "Retrieves information about a specific ticket. [See the documentation](https://developer.zendesk.com/api-reference/ticketing/tickets/tickets/#show-ticket).",
   type: "action",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zendesk/actions/get-user-info/get-user-info.mjs
+++ b/components/zendesk/actions/get-user-info/get-user-info.mjs
@@ -4,7 +4,7 @@ export default {
   key: "zendesk-get-user-info",
   name: "Get User Info",
   description: "Retrieves information about a specific user. [See the documentation](https://developer.zendesk.com/api-reference/ticketing/users/users/#show-user).",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zendesk/actions/list-active-macros/list-active-macros.mjs
+++ b/components/zendesk/actions/list-active-macros/list-active-macros.mjs
@@ -6,7 +6,7 @@ export default {
   name: "List Active Macros",
   description: "Lists all active shared and personal macros available to the current user. [See the documentation](https://developer.zendesk.com/api-reference/ticketing/business-rules/macros/#list-active-macros).",
   type: "action",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zendesk/actions/list-articles/list-articles.mjs
+++ b/components/zendesk/actions/list-articles/list-articles.mjs
@@ -6,7 +6,7 @@ export default {
   name: "List Articles",
   description: "Retrieves a list of articles. [See the documentation](https://developer.zendesk.com/api-reference/help_center/help-center-api/articles/#list-articles).",
   type: "action",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zendesk/actions/list-locales/list-locales.mjs
+++ b/components/zendesk/actions/list-locales/list-locales.mjs
@@ -4,7 +4,7 @@ export default {
   key: "zendesk-list-locales",
   name: "List Locales",
   description: "Retrieves all locales. [See the documentation](https://developer.zendesk.com/api-reference/ticketing/account-configuration/locales/).",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zendesk/actions/list-macros/list-macros.mjs
+++ b/components/zendesk/actions/list-macros/list-macros.mjs
@@ -4,7 +4,7 @@ export default {
   key: "zendesk-list-macros",
   name: "List Macros",
   description: "Retrieves all macros. [See the documentation](https://developer.zendesk.com/api-reference/ticketing/business-rules/macros/#list-macros).",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zendesk/actions/list-ticket-comments/list-ticket-comments.mjs
+++ b/components/zendesk/actions/list-ticket-comments/list-ticket-comments.mjs
@@ -4,7 +4,7 @@ export default {
   key: "zendesk-list-ticket-comments",
   name: "List Ticket Comments",
   description: "Retrieves all comments for a specific ticket. [See the documentation](https://developer.zendesk.com/api-reference/ticketing/tickets/ticket_comments/#list-comments).",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zendesk/actions/list-tickets/list-tickets.mjs
+++ b/components/zendesk/actions/list-tickets/list-tickets.mjs
@@ -5,7 +5,7 @@ export default {
   name: "List Tickets",
   description: "Retrieves a list of tickets. [See the documentation](https://developer.zendesk.com/api-reference/ticketing/tickets/tickets/#list-tickets).",
   type: "action",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zendesk/actions/remove-ticket-tags/remove-ticket-tags.mjs
+++ b/components/zendesk/actions/remove-ticket-tags/remove-ticket-tags.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Remove Ticket Tags",
   description: "Remove specific tags from a ticket. [See the documentation](https://developer.zendesk.com/api-reference/ticketing/ticket-management/tags/#remove-tags).",
   type: "action",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/zendesk/actions/search-articles/search-articles.mjs
+++ b/components/zendesk/actions/search-articles/search-articles.mjs
@@ -1,0 +1,206 @@
+import app from "../../zendesk.app.mjs";
+import { toCommaSeparated } from "../../common/utils.mjs";
+
+export default {
+  key: "zendesk-search-articles",
+  name: "Search Articles",
+  description: "Searches Help Center articles. [See the documentation](https://developer.zendesk.com/api-reference/help_center/help-center-api/search/).",
+  type: "action",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    app,
+    // eslint-disable-next-line pipedream/props-label, pipedream/props-description
+    alert: {
+      type: "alert",
+      alertType: "warning",
+      content: "At least one of **Query**, **Category**, **Section**, or **Label Names** must be provided.",
+    },
+    query: {
+      type: "string",
+      label: "Search Query",
+      description: "The search text to match (e.g. `carrot potato`). At least one of this, **Category**, **Section**, or **Label Names** must be provided.",
+      optional: true,
+    },
+    locale: {
+      propDefinition: [
+        app,
+        "locale",
+      ],
+      description: "Search for articles in the specified locale (e.g. `en-us`). Use `*` to search across all valid locales. Defaults to the Help Center's default locale if omitted or invalid.",
+      optional: true,
+    },
+    articleCategoryId: {
+      propDefinition: [
+        app,
+        "articleCategoryId",
+      ],
+      type: "string[]",
+      label: "Category",
+      description: "Limit results to articles in these categories. Accepts one or more category IDs.",
+      optional: true,
+    },
+    sectionId: {
+      propDefinition: [
+        app,
+        "sectionId",
+      ],
+      type: "string[]",
+      label: "Section",
+      description: "Limit results to articles in these sections. Accepts one or more section IDs.",
+      optional: true,
+    },
+    labelNames: {
+      propDefinition: [
+        app,
+        "labelName",
+      ],
+      type: "string[]",
+      label: "Label Names",
+      description: "Filter articles by label names. An article must have at least one of the labels to match. Matching is case-insensitive. Only available on Professional and Enterprise plans.",
+    },
+    brandId: {
+      propDefinition: [
+        app,
+        "brandId",
+      ],
+      description: "Limit results to articles in the specified brand. If **Multibrand** is also set, results are still scoped to this brand.",
+    },
+    multibrand: {
+      type: "boolean",
+      label: "Multibrand",
+      description: "If `true`, search returns results from all brands. If **Brand ID** is also set, results are scoped to that brand regardless of this setting.",
+      optional: true,
+    },
+    sortBy: {
+      type: "string",
+      label: "Sort By",
+      description: "Sort results by `created_at` or `updated_at`. Defaults to sorting by relevance.",
+      optional: true,
+      options: [
+        "created_at",
+        "updated_at",
+      ],
+    },
+    sortOrder: {
+      type: "string",
+      label: "Sort Order",
+      description: "Sort direction. Defaults to `desc`.",
+      optional: true,
+      options: [
+        "asc",
+        "desc",
+      ],
+    },
+    createdBefore: {
+      type: "string",
+      label: "Created Before",
+      description: "Limit results to articles created before this date (format `YYYY-MM-DD`).",
+      optional: true,
+    },
+    createdAfter: {
+      type: "string",
+      label: "Created After",
+      description: "Limit results to articles created after this date (format `YYYY-MM-DD`).",
+      optional: true,
+    },
+    createdAt: {
+      type: "string",
+      label: "Created At",
+      description: "Limit results to articles created on this date (format `YYYY-MM-DD`).",
+      optional: true,
+    },
+    updatedBefore: {
+      type: "string",
+      label: "Updated Before",
+      description: "Limit results to articles updated before this date (format `YYYY-MM-DD`). Note: only content-meaningful updates are re-indexed.",
+      optional: true,
+    },
+    updatedAfter: {
+      type: "string",
+      label: "Updated After",
+      description: "Limit results to articles updated after this date (format `YYYY-MM-DD`). Note: only content-meaningful updates are re-indexed.",
+      optional: true,
+    },
+    updatedAt: {
+      type: "string",
+      label: "Updated At",
+      description: "Limit results to articles updated on this date (format `YYYY-MM-DD`).",
+      optional: true,
+    },
+    limit: {
+      type: "integer",
+      label: "Per Page",
+      description: "Number of results per page. Between 1 and 100. Default is 25.",
+      optional: true,
+      default: 25,
+    },
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "Page number to retrieve. Must be greater than 0. Default is 1.",
+      optional: true,
+      default: 1,
+    },
+    customSubdomain: {
+      propDefinition: [
+        app,
+        "customSubdomain",
+      ],
+    },
+  },
+  async run({ $: step }) {
+    const {
+      query,
+      locale,
+      articleCategoryId,
+      sectionId,
+      labelNames,
+      brandId,
+      multibrand,
+      sortBy,
+      sortOrder,
+      createdBefore,
+      createdAfter,
+      createdAt,
+      updatedBefore,
+      updatedAfter,
+      updatedAt,
+      limit,
+      page,
+      customSubdomain,
+    } = this;
+
+    const results = await this.app.searchArticles({
+      step,
+      customSubdomain,
+      params: {
+        query,
+        locale,
+        category: toCommaSeparated(articleCategoryId),
+        section: toCommaSeparated(sectionId),
+        label_names: toCommaSeparated(labelNames),
+        brand_id: brandId,
+        multibrand,
+        sort_by: sortBy,
+        sort_order: sortOrder,
+        created_before: createdBefore,
+        created_after: createdAfter,
+        created_at: createdAt,
+        updated_before: updatedBefore,
+        updated_after: updatedAfter,
+        updated_at: updatedAt,
+        per_page: limit,
+        page,
+      },
+    });
+
+    step.export("$summary", `Successfully retrieved ${results.results?.length ?? 0} article(s)`);
+
+    return results;
+  },
+};

--- a/components/zendesk/actions/search-community-posts/search-community-posts.mjs
+++ b/components/zendesk/actions/search-community-posts/search-community-posts.mjs
@@ -1,0 +1,145 @@
+import app from "../../zendesk.app.mjs";
+
+export default {
+  key: "zendesk-search-community-posts",
+  name: "Search Community Posts",
+  description: "Searches Help Center community posts. [See the documentation](https://developer.zendesk.com/api-reference/help_center/help-center-api/search/).",
+  type: "action",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    app,
+    query: {
+      type: "string",
+      label: "Search Query",
+      description: "The search text to match (e.g. `carrot potato`).",
+    },
+    topicId: {
+      propDefinition: [
+        app,
+        "topicId",
+      ],
+      description: "Limit results to posts in the specified community topic.",
+    },
+    sortBy: {
+      type: "string",
+      label: "Sort By",
+      description: "Sort results by `created_at` or `updated_at`. Defaults to sorting by relevance.",
+      optional: true,
+      options: [
+        "created_at",
+        "updated_at",
+      ],
+    },
+    sortOrder: {
+      type: "string",
+      label: "Sort Order",
+      description: "Sort direction. Defaults to `desc`.",
+      optional: true,
+      options: [
+        "asc",
+        "desc",
+      ],
+    },
+    createdBefore: {
+      type: "string",
+      label: "Created Before",
+      description: "Limit results to posts created before this date (format `YYYY-MM-DD`).",
+      optional: true,
+    },
+    createdAfter: {
+      type: "string",
+      label: "Created After",
+      description: "Limit results to posts created after this date (format `YYYY-MM-DD`).",
+      optional: true,
+    },
+    createdAt: {
+      type: "string",
+      label: "Created At",
+      description: "Limit results to posts created on this date (format `YYYY-MM-DD`).",
+      optional: true,
+    },
+    updatedBefore: {
+      type: "string",
+      label: "Updated Before",
+      description: "Limit results to posts updated before this date (format `YYYY-MM-DD`).",
+      optional: true,
+    },
+    updatedAfter: {
+      type: "string",
+      label: "Updated After",
+      description: "Limit results to posts updated after this date (format `YYYY-MM-DD`).",
+      optional: true,
+    },
+    updatedAt: {
+      type: "string",
+      label: "Updated At",
+      description: "Limit results to posts updated on this date (format `YYYY-MM-DD`).",
+      optional: true,
+    },
+    limit: {
+      type: "integer",
+      label: "Per Page",
+      description: "Number of results per page. Between 1 and 100. Default is 25.",
+      optional: true,
+      default: 25,
+    },
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "Page number to retrieve. Must be greater than 0. Offset pagination is limited to the first 100 pages (10,000 records) — requests beyond this will return a 400 error. Default is 1.",
+      optional: true,
+      default: 1,
+    },
+    customSubdomain: {
+      propDefinition: [
+        app,
+        "customSubdomain",
+      ],
+    },
+  },
+  async run({ $: step }) {
+    const {
+      query,
+      topicId,
+      sortBy,
+      sortOrder,
+      createdBefore,
+      createdAfter,
+      createdAt,
+      updatedBefore,
+      updatedAfter,
+      updatedAt,
+      limit,
+      page,
+      customSubdomain,
+    } = this;
+
+    const results = await this.app.searchCommunityPosts({
+      step,
+      customSubdomain,
+      params: {
+        query,
+        topic: topicId,
+        sort_by: sortBy,
+        sort_order: sortOrder,
+        created_before: createdBefore,
+        created_after: createdAfter,
+        created_at: createdAt,
+        updated_before: updatedBefore,
+        updated_after: updatedAfter,
+        updated_at: updatedAt,
+        per_page: limit,
+        page,
+      },
+    });
+
+    step.export("$summary", `Successfully retrieved ${results.results?.length ?? 0} community post(s)`);
+
+    return results;
+  },
+};

--- a/components/zendesk/actions/search-help-center/search-help-center.mjs
+++ b/components/zendesk/actions/search-help-center/search-help-center.mjs
@@ -1,0 +1,145 @@
+import app from "../../zendesk.app.mjs";
+import { toCommaSeparated } from "../../common/utils.mjs";
+
+export default {
+  key: "zendesk-search-help-center",
+  name: "Search Help Center",
+  description: "Searches across knowledge base articles, community posts, and external records using the Zendesk unified Guide search. [See the documentation](https://developer.zendesk.com/api-reference/help_center/help-center-api/search/).",
+  type: "action",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    app,
+    locales: {
+      propDefinition: [
+        app,
+        "locale",
+      ],
+      type: "string[]",
+      label: "Locales",
+      description: "Required. One or more locales to search in (e.g. `en-us`, `en-gb`). If an invalid or disabled locale is specified, no results are returned.",
+    },
+    query: {
+      type: "string",
+      label: "Search Query",
+      description: "The search text to match. If omitted, results are returned using internal ordering.",
+      optional: true,
+    },
+    contentTypes: {
+      type: "string[]",
+      label: "Content Types",
+      description: "Limit results to one or more content types. Use `ARTICLE` or `POST`. To search external records, use the **External Source IDs** filter instead.",
+      optional: true,
+      options: [
+        "ARTICLE",
+        "POST",
+      ],
+    },
+    brandIds: {
+      propDefinition: [
+        app,
+        "brandId",
+      ],
+      type: "string[]",
+      label: "Brand IDs",
+      description: "Limit results to articles or posts within these brands. If omitted, results are returned across all brands.",
+    },
+    categoryIds: {
+      propDefinition: [
+        app,
+        "articleCategoryId",
+      ],
+      type: "string[]",
+      label: "Category IDs",
+      description: "Limit results to articles in these categories.",
+      optional: true,
+    },
+    sectionIds: {
+      propDefinition: [
+        app,
+        "sectionId",
+      ],
+      type: "string[]",
+      label: "Section IDs",
+      description: "Limit results to articles in these sections.",
+      optional: true,
+    },
+    topicIds: {
+      propDefinition: [
+        app,
+        "topicId",
+      ],
+      type: "string[]",
+      label: "Topic IDs",
+      description: "Limit results to posts in these community topics.",
+    },
+    externalSourceIds: {
+      propDefinition: [
+        app,
+        "externalSourceId",
+      ],
+      type: "string[]",
+      label: "External Source IDs",
+      description: "Limit results to specific external sources. If omitted, results are returned across all sources.",
+    },
+    pageSize: {
+      type: "integer",
+      label: "Page Size",
+      description: "Maximum number of results to return per page. Between 1 and 50. Default is 10.",
+      optional: true,
+      default: 10,
+    },
+    pageAfter: {
+      type: "string",
+      label: "Page After Cursor",
+      description: "Cursor string for the next page of results, obtained from a previous response.",
+      optional: true,
+    },
+    customSubdomain: {
+      propDefinition: [
+        app,
+        "customSubdomain",
+      ],
+    },
+  },
+  async run({ $: step }) {
+    const {
+      locales,
+      query,
+      contentTypes,
+      brandIds,
+      categoryIds,
+      sectionIds,
+      topicIds,
+      externalSourceIds,
+      pageSize,
+      pageAfter,
+      customSubdomain,
+    } = this;
+
+    const results = await this.app.searchHelpCenter({
+      step,
+      customSubdomain,
+      params: {
+        query,
+        "filter[locales]": toCommaSeparated(locales),
+        "filter[content_types]": toCommaSeparated(contentTypes),
+        "filter[brand_ids]": toCommaSeparated(brandIds),
+        "filter[category_ids]": toCommaSeparated(categoryIds),
+        "filter[section_ids]": toCommaSeparated(sectionIds),
+        "filter[topic_ids]": toCommaSeparated(topicIds),
+        "filter[external_source_ids]": toCommaSeparated(externalSourceIds),
+        "page[size]": pageSize,
+        "page[after]": pageAfter,
+      },
+    });
+
+    step.export("$summary", `Successfully retrieved ${results.results?.length ?? 0} Help Center result(s)`);
+
+    return results;
+  },
+};

--- a/components/zendesk/actions/search-macros/search-macros.mjs
+++ b/components/zendesk/actions/search-macros/search-macros.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Search Macros",
   description: "Search for macros by name. [See the documentation](https://developer.zendesk.com/api-reference/ticketing/business-rules/macros/#search-macros).",
   type: "action",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zendesk/actions/search-tickets/search-tickets.mjs
+++ b/components/zendesk/actions/search-tickets/search-tickets.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Search Tickets",
   description: "Searches for tickets using Zendesk's search API. [See the documentation](https://developer.zendesk.com/api-reference/ticketing/ticket-management/search/#search-tickets).",
   type: "action",
-  version: "0.0.11",
+  version: "0.0.12",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zendesk/actions/set-custom-ticket-fields/set-custom-ticket-fields.mjs
+++ b/components/zendesk/actions/set-custom-ticket-fields/set-custom-ticket-fields.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Set Custom Ticket Fields",
   description: "Sets one or more custom field values on a ticket. [See the documentation](https://developer.zendesk.com/api-reference/ticketing/tickets/tickets/#update-ticket).",
   type: "action",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zendesk/actions/set-ticket-tags/set-ticket-tags.mjs
+++ b/components/zendesk/actions/set-ticket-tags/set-ticket-tags.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Set Ticket Tags",
   description: "Set tags on a ticket (replaces all existing tags). [See the documentation](https://developer.zendesk.com/api-reference/ticketing/ticket-management/tags/#set-tags).",
   type: "action",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/zendesk/actions/update-ticket/update-ticket.mjs
+++ b/components/zendesk/actions/update-ticket/update-ticket.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Update Ticket",
   description: "Updates a ticket. [See the documentation](https://developer.zendesk.com/api-reference/ticketing/tickets/tickets/#update-ticket).",
   type: "action",
-  version: "0.2.5",
+  version: "0.2.6",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/zendesk/common/utils.mjs
+++ b/components/zendesk/common/utils.mjs
@@ -1,3 +1,20 @@
+export const toCommaSeparated = (value) => {
+  if (Array.isArray(value)) {
+    return value.join(",");
+  }
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      if (Array.isArray(parsed)) {
+        return parsed.join(",");
+      }
+    } catch {
+      // not a JSON array string, return as-is
+    }
+  }
+  return value;
+};
+
 export const parseObject = (obj) => {
   if (!obj) {
     return {};

--- a/components/zendesk/package.json
+++ b/components/zendesk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/zendesk",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Pipedream Zendesk Components",
   "main": "zendesk.app.mjs",
   "keywords": [

--- a/components/zendesk/sources/locale-updated/locale-updated.mjs
+++ b/components/zendesk/sources/locale-updated/locale-updated.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Locale Updated",
   type: "source",
   description: "Emit new event when a locale has been updated",
-  version: "0.0.6",
+  version: "0.0.7",
   dedupe: "unique",
   async run() {
     const lastTs = this._getLastTs();

--- a/components/zendesk/sources/new-ticket-comment-added/new-ticket-comment-added.mjs
+++ b/components/zendesk/sources/new-ticket-comment-added/new-ticket-comment-added.mjs
@@ -7,7 +7,7 @@ export default {
   key: "zendesk-new-ticket-comment-added",
   type: "source",
   description: "Emit new event when a ticket comment has been added",
-  version: "0.1.3",
+  version: "0.1.4",
   dedupe: "unique",
   props: {
     app,

--- a/components/zendesk/sources/new-ticket/new-ticket.mjs
+++ b/components/zendesk/sources/new-ticket/new-ticket.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zendesk-new-ticket",
   type: "source",
   description: "Emit new event when a ticket is created",
-  version: "0.2.11",
+  version: "0.2.12",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/zendesk/sources/ticket-added-to-view/ticket-added-to-view.mjs
+++ b/components/zendesk/sources/ticket-added-to-view/ticket-added-to-view.mjs
@@ -5,7 +5,7 @@ export default {
   key: "zendesk-ticket-added-to-view",
   name: "New Ticket Added to View (Instant)",
   description: "Emit new event when a ticket is added to the specified view",
-  version: "0.0.11",
+  version: "0.0.12",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/zendesk/sources/ticket-closed/ticket-closed.mjs
+++ b/components/zendesk/sources/ticket-closed/ticket-closed.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zendesk-ticket-closed",
   type: "source",
   description: "Emit new event when a ticket has changed to closed status",
-  version: "0.2.11",
+  version: "0.2.12",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/zendesk/sources/ticket-pended/ticket-pended.mjs
+++ b/components/zendesk/sources/ticket-pended/ticket-pended.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zendesk-ticket-pended",
   type: "source",
   description: "Emit new event when a ticket has changed to pending status",
-  version: "0.2.11",
+  version: "0.2.12",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/zendesk/sources/ticket-solved/ticket-solved.mjs
+++ b/components/zendesk/sources/ticket-solved/ticket-solved.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zendesk-ticket-solved",
   type: "source",
   description: "Emit new event when a ticket has changed to solved status",
-  version: "0.2.11",
+  version: "0.2.12",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/zendesk/sources/ticket-updated/ticket-updated.mjs
+++ b/components/zendesk/sources/ticket-updated/ticket-updated.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zendesk-ticket-updated",
   type: "source",
   description: "Emit new event when a ticket has been updated",
-  version: "0.2.11",
+  version: "0.2.12",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/zendesk/zendesk.app.mjs
+++ b/components/zendesk/zendesk.app.mjs
@@ -442,6 +442,117 @@ export default {
       description: "The email address of the agent to assign the ticket to",
       optional: true,
     },
+    brandId: {
+      type: "string",
+      label: "Brand ID",
+      description: "The ID of the brand",
+      optional: true,
+      async options({ prevContext }) {
+        const { afterCursor } = prevContext;
+        const {
+          brands,
+          meta,
+        } = await this.listBrands({
+          params: {
+            [constants.PAGE_SIZE_PARAM]: constants.DEFAULT_LIMIT,
+            [constants.PAGE_AFTER_PARAM]: afterCursor,
+          },
+        });
+        return {
+          context: {
+            afterCursor: meta?.after_cursor,
+          },
+          options: brands.map(({
+            id: value, name: label,
+          }) => ({
+            value,
+            label,
+          })),
+        };
+      },
+    },
+    topicId: {
+      type: "string",
+      label: "Topic ID",
+      description: "The ID of the community topic",
+      optional: true,
+      async options({ prevContext }) {
+        const { afterCursor } = prevContext;
+        const {
+          topics,
+          meta,
+        } = await this.listTopics({
+          params: {
+            [constants.PAGE_SIZE_PARAM]: constants.DEFAULT_LIMIT,
+            [constants.PAGE_AFTER_PARAM]: afterCursor,
+          },
+        });
+        return {
+          context: {
+            afterCursor: meta?.after_cursor,
+          },
+          options: topics.map(({
+            id: value, name: label,
+          }) => ({
+            value,
+            label,
+          })),
+        };
+      },
+    },
+    externalSourceId: {
+      type: "string",
+      label: "External Source ID",
+      description: "The ID of the external content source",
+      optional: true,
+      async options({ prevContext }) {
+        const { afterCursor } = prevContext;
+        const {
+          sources,
+          meta,
+        } = await this.listExternalContentSources({
+          params: {
+            [constants.PAGE_SIZE_PARAM]: constants.DEFAULT_LIMIT,
+            [constants.PAGE_AFTER_PARAM]: afterCursor,
+          },
+        });
+        return {
+          context: {
+            afterCursor: meta?.after_cursor,
+          },
+          options: sources.map(({
+            id: value, name: label,
+          }) => ({
+            value,
+            label,
+          })),
+        };
+      },
+    },
+    labelName: {
+      type: "string",
+      label: "Label Name",
+      description: "The name of an article label",
+      optional: true,
+      async options({ prevContext }) {
+        const { afterCursor } = prevContext;
+        const {
+          labels,
+          meta,
+        } = await this.listArticleLabels({
+          params: {
+            [constants.PAGE_SIZE_PARAM]: constants.DEFAULT_LIMIT,
+            [constants.PAGE_AFTER_PARAM]: afterCursor,
+          },
+        });
+        return {
+          context: {
+            afterCursor: meta?.after_cursor,
+          },
+          options: labels.map(({ name }) => name),
+        };
+      },
+    },
   },
   methods: {
     getUrl(path, customSubdomain) {
@@ -743,6 +854,48 @@ export default {
           locale,
           path: `/articles/${articleId}`,
         }),
+        ...args,
+      });
+    },
+    listArticleLabels(args = {}) {
+      return this.makeRequest({
+        path: "/help_center/articles/labels",
+        ...args,
+      });
+    },
+    listBrands(args = {}) {
+      return this.makeRequest({
+        path: "/brands",
+        ...args,
+      });
+    },
+    listTopics(args = {}) {
+      return this.makeRequest({
+        path: "/community/topics",
+        ...args,
+      });
+    },
+    listExternalContentSources(args = {}) {
+      return this.makeRequest({
+        path: "/guide/external_content/sources",
+        ...args,
+      });
+    },
+    searchHelpCenter(args = {}) {
+      return this.makeRequest({
+        path: "/guide/search",
+        ...args,
+      });
+    },
+    searchArticles(args = {}) {
+      return this.makeRequest({
+        path: "/help_center/articles/search",
+        ...args,
+      });
+    },
+    searchCommunityPosts(args = {}) {
+      return this.makeRequest({
+        path: "/help_center/community_posts/search",
         ...args,
       });
     },


### PR DESCRIPTION
## WHY

Resolves #20205


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three Zendesk search actions: Articles, Community Posts, and Help Center — each with rich filters (query, dates, locales, content types, categories, topics, labels, brands, external sources), pagination, sorting, and custom subdomain support.
  * App now exposes picklist options for brands, topics, article labels, and external sources.

* **Chores**
  * Package and multiple action/source versions bumped to 0.13.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->