### PR TITLE
feat(sendcloud): add get-tracking-info action

### DIFF
--- a/components/sendcloud/actions/bulk-pdf-label-printing/bulk-pdf-label-printing.mjs
+++ b/components/sendcloud/actions/bulk-pdf-label-printing/bulk-pdf-label-printing.mjs
@@ -5,7 +5,7 @@ export default {
   key: "sendcloud-bulk-pdf-label-printing",
   name: "Bulk PDF Label Printing",
   description: "Bulk PDF label printing. [See the documentation](https://api.sendcloud.dev/docs/sendcloud-public-api/branches/v2/labels/operations/create-a-label)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/sendcloud/actions/create-a-parcel/create-a-parcel.mjs
+++ b/components/sendcloud/actions/create-a-parcel/create-a-parcel.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sendcloud-create-a-parcel",
   name: "Create a Parcel",
   description: "Creates a new parcel under your Sendcloud API credentials. [See the documentation](https://api.sendcloud.dev/docs/sendcloud-public-api/parcels/operations/create-a-parcel)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/sendcloud/actions/create-return/create-return.mjs
+++ b/components/sendcloud/actions/create-return/create-return.mjs
@@ -5,7 +5,7 @@ export default {
   key: "sendcloud-create-return",
   name: "Create Return",
   description: "Create a return. [See the documentation](https://api.sendcloud.dev/docs/sendcloud-public-api/returns/operations/create-a-return)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/sendcloud/actions/create-update-integration-shipment/create-update-integration-shipment.mjs
+++ b/components/sendcloud/actions/create-update-integration-shipment/create-update-integration-shipment.mjs
@@ -5,7 +5,7 @@ export default {
   key: "sendcloud-create-update-integration-shipment",
   name: "Create Or Update Integration Shipment",
   description: "Create or update an integration shipment. [See the documentation](https://api.sendcloud.dev/docs/sendcloud-public-api/branches/v2/integrations/operations/create-a-integration-shipment)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/sendcloud/actions/get-current-user/get-current-user.mjs
+++ b/components/sendcloud/actions/get-current-user/get-current-user.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sendcloud-get-current-user",
   name: "Get Current User",
   description: "Get the authenticated user info. [See the documentation](https://api.sendcloud.dev/docs/sendcloud-public-api/user/operations/list-user-auth-metadata)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/sendcloud/actions/get-label/get-label.mjs
+++ b/components/sendcloud/actions/get-label/get-label.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sendcloud-get-label",
   name: "Get Label",
   description: "Retrieve a label by parcel ID. [See the documentation](https://api.sendcloud.dev/docs/sendcloud-public-api/branches/v2/labels/operations/get-a-label)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/sendcloud/actions/get-parcel/get-parcel.mjs
+++ b/components/sendcloud/actions/get-parcel/get-parcel.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sendcloud-get-parcel",
   name: "Get Parcel",
   description: "Retrieve a parcel by ID. [See the documentation](https://api.sendcloud.dev/docs/sendcloud-public-api/branches/v2/parcels/operations/get-a-parcel)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/sendcloud/actions/get-return-portal-settings/get-return-portal-settings.mjs
+++ b/components/sendcloud/actions/get-return-portal-settings/get-return-portal-settings.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sendcloud-get-return-portal-settings",
   name: "Get Return Portal Settings",
   description: "Get return portal settings for the current brand/user. [See the documentation](https://api.sendcloud.dev/docs/sendcloud-public-api/branches/v2/return-portal/operations/get-a-brand-return-portal)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/sendcloud/actions/get-return/get-return.mjs
+++ b/components/sendcloud/actions/get-return/get-return.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sendcloud-get-return",
   name: "Get Return",
   description: "Retrieve a return by ID. [See the documentation](https://api.sendcloud.dev/docs/sendcloud-public-api/returns/operations/get-a-return)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/sendcloud/actions/get-sender-address/get-sender-address.mjs
+++ b/components/sendcloud/actions/get-sender-address/get-sender-address.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sendcloud-get-sender-address",
   name: "Get Sender Address",
   description: "Retrieve a sender address by ID. [See the documentation](https://api.sendcloud.dev/docs/sendcloud-public-api/branches/v2/sender-addresses/operations/get-a-user-address-sender-1)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/sendcloud/actions/get-service-point/get-service-point.mjs
+++ b/components/sendcloud/actions/get-service-point/get-service-point.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sendcloud-get-service-point",
   name: "Get Service Point",
   description: "Retrieve a service point by ID. [See the documentation](https://api.sendcloud.dev/docs/sendcloud-public-api/branches/v2/service-points/operations/get-a-service-point)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/sendcloud/actions/get-shipping-method/get-shipping-method.mjs
+++ b/components/sendcloud/actions/get-shipping-method/get-shipping-method.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sendcloud-get-shipping-method",
   name: "Get Shipping Method",
   description: "Retrieve a shipping method by ID. [See the documentation](https://api.sendcloud.dev/docs/sendcloud-public-api/branches/v2/shipping-methods/operations/get-a-shipping-method)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/sendcloud/actions/get-tracking-info/get-tracking-info.mjs
+++ b/components/sendcloud/actions/get-tracking-info/get-tracking-info.mjs
@@ -1,0 +1,38 @@
+import app from "../../sendcloud.app.mjs";
+
+export default {
+  key: "sendcloud-get-tracking-info",
+  name: "Get Tracking Info",
+  description: "Retrieve tracking information of a parcel. [See the documentation](https://sendcloud.dev/api/v2/tracking/retrieve-tracking-information-of-a-parcel)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  type: "action",
+  props: {
+    app,
+    parcelUuid: {
+      propDefinition: [
+        app,
+        "parcelUuid",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const {
+      app,
+      parcelUuid,
+    } = this;
+
+    const response = await app.getTrackingInfo({
+      $,
+      parcelUuid,
+    });
+
+    $.export("$summary", `Successfully retrieved tracking info for parcel \`${parcelUuid}\``);
+
+    return response;
+  },
+};

--- a/components/sendcloud/actions/get-tracking-info/get-tracking-info.mjs
+++ b/components/sendcloud/actions/get-tracking-info/get-tracking-info.mjs
@@ -13,25 +13,25 @@ export default {
   type: "action",
   props: {
     app,
-    parcelUuid: {
+    trackingNumber: {
       propDefinition: [
         app,
-        "parcelUuid",
+        "trackingNumber",
       ],
     },
   },
   async run({ $ }) {
     const {
       app,
-      parcelUuid,
+      trackingNumber,
     } = this;
 
     const response = await app.getTrackingInfo({
       $,
-      parcelUuid,
+      trackingNumber,
     });
 
-    $.export("$summary", `Successfully retrieved tracking info for parcel \`${parcelUuid}\``);
+    $.export("$summary", `Successfully retrieved tracking info for parcel \`${trackingNumber}\``);
 
     return response;
   },

--- a/components/sendcloud/actions/list-integration-shipments/list-integration-shipments.mjs
+++ b/components/sendcloud/actions/list-integration-shipments/list-integration-shipments.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sendcloud-list-integration-shipments",
   name: "List Integration Shipments",
   description: "List integration shipments. [See the documentation](https://api.sendcloud.dev/docs/sendcloud-public-api/branches/v2/integrations/operations/list-integration-shipments)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/sendcloud/actions/list-parcel-documents/list-parcel-documents.mjs
+++ b/components/sendcloud/actions/list-parcel-documents/list-parcel-documents.mjs
@@ -6,7 +6,7 @@ export default {
   key: "sendcloud-list-parcel-documents",
   name: "List Parcel Documents",
   description: "List parcel documents. [See the documentation](https://api.sendcloud.dev/docs/sendcloud-public-api/parcel-documents/operations/get-a-parcel-document-1)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/sendcloud/actions/list-parcel-statuses/list-parcel-statuses.mjs
+++ b/components/sendcloud/actions/list-parcel-statuses/list-parcel-statuses.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sendcloud-list-parcel-statuses",
   name: "List Parcel Statuses",
   description: "List parcel statuses. [See the documentation](https://api.sendcloud.dev/docs/sendcloud-public-api/parcel-statuses/operations/list-parcel-statuses)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/sendcloud/actions/list-parcels/list-parcels.mjs
+++ b/components/sendcloud/actions/list-parcels/list-parcels.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sendcloud-list-parcels",
   name: "List Parcels",
   description: "Retrieves a list of all the parcels under your API credentials. [See the documentation](https://api.sendcloud.dev/docs/sendcloud-public-api/parcels/operations/list-parcels)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/sendcloud/actions/list-returns/list-returns.mjs
+++ b/components/sendcloud/actions/list-returns/list-returns.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sendcloud-list-returns",
   name: "List Returns",
   description: "List returns. [See the documentation](https://api.sendcloud.dev/docs/sendcloud-public-api/returns/operations/list-returns)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/sendcloud/actions/list-sender-addresses/list-sender-addresses.mjs
+++ b/components/sendcloud/actions/list-sender-addresses/list-sender-addresses.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sendcloud-list-sender-addresses",
   name: "List Sender Addresses",
   description: "List sender addresses for the authenticated user. [See the documentation](https://api.sendcloud.dev/docs/sendcloud-public-api/branches/v2/sender-addresses/operations/get-a-user-address-sender)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/sendcloud/actions/list-service-point-carriers/list-service-point-carriers.mjs
+++ b/components/sendcloud/actions/list-service-point-carriers/list-service-point-carriers.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sendcloud-list-service-point-carriers",
   name: "List Service Point Carriers",
   description: "List carriers that support service points. [See the documentation](https://api.sendcloud.dev/docs/sendcloud-public-api/branches/v2/service-points/operations/list-carriers)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/sendcloud/actions/list-service-points/list-service-points.mjs
+++ b/components/sendcloud/actions/list-service-points/list-service-points.mjs
@@ -5,7 +5,7 @@ export default {
   key: "sendcloud-list-service-points",
   name: "List Service Points",
   description: "List service points. [See the documentation](https://api.sendcloud.dev/docs/sendcloud-public-api/branches/v2/service-points/operations/list-service-points)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/sendcloud/actions/list-shipping-methods/list-shipping-methods.mjs
+++ b/components/sendcloud/actions/list-shipping-methods/list-shipping-methods.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sendcloud-list-shipping-methods",
   name: "List Shipping Methods",
   description: "List shipping methods. [See the documentation](https://api.sendcloud.dev/docs/sendcloud-public-api/branches/v2/shipping-methods/operations/list-shipping-methods)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/sendcloud/actions/update-a-parcel/update-a-parcel.mjs
+++ b/components/sendcloud/actions/update-a-parcel/update-a-parcel.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sendcloud-update-a-parcel",
   name: "Update a Parcel",
   description: "Updates a parcel under your API credentials. [See the documentation](https://api.sendcloud.dev/docs/sendcloud-public-api/parcels/operations/update-a-parcel)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/sendcloud/actions/update-a-parcel/update-a-parcel.mjs
+++ b/components/sendcloud/actions/update-a-parcel/update-a-parcel.mjs
@@ -6,7 +6,7 @@ export default {
   description: "Updates a parcel under your API credentials. [See the documentation](https://api.sendcloud.dev/docs/sendcloud-public-api/parcels/operations/update-a-parcel)",
   version: "0.0.4",
   annotations: {
-    destructiveHint: true,
+    destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },

--- a/components/sendcloud/actions/validate-return/validate-return.mjs
+++ b/components/sendcloud/actions/validate-return/validate-return.mjs
@@ -5,7 +5,7 @@ export default {
   key: "sendcloud-validate-return",
   name: "Validate Return",
   description: "Validate a return. [See the documentation](https://api.sendcloud.dev/docs/sendcloud-public-api/returns/operations/create-a-return-validate)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/sendcloud/package.json
+++ b/components/sendcloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/sendcloud",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Sendcloud Components",
   "main": "sendcloud.app.mjs",
   "keywords": [

--- a/components/sendcloud/sendcloud.app.mjs
+++ b/components/sendcloud/sendcloud.app.mjs
@@ -33,6 +33,11 @@ export default {
         };
       },
     },
+    parcelUuid: {
+      type: "string",
+      label: "Parcel UUID",
+      description: "The unique UUID of the parcel to track",
+    },
     name: {
       type: "string",
       label: "Name",
@@ -679,6 +684,14 @@ Example:
       return this._makeRequest({
         path: `/parcels/${parcelId}`,
         mockPath: `/299107074/parcels/${parcelId}`,
+        ...args,
+      });
+    },
+    getTrackingInfo({
+      parcelUuid, ...args
+    } = {}) {
+      return this._makeRequest({
+        path: `/tracking/${parcelUuid}`,
         ...args,
       });
     },

--- a/components/sendcloud/sendcloud.app.mjs
+++ b/components/sendcloud/sendcloud.app.mjs
@@ -33,10 +33,10 @@ export default {
         };
       },
     },
-    parcelUuid: {
+    trackingNumber: {
       type: "string",
-      label: "Parcel UUID",
-      description: "The unique UUID of the parcel to track",
+      label: "Tracking Number",
+      description: "The tracking number of the parcel to retrieve tracking information for",
     },
     name: {
       type: "string",
@@ -688,10 +688,10 @@ Example:
       });
     },
     getTrackingInfo({
-      parcelUuid, ...args
+      trackingNumber, ...args
     } = {}) {
       return this._makeRequest({
-        path: `/tracking/${parcelUuid}`,
+        path: `/tracking/${trackingNumber}`,
         ...args,
       });
     },

--- a/components/sendcloud/sources/parcel-created/parcel-created.mjs
+++ b/components/sendcloud/sources/parcel-created/parcel-created.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Parcel Created",
   description: "Emit new event each time a parcel is created.",
   type: "source",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/sendcloud/sources/parcel-status-changed/parcel-status-changed.mjs
+++ b/components/sendcloud/sources/parcel-status-changed/parcel-status-changed.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Parcel Status Changed",
   description: "Emit new event each time a parcel status changes.",
   type: "source",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/sendcloud/sources/parcel-updated/parcel-updated.mjs
+++ b/components/sendcloud/sources/parcel-updated/parcel-updated.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Parcel Updated",
   description: "Emit new event each time a parcel is updated.",
   type: "source",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/sendcloud/sources/return-created/return-created.mjs
+++ b/components/sendcloud/sources/return-created/return-created.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Return Created",
   description: "Emit new event each time a return is created.",
   type: "source",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/sendcloud/sources/return-updated/return-updated.mjs
+++ b/components/sendcloud/sources/return-updated/return-updated.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Return Updated",
   description: "Emit new event each time a return is updated.",
   type: "source",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
   props: {
     ...common.props,


### PR DESCRIPTION
Added a new action to retrieve tracking information for a parcel using the SendCloud tracking API.

- New `getTrackingInfo` method in `sendcloud.app.mjs` calling `GET /tracking/{parcel_uuid}`
- New `parcelUuid` prop definition
- New `get-tracking-info` action component following the existing `get-parcel` pattern

API docs: https://sendcloud.dev/api/v2/tracking/retrieve-tracking-information-of-a-parcel

Closes #20629

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Get Tracking Info" action to fetch parcel tracking details and display a concise success summary.
  * Added a "Tracking Number" input for supplying parcel identifiers.

* **Chores**
  * Bumped component version to 0.3.0.
  * Incremented minor versions for multiple Sendcloud actions and event sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->