### PR TITLE
Asana - Search Tasks Premium action

### DIFF
--- a/components/asana/actions/add-task-to-section/add-task-to-section.mjs
+++ b/components/asana/actions/add-task-to-section/add-task-to-section.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Add Task To Section",
   description: "Add a task to a specific, existing section. This will remove the task from other sections of the project. [See the documentation](https://developers.asana.com/docs/add-task-to-section)",
   key: "asana-add-task-to-section",
-  version: "0.2.11",
+  version: "0.2.12",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/asana/actions/add-task-to-section/add-task-to-section.mjs
+++ b/components/asana/actions/add-task-to-section/add-task-to-section.mjs
@@ -7,7 +7,7 @@ export default {
   key: "asana-add-task-to-section",
   version: "0.2.12",
   annotations: {
-    destructiveHint: true,
+    destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },

--- a/components/asana/actions/create-project/create-project.mjs
+++ b/components/asana/actions/create-project/create-project.mjs
@@ -5,7 +5,7 @@ export default {
   key: "asana-create-project",
   name: "Create Project",
   description: "Create a new project in a workspace or team. [See the documentation](https://developers.asana.com/docs/create-a-project)",
-  version: "0.10.5",
+  version: "0.10.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/asana/actions/create-subtask/create-subtask.mjs
+++ b/components/asana/actions/create-subtask/create-subtask.mjs
@@ -5,7 +5,7 @@ export default {
   key: "asana-create-subtask",
   name: "Create Subtask",
   description: "Creates a new subtask and adds it to the parent task. [See the documentation](https://developers.asana.com/docs/create-a-subtask)",
-  version: "0.4.4",
+  version: "0.4.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/asana/actions/create-task-comment/create-task-comment.mjs
+++ b/components/asana/actions/create-task-comment/create-task-comment.mjs
@@ -5,7 +5,7 @@ export default {
   key: "asana-create-task-comment",
   name: "Create Task Comment",
   description: "Adds a comment to a task. [See the documentation](https://developers.asana.com/docs/create-a-story-on-a-task)",
-  version: "0.2.11",
+  version: "0.2.12",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/asana/actions/create-task-from-template/create-task-from-template.mjs
+++ b/components/asana/actions/create-task-from-template/create-task-from-template.mjs
@@ -4,7 +4,7 @@ export default {
   name: "Create Task from Template",
   key: "asana-create-task-from-template",
   description: "Creates a new task from a task template. [See the documentation](https://developers.asana.com/reference/instantiatetask)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/asana/actions/create-task/create-task.mjs
+++ b/components/asana/actions/create-task/create-task.mjs
@@ -5,7 +5,7 @@ export default {
   key: "asana-create-task",
   name: "Create Task",
   description: "Creates a new task. [See the documentation](https://developers.asana.com/docs/create-a-task)",
-  version: "0.4.4",
+  version: "0.4.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/asana/actions/delete-task/delete-task.mjs
+++ b/components/asana/actions/delete-task/delete-task.mjs
@@ -5,7 +5,7 @@ export default {
   key: "asana-delete-task",
   name: "Delete Task",
   description: "Deletes a specific and existing task. [See the documentation](https://developers.asana.com/docs/delete-a-task)",
-  version: "0.0.12",
+  version: "0.0.13",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/asana/actions/find-task-by-id/find-task-by-id.mjs
+++ b/components/asana/actions/find-task-by-id/find-task-by-id.mjs
@@ -5,7 +5,7 @@ export default {
   key: "asana-find-task-by-id",
   name: "Find Task by ID",
   description: "Searches for a task by id. Returns the complete task record for a single task. [See the documentation](https://developers.asana.com/docs/get-a-task)",
-  version: "0.2.11",
+  version: "0.2.12",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/asana/actions/get-tasks-from-task-list/get-tasks-from-task-list.mjs
+++ b/components/asana/actions/get-tasks-from-task-list/get-tasks-from-task-list.mjs
@@ -4,7 +4,7 @@ export default {
   key: "asana-get-tasks-from-task-list",
   name: "Get Tasks From Task List",
   description: "Returns the compact list of tasks in a user’s My Tasks list. [See the documentation](https://developers.asana.com/reference/gettasksforusertasklist)",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/asana/actions/list-task-stories/list-task-stories.mjs
+++ b/components/asana/actions/list-task-stories/list-task-stories.mjs
@@ -4,7 +4,7 @@ export default {
   key: "asana-list-task-stories",
   name: "List Task Stories",
   description: "List stories (including comments) for a task. [See the documentation](https://developers.asana.com/reference/getstoriesfortask)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/asana/actions/search-projects/search-projects.mjs
+++ b/components/asana/actions/search-projects/search-projects.mjs
@@ -3,7 +3,7 @@ import asana from "../../asana.app.mjs";
 export default {
   type: "action",
   key: "asana-search-projects",
-  version: "0.2.11",
+  version: "0.2.12",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/asana/actions/search-sections/search-sections.mjs
+++ b/components/asana/actions/search-sections/search-sections.mjs
@@ -4,7 +4,7 @@ export default {
   key: "asana-search-sections",
   name: "Search Sections",
   description: "Searches for a section by name within a particular project. [See the documentation](https://developers.asana.com/docs/get-sections-in-a-project)",
-  version: "0.2.11",
+  version: "0.2.12",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/asana/actions/search-tasks-premium/search-tasks-premium.mjs
+++ b/components/asana/actions/search-tasks-premium/search-tasks-premium.mjs
@@ -46,7 +46,7 @@ export default {
     section: {
       label: "Section",
       type: "string",
-      description: "The section to filter tasks on. Must specify Project to list options.",
+      description: "Section GID used to filter tasks (for example: `1200123456789013`). Provide `project` so valid section IDs can be resolved.",
       optional: true,
       propDefinition: [
         asana,

--- a/components/asana/actions/search-tasks-premium/search-tasks-premium.mjs
+++ b/components/asana/actions/search-tasks-premium/search-tasks-premium.mjs
@@ -1,0 +1,92 @@
+import asana from "../../asana.app.mjs";
+import common from "../common/common.mjs";
+
+export default {
+  key: "asana-search-tasks-premium",
+  name: "Search Tasks Premium",
+  description: "Searches for a task by name, assignee, section, project, completed since, and modified since. Requires a Premium Asana account. [See the documentation](https://developers.asana.com/reference/searchtasksforworkspace)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  type: "action",
+  props: {
+    asana,
+    info: {
+      type: "alert",
+      alertType: "info",
+      content: "This action requires a Premium Asana account. [See the documentation](https://developers.asana.com/reference/searchtasksforworkspace)",
+    },
+    ...common.props,
+    project: {
+      ...common.props.project,
+      optional: true,
+    },
+    name: {
+      label: "Name",
+      description: "The task name to search for",
+      type: "string",
+      optional: true,
+    },
+    assignee: {
+      label: "Assignee",
+      description: "The assignee to filter tasks on",
+      type: "string",
+      optional: true,
+      propDefinition: [
+        asana,
+        "users",
+        ({ workspace }) => ({
+          workspace,
+        }),
+      ],
+    },
+    section: {
+      label: "Section",
+      type: "string",
+      description: "The section to filter tasks on. Must specify Project to list options.",
+      optional: true,
+      propDefinition: [
+        asana,
+        "sections",
+        (c) => ({
+          project: c.project,
+        }),
+      ],
+    },
+    completedSince: {
+      label: "Completed Since",
+      type: "string",
+      description: "Only return tasks that are either incomplete or that have been completed since this time. ISO 8601 date string",
+      optional: true,
+    },
+    modifiedSince: {
+      label: "Modified Since",
+      type: "string",
+      description: "Only return tasks that have been modified since the given time. ISO 8601 date string",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const params = {
+      "completed_on.after": this.completedSince,
+      "modified_at.after": this.modifiedSince,
+      "assignee.any": this.assignee,
+      "sections.any": this.section,
+      "project.any": this.project,
+      "text": this.name,
+    };
+
+    const { data: tasks } = await this.asana.searchTasks({
+      workspace: this.workspace,
+      params,
+      $,
+    });
+
+    $.export("$summary", "Successfully retrieved tasks");
+
+    return tasks;
+  },
+};

--- a/components/asana/actions/search-tasks-premium/search-tasks-premium.mjs
+++ b/components/asana/actions/search-tasks-premium/search-tasks-premium.mjs
@@ -59,13 +59,13 @@ export default {
     completedSince: {
       label: "Completed Since",
       type: "string",
-      description: "Only return tasks that are either incomplete or that have been completed since this time. ISO 8601 date string",
+      description: "Only return tasks that are either incomplete or completed since this time. ISO 8601 format (for example: `2026-04-14` or `2026-04-14T00:00:00Z`).",
       optional: true,
     },
     modifiedSince: {
       label: "Modified Since",
       type: "string",
-      description: "Only return tasks that have been modified since the given time. ISO 8601 date string",
+      description: "Only return tasks modified since this time. ISO 8601 format (for example: `2026-04-14` or `2026-04-14T00:00:00Z`).",
       optional: true,
     },
   },
@@ -75,7 +75,7 @@ export default {
       "modified_at.after": this.modifiedSince,
       "assignee.any": this.assignee,
       "sections.any": this.section,
-      "project.any": this.project,
+      "projects.any": this.project,
       "text": this.name,
     };
 

--- a/components/asana/actions/search-tasks/search-tasks.mjs
+++ b/components/asana/actions/search-tasks/search-tasks.mjs
@@ -6,7 +6,7 @@ export default {
   key: "asana-search-tasks",
   name: "Search Tasks",
   description: "Searches for a Task by name within a Project. [See the documentation](https://developers.asana.com/docs/get-multiple-tasks)",
-  version: "0.3.5",
+  version: "0.3.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/asana/actions/search-user-projects/search-user-projects.mjs
+++ b/components/asana/actions/search-user-projects/search-user-projects.mjs
@@ -5,7 +5,7 @@ export default {
   key: "asana-search-user-projects",
   name: "Get list of user projects",
   description: "Return list of projects given the user and workspace gid. [See the documentation](https://developers.asana.com/docs/get-multiple-projects)",
-  version: "0.5.4",
+  version: "0.5.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/asana/actions/update-task/update-task.mjs
+++ b/components/asana/actions/update-task/update-task.mjs
@@ -5,7 +5,7 @@ export default {
   key: "asana-update-task",
   name: "Update Task",
   description: "Updates a specific and existing task. [See the documentation](https://developers.asana.com/docs/update-a-task)",
-  version: "0.4.4",
+  version: "0.4.5",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/asana/actions/update-task/update-task.mjs
+++ b/components/asana/actions/update-task/update-task.mjs
@@ -7,7 +7,7 @@ export default {
   description: "Updates a specific and existing task. [See the documentation](https://developers.asana.com/docs/update-a-task)",
   version: "0.4.5",
   annotations: {
-    destructiveHint: true,
+    destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },

--- a/components/asana/asana.app.mjs
+++ b/components/asana/asana.app.mjs
@@ -461,6 +461,22 @@ export default {
       });
     },
     /**
+     * Search for tasks in a workspace.
+     *
+     * @param {string} workspace - The workspace GID.
+     * @param {object} opts - The params to filter tasks.
+     *
+     * @returns {string} An Asana Task list.
+     */
+    searchTasks({
+      workspace, ...opts
+    }) {
+      return this._makeRequest({
+        path: `workspaces/${workspace}/tasks/search`,
+        ...opts,
+      });
+    },
+    /**
      * Get an Asana Section list.
      *
      * @param {string} projectId - A Project GID.

--- a/components/asana/package.json
+++ b/components/asana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/asana",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Pipedream Asana Components",
   "main": "asana.app.mjs",
   "keywords": [

--- a/components/asana/package.json
+++ b/components/asana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/asana",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "Pipedream Asana Components",
   "main": "asana.app.mjs",
   "keywords": [

--- a/components/asana/sources/new-completed-task/new-completed-task.mjs
+++ b/components/asana/sources/new-completed-task/new-completed-task.mjs
@@ -7,7 +7,7 @@ export default {
   type: "source",
   name: "New Completed Task (Instant)",
   description: "Emit new event for each task completed in a project.",
-  version: "0.1.10",
+  version: "0.1.11",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/asana/sources/new-project/new-project.mjs
+++ b/components/asana/sources/new-project/new-project.mjs
@@ -6,7 +6,7 @@ export default {
   key: "asana-new-project",
   name: "New Project Added To Workspace (Instant)",
   description: "Emit new event for each new project added to a workspace.",
-  version: "0.1.10",
+  version: "0.1.11",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/asana/sources/new-story/new-story.mjs
+++ b/components/asana/sources/new-story/new-story.mjs
@@ -7,7 +7,7 @@ export default {
   type: "source",
   name: "New Story Added To Project (Instant)",
   description: "Emit new event for each story added to a project.",
-  version: "0.1.10",
+  version: "0.1.11",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/asana/sources/new-subtask/new-subtask.mjs
+++ b/components/asana/sources/new-subtask/new-subtask.mjs
@@ -7,7 +7,7 @@ export default {
   type: "source",
   name: "New Subtask (Instant)",
   description: "Emit new event for each subtask added to a project.",
-  version: "1.0.10",
+  version: "1.0.11",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/asana/sources/new-tag/new-tag.mjs
+++ b/components/asana/sources/new-tag/new-tag.mjs
@@ -6,7 +6,7 @@ export default {
   type: "source",
   name: "New Tag",
   description: "Emit new event for each tag created in a workspace.",
-  version: "0.0.12",
+  version: "0.0.13",
   dedupe: "unique",
   props: {
     asana,

--- a/components/asana/sources/new-task/new-task.mjs
+++ b/components/asana/sources/new-task/new-task.mjs
@@ -7,7 +7,7 @@ export default {
   type: "source",
   name: "New Task (Instant)",
   description: "Emit new event for each task added to a project. [See docs here](https://developers.asana.com/docs/establish-a-webhook)",
-  version: "0.1.10",
+  version: "0.1.11",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/asana/sources/new-team/new-team.mjs
+++ b/components/asana/sources/new-team/new-team.mjs
@@ -6,7 +6,7 @@ export default {
   type: "source",
   name: "New Team",
   description: "Emit new event for each team added to an organization.",
-  version: "0.1.11",
+  version: "0.1.12",
   dedupe: "unique",
   props: {
     asana,

--- a/components/asana/sources/new-user/new-user.mjs
+++ b/components/asana/sources/new-user/new-user.mjs
@@ -6,7 +6,7 @@ export default {
   type: "source",
   name: "New User (Instant)",
   description: "Emit new event for each user added to a workspace.",
-  version: "0.1.10",
+  version: "0.1.11",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/asana/sources/new-workspace/new-workspace.mjs
+++ b/components/asana/sources/new-workspace/new-workspace.mjs
@@ -6,7 +6,7 @@ export default {
   key: "asana-new-workspace",
   name: "New Workspace Added",
   description: "Emit new event each time you add a new workspace/organization.",
-  version: "0.1.11",
+  version: "0.1.12",
   dedupe: "unique",
   props: {
     asana,

--- a/components/asana/sources/tag-added-to-task/tag-added-to-task.mjs
+++ b/components/asana/sources/tag-added-to-task/tag-added-to-task.mjs
@@ -7,7 +7,7 @@ export default {
   type: "source",
   name: "New Tag Added To Task (Instant)",
   description: "Emit new event for each new tag added to a task.",
-  version: "0.1.10",
+  version: "0.1.11",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/asana/sources/tags-added-to-any-task/tags-added-to-any-task.mjs
+++ b/components/asana/sources/tags-added-to-any-task/tags-added-to-any-task.mjs
@@ -7,7 +7,7 @@ export default {
   type: "source",
   name: "New Tags added to any task (Instant)",
   description: "Emit new event each time a tag is added to any task, optionally filtering by a given set of tags.",
-  version: "0.0.9",
+  version: "0.0.10",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/asana/sources/task-assigned-in-project/task-assigned-in-project.mjs
+++ b/components/asana/sources/task-assigned-in-project/task-assigned-in-project.mjs
@@ -7,7 +7,7 @@ export default {
   type: "source",
   name: "New Task Assigned in Project (Instant)",
   description: "Emit new event each time a task is assigned, reassigned or unassigned.",
-  version: "0.1.3",
+  version: "0.1.4",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/asana/sources/task-field-updated-in-project/task-field-updated-in-project.mjs
+++ b/components/asana/sources/task-field-updated-in-project/task-field-updated-in-project.mjs
@@ -7,7 +7,7 @@ export default {
   type: "source",
   name: "New Task Field Updated In Project (Instant)",
   description: "Emit new event whenever given task fields are updated.",
-  version: "0.0.9",
+  version: "0.0.10",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/asana/sources/task-updated-in-project/task-updated-in-project.mjs
+++ b/components/asana/sources/task-updated-in-project/task-updated-in-project.mjs
@@ -7,7 +7,7 @@ export default {
   type: "source",
   name: "New Task Updated In Project (Instant)",
   description: "Emit new event for each update to a task.",
-  version: "1.1.9",
+  version: "1.1.10",
   dedupe: "unique",
   props: {
     ...common.props,


### PR DESCRIPTION
Resolves #20593 

The [Get multilple tasks endpoint](https://developers.asana.com/reference/gettasks) being used by action "Search Tasks" doesn't support searching by name, but is available to all users.

The [Search tasks in a workspace endpoint](https://developers.asana.com/reference/searchtasksforworkspace) supports a `text` prop, but is only available to premium users.

I chose to leave the "Search Tasks" action in place and added a "Search Tasks Premium" action that filters by name client-side.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Search Tasks Premium" with advanced filtering (project, assignee, section, text, completed/modified dates).

* **Bug Fixes**
  * Adjusted several Asana actions to reflect updated metadata and non-destructive annotations.

* **Chores**
  * Bumped package to 0.9.0 and incremented versions across multiple Asana actions and sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->