### PR TITLE
fix(google-sheets): return explicit null/[] instead of undefined for empty results

### DIFF
--- a/components/google_sheets/actions/get-cell/get-cell.mjs
+++ b/components/google_sheets/actions/get-cell/get-cell.mjs
@@ -47,7 +47,7 @@ export default {
       ],
     },
   },
-  async run() {
+  async run({ $ }) {
     const worksheet = await this.getWorksheetById(this.sheetId, this.worksheetId);
     const sheets = this.googleSheets.sheets();
 
@@ -55,8 +55,10 @@ export default {
       spreadsheetId: this.sheetId,
       range: `${worksheet?.properties?.title}!${this.cell}:${this.cell}`,
     })).data.values;
-    return values?.length
-      ? values[0][0]
-      : null;
+    const ret = values?.[0]?.[0] ?? null;
+    $.export("$summary", ret === null
+      ? `No value found in cell ${this.cell}.`
+      : `Retrieved value from cell ${this.cell}.`);
+    return ret;
   },
 };

--- a/components/google_sheets/actions/get-cell/get-cell.mjs
+++ b/components/google_sheets/actions/get-cell/get-cell.mjs
@@ -7,7 +7,7 @@ export default {
   key: "google_sheets-get-cell",
   name: "Get Cell",
   description: "Fetch the contents of a specific cell in a spreadsheet. [See the documentation](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/get)",
-  version: "0.1.17",
+  version: "0.1.18",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -55,8 +55,8 @@ export default {
       spreadsheetId: this.sheetId,
       range: `${worksheet?.properties?.title}!${this.cell}:${this.cell}`,
     })).data.values;
-    if (values?.length) {
-      return values[0][0];
-    }
+    return values?.length
+      ? values[0][0]
+      : null;
   },
 };

--- a/components/google_sheets/actions/get-values-in-range/get-values-in-range.mjs
+++ b/components/google_sheets/actions/get-values-in-range/get-values-in-range.mjs
@@ -48,15 +48,17 @@ export default {
       optional: true,
     },
   },
-  async run() {
+  async run({ $ }) {
     const worksheet = await this.getWorksheetById(this.sheetId, this.worksheetId);
     const sheets = this.googleSheets.sheets();
 
-    return (await sheets.spreadsheets.values.get({
+    const values = (await sheets.spreadsheets.values.get({
       spreadsheetId: this.sheetId,
       range: this.range
         ? `${worksheet?.properties?.title}!${this.range}`
         : `${worksheet?.properties?.title}`,
     })).data.values ?? [];
+    $.export("$summary", `Returned ${values.length} row(s) of values.`);
+    return values;
   },
 };

--- a/components/google_sheets/actions/get-values-in-range/get-values-in-range.mjs
+++ b/components/google_sheets/actions/get-values-in-range/get-values-in-range.mjs
@@ -7,7 +7,7 @@ export default {
   key: "google_sheets-get-values-in-range",
   name: "Get Values in Range",
   description: "Get all values or values from a range of cells using A1 notation. [See the documentation](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/get)",
-  version: "0.1.17",
+  version: "0.1.18",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -57,6 +57,6 @@ export default {
       range: this.range
         ? `${worksheet?.properties?.title}!${this.range}`
         : `${worksheet?.properties?.title}`,
-    })).data.values;
+    })).data.values ?? [];
   },
 };

--- a/components/google_sheets/actions/list-worksheets/list-worksheets.mjs
+++ b/components/google_sheets/actions/list-worksheets/list-worksheets.mjs
@@ -31,8 +31,11 @@ export default {
       description: "List worksheets in the specified spreadsheet",
     },
   },
-  async run() {
+  async run({ $ }) {
     const { sheets = [] } = await this.googleSheets.getSpreadsheet(this.sheetId);
+    $.export("$summary", `Returned ${sheets.length} worksheet${sheets.length === 1
+      ? ""
+      : "s"}.`);
     return sheets;
   },
 };

--- a/components/google_sheets/actions/list-worksheets/list-worksheets.mjs
+++ b/components/google_sheets/actions/list-worksheets/list-worksheets.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_sheets-list-worksheets",
   name: "List Worksheets",
   description: "Get a list of all worksheets in a spreadsheet. [See the documentation](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/get)",
-  version: "0.1.15",
+  version: "0.1.16",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -32,7 +32,7 @@ export default {
     },
   },
   async run() {
-    const { sheets } = await this.googleSheets.getSpreadsheet(this.sheetId);
+    const { sheets = [] } = await this.googleSheets.getSpreadsheet(this.sheetId);
     return sheets;
   },
 };

--- a/components/google_sheets/package.json
+++ b/components/google_sheets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_sheets",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Pipedream Google_sheets Components",
   "main": "google_sheets.app.mjs",
   "keywords": [


### PR DESCRIPTION
## Summary

- `get-cell`: returned implicit `undefined` (no `return` statement) when the cell is empty — changed to explicit `null`
- `get-values-in-range`: returned `undefined` when Google API omits the `values` key for an empty range — added `?? []` fallback  
- `list-worksheets`: destructured `sheets` with no default — changed to `{ sheets = [] }` to guard against a missing key

## Root cause

JavaScript `undefined` is stripped by `JSON.stringify`, so these edge cases caused `ret` to be **absent** from the action response JSON rather than a meaningful value. The Pipedream Python SDK (`run_action_response.py:26`) declares `ret: Optional[Any] = Field(default=None)`, so any absent `ret` becomes `None` — indistinguishable from an explicit `null`. MCP clients (and LLMs interpreting tool results) were seeing `None`/`null` and incorrectly concluding the operation failed or produced no data.

These three actions are all read-only and the affected scenarios (empty cells, empty ranges) are common in production.

## Test plan

- [ ] `get-cell` on an empty cell returns `{"ret": null, ...}` (not absent `ret`)
- [ ] `get-values-in-range` on an empty range returns `{"ret": [], ...}`
- [ ] `list-worksheets` returns `{"ret": [], ...}` even if API response lacks a `sheets` key
- [ ] All three still work correctly for non-empty data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Actions now emit concise retrieval summaries describing results.
* **Bug Fixes**
  * Get Cell now returns null consistently when no cell data is present.
  * Get Values in Range now returns an empty list consistently when no values exist.
  * List Worksheets now returns an empty list when no worksheets are found.
* **Chore**
  * Google Sheets component package bumped to v0.14.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->