### PR TITLE
(google_drive) return fileId in download-file and stashFile

### DIFF
--- a/components/google_drive/actions/add-comment/add-comment.mjs
+++ b/components/google_drive/actions/add-comment/add-comment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-add-comment",
   name: "Add Comment",
   description: "Add an unanchored comment to a Google Doc (general feedback, no text highlighting). [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/comments/create)",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/add-file-sharing-preference/add-file-sharing-preference.mjs
+++ b/components/google_drive/actions/add-file-sharing-preference/add-file-sharing-preference.mjs
@@ -20,7 +20,7 @@ export default {
   name: "Share File or Folder",
   description:
     "Add a [sharing permission](https://support.google.com/drive/answer/7166529) to the sharing preferences of a file or folder and provide a sharing URL. [See the documentation](https://developers.google.com/drive/api/v3/reference/permissions/create)",
-  version: "0.2.12",
+  version: "0.2.13",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/copy-file/copy-file.mjs
+++ b/components/google_drive/actions/copy-file/copy-file.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-copy-file",
   name: "Copy File",
   description: "Create a copy of the specified file. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/copy) for more information",
-  version: "0.1.19",
+  version: "0.1.20",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/create-file-from-template/create-file-from-template.mjs
+++ b/components/google_drive/actions/create-file-from-template/create-file-from-template.mjs
@@ -9,7 +9,7 @@ export default {
   key: "google_drive-create-file-from-template",
   name: "Create New File From Template",
   description: "Create a new Google Docs file from a template. Optionally include placeholders in the template document that will get replaced from this action. [See documentation](https://www.npmjs.com/package/google-docs-mustaches)",
-  version: "0.1.22",
+  version: "0.1.23",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_drive/actions/create-file-from-text/create-file-from-text.mjs
+++ b/components/google_drive/actions/create-file-from-text/create-file-from-text.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_drive-create-file-from-text",
   name: "Create New File From Text",
   description: "Create a new file from plain text. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/create) for more information",
-  version: "0.2.12",
+  version: "0.2.13",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/create-folder/create-folder.mjs
+++ b/components/google_drive/actions/create-folder/create-folder.mjs
@@ -13,7 +13,7 @@ export default {
   key: "google_drive-create-folder",
   name: "Create Folder",
   description: "Create a new empty folder. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/create) for more information",
-  version: "0.1.20",
+  version: "0.1.21",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/create-shared-drive/create-shared-drive.mjs
+++ b/components/google_drive/actions/create-shared-drive/create-shared-drive.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-create-shared-drive",
   name: "Create Shared Drive",
   description: "Create a new shared drive. [See the documentation](https://developers.google.com/drive/api/v3/reference/drives/create) for more information",
-  version: "0.1.20",
+  version: "0.1.21",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/delete-comment/delete-comment.mjs
+++ b/components/google_drive/actions/delete-comment/delete-comment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-delete-comment",
   name: "Delete Comment",
   description: "Delete a specific comment (Requires ownership or permissions). [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/comments/delete)",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_drive/actions/delete-file/delete-file.mjs
+++ b/components/google_drive/actions/delete-file/delete-file.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Delete File",
   description:
     "Permanently delete a file or folder without moving it to the trash. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/delete) for more information",
-  version: "0.1.20",
+  version: "0.1.21",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_drive/actions/delete-reply/delete-reply.mjs
+++ b/components/google_drive/actions/delete-reply/delete-reply.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-delete-reply",
   name: "Delete Reply",
   description: "Delete a reply on a specific comment. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/replies/delete) for more information",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_drive/actions/delete-shared-drive/delete-shared-drive.mjs
+++ b/components/google_drive/actions/delete-shared-drive/delete-shared-drive.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-delete-shared-drive",
   name: "Delete Shared Drive",
   description: "Delete a shared drive without any content. [See the documentation](https://developers.google.com/drive/api/v3/reference/drives/delete) for more information",
-  version: "0.1.19",
+  version: "0.1.20",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_drive/actions/download-file/download-file.mjs
+++ b/components/google_drive/actions/download-file/download-file.mjs
@@ -18,7 +18,7 @@ export default {
   key: "google_drive-download-file",
   name: "Download File",
   description: "Download a file. [See the documentation](https://developers.google.com/drive/api/v3/manage-downloads) for more information",
-  version: "0.1.22",
+  version: "0.1.23",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -146,6 +146,7 @@ export default {
       const buffer = Buffer.concat(chunks);
 
       return {
+        fileId: this.fileId,
         fileMetadata,
         content: buffer,
       };
@@ -159,6 +160,7 @@ export default {
     await pipeline(file, fs.createWriteStream(filePath));
     $.export("$summary", `Successfully downloaded the file, "${fileMetadata.name}"`);
     return {
+      fileId: this.fileId,
       fileMetadata,
       filePath,
     };

--- a/components/google_drive/actions/find-file/find-file.mjs
+++ b/components/google_drive/actions/find-file/find-file.mjs
@@ -6,7 +6,7 @@ export default {
   key: "google_drive-find-file",
   name: "Find File",
   description: "Search for a specific file by name. [See the documentation](https://developers.google.com/drive/api/v3/search-files) for more information",
-  version: "0.1.19",
+  version: "0.1.20",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/find-folder/find-folder.mjs
+++ b/components/google_drive/actions/find-folder/find-folder.mjs
@@ -7,7 +7,7 @@ export default {
   key: "google_drive-find-folder",
   name: "Find Folder",
   description: "Search for a specific folder by name. [See the documentation](https://developers.google.com/drive/api/v3/search-files) for more information",
-  version: "0.1.19",
+  version: "0.1.20",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/find-forms/find-forms.mjs
+++ b/components/google_drive/actions/find-forms/find-forms.mjs
@@ -6,7 +6,7 @@ export default {
   key: "google_drive-find-forms",
   name: "Find Forms",
   description: "List Google Form documents or search for a Form by name. [See the documentation](https://developers.google.com/drive/api/v3/search-files) for more information",
-  version: "0.0.20",
+  version: "0.0.21",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/find-spreadsheets/find-spreadsheets.mjs
+++ b/components/google_drive/actions/find-spreadsheets/find-spreadsheets.mjs
@@ -6,7 +6,7 @@ export default {
   key: "google_drive-find-spreadsheets",
   name: "Find Spreadsheets",
   description: "Search for a specific spreadsheet by name. [See the documentation](https://developers.google.com/drive/api/v3/search-files) for more information",
-  version: "0.1.19",
+  version: "0.1.20",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/get-comment/get-comment.mjs
+++ b/components/google_drive/actions/get-comment/get-comment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-get-comment",
   name: "Get Comment By ID",
   description: "Get comment by ID on a specific file. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/comments/get) for more information",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/get-current-user/get-current-user.mjs
+++ b/components/google_drive/actions/get-current-user/get-current-user.mjs
@@ -6,7 +6,7 @@ export default {
   key: "google_drive-get-current-user",
   name: "Get Current User",
   description: "Retrieve Google Drive account metadata for the authenticated user via `about.get`, including display name, email, permission ID, and storage quota. Useful when flows or agents need to confirm the active Google identity or understand available storage. [See the documentation](https://developers.google.com/drive/api/v3/reference/about/get).",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/google_drive/actions/get-file-by-id/get-file-by-id.mjs
+++ b/components/google_drive/actions/get-file-by-id/get-file-by-id.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_drive-get-file-by-id",
   name: "Get File By ID",
   description: "Get info on a specific file. [See the documentation](https://developers.google.com/drive/api/reference/rest/v3/files/get) for more information",
-  version: "0.0.16",
+  version: "0.0.17",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/get-folder-id-for-path/get-folder-id-for-path.mjs
+++ b/components/google_drive/actions/get-folder-id-for-path/get-folder-id-for-path.mjs
@@ -12,7 +12,7 @@ export default {
   key: "google_drive-get-folder-id-for-path",
   name: "Get Folder ID for a Path",
   description: "Retrieve a folderId for a path. [See the documentation](https://developers.google.com/drive/api/v3/search-files) for more information",
-  version: "0.1.21",
+  version: "0.1.22",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/get-reply/get-reply.mjs
+++ b/components/google_drive/actions/get-reply/get-reply.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-get-reply",
   name: "Get Reply By ID",
   description: "Get reply by ID on a specific comment. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/replies/get) for more information",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/get-shared-drive/get-shared-drive.mjs
+++ b/components/google_drive/actions/get-shared-drive/get-shared-drive.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-get-shared-drive",
   name: "Get Shared Drive",
   description: "Get metadata for one or all shared drives. [See the documentation](https://developers.google.com/drive/api/v3/reference/drives/get) for more information",
-  version: "0.1.19",
+  version: "0.1.20",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/list-access-proposals/list-access-proposals.mjs
+++ b/components/google_drive/actions/list-access-proposals/list-access-proposals.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-list-access-proposals",
   name: "List Access Proposals",
   description: "List access proposals for a file or folder. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/accessproposals/list)",
-  version: "0.0.12",
+  version: "0.0.13",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/list-comments/list-comments.mjs
+++ b/components/google_drive/actions/list-comments/list-comments.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-list-comments",
   name: "List Comments",
   description: "List all comments on a file. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/comments/list)",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/list-files/list-files.mjs
+++ b/components/google_drive/actions/list-files/list-files.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_drive-list-files",
   name: "List Files",
   description: "List files from a specific folder. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/list) for more information",
-  version: "0.2.1",
+  version: "0.2.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/list-replies/list-replies.mjs
+++ b/components/google_drive/actions/list-replies/list-replies.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-list-replies",
   name: "List Replies",
   description: "List replies to a specific comment. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/replies/list) for more information",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/move-file-to-trash/move-file-to-trash.mjs
+++ b/components/google_drive/actions/move-file-to-trash/move-file-to-trash.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_drive-move-file-to-trash",
   name: "Move File to Trash",
   description: "Move a file or folder to trash. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/update) for more information",
-  version: "0.1.19",
+  version: "0.1.20",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_drive/actions/move-file/move-file.mjs
+++ b/components/google_drive/actions/move-file/move-file.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-move-file",
   name: "Move File",
   description: "Move a file from one folder to another. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/update) for more information",
-  version: "0.1.19",
+  version: "0.1.20",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_drive/actions/remove-file-sharing-permission/remove-file-sharing-permission.mjs
+++ b/components/google_drive/actions/remove-file-sharing-permission/remove-file-sharing-permission.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Remove File Sharing Permission",
   description:
     "Remove a [sharing permission](https://support.google.com/drive/answer/7166529) from the sharing preferences of a file or folder. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/permissions/delete)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_drive/actions/reply-to-comment/reply-to-comment.mjs
+++ b/components/google_drive/actions/reply-to-comment/reply-to-comment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-reply-to-comment",
   name: "Reply to Comment",
   description: "Add a reply to an existing comment. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/replies/create)",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/resolve-access-proposal/resolve-access-proposal.mjs
+++ b/components/google_drive/actions/resolve-access-proposal/resolve-access-proposal.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_drive-resolve-access-proposal",
   name: "Resolve Access Proposals",
   description: "Accept or deny a request for access to a file or folder in Google Drive. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/accessproposals/resolve)",
-  version: "0.0.12",
+  version: "0.0.13",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/resolve-comment/resolve-comment.mjs
+++ b/components/google_drive/actions/resolve-comment/resolve-comment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-resolve-comment",
   name: "Resolve Comment",
   description: "Mark a comment as resolved. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/comments/update)",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_drive/actions/search-shared-drives/search-shared-drives.mjs
+++ b/components/google_drive/actions/search-shared-drives/search-shared-drives.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-search-shared-drives",
   name: "Search for Shared Drives",
   description: "Search for shared drives with query options. [See the documentation](https://developers.google.com/drive/api/v3/search-shareddrives) for more information",
-  version: "0.1.20",
+  version: "0.1.21",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/update-comment/update-comment.mjs
+++ b/components/google_drive/actions/update-comment/update-comment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-update-comment",
   name: "Update Comment",
   description: "Update the content of a specific comment. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/comments/update) for more information",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/update-file/update-file.mjs
+++ b/components/google_drive/actions/update-file/update-file.mjs
@@ -6,7 +6,7 @@ export default {
   key: "google_drive-update-file",
   name: "Update File",
   description: "Update a file's metadata and/or content. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/update) for more information",
-  version: "2.0.11",
+  version: "2.0.12",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_drive/actions/update-reply/update-reply.mjs
+++ b/components/google_drive/actions/update-reply/update-reply.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-update-reply",
   name: "Update Reply",
   description: "Update a reply on a specific comment. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/replies/update) for more information",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/update-shared-drive/update-shared-drive.mjs
+++ b/components/google_drive/actions/update-shared-drive/update-shared-drive.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-update-shared-drive",
   name: "Update Shared Drive",
   description: "Update an existing shared drive. [See the documentation](https://developers.google.com/drive/api/v3/reference/drives/update) for more information",
-  version: "0.1.19",
+  version: "0.1.20",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_drive/actions/upload-file/upload-file.mjs
+++ b/components/google_drive/actions/upload-file/upload-file.mjs
@@ -13,7 +13,7 @@ export default {
   key: "google_drive-upload-file",
   name: "Upload File",
   description: "Upload a file to Google Drive. [See the documentation](https://developers.google.com/drive/api/v3/manage-uploads) for more information",
-  version: "2.0.12",
+  version: "2.0.13",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/common/utils.mjs
+++ b/components/google_drive/common/utils.mjs
@@ -302,8 +302,12 @@ async function stashFile(item, googleDrive, dir) {
     buffer.length,
   );
   // Return file details and temporary download link:
-  // { path, get_url, s3Key, type }
-  return await file.withoutPutUrl().withGetUrl();
+  // { fileId, path, get_url, s3Key, type }
+  const stashedFile = await file.withoutPutUrl().withGetUrl();
+  return {
+    fileId: item.id,
+    ...stashedFile,
+  };
 }
 
 export {

--- a/components/google_drive/package.json
+++ b/components/google_drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_drive",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Pipedream Google_drive Components",
   "main": "google_drive.app.mjs",
   "keywords": [

--- a/components/google_drive/sources/changes-to-files-in-drive/changes-to-files-in-drive.mjs
+++ b/components/google_drive/sources/changes-to-files-in-drive/changes-to-files-in-drive.mjs
@@ -14,7 +14,7 @@ export default {
   key: "google_drive-changes-to-files-in-drive",
   name: "Changes to Files in Drive",
   description: "Emit new event when a change is made to one of the specified files. [See the documentation](https://developers.google.com/drive/api/v3/reference/changes/watch)",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_drive/sources/changes-to-specific-files-shared-drive/changes-to-specific-files-shared-drive.mjs
+++ b/components/google_drive/sources/changes-to-specific-files-shared-drive/changes-to-specific-files-shared-drive.mjs
@@ -29,7 +29,7 @@ export default {
   key: "google_drive-changes-to-specific-files-shared-drive",
   name: "Changes to Specific Files (Shared Drive)",
   description: "Watches for changes to specific files in a shared drive, emitting an event when a change is made to one of those files",
-  version: "0.3.7",
+  version: "0.3.8",
   type: "source",
   // Dedupe events based on the "x-goog-message-number" header for the target channel:
   // https://developers.google.com/drive/api/v3/push#making-watch-requests

--- a/components/google_drive/sources/changes-to-specific-files/changes-to-specific-files.mjs
+++ b/components/google_drive/sources/changes-to-specific-files/changes-to-specific-files.mjs
@@ -16,7 +16,7 @@ export default {
   key: "google_drive-changes-to-specific-files",
   name: "Changes to Specific Files",
   description: "Watches for changes to specific files, emitting an event when a change is made to one of those files. To watch for changes to [shared drive](https://support.google.com/a/users/answer/9310351) files, use the **Changes to Specific Files (Shared Drive)** source instead.",
-  version: "0.3.6",
+  version: "0.3.7",
   type: "source",
   // Dedupe events based on the "x-goog-message-number" header for the target channel:
   // https://developers.google.com/drive/api/v3/push#making-watch-requests

--- a/components/google_drive/sources/new-access-proposal/new-access-proposal.mjs
+++ b/components/google_drive/sources/new-access-proposal/new-access-proposal.mjs
@@ -6,7 +6,7 @@ export default {
   key: "google_drive-new-access-proposal",
   name: "New Access Proposal",
   description: "Emit new event when a new access proposal is requested in Google Drive",
-  version: "0.0.11",
+  version: "0.0.12",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_drive/sources/new-files-instant-polling/new-files-instant-polling.mjs
+++ b/components/google_drive/sources/new-files-instant-polling/new-files-instant-polling.mjs
@@ -8,7 +8,7 @@ export default {
   key: "google_drive-new-files-instant-polling",
   name: "New Files (Polling)",
   description: "Emit new event when a new file is added in your linked Google Drive",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_drive/sources/new-files-instant/new-files-instant.mjs
+++ b/components/google_drive/sources/new-files-instant/new-files-instant.mjs
@@ -11,7 +11,7 @@ export default {
   key: "google_drive-new-files-instant",
   name: "New Files (Instant)",
   description: "Emit new event when a new file is added in your linked Google Drive",
-  version: "0.2.7",
+  version: "0.2.8",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_drive/sources/new-files-shared-drive/new-files-shared-drive.mjs
+++ b/components/google_drive/sources/new-files-shared-drive/new-files-shared-drive.mjs
@@ -7,7 +7,7 @@ export default {
   key: "google_drive-new-files-shared-drive",
   name: "New Files (Shared Drive)",
   description: "Emit new event when a new file is added in your shared Google Drive",
-  version: "0.1.7",
+  version: "0.1.8",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_drive/sources/new-or-modified-comments-polling/new-or-modified-comments-polling.mjs
+++ b/components/google_drive/sources/new-or-modified-comments-polling/new-or-modified-comments-polling.mjs
@@ -7,7 +7,7 @@ export default {
   key: "google_drive-new-or-modified-comments-polling",
   name: "New or Modified Comments (Polling)",
   description: "Emit new event when a comment is created or modified in the selected file",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_drive/sources/new-or-modified-comments/new-or-modified-comments.mjs
+++ b/components/google_drive/sources/new-or-modified-comments/new-or-modified-comments.mjs
@@ -18,7 +18,7 @@ export default {
   name: "New or Modified Comments (Instant)",
   description:
     "Emit new event when a comment is created or modified in the selected file",
-  version: "1.0.16",
+  version: "1.0.17",
   type: "source",
   // Dedupe events based on the "x-goog-message-number" header for the target channel:
   // https://developers.google.com/drive/api/v3/push#making-watch-requests

--- a/components/google_drive/sources/new-or-modified-files-polling/new-or-modified-files-polling.mjs
+++ b/components/google_drive/sources/new-or-modified-files-polling/new-or-modified-files-polling.mjs
@@ -9,7 +9,7 @@ export default {
   key: "google_drive-new-or-modified-files-polling",
   name: "New or Modified Files (Polling)",
   description: "Emit new event when a file in the selected Drive is created, modified or trashed. [See the documentation](https://developers.google.com/drive/api/v3/reference/changes/list)",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_drive/sources/new-or-modified-files/new-or-modified-files.mjs
+++ b/components/google_drive/sources/new-or-modified-files/new-or-modified-files.mjs
@@ -26,7 +26,7 @@ export default {
   key: "google_drive-new-or-modified-files",
   name: "New or Modified Files (Instant)",
   description: "Emit new event when a file in the selected Drive is created, modified or trashed.",
-  version: "0.4.7",
+  version: "0.4.8",
   type: "source",
   // Dedupe events based on the "x-goog-message-number" header for the target channel:
   // https://developers.google.com/drive/api/v3/push#making-watch-requests

--- a/components/google_drive/sources/new-or-modified-folders-polling/new-or-modified-folders-polling.mjs
+++ b/components/google_drive/sources/new-or-modified-folders-polling/new-or-modified-folders-polling.mjs
@@ -12,7 +12,7 @@ export default {
   key: "google_drive-new-or-modified-folders-polling",
   name: "New or Modified Folders (Polling)",
   description: "Emit new event when a folder is created or modified in the selected Drive",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_drive/sources/new-or-modified-folders/new-or-modified-folders.mjs
+++ b/components/google_drive/sources/new-or-modified-folders/new-or-modified-folders.mjs
@@ -21,7 +21,7 @@ export default {
   key: "google_drive-new-or-modified-folders",
   name: "New or Modified Folders (Instant)",
   description: "Emit new event when a folder is created or modified in the selected Drive",
-  version: "0.2.10",
+  version: "0.2.11",
   type: "source",
   // Dedupe events based on the "x-goog-message-number" header for the target channel:
   // https://developers.google.com/drive/api/v3/push#making-watch-requests

--- a/components/google_drive/sources/new-shared-drive/new-shared-drive.mjs
+++ b/components/google_drive/sources/new-shared-drive/new-shared-drive.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_drive-new-shared-drive",
   name: "New Shared Drive",
   description: "Emits a new event any time a shared drive is created.",
-  version: "0.1.18",
+  version: "0.1.19",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_drive/sources/new-spreadsheet-polling/new-spreadsheet-polling.mjs
+++ b/components/google_drive/sources/new-spreadsheet-polling/new-spreadsheet-polling.mjs
@@ -8,7 +8,7 @@ export default {
   key: "google_drive-new-spreadsheet-polling",
   name: "New Spreadsheet (Polling)",
   description: "Emit new event when a new spreadsheet is created in a drive.",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_drive/sources/new-spreadsheet/new-spreadsheet.mjs
+++ b/components/google_drive/sources/new-spreadsheet/new-spreadsheet.mjs
@@ -6,7 +6,7 @@ export default {
   type: "source",
   name: "New Spreadsheet (Instant)",
   description: "Emit new event when a new spreadsheet is created in a drive.",
-  version: "0.1.21",
+  version: "0.1.22",
   props: {
     googleDrive: newFilesInstant.props.googleDrive,
     db: newFilesInstant.props.db,


### PR DESCRIPTION
## Summary

- `download-file.mjs`: adds `fileId: this.fileId` to both return paths (buffer and filePath). The file ID was already available as an input prop but was never included in the response, leaving callers with no durable reference once File Stash's 24h TTL expires.
- `common/utils.mjs` → `stashFile`: adds `fileId: item.id` to the return value so event sources propagate the Google Drive file ID alongside the existing File Stash fields.

Both changes are additive and non-breaking. No existing keys are renamed or removed.

## Test plan

- [ ] Call `google_drive-download-file` with a known file ID using the buffer path — confirm `fileId` is present in the response and matches the input
- [ ] Call `google_drive-download-file` using the filePath path — confirm `fileId` is present in the response
- [ ] Trigger an event source that calls `stashFile` (e.g. New File trigger) — confirm `fileId` appears in the emitted event payload and existing fields (`path`, `get_url`, `s3Key`, `type`) are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Download action now returns the Google Drive file ID alongside file metadata and content/file path.
  * Stored/stashed file records now include the original Google Drive file ID with existing file metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->