### PR TITLE
shopify_developer_app: include fulfillment tracking in search_orders

### DIFF
--- a/components/shopify_developer_app/actions/add-product-to-custom-collection/add-product-to-custom-collection.mjs
+++ b/components/shopify_developer_app/actions/add-product-to-custom-collection/add-product-to-custom-collection.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, shopify);
 export default {
   ...others,
   key: "shopify_developer_app-add-product-to-custom-collection",
-  version: "0.0.13",
+  version: "0.0.14",
   name,
   description,
   type,

--- a/components/shopify_developer_app/actions/add-tags/add-tags.mjs
+++ b/components/shopify_developer_app/actions/add-tags/add-tags.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, shopify);
 export default {
   ...others,
   key: "shopify_developer_app-add-tags",
-  version: "0.0.13",
+  version: "0.0.14",
   name,
   description,
   type,

--- a/components/shopify_developer_app/actions/create-article/create-article.mjs
+++ b/components/shopify_developer_app/actions/create-article/create-article.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, shopify);
 export default {
   ...others,
   key: "shopify_developer_app-create-article",
-  version: "0.0.15",
+  version: "0.0.16",
   name,
   description,
   type,

--- a/components/shopify_developer_app/actions/create-blog/create-blog.mjs
+++ b/components/shopify_developer_app/actions/create-blog/create-blog.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, shopify);
 export default {
   ...others,
   key: "shopify_developer_app-create-blog",
-  version: "0.0.15",
+  version: "0.0.16",
   name,
   description,
   type,

--- a/components/shopify_developer_app/actions/create-custom-collection/create-custom-collection.mjs
+++ b/components/shopify_developer_app/actions/create-custom-collection/create-custom-collection.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, shopify);
 export default {
   ...others,
   key: "shopify_developer_app-create-custom-collection",
-  version: "0.0.13",
+  version: "0.0.14",
   name,
   description,
   type,

--- a/components/shopify_developer_app/actions/create-customer/create-customer.mjs
+++ b/components/shopify_developer_app/actions/create-customer/create-customer.mjs
@@ -4,7 +4,7 @@ export default {
   key: "shopify_developer_app-create-customer",
   name: "Create Customer",
   description: "Create a new customer. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/customercreate)",
-  version: "0.0.13",
+  version: "0.0.14",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify_developer_app/actions/create-fulfillment/create-fulfillment.mjs
+++ b/components/shopify_developer_app/actions/create-fulfillment/create-fulfillment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "shopify_developer_app-create-fulfillment",
   name: "Create Fulfillment",
   description: "Create a fulfillment. [See the documentation](https://shopify.dev/docs/api/admin-graphql/unstable/mutations/fulfillmentcreate)",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify_developer_app/actions/create-metafield/create-metafield.mjs
+++ b/components/shopify_developer_app/actions/create-metafield/create-metafield.mjs
@@ -10,7 +10,7 @@ const {
 export default {
   ...others,
   key: "shopify_developer_app-create-metafield",
-  version: "0.0.14",
+  version: "0.0.15",
   name,
   description,
   type,

--- a/components/shopify_developer_app/actions/create-metaobject/create-metaobject.mjs
+++ b/components/shopify_developer_app/actions/create-metaobject/create-metaobject.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, shopify);
 export default {
   ...others,
   key: "shopify_developer_app-create-metaobject",
-  version: "0.0.15",
+  version: "0.0.16",
   name,
   description,
   type,

--- a/components/shopify_developer_app/actions/create-order/create-order.mjs
+++ b/components/shopify_developer_app/actions/create-order/create-order.mjs
@@ -5,7 +5,7 @@ export default {
   key: "shopify_developer_app-create-order",
   name: "Create Order",
   description: "Creates a new order. For full order object details [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/ordercreate)",
-  version: "0.0.14",
+  version: "0.0.15",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify_developer_app/actions/create-page/create-page.mjs
+++ b/components/shopify_developer_app/actions/create-page/create-page.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, shopify);
 export default {
   ...others,
   key: "shopify_developer_app-create-page",
-  version: "0.0.15",
+  version: "0.0.16",
   name,
   description,
   type,

--- a/components/shopify_developer_app/actions/create-product-variant/create-product-variant.mjs
+++ b/components/shopify_developer_app/actions/create-product-variant/create-product-variant.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, shopify);
 export default {
   ...others,
   key: "shopify_developer_app-create-product-variant",
-  version: "0.0.14",
+  version: "0.0.15",
   name,
   description,
   type,

--- a/components/shopify_developer_app/actions/create-product/create-product.mjs
+++ b/components/shopify_developer_app/actions/create-product/create-product.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, shopify);
 export default {
   ...others,
   key: "shopify_developer_app-create-product",
-  version: "0.0.13",
+  version: "0.0.14",
   name,
   description,
   type,

--- a/components/shopify_developer_app/actions/create-smart-collection/create-smart-collection.mjs
+++ b/components/shopify_developer_app/actions/create-smart-collection/create-smart-collection.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, shopify);
 export default {
   ...others,
   key: "shopify_developer_app-create-smart-collection",
-  version: "0.0.13",
+  version: "0.0.14",
   name,
   description,
   type,

--- a/components/shopify_developer_app/actions/delete-article/delete-article.mjs
+++ b/components/shopify_developer_app/actions/delete-article/delete-article.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, shopify);
 export default {
   ...others,
   key: "shopify_developer_app-delete-article",
-  version: "0.0.15",
+  version: "0.0.16",
   name,
   description,
   type,

--- a/components/shopify_developer_app/actions/delete-blog/delete-blog.mjs
+++ b/components/shopify_developer_app/actions/delete-blog/delete-blog.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, shopify);
 export default {
   ...others,
   key: "shopify_developer_app-delete-blog",
-  version: "0.0.15",
+  version: "0.0.16",
   name,
   description,
   type,

--- a/components/shopify_developer_app/actions/delete-metafield/delete-metafield.mjs
+++ b/components/shopify_developer_app/actions/delete-metafield/delete-metafield.mjs
@@ -9,7 +9,7 @@ const {
 export default {
   ...others,
   key: "shopify_developer_app-delete-metafield",
-  version: "0.0.14",
+  version: "0.0.15",
   name,
   description,
   type,

--- a/components/shopify_developer_app/actions/delete-page/delete-page.mjs
+++ b/components/shopify_developer_app/actions/delete-page/delete-page.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, shopify);
 export default {
   ...others,
   key: "shopify_developer_app-delete-page",
-  version: "0.0.15",
+  version: "0.0.16",
   name,
   description,
   type,

--- a/components/shopify_developer_app/actions/get-articles/get-articles.mjs
+++ b/components/shopify_developer_app/actions/get-articles/get-articles.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, shopify);
 export default {
   ...others,
   key: "shopify_developer_app-get-articles",
-  version: "0.0.15",
+  version: "0.0.16",
   name,
   description,
   type,

--- a/components/shopify_developer_app/actions/get-metafields/get-metafields.mjs
+++ b/components/shopify_developer_app/actions/get-metafields/get-metafields.mjs
@@ -8,7 +8,7 @@ const {
 
 export default {
   key: "shopify_developer_app-get-metafields",
-  version: "0.0.14",
+  version: "0.0.15",
   name,
   description,
   type,

--- a/components/shopify_developer_app/actions/get-metaobjects/get-metaobjects.mjs
+++ b/components/shopify_developer_app/actions/get-metaobjects/get-metaobjects.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, shopify);
 export default {
   ...others,
   key: "shopify_developer_app-get-metaobjects",
-  version: "0.0.14",
+  version: "0.0.15",
   name,
   description,
   type,

--- a/components/shopify_developer_app/actions/get-order/get-order.mjs
+++ b/components/shopify_developer_app/actions/get-order/get-order.mjs
@@ -6,7 +6,7 @@ export default {
   key: "shopify_developer_app-get-order",
   name: "Get Order",
   description: "Retrieve an order by specifying the order ID. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/queries/order)",
-  version: "0.0.13",
+  version: "0.0.14",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify_developer_app/actions/get-pages/get-pages.mjs
+++ b/components/shopify_developer_app/actions/get-pages/get-pages.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, shopify);
 export default {
   ...others,
   key: "shopify_developer_app-get-pages",
-  version: "0.0.15",
+  version: "0.0.16",
   name,
   description,
   type,

--- a/components/shopify_developer_app/actions/refund-order/refund-order.mjs
+++ b/components/shopify_developer_app/actions/refund-order/refund-order.mjs
@@ -5,7 +5,7 @@ export default {
   key: "shopify_developer_app-refund-order",
   name: "Refund Order",
   description: "Refund an order. [See the documentation](https://shopify.dev/docs/api/admin-graphql/unstable/mutations/refundcreate)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify_developer_app/actions/search-custom-collection-by-name/search-custom-collection-by-name.mjs
+++ b/components/shopify_developer_app/actions/search-custom-collection-by-name/search-custom-collection-by-name.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, shopify);
 export default {
   ...others,
   key: "shopify_developer_app-search-custom-collection-by-name",
-  version: "0.0.13",
+  version: "0.0.14",
   name,
   description,
   type,

--- a/components/shopify_developer_app/actions/search-customers/search-customers.mjs
+++ b/components/shopify_developer_app/actions/search-customers/search-customers.mjs
@@ -4,7 +4,7 @@ export default {
   key: "shopify_developer_app-search-customers",
   name: "Search for Customers",
   description: "Search for a customer or a list of customers. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/queries/customers)",
-  version: "0.0.13",
+  version: "0.0.14",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify_developer_app/actions/search-fulfillment-orders/search-fulfillment-orders.mjs
+++ b/components/shopify_developer_app/actions/search-fulfillment-orders/search-fulfillment-orders.mjs
@@ -4,7 +4,7 @@ export default {
   key: "shopify_developer_app-search-fulfillment-orders",
   name: "Search for Fulfillment Orders",
   description: "Search for a fulfillment order or a list of fulfillment orders. [See the documentation](https://shopify.dev/docs/api/admin-graphql/unstable/queries/fulfillmentorders)",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify_developer_app/actions/search-orders/search-orders.mjs
+++ b/components/shopify_developer_app/actions/search-orders/search-orders.mjs
@@ -5,7 +5,7 @@ export default {
   key: "shopify_developer_app-search-orders",
   name: "Search for Orders",
   description: "Search for an order or a list of orders. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/queries/orders)",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify_developer_app/actions/search-product-variant/search-product-variant.mjs
+++ b/components/shopify_developer_app/actions/search-product-variant/search-product-variant.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, shopify);
 export default {
   ...others,
   key: "shopify_developer_app-search-product-variant",
-  version: "0.0.13",
+  version: "0.0.14",
   name,
   description,
   type,

--- a/components/shopify_developer_app/actions/search-products/search-products.mjs
+++ b/components/shopify_developer_app/actions/search-products/search-products.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, shopify);
 export default {
   ...others,
   key: "shopify_developer_app-search-products",
-  version: "0.0.13",
+  version: "0.0.14",
   name,
   description,
   type,

--- a/components/shopify_developer_app/actions/send-order-invoice/send-order-invoice.mjs
+++ b/components/shopify_developer_app/actions/send-order-invoice/send-order-invoice.mjs
@@ -5,7 +5,7 @@ export default {
   key: "shopify_developer_app-send-order-invoice",
   name: "Send Order Invoice",
   description: "Sends an invoice for an order. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/OrderInvoiceSend)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify_developer_app/actions/update-article/update-article.mjs
+++ b/components/shopify_developer_app/actions/update-article/update-article.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, shopify);
 export default {
   ...others,
   key: "shopify_developer_app-update-article",
-  version: "0.0.15",
+  version: "0.0.16",
   name,
   description,
   type,

--- a/components/shopify_developer_app/actions/update-customer/update-customer.mjs
+++ b/components/shopify_developer_app/actions/update-customer/update-customer.mjs
@@ -6,7 +6,7 @@ export default {
   key: "shopify_developer_app-update-customer",
   name: "Update Customer",
   description: "Update a existing customer. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/customerupdate)",
-  version: "0.0.14",
+  version: "0.0.15",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/shopify_developer_app/actions/update-fulfillment-tracking-info/update-fulfillment-tracking-info.mjs
+++ b/components/shopify_developer_app/actions/update-fulfillment-tracking-info/update-fulfillment-tracking-info.mjs
@@ -4,7 +4,7 @@ export default {
   key: "shopify_developer_app-update-fulfillment-tracking-info",
   name: "Update Fulfillment Tracking Info",
   description: "Update the tracking info for a fulfillment. [See the documentation](https://shopify.dev/docs/api/admin-graphql/unstable/mutations/fulfillmenttrackinginfoupdate)",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/shopify_developer_app/actions/update-inventory-level/update-inventory-level.mjs
+++ b/components/shopify_developer_app/actions/update-inventory-level/update-inventory-level.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, shopify);
 export default {
   ...others,
   key: "shopify_developer_app-update-inventory-level",
-  version: "0.0.13",
+  version: "0.0.14",
   name,
   description,
   type,

--- a/components/shopify_developer_app/actions/update-metafield/update-metafield.mjs
+++ b/components/shopify_developer_app/actions/update-metafield/update-metafield.mjs
@@ -9,7 +9,7 @@ const {
 export default {
   ...others,
   key: "shopify_developer_app-update-metafield",
-  version: "0.0.14",
+  version: "0.0.15",
   name,
   description,
   type,

--- a/components/shopify_developer_app/actions/update-metaobject/update-metaobject.mjs
+++ b/components/shopify_developer_app/actions/update-metaobject/update-metaobject.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, shopify);
 export default {
   ...others,
   key: "shopify_developer_app-update-metaobject",
-  version: "0.0.16",
+  version: "0.0.17",
   name,
   description,
   type,

--- a/components/shopify_developer_app/actions/update-page/update-page.mjs
+++ b/components/shopify_developer_app/actions/update-page/update-page.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, shopify);
 export default {
   ...others,
   key: "shopify_developer_app-update-page",
-  version: "0.0.15",
+  version: "0.0.16",
   name,
   description,
   type,

--- a/components/shopify_developer_app/actions/update-product-variant/update-product-variant.mjs
+++ b/components/shopify_developer_app/actions/update-product-variant/update-product-variant.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, shopify);
 export default {
   ...others,
   key: "shopify_developer_app-update-product-variant",
-  version: "0.0.15",
+  version: "0.0.16",
   name,
   description,
   type,

--- a/components/shopify_developer_app/actions/update-product/update-product.mjs
+++ b/components/shopify_developer_app/actions/update-product/update-product.mjs
@@ -6,7 +6,7 @@ export default {
   key: "shopify_developer_app-update-product",
   name: "Update Product",
   description: "Update an existing product. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/productupdate)",
-  version: "0.0.14",
+  version: "0.0.15",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/shopify_developer_app/common/queries.mjs
+++ b/components/shopify_developer_app/common/queries.mjs
@@ -700,6 +700,13 @@ const LIST_ORDERS = `
           id
           status
           displayStatus
+          createdAt
+          updatedAt
+          trackingInfo {
+            number
+            url
+            company
+          }
         }
         metafields (first: $first) {
           nodes {

--- a/components/shopify_developer_app/package.json
+++ b/components/shopify_developer_app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/shopify_developer_app",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "Pipedream Shopify (Developer App) Components",
   "main": "shopify_developer_app.app.mjs",
   "keywords": [

--- a/components/shopify_developer_app/sources/cart-updated/cart-updated.mjs
+++ b/components/shopify_developer_app/sources/cart-updated/cart-updated.mjs
@@ -5,7 +5,7 @@ export default {
   key: "shopify_developer_app-cart-updated",
   name: "Cart Updated (Instant)",
   description: "Emit new event when a cart is updated.",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/shopify_developer_app/sources/draft-order-updated/draft-order-updated.mjs
+++ b/components/shopify_developer_app/sources/draft-order-updated/draft-order-updated.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Draft Order Updated (Instant)",
   type: "source",
   description: "Emit new event for each draft order updated in a store.",
-  version: "0.0.5",
+  version: "0.0.6",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/shopify_developer_app/sources/inventory-level-updated/inventory-level-updated.mjs
+++ b/components/shopify_developer_app/sources/inventory-level-updated/inventory-level-updated.mjs
@@ -5,7 +5,7 @@ export default {
   key: "shopify_developer_app-inventory-level-updated",
   name: "Inventory Level Updated (Instant)",
   description: "Emit new event when an inventory level is updated.",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/shopify_developer_app/sources/new-abandoned-cart/new-abandoned-cart.mjs
+++ b/components/shopify_developer_app/sources/new-abandoned-cart/new-abandoned-cart.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, shopify);
 export default {
   ...others,
   key: "shopify_developer_app-new-abandoned-cart",
-  version: "0.0.14",
+  version: "0.0.15",
   name,
   description,
   type,

--- a/components/shopify_developer_app/sources/new-article/new-article.mjs
+++ b/components/shopify_developer_app/sources/new-article/new-article.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, shopify);
 export default {
   ...others,
   key: "shopify_developer_app-new-article",
-  version: "0.0.13",
+  version: "0.0.14",
   name,
   description,
   type,

--- a/components/shopify_developer_app/sources/new-cancelled-order/new-cancelled-order.mjs
+++ b/components/shopify_developer_app/sources/new-cancelled-order/new-cancelled-order.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Cancelled Order (Instant)",
   type: "source",
   description: "Emit new event each time a new order is cancelled.",
-  version: "0.0.17",
+  version: "0.0.18",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/shopify_developer_app/sources/new-cart-created/new-cart-created.mjs
+++ b/components/shopify_developer_app/sources/new-cart-created/new-cart-created.mjs
@@ -5,7 +5,7 @@ export default {
   key: "shopify_developer_app-new-cart-created",
   name: "New Cart Created (Instant)",
   description: "Emit new event when a new cart is created.",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/shopify_developer_app/sources/new-customer-created/new-customer-created.mjs
+++ b/components/shopify_developer_app/sources/new-customer-created/new-customer-created.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Customer Created (Instant)",
   type: "source",
   description: "Emit new event for each new customer added to a store.",
-  version: "0.0.17",
+  version: "0.0.18",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/shopify_developer_app/sources/new-draft-order/new-draft-order.mjs
+++ b/components/shopify_developer_app/sources/new-draft-order/new-draft-order.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Draft Order (Instant)",
   type: "source",
   description: "Emit new event for each new draft order submitted to a store.",
-  version: "0.0.17",
+  version: "0.0.18",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/shopify_developer_app/sources/new-event-emitted/new-event-emitted.mjs
+++ b/components/shopify_developer_app/sources/new-event-emitted/new-event-emitted.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Event Emitted (Instant)",
   type: "source",
   description: "Emit new event for each new Shopify event.",
-  version: "0.0.18",
+  version: "0.0.19",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/shopify_developer_app/sources/new-fulfillment-event/new-fulfillment-event.mjs
+++ b/components/shopify_developer_app/sources/new-fulfillment-event/new-fulfillment-event.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Fulfillment Event (Instant)",
   type: "source",
   description: "Emit new event for each new fulfillment event for a store.",
-  version: "0.0.15",
+  version: "0.0.16",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/shopify_developer_app/sources/new-order-created/new-order-created.mjs
+++ b/components/shopify_developer_app/sources/new-order-created/new-order-created.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Order Created (Instant)",
   type: "source",
   description: "Emit new event for each new order submitted to a store.",
-  version: "0.0.17",
+  version: "0.0.18",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/shopify_developer_app/sources/new-order-fulfilled/new-order-fulfilled.mjs
+++ b/components/shopify_developer_app/sources/new-order-fulfilled/new-order-fulfilled.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Order Fulfilled (Instant)",
   type: "source",
   description: "Emit new event whenever an order is fulfilled.",
-  version: "0.0.14",
+  version: "0.0.15",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/shopify_developer_app/sources/new-page/new-page.mjs
+++ b/components/shopify_developer_app/sources/new-page/new-page.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, shopify);
 export default {
   ...others,
   key: "shopify_developer_app-new-page",
-  version: "0.0.13",
+  version: "0.0.14",
   name,
   description,
   type,

--- a/components/shopify_developer_app/sources/new-paid-order/new-paid-order.mjs
+++ b/components/shopify_developer_app/sources/new-paid-order/new-paid-order.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Paid Order (Instant)",
   type: "source",
   description: "Emit new event each time a new order is paid.",
-  version: "0.0.17",
+  version: "0.0.18",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/shopify_developer_app/sources/new-product-created/new-product-created.mjs
+++ b/components/shopify_developer_app/sources/new-product-created/new-product-created.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Product Created (Instant)",
   type: "source",
   description: "Emit new event for each product added to a store.",
-  version: "0.0.17",
+  version: "0.0.18",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/shopify_developer_app/sources/new-product-updated/new-product-updated.mjs
+++ b/components/shopify_developer_app/sources/new-product-updated/new-product-updated.mjs
@@ -5,7 +5,7 @@ export default {
   key: "shopify_developer_app-new-product-updated",
   name: "New Product Updated (Instant)",
   description: "Emit new event for each product updated in a store.",
-  version: "0.0.15",
+  version: "0.0.16",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/shopify_developer_app/sources/new-refund-created/new-refund-created.mjs
+++ b/components/shopify_developer_app/sources/new-refund-created/new-refund-created.mjs
@@ -5,7 +5,7 @@ export default {
   key: "shopify_developer_app-new-refund-created",
   name: "New Refund Created (Instant)",
   description: "Emit new event when a new refund is created.",
-  version: "0.0.14",
+  version: "0.0.15",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/shopify_developer_app/sources/new-updated-customer/new-updated-customer.mjs
+++ b/components/shopify_developer_app/sources/new-updated-customer/new-updated-customer.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Updated Customer (Instant)",
   type: "source",
   description: "Emit new event each time a customer's information is updated.",
-  version: "0.0.17",
+  version: "0.0.18",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/shopify_developer_app/sources/new-updated-order/new-updated-order.mjs
+++ b/components/shopify_developer_app/sources/new-updated-order/new-updated-order.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Updated Order (Instant)",
   type: "source",
   description: "Emit new event each time an order is updated.",
-  version: "0.0.17",
+  version: "0.0.18",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/shopify_developer_app/sources/product-added-to-custom-collection/product-added-to-custom-collection.mjs
+++ b/components/shopify_developer_app/sources/product-added-to-custom-collection/product-added-to-custom-collection.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, shopify);
 export default {
   ...others,
   key: "shopify_developer_app-product-added-to-custom-collection",
-  version: "0.0.13",
+  version: "0.0.14",
   name,
   description,
   type,

--- a/components/shopify_developer_app/sources/shop-update/shop-update.mjs
+++ b/components/shopify_developer_app/sources/shop-update/shop-update.mjs
@@ -5,7 +5,7 @@ export default {
   key: "shopify_developer_app-shop-update",
   name: "Shop Updated (Instant)",
   description: "Emit new event when a shop is updated.",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   dedupe: "unique",
   methods: {


### PR DESCRIPTION
## Summary

- `search_orders` is backed by Shopify Admin GraphQL (`this.shopify.listOrders` → `LIST_ORDERS` in `components/shopify_developer_app/common/queries.mjs`).
- Tracking info was missing from the action output because `LIST_ORDERS` did not request it — the `fulfillments` selection only asked for `id`, `status`, and `displayStatus`.
- This PR expands the `fulfillments` selection so downstream consumers can map shipment tracking directly from `fulfillments` without a separate fetch.

## Changes

`components/shopify_developer_app/common/queries.mjs` — add fields to the `LIST_ORDERS` `fulfillments` selection:

```graphql
fulfillments {
  id
  status
  displayStatus
  createdAt
  updatedAt
  trackingInfo {
    number
    url
    company
  }
}
```

Tracking will now be available on each returned order at:

```
result[x].fulfillments[y].trackingInfo[0].number
result[x].fulfillments[y].trackingInfo[0].url
result[x].fulfillments[y].trackingInfo[0].company
```

Also bumped:
- `actions/search-orders/search-orders.mjs` → `0.0.9` (output shape changed additively)
- `package.json` → `0.10.7`

## Compatibility

No breaking changes. All existing fulfillment fields (`id`, `status`, `displayStatus`) are preserved; the new fields are purely additive. `trackingInfo` comes back empty for fulfillments that don't have tracking.

## Related

Closes #20673

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced fulfillment data now includes tracking information, creation/update timestamps in order queries.

* **Chores**
  * Updated component versions across multiple Shopify actions and event sources for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->