### PR TITLE
Microsoft Outlook - details updates

### DIFF
--- a/components/microsoft_outlook/actions/find-email/find-email.mjs
+++ b/components/microsoft_outlook/actions/find-email/find-email.mjs
@@ -5,7 +5,7 @@ export default {
   key: "microsoft_outlook-find-email",
   name: "Find Email",
   description: "Search for an email in Microsoft Outlook. [See the documentation](https://learn.microsoft.com/en-us/graph/api/user-list-messages)",
-  version: "0.1.4",
+  version: "0.2.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -58,6 +58,12 @@ export default {
       optional: true,
       default: false,
     },
+    select: {
+      type: "string",
+      label: "Properties to return ($select)",
+      description: "Comma-separated Microsoft Graph [message](https://learn.microsoft.com/en-us/graph/api/resources/message) property names to return for each message (for example `id,subject,from,receivedDateTime`). When empty, the API returns its default property set. Use this to shrink responses and downstream token usage.",
+      optional: true,
+    },
   },
   methods: {
     ensureQuotes(str) {
@@ -71,6 +77,18 @@ export default {
       throw new ConfigurationError("`$search` not supported when using `$filter` or `$orderby`.");
     }
 
+    const normalizedSelect = this.select?.trim()
+      ? this.select.split(",")
+        .map((p) => p.trim())
+        .filter(Boolean)
+        .join(",")
+      : "";
+    const selectParams = normalizedSelect
+      ? {
+        "$select": normalizedSelect,
+      }
+      : {};
+
     let emails = [];
 
     if (!this.search) {
@@ -82,6 +100,7 @@ export default {
           params: {
             "$filter": this.filter,
             "$orderby": this.orderBy,
+            ...selectParams,
             ...(this.includeAttachments
               ? {
                 "$expand": "attachments",
@@ -102,6 +121,7 @@ export default {
         params: {
           "$search": this.ensureQuotes(this.search),
           "$top": this.maxResults,
+          ...selectParams,
           ...(this.includeAttachments
             ? {
               "$expand": "attachments",

--- a/components/microsoft_outlook/package.json
+++ b/components/microsoft_outlook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/microsoft_outlook",
-  "version": "1.11.3",
+  "version": "1.12.0",
   "description": "Pipedream Microsoft Outlook Components",
   "main": "microsoft_outlook.app.mjs",
   "keywords": [

--- a/components/microsoft_outlook_calendar/actions/get-event/get-event.mjs
+++ b/components/microsoft_outlook_calendar/actions/get-event/get-event.mjs
@@ -1,0 +1,54 @@
+import microsoftOutlook from "../../microsoft_outlook_calendar.app.mjs";
+
+export default {
+  type: "action",
+  key: "microsoft_outlook_calendar-get-event",
+  name: "Get Event",
+  description: "Retrieve a calendar event by its Microsoft Graph event ID. Pass the `id` from **List Events** when you need full details (for example `body`, `attendees`, or `recurrence`) that list responses may omit or truncate. [See the documentation](https://learn.microsoft.com/en-us/graph/api/event-get?view=graph-rest-1.0&tabs=http)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    microsoftOutlook,
+    eventId: {
+      propDefinition: [
+        microsoftOutlook,
+        "eventId",
+      ],
+      description: "The Microsoft Graph event ID — the `id` field on each object returned by **List Events** (including occurrences from calendar view when **Include Recurring** is enabled).",
+    },
+    select: {
+      type: "string",
+      label: "Properties to return ($select)",
+      description: "Optional. Comma-separated Microsoft Graph [event](https://learn.microsoft.com/en-us/graph/api/resources/event) property names (for example `subject,body,bodyPreview,start,end,attendees,organizer,location`). When empty, the API returns its default property set.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const normalizedSelect = this.select?.trim()
+      ? this.select.split(",")
+        .map((p) => p.trim())
+        .filter(Boolean)
+        .join(",")
+      : "";
+
+    const params = normalizedSelect
+      ? {
+        $select: normalizedSelect,
+      }
+      : {};
+
+    const event = await this.microsoftOutlook.getCalendarEvent({
+      $,
+      eventId: this.eventId,
+      params,
+    });
+
+    const label = event?.subject ?? this.eventId;
+    $.export("$summary", `Successfully retrieved event "${label}"`);
+    return event;
+  },
+};

--- a/components/microsoft_outlook_calendar/package.json
+++ b/components/microsoft_outlook_calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/microsoft_outlook_calendar",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "description": "Pipedream Microsoft Outlook Calendar Components",
   "main": "microsoft_outlook_calendar.app.mjs",
   "keywords": [


### PR DESCRIPTION
## WHY

Allow for some more granularity in retrieving information about emails and calendar events, to allow users to cut down on context and token size by omitting unnecessary properties.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Get Event action: retrieve Outlook calendar events with an optional field selector to return only desired properties.

* **Enhancements**
  * Find Email action: optional field selector added so users can specify which message properties to return for finer result control.

* **Chores**
  * Package versions for Outlook and Outlook Calendar components bumped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->