### PR TITLE
fix(google-sheets): return empty string instead of null for empty cell

### DIFF
--- a/components/google_sheets/actions/get-cell/get-cell.mjs
+++ b/components/google_sheets/actions/get-cell/get-cell.mjs
@@ -7,7 +7,7 @@ export default {
   key: "google_sheets-get-cell",
   name: "Get Cell",
   description: "Fetch the contents of a specific cell in a spreadsheet. [See the documentation](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/get)",
-  version: "0.1.18",
+  version: "0.1.19",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -55,8 +55,8 @@ export default {
       spreadsheetId: this.sheetId,
       range: `${worksheet?.properties?.title}!${this.cell}:${this.cell}`,
     })).data.values;
-    const ret = values?.[0]?.[0] ?? null;
-    $.export("$summary", ret === null
+    const ret = values?.[0]?.[0] ?? "";
+    $.export("$summary", ret === ""
       ? `No value found in cell ${this.cell}.`
       : `Retrieved value from cell ${this.cell}.`);
     return ret;

--- a/components/google_sheets/package.json
+++ b/components/google_sheets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_sheets",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Pipedream Google_sheets Components",
   "main": "google_sheets.app.mjs",
   "keywords": [


### PR DESCRIPTION
## Summary

- `get-cell` was returning `null` for empty cells after #20694, which is the exact problem we were trying to fix
- Changed `?? null` to `?? ""` so an empty cell returns an empty string — `ret` is always a non-null value

## Test plan

- [ ] `get-cell` on an empty cell returns `{"ret": "", ...}` with `$summary: "No value found in cell X."`
- [ ] `get-cell` on a cell with a value still returns the value correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Google Sheets get-cell action to return an empty string instead of null when retrieving cells with no value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->