### PR TITLE
CodeRabbit improvements + PR Template file

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -19,19 +19,19 @@ reviews:
         Review this file against the Pipedream component model described in
         .github/pipedream-component-guidelines.md.
 
+        - Verify the `version` field is incremented from its previous value and the bump
+          follows semantic versioning (see the Versioning section of the guidelines):
+          new components start at `0.0.1`; bug fixes and non-breaking refactors → patch;
+          new optional props or backwards-compatible additions → minor; removed/renamed props
+          or breaking behavior changes → major; flag any PR where the version was not bumped
+          or where the bump level seems inconsistent with the scope of the change
+        - Verify the app's `package.json` version is also bumped by the same or greater
+          semver segment as the component change
         - All prop names, method names, and local variables must use camelCase; API request
           parameter names follow the API's own convention and are the only exception
         - Props used in more than one component must be defined in the app file's
           `propDefinitions` and referenced via `propDefinition` — flag any inline prop
           definition that duplicates one already in the app file
-        - Verify `annotations` values are semantically correct (ESLint already enforces presence):
-          - `readOnlyHint: true` only when the component exclusively reads data with no side effects
-          - `destructiveHint: true` for operations that permanently delete data or irreversibly
-            overwrite it with no recovery path; update/patch/upsert operations are generally
-            `false` (reversible by another update) unless the specific endpoint does a full
-            destructive replace — when in doubt, flag and let the author decide
-          - `openWorldHint: true` for any component making external API calls (almost all);
-            `false` only for pure utility/formatting components with no HTTP requests
         - Prop `description` fields must be written for AI agent consumption:
           - Include concrete inline examples for non-obvious formats (JSON objects, IDs, dates, enums)
           - Avoid UI-centric language ("select from the dropdown", "choose from the list")
@@ -55,6 +55,14 @@ reviews:
         guidelines in .github/pipedream-action-guidelines.md.
 
         Key checks:
+        - Verify `annotations` values are semantically correct (ESLint already enforces presence):
+          - `readOnlyHint: true` only when the action exclusively reads data with no side effects
+          - `destructiveHint: true` for operations that permanently delete data or irreversibly
+            overwrite it with no recovery path; update/patch/upsert operations are generally
+            `false` (reversible by another update) unless the specific endpoint does a full
+            destructive replace — when in doubt, flag and let the author decide
+          - `openWorldHint: true` for any action making external API calls (almost all);
+            `false` only for pure utility/formatting actions with no HTTP requests
         - `run()` must call `$.export("$summary", ...)` on every successful execution path;
           summaries should be concise one-liners with key result info (record ID, name, count)
         - When `additionalProps()` or `reloadProps: true` are present, verify they are
@@ -87,6 +95,7 @@ reviews:
         guidelines in .github/pipedream-source-guidelines.md.
 
         Key checks:
+        - Source components must NOT include an `annotations` field — flag its presence as an error
         - `dedupe: "unique"` must be set at the top level of the component export
         - `$emit(data, metadata)` must include all three metadata fields: `id`, `summary`, `ts`
         - The `id` must be stable (deterministic for the same real-world event across runs) and

--- a/.github/ISSUE_TEMPLATE/app---service-integration.md
+++ b/.github/ISSUE_TEMPLATE/app---service-integration.md
@@ -12,4 +12,4 @@ assignees: ""
 
 **Is lack of support preventing you from moving forward, or do you have a workaround?**
 
-**Are there specific actions or triggers, you'd like to see for this app? Please let us know here or use the Action and Trigger issue templates to open requests for each!**
+**Are there specific actions or triggers you'd like to see for this app? Please let us know here or use the Action and Trigger issue templates to open requests for each!**

--- a/.github/pipedream-component-guidelines.md
+++ b/.github/pipedream-component-guidelines.md
@@ -37,7 +37,6 @@ export default {
   description: "...",           // shown in UI and used as MCP tool documentation
   version: "0.0.1",            // semantic versioning; must be incremented on every change
   type: "action",               // or "source"
-  annotations: { ... },        // MCP tool metadata — see Annotations section
   props: { ... },              // configuration inputs
   async run({ $ }) { ... },    // execution entry point (signature differs for sources)
 };

