### PR TITLE
Kendo AI integration

### DIFF
--- a/components/kendo/actions/submit-call/submit-call.mjs
+++ b/components/kendo/actions/submit-call/submit-call.mjs
@@ -1,0 +1,122 @@
+import kendo from "../../kendo.app.mjs";
+
+export default {
+  key: "kendo-submit-call",
+  name: "Submit Call for Analysis",
+  description:
+    "Submits a call recording or transcript to Kendo AI for analysis via the Push API. [See the documentation](https://docs.kendo.ai/docs/push-api)",
+  version: "0.1.0",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: false,
+    readOnlyHint: false,
+  },
+  props: {
+    kendo,
+    audioUrl: {
+      type: "string",
+      label: "Audio URL",
+      description:
+        "Publicly accessible URL of the call recording. Kendo will download and transcribe this. Required if **Transcript** is not provided.",
+      optional: true,
+    },
+    transcript: {
+      type: "string",
+      label: "Transcript",
+      description:
+        "Plain-text transcript of the call. Required if **Audio URL** is not provided. If both are supplied, audio takes priority.",
+      optional: true,
+    },
+    repName: {
+      propDefinition: [
+        kendo,
+        "repName",
+      ],
+    },
+    repEmail: {
+      propDefinition: [
+        kendo,
+        "repEmail",
+      ],
+    },
+    callTitle: {
+      propDefinition: [
+        kendo,
+        "callTitle",
+      ],
+    },
+    disableAiTitle: {
+      propDefinition: [
+        kendo,
+        "disableAiTitle",
+      ],
+    },
+    callDate: {
+      propDefinition: [
+        kendo,
+        "callDate",
+      ],
+    },
+    duration: {
+      propDefinition: [
+        kendo,
+        "duration",
+      ],
+    },
+    metadata: {
+      propDefinition: [
+        kendo,
+        "metadata",
+      ],
+    },
+  },
+  async run({ $ }) {
+    if (!this.audioUrl && !this.transcript) {
+      throw new Error(
+        "At least one of Audio URL or Transcript must be provided.",
+      );
+    }
+
+    const body = {
+      ...(this.audioUrl && {
+        audioUrl: this.audioUrl,
+      }),
+      ...(this.transcript && {
+        transcript: this.transcript,
+      }),
+      ...(this.repName && {
+        repName: this.repName,
+      }),
+      ...(this.repEmail && {
+        repEmail: this.repEmail,
+      }),
+      ...(this.callTitle && {
+        callTitle: this.callTitle,
+      }),
+      ...(this.disableAiTitle !== undefined && {
+        disableAiTitleGeneration: this.disableAiTitle,
+      }),
+      ...(this.callDate && {
+        callDate: this.callDate,
+      }),
+      ...(this.duration && {
+        duration: this.duration,
+      }),
+      ...(this.metadata && {
+        metadata: this.metadata,
+      }),
+    };
+
+    const response = await this.kendo.submitCall({
+      $,
+      data: body,
+    });
+
+    $.export(
+      "$summary",
+      `Call submitted successfully. Call ID: ${response.callId}`,
+    );
+    return response;
+  },
+};

