### PR TITLE
Monday — add queryParams to Get Board Items Page action

### DIFF
--- a/components/monday/actions/create-board/create-board.mjs
+++ b/components/monday/actions/create-board/create-board.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Create Board",
   description: "Creates a new board. [See the documentation](https://developer.monday.com/api-reference/reference/boards#create-a-board)",
   type: "action",
-  version: "0.0.11",
+  version: "0.0.12",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monday/actions/create-column/create-column.mjs
+++ b/components/monday/actions/create-column/create-column.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Create Column",
   description: "Creates a column. [See the documentation](https://developer.monday.com/api-reference/reference/columns#create-a-column)",
   type: "action",
-  version: "0.1.3",
+  version: "0.1.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monday/actions/create-group/create-group.mjs
+++ b/components/monday/actions/create-group/create-group.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Create Group",
   description: "Creates a new group in a specific board. [See the documentation](https://developer.monday.com/api-reference/reference/groups#create-a-group)",
   type: "action",
-  version: "0.0.12",
+  version: "0.0.13",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monday/actions/create-item/create-item.mjs
+++ b/components/monday/actions/create-item/create-item.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Create Item",
   description: "Creates an item. [See the documentation](https://developer.monday.com/api-reference/reference/items#create-an-item)",
   type: "action",
-  version: "0.1.3",
+  version: "0.1.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monday/actions/create-subitem/create-subitem.mjs
+++ b/components/monday/actions/create-subitem/create-subitem.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Create Subitem",
   description: "Creates a subitem. [See the documentation](https://developer.monday.com/api-reference/reference/subitems#create-a-subitem)",
   type: "action",
-  version: "0.1.3",
+  version: "0.1.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monday/actions/create-update/create-update.mjs
+++ b/components/monday/actions/create-update/create-update.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Create an Update",
   description: "Creates a new update. [See the documentation](https://developer.monday.com/api-reference/reference/updates#create-an-update)",
   type: "action",
-  version: "0.0.14",
+  version: "0.0.15",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/monday/actions/get-board-items-page/get-board-items-page.mjs
+++ b/components/monday/actions/get-board-items-page/get-board-items-page.mjs
@@ -1,4 +1,5 @@
 import common from "../common/column-values.mjs";
