### PR TITLE
LiveAgent - new components

### DIFF
--- a/components/liveagent/actions/add-tag-to-ticket/add-tag-to-ticket.mjs
+++ b/components/liveagent/actions/add-tag-to-ticket/add-tag-to-ticket.mjs
@@ -9,7 +9,7 @@ export default {
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
-    readOnlyHint: true,
+    readOnlyHint: false,
   },
   props: {
     liveagent,

--- a/components/liveagent/actions/add-tag-to-ticket/add-tag-to-ticket.mjs
+++ b/components/liveagent/actions/add-tag-to-ticket/add-tag-to-ticket.mjs
@@ -1,0 +1,53 @@
+import liveagent from "../../liveagent.app.mjs";
+
+export default {
+  key: "add-tag-to-ticket",
+  name: "Add Tag to Ticket",
+  description: "Add a tag to a ticket. [See the documentation](https://support.liveagent.com/911737-API-v3)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    liveagent,
+    ticketId: {
+      propDefinition: [
+        liveagent,
+        "ticketId",
+      ],
+    },
+    tagId: {
+      propDefinition: [
+        liveagent,
+        "tagId",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const ticket = await this.liveagent.getTicket({
+      $,
+      ticketId: this.ticketId,
+    });
+
+    ticket.tags = ticket.tags || [];
+    if (!ticket.tags.includes(this.tagId)) {
+      ticket.tags = [
+        ...ticket.tags,
+        this.tagId,
+      ];
+    }
+
+    const response = await this.liveagent.updateTicket({
+      $,
+      ticketId: this.ticketId,
+      data: {
+        ...ticket,
+      },
+    });
+    $.export("$summary", `Successfully added tag to ticket with ID: ${this.ticketId}`);
+    return response;
+  },
+};

--- a/components/liveagent/actions/add-tag-to-ticket/add-tag-to-ticket.mjs
+++ b/components/liveagent/actions/add-tag-to-ticket/add-tag-to-ticket.mjs
@@ -1,7 +1,7 @@
 import liveagent from "../../liveagent.app.mjs";
 
 export default {
-  key: "add-tag-to-ticket",
+  key: "liveagent-add-tag-to-ticket",
   name: "Add Tag to Ticket",
   description: "Add a tag to a ticket. [See the documentation](https://support.liveagent.com/911737-API-v3)",
   version: "0.0.1",

--- a/components/liveagent/actions/add-tag-to-ticket/add-tag-to-ticket.mjs
+++ b/components/liveagent/actions/add-tag-to-ticket/add-tag-to-ticket.mjs
@@ -17,6 +17,9 @@ export default {
       propDefinition: [
         liveagent,
         "ticketId",
+        () => ({
+          excludeClosedAndDeleted: true,
+        }),
       ],
     },
     tagId: {

--- a/components/liveagent/actions/create-customer/create-customer.mjs
+++ b/components/liveagent/actions/create-customer/create-customer.mjs
@@ -2,14 +2,14 @@ import liveagent from "../../liveagent.app.mjs";
 
 export default {
   name: "Create Customer",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   key: "liveagent-create-customer",
-  description: "Creates a customer. [See docs here](https://pipedream.ladesk.com/docs/api/v3/#/contacts/createContact)",
+  description: "Creates a customer. [See the documentation](https://support.liveagent.com/911737-API-v3)",
   type: "action",
   props: {
     liveagent,

--- a/components/liveagent/actions/get-agent/get-agent.mjs
+++ b/components/liveagent/actions/get-agent/get-agent.mjs
@@ -1,7 +1,7 @@
 import liveagent from "../../liveagent.app.mjs";
 
 export default {
-  key: "get-agent",
+  key: "liveagent-get-agent",
   name: "Get Agent",
   description: "Retrieves agent info and auth token. [See the documentation](https://support.liveagent.com/911737-API-v3)",
   type: "action",

--- a/components/liveagent/actions/get-agent/get-agent.mjs
+++ b/components/liveagent/actions/get-agent/get-agent.mjs
@@ -1,0 +1,31 @@
+import liveagent from "../../liveagent.app.mjs";
+
+export default {
+  key: "get-agent",
+  name: "Get Agent",
+  description: "Retrieves agent info and auth token. [See the documentation](https://support.liveagent.com/911737-API-v3)",
+  type: "action",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    liveagent,
+    agentId: {
+      propDefinition: [
+        liveagent,
+        "agentId",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.liveagent.getAgent({
+      agentId: this.agentId,
+      $,
+    });
+    $.export("$summary", `Successfully retrieved agent: ${response.name}`);
+    return response;
+  },
+};

--- a/components/liveagent/actions/get-ticket/get-ticket.mjs
+++ b/components/liveagent/actions/get-ticket/get-ticket.mjs
@@ -1,0 +1,31 @@
+import liveagent from "../../liveagent.app.mjs";
+
+export default {
+  key: "get-ticket",
+  name: "Get Ticket",
+  description: "Get a ticket. [See the documentation](https://support.liveagent.com/911737-API-v3)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    liveagent,
+    ticketId: {
+      propDefinition: [
+        liveagent,
+        "ticketId",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.liveagent.getTicket({
+      $,
+      ticketId: this.ticketId,
+    });
+    $.export("$summary", `Successfully retrieved ticket with ID: ${this.ticketId}`);
+    return response;
+  },
+};

--- a/components/liveagent/actions/get-ticket/get-ticket.mjs
+++ b/components/liveagent/actions/get-ticket/get-ticket.mjs
@@ -1,7 +1,7 @@
 import liveagent from "../../liveagent.app.mjs";
 
 export default {
-  key: "get-ticket",
+  key: "liveagent-get-ticket",
   name: "Get Ticket",
   description: "Get a ticket. [See the documentation](https://support.liveagent.com/911737-API-v3)",
   version: "0.0.1",

--- a/components/liveagent/actions/list-tags/list-tags.mjs
+++ b/components/liveagent/actions/list-tags/list-tags.mjs
@@ -1,7 +1,7 @@
 import liveagent from "../../liveagent.app.mjs";
 
 export default {
-  key: "list-tags",
+  key: "liveagent-list-tags",
   name: "List Tags",
   description: "Lists all tags. [See the documentation](https://support.liveagent.com/911737-API-v3)",
   version: "0.0.1",

--- a/components/liveagent/actions/list-tags/list-tags.mjs
+++ b/components/liveagent/actions/list-tags/list-tags.mjs
@@ -1,0 +1,24 @@
+import liveagent from "../../liveagent.app.mjs";
+
+export default {
+  key: "list-tags",
+  name: "List Tags",
+  description: "Lists all tags. [See the documentation](https://support.liveagent.com/911737-API-v3)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    liveagent,
+  },
+  async run({ $ }) {
+    const response = await this.liveagent.listTags({
+      $,
+    });
+    $.export("$summary", `Successfully listed ${response.length} tag(s).`);
+    return response;
+  },
+};

--- a/components/liveagent/actions/list-ticket-messages/list-ticket-messages.mjs
+++ b/components/liveagent/actions/list-ticket-messages/list-ticket-messages.mjs
@@ -1,7 +1,7 @@
 import liveagent from "../../liveagent.app.mjs";
 
 export default {
-  key: "list-ticket-messages",
+  key: "liveagent-list-ticket-messages",
   name: "List Ticket Messages",
   description: "List all messages for a specific ticket. [See the documentation](https://support.liveagent.com/911737-API-v3)",
   version: "0.0.1",

--- a/components/liveagent/actions/list-ticket-messages/list-ticket-messages.mjs
+++ b/components/liveagent/actions/list-ticket-messages/list-ticket-messages.mjs
@@ -1,0 +1,68 @@
+import liveagent from "../../liveagent.app.mjs";
+
+export default {
+  key: "list-ticket-messages",
+  name: "List Ticket Messages",
+  description: "List all messages for a specific ticket. [See the documentation](https://support.liveagent.com/911737-API-v3)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    liveagent,
+    ticketId: {
+      propDefinition: [
+        liveagent,
+        "ticketId",
+      ],
+    },
+    page: {
+      propDefinition: [
+        liveagent,
+        "page",
+      ],
+    },
+    perPage: {
+      propDefinition: [
+        liveagent,
+        "perPage",
+      ],
+    },
+    sortDir: {
+      propDefinition: [
+        liveagent,
+        "sortDir",
+      ],
+    },
+    sortField: {
+      propDefinition: [
+        liveagent,
+        "sortField",
+      ],
+    },
+    filters: {
+      propDefinition: [
+        liveagent,
+        "filters",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.liveagent.listTicketMessages({
+      $,
+      ticketId: this.ticketId,
+      params: {
+        _page: this.page,
+        _perPage: this.perPage,
+        _sortDir: this.sortDir,
+        _sortField: this.sortField,
+        _filters: this.filters,
+      },
+    });
+    $.export("$summary", `Successfully listed ${response.length} message(s) for ticket with ID: ${this.ticketId}`);
+    return response;
+  },
+};

--- a/components/liveagent/actions/list-tickets/list-tickets.mjs
+++ b/components/liveagent/actions/list-tickets/list-tickets.mjs
@@ -1,0 +1,47 @@
+import liveagent from "../../liveagent.app.mjs";
+
+export default {
+  key: "list-tickets",
+  name: "List Tickets",
+  description: "Lists all tickets. [See the documentation](https://support.liveagent.com/911737-API-v3)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    liveagent,
+    sortDir: {
+      propDefinition: [
+        liveagent,
+        "sortDir",
+      ],
+    },
+    sortField: {
+      propDefinition: [
+        liveagent,
+        "sortField",
+      ],
+    },
+    filters: {
+      propDefinition: [
+        liveagent,
+        "filters",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.liveagent.listTickets({
+      $,
+      params: {
+        _sortDir: this.sortDir,
+        _sortField: this.sortField,
+        _filters: this.filters,
+      },
+    });
+    $.export("$summary", `Successfully listed ${response.length} ticket(s).`);
+    return response;
+  },
+};

--- a/components/liveagent/actions/list-tickets/list-tickets.mjs
+++ b/components/liveagent/actions/list-tickets/list-tickets.mjs
@@ -1,7 +1,7 @@
 import liveagent from "../../liveagent.app.mjs";
 
 export default {
-  key: "list-tickets",
+  key: "liveagent-list-tickets",
   name: "List Tickets",
   description: "Lists all tickets. [See the documentation](https://support.liveagent.com/911737-API-v3)",
   version: "0.0.1",

--- a/components/liveagent/actions/update-ticket-status/update-ticket-status.mjs
+++ b/components/liveagent/actions/update-ticket-status/update-ticket-status.mjs
@@ -1,7 +1,7 @@
 import liveagent from "../../liveagent.app.mjs";
 
 export default {
-  key: "update-ticket-status",
+  key: "liveagent-update-ticket-status",
   name: "Update Ticket Status",
   description: "Update the status of a ticket. [See the documentation](https://support.liveagent.com/911737-API-v3)",
   version: "0.0.1",

--- a/components/liveagent/actions/update-ticket-status/update-ticket-status.mjs
+++ b/components/liveagent/actions/update-ticket-status/update-ticket-status.mjs
@@ -1,0 +1,88 @@
+import liveagent from "../../liveagent.app.mjs";
+
+export default {
+  key: "update-ticket-status",
+  name: "Update Ticket Status",
+  description: "Update the status of a ticket. [See the documentation](https://support.liveagent.com/911737-API-v3)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    liveagent,
+    ticketId: {
+      propDefinition: [
+        liveagent,
+        "ticketId",
+      ],
+    },
+    status: {
+      type: "string",
+      label: "Status",
+      description: "The status of the ticket",
+      options: [
+        {
+          value: "I",
+          label: "init",
+        },
+        {
+          value: "N",
+          label: "new",
+        },
+        {
+          value: "T",
+          label: "chatting",
+        },
+        {
+          value: "P",
+          label: "calling",
+        },
+        {
+          value: "R",
+          label: "resolved",
+        },
+        {
+          value: "X",
+          label: "deleted",
+        },
+        {
+          value: "B",
+          label: "spam",
+        },
+        {
+          value: "A",
+          label: "answered",
+        },
+        {
+          value: "C",
+          label: "open",
+        },
+        {
+          value: "W",
+          label: "postponed",
+        },
+      ],
+    },
+  },
+  async run({ $ }) {
+    const ticket = await this.liveagent.getTicket({
+      $,
+      ticketId: this.ticketId,
+    });
+
+    ticket.status = this.status;
+
+    const response = await this.liveagent.updateTicket({
+      $,
+      ticketId: this.ticketId,
+      data: {
+        ...ticket,
+      },
+    });
+    $.export("$summary", `Successfully updated ticket status to ${this.status}`);
+    return response;
+  },
+};

--- a/components/liveagent/actions/update-ticket-status/update-ticket-status.mjs
+++ b/components/liveagent/actions/update-ticket-status/update-ticket-status.mjs
@@ -9,7 +9,7 @@ export default {
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
-    readOnlyHint: true,
+    readOnlyHint: false,
   },
   props: {
     liveagent,

--- a/components/liveagent/actions/update-ticket-status/update-ticket-status.mjs
+++ b/components/liveagent/actions/update-ticket-status/update-ticket-status.mjs
@@ -17,6 +17,9 @@ export default {
       propDefinition: [
         liveagent,
         "ticketId",
+        () => ({
+          excludeClosedAndDeleted: true,
+        }),
       ],
     },
     status: {

--- a/components/liveagent/liveagent.app.mjs
+++ b/components/liveagent/liveagent.app.mjs
@@ -23,7 +23,7 @@ export default {
     },
     agentId: {
       label: "Agent ID",
-      description: "The agent ID. Example: `0rnbfcr8",
+      description: "The agent ID. Example: `0rnbfcr8`",
       type: "string",
       async options({ page }) {
         const agents = await this.listAgents({

--- a/components/liveagent/liveagent.app.mjs
+++ b/components/liveagent/liveagent.app.mjs
@@ -41,12 +41,17 @@ export default {
       type: "string",
       label: "Ticket ID",
       description: "The ID of the ticket. Example: `fp80688h`",
-      async options({ page }) {
-        const tickets = await this.listTickets({
+      async options({
+        page, excludeClosedAndDeleted = false,
+      }) {
+        let tickets = await this.listTickets({
           params: {
             _page: page + 1,
           },
         });
+        if (excludeClosedAndDeleted) {
+          tickets = tickets.filter((ticket) => ticket.status !== "X" && ticket.status !== "L");
+        }
         return tickets.map((ticket) => ({
           label: ticket.subject,
           value: ticket.id,

--- a/components/liveagent/liveagent.app.mjs
+++ b/components/liveagent/liveagent.app.mjs
@@ -21,6 +21,93 @@ export default {
         }));
       },
     },
+    agentId: {
+      label: "Agent ID",
+      description: "The agent ID. Example: `0rnbfcr8",
+      type: "string",
+      async options({ page }) {
+        const agents = await this.listAgents({
+          params: {
+            _page: page + 1,
+          },
+        });
+        return agents.map((agent) => ({
+          label: agent.name,
+          value: agent.id,
+        }));
+      },
+    },
+    ticketId: {
+      type: "string",
+      label: "Ticket ID",
+      description: "The ID of the ticket. Example: `fp80688h`",
+      async options({ page }) {
+        const tickets = await this.listTickets({
+          params: {
+            _page: page + 1,
+          },
+        });
+        return tickets.map((ticket) => ({
+          label: ticket.subject,
+          value: ticket.id,
+        }));
+      },
+    },
+    tagId: {
+      type: "string",
+      label: "Tag ID",
+      description: "The ID of the tag to add",
+      async options() {
+        const tags = await this.listTags();
+        return tags.map((tag) => ({
+          label: tag.name,
+          value: tag.id,
+        }));
+      },
+    },
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "Page number to return",
+      optional: true,
+      default: 1,
+      min: 1,
+    },
+    perPage: {
+      type: "integer",
+      label: "Per Page",
+      description: "Number of results to return per page",
+      optional: true,
+      default: 100,
+      min: 1,
+    },
+    sortDir: {
+      type: "string",
+      label: "Sort Direction",
+      description: "Sort direction",
+      optional: true,
+      options: [
+        "ASC",
+        "DESC",
+      ],
+    },
+    sortField: {
+      type: "string",
+      label: "Sort Field",
+      description: "Sort field",
+      optional: true,
+      options: [
+        "importance",
+        "date_created",
+        "date_changed",
+      ],
+    },
+    filters: {
+      type: "string",
+      label: "Filters",
+      description: "Filter as json object {\"column1\":\"value\", \"column2\":\"value\", …} or list of filters as json array [[\"column\",\"operator\",\"value\"], …]",
+      optional: true,
+    },
   },
   methods: {
     _domain() {
@@ -32,10 +119,11 @@ export default {
     _apiUrl() {
       return `https://${this._domain()}.ladesk.com/api/v3`;
     },
-    async _makeRequest({
+    _makeRequest({
       $ = this, path, ...args
     }) {
       return axios($, {
+        debug: true,
         url: `${this._apiUrl()}${path}`,
         ...args,
         headers: {
@@ -43,19 +131,70 @@ export default {
         },
       });
     },
-    async getCustomers(args = {}) {
+    getCustomers(args = {}) {
       return this._makeRequest({
         path: "/contacts",
         ...args,
       });
     },
-    async getGroups(args = {}) {
+    getGroups(args = {}) {
       return this._makeRequest({
         path: "/groups",
         ...args,
       });
     },
-    async createCustomer(args = {}) {
+    getAgent({
+      agentId, ...args
+    }) {
+      return this._makeRequest({
+        path: `/agents/${agentId}`,
+        ...args,
+      });
+    },
+    getTicket({
+      ticketId, ...args
+    }) {
+      return this._makeRequest({
+        path: `/tickets/${ticketId}`,
+        ...args,
+      });
+    },
+    listAgents(args = {}) {
+      return this._makeRequest({
+        path: "/agents",
+        ...args,
+      });
+    },
+    listTickets(args = {}) {
+      return this._makeRequest({
+        path: "/tickets",
+        ...args,
+      });
+    },
+    listTicketMessages({
+      ticketId, ...args
+    }) {
+      return this._makeRequest({
+        path: `/tickets/${ticketId}/messages`,
+        ...args,
+      });
+    },
+    listTags(args = {}) {
+      return this._makeRequest({
+        path: "/tags",
+        ...args,
+      });
+    },
+    updateTicket({
+      ticketId, ...args
+    }) {
+      return this._makeRequest({
+        path: `/tickets/${ticketId}`,
+        method: "put",
+        ...args,
+      });
+    },
+    createCustomer(args = {}) {
       return this._makeRequest({
         path: "/contacts",
         method: "post",

--- a/components/liveagent/liveagent.app.mjs
+++ b/components/liveagent/liveagent.app.mjs
@@ -123,7 +123,6 @@ export default {
       $ = this, path, ...args
     }) {
       return axios($, {
-        debug: true,
         url: `${this._apiUrl()}${path}`,
         ...args,
         headers: {

--- a/components/liveagent/package.json
+++ b/components/liveagent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/liveagent",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "Pipedream Liveagent Components",
   "main": "liveagent.app.mjs",
   "keywords": [
@@ -14,6 +14,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@pipedream/platform": "^1.6.8"
+    "@pipedream/platform": "^3.3.1"
   }
 }

--- a/components/liveagent/sources/new-customer/new-customer.mjs
+++ b/components/liveagent/sources/new-customer/new-customer.mjs
@@ -3,7 +3,7 @@ import { DEFAULT_POLLING_SOURCE_TIMER_INTERVAL } from "@pipedream/platform";
 
 export default {
   name: "New Customer",
-  version: "0.0.2",
+  version: "0.0.3",
   key: "liveagent-new-customer",
   description: "Emit new event on each new customer.",
   type: "source",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41101,7 +41101,7 @@ snapshots:
 
   '@pipedream/platform@3.3.1':
     dependencies:
-      axios: 1.13.2(debug@3.2.7)
+      axios: 1.15.0(debug@3.2.7)
       fp-ts: 2.16.11
       io-ts: 2.2.22(fp-ts@2.16.11)
       mime-types: 3.0.1
@@ -41728,7 +41728,6 @@ snapshots:
     transitivePeerDependencies:
       - rolldown
       - rollup
-      - supports-color
 
   '@putout/operator-parens@2.0.0(rolldown@1.0.0-beta.60(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1))(rollup@4.60.1)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3950,8 +3950,7 @@ importers:
         specifier: ^8.3.2
         version: 8.3.2
 
-  components/dataforb2b:
-    specifiers: {}
+  components/dataforb2b: {}
 
   components/dataforseo:
     dependencies:
@@ -5592,8 +5591,7 @@ importers:
         specifier: ^3.1.1
         version: 3.1.1
 
-  components/fleetbase:
-    specifiers: {}
+  components/fleetbase: {}
 
   components/flexie:
     dependencies:
@@ -5637,8 +5635,7 @@ importers:
         specifier: ^3.2.2
         version: 3.2.4
 
-  components/flock:
-    specifiers: {}
+  components/flock: {}
 
   components/flodesk:
     dependencies:
@@ -8917,8 +8914,8 @@ importers:
   components/liveagent:
     dependencies:
       '@pipedream/platform':
-        specifier: ^1.6.8
-        version: 1.6.8
+        specifier: ^3.3.1
+        version: 3.3.1
 
   components/livechat: {}
 
@@ -21855,6 +21852,9 @@ packages:
 
   '@pipedream/platform@3.3.0':
     resolution: {integrity: sha512-vqJ4yp9Ng3tQEr33qiilZlNHsBFP7V1XsHdza+2ksYVs7UA20dfy9ryd1WGWoVfsRaSakPCe+nq2O6Pgp0KtYA==}
+
+  '@pipedream/platform@3.3.1':
+    resolution: {integrity: sha512-efVpYQQxYKcNf+kJJadu4uD5jCdyv+x1UgBRVG0OGOXnQmUvl33KjxXft575tJwLeW5kMJWL+TQngKk4phHMDA==}
 
   '@pipedream/postgresql@2.2.4':
     resolution: {integrity: sha512-ANR8xURO+5tDp/85oP/SrAwUjk+G6Xz5LOU40hsR2OAYGN6wU0cNAMRSq4durl3MVcb2+oxJwB9uNAdYQgga/g==}
@@ -40924,7 +40924,7 @@ snapshots:
 
   '@pipedream/microsoft_outlook@1.7.5':
     dependencies:
-      '@pipedream/platform': 3.3.0
+      '@pipedream/platform': 3.3.1
       axios: 0.30.2
       js-base64: 3.7.8
       md5: 2.3.0
@@ -40934,7 +40934,7 @@ snapshots:
 
   '@pipedream/monday@0.7.0(encoding@0.1.13)':
     dependencies:
-      '@pipedream/platform': 3.3.0
+      '@pipedream/platform': 3.3.1
       form-data: 4.0.4
       lodash.flatmap: 4.5.0
       lodash.map: 4.6.0
@@ -40946,14 +40946,14 @@ snapshots:
 
   '@pipedream/notiff_io@0.1.0':
     dependencies:
-      '@pipedream/platform': 3.3.0
+      '@pipedream/platform': 3.3.1
     transitivePeerDependencies:
       - debug
 
   '@pipedream/notion@1.0.6(encoding@0.1.13)':
     dependencies:
       '@notionhq/client': 5.4.0
-      '@pipedream/platform': 3.3.0
+      '@pipedream/platform': 3.3.1
       '@tryfabric/martian': 1.2.4(encoding@0.1.13)
       lodash-es: 4.18.1
       notion-helper: 1.3.29
@@ -41071,6 +41071,17 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  '@pipedream/platform@3.3.1':
+    dependencies:
+      axios: 1.13.2(debug@3.2.7)
+      fp-ts: 2.16.11
+      io-ts: 2.2.22(fp-ts@2.16.11)
+      mime-types: 3.0.1
+      querystring: 0.2.1
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - debug
+
   '@pipedream/postgresql@2.2.4':
     dependencies:
       '@pipedream/platform': 2.0.2
@@ -41082,20 +41093,20 @@ snapshots:
 
   '@pipedream/procore@0.1.0':
     dependencies:
-      '@pipedream/platform': 3.3.0
+      '@pipedream/platform': 3.3.1
       uuid: 11.1.0
     transitivePeerDependencies:
       - debug
 
   '@pipedream/quickbooks@0.8.0':
     dependencies:
-      '@pipedream/platform': 3.3.0
+      '@pipedream/platform': 3.3.1
     transitivePeerDependencies:
       - debug
 
   '@pipedream/ramp@0.1.2':
     dependencies:
-      '@pipedream/platform': 3.3.0
+      '@pipedream/platform': 3.3.1
       uuid: 10.0.0
     transitivePeerDependencies:
       - debug
@@ -41114,14 +41125,14 @@ snapshots:
 
   '@pipedream/sftp@0.5.1':
     dependencies:
-      '@pipedream/platform': 3.3.0
+      '@pipedream/platform': 3.3.1
       ssh2-sftp-client: 11.0.0
     transitivePeerDependencies:
       - debug
 
   '@pipedream/shopify@0.7.2':
     dependencies:
-      '@pipedream/platform': 3.3.0
+      '@pipedream/platform': 3.3.1
       async-retry: 1.3.3
       bottleneck: 2.19.5
       form-data: 4.0.4
@@ -41133,7 +41144,7 @@ snapshots:
 
   '@pipedream/slack@0.10.3':
     dependencies:
-      '@pipedream/platform': 3.3.0
+      '@pipedream/platform': 3.3.1
       '@slack/web-api': 7.12.0
       async-retry: 1.3.3
       lodash: 4.18.1
@@ -41155,7 +41166,7 @@ snapshots:
   '@pipedream/youtube_data_api@1.0.1(encoding@0.1.13)':
     dependencies:
       '@googleapis/youtube': 6.0.0(encoding@0.1.13)
-      '@pipedream/platform': 3.3.0
+      '@pipedream/platform': 3.3.1
       got: 14.6.4
       util: 0.12.5
     transitivePeerDependencies:
@@ -41689,6 +41700,7 @@ snapshots:
     transitivePeerDependencies:
       - rolldown
       - rollup
+      - supports-color
 
   '@putout/operator-parens@2.0.0(rolldown@1.0.0-beta.60(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1))(rollup@4.60.1)':
     dependencies:


### PR DESCRIPTION
Resolves #20282

Note to QA: The API Key in 1PW is for a live production environment, so please be mindful of testing (only read actions or by creating a test ticket).

The actions requested in the issue reference the deprecated v1 of the LiveAgent api, so I implemented the following actions that use LiveAgent's v3 api.

- Get Agent
- List Tickets
- Get Ticket
- List Ticket Messages
- Update Ticket Status
- List Tags
- Add Tag to Ticket


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added LiveAgent actions: Get Agent, Get Ticket, Add Tag to Ticket, Update Ticket Status, List Tickets, List Ticket Messages, List Tags.
  * Actions support pagination, sorting, filtering and selectable agent/ticket/tag IDs; ticket updates now allow status and tag changes.

* **Chores**
  * Bumped component/package versions and updated component metadata and documentation links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->