### PR TITLE
Freshdesk - Add Get Agent action

### DIFF
--- a/components/freshdesk/actions/add-note-to-ticket/add-note-to-ticket.mjs
+++ b/components/freshdesk/actions/add-note-to-ticket/add-note-to-ticket.mjs
@@ -5,7 +5,7 @@ export default {
   key: "freshdesk-add-note-to-ticket",
   name: "Add Note to Ticket",
   description: "Add a note or conversation to an existing ticket. [See the documentation](https://developers.freshdesk.com/api/#add_note_to_a_ticket).",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/freshdesk/actions/add-ticket-tags/add-ticket-tags.mjs
+++ b/components/freshdesk/actions/add-ticket-tags/add-ticket-tags.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Add Ticket Tags",
   description: "Add tags to a ticket (appends to existing tags). [See the documentation](https://developers.freshdesk.com/api/#update_ticket)",
   type: "action",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/freshdesk/actions/assign-ticket-to-agent/assign-ticket-to-agent.mjs
+++ b/components/freshdesk/actions/assign-ticket-to-agent/assign-ticket-to-agent.mjs
@@ -4,7 +4,7 @@ export default {
   key: "freshdesk-assign-ticket-to-agent",
   name: "Assign Ticket to Agent",
   description: "Assign a Freshdesk ticket to a specific agent. [See the documentation](https://developers.freshdesk.com/api/#update_ticket).",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/freshdesk/actions/assign-ticket-to-group/assign-ticket-to-group.mjs
+++ b/components/freshdesk/actions/assign-ticket-to-group/assign-ticket-to-group.mjs
@@ -4,7 +4,7 @@ export default {
   key: "freshdesk-assign-ticket-to-group",
   name: "Assign Ticket to Group",
   description: "Assign a Freshdesk ticket to a specific group [See the documentation](https://developers.freshdesk.com/api/#update_ticket).",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/freshdesk/actions/close-ticket/close-ticket.mjs
+++ b/components/freshdesk/actions/close-ticket/close-ticket.mjs
@@ -4,7 +4,7 @@ export default {
   key: "freshdesk-close-ticket",
   name: "Close Ticket",
   description: "Set a Freshdesk ticket's status to 'Closed'. [See docs](https://developers.freshdesk.com/api/#update_a_ticket)",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/freshdesk/actions/create-agent/create-agent.mjs
+++ b/components/freshdesk/actions/create-agent/create-agent.mjs
@@ -5,7 +5,7 @@ export default {
   key: "freshdesk-create-agent",
   name: "Create Agent",
   description: "Create an agent in Freshdesk. [See the documentation](https://developers.freshdesk.com/api/#create_agent)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/freshdesk/actions/create-company/create-company.mjs
+++ b/components/freshdesk/actions/create-company/create-company.mjs
@@ -4,7 +4,7 @@ export default {
   key: "freshdesk-create-company",
   name: "Create a Company",
   description: "Create a company. [See the documentation](https://developers.freshdesk.com/api/#create_company)",
-  version: "0.0.12",
+  version: "0.0.13",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/freshdesk/actions/create-contact/create-contact.mjs
+++ b/components/freshdesk/actions/create-contact/create-contact.mjs
@@ -5,7 +5,7 @@ export default {
   key: "freshdesk-create-contact",
   name: "Create a Contact",
   description: "Create a contact. [See the documentation](https://developers.freshdesk.com/api/#create_contact)",
-  version: "0.0.12",
+  version: "0.0.13",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/freshdesk/actions/create-message-for-thread/create-message-for-thread.mjs
+++ b/components/freshdesk/actions/create-message-for-thread/create-message-for-thread.mjs
@@ -5,7 +5,7 @@ export default {
   key: "freshdesk-create-message-for-thread",
   name: "Create Message For Thread",
   description: "Create message for a thread. [See the documentation](https://developers.freshdesk.com/api/#create_message_for_thread).",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/freshdesk/actions/create-reply/create-reply.mjs
+++ b/components/freshdesk/actions/create-reply/create-reply.mjs
@@ -7,7 +7,7 @@ export default {
   key: "freshdesk-create-reply",
   name: "Create a Reply",
   description: "Create a reply to a ticket. [See the documentation](https://developers.freshdesk.com/api/#reply_ticket).",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/freshdesk/actions/create-solution-article/create-solution-article.mjs
+++ b/components/freshdesk/actions/create-solution-article/create-solution-article.mjs
@@ -6,7 +6,7 @@ export default {
   key: "freshdesk-create-solution-article",
   name: "Create Solution Article",
   description: "Create a solution article in Freshdesk. [See the documentation](https://developers.freshdesk.com/api/#solution_article_attributes)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/freshdesk/actions/create-thread/create-thread.mjs
+++ b/components/freshdesk/actions/create-thread/create-thread.mjs
@@ -4,7 +4,7 @@ export default {
   key: "freshdesk-create-thread",
   name: "Create a Thread",
   description: "Create a thread to a ticket. [See the documentation](https://developers.freshdesk.com/api/#create_a_thread).",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/freshdesk/actions/create-ticket-field/create-ticket-field.mjs
+++ b/components/freshdesk/actions/create-ticket-field/create-ticket-field.mjs
@@ -6,7 +6,7 @@ export default {
   key: "freshdesk-create-ticket-field",
   name: "Create Ticket Field",
   description: "Create a ticket field in Freshdesk. [See the documentation](https://developers.freshdesk.com/api/#create_ticket_field)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/freshdesk/actions/create-ticket/create-ticket.mjs
+++ b/components/freshdesk/actions/create-ticket/create-ticket.mjs
@@ -4,7 +4,7 @@ export default {
   key: "freshdesk-create-ticket",
   name: "Create a Ticket",
   description: "Create a ticket. [See the documentation](https://developers.freshdesk.com/api/#create_ticket)",
-  version: "0.0.13",
+  version: "0.0.14",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/freshdesk/actions/delete-solution-article/delete-solution-article.mjs
+++ b/components/freshdesk/actions/delete-solution-article/delete-solution-article.mjs
@@ -4,7 +4,7 @@ export default {
   key: "freshdesk-delete-solution-article",
   name: "Delete Solution Article",
   description: "Delete a solution article in Freshdesk. [See the documentation](https://developers.freshdesk.com/api/#solution_article_attributes)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/freshdesk/actions/download-attachment/download-attachment.mjs
+++ b/components/freshdesk/actions/download-attachment/download-attachment.mjs
@@ -6,7 +6,7 @@ export default {
   key: "freshdesk-download-attachment",
   name: "Download Attachment",
   description: "Download an attachment from a ticket. [See the documentation](https://developers.freshdesk.com/api/#view_a_ticket)",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/freshdesk/actions/forward-ticket/forward-ticket.mjs
+++ b/components/freshdesk/actions/forward-ticket/forward-ticket.mjs
@@ -5,7 +5,7 @@ export default {
   key: "freshdesk-forward-ticket",
   name: "Forward Ticket",
   description: "Forward a ticket to an external email address. [See the documentation](https://developers.freshdesk.com/api/#forward_a_ticket).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/freshdesk/actions/get-agent/get-agent.mjs
+++ b/components/freshdesk/actions/get-agent/get-agent.mjs
@@ -1,0 +1,31 @@
+import freshdesk from "../../freshdesk.app.mjs";
+
+export default {
+  key: "freshdesk-get-agent",
+  name: "Get Agent",
+  description: "Retrieve a single agent by their ID. [See the documentation](https://developers.freshdesk.com/api/#view_agent)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  type: "action",
+  props: {
+    freshdesk,
+    agentId: {
+      propDefinition: [
+        freshdesk,
+        "agentId",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.freshdesk.getAgent({
+      agentId: this.agentId,
+      $,
+    });
+    $.export("$summary", `Successfully retrieved agent: ${response.contact?.name || response.id}`);
+    return response;
+  },
+};

--- a/components/freshdesk/actions/get-canned-response/get-canned-response.mjs
+++ b/components/freshdesk/actions/get-canned-response/get-canned-response.mjs
@@ -4,7 +4,7 @@ export default {
   key: "freshdesk-get-canned-response",
   name: "Get Canned Response",
   description: "View a Canned Response. [See the documentation](https://developers.freshdesk.com/api/#view_a_canned_response)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/freshdesk/actions/get-contact/get-contact.mjs
+++ b/components/freshdesk/actions/get-contact/get-contact.mjs
@@ -4,7 +4,7 @@ export default {
   key: "freshdesk-get-contact",
   name: "Get Contact",
   description: "Get a contact from Freshdesk. [See the documentation](https://developers.freshdesk.com/api/#view_contact)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/freshdesk/actions/get-folder-canned-responses/get-folder-canned-responses.mjs
+++ b/components/freshdesk/actions/get-folder-canned-responses/get-folder-canned-responses.mjs
@@ -4,7 +4,7 @@ export default {
   key: "freshdesk-get-folder-canned-responses",
   name: "Get Canned Responses In A Folder",
   description: "View all the details of canned responses in a folder. [See the documentation](https://developers.freshdesk.com/api/#get_details_of_canned_responses_in_a_folder)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/freshdesk/actions/get-solution-article/get-solution-article.mjs
+++ b/components/freshdesk/actions/get-solution-article/get-solution-article.mjs
@@ -4,7 +4,7 @@ export default {
   key: "freshdesk-get-solution-article",
   name: "Get Solution Article",
   description: "Get a solution article in Freshdesk. [See the documentation](https://developers.freshdesk.com/api/#solution_article_attributes)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/freshdesk/actions/get-ticket/get-ticket.mjs
+++ b/components/freshdesk/actions/get-ticket/get-ticket.mjs
@@ -4,7 +4,7 @@ export default {
   key: "freshdesk-get-ticket",
   name: "Get Ticket Details",
   description: "Get details of a Ticket. [See the documentation](https://developers.freshdesk.com/api/#view_a_ticket)",
-  version: "0.1.11",
+  version: "0.1.12",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/freshdesk/actions/list-agents/list-agents.mjs
+++ b/components/freshdesk/actions/list-agents/list-agents.mjs
@@ -4,7 +4,7 @@ export default {
   key: "freshdesk-list-agents",
   name: "List Agents",
   description: "List all agents in Freshdesk. [See the documentation](https://developers.freshdesk.com/api/#list_all_agents)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/freshdesk/actions/list-all-folders/list-all-folders.mjs
+++ b/components/freshdesk/actions/list-all-folders/list-all-folders.mjs
@@ -4,7 +4,7 @@ export default {
   key: "freshdesk-list-all-folders",
   name: "List All Folders",
   description: "View all the canned response folders. [See the documentation](https://developers.freshdesk.com/api/#list_all_canned_response_folders)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/freshdesk/actions/list-all-tickets/list-all-tickets.mjs
+++ b/components/freshdesk/actions/list-all-tickets/list-all-tickets.mjs
@@ -5,7 +5,7 @@ export default {
   name: "List Tickets",
   description:
     "Fetch up to 100 tickets according to the selected filters. [See the documentation](https://developers.freshdesk.com/api/#list_all_tickets)",
-  version: "0.2.10",
+  version: "0.2.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/freshdesk/actions/list-category-folders/list-category-folders.mjs
+++ b/components/freshdesk/actions/list-category-folders/list-category-folders.mjs
@@ -4,7 +4,7 @@ export default {
   key: "freshdesk-list-category-folders",
   name: "List Category Folders",
   description: "List category folders in Freshdesk. [See the documentation](https://developers.freshdesk.com/api/#solution_folder_attributes)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/freshdesk/actions/list-folder-articles/list-folder-articles.mjs
+++ b/components/freshdesk/actions/list-folder-articles/list-folder-articles.mjs
@@ -4,7 +4,7 @@ export default {
   key: "freshdesk-list-folder-articles",
   name: "List Folder Articles",
   description: "List folder articles in Freshdesk. [See the documentation](https://developers.freshdesk.com/api/#solution_article_attributes)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/freshdesk/actions/list-folder-canned-responses/list-folder-canned-responses.mjs
+++ b/components/freshdesk/actions/list-folder-canned-responses/list-folder-canned-responses.mjs
@@ -4,7 +4,7 @@ export default {
   key: "freshdesk-list-folder-canned-responses",
   name: "List All Canned Responses In A Folder",
   description: "View all canned responses in a folder. [See the documentation](https://developers.freshdesk.com/api/#list_all_canned_responses_in_a_folder)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/freshdesk/actions/list-solution-categories/list-solution-categories.mjs
+++ b/components/freshdesk/actions/list-solution-categories/list-solution-categories.mjs
@@ -4,7 +4,7 @@ export default {
   key: "freshdesk-list-solution-categories",
   name: "List Solution Categories",
   description: "List solution categories in Freshdesk. [See the documentation](https://developers.freshdesk.com/api/#solution_category_attributes)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/freshdesk/actions/list-ticket-conversations/list-ticket-conversations.mjs
+++ b/components/freshdesk/actions/list-ticket-conversations/list-ticket-conversations.mjs
@@ -4,7 +4,7 @@ export default {
   key: "freshdesk-list-ticket-conversations",
   name: "List Conversations of a Ticket",
   description: "List all conversations for a ticket. [See the documentation](https://developers.freshdesk.com/api/#list_all_ticket_notes)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/freshdesk/actions/list-ticket-fields/list-ticket-fields.mjs
+++ b/components/freshdesk/actions/list-ticket-fields/list-ticket-fields.mjs
@@ -4,7 +4,7 @@ export default {
   key: "freshdesk-list-ticket-fields",
   name: "List Ticket Fields",
   description: "List all ticket fields in Freshdesk. [See the documentation](https://developers.freshdesk.com/api/#list_all_ticket_fields)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/freshdesk/actions/remove-ticket-tags/remove-ticket-tags.mjs
+++ b/components/freshdesk/actions/remove-ticket-tags/remove-ticket-tags.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Remove Ticket Tags",
   description: "Remove specific tags from a ticket. [See the documentation](https://developers.freshdesk.com/api/#update_ticket)",
   type: "action",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/freshdesk/actions/reply-to-forward/reply-to-forward.mjs
+++ b/components/freshdesk/actions/reply-to-forward/reply-to-forward.mjs
@@ -5,7 +5,7 @@ export default {
   key: "freshdesk-reply-to-forward",
   name: "Reply to Forward",
   description: "Reply to a previously forwarded ticket email. [See the documentation](https://developers.freshdesk.com/api/#reply_to_forward).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/freshdesk/actions/search-solution-article/search-solution-article.mjs
+++ b/components/freshdesk/actions/search-solution-article/search-solution-article.mjs
@@ -4,7 +4,7 @@ export default {
   key: "freshdesk-search-solution-article",
   name: "Search Solution Article",
   description: "Search solution articles in Freshdesk by keyword. Returns matching articles with their category/folder hierarchy, metadata, and content. [See the documentation](https://developers.freshdesk.com/api/#solution_article_attributes)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/freshdesk/actions/set-ticket-priority/set-ticket-priority.mjs
+++ b/components/freshdesk/actions/set-ticket-priority/set-ticket-priority.mjs
@@ -4,7 +4,7 @@ export default {
   key: "freshdesk-set-ticket-priority",
   name: "Set Ticket Priority",
   description: "Update the priority of a ticket in Freshdesk  [See the documentation](https://developers.freshdesk.com/api/#update_ticket).",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/freshdesk/actions/set-ticket-status/set-ticket-status.mjs
+++ b/components/freshdesk/actions/set-ticket-status/set-ticket-status.mjs
@@ -4,7 +4,7 @@ export default {
   key: "freshdesk-set-ticket-status",
   name: "Set Ticket Status",
   description: "Update the status of a ticket in Freshdesk  [See the documentation](https://developers.freshdesk.com/api/#update_ticket).",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/freshdesk/actions/set-ticket-tags/set-ticket-tags.mjs
+++ b/components/freshdesk/actions/set-ticket-tags/set-ticket-tags.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Set Ticket Tags",
   description: "Set tags on a ticket (replaces all existing tags). [See the documentation](https://developers.freshdesk.com/api/#update_ticket)",
   type: "action",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/freshdesk/actions/update-agent/update-agent.mjs
+++ b/components/freshdesk/actions/update-agent/update-agent.mjs
@@ -5,7 +5,7 @@ export default {
   key: "freshdesk-update-agent",
   name: "Update Agent",
   description: "Update an agent in Freshdesk. [See the documentation](https://developers.freshdesk.com/api/#update_agent)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/freshdesk/actions/update-contact/update-contact.mjs
+++ b/components/freshdesk/actions/update-contact/update-contact.mjs
@@ -4,7 +4,7 @@ export default {
   key: "freshdesk-update-contact",
   name: "Update Contact",
   description: "Update a contact in Freshdesk. [See the documentation](https://developers.freshdesk.com/api/#update_contact)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/freshdesk/actions/update-solution-article/update-solution-article.mjs
+++ b/components/freshdesk/actions/update-solution-article/update-solution-article.mjs
@@ -6,7 +6,7 @@ export default {
   key: "freshdesk-update-solution-article",
   name: "Update Solution Article",
   description: "Update a solution article in Freshdesk. [See the documentation](https://developers.freshdesk.com/api/#solution_article_attributes)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/freshdesk/actions/update-ticket-field/update-ticket-field.mjs
+++ b/components/freshdesk/actions/update-ticket-field/update-ticket-field.mjs
@@ -5,7 +5,7 @@ export default {
   key: "freshdesk-update-ticket-field",
   name: "Update Ticket Field",
   description: "Update a ticket field in Freshdesk. [See the documentation](https://developers.freshdesk.com/api/#update_ticket_field)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/freshdesk/actions/update-ticket/update-ticket.mjs
+++ b/components/freshdesk/actions/update-ticket/update-ticket.mjs
@@ -5,7 +5,7 @@ export default {
   key: "freshdesk-update-ticket",
   name: "Update a Ticket",
   description: "Update status, priority, subject, description, agent, group, etc.  [See the documentation](https://developers.freshdesk.com/api/#update_ticket).",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/freshdesk/freshdesk.app.mjs
+++ b/components/freshdesk/freshdesk.app.mjs
@@ -492,6 +492,14 @@ export default {
         ...args,
       });
     },
+    getAgent({
+      agentId, ...args
+    }) {
+      return this._makeRequest({
+        url: `/agents/${agentId}`,
+        ...args,
+      });
+    },
     createAgent(args) {
       return this._makeRequest({
         url: "/agents",

--- a/components/freshdesk/package.json
+++ b/components/freshdesk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/freshdesk",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Pipedream Freshdesk Components",
   "main": "freshdesk.app.mjs",
   "keywords": [

--- a/components/freshdesk/sources/contact-updated/contact-updated.mjs
+++ b/components/freshdesk/sources/contact-updated/contact-updated.mjs
@@ -5,7 +5,7 @@ export default {
   key: "freshdesk-contact-updated",
   name: "Contact Updated",
   description: "Emit new event when a contact is updated. [See the documentation](https://developers.freshdesk.com/api/#filter_contacts)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/freshdesk/sources/new-contact/new-contact.mjs
+++ b/components/freshdesk/sources/new-contact/new-contact.mjs
@@ -5,7 +5,7 @@ export default {
   key: "freshdesk-new-contact",
   name: "New Contact Created",
   description: "Emit new event when a contact is created. [See the documentation](https://developers.freshdesk.com/api/#filter_contacts)",
-  version: "0.0.13",
+  version: "0.0.14",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/freshdesk/sources/new-ticket/new-ticket.mjs
+++ b/components/freshdesk/sources/new-ticket/new-ticket.mjs
@@ -5,7 +5,7 @@ export default {
   key: "freshdesk-new-ticket",
   name: "New Ticket Created",
   description: "Emit new event when a ticket is created. [See the documentation](https://developers.freshdesk.com/api/#filter_tickets)",
-  version: "0.0.13",
+  version: "0.0.14",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/freshdesk/sources/ticket-updated/ticket-updated.mjs
+++ b/components/freshdesk/sources/ticket-updated/ticket-updated.mjs
@@ -5,7 +5,7 @@ export default {
   key: "freshdesk-ticket-updated",
   name: "Ticket Updated",
   description: "Emit new event when a ticket is updated. [See the documentation](https://developers.freshdesk.com/api/#filter_tickets)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "source",
   dedupe: "unique",
   methods: {


### PR DESCRIPTION
## Summary
- Adds new **Get Agent** action to retrieve a single agent by their ID
- Resolves issue #20451
- Implements endpoint: `GET /api/v2/agents/{agent_id}` from [Freshdesk API docs](https://developers.freshdesk.com/api/#view_agent)

## Changes
- Added `getAgent()` method to `freshdesk.app.mjs`
- Created new action: `actions/get-agent/get-agent.mjs`
- Bumped all 46 component versions (42 actions + 4 sources) due to shared app file modification
- Bumped package version: 0.10.0 → 0.10.1

## Test plan
- [ ] Verify the Get Agent action appears in Pipedream's Freshdesk integration
- [ ] Test retrieving an agent by ID
- [ ] Verify proper error handling for invalid agent IDs
- [ ] Confirm version bumps are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving agent details via new Get Agent action

* **Chores**
  * Updated package version to 0.10.1
  * Version updates across multiple Freshdesk actions and event sources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->