### PR TITLE
feat(microsoft-teams): add hostedContents support to send-channel-message action

### DIFF
--- a/components/microsoft_teams/actions/send-channel-message/send-channel-message.mjs
+++ b/components/microsoft_teams/actions/send-channel-message/send-channel-message.mjs
@@ -3,7 +3,7 @@ import microsoftTeams from "../../microsoft_teams.app.mjs";
 export default {
   key: "microsoft_teams-send-channel-message",
   name: "Send Channel Message",
-  description: "Send a message to a team's channel. Optionally include inline images via `hostedContents`. [See the docs here](https://learn.microsoft.com/en-us/graph/api/chatmessage-post?view=graph-rest-1.0&tabs=http)",
+  description: "Send a message to a team's channel. Optionally include inline images via `hostedContents`. [See the documentation](https://learn.microsoft.com/en-us/graph/api/chatmessage-post?view=graph-rest-1.0&tabs=http)",
   type: "action",
   version: "0.1.0",
   annotations: {
@@ -59,8 +59,7 @@ export default {
     const parsedHostedContents = hostedContents?.map((item) =>
       typeof item === "string"
         ? JSON.parse(item)
-        : item
-    );
+        : item);
 
     const content = {
       body: {

--- a/components/microsoft_teams/actions/send-channel-message/send-channel-message.mjs
+++ b/components/microsoft_teams/actions/send-channel-message/send-channel-message.mjs
@@ -3,9 +3,9 @@ import microsoftTeams from "../../microsoft_teams.app.mjs";
 export default {
   key: "microsoft_teams-send-channel-message",
   name: "Send Channel Message",
-  description: "Send a message to a team&#39;s channel. [See the docs here](https://docs.microsoft.com/en-us/graph/api/channel-post-messages?view=graph-rest-1.0&tabs=http)",
+  description: "Send a message to a team's channel. Optionally include inline images via `hostedContents`. [See the docs here](https://learn.microsoft.com/en-us/graph/api/chatmessage-post?view=graph-rest-1.0&tabs=http)",
   type: "action",
-  version: "0.0.12",
+  version: "0.1.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -40,6 +40,12 @@ export default {
         "contentType",
       ],
     },
+    hostedContents: {
+      type: "string[]",
+      label: "Hosted Contents",
+      description: "An array of JSON strings, each representing an inline hosted image to attach. Each item must be a JSON object with `'@microsoft.graph.temporaryId'` (string), `contentBytes` (base64-encoded image data), and `contentType` (MIME type, e.g. `image/png`). Example: `{\"@microsoft.graph.temporaryId\": \"1\", \"contentBytes\": \"BASE64_STRING\", \"contentType\": \"image/png\"}`. Reference each image in your HTML message body using `<img src=\"../hostedContents/1/$value\">`. [See the docs](https://learn.microsoft.com/en-us/graph/api/chatmessage-post?view=graph-rest-1.0&tabs=http#example-6-send-inline-images-along-with-the-message)",
+      optional: true,
+    },
   },
   async run({ $ }) {
     const {
@@ -47,22 +53,33 @@ export default {
       channelId,
       message,
       contentType,
+      hostedContents,
     } = this;
 
-    const response =
-      await this.microsoftTeams.sendChannelMessage({
-        teamId,
-        channelId,
-        content: {
-          body: {
-            content: message,
-            contentType,
-          },
-        },
-      });
+    const parsedHostedContents = hostedContents?.map((item) =>
+      typeof item === "string"
+        ? JSON.parse(item)
+        : item
+    );
+
+    const content = {
+      body: {
+        content: message,
+        contentType: contentType ?? "text",
+      },
+    };
+
+    if (parsedHostedContents?.length) {
+      content.hostedContents = parsedHostedContents;
+    }
+
+    const response = await this.microsoftTeams.sendChannelMessage({
+      teamId,
+      channelId,
+      content,
+    });
 
     $.export("$summary", `Successfully sent message to channel ${channelId}`);
-
     return response;
   },
 };

--- a/components/microsoft_teams/package.json
+++ b/components/microsoft_teams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/microsoft_teams",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Pipedream Microsoft Teams Components",
   "main": "microsoft_teams.app.mjs",
   "keywords": [


### PR DESCRIPTION
Resolves #20536

## Summary

The existing `send-channel-message` action did not support the `hostedContents` property, which is required to send inline base64-encoded images via the Microsoft Graph API.

This PR adds an optional `hostedContents` prop that accepts an array of JSON strings. Each entry maps to a `{ '@microsoft.graph.temporaryId': string, contentBytes: string, contentType: string }` object as described in the [Graph API docs](https://learn.microsoft.com/en-us/graph/api/chatmessage-post?view=graph-rest-1.0&tabs=http#example-6-send-inline-images-along-with-the-message).

## Changes

- Added optional `hostedContents` prop (`string[]`) to `send-channel-message.mjs`
- Each string is parsed as JSON at runtime before being sent in the request body
- `hostedContents` is only included in the payload when provided
- Bumped version from `0.0.12` to `0.1.0`
- Updated description to reference the correct Graph API docs URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Microsoft Teams channel message action now supports hosted contents, letting you attach hosted content items to messages via an optional input.

* **Chores**
  * Action and package versions updated and action metadata description refined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->