### PR TITLE
pdfcrowd: add label/description to syncDir prop

### DIFF
--- a/components/pdfcrowd/actions/html-to-pdf/html-to-pdf.mjs
+++ b/components/pdfcrowd/actions/html-to-pdf/html-to-pdf.mjs
@@ -6,7 +6,7 @@ export default {
   key: "pdfcrowd-html-to-pdf",
   name: "Convert HTML to PDF",
   description: "Convert URL or HTML to PDF. [See docs](https://pdfcrowd.com/api/)",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -118,6 +118,9 @@ export default {
       type: "dir",
       accessMode: "write",
       sync: true,
+      label: "Sync Directory",
+      description: "Directory used for saving the generated PDF to `/tmp` so it can be referenced by later steps in the same workflow.",
+      optional: true,
     },
   },
   additionalProps() {

--- a/components/pdfcrowd/package.json
+++ b/components/pdfcrowd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/pdfcrowd",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream PDFCrowd Components",
   "main": "pdfcrowd.app.mjs",
   "keywords": [


### PR DESCRIPTION
Addresses CodeRabbit review comment on #20285: the syncDir prop was declared without user-facing label or description and as required, even though run() already tolerates write failures. Adds label and description for clarity and marks it optional.

## WHY

- Addresses a CodeRabbit review comment on #20285 that was flagged minutes
    before that PR merged.                                                  
  - The `syncDir` prop on the Convert HTML to PDF action had no label or                                                                                         
    description and was required, even though run() already tolerates write
    failures.                                                                                                                                                    
  - Adds a user-facing label and description and marks the prop `optional: true`.
  - Bumps action version 0.1.0 → 0.1.1 and package version 0.2.0 → 0.2.1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added optional temporary directory option to save generated PDFs for use in subsequent workflow steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->