+import { ConfigurationError } from "@pipedream/platform";
 
 export default {
   ...common,
@@ -39,10 +40,10 @@ export default {
       try {
         queryParams = JSON.parse(this.queryParams);
       } catch (error) {
-        throw new Error(`Invalid query params: ${error.message}`);
+        throw new ConfigurationError(`Invalid query params: ${error.message}`);
       }
     }
-    console.log(queryParams);
+
     const args = {
       boardId: +this.boardId,
     };

--- a/components/monday/actions/get-board-items-page/get-board-items-page.mjs
+++ b/components/monday/actions/get-board-items-page/get-board-items-page.mjs
@@ -5,7 +5,7 @@ export default {
   key: "monday-get-board-items-page",
   name: "Get Board Items Page",
   description: "Retrieves all items from a board. [See the documentation](https://developer.monday.com/api-reference/reference/items-page)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -14,11 +14,43 @@ export default {
   type: "action",
   props: {
     ...common.props,
+    queryParams: {
+      type: "string",
+      label: "Query Params",
+      description: "A JSON object containing parameters to filter, sort, and control the scope of the query. [See the documentation](https://developer.monday.com/api-reference/reference/items-page-other-types#itemsquery)\n\n"
+        + "Example:\n"
+        + "```json\n"
+        + "{\n"
+        + "  \"rules\": [\n"
+        + "    {\n"
+        + "      \"column_id\": \"name\",\n"
+        + "      \"compare_value\": \"test\",\n"
+        + "      \"operator\": \"is_not_empty\"\n"
+        + "    }\n"
+        + "  ]\n"
+        + "}\n"
+        + "```",
+      optional: true,
+    },
   },
   async run({ $ }) {
-    const response = await this.monday.listBoardItemsPage({
+    let queryParams;
+    if (this.queryParams) {
+      try {
+        queryParams = JSON.parse(this.queryParams);
+      } catch (error) {
+        throw new Error(`Invalid query params: ${error.message}`);
+      }
+    }
+    console.log(queryParams);
+    const args = {
       boardId: +this.boardId,
-    });
+    };
+    if (queryParams) {
+      args.query_params = queryParams;
+    }
+
+    const response = await this.monday.listBoardItemsPage(args);
 
     if (response.errors) {
       throw new Error(response.errors[0].message);

--- a/components/monday/actions/get-column-values/get-column-values.mjs
+++ b/components/monday/actions/get-column-values/get-column-values.mjs
@@ -5,7 +5,7 @@ export default {
   key: "monday-get-column-values",
   name: "Get Column Values",
   description: "Return values of specific column(s) for a board item. [See the documentation](https://developer.monday.com/api-reference/reference/column-values-v2)",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monday/actions/get-items-by-column-value/get-items-by-column-value.mjs
+++ b/components/monday/actions/get-items-by-column-value/get-items-by-column-value.mjs
@@ -6,7 +6,7 @@ export default {
   key: "monday-get-items-by-column-value",
   name: "Get Items By Column Value",
   description: "Searches a column for items matching a value. [See the documentation](https://developer.monday.com/api-reference/reference/items-page-by-column-values)",
-  version: "0.1.3",
+  version: "0.1.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monday/actions/update-column-values/update-column-values.mjs
+++ b/components/monday/actions/update-column-values/update-column-values.mjs
@@ -12,7 +12,7 @@ export default {
   key: "monday-update-column-values",
   name: "Update Column Values",
   description: "Update multiple column values of an item. [See the documentation](https://developer.monday.com/api-reference/reference/columns#change-multiple-column-values)",
-  version: "0.2.5",
+  version: "0.2.6",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/monday/actions/update-item-name/update-item-name.mjs
+++ b/components/monday/actions/update-item-name/update-item-name.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Update Item Name",
   description: "Update an item's name. [See the documentation](https://developer.monday.com/api-reference/reference/columns#change-multiple-column-values)",
   type: "action",
-  version: "0.0.13",
+  version: "0.0.14",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/monday/common/queries.mjs
+++ b/components/monday/common/queries.mjs
@@ -106,13 +106,28 @@ export default {
     }
   `,
   listBoardItemsPage: `
-    query listBoardItemsPage ($boardId: ID!, $cursor: String) {
+    query listBoardItemsPage ($boardId: ID!, $cursor: String, $query_params: ItemsQuery) {
       boards (ids: [$boardId]){
-        items_page (cursor: $cursor) {
+        items_page (
+          cursor: $cursor
+          query_params: $query_params
+        ) {
           cursor
           items {
             id 
             name 
+            column_values {
+              column {
+                title
+              }
+            }
+            created_at
+            creator_id
+            email
+            relative_link
+            state
+            updated_at
+            url
           }
         }
       }

--- a/components/monday/package.json
+++ b/components/monday/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/monday",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Pipedream Monday Components",
   "main": "monday.app.mjs",
   "keywords": [

--- a/components/monday/sources/column-value-updated/column-value-updated.mjs
+++ b/components/monday/sources/column-value-updated/column-value-updated.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Column Value Updated (Instant)",
   description: "Emit new event when a column value is updated on a board. [See the documentation](https://developer.monday.com/api-reference/reference/webhooks#sample-payload-for-webhook-events)",
   type: "source",
-  version: "0.0.10",
+  version: "0.0.11",
   dedupe: "unique",
   hooks: {
     ...common.hooks,

--- a/components/monday/sources/name-updated/name-updated.mjs
+++ b/components/monday/sources/name-updated/name-updated.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Name Updated (Instant)",
   description: "Emit new event when an item's name is updated. [See the documentation](https://developer.monday.com/api-reference/reference/webhooks#sample-payload-for-webhook-events)",
   type: "source",
-  version: "0.0.10",
+  version: "0.0.11",
   dedupe: "unique",
   hooks: {
     ...common.hooks,

--- a/components/monday/sources/new-board/new-board.mjs
+++ b/components/monday/sources/new-board/new-board.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Board Created",
   description: "Emit new event when a board is created in Monday. [See the documentation](https://developer.monday.com/api-reference/reference/webhooks#sample-payload-for-webhook-events)",
   type: "source",
-  version: "0.0.11",
+  version: "0.0.12",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/monday/sources/new-item/new-item.mjs
+++ b/components/monday/sources/new-item/new-item.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Item Created (Instant)",
   description: "Emit new event when a new item is added to a board. [See the documentation](https://developer.monday.com/api-reference/reference/webhooks#sample-payload-for-webhook-events)",
   type: "source",
-  version: "0.0.10",
+  version: "0.0.11",
   dedupe: "unique",
   hooks: {
     ...common.hooks,

--- a/components/monday/sources/new-subitem-update/new-subitem-update.mjs
+++ b/components/monday/sources/new-subitem-update/new-subitem-update.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Sub-Item Update (Instant)",
   description: "Emit new event when an update is posted in sub-items. [See the documentation](https://developer.monday.com/api-reference/reference/webhooks#sample-payload-for-webhook-events)",
   type: "source",
-  version: "0.0.9",
+  version: "0.0.10",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/monday/sources/new-subitem/new-subitem.mjs
+++ b/components/monday/sources/new-subitem/new-subitem.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Sub-Item Created (Instant)",
   description: "Emit new event when a sub-item is created. [See the documentation](https://developer.monday.com/api-reference/reference/webhooks#sample-payload-for-webhook-events)",
   type: "source",
-  version: "0.0.9",
+  version: "0.0.10",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/monday/sources/new-user/new-user.mjs
+++ b/components/monday/sources/new-user/new-user.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New User Created",
   description: "Emit new event when a new user is created in Monday. [See the documentation](https://developer.monday.com/api-reference/reference/webhooks#sample-payload-for-webhook-events)",
   type: "source",
-  version: "0.0.11",
+  version: "0.0.12",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/monday/sources/specific-column-updated/specific-column-updated.mjs
+++ b/components/monday/sources/specific-column-updated/specific-column-updated.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Specific Column Updated (Instant)",
   description: "Emit new event when a value in the specified column is updated. [See the documentation](https://developer.monday.com/api-reference/reference/webhooks#sample-payload-for-webhook-events)",
   type: "source",
-  version: "0.0.10",
+  version: "0.0.11",
   dedupe: "unique",
   hooks: {
     ...common.hooks,

--- a/components/monday/sources/subitem-column-value-updated/subitem-column-value-updated.mjs
+++ b/components/monday/sources/subitem-column-value-updated/subitem-column-value-updated.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Sub-Item Column Value Updated (Instant)",
   description: "Emit new event when any sub-item column changes. [See the documentation](https://developer.monday.com/api-reference/reference/webhooks#sample-payload-for-webhook-events)",
   type: "source",
-  version: "0.0.10",
+  version: "0.0.11",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/monday/sources/subitem-name-updated/subitem-name-updated.mjs
+++ b/components/monday/sources/subitem-name-updated/subitem-name-updated.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Sub-Item Name Updated (Instant)",
   description: "Emit new event when a sub-item name changes. [See the documentation](https://developer.monday.com/api-reference/reference/webhooks#sample-payload-for-webhook-events)",
   type: "source",
-  version: "0.0.9",
+  version: "0.0.10",
   dedupe: "unique",
   props: {
     ...common.props,


### PR DESCRIPTION
Resolves #20591 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional query-params support for retrieving board items, enabling filtered/sorted pages and returning expanded item metadata (more fields per item).

* **Chores**
  * Bumped package and component versions across the Monday.com integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->