### PR TITLE
[20473] Power BI — add Get Report action

### DIFF
--- a/components/microsoft_power_bi/actions/add-rows-to-push-dataset/add-rows-to-push-dataset.mjs
+++ b/components/microsoft_power_bi/actions/add-rows-to-push-dataset/add-rows-to-push-dataset.mjs
@@ -12,7 +12,7 @@ export default {
     + " Common mistakes: (1) case mismatch on `tableName` returns 404 — copy the exact string from the dataset's `tables` array. (2) Sending values that don't match the declared column data type returns `RequestedResourceNotFound` or `DMTS_DatasourceHasNoCredentialsError`."
     + " Push-dataset rows have no individual IDs and cannot be updated or deleted — only appended or bulk-cleared."
     + " [See the documentation](https://learn.microsoft.com/en-us/rest/api/power-bi/push-datasets/datasets-post-rows-in-group)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/microsoft_power_bi/actions/execute-dax-query/execute-dax-query.mjs
+++ b/components/microsoft_power_bi/actions/execute-dax-query/execute-dax-query.mjs
@@ -17,7 +17,7 @@ export default {
     + " The tenant must have 'Dataset Execute Queries REST API' enabled (admin setting) or the call returns 401/403."
     + " Pass `workspaceId` (from **List Workspaces**) or `workspaceName` to target a specific workspace, or omit both for My workspace."
     + " [See the documentation](https://learn.microsoft.com/en-us/rest/api/power-bi/datasets/execute-queries-in-group)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/microsoft_power_bi/actions/export-report/export-report.mjs
+++ b/components/microsoft_power_bi/actions/export-report/export-report.mjs
@@ -18,7 +18,7 @@ export default {
     + " The export is asynchronous — this tool starts the export, then polls until the job reaches `Succeeded` or `Failed` (or `pollTimeoutSeconds` elapses), then downloads the file and returns it as base64 along with the job metadata."
     + " PNG exports only work for single-page reports. For PPTX/PDF, pass `pages` (array of page names, e.g., `[\"ReportSection\", \"ReportSection1\"]`) to limit the export."
     + " [See the documentation](https://learn.microsoft.com/en-us/rest/api/power-bi/reports/export-to-file-in-group)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/microsoft_power_bi/actions/get-refresh-history/get-refresh-history.mjs
+++ b/components/microsoft_power_bi/actions/get-refresh-history/get-refresh-history.mjs
@@ -8,7 +8,7 @@ export default {
     + " Pass `workspaceId` (from **List Workspaces**) or `workspaceName` to scope to a specific workspace, or omit both for My workspace."
     + " Each entry includes `requestId`, `refreshType` (`OnDemand`, `Scheduled`, `ViaApi`, etc.), `startTime`, `endTime`, `status` (`Completed`, `Failed`, `Disabled`, `Cancelled`, `Unknown` — `Unknown` means still in progress), and `serviceExceptionJson` on failures."
     + " [See the documentation](https://learn.microsoft.com/en-us/rest/api/power-bi/datasets/get-refresh-history-in-group)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/microsoft_power_bi/actions/get-reports-by-id/get-reports-by-id.mjs
+++ b/components/microsoft_power_bi/actions/get-reports-by-id/get-reports-by-id.mjs
@@ -4,7 +4,7 @@ export default {
   key: "microsoft_power_bi-get-reports-by-id",
   name: "Get Report by id",
   description: "Retrieve metadata for a single Power BI report by ID. Uses My workspace by default; set Workspace (Group) ID for a specific workspace. [See the documentation](https://learn.microsoft.com/en-us/rest/api/power-bi/reports/get-report)",
-  version: "0.0.6",
+  version: "0.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -32,9 +32,9 @@ export default {
       type: "string",
       label: "Report ID",
       description: "Power BI report ID (GUID), e.g. `2f1f6a59-1b2c-4d84-9d89-4c27f8a3c111`. Set **Workspace (Group) ID** to scope options to one workspace.",
-      async options({ groupId } = {}) {
+      async options() {
         const reports = await this.microsoftPowerBi.listReports({
-          groupId: groupId || undefined,
+          groupId: this.groupId || undefined,
         });
         return reports?.map?.(({
           id, name,

--- a/components/microsoft_power_bi/actions/get-reports-by-id/get-reports-by-id.mjs
+++ b/components/microsoft_power_bi/actions/get-reports-by-id/get-reports-by-id.mjs
@@ -14,19 +14,35 @@ export default {
   props: {
     microsoftPowerBi,
     groupId: {
-      propDefinition: [
-        microsoftPowerBi,
-        "groupId",
-      ],
+      type: "string",
+      label: "Workspace (Group) ID",
+      description: "Workspace group ID (GUID), e.g. `f089354e-8366-4e18-aea3-4cb4a3a50b48`. Omit to target My workspace.",
+      optional: true,
+      async options() {
+        const groups = await this.microsoftPowerBi.listGroups();
+        return groups?.map?.(({
+          id, name,
+        }) => ({
+          label: name,
+          value: id,
+        })) ?? [];
+      },
     },
     reportId: {
-      propDefinition: [
-        microsoftPowerBi,
-        "reportId",
-        ({ groupId }) => ({
-          groupId,
-        }),
-      ],
+      type: "string",
+      label: "Report ID",
+      description: "Power BI report ID (GUID), e.g. `2f1f6a59-1b2c-4d84-9d89-4c27f8a3c111`. Set **Workspace (Group) ID** to scope options to one workspace.",
+      async options({ groupId } = {}) {
+        const reports = await this.microsoftPowerBi.listReports({
+          groupId: groupId || undefined,
+        });
+        return reports?.map?.(({
+          id, name,
+        }) => ({
+          label: name,
+          value: id,
+        })) ?? [];
+      },
     },
   },
   async run({ $ }) {

--- a/components/microsoft_power_bi/actions/get-reports-by-id/get-reports-by-id.mjs
+++ b/components/microsoft_power_bi/actions/get-reports-by-id/get-reports-by-id.mjs
@@ -1,0 +1,41 @@
+import microsoftPowerBi from "../../microsoft_power_bi.app.mjs";
+
+export default {
+  key: "microsoft_power_bi-get-reports-by-id",
+  name: "Get Report by id",
+  description: "Retrieve metadata for a single Power BI report by ID. Uses My workspace by default; set Workspace (Group) ID for a specific workspace. [See the documentation](https://learn.microsoft.com/en-us/rest/api/power-bi/reports/get-report)",
+  version: "0.0.6",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  type: "action",
+  props: {
+    microsoftPowerBi,
+    groupId: {
+      propDefinition: [
+        microsoftPowerBi,
+        "groupId",
+      ],
+    },
+    reportId: {
+      propDefinition: [
+        microsoftPowerBi,
+        "reportId",
+        ({ groupId }) => ({
+          groupId,
+        }),
+      ],
+    },
+  },
+  async run({ $ }) {
+    const report = await this.microsoftPowerBi.getReport({
+      $,
+      reportId: this.reportId,
+      groupId: this.groupId,
+    });
+    $.export("$summary", `Retrieved report "${report.name}" (${report.id})`);
+    return report;
+  },
+};

--- a/components/microsoft_power_bi/actions/get-reports/get-reports.mjs
+++ b/components/microsoft_power_bi/actions/get-reports/get-reports.mjs
@@ -4,7 +4,7 @@ export default {
   key: "microsoft_power_bi-get-reports",
   name: "Get Reports",
   description: "Get reports from a Power BI workspace. [See the documentation](https://learn.microsoft.com/en-us/rest/api/power-bi/reports/get-reports)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/microsoft_power_bi/actions/list-dashboards/list-dashboards.mjs
+++ b/components/microsoft_power_bi/actions/list-dashboards/list-dashboards.mjs
@@ -9,7 +9,7 @@ export default {
     + " Each dashboard includes `id`, `displayName`, `isReadOnly`, `webUrl`, and `embedUrl`."
     + " Note: dashboards cannot be created via the REST API — they are built interactively in the Power BI service."
     + " [See the documentation](https://learn.microsoft.com/en-us/rest/api/power-bi/dashboards/get-dashboards-in-group)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/microsoft_power_bi/actions/list-datasets/list-datasets.mjs
+++ b/components/microsoft_power_bi/actions/list-datasets/list-datasets.mjs
@@ -10,7 +10,7 @@ export default {
     + " Use this tool to resolve a dataset name → ID before calling **Refresh Dataset**, **Execute DAX Query**, **Get Refresh History**, or **Add Rows To Push Dataset**."
     + " For push-dataset row inserts, call the dataset's `GET tables` endpoint (not exposed as a separate tool) by inspecting the dataset's `name` → tables are defined at dataset creation; the table name is the string configured at creation time (e.g., `Species`)."
     + " [See the documentation](https://learn.microsoft.com/en-us/rest/api/power-bi/datasets/get-datasets-in-group)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/microsoft_power_bi/actions/list-reports/list-reports.mjs
+++ b/components/microsoft_power_bi/actions/list-reports/list-reports.mjs
@@ -9,7 +9,7 @@ export default {
     + " Each report includes `id`, `name`, `webUrl`, `embedUrl`, `datasetId`, and `reportType` (`PowerBIReport` or `PaginatedReport`)."
     + " Note: reports cannot be created via the REST API — they are published from Power BI Desktop."
     + " [See the documentation](https://learn.microsoft.com/en-us/rest/api/power-bi/reports/get-reports)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/microsoft_power_bi/actions/list-workspaces/list-workspaces.mjs
+++ b/components/microsoft_power_bi/actions/list-workspaces/list-workspaces.mjs
@@ -9,7 +9,7 @@ export default {
     + " Every item in the response includes `id`, `name`, `isReadOnly`, `isOnDedicatedCapacity`, and `type`."
     + " Note: when a user says 'my workspace' without a name, they may mean personal My workspace (implicit — pass no `workspaceId` to other tools) OR a specific named workspace — ask only if ambiguous."
     + " [See the documentation](https://learn.microsoft.com/en-us/rest/api/power-bi/groups/get-groups)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/microsoft_power_bi/actions/refresh-dataset/refresh-dataset.mjs
+++ b/components/microsoft_power_bi/actions/refresh-dataset/refresh-dataset.mjs
@@ -10,7 +10,7 @@ export default {
     + " Power BI Pro licenses allow up to 8 scheduled refreshes per day; Premium allows 48."
     + " Note: Push datasets accept this endpoint but the refresh is metadata-only (tile refresh), not a data refresh — no cancellable history entry is produced."
     + " [See the documentation](https://learn.microsoft.com/en-us/rest/api/power-bi/datasets/refresh-dataset-in-group)",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/microsoft_power_bi/microsoft_power_bi.app.mjs
+++ b/components/microsoft_power_bi/microsoft_power_bi.app.mjs
@@ -55,14 +55,45 @@ export default {
     workspaceId: {
       type: "string",
       label: "Workspace ID",
-      description: "ID of the workspace. Use **List Workspaces** to find IDs. Omit to target My workspace.",
+      description: "ID of the workspace. Use the **List Workspaces** tool to see accessible workspaces. Omit to target My workspace.",
       optional: true,
     },
     workspaceName: {
       type: "string",
       label: "Workspace Name",
-      description: "Name of the workspace (alternative to `workspaceId`). Resolved via **List Workspaces**.",
+      description: "Name of the workspace (alternative to **Workspace ID**). Use the **List Workspaces** tool to see accessible workspaces.",
       optional: true,
+    },
+    groupId: {
+      type: "string",
+      label: "Workspace (Group) ID",
+      description: "Select a workspace or provide a Group ID directly. Omit to target My workspace.",
+      optional: true,
+      async options() {
+        const groups = await this.listGroups();
+        return groups?.map?.(({
+          id, name,
+        }) => ({
+          label: name,
+          value: id,
+        })) ?? [];
+      },
+    },
+    reportId: {
+      type: "string",
+      label: "Report ID",
+      description: "Select a report or provide a Report ID directly. Set **Workspace (Group) ID** to scope options to a specific workspace; omit for My workspace.",
+      async options({ groupId } = {}) {
+        const reports = await this.listReports({
+          groupId: groupId || undefined,
+        });
+        return reports?.map?.(({
+          id, name,
+        }) => ({
+          label: name,
+          value: id,
+        })) ?? [];
+      },
     },
   },
   methods: {
@@ -238,6 +269,21 @@ export default {
         path: `${this._groupPrefix(groupId)}/reports/${reportId}/exports/${exportId}/file`,
         responseType: "arraybuffer",
         returnFullResponse: true,
+      });
+    },
+    getReport({
+      reportId, groupId, ...args
+    }) {
+      if (reportId == null || reportId === "") {
+        throw new ConfigurationError("Report ID is required.");
+      }
+      const path = groupId
+        ? `/groups/${groupId}/reports/${reportId}`
+        : `/reports/${reportId}`;
+      return this._makeRequest({
+        method: "GET",
+        path,
+        ...args,
       });
     },
   },

--- a/components/microsoft_power_bi/microsoft_power_bi.app.mjs
+++ b/components/microsoft_power_bi/microsoft_power_bi.app.mjs
@@ -64,37 +64,6 @@ export default {
       description: "Name of the workspace (alternative to **Workspace ID**). Use the **List Workspaces** tool to see accessible workspaces.",
       optional: true,
     },
-    groupId: {
-      type: "string",
-      label: "Workspace (Group) ID",
-      description: "Select a workspace or provide a Group ID directly. Omit to target My workspace.",
-      optional: true,
-      async options() {
-        const groups = await this.listGroups();
-        return groups?.map?.(({
-          id, name,
-        }) => ({
-          label: name,
-          value: id,
-        })) ?? [];
-      },
-    },
-    reportId: {
-      type: "string",
-      label: "Report ID",
-      description: "Select a report or provide a Report ID directly. Set **Workspace (Group) ID** to scope options to a specific workspace; omit for My workspace.",
-      async options({ groupId } = {}) {
-        const reports = await this.listReports({
-          groupId: groupId || undefined,
-        });
-        return reports?.map?.(({
-          id, name,
-        }) => ({
-          label: name,
-          value: id,
-        })) ?? [];
-      },
-    },
   },
   methods: {
     _baseUrl() {

--- a/components/microsoft_power_bi/package.json
+++ b/components/microsoft_power_bi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/microsoft_power_bi",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Pipedream Microsoft Power BI Components",
   "main": "microsoft_power_bi.app.mjs",
   "keywords": [

--- a/components/microsoft_power_bi/sources/dataset-refresh-completed/dataset-refresh-completed.mjs
+++ b/components/microsoft_power_bi/sources/dataset-refresh-completed/dataset-refresh-completed.mjs
@@ -4,7 +4,7 @@ export default {
   key: "microsoft_power_bi-dataset-refresh-completed",
   name: "Dataset Refresh Completed",
   description: "Emit new event when a dataset refresh operation has completed. [See the documentation](https://learn.microsoft.com/en-us/rest/api/power-bi/datasets/get-refresh-history)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "source",
   dedupe: "unique",
   ...common,

--- a/components/microsoft_power_bi/sources/dataset-refresh-failed/dataset-refresh-failed.mjs
+++ b/components/microsoft_power_bi/sources/dataset-refresh-failed/dataset-refresh-failed.mjs
@@ -4,7 +4,7 @@ export default {
   key: "microsoft_power_bi-dataset-refresh-failed",
   name: "Dataset Refresh Failed",
   description: "Emit new event when a dataset refresh operation has failed in Power BI. [See the documentation](https://learn.microsoft.com/en-us/rest/api/power-bi/datasets/get-refresh-history)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "source",
   dedupe: "unique",
   ...common,

--- a/components/microsoft_power_bi/sources/new-dataset-refresh-created/new-dataset-refresh-created.mjs
+++ b/components/microsoft_power_bi/sources/new-dataset-refresh-created/new-dataset-refresh-created.mjs
@@ -4,7 +4,7 @@ export default {
   key: "microsoft_power_bi-new-dataset-refresh-created",
   name: "New Dataset Refresh Created",
   description: "Emit new event when a new dataset refresh operation is created. [See the documentation](https://learn.microsoft.com/en-us/rest/api/power-bi/datasets/get-refresh-history)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "source",
   dedupe: "unique",
   ...common,


### PR DESCRIPTION
Problem
The existing Get Reports action lists all reports, but there is no way to get details for a single report by ID. There is also no reportId prop with options, so an agent cannot discover or select a specific report. An agent that needs to reference a particular report has no way to look it up or confirm it exists.

What's needed
Add a Get Report action that accepts a reportId input and calls GET /v1.0/myorg/reports/{reportId}. Also add a reportId prop definition with options that call the existing list reports endpoint to populate available reports.

Notes
The existing get-reports action calls GET /v1.0/myorg/reports (list all) — the new action is for a single report datasetId and tableName props already have options defined, so the pattern for adding reportId options is established Consider whether group-scoped reports (/v1.0/myorg/groups/{groupId}/reports) should also be supported

link: https://learn.microsoft.com/en-us/rest/api/power-bi/reports/get-report

Github link: https://github.com/PipedreamHQ/pipedream/issues/20473

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retrieve a specific Power BI report by ID
  * Optionally filter report retrieval by workspace (group) ID
  * Dynamic workspace and report selection when configuring the action
  * New API method for fetching a report by ID (handles workspace scope)
* **Chores**
  * Package bumped to 0.6.0
  * Multiple action and source components: version metadata updates
* **Documentation**
  * Improved guidance for the "List Workspaces" action
<!-- end of auto-generated comment: release notes by coderabbit.ai -->