### PR TITLE
Make snowflake log to stdout

### DIFF
--- a/components/snowflake/snowflake.app.mjs
+++ b/components/snowflake/snowflake.app.mjs
@@ -7,6 +7,7 @@ import {
 import utils from "./common/utils.mjs";
 
 snowflake.configure({
+  logFilePath: "STDOUT",
   logLevel: "WARN",
 });
 


### PR DESCRIPTION
By default, snowflake-sdk logs to a snowflake.log file in the current directory

https://github.com/snowflakedb/snowflake-connector-nodejs/blob/v2.3.6/lib/logger/node.js#L17

https://github.com/snowflakedb/snowflake-connector-nodejs/blob/da6afd13b5997f8c8c405edc83a576422568062e/lib/logger/node.js#L71-L83

This is probably not what we want, so this makes it log just to STDOUT. The other options are to log to a different file, disable logging entirely by logging to /dev/null or with `logLevel: "OFF"`, or log to both a file and STDOUT, or log to stderr by passing /dev/stderr (would have to check this actually works, unfortunately we can't pass `"STDERR"` here, even though it's [been requested](https://github.com/snowflakedb/snowflake-connector-nodejs/issues/1026)).