### PR TITLE
feat(fitbit): add sleep and nutrition/water MCP tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ components/**/package-lock.json
 .cursor
 **/.claude/settings.local.json
 mcp-exploration/
+.archiver_shadow/
+.snapshots/

--- a/components/fitbit/actions/get-activity-summary/get-activity-summary.mjs
+++ b/components/fitbit/actions/get-activity-summary/get-activity-summary.mjs
@@ -1,0 +1,69 @@
+import fitbit from "../../fitbit.app.mjs";
+
+export default {
+  key: "fitbit-get-activity-summary",
+  name: "Get Activity Summary",
+  description: "Get a daily activity summary including calories, distance, and active minutes. [See the documentation](https://dev.fitbit.com/build/reference/web-api/activity/get-daily-activity-summary/)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  type: "action",
+  props: {
+    fitbit,
+    date: {
+      type: "string",
+      label: "Date",
+      description: "Date in `YYYY-MM-DD` format. Defaults to today.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const date = this.date || new Date().toISOString().slice(0, 10);
+    const response = await this.fitbit.getActivitySummary({
+      $,
+      date,
+    });
+
+    const summary = response?.summary ?? {};
+    const distanceByActivity = {};
+    for (const item of summary.distances || []) {
+      if (item?.activity) {
+        distanceByActivity[item.activity] = item.distance;
+      }
+    }
+
+    const veryActiveMinutes = summary.veryActiveMinutes ?? 0;
+    const fairlyActiveMinutes = summary.fairlyActiveMinutes ?? 0;
+    const lightlyActiveMinutes = summary.lightlyActiveMinutes ?? 0;
+
+    const activitySummary = {
+      date,
+      calories: {
+        out: summary.caloriesOut ?? null,
+        bmr: summary.caloriesBMR ?? null,
+      },
+      distance: {
+        total: distanceByActivity.total ?? null,
+        tracker: distanceByActivity.tracker ?? null,
+        logged: distanceByActivity.loggedActivities ?? null,
+        byActivity: distanceByActivity,
+      },
+      activeMinutes: {
+        very: veryActiveMinutes,
+        fairly: fairlyActiveMinutes,
+        lightly: lightlyActiveMinutes,
+        sedentary: summary.sedentaryMinutes ?? null,
+        total: veryActiveMinutes + fairlyActiveMinutes + lightlyActiveMinutes,
+      },
+      summary,
+      goals: response?.goals ?? null,
+      activities: response?.activities ?? [],
+    };
+
+    $.export("$summary", `Successfully retrieved Fitbit activity summary for ${date}.`);
+    return activitySummary;
+  },
+};

--- a/components/fitbit/actions/get-nutrition-water/get-nutrition-water.mjs
+++ b/components/fitbit/actions/get-nutrition-water/get-nutrition-water.mjs
@@ -1,0 +1,59 @@
+import fitbit from "../../fitbit.app.mjs";
+
+export default {
+  key: "fitbit-get-nutrition-water",
+  name: "Get Nutrition and Water Logs",
+  description: "Get nutrition and water logs for a date, including food entries, meals, water intake, and daily summaries. [See the Fitbit Web API documentation](https://dev.fitbit.com/build/reference/web-api/)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  type: "action",
+  props: {
+    fitbit,
+    date: {
+      type: "string",
+      label: "Date",
+      description: "Date in `YYYY-MM-DD` format. Defaults to today.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const date = this.fitbit._getDateOrToday(this.date);
+    const [
+      nutritionResponse,
+      waterResponse,
+    ] = await Promise.all([
+      this.fitbit.getNutritionLogs({
+        $,
+        date,
+      }),
+      this.fitbit.getWaterLogs({
+        $,
+        date,
+      }),
+    ]);
+
+    $.export("$summary", `Successfully retrieved Fitbit nutrition and water logs for ${date}.`);
+    return {
+      date,
+      nutrition: {
+        summary: nutritionResponse?.summary ?? null,
+        goals: nutritionResponse?.goals ?? null,
+        foods: nutritionResponse?.foods ?? [],
+        meals: nutritionResponse?.meals ?? [],
+      },
+      water: {
+        summary: waterResponse?.summary ?? null,
+        goal: waterResponse?.goal ?? null,
+        entries: waterResponse?.water ?? [],
+      },
+      raw: {
+        nutrition: nutritionResponse,
+        water: waterResponse,
+      },
+    };
+  },
+};

--- a/components/fitbit/actions/get-sleep-data/get-sleep-data.mjs
+++ b/components/fitbit/actions/get-sleep-data/get-sleep-data.mjs
@@ -1,0 +1,62 @@
+import fitbit from "../../fitbit.app.mjs";
+
+export default {
+  key: "fitbit-get-sleep-data",
+  name: "Get Sleep Data",
+  description: "Get sleep data for a date, including duration, stages, and sleep score when available. [See the Fitbit Web API documentation](https://dev.fitbit.com/build/reference/web-api/)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  type: "action",
+  props: {
+    fitbit,
+    date: {
+      type: "string",
+      label: "Date",
+      description: "Date in `YYYY-MM-DD` format. Defaults to today.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const date = this.fitbit._getDateOrToday(this.date);
+    const response = await this.fitbit.getSleep({
+      $,
+      date,
+    });
+
+    const sleepEntries = response?.sleep ?? [];
+    const mainSleep = sleepEntries.find((entry) => entry?.isMainSleep) ?? sleepEntries[0] ?? null;
+    const levelsSummary = mainSleep?.levels?.summary ?? {};
+
+    $.export("$summary", `Successfully retrieved Fitbit sleep data for ${date}.`);
+    return {
+      date,
+      summary: response?.summary ?? null,
+      mainSleep: mainSleep
+        ? {
+          durationMs: mainSleep.duration ?? null,
+          startTime: mainSleep.startTime ?? null,
+          endTime: mainSleep.endTime ?? null,
+          minutesAsleep: mainSleep.minutesAsleep ?? null,
+          timeInBed: mainSleep.timeInBed ?? null,
+          efficiency: mainSleep.efficiency ?? null,
+          stages: {
+            deep: levelsSummary?.deep ?? null,
+            light: levelsSummary?.light ?? null,
+            rem: levelsSummary?.rem ?? null,
+            wake: levelsSummary?.wake ?? null,
+          },
+          sleepScore: mainSleep?.levels?.shortData?.sleepScore
+            ?? mainSleep?.score
+            ?? mainSleep?.sleepScore
+            ?? null,
+        }
+        : null,
+      entries: sleepEntries,
+      raw: response,
+    };
+  },
+};

--- a/components/fitbit/fitbit.app.mjs
+++ b/components/fitbit/fitbit.app.mjs
@@ -1,8 +1,43 @@
+import { axios } from "@pipedream/platform";
+
 export default {
   type: "app",
   app: "fitbit",
   propDefinitions: {},
   methods: {
+    _getHeaders(headers = {}) {
+      return {
+        Authorization: `Bearer ${this.$auth.oauth_access_token}`,
+        "Content-Type": "application/json",
+        "user-agent": "@PipedreamHQ/pipedream v0.1",
+        ...headers,
+      };
+    },
+    _getUrl(path) {
+      return `https://api.fitbit.com${path}`;
+    },
+    async _makeRequest({
+      $,
+      path,
+      headers,
+      ...otherConfig
+    } = {}) {
+      return axios($ ?? this, {
+        url: this._getUrl(path),
+        headers: this._getHeaders(headers),
+        ...otherConfig,
+      });
+    },
+    async getActivitySummary({
+      date,
+      ...args
+    } = {}) {
+      return this._makeRequest({
+        method: "GET",
+        path: `/1/user/-/activities/date/${date}.json`,
+        ...args,
+      });
+    },
     // this.$auth contains connected account data
     authKeys() {
       console.log(Object.keys(this.$auth));

--- a/components/fitbit/fitbit.app.mjs
+++ b/components/fitbit/fitbit.app.mjs
@@ -5,6 +5,9 @@ export default {
   app: "fitbit",
   propDefinitions: {},
   methods: {
+    _getDateOrToday(date) {
+      return date || new Date().toISOString().slice(0, 10);
+    },
     _getHeaders(headers = {}) {
       return {
         Authorization: `Bearer ${this.$auth.oauth_access_token}`,
@@ -35,6 +38,36 @@ export default {
       return this._makeRequest({
         method: "GET",
         path: `/1/user/-/activities/date/${date}.json`,
+        ...args,
+      });
+    },
+    async getSleep({
+      date,
+      ...args
+    } = {}) {
+      return this._makeRequest({
+        method: "GET",
+        path: `/1.2/user/-/sleep/date/${date}.json`,
+        ...args,
+      });
+    },
+    async getNutritionLogs({
+      date,
+      ...args
+    } = {}) {
+      return this._makeRequest({
+        method: "GET",
+        path: `/1/user/-/foods/log/date/${date}.json`,
+        ...args,
+      });
+    },
+    async getWaterLogs({
+      date,
+      ...args
+    } = {}) {
+      return this._makeRequest({
+        method: "GET",
+        path: `/1/user/-/foods/log/water/date/${date}.json`,
         ...args,
       });
     },


### PR DESCRIPTION
## Summary
- add a Fitbit sleep data action for retrieving duration, stages, and sleep score when available
- add a Fitbit nutrition and water logs action for retrieving food entries, meals, water intake, and daily summaries
- extend the Fitbit app helper with shared methods for the sleep, nutrition, and water endpoints

## Scope
This PR only covers my assigned Fitbit MCP tools for:
- Get sleep data (duration, stages, score)
- Get nutrition/water logs

The other Fitbit MCP tools for this issue are being completed separately by my teammates: @josegerm, @TonyHeeee, and @zheng05jess.

It does not include the other Fitbit tools from issue #20573 such as steps, heart rate, activity summary, or body weight/BMI.

## Testing
- ran `node --check components/fitbit/fitbit.app.mjs`
- ran `node --check components/fitbit/actions/get-sleep-data/get-sleep-data.mjs`
- ran `node --check components/fitbit/actions/get-nutrition-water/get-nutrition-water.mjs`

Closes #20573


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Get Activity Summary: Retrieve daily Fitbit activity data including calories, distance, and active minutes
  * Get Sleep Data: Access comprehensive sleep analytics with duration, sleep stages, and efficiency metrics
  * Get Nutrition and Water Logs: Fetch daily nutrition summaries and water intake logs from Fitbit

<!-- end of auto-generated comment: release notes by coderabbit.ai -->