### PR TITLE
feat(fitbit): add activity summary MCP action

### DIFF
--- a/components/fitbit/actions/get-activity-summary/get-activity-summary.mjs
+++ b/components/fitbit/actions/get-activity-summary/get-activity-summary.mjs
@@ -1,0 +1,69 @@
+import fitbit from "../../fitbit.app.mjs";
+
+export default {
+  key: "fitbit-get-activity-summary",
+  name: "Get Activity Summary",
+  description: "Get a daily activity summary including calories, distance, and active minutes. [See the documentation](https://dev.fitbit.com/build/reference/web-api/activity/get-daily-activity-summary/)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  type: "action",
+  props: {
+    fitbit,
+    date: {
+      type: "string",
+      label: "Date",
+      description: "Date in `YYYY-MM-DD` format. Defaults to today.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const date = this.date || new Date().toISOString().slice(0, 10);
+    const response = await this.fitbit.getActivitySummary({
+      $,
+      date,
+    });
+
+    const summary = response?.summary ?? {};
+    const distanceByActivity = {};
+    for (const item of summary.distances || []) {
+      if (item?.activity) {
+        distanceByActivity[item.activity] = item.distance;
+      }
+    }
+
+    const veryActiveMinutes = summary.veryActiveMinutes ?? 0;
+    const fairlyActiveMinutes = summary.fairlyActiveMinutes ?? 0;
+    const lightlyActiveMinutes = summary.lightlyActiveMinutes ?? 0;
+
+    const activitySummary = {
+      date,
+      calories: {
+        out: summary.caloriesOut ?? null,
+        bmr: summary.caloriesBMR ?? null,
+      },
+      distance: {
+        total: distanceByActivity.total ?? null,
+        tracker: distanceByActivity.tracker ?? null,
+        logged: distanceByActivity.loggedActivities ?? null,
+        byActivity: distanceByActivity,
+      },
+      activeMinutes: {
+        very: veryActiveMinutes,
+        fairly: fairlyActiveMinutes,
+        lightly: lightlyActiveMinutes,
+        sedentary: summary.sedentaryMinutes ?? null,
+        total: veryActiveMinutes + fairlyActiveMinutes + lightlyActiveMinutes,
+      },
+      summary,
+      goals: response?.goals ?? null,
+      activities: response?.activities ?? [],
+    };
+
+    $.export("$summary", `Successfully retrieved Fitbit activity summary for ${date}.`);
+    return activitySummary;
+  },
+};

--- a/components/fitbit/fitbit.app.mjs
+++ b/components/fitbit/fitbit.app.mjs
@@ -1,8 +1,43 @@
+import { axios } from "@pipedream/platform";
+
 export default {
   type: "app",
   app: "fitbit",
   propDefinitions: {},
   methods: {
+    _getHeaders(headers = {}) {
+      return {
+        Authorization: `Bearer ${this.$auth.oauth_access_token}`,
+        "Content-Type": "application/json",
+        "user-agent": "@PipedreamHQ/pipedream v0.1",
+        ...headers,
+      };
+    },
+    _getUrl(path) {
+      return `https://api.fitbit.com${path}`;
+    },
+    async _makeRequest({
+      $,
+      path,
+      headers,
+      ...otherConfig
+    } = {}) {
+      return axios($ ?? this, {
+        url: this._getUrl(path),
+        headers: this._getHeaders(headers),
+        ...otherConfig,
+      });
+    },
+    async getActivitySummary({
+      date,
+      ...args
+    } = {}) {
+      return this._makeRequest({
+        method: "GET",
+        path: `/1/user/-/activities/date/${date}.json`,
+        ...args,
+      });
+    },
     // this.$auth contains connected account data
     authKeys() {
       console.log(Object.keys(this.$auth));


### PR DESCRIPTION
## Summary
- add Fitbit app request helpers for authenticated Fitbit Web API calls
- add `fitbit-get-activity-summary` action for daily activity summary
- return structured activity metrics for calories, distance, and active minutes

## Testing
- `node --check components/fitbit/fitbit.app.mjs`
- `node --check components/fitbit/actions/get-activity-summary/get-activity-summary.mjs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Fitbit integration action to retrieve daily activity summaries with detailed metrics including calories burned (with BMR breakdown), distance data (total, device-tracked, and manually logged), activity-specific distance breakdowns, and active minutes by intensity level with automatic total calculations. Supports custom date selection, defaulting to today.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->