### PR TITLE
feat: add urlSource to Trello create card

### DIFF
--- a/components/trello/actions/create-card/create-card.mjs
+++ b/components/trello/actions/create-card/create-card.mjs
@@ -7,7 +7,7 @@ export default {
   key: "trello-create-card",
   name: "Create Card",
   description: "Creates a new card. [See the documentation](https://developer.atlassian.com/cloud/trello/rest/api-group-cards/#api-cards-post).",
-  version: "1.0.6",
+  version: "1.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -92,6 +92,12 @@ export default {
       type: "string[]",
       label: "Labels",
       description: "Array of labelIDs to add to the card",
+      optional: true,
+    },
+    urlSource: {
+      type: "string",
+      label: "URL Attachment",
+      description: "A URL to attach as a link on the card. Must start with `http://` or `https://`.",
       optional: true,
     },
     file: {
@@ -226,6 +232,7 @@ export default {
       idList,
       idMembers,
       idLabels,
+      urlSource,
       mimeType,
       file,
       idCardSource,
@@ -246,6 +253,7 @@ export default {
       idList,
       idMembers,
       idLabels,
+      urlSource,
       mimeType,
       idCardSource,
       keepFromSource: keepFromSource?.join(","),

--- a/components/trello/package.json
+++ b/components/trello/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/trello",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Pipedream Trello Components",
   "main": "trello.app.mjs",
   "keywords": [


### PR DESCRIPTION
Closes: https://github.com/PipedreamHQ/pipedream/issues/20499


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * URL Attachment for card creation: optionally add HTTP/HTTPS links when creating Trello cards; values are validated at creation to ensure they start with http:// or https://.

* **Chores**
  * Trello component version updated to publish the change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->