### PR TITLE
shopify: include fulfillment tracking in search_orders

### DIFF
--- a/components/shopify/actions/add-product-to-custom-collection/add-product-to-custom-collection.mjs
+++ b/components/shopify/actions/add-product-to-custom-collection/add-product-to-custom-collection.mjs
@@ -4,7 +4,7 @@ export default {
   key: "shopify-add-product-to-custom-collection",
   name: "Add Products to Custom Collection",
   description: "Adds a product or products to a custom collection. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/collectionAddProductsV2)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify/actions/add-tags/add-tags.mjs
+++ b/components/shopify/actions/add-tags/add-tags.mjs
@@ -4,7 +4,7 @@ export default {
   key: "shopify-add-tags",
   name: "Add Tags",
   description: "Add tags. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/tagsAdd)",
-  version: "0.0.16",
+  version: "0.0.17",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify/actions/bulk-import/bulk-import.mjs
+++ b/components/shopify/actions/bulk-import/bulk-import.mjs
@@ -7,7 +7,7 @@ export default {
   key: "shopify-bulk-import",
   name: "Bulk Import",
   description: "Execute bulk mutations by uploading a JSONL file containing mutation variables. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/bulkoperationrunmutation)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify/actions/create-article/create-article.mjs
+++ b/components/shopify/actions/create-article/create-article.mjs
@@ -4,7 +4,7 @@ export default {
   key: "shopify-create-article",
   name: "Create Article",
   description: "Create a new blog article. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/articleCreate)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify/actions/create-blog/create-blog.mjs
+++ b/components/shopify/actions/create-blog/create-blog.mjs
@@ -4,7 +4,7 @@ export default {
   key: "shopify-create-blog",
   name: "Create Blog",
   description: "Create a new blog. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/blogCreate)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify/actions/create-custom-collection/create-custom-collection.mjs
+++ b/components/shopify/actions/create-custom-collection/create-custom-collection.mjs
@@ -5,7 +5,7 @@ export default {
   key: "shopify-create-custom-collection",
   name: "Create Custom Collection",
   description: "Create a new custom collection. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/collectionCreate)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify/actions/create-metafield/create-metafield.mjs
+++ b/components/shopify/actions/create-metafield/create-metafield.mjs
@@ -5,7 +5,7 @@ export default {
   key: "shopify-create-metafield",
   name: "Create Metafield",
   description: "Creates a metafield belonging to a resource. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/metafieldDefinitionCreate)",
-  version: "0.0.14",
+  version: "0.0.15",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify/actions/create-metaobject/create-metaobject.mjs
+++ b/components/shopify/actions/create-metaobject/create-metaobject.mjs
@@ -7,7 +7,7 @@ export default {
   key: "shopify-create-metaobject",
   name: "Create Metaobject",
   description: "Creates a metaobject. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/metaobjectCreate)",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify/actions/create-page/create-page.mjs
+++ b/components/shopify/actions/create-page/create-page.mjs
@@ -4,7 +4,7 @@ export default {
   key: "shopify-create-page",
   name: "Create Page",
   description: "Create a new page. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/pageCreate)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify/actions/create-product-variant/create-product-variant.mjs
+++ b/components/shopify/actions/create-product-variant/create-product-variant.mjs
@@ -9,7 +9,7 @@ export default {
   key: "shopify-create-product-variant",
   name: "Create Product Variant",
   description: "Create a new product variant. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/productVariantsBulkCreate)",
-  version: "0.0.17",
+  version: "0.0.18",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify/actions/create-product/create-product.mjs
+++ b/components/shopify/actions/create-product/create-product.mjs
@@ -5,7 +5,7 @@ export default {
   key: "shopify-create-product",
   name: "Create Product",
   description: "Create a new product. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/productCreate)",
-  version: "0.0.16",
+  version: "0.0.17",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify/actions/create-smart-collection/create-smart-collection.mjs
+++ b/components/shopify/actions/create-smart-collection/create-smart-collection.mjs
@@ -7,7 +7,7 @@ export default {
   key: "shopify-create-smart-collection",
   name: "Create Smart Collection",
   description: "Creates a smart collection. You can fill in any number of rules by selecting more than one option in each prop.[See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/collectionCreate)",
-  version: "0.0.16",
+  version: "0.0.17",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify/actions/delete-article/delete-article.mjs
+++ b/components/shopify/actions/delete-article/delete-article.mjs
@@ -4,7 +4,7 @@ export default {
   key: "shopify-delete-article",
   name: "Delete Article",
   description: "Delete an existing blog article. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/articleDelete)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/shopify/actions/delete-blog/delete-blog.mjs
+++ b/components/shopify/actions/delete-blog/delete-blog.mjs
@@ -4,7 +4,7 @@ export default {
   key: "shopify-delete-blog",
   name: "Delete Blog",
   description: "Delete an existing blog. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/blogDelete)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/shopify/actions/delete-metafield/delete-metafield.mjs
+++ b/components/shopify/actions/delete-metafield/delete-metafield.mjs
@@ -5,7 +5,7 @@ export default {
   key: "shopify-delete-metafield",
   name: "Delete Metafield",
   description: "Deletes a metafield belonging to a resource. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/metafieldsDelete)",
-  version: "0.0.12",
+  version: "0.0.13",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/shopify/actions/delete-page/delete-page.mjs
+++ b/components/shopify/actions/delete-page/delete-page.mjs
@@ -4,7 +4,7 @@ export default {
   key: "shopify-delete-page",
   name: "Delete Page",
   description: "Delete an existing page. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/pageDelete)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/shopify/actions/get-articles/get-articles.mjs
+++ b/components/shopify/actions/get-articles/get-articles.mjs
@@ -4,7 +4,7 @@ export default {
   key: "shopify-get-articles",
   name: "Get Articles",
   description: "Retrieve a list of all articles from a blog. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/queries/articles)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify/actions/get-assigned-fulfillment-orders/get-assigned-fulfillment-orders.mjs
+++ b/components/shopify/actions/get-assigned-fulfillment-orders/get-assigned-fulfillment-orders.mjs
@@ -4,7 +4,7 @@ export default {
   key: "shopify-get-assigned-fulfillment-orders",
   name: "Get Assigned Fulfillment Orders",
   description: "Retrieve a list of fulfillment orders assigned to a merchant location. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/queries/assignedfulfillmentorders)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify/actions/get-customer/get-customer.mjs
+++ b/components/shopify/actions/get-customer/get-customer.mjs
@@ -4,7 +4,7 @@ export default {
   key: "shopify-get-customer",
   name: "Get Customer",
   description: "Retrieve a single customer by ID. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/queries/customer)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify/actions/get-customers/get-customers.mjs
+++ b/components/shopify/actions/get-customers/get-customers.mjs
@@ -4,7 +4,7 @@ export default {
   key: "shopify-get-customers",
   name: "Get Customers",
   description: "Retrieve a list of customers. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/queries/customers)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify/actions/get-draft-order/get-draft-order.mjs
+++ b/components/shopify/actions/get-draft-order/get-draft-order.mjs
@@ -4,7 +4,7 @@ export default {
   key: "shopify-get-draft-order",
   name: "Get Draft Order",
   description: "Retrieve a single draft order by ID. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/queries/draftorder)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify/actions/get-draft-orders/get-draft-orders.mjs
+++ b/components/shopify/actions/get-draft-orders/get-draft-orders.mjs
@@ -4,7 +4,7 @@ export default {
   key: "shopify-get-draft-orders",
   name: "Get Draft Orders",
   description: "Retrieve a list of draft orders. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/queries/draftorders)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify/actions/get-fulfillment-order/get-fulfillment-order.mjs
+++ b/components/shopify/actions/get-fulfillment-order/get-fulfillment-order.mjs
@@ -5,7 +5,7 @@ export default {
   key: "shopify-get-fulfillment-order",
   name: "Get Fulfillment Order",
   description: "Retrieve a single fulfillment order by ID. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/queries/fulfillmentorder)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify/actions/get-fulfillment-orders/get-fulfillment-orders.mjs
+++ b/components/shopify/actions/get-fulfillment-orders/get-fulfillment-orders.mjs
@@ -4,7 +4,7 @@ export default {
   key: "shopify-get-fulfillment-orders",
   name: "Get Fulfillment Orders",
   description: "Retrieve a list of fulfillment orders. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/queries/fulfillmentorders)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify/actions/get-metafields/get-metafields.mjs
+++ b/components/shopify/actions/get-metafields/get-metafields.mjs
@@ -5,7 +5,7 @@ export default {
   key: "shopify-get-metafields",
   name: "Get Metafields",
   description: "Retrieves a list of metafields that belong to a resource. [See the documentation](https://shopify.dev/docs/api/admin-graphql/unstable/queries/metafields)",
-  version: "0.0.15",
+  version: "0.0.16",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify/actions/get-metaobjects/get-metaobjects.mjs
+++ b/components/shopify/actions/get-metaobjects/get-metaobjects.mjs
@@ -7,7 +7,7 @@ export default {
   key: "shopify-get-metaobjects",
   name: "Get Metaobjects",
   description: "Retrieves a list of metaobjects. [See the documentation](https://shopify.dev/docs/api/admin-graphql/unstable/queries/metaobjects)",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify/actions/get-pages/get-pages.mjs
+++ b/components/shopify/actions/get-pages/get-pages.mjs
@@ -4,7 +4,7 @@ export default {
   key: "shopify-get-pages",
   name: "Get Pages",
   description: "Retrieve a list of all pages. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/queries/pages)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify/actions/search-custom-collection-by-name/search-custom-collection-by-name.mjs
+++ b/components/shopify/actions/search-custom-collection-by-name/search-custom-collection-by-name.mjs
@@ -5,7 +5,7 @@ export default {
   key: "shopify-search-custom-collection-by-name",
   name: "Search Custom Collection by Name",
   description: "Search for a custom collection by name/title. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/queries/collections)",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify/actions/search-orders/search-orders.mjs
+++ b/components/shopify/actions/search-orders/search-orders.mjs
@@ -5,7 +5,7 @@ export default {
   key: "shopify-search-orders",
   name: "Search for Orders",
   description: "Search for an order or a list of orders. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/queries/orders)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify/actions/search-product-variant/search-product-variant.mjs
+++ b/components/shopify/actions/search-product-variant/search-product-variant.mjs
@@ -7,7 +7,7 @@ export default {
   key: "shopify-search-product-variant",
   name: "Search for Product Variant",
   description: "Search for product variants or create one if not found. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/queries/productVariants)",
-  version: "0.0.16",
+  version: "0.0.17",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify/actions/search-products/search-products.mjs
+++ b/components/shopify/actions/search-products/search-products.mjs
@@ -6,7 +6,7 @@ export default {
   key: "shopify-search-products",
   name: "Search for Products",
   description: "Search for products. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/queries/products)",
-  version: "0.0.16",
+  version: "0.0.17",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify/actions/update-article/update-article.mjs
+++ b/components/shopify/actions/update-article/update-article.mjs
@@ -4,7 +4,7 @@ export default {
   key: "shopify-update-article",
   name: "Update Article",
   description: "Update a blog article. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/articleUpdate)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/shopify/actions/update-inventory-level/update-inventory-level.mjs
+++ b/components/shopify/actions/update-inventory-level/update-inventory-level.mjs
@@ -5,7 +5,7 @@ export default {
   key: "shopify-update-inventory-level",
   name: "Update Inventory Level",
   description: "Sets the inventory level for an inventory item at a location. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/inventorySetOnHandQuantities)",
-  version: "0.0.17",
+  version: "0.0.18",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/shopify/actions/update-metafield/update-metafield.mjs
+++ b/components/shopify/actions/update-metafield/update-metafield.mjs
@@ -5,7 +5,7 @@ export default {
   key: "shopify-update-metafield",
   name: "Update Metafield",
   description: "Updates a metafield belonging to a resource. [See the documentation]()",
-  version: "0.0.14",
+  version: "0.0.15",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/shopify/actions/update-metaobject/update-metaobject.mjs
+++ b/components/shopify/actions/update-metaobject/update-metaobject.mjs
@@ -7,7 +7,7 @@ export default {
   key: "shopify-update-metaobject",
   name: "Update Metaobject",
   description: "Updates a metaobject. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/metaobjectUpdate)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/shopify/actions/update-order/update-order.mjs
+++ b/components/shopify/actions/update-order/update-order.mjs
@@ -5,7 +5,7 @@ export default {
   key: "shopify-update-order",
   name: "Update Order",
   description: "Update an existing order. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/orderupdate)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/shopify/actions/update-page/update-page.mjs
+++ b/components/shopify/actions/update-page/update-page.mjs
@@ -4,7 +4,7 @@ export default {
   key: "shopify-update-page",
   name: "Update Page",
   description: "Update an existing page. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/pageUpdate)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/shopify/actions/update-product-variant/update-product-variant.mjs
+++ b/components/shopify/actions/update-product-variant/update-product-variant.mjs
@@ -9,7 +9,7 @@ export default {
   key: "shopify-update-product-variant",
   name: "Update Product Variant",
   description: "Update an existing product variant. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/productVariantsBulkUpdate)",
-  version: "0.0.19",
+  version: "0.0.20",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/shopify/actions/update-product/update-product.mjs
+++ b/components/shopify/actions/update-product/update-product.mjs
@@ -6,7 +6,7 @@ export default {
   key: "shopify-update-product",
   name: "Update Product",
   description: "Update an existing product. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/productUpdate)",
-  version: "0.1.8",
+  version: "0.1.9",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/shopify/common/queries.mjs
+++ b/components/shopify/common/queries.mjs
@@ -604,6 +604,13 @@ const LIST_ORDERS = `
           id
           status
           displayStatus
+          createdAt
+          updatedAt
+          trackingInfo {
+            number
+            url
+            company
+          }
         }
         metafields (first: $first) {
           nodes {

--- a/components/shopify/package.json
+++ b/components/shopify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/shopify",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Pipedream Shopify Components",
   "main": "shopify.app.mjs",
   "keywords": [

--- a/components/shopify/sources/collection-updated/collection-updated.mjs
+++ b/components/shopify/sources/collection-updated/collection-updated.mjs
@@ -6,7 +6,7 @@ export default {
   key: "shopify-collection-updated",
   name: "Collection Updated (Instant)",
   description: "Emit new event whenever a collection is updated, including whenever products are added or removed from a collection.",
-  version: "0.0.9",
+  version: "0.0.10",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/shopify/sources/customer-data-request/customer-data-request.mjs
+++ b/components/shopify/sources/customer-data-request/customer-data-request.mjs
@@ -2,7 +2,7 @@ import shopify from "../../shopify.app.mjs";
 
 export default {
   name: "New Customer Data Request",
-  version: "0.0.16",
+  version: "0.0.17",
   key: "shopify-customer-data-request",
   description: "Emit new customer data requests for data via a GDPR request.",
   type: "source",

--- a/components/shopify/sources/new-abandoned-cart/new-abandoned-cart.mjs
+++ b/components/shopify/sources/new-abandoned-cart/new-abandoned-cart.mjs
@@ -6,7 +6,7 @@ export default {
   key: "shopify-new-abandoned-cart",
   name: "New Abandoned Cart",
   description: "Emit new event each time a user abandons their cart.",
-  version: "0.0.22",
+  version: "0.0.23",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/shopify/sources/new-article/new-article.mjs
+++ b/components/shopify/sources/new-article/new-article.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Article",
   type: "source",
   description: "Emit new event for each new article in a blog.",
-  version: "0.0.21",
+  version: "0.0.22",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/shopify/sources/new-event-emitted/new-event-emitted.mjs
+++ b/components/shopify/sources/new-event-emitted/new-event-emitted.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Event Emitted (Instant)",
   type: "source",
   description: "Emit new event for each new Shopify event.",
-  version: "0.0.17",
+  version: "0.0.18",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/shopify/sources/new-page/new-page.mjs
+++ b/components/shopify/sources/new-page/new-page.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Page",
   type: "source",
   description: "Emit new event for each new page published.",
-  version: "0.0.21",
+  version: "0.0.22",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/shopify/sources/new-product-created/new-product-created.mjs
+++ b/components/shopify/sources/new-product-created/new-product-created.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Product Created (Instant)",
   type: "source",
   description: "Emit new event for each product added to a store.",
-  version: "0.0.17",
+  version: "0.0.18",
   dedupe: "unique",
   methods: {
     ...common.methods,


### PR DESCRIPTION
## Summary

- `search_orders` is backed by Shopify Admin GraphQL (`this.shopify.listOrders` → `LIST_ORDERS` in `components/shopify/common/queries.mjs`).
- Tracking info was missing from the action output because `LIST_ORDERS` did not request it — the `fulfillments` selection only asked for `id`, `status`, and `displayStatus`.
- This PR expands the `fulfillments` selection so downstream consumers can map shipment tracking directly from `fulfillments` without a separate fetch.

## Changes

`components/shopify/common/queries.mjs` — add fields to the `LIST_ORDERS` `fulfillments` selection:

```graphql
fulfillments {
  id
  status
  displayStatus
  createdAt
  updatedAt
  trackingInfo {
    number
    url
    company
  }
}
```

Tracking will now be available on each returned order at:

```
result[x].fulfillments[y].trackingInfo[0].number
result[x].fulfillments[y].trackingInfo[0].url
result[x].fulfillments[y].trackingInfo[0].company
```

Also bumped:
- `actions/search-orders/search-orders.mjs` → `0.0.4` (output shape changed additively)
- `package.json` → `0.8.4`

I'll follow up with the CI-required version bumps for the other components in this package as soon as the check runs.

## Compatibility

No breaking changes. All existing fulfillment fields (`id`, `status`, `displayStatus`) are preserved; the new fields are purely additive. `trackingInfo` comes back empty for fulfillments that don't have tracking.

## Related

Closes #20675

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Order search now returns fulfillment details including creation/update timestamps and tracking info (carrier, tracking number, URL) for better shipment visibility.
* **Chores**
  * Incremental version updates across Shopify actions, sources, and the Shopify package to reflect maintenance and releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->