--- a/.github/pipedream-component-guidelines.md
+++ b/.github/pipedream-component-guidelines.md
@@ -35,7 +35,7 @@ export default {
   key: "app-action-name",       // globally unique; kebab-case; prefixed with app slug
   name: "Human Readable Name",  // shown in UI and as the MCP tool name
   description: "...",           // shown in UI and used as MCP tool documentation
-  version: "0.1.0",            // semantic versioning; must be incremented on every change
+  version: "0.0.1",            // semantic versioning; must be incremented on every change
   type: "action",               // or "source"
   annotations: { ... },        // MCP tool metadata — see Annotations section
   props: { ... },              // configuration inputs
@@ -45,6 +45,23 @@ export default {
 
 ESLint enforces the **presence** of all required properties. Reviews should focus on whether
 values are **semantically correct**, not whether properties exist.
+
+---
+
+## Versioning
+
+Every component has a `version` field that must be incremented on every change. New
+components always start at `0.0.1`. Follow semantic versioning:
+
+| Change type | Version segment | Examples |
+|---|---|---|
+| Bug fix, copy/description tweak, refactor with no behavior change | patch (`0.0.x`) | `0.0.1` → `0.0.2` |
+| New optional prop, new output field, backwards-compatible improvement | minor (`0.x.0`) | `0.0.2` → `0.1.0` |
+| Removed or renamed prop, changed output shape, behavior change that breaks existing configs | major (`x.0.0`) | `0.1.0` → `1.0.0` |
+
+The app's `package.json` must also be bumped by the same or greater segment whenever a
+component in that app changes — patch for patch, minor for minor (or higher), major for
+major (or higher).
 
 ---
 
@@ -218,7 +235,10 @@ depends on an earlier selection in a way that fixed optional props cannot repres
 
 ## Annotations
 
-Every component must include an `annotations` object that communicates its runtime behavior
+**Actions only.** Source components must NOT include an `annotations` object — flag its
+presence in any source file as an error.
+
+Every action must include an `annotations` object that communicates its runtime behavior
 to AI agents and the Pipedream platform:
 
 ```javascript

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,25 @@
-## WHY
+## Summary
 
-<!-- author to complete -->
+<!-- Add your PR description here -->
+
+
+
+## Checklist
+Please check the following items:
+
+### PR Type
+
+Check all that apply to this PR:
+- [ ] New component(s)
+- [ ] Enhancement to existing component(s)
+- [ ] Bug fixes
+- [ ] Other
+
+### Versioning
+- [ ] All components updated in this PR had their version updated (`0.0.1` for new ones)
+- [ ] The app updated in this PR had its `package.json`'s version updated
+
+### New app
+If this a new app, please submit [an app integration request](https://github.com/PipedreamHQ/pipedream/issues/new?template=app---service-integration.md) - the PR will only be reviewed after the app is integrated.
+- [ ] The app updated in this PR is already integrated
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,15 +5,7 @@
 
 
 ## Checklist
-Please check the following items:
-
-### PR Type
-
-Check all that apply to this PR:
-- [ ] New component(s)
-- [ ] Enhancement to existing component(s)
-- [ ] Bug fixes
-- [ ] Other
+Please check the following items before your PR can be reviewed:
 
 ### Versioning
 - [ ] All components updated in this PR had their version updated (`0.0.1` for new ones)
@@ -22,4 +14,8 @@ Check all that apply to this PR:
 ### New app
 If this a new app, please submit [an app integration request](https://github.com/PipedreamHQ/pipedream/issues/new?template=app---service-integration.md) - the PR will only be reviewed after the app is integrated.
 - [ ] The app updated in this PR is already integrated
+
+### CodeRabbit review
+After the PR is opened, and if new changes are pushed, CodeRabbit will automatically review it. Do not 'mark as resolved' CodeRabbit's comments, but reply to them instead, whether you agree (and update the PR accordingly) or disagree.
+- [ ] I have addressed or acknowledged all of CodeRabbit's review comments
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,7 @@ Please check the following items before your PR can be reviewed:
 - [ ] The app updated in this PR had its `package.json`'s version updated
 
 ### New app
-If this a new app, please submit [an app integration request](https://github.com/PipedreamHQ/pipedream/issues/new?template=app---service-integration.md) - the PR will only be reviewed after the app is integrated.
+If this is a new app, please submit [an app integration request](https://github.com/PipedreamHQ/pipedream/issues/new?template=app---service-integration.md) - the PR will only be reviewed after the app is integrated.
 - [ ] The app updated in this PR is already integrated
 
 ### CodeRabbit review


### PR DESCRIPTION
Improved some CodeRabbit guidelines and revamped our `pull_request_template` file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added formal component versioning rules: start new components at 0.0.1 and require semver bumps for changes; app-level version must be bumped by the same-or-greater segment
  * Clarified annotations guidance: annotations disallowed for source components and required/validated for action components (including readOnly/destructive/openWorld hints)
  * Updated PR and issue templates with a new summary/checklist and minor wording tweak
* **Chores**
  * Strengthened automated review validation to enforce the above rules
<!-- end of auto-generated comment: release notes by coderabbit.ai -->