### PR TITLE
Google Drive Download File: default to buffer response in Connect

### DIFF
--- a/components/google_drive/actions/download-file/download-file.mjs
+++ b/components/google_drive/actions/download-file/download-file.mjs
@@ -18,7 +18,7 @@ export default {
   key: "google_drive-download-file",
   name: "Download File",
   description: "Download a file. [See the documentation](https://developers.google.com/drive/api/v3/manage-downloads) for more information",
-  version: "0.1.22",
+  version: "0.1.23",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -107,10 +107,7 @@ export default {
     },
   },
   async run({ $ }) {
-    // Validate that filePath is provided when not getting raw response
-    if (!this.getBufferResponse && !this.filePath) {
-      throw new Error("File Path is required when not using Get Buffer Response");
-    }
+    const useBufferResponse = this.getBufferResponse || !this.filePath;
 
     // Get file metadata to get file's MIME type
     const fileMetadata = await this.googleDrive.getFile(this.fileId, {
@@ -135,7 +132,7 @@ export default {
         alt: "media",
       });
 
-    if (this.getBufferResponse) {
+    if (useBufferResponse) {
       $.export("$summary", `Successfully retrieved raw content for file "${fileMetadata.name}"`);
 
       // Convert stream to buffer


### PR DESCRIPTION
## Summary
- The `syncDir` prop (`type: "dir"`) is skipped by the Connect React SDK (`skippablePropTypes`), and when neither `filePath` nor `getBufferResponse` is configured, the action throws `"File Path is required when not using Get Buffer Response"`
- This makes the Download File action unusable via Connect and MCP — agents cannot configure `syncDir` and have no way to avoid the error without prior knowledge of the prop dependencies
- Instead of throwing, the action now defaults to returning file content as a buffer when `filePath` is not provided

## Changes
- Replaced the hard error with `const useBufferResponse = this.getBufferResponse || !this.filePath`
- When `filePath` is set, behavior is unchanged — file is written to the specified path
- When neither is set (the Connect case), the action returns the file content as a buffer
- Version bump to 0.1.23

## Test plan
- [ ] Invoke Download File via Connect without setting `filePath` or `getBufferResponse` — should return file content as buffer instead of throwing
- [ ] Invoke with `filePath` set — should write to path as before
- [ ] Invoke with `getBufferResponse: true` — should return buffer as before
- [ ] Invoke in workflow builder with `filePath` set — no change in behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Google Drive file download action now returns raw file content when no destination path is specified, instead of throwing an error. This enables more flexible file handling workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->