--- a/components/kendo/kendo.app.mjs
+++ b/components/kendo/kendo.app.mjs
@@ -1,0 +1,109 @@
+import { axios } from "@pipedream/platform";
+import crypto from "crypto";
+
+export default {
+  type: "app",
+  app: "kendo",
+  description: "Pipedream Kendo AI Components",
+  propDefinitions: {
+    repName: {
+      type: "string",
+      label: "Rep Name",
+      description: "Full name of the sales rep on the call.",
+      optional: true,
+    },
+    repEmail: {
+      type: "string",
+      label: "Rep Email",
+      description: "Email of the sales rep on the call.",
+      optional: true,
+    },
+    callTitle: {
+      type: "string",
+      label: "Call Title",
+      description:
+        "Title for the call. If omitted, Kendo will auto-generate one using AI.",
+      optional: true,
+    },
+    disableAiTitle: {
+      type: "boolean",
+      label: "Disable AI Title Generation",
+      description:
+        "Set to `true` to use your provided **Call Title** as-is, skipping Kendo's AI title generation.",
+      optional: true,
+      default: false,
+    },
+    callDate: {
+      type: "string",
+      label: "Call Date",
+      description: "ISO 8601 date of the call (e.g. `2026-04-27T10:00:00Z`).",
+      optional: true,
+    },
+    duration: {
+      type: "string",
+      label: "Duration",
+      description:
+        "Call duration. Kendo accepts minutes, seconds, or milliseconds and normalizes automatically.",
+      optional: true,
+    },
+    metadata: {
+      type: "object",
+      label: "Metadata",
+      description:
+        "Flat key/value object of custom metadata to attach to the call (e.g. `{ source: 'hubspot', recordId: '123' }`).",
+      optional: true,
+    },
+  },
+  methods: {
+    _baseUrl() {
+      return "https://app.kendo.ai/api/integrations/push-api";
+    },
+    _apiKey() {
+      return this.$auth.apiKey;
+    },
+    _webhookSecret() {
+      return this.$auth.webhookSecret;
+    },
+    _makeRequest({
+      $ = this, path, ...args
+    } = {}) {
+      return axios($, {
+        ...args,
+        url: `${this._baseUrl()}${path}`,
+        headers: {
+          "Content-Type": "application/json",
+          "X-API-Key": this._apiKey(),
+        },
+      });
+    },
+    post(args = {}) {
+      return this._makeRequest({
+        method: "POST",
+        ...args,
+      });
+    },
+    submitCall({
+      $, data,
+    }) {
+      return this.post({
+        $,
+        path: "/ingest",
+        data,
+      });
+    },
+    verifyWebhookSignature(raw_body, signature) {
+      const expected = crypto
+        .createHmac("sha256", this._webhookSecret())
+        .update(raw_body)
+        .digest("hex");
+      try {
+        return crypto.timingSafeEqual(
+          Buffer.from(signature),
+          Buffer.from(expected),
+        );
+      } catch {
+        return false;
+      }
+    },
+  },
+};

