### PR TITLE
Datadog: use region from auth; remove per-component region prop

### DIFF
--- a/components/datadog/actions/common/log-props.mjs
+++ b/components/datadog/actions/common/log-props.mjs
@@ -2,12 +2,6 @@ import datadog from "../../datadog.app.mjs";
 
 export default {
   datadog,
-  region: {
-    propDefinition: [
-      datadog,
-      "region",
-    ],
-  },
   query: {
     type: "string",
     label: "Query",

--- a/components/datadog/actions/get-account-info/get-account-info.mjs
+++ b/components/datadog/actions/get-account-info/get-account-info.mjs
@@ -15,7 +15,7 @@ export default {
     + " **Get Metric Data**, and all other Datadog tools."
     + " [See the docs](https://docs.datadoghq.com/api/"
     + "latest/authentication/#validate-api-key)",
-  version: "0.0.3",
+  version: "1.0.0",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/datadog/actions/get-account-info/get-account-info.mjs
+++ b/components/datadog/actions/get-account-info/get-account-info.mjs
@@ -15,7 +15,7 @@ export default {
     + " **Get Metric Data**, and all other Datadog tools."
     + " [See the docs](https://docs.datadoghq.com/api/"
     + "latest/authentication/#validate-api-key)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/datadog/actions/get-metric-data/get-metric-data.mjs
+++ b/components/datadog/actions/get-metric-data/get-metric-data.mjs
@@ -17,7 +17,7 @@ export default {
     + " [See the docs](https://docs.datadoghq.com/api/"
     + "latest/metrics/#query-timeseries-data-across"
     + "-multiple-products)",
-  version: "0.0.3",
+  version: "1.0.0",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/datadog/actions/get-metric-data/get-metric-data.mjs
+++ b/components/datadog/actions/get-metric-data/get-metric-data.mjs
@@ -17,7 +17,7 @@ export default {
     + " [See the docs](https://docs.datadoghq.com/api/"
     + "latest/metrics/#query-timeseries-data-across"
     + "-multiple-products)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -26,12 +26,6 @@ export default {
   },
   props: {
     datadog,
-    region: {
-      propDefinition: [
-        datadog,
-        "region",
-      ],
-    },
     query: {
       type: "string",
       label: "Query",
@@ -65,7 +59,6 @@ export default {
         from: this.from,
         to: this.to,
       },
-      region: this.region,
     });
 
     const count = response?.series?.length ?? 0;

--- a/components/datadog/actions/post-metric-data/post-metric-data.mjs
+++ b/components/datadog/actions/post-metric-data/post-metric-data.mjs
@@ -16,7 +16,7 @@ export default {
     + " appends data to a metric time series."
     + " [See the docs](https://docs.datadoghq.com/"
     + "metrics)",
-  version: "0.1.5",
+  version: "0.1.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -25,19 +25,10 @@ export default {
   type: "action",
   props: {
     datadog,
-    region: {
-      propDefinition: [
-        datadog,
-        "region",
-      ],
-    },
     metric: {
       propDefinition: [
         datadog,
         "metric",
-        (c) => ({
-          region: c.region,
-        }),
       ],
     },
     points: {
@@ -65,7 +56,6 @@ export default {
           },
         ],
       },
-      region: this.region,
     });
 
     $.export("$summary", `Posted to ${this.metric} timeseries`);

--- a/components/datadog/actions/post-metric-data/post-metric-data.mjs
+++ b/components/datadog/actions/post-metric-data/post-metric-data.mjs
@@ -16,7 +16,7 @@ export default {
     + " appends data to a metric time series."
     + " [See the docs](https://docs.datadoghq.com/"
     + "metrics)",
-  version: "0.1.6",
+  version: "1.0.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/datadog/actions/search-dashboards/search-dashboards.mjs
+++ b/components/datadog/actions/search-dashboards/search-dashboards.mjs
@@ -11,7 +11,7 @@ export default {
     + " dashboards related to a specific service."
     + " [See the docs](https://docs.datadoghq.com/api/"
     + "latest/dashboards/#get-all-dashboards)",
-  version: "0.0.3",
+  version: "1.0.0",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/datadog/actions/search-dashboards/search-dashboards.mjs
+++ b/components/datadog/actions/search-dashboards/search-dashboards.mjs
@@ -5,15 +5,13 @@ export default {
   name: "Search Dashboards",
   description:
     "List and search Datadog dashboards. Returns"
-    + " dashboard IDs, titles, URLs, and metadata."
-    + " Dashboard URL:"
-    + " `https://app.{region}/dashboard/{id}` where"
-    + " region comes from **Get Account Info**. Use"
-    + " alongside **Search Services** to find"
+    + " dashboard IDs, titles, metadata, and a"
+    + " ready-to-use `dashboard_url` for each result."
+    + " Use alongside **Search Services** to find"
     + " dashboards related to a specific service."
     + " [See the docs](https://docs.datadoghq.com/api/"
     + "latest/dashboards/#get-all-dashboards)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -22,12 +20,6 @@ export default {
   },
   props: {
     datadog,
-    region: {
-      propDefinition: [
-        datadog,
-        "region",
-      ],
-    },
     filterShared: {
       type: "boolean",
       label: "Shared Only",
@@ -59,8 +51,15 @@ export default {
     const response = await this.datadog.listDashboards({
       $,
       params,
-      region: this.region,
     });
+
+    const region = this.datadog._region();
+    if (Array.isArray(response?.dashboards)) {
+      response.dashboards = response.dashboards.map((d) => ({
+        ...d,
+        dashboard_url: `https://app.${region}/dashboard/${d.id}`,
+      }));
+    }
 
     const count = response?.dashboards?.length ?? 0;
     $.export(

--- a/components/datadog/actions/search-events/search-events.mjs
+++ b/components/datadog/actions/search-events/search-events.mjs
@@ -17,7 +17,7 @@ export default {
     + " **Search Logs** for deeper investigation."
     + " [See the docs](https://docs.datadoghq.com/api/"
     + "latest/events/#get-a-list-of-events)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -26,12 +26,6 @@ export default {
   },
   props: {
     datadog,
-    region: {
-      propDefinition: [
-        datadog,
-        "region",
-      ],
-    },
     start: {
       type: "integer",
       label: "Start",
@@ -88,7 +82,6 @@ export default {
     const response = await this.datadog.getEvents({
       $,
       params,
-      region: this.region,
     });
 
     const count = response?.events?.length ?? 0;

--- a/components/datadog/actions/search-events/search-events.mjs
+++ b/components/datadog/actions/search-events/search-events.mjs
@@ -17,7 +17,7 @@ export default {
     + " **Search Logs** for deeper investigation."
     + " [See the docs](https://docs.datadoghq.com/api/"
     + "latest/events/#get-a-list-of-events)",
-  version: "0.0.3",
+  version: "1.0.0",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/datadog/actions/search-hosts/search-hosts.mjs
+++ b/components/datadog/actions/search-hosts/search-hosts.mjs
@@ -17,7 +17,7 @@ export default {
     + " [See the docs](https://docs.datadoghq.com/api/"
     + "latest/hosts/"
     + "#get-all-hosts-for-your-organization)",
-  version: "0.0.3",
+  version: "1.0.0",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/datadog/actions/search-hosts/search-hosts.mjs
+++ b/components/datadog/actions/search-hosts/search-hosts.mjs
@@ -17,7 +17,7 @@ export default {
     + " [See the docs](https://docs.datadoghq.com/api/"
     + "latest/hosts/"
     + "#get-all-hosts-for-your-organization)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -26,12 +26,6 @@ export default {
   },
   props: {
     datadog,
-    region: {
-      propDefinition: [
-        datadog,
-        "region",
-      ],
-    },
     filter: {
       type: "string",
       label: "Filter",
@@ -81,7 +75,6 @@ export default {
     const response = await this.datadog.listHosts({
       $,
       params,
-      region: this.region,
     });
 
     const count = response?.hostList?.length

--- a/components/datadog/actions/search-incidents/search-incidents.mjs
+++ b/components/datadog/actions/search-incidents/search-incidents.mjs
@@ -14,7 +14,7 @@ export default {
     + " and **Search Services** for ownership info."
     + " [See the docs](https://docs.datadoghq.com/api/"
     + "latest/incidents/#get-a-list-of-incidents)",
-  version: "0.0.3",
+  version: "1.0.0",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/datadog/actions/search-incidents/search-incidents.mjs
+++ b/components/datadog/actions/search-incidents/search-incidents.mjs
@@ -14,7 +14,7 @@ export default {
     + " and **Search Services** for ownership info."
     + " [See the docs](https://docs.datadoghq.com/api/"
     + "latest/incidents/#get-a-list-of-incidents)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -23,12 +23,6 @@ export default {
   },
   props: {
     datadog,
-    region: {
-      propDefinition: [
-        datadog,
-        "region",
-      ],
-    },
     query: {
       type: "string",
       label: "Query",
@@ -61,7 +55,6 @@ export default {
     const response = await this.datadog.listIncidents({
       $,
       params,
-      region: this.region,
     });
 
     const count = response?.data?.length ?? 0;

--- a/components/datadog/actions/search-logs/search-logs.mjs
+++ b/components/datadog/actions/search-logs/search-logs.mjs
@@ -16,7 +16,7 @@ export default {
     + " search logs for that time window and service."
     + " [See the docs](https://docs.datadoghq.com/api/"
     + "latest/logs/#search-logs)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -45,7 +45,6 @@ export default {
     const response = await this.datadog.searchLogs({
       $,
       data: body,
-      region: this.region,
     });
 
     const count = response?.data?.length ?? 0;

--- a/components/datadog/actions/search-logs/search-logs.mjs
+++ b/components/datadog/actions/search-logs/search-logs.mjs
@@ -16,7 +16,7 @@ export default {
     + " search logs for that time window and service."
     + " [See the docs](https://docs.datadoghq.com/api/"
     + "latest/logs/#search-logs)",
-  version: "0.0.3",
+  version: "1.0.0",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/datadog/actions/search-metrics/search-metrics.mjs
+++ b/components/datadog/actions/search-metrics/search-metrics.mjs
@@ -14,7 +14,7 @@ export default {
     + " the `host` filter."
     + " [See the docs](https://docs.datadoghq.com/api/"
     + "latest/metrics/#get-active-metrics-list)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -23,12 +23,6 @@ export default {
   },
   props: {
     datadog,
-    region: {
-      propDefinition: [
-        datadog,
-        "region",
-      ],
-    },
     host: {
       type: "string",
       label: "Host",
@@ -44,7 +38,6 @@ export default {
         from: 1,
         host: this.host,
       },
-      region: this.region,
     });
 
     const count = response?.metrics?.length ?? 0;

--- a/components/datadog/actions/search-metrics/search-metrics.mjs
+++ b/components/datadog/actions/search-metrics/search-metrics.mjs
@@ -14,7 +14,7 @@ export default {
     + " the `host` filter."
     + " [See the docs](https://docs.datadoghq.com/api/"
     + "latest/metrics/#get-active-metrics-list)",
-  version: "0.0.3",
+  version: "1.0.0",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/datadog/actions/search-monitors/search-monitors.mjs
+++ b/components/datadog/actions/search-monitors/search-monitors.mjs
@@ -15,7 +15,7 @@ export default {
     + " ID, name, type, query, status, and tags."
     + " [See the docs](https://docs.datadoghq.com/api/"
     + "latest/monitors/#get-all-monitor-details)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -24,12 +24,6 @@ export default {
   },
   props: {
     datadog,
-    region: {
-      propDefinition: [
-        datadog,
-        "region",
-      ],
-    },
     query: {
       type: "string",
       label: "Query",
@@ -70,7 +64,6 @@ export default {
     const response = await this.datadog.listMonitors({
       $,
       params,
-      region: this.region,
     });
 
     const count = Array.isArray(response)

--- a/components/datadog/actions/search-monitors/search-monitors.mjs
+++ b/components/datadog/actions/search-monitors/search-monitors.mjs
@@ -15,7 +15,7 @@ export default {
     + " ID, name, type, query, status, and tags."
     + " [See the docs](https://docs.datadoghq.com/api/"
     + "latest/monitors/#get-all-monitor-details)",
-  version: "0.0.3",
+  version: "1.0.0",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/datadog/actions/search-services/search-services.mjs
+++ b/components/datadog/actions/search-services/search-services.mjs
@@ -14,7 +14,7 @@ export default {
     + " [See the docs](https://docs.datadoghq.com/api/"
     + "latest/service-definition/"
     + "#get-all-service-definitions)",
-  version: "0.0.3",
+  version: "1.0.0",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/datadog/actions/search-services/search-services.mjs
+++ b/components/datadog/actions/search-services/search-services.mjs
@@ -14,7 +14,7 @@ export default {
     + " [See the docs](https://docs.datadoghq.com/api/"
     + "latest/service-definition/"
     + "#get-all-service-definitions)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -23,12 +23,6 @@ export default {
   },
   props: {
     datadog,
-    region: {
-      propDefinition: [
-        datadog,
-        "region",
-      ],
-    },
     pageSize: {
       type: "integer",
       label: "Page Size",
@@ -51,7 +45,6 @@ export default {
     const response = await this.datadog.listServices({
       $,
       params,
-      region: this.region,
     });
 
     const count = response?.data?.length ?? 0;

--- a/components/datadog/datadog.app.mjs
+++ b/components/datadog/datadog.app.mjs
@@ -3,7 +3,6 @@ import {
 } from "@pipedream/platform";
 import { v4 as uuid } from "uuid";
 import constants from "./actions/common/constants.mjs";
-import regions from "./common/constants.mjs";
 
 export default {
   type: "app",
@@ -35,15 +34,12 @@ export default {
       type: "string",
       label: "Metric",
       description: "The name of the timeseries",
-      async options({
-        host, region,
-      }) {
+      async options({ host }) {
         const { metrics } = await this.listActiveMetrics({
           params: {
             from: 1,
             host,
           },
-          region,
         });
         return metrics;
       },
@@ -53,14 +49,11 @@ export default {
       label: "Tags",
       description: "A list of tags associated with the metric",
       optional: true,
-      async options({
-        hostName, region,
-      }) {
+      async options({ hostName }) {
         const { tags } = await this.listTags({
           query: {
             hostName,
           },
-          region,
         });
         return tags;
       },
@@ -75,15 +68,12 @@ export default {
       type: "integer[]",
       label: "Monitors",
       description: "The monitors to observe for notifications",
-      async options({
-        page, region,
-      }) {
+      async options({ page }) {
         const monitors = await this.listMonitors({
           query: {
             page,
             pageSize: 1000,
           },
-          region,
         });
         if (!(monitors?.length > 0)) {
           throw new ConfigurationError("No Monitors Found");
@@ -94,12 +84,6 @@ export default {
         }));
       },
     },
-    region: {
-      type: "string",
-      label: "Region",
-      description: "The regional site for a Datadog customer",
-      options: regions.REGION_OPTIONS,
-    },
   },
   methods: {
     _apiKey() {
@@ -108,14 +92,17 @@ export default {
     _applicationKey() {
       return this.$auth.application_key;
     },
-    _apiUrl(region) {
-      return `https://api.${region}/api`;
+    _region() {
+      return this.$auth.region ?? "datadoghq.com";
+    },
+    _apiUrl() {
+      return `https://api.${this._region()}/api`;
     },
     async _makeRequest({
-      $ = this, path, region, ...args
+      $ = this, path, ...args
     }) {
       return axios($ ?? this, {
-        url: `${this._apiUrl(region)}${path}`,
+        url: `${this._apiUrl()}${path}`,
         headers: {
           "DD-API-KEY": this._apiKey(),
           "DD-APPLICATION-KEY": this._applicationKey(),
@@ -133,10 +120,9 @@ export default {
       const { headers } = event;
       return headers[this._webhookSecretKeyHeader()] === secretKey;
     },
-    async _getMonitor(monitorId, region) {
+    async _getMonitor(monitorId) {
       return this._makeRequest({
         path: `/v1/monitor/${monitorId}`,
-        region,
       });
     },
     async _editMonitor({
@@ -177,7 +163,6 @@ export default {
     async createWebhook(
       url,
       payloadFormat = null,
-      region,
       secretKey = uuid(),
     ) {
       const name = `pd-${uuid()}`;
@@ -193,7 +178,6 @@ export default {
           name,
           url,
         },
-        region,
       });
 
       return {
@@ -201,17 +185,16 @@ export default {
         secretKey,
       };
     },
-    async deleteWebhook(webhookName, region) {
+    async deleteWebhook(webhookName) {
       if (!webhookName) return;
 
       await this._makeRequest({
         path: `/v1/integration/webhooks/configuration/webhooks/${webhookName}`,
         method: "delete",
-        region,
       });
     },
-    async addWebhookNotification(webhookName, monitorId, region) {
-      const { message } = await this._getMonitor(monitorId, region);
+    async addWebhookNotification(webhookName, monitorId) {
+      const { message } = await this._getMonitor(monitorId);
       const webhookTagPattern = this._webhookTagPattern(webhookName);
       if (new RegExp(webhookTagPattern).test(message)) {
         // Monitor is already notifying this webhook
@@ -225,14 +208,9 @@ export default {
         data: {
           message: newMessage,
         },
-        region,
       });
     },
-    async removeWebhookNotifications(webhookName, region) {
-      // Users could have manually added this webhook in other monitors, or
-      // removed the webhook from the monitors specified as user props. Hence,
-      // we need to search through all the monitors that notify this webhook and
-      // remove the notification.
+    async removeWebhookNotifications(webhookName) {
       const webhookTagPattern = new RegExp(
         `\n?${this._webhookTagPattern(webhookName)}`,
       );
@@ -240,11 +218,10 @@ export default {
         query: {
           query: webhookName,
         },
-        region,
       });
       for await (const monitorInfo of monitorSearchResults) {
         const { id: monitorId } = monitorInfo;
-        const { message } = await this._getMonitor(monitorId, region);
+        const { message } = await this._getMonitor(monitorId);
 
         if (!new RegExp(webhookTagPattern).test(message)) {
           // Monitor is not notifying this webhook, skip it...
@@ -258,7 +235,6 @@ export default {
         await this._editMonitor({
           monitorId,
           data: monitorChanges,
-          region,
         });
       }
     },
@@ -325,6 +301,26 @@ export default {
     async listDashboards(args) {
       return this._makeRequest({
         path: "/v1/dashboard",
+        ...args,
+      });
+    },
+    async createDashboard(args) {
+      return this._makeRequest({
+        path: "/v1/dashboard",
+        method: "post",
+        ...args,
+      });
+    },
+    async createMonitor(args) {
+      return this._makeRequest({
+        path: "/v1/monitor",
+        method: "post",
+        ...args,
+      });
+    },
+    async listSyntheticTests(args) {
+      return this._makeRequest({
+        path: "/v1/synthetics/tests",
         ...args,
       });
     },

--- a/components/datadog/package.json
+++ b/components/datadog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/datadog",
-  "version": "0.5.0",
+  "version": "1.0.0",
   "description": "Pipedream Datadog Components",
   "main": "datadog.app.mjs",
   "keywords": [

--- a/components/datadog/package.json
+++ b/components/datadog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/datadog",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Pipedream Datadog Components",
   "main": "datadog.app.mjs",
   "keywords": [

--- a/components/datadog/sources/new-monitor-event/new-monitor-event.mjs
+++ b/components/datadog/sources/new-monitor-event/new-monitor-event.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Monitor Event (Instant)",
   description: "Emit new events captured by a Datadog monitor",
   dedupe: "unique",
-  version: "0.1.5",
+  version: "1.0.0",
   type: "source",
   props: {
     datadog,

--- a/components/datadog/sources/new-monitor-event/new-monitor-event.mjs
+++ b/components/datadog/sources/new-monitor-event/new-monitor-event.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Monitor Event (Instant)",
   description: "Emit new events captured by a Datadog monitor",
   dedupe: "unique",
-  version: "0.1.4",
+  version: "0.1.5",
   type: "source",
   props: {
     datadog,
@@ -15,19 +15,10 @@ export default {
       type: "$.interface.http",
       customResponse: true,
     },
-    region: {
-      propDefinition: [
-        datadog,
-        "region",
-      ],
-    },
     monitors: {
       propDefinition: [
         datadog,
         "monitors",
-        (c) => ({
-          region: c.region,
-        }),
       ],
     },
   },
@@ -39,7 +30,6 @@ export default {
           start: Math.floor(this.datadog.daysAgo(7) / 1000), // one week ago
           end: Math.floor(Date.now() / 1000), // now
         },
-        region: this.region,
       });
       const relevantEvents = events.filter((event) => this.monitors.includes(event.monitor_id));
 
@@ -68,7 +58,6 @@ export default {
       } = await this.datadog.createWebhook(
         this.http.endpoint,
         payloadFormat,
-        this.region,
       );
 
       console.log(`Created webhook "${webhookName}"`);
@@ -77,13 +66,13 @@ export default {
 
       await Promise.all(
         this.monitors.map((monitorId) =>
-          this.datadog.addWebhookNotification(webhookName, monitorId, this.region)),
+          this.datadog.addWebhookNotification(webhookName, monitorId)),
       );
     },
     async deactivate() {
       const webhookName = this._getWebhookName();
-      await this.datadog.removeWebhookNotifications(webhookName, this.region);
-      await this.datadog.deleteWebhook(webhookName, this.region);
+      await this.datadog.removeWebhookNotifications(webhookName);
+      await this.datadog.deleteWebhook(webhookName);
     },
   },
   methods: {


### PR DESCRIPTION
## Summary

- `datadog.app.mjs` now reads region from `this.$auth.region` with a `datadoghq.com` fallback for legacy accounts predating the new Host Site auth field.
- Removes the redundant `region` prop (and threaded `region: this.region` call args) from 10 actions, `actions/common/log-props.mjs`, and `sources/new-monitor-event`.
- `search-dashboards` drops the stale "region comes from **Get Account Info**" description hint and now returns a computed `dashboard_url` on each result so the LLM no longer has to construct the URL itself.
- Package bumped `0.4.0` → `0.5.0`; touched components bumped to their next patch.

`actions/get-account-info` is intentionally untouched in this PR — will be re-evaluated after an eval run to decide whether to repurpose or retire it now that region is always available via auth.

## Test plan

- [ ] Connect a Datadog account, pick a non-US1-E region (e.g. `datadoghq.eu`), and verify actions hit the correct regional endpoint.
- [ ] Connect a Datadog account with region left at its default and verify the `datadoghq.com` fallback works.
- [ ] Run **Search Dashboards** and confirm each result includes a valid `dashboard_url`.
- [ ] Configure the **New Monitor Event** source against a non-US1-E account and verify the webhook registers and events emit correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic region detection from authentication; added dashboard and monitor creation, plus synthetic tests listing.
  * Dashboard search now returns ready-to-use dashboard URLs.
  * Guidance updated to call account-info first when region is unknown.

* **Chores**
  * Removed explicit region inputs across Datadog actions and sources; region is managed internally.
  * Component package bumped to 1.0.0 and many actions/sources versioned to 1.0.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->