--- a/components/kendo/package.json
+++ b/components/kendo/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@pipedream/kendo",
+  "version": "0.1.0",
+  "description": "Pipedream Kendo AI components",
+  "main": "kendo.app.mjs",
+  "keywords": [
+    "pipedream",
+    "kendo",
+    "kendoai"
+  ],
+  "homepage": "https://pipedream.com/apps/kendo",
+  "author": "Sambot <0xsambot@pm.me> (https://kendo.ai)",
+  "dependencies": {
+    "@pipedream/sdk": "^2.4.7"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/components/kendo/sources/ai-training-completed/ai-training-completed.mjs
+++ b/components/kendo/sources/ai-training-completed/ai-training-completed.mjs
@@ -1,0 +1,25 @@
+import base from "../common/webhook-base.mjs";
+import sampleEmit from "./test-event.mjs";
+
+export default {
+  ...base,
+  key: "kendo-ai-training-completed",
+  name: "New AI Training Completed",
+  description:
+    "Emit new event when Kendo completes an AI training session for an agent.",
+  version: "0.1.0",
+  type: "source",
+  dedupe: "unique",
+  methods: {
+    ...base.methods,
+    getEventType() {
+      return "ai.training.completed";
+    },
+    getSummary(data) {
+      return `AI training completed: ${data?.agentName ?? "Unknown"} — Score: ${
+        data?.aiScore ?? "N/A"
+      }`;
+    },
+  },
+  sampleEmit,
+};

--- a/components/kendo/sources/ai-training-completed/test-event.mjs
+++ b/components/kendo/sources/ai-training-completed/test-event.mjs
@@ -1,0 +1,13 @@
+export default {
+  id: "evt_456",
+  event: "ai.training.completed",
+  createdAt: "2026-03-05T12:02:00Z",
+  trainingId: "abc",
+  agentId: "agent_1",
+  agentName: "Sales Agent",
+  userId: "user_1",
+  teamMemberUserId: "member_1",
+  duration: 300,
+  aiScore: "90",
+  timestamp: "2026-03-05T12:02:00Z",
+};

--- a/components/kendo/sources/call-analyzed/call-analyzed.mjs
+++ b/components/kendo/sources/call-analyzed/call-analyzed.mjs
@@ -1,0 +1,22 @@
+import base from "../common/webhook-base.mjs";
+
+export default {
+  ...base,
+  key: "kendo-call-analyzed",
+  name: "New Call Analyzed",
+  description: "Emit new event when Kendo finishes AI analysis on a call.",
+  version: "0.1.0",
+  type: "source",
+  dedupe: "unique",
+  methods: {
+    ...base.methods,
+    getEventType() {
+      return "call.uploaded";
+    },
+    getSummary(data) {
+      return `Call analyzed: ${data?.agentName ?? "Unknown"} — Score: ${
+        data?.aiScore ?? "N/A"
+      }`;
+    },
+  },
+};

--- a/components/kendo/sources/common/webhook-base.mjs
+++ b/components/kendo/sources/common/webhook-base.mjs
@@ -1,0 +1,94 @@
+import kendo from "../../kendo.app.mjs";
+
+export default {
+  props: {
+    kendo,
+    http: {
+      type: "$.interface.http",
+      customResponse: true,
+      label: "Webhook Endpoint",
+      description:
+        "Pipedream will generate a unique URL below. Copy it into **Integrations > Webhooks > Add Webhook** in your Kendo dashboard.",
+    },
+    db: {
+      type: "$.service.db",
+      label: "DB",
+      description: "Stores data between executions for deduplication.",
+    },
+  },
+  methods: {
+    getEventType() {
+      throw new Error("getEventType() must be implemented by the source");
+    },
+    getSummary() {
+      throw new Error("getSummary() must be implemented by the source");
+    },
+    getEmitPayload(body) {
+      const {
+        id, event, created_at, data,
+      } = body;
+      return {
+        id,
+        event,
+        createdAt: created_at,
+        ...data,
+      };
+    },
+    _respond(status, body) {
+      this.http.respond({
+        status,
+        body,
+      });
+    },
+    _rejectUnauthorized(reason) {
+      console.warn(`${reason} — request rejected.`);
+      this._respond(401, {
+        error: reason,
+      });
+    },
+  },
+  async run(event) {
+    const {
+      headers, bodyRaw, body,
+    } = event;
+
+    const signature = headers["x-kendo-signature"];
+    if (!signature) {
+      this._rejectUnauthorized("Missing signature");
+      return;
+    }
+
+    const is_valid = this.kendo.verifyWebhookSignature(bodyRaw, signature);
+    if (!is_valid) {
+      this._rejectUnauthorized("Invalid signature");
+      return;
+    }
+
+    this._respond(200, {
+      received: true,
+    });
+
+    const kendo_event = headers["x-kendo-event"];
+    if (kendo_event === "test") {
+      console.log("Test delivery received — not emitting.");
+      return;
+    }
+
+    const expected_event = this.getEventType();
+    if (kendo_event !== expected_event) {
+      console.log(`Ignoring event type: ${kendo_event}`);
+      return;
+    }
+
+    const {
+      id, created_at, data,
+    } = body;
+    const payload = this.getEmitPayload(body);
+
+    this.$emit(payload, {
+      id,
+      summary: this.getSummary(data),
+      ts: Date.parse(created_at),
+    });
+  },
+};


### PR DESCRIPTION
- Add `kendo.app.mjs` with auth (apiKey + webhookSecret), shared prop definitions and common API methods (HMAC signature verification, call ingestion via Push API)
- Add `sources/common/webhook-base.mjs` as a shared webhook base
- Add Webhook Sources: `call-analyzed` (`call.uploaded`) and `ai-training-completed` (`ai.training.completed`)
- Add Call Submission Action: `submit-call`. Submits a call recording or transcript to Kendo's Push API for AI analysis

## WHY
Kendo AI is an AI enabled sales management and training platform. This new component aims to integrate webhook and push API endpoints exposed by Kendo:

### Sources
- New Call Analyzed: After an uploaded sales call has been analyzed and scored
- New AI Training Completed: After a sales agent completes an AI Roleplay session

### Actions
- Submit Call for Analysis: Upload a new sales call using either audio or transcript

More documentation: https://docs.kendo.ai/docs/introduction


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added Kendo AI integration to Pipedream
* New "Submit Call for Analysis" action to submit call recordings and transcripts for Kendo AI analysis with optional rep and call details
* New event sources to receive Kendo AI training completion and call analysis event notifications
* Built-in automatic webhook signature verification for secure event handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->