### PR TITLE
feat(virtualsms): new app — SMS verification with real physical SIMs

### DIFF
--- a/components/virtualsms/README.md
+++ b/components/virtualsms/README.md
@@ -1,0 +1,29 @@
+# Overview
+
+[VirtualSMS](https://virtualsms.io) is an SMS-verification provider backed by **real, physical SIM cards** in Europe. The API gives you on-demand virtual phone numbers across 145+ countries to receive SMS verification codes for 700+ services (WhatsApp, Telegram, Google, Facebook, Tinder, Instagram, exchanges, marketplaces, dating apps, and more). Numbers are non-VoIP, you pay only when an SMS arrives, and rentals can be cancelled for a refund if no message is received.
+
+With Pipedream you can wire VirtualSMS into any of 3,000+ apps to automate verification flows that previously required a human to copy a code by hand.
+
+# Example Use Cases
+
+- **Headless account creation pipeline.** A workflow rents a number for the target service, posts the number to your signup automation, and the **New SMS Received** trigger forwards the verification code back the moment it arrives — no polling code on your side.
+- **Multi-region testing.** Rent UK / Poland / Germany / Czech numbers in parallel from a Pipedream loop, capture the SMS each provider delivers, and write the latency + success matrix to Google Sheets or a database.
+- **Low-balance Slack alerts.** Run **Get Balance** on a daily schedule and post to Slack when balance falls below your reorder threshold so a verification campaign never stalls mid-batch.
+- **Refund unused rentals.** When a downstream signup flow detects an account creation failure, branch into **Cancel Rental** to release the number and refund the unused balance automatically.
+
+# Getting Started
+
+1. Sign in at [virtualsms.io](https://virtualsms.io) and open **Settings → API Keys**.
+2. Create a key (we recommend naming it `Pipedream` for easy identification) and copy it.
+3. In Pipedream, when prompted by any VirtualSMS action or trigger, paste the key into the **API Key** field of the connected account dialog.
+4. Top up your balance from the dashboard before renting numbers — the **Rent Number** action will return a `402` if you're under the per-rental price.
+
+# Troubleshooting
+
+VirtualSMS uses standard HTTP status codes:
+
+- **401 Unauthorized** — your API key is missing, mistyped, or revoked. Re-create the key in the dashboard and reconnect the account.
+- **402 Payment Required** — insufficient balance. Top up at [virtualsms.io](https://virtualsms.io) and retry.
+- **404 Not Found** — the order ID does not belong to your account, or the requested service / country combination is currently out of stock.
+- **429 Too Many Requests** — you've exceeded the per-key rate limit (60 req/min). Throttle the workflow or use Pipedream's [concurrency controls](https://pipedream.com/docs/workflows/concurrency-and-throttling).
+- **5xx** — VirtualSMS server-side issue; retry with backoff. Pipedream surfaces the upstream status code so you can branch on it.

--- a/components/virtualsms/actions/cancel-rental/cancel-rental.mjs
+++ b/components/virtualsms/actions/cancel-rental/cancel-rental.mjs
@@ -7,7 +7,7 @@ export default {
   version: "0.0.1",
   type: "action",
   annotations: {
-    destructiveHint: true,
+    destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },

--- a/components/virtualsms/actions/cancel-rental/cancel-rental.mjs
+++ b/components/virtualsms/actions/cancel-rental/cancel-rental.mjs
@@ -3,7 +3,7 @@ import virtualsms from "../../virtualsms.app.mjs";
 export default {
   key: "virtualsms-cancel-rental",
   name: "Cancel Rental",
-  description: "Cancel an active rental and refund any unused balance. Cancellation is only possible while the rental is still active and no SMS has been received (or the cancellation policy permits a refund). [See the docs](https://virtualsms.io/docs/api-reference/introduction)",
+  description: "Cancel an active rental and refund any unused balance. Cancellation is only possible while the rental is still active and no SMS has been received (or the cancellation policy permits a refund). [See the documentation](https://virtualsms.io/docs/api-reference/introduction)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/virtualsms/actions/cancel-rental/cancel-rental.mjs
+++ b/components/virtualsms/actions/cancel-rental/cancel-rental.mjs
@@ -26,10 +26,21 @@ export default {
       orderId: this.orderId,
     });
 
-    const refunded = response?.refunded
-      ? "refunded"
-      : "no refund";
-    $.export("$summary", `Cancelled rental ${this.orderId} (${refunded})`);
+    // Real API returns { success, order_id, status: "cancelled", refund_amount }
+    const refundAmount = typeof response?.refund_amount === "number"
+      ? response.refund_amount
+      : null;
+    const cancelled = response?.status === "cancelled";
+
+    let summary;
+    if (cancelled && refundAmount !== null && refundAmount > 0) {
+      summary = `Cancelled rental ${this.orderId} (refunded $${refundAmount.toFixed(2)})`;
+    } else if (cancelled) {
+      summary = `Cancelled rental ${this.orderId} (no refund)`;
+    } else {
+      summary = `Cancel attempt for rental ${this.orderId} — status ${response?.status ?? "unknown"}`;
+    }
+    $.export("$summary", summary);
     return response;
   },
 };

--- a/components/virtualsms/actions/cancel-rental/cancel-rental.mjs
+++ b/components/virtualsms/actions/cancel-rental/cancel-rental.mjs
@@ -1,0 +1,35 @@
+import virtualsms from "../../virtualsms.app.mjs";
+
+export default {
+  key: "virtualsms-cancel-rental",
+  name: "Cancel Rental",
+  description: "Cancel an active rental and refund any unused balance. Cancellation is only possible while the rental is still active and no SMS has been received (or the cancellation policy permits a refund). [See the docs](https://virtualsms.io/docs/api-reference/introduction)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: true,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    virtualsms,
+    orderId: {
+      propDefinition: [
+        virtualsms,
+        "orderId",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.virtualsms.cancelOrder({
+      $,
+      orderId: this.orderId,
+    });
+
+    const refunded = response?.refunded
+      ? "refunded"
+      : "no refund";
+    $.export("$summary", `Cancelled rental ${this.orderId} (${refunded})`);
+    return response;
+  },
+};

--- a/components/virtualsms/actions/check-messages/check-messages.mjs
+++ b/components/virtualsms/actions/check-messages/check-messages.mjs
@@ -1,0 +1,37 @@
+import virtualsms from "../../virtualsms.app.mjs";
+
+export default {
+  key: "virtualsms-check-messages",
+  name: "Check Messages",
+  description: "Poll an active rental for any SMS messages received so far. Returns the current order state including `sms_code` and `sms_text` if a message has arrived. For event-driven workflows prefer the **New SMS Received** trigger. [See the docs](https://virtualsms.io/docs/api-reference/introduction)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    virtualsms,
+    orderId: {
+      propDefinition: [
+        virtualsms,
+        "orderId",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.virtualsms.getOrder({
+      $,
+      orderId: this.orderId,
+    });
+
+    const status = response?.status ?? "unknown";
+    const code = response?.sms_code;
+    const summary = code
+      ? `SMS received: ${code} (status ${status})`
+      : `No SMS yet — status ${status}`;
+    $.export("$summary", summary);
+    return response;
+  },
+};

--- a/components/virtualsms/actions/check-messages/check-messages.mjs
+++ b/components/virtualsms/actions/check-messages/check-messages.mjs
@@ -3,7 +3,7 @@ import virtualsms from "../../virtualsms.app.mjs";
 export default {
   key: "virtualsms-check-messages",
   name: "Check Messages",
-  description: "Poll an active rental for any SMS messages received so far. Returns the current order state including `sms_code` and `sms_text` if a message has arrived. For event-driven workflows prefer the **New SMS Received** trigger. [See the docs](https://virtualsms.io/docs/api-reference/introduction)",
+  description: "Poll an active rental for any SMS messages received so far. Returns the current order state including `sms_code` and `sms_text` if a message has arrived. For event-driven workflows prefer the **New SMS Received** trigger. [See the documentation](https://virtualsms.io/docs/api-reference/introduction)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/virtualsms/actions/check-messages/check-messages.mjs
+++ b/components/virtualsms/actions/check-messages/check-messages.mjs
@@ -3,7 +3,7 @@ import virtualsms from "../../virtualsms.app.mjs";
 export default {
   key: "virtualsms-check-messages",
   name: "Check Messages",
-  description: "Poll an active rental for any SMS messages received so far. Returns the current order state including `sms_code` and `sms_text` if a message has arrived. For event-driven workflows prefer the **New SMS Received** trigger. [See the documentation](https://virtualsms.io/docs/api-reference/introduction)",
+  description: "Poll an active rental for any SMS messages received so far. Returns the current order state, including a `messages` array (each item has `sender`, `content`, `received_at`) when one or more SMS have arrived. For event-driven workflows prefer the **New SMS Received** trigger. [See the documentation](https://virtualsms.io/docs/api-reference/introduction)",
   version: "0.0.1",
   type: "action",
   annotations: {
@@ -27,10 +27,10 @@ export default {
     });
 
     const status = response?.status ?? "unknown";
-    const code = response?.sms_code;
-    // Do NOT include the OTP in $summary — summary is shown in run history,
-    // logs, and notifications. Keep the code in the response payload only.
-    const summary = code
+    const hasMessage = Array.isArray(response?.messages) && response.messages.length > 0;
+    // Do NOT include the OTP / SMS body in $summary — summary is shown in run history,
+    // logs, and notifications. Keep the message contents in the response payload only.
+    const summary = hasMessage
       ? `SMS received (status ${status})`
       : `No SMS yet — status ${status}`;
     $.export("$summary", summary);

--- a/components/virtualsms/actions/check-messages/check-messages.mjs
+++ b/components/virtualsms/actions/check-messages/check-messages.mjs
@@ -28,8 +28,10 @@ export default {
 
     const status = response?.status ?? "unknown";
     const code = response?.sms_code;
+    // Do NOT include the OTP in $summary — summary is shown in run history,
+    // logs, and notifications. Keep the code in the response payload only.
     const summary = code
-      ? `SMS received: ${code} (status ${status})`
+      ? `SMS received (status ${status})`
       : `No SMS yet — status ${status}`;
     $.export("$summary", summary);
     return response;

--- a/components/virtualsms/actions/get-balance/get-balance.mjs
+++ b/components/virtualsms/actions/get-balance/get-balance.mjs
@@ -1,0 +1,27 @@
+import virtualsms from "../../virtualsms.app.mjs";
+
+export default {
+  key: "virtualsms-get-balance",
+  name: "Get Balance",
+  description: "Retrieve the current account balance in USD. Useful for low-balance alerts or pre-flight checks before renting numbers. [See the docs](https://virtualsms.io/docs/api-reference/introduction)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    virtualsms,
+  },
+  async run({ $ }) {
+    const response = await this.virtualsms.getBalance({
+      $,
+    });
+    const balance = response?.balance_usd ?? response?.balance;
+    $.export("$summary", balance != null
+      ? `Balance: $${balance}`
+      : "Retrieved balance");
+    return response;
+  },
+};

--- a/components/virtualsms/actions/get-balance/get-balance.mjs
+++ b/components/virtualsms/actions/get-balance/get-balance.mjs
@@ -3,7 +3,7 @@ import virtualsms from "../../virtualsms.app.mjs";
 export default {
   key: "virtualsms-get-balance",
   name: "Get Balance",
-  description: "Retrieve the current account balance in USD. Useful for low-balance alerts or pre-flight checks before renting numbers. [See the docs](https://virtualsms.io/docs/api-reference/introduction)",
+  description: "Retrieve the current account balance in USD. Useful for low-balance alerts or pre-flight checks before renting numbers. [See the documentation](https://virtualsms.io/docs/api-reference/introduction)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/virtualsms/actions/list-countries/list-countries.mjs
+++ b/components/virtualsms/actions/list-countries/list-countries.mjs
@@ -3,7 +3,7 @@ import virtualsms from "../../virtualsms.app.mjs";
 export default {
   key: "virtualsms-list-countries",
   name: "List Countries",
-  description: "List all supported countries with current stock indicators (`available_phones`, `total_phones`). Use the returned `country_id` (ISO-3166-1 alpha-2) when calling **Rent Number**. [See the docs](https://virtualsms.io/docs/api-reference/introduction)",
+  description: "List all supported countries with current stock indicators (`available_phones`, `total_phones`). Use the returned `country_id` (ISO-3166-1 alpha-2) when calling **Rent Number**. [See the documentation](https://virtualsms.io/docs/api-reference/introduction)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/virtualsms/actions/list-countries/list-countries.mjs
+++ b/components/virtualsms/actions/list-countries/list-countries.mjs
@@ -1,0 +1,29 @@
+import virtualsms from "../../virtualsms.app.mjs";
+
+export default {
+  key: "virtualsms-list-countries",
+  name: "List Countries",
+  description: "List all supported countries with current stock indicators (`available_phones`, `total_phones`). Use the returned `country_id` (ISO-3166-1 alpha-2) when calling **Rent Number**. [See the docs](https://virtualsms.io/docs/api-reference/introduction)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    virtualsms,
+  },
+  async run({ $ }) {
+    const response = await this.virtualsms.listCountries({
+      $,
+    });
+    const count = Array.isArray(response?.countries)
+      ? response.countries.length
+      : (Array.isArray(response)
+        ? response.length
+        : 0);
+    $.export("$summary", `Retrieved ${count} countries`);
+    return response;
+  },
+};

--- a/components/virtualsms/actions/list-services/list-services.mjs
+++ b/components/virtualsms/actions/list-services/list-services.mjs
@@ -1,0 +1,29 @@
+import virtualsms from "../../virtualsms.app.mjs";
+
+export default {
+  key: "virtualsms-list-services",
+  name: "List Services",
+  description: "List all supported services (700+) with their service codes, categories, and base prices. Use the returned `service_id` (or `code`) when calling **Rent Number**. [See the docs](https://virtualsms.io/docs/api-reference/introduction)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    virtualsms,
+  },
+  async run({ $ }) {
+    const response = await this.virtualsms.listServices({
+      $,
+    });
+    const count = Array.isArray(response?.services)
+      ? response.services.length
+      : (Array.isArray(response)
+        ? response.length
+        : 0);
+    $.export("$summary", `Retrieved ${count} services`);
+    return response;
+  },
+};

--- a/components/virtualsms/actions/list-services/list-services.mjs
+++ b/components/virtualsms/actions/list-services/list-services.mjs
@@ -3,7 +3,7 @@ import virtualsms from "../../virtualsms.app.mjs";
 export default {
   key: "virtualsms-list-services",
   name: "List Services",
-  description: "List all supported services (700+) with their service codes, categories, and base prices. Use the returned `service_id` (or `code`) when calling **Rent Number**. [See the docs](https://virtualsms.io/docs/api-reference/introduction)",
+  description: "List all supported services (700+) with their service codes, categories, and base prices. Use the returned `service_id` (or `code`) when calling **Rent Number**. [See the documentation](https://virtualsms.io/docs/api-reference/introduction)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/virtualsms/actions/rent-number/rent-number.mjs
+++ b/components/virtualsms/actions/rent-number/rent-number.mjs
@@ -1,0 +1,41 @@
+import virtualsms from "../../virtualsms.app.mjs";
+
+export default {
+  key: "virtualsms-rent-number",
+  name: "Rent Number",
+  description: "Rent a real-SIM virtual phone number to receive an SMS verification code. Returns the order ID and assigned phone number — pair this with the **New SMS Received** trigger or the **Check Messages** action to retrieve the code. [See the docs](https://virtualsms.io/docs/api-reference/introduction)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    virtualsms,
+    service: {
+      propDefinition: [
+        virtualsms,
+        "service",
+      ],
+    },
+    country: {
+      propDefinition: [
+        virtualsms,
+        "country",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.virtualsms.rentNumber({
+      $,
+      service: this.service,
+      country: this.country,
+    });
+
+    const phone = response?.phone_number ?? "(pending)";
+    const orderId = response?.order_id ?? response?.id ?? "(unknown)";
+    $.export("$summary", `Rented ${phone} for ${this.service} (order ${orderId})`);
+    return response;
+  },
+};

--- a/components/virtualsms/actions/rent-number/rent-number.mjs
+++ b/components/virtualsms/actions/rent-number/rent-number.mjs
@@ -3,7 +3,7 @@ import virtualsms from "../../virtualsms.app.mjs";
 export default {
   key: "virtualsms-rent-number",
   name: "Rent Number",
-  description: "Rent a real-SIM virtual phone number to receive an SMS verification code. Returns the order ID and assigned phone number — pair this with the **New SMS Received** trigger or the **Check Messages** action to retrieve the code. [See the docs](https://virtualsms.io/docs/api-reference/introduction)",
+  description: "Rent a real-SIM virtual phone number to receive an SMS verification code. Returns the order ID and assigned phone number — pair this with the **New SMS Received** trigger or the **Check Messages** action to retrieve the code. [See the documentation](https://virtualsms.io/docs/api-reference/introduction)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/virtualsms/actions/rent-number/rent-number.mjs
+++ b/components/virtualsms/actions/rent-number/rent-number.mjs
@@ -33,9 +33,14 @@ export default {
       country: this.country,
     });
 
-    const phone = response?.phone_number ?? "(pending)";
     const orderId = response?.order_id ?? response?.id ?? "(unknown)";
-    $.export("$summary", `Rented ${phone} for ${this.service} (order ${orderId})`);
+    // Avoid leaking the full phone number into $summary (run history / logs /
+    // notifications). Show only the last 4 digits if available.
+    const rawPhone = response?.phone_number ?? "";
+    const phoneTail = rawPhone
+      ? `***${String(rawPhone).slice(-4)}`
+      : "(pending)";
+    $.export("$summary", `Rented ${phoneTail} for ${this.service} (order ${orderId})`);
     return response;
   },
 };

--- a/components/virtualsms/package.json
+++ b/components/virtualsms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/virtualsms",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Pipedream VirtualSMS Components",
   "main": "virtualsms.app.mjs",
   "keywords": [
@@ -11,5 +11,8 @@
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^3.2.5"
   }
 }

--- a/components/virtualsms/sources/new-sms-received/new-sms-received.mjs
+++ b/components/virtualsms/sources/new-sms-received/new-sms-received.mjs
@@ -1,10 +1,11 @@
-import virtualsms from "../../virtualsms.app.mjs";
+import { createHash } from "crypto";
 import { DEFAULT_POLLING_SOURCE_TIMER_INTERVAL } from "@pipedream/platform";
+import virtualsms from "../../virtualsms.app.mjs";
 
 export default {
   key: "virtualsms-new-sms-received",
   name: "New SMS Received",
-  description: "Emit a new event for each SMS message received on any of your active rentals. Polls the VirtualSMS API on the configured interval (default 60s) and de-duplicates by order ID so each SMS is emitted exactly once. [See the docs](https://virtualsms.io/docs/api-reference/introduction)",
+  description: "Emit a new event for each SMS message received on any of your active rentals. Polls the VirtualSMS API on the configured interval (default 60s) and de-duplicates by order ID so each SMS is emitted exactly once. [See the documentation](https://virtualsms.io/docs/api-reference/introduction)",
   version: "0.0.1",
   type: "source",
   dedupe: "unique",
@@ -31,16 +32,24 @@ export default {
           seen[id] = code;
         }
       }
-      this.db.set("seenCodes", seen);
+      this._setSeenCodes(seen);
     },
   },
   methods: {
+    _getSeenCodes() {
+      return this.db.get("seenCodes") ?? {};
+    },
+    _setSeenCodes(seenCodes) {
+      this.db.set("seenCodes", seenCodes);
+    },
     generateMeta(order) {
       const orderId = String(order.order_id ?? order.id ?? "");
       const code = order.sms_code ?? "";
-      // Compose unique id so the same code arriving twice on different
-      // orders (or the same order across restarts) only fires once.
-      const id = `${orderId}:${code}`;
+      // Hash to a 64-char SHA256 hex digest so we always stay within
+      // Pipedream's 64-char dedupe id limit, regardless of orderId/code length.
+      const id = createHash("sha256")
+        .update(`${orderId}:${code}`)
+        .digest("hex");
       const ts = order.received_at
         ? Date.parse(order.received_at)
         : Date.now();
@@ -57,7 +66,7 @@ export default {
       return;
     }
 
-    const seen = this.db.get("seenCodes") ?? {};
+    const seen = this._getSeenCodes();
     const updated = {
       ...seen,
     };
@@ -76,6 +85,6 @@ export default {
       updated[id] = code;
     }
 
-    this.db.set("seenCodes", updated);
+    this._setSeenCodes(updated);
   },
 };

--- a/components/virtualsms/sources/new-sms-received/new-sms-received.mjs
+++ b/components/virtualsms/sources/new-sms-received/new-sms-received.mjs
@@ -55,7 +55,9 @@ export default {
         : Date.now();
       return {
         id,
-        summary: `New SMS for ${order.phone_number ?? orderId}: ${code}`,
+        // Avoid leaking the phone number or the OTP in the emitted event
+        // summary — the full payload is still available on the event itself.
+        summary: `New SMS received for order ${orderId}`,
         ts,
       };
     },

--- a/components/virtualsms/sources/new-sms-received/new-sms-received.mjs
+++ b/components/virtualsms/sources/new-sms-received/new-sms-received.mjs
@@ -72,7 +72,8 @@ export default {
       const seed = receivedAt
         ? `${orderId}:${receivedAt}:${content}`
         : `${orderId}:${content}`;
-      return createHash("sha256").update(seed).digest("hex");
+      return createHash("sha256").update(seed)
+        .digest("hex");
     },
     async _safeGetOrder(orderId) {
       try {
@@ -97,7 +98,9 @@ export default {
         // Avoid leaking the phone number, sender, or OTP body in the emitted
         // event summary — the full payload is still available on the event.
         summary: `New SMS received for order ${orderId}`,
-        ts: Number.isFinite(ts) ? ts : Date.now(),
+        ts: Number.isFinite(ts)
+          ? ts
+          : Date.now(),
       };
     },
   },

--- a/components/virtualsms/sources/new-sms-received/new-sms-received.mjs
+++ b/components/virtualsms/sources/new-sms-received/new-sms-received.mjs
@@ -19,7 +19,7 @@ const MAX_ACTIVE_ORDERS_PER_POLL = 50;
 export default {
   key: "virtualsms-new-sms-received",
   name: "New SMS Received",
-  description: "Emit a new event for each SMS message received on any of your active rentals. Polls the VirtualSMS API on the configured interval (default 60s) and de-duplicates so each SMS is emitted exactly once. [See the documentation](https://virtualsms.io/docs/api-reference/introduction)",
+  description: "Emit new event for each SMS message received on any of your active rentals. Polls the VirtualSMS API on the configured interval (default 60s) and de-duplicates so each SMS is emitted exactly once. [See the documentation](https://virtualsms.io/docs/api-reference/introduction)",
   version: "0.0.1",
   type: "source",
   dedupe: "unique",

--- a/components/virtualsms/sources/new-sms-received/new-sms-received.mjs
+++ b/components/virtualsms/sources/new-sms-received/new-sms-received.mjs
@@ -1,0 +1,81 @@
+import virtualsms from "../../virtualsms.app.mjs";
+import { DEFAULT_POLLING_SOURCE_TIMER_INTERVAL } from "@pipedream/platform";
+
+export default {
+  key: "virtualsms-new-sms-received",
+  name: "New SMS Received",
+  description: "Emit a new event for each SMS message received on any of your active rentals. Polls the VirtualSMS API on the configured interval (default 60s) and de-duplicates by order ID so each SMS is emitted exactly once. [See the docs](https://virtualsms.io/docs/api-reference/introduction)",
+  version: "0.0.1",
+  type: "source",
+  dedupe: "unique",
+  props: {
+    virtualsms,
+    db: "$.service.db",
+    timer: {
+      type: "$.interface.timer",
+      default: {
+        intervalSeconds: DEFAULT_POLLING_SOURCE_TIMER_INTERVAL,
+      },
+    },
+  },
+  hooks: {
+    async deploy() {
+      // On deploy, mark currently-received SMS as already seen
+      // so we only emit truly new messages going forward.
+      const orders = await this.virtualsms.listOrders();
+      const seen = {};
+      for (const o of orders) {
+        const id = String(o.order_id ?? o.id ?? "");
+        const code = o.sms_code ?? null;
+        if (id && code) {
+          seen[id] = code;
+        }
+      }
+      this.db.set("seenCodes", seen);
+    },
+  },
+  methods: {
+    generateMeta(order) {
+      const orderId = String(order.order_id ?? order.id ?? "");
+      const code = order.sms_code ?? "";
+      // Compose unique id so the same code arriving twice on different
+      // orders (or the same order across restarts) only fires once.
+      const id = `${orderId}:${code}`;
+      const ts = order.received_at
+        ? Date.parse(order.received_at)
+        : Date.now();
+      return {
+        id,
+        summary: `New SMS for ${order.phone_number ?? orderId}: ${code}`,
+        ts,
+      };
+    },
+  },
+  async run() {
+    const orders = await this.virtualsms.listOrders();
+    if (!orders?.length) {
+      return;
+    }
+
+    const seen = this.db.get("seenCodes") ?? {};
+    const updated = {
+      ...seen,
+    };
+
+    for (const order of orders) {
+      const id = String(order.order_id ?? order.id ?? "");
+      const code = order.sms_code ?? null;
+      if (!id || !code) {
+        continue;
+      }
+      if (seen[id] === code) {
+        continue;
+      }
+      const meta = this.generateMeta(order);
+      this.$emit(order, meta);
+      updated[id] = code;
+    }
+
+    this.db.set("seenCodes", updated);
+  },
+};

--- a/components/virtualsms/sources/new-sms-received/new-sms-received.mjs
+++ b/components/virtualsms/sources/new-sms-received/new-sms-received.mjs
@@ -2,10 +2,24 @@ import { createHash } from "crypto";
 import { DEFAULT_POLLING_SOURCE_TIMER_INTERVAL } from "@pipedream/platform";
 import virtualsms from "../../virtualsms.app.mjs";
 
+// Statuses considered terminal — no SMS can arrive after these.
+// Anything NOT in this set is treated as still-active and polled.
+const TERMINAL_STATUSES = new Set([
+  "cancelled",
+  "expired",
+  "completed",
+  "refunded",
+  "failed",
+]);
+
+// Cap the per-poll fan-out so a user with many active orders does not flood
+// the API. Pipedream polls every 60 s by default, so this is per-minute.
+const MAX_ACTIVE_ORDERS_PER_POLL = 50;
+
 export default {
   key: "virtualsms-new-sms-received",
   name: "New SMS Received",
-  description: "Emit a new event for each SMS message received on any of your active rentals. Polls the VirtualSMS API on the configured interval (default 60s) and de-duplicates by order ID so each SMS is emitted exactly once. [See the documentation](https://virtualsms.io/docs/api-reference/introduction)",
+  description: "Emit a new event for each SMS message received on any of your active rentals. Polls the VirtualSMS API on the configured interval (default 60s) and de-duplicates so each SMS is emitted exactly once. [See the documentation](https://virtualsms.io/docs/api-reference/introduction)",
   version: "0.0.1",
   type: "source",
   dedupe: "unique",
@@ -24,41 +38,66 @@ export default {
       // On deploy, mark currently-received SMS as already seen
       // so we only emit truly new messages going forward.
       const orders = await this.virtualsms.listOrders();
+      const active = orders
+        .filter((o) => !TERMINAL_STATUSES.has(String(o.status ?? "").toLowerCase()))
+        .slice(0, MAX_ACTIVE_ORDERS_PER_POLL);
       const seen = {};
-      for (const o of orders) {
-        const id = String(o.order_id ?? o.id ?? "");
-        const code = o.sms_code ?? null;
-        if (id && code) {
-          seen[id] = code;
+      for (const o of active) {
+        const orderId = String(o.id ?? o.order_id ?? "");
+        if (!orderId) continue;
+        const detail = await this._safeGetOrder(orderId);
+        if (!detail || !Array.isArray(detail.messages)) continue;
+        for (const msg of detail.messages) {
+          const dedupeId = this._dedupeId(orderId, msg);
+          if (dedupeId) {
+            seen[dedupeId] = true;
+          }
         }
       }
-      this._setSeenCodes(seen);
+      this._setSeenIds(seen);
     },
   },
   methods: {
-    _getSeenCodes() {
-      return this.db.get("seenCodes") ?? {};
+    _getSeenIds() {
+      return this.db.get("seenIds") ?? {};
     },
-    _setSeenCodes(seenCodes) {
-      this.db.set("seenCodes", seenCodes);
+    _setSeenIds(seenIds) {
+      this.db.set("seenIds", seenIds);
     },
-    generateMeta(order) {
-      const orderId = String(order.order_id ?? order.id ?? "");
-      const code = order.sms_code ?? "";
-      // Hash to a 64-char SHA256 hex digest so we always stay within
-      // Pipedream's 64-char dedupe id limit, regardless of orderId/code length.
-      const id = createHash("sha256")
-        .update(`${orderId}:${code}`)
-        .digest("hex");
-      const ts = order.received_at
-        ? Date.parse(order.received_at)
+    _dedupeId(orderId, msg) {
+      const content = String(msg?.content ?? "");
+      const receivedAt = String(msg?.received_at ?? "");
+      // Use received_at when available (stable identifier) plus content;
+      // fall back to content alone if backend omits the timestamp.
+      const seed = receivedAt
+        ? `${orderId}:${receivedAt}:${content}`
+        : `${orderId}:${content}`;
+      return createHash("sha256").update(seed).digest("hex");
+    },
+    async _safeGetOrder(orderId) {
+      try {
+        return await this.virtualsms.getOrder({
+          orderId,
+        });
+      } catch (err) {
+        // 404 / 4xx / 5xx — skip this order this round, do not crash polling.
+        const status = err?.response?.status;
+        // eslint-disable-next-line no-console
+        console.log(`[new-sms-received] getOrder ${orderId} failed (status=${status ?? "?"}); skipping`);
+        return null;
+      }
+    },
+    generateMeta(orderId, msg) {
+      const id = this._dedupeId(orderId, msg);
+      const ts = msg?.received_at
+        ? Date.parse(msg.received_at)
         : Date.now();
       return {
         id,
-        // Avoid leaking the phone number or the OTP in the emitted event
-        // summary — the full payload is still available on the event itself.
+        // Avoid leaking the phone number, sender, or OTP body in the emitted
+        // event summary — the full payload is still available on the event.
         summary: `New SMS received for order ${orderId}`,
-        ts,
+        ts: Number.isFinite(ts) ? ts : Date.now(),
       };
     },
   },
@@ -68,25 +107,43 @@ export default {
       return;
     }
 
-    const seen = this._getSeenCodes();
+    const active = orders
+      .filter((o) => !TERMINAL_STATUSES.has(String(o.status ?? "").toLowerCase()))
+      .slice(0, MAX_ACTIVE_ORDERS_PER_POLL);
+    if (!active.length) {
+      return;
+    }
+
+    const seen = this._getSeenIds();
     const updated = {
       ...seen,
     };
 
-    for (const order of orders) {
-      const id = String(order.order_id ?? order.id ?? "");
-      const code = order.sms_code ?? null;
-      if (!id || !code) {
+    for (const order of active) {
+      const orderId = String(order.id ?? order.order_id ?? "");
+      if (!orderId) continue;
+
+      const detail = await this._safeGetOrder(orderId);
+      if (!detail || !Array.isArray(detail.messages) || detail.messages.length === 0) {
         continue;
       }
-      if (seen[id] === code) {
-        continue;
+
+      for (const msg of detail.messages) {
+        const dedupeId = this._dedupeId(orderId, msg);
+        if (!dedupeId || seen[dedupeId]) {
+          continue;
+        }
+        const meta = this.generateMeta(orderId, msg);
+        // Emit the full order detail (which includes the messages array)
+        // plus the single triggering message at top-level for convenience.
+        this.$emit({
+          ...detail,
+          message: msg,
+        }, meta);
+        updated[dedupeId] = true;
       }
-      const meta = this.generateMeta(order);
-      this.$emit(order, meta);
-      updated[id] = code;
     }
 
-    this._setSeenCodes(updated);
+    this._setSeenIds(updated);
   },
 };

--- a/components/virtualsms/virtualsms.app.mjs
+++ b/components/virtualsms/virtualsms.app.mjs
@@ -21,7 +21,7 @@ export default {
     country: {
       type: "string",
       label: "Country",
-      description: "The ISO-3166-1 alpha-2 country code of the number (e.g. `GB`, `US`, `PL`). Use the **List Countries** action to see all available countries with current stock indicators. Pass an empty string or omit for the cheapest available country.",
+      description: "The numeric country ID expected by the VirtualSMS API (e.g., `0` for Russia, `1` for Ukraine). Use the **List Countries** action to discover all available countries and their numeric IDs. Omit for the cheapest available country.",
       optional: true,
       async options() {
         const { countries = [] } = await this.listCountries();

--- a/components/virtualsms/virtualsms.app.mjs
+++ b/components/virtualsms/virtualsms.app.mjs
@@ -1,11 +1,153 @@
+import { axios } from "@pipedream/platform";
+
 export default {
   type: "app",
   app: "virtualsms",
-  propDefinitions: {},
+  propDefinitions: {
+    service: {
+      type: "string",
+      label: "Service",
+      description: "The service to receive an SMS verification code for (e.g. `wa` for WhatsApp, `tg` for Telegram, `gm` for Google/Gmail). Use the **List Services** action to discover all 700+ supported services and their codes.",
+      async options() {
+        const { services = [] } = await this.listServices();
+        return services
+          .map((s) => ({
+            label: `${s.service_name ?? s.name} (${s.service_id ?? s.code ?? s.id})`,
+            value: String(s.service_id ?? s.code ?? s.id),
+          }))
+          .filter((opt) => opt.value);
+      },
+    },
+    country: {
+      type: "string",
+      label: "Country",
+      description: "The ISO-3166-1 alpha-2 country code of the number (e.g. `GB`, `US`, `PL`). Use the **List Countries** action to see all available countries with current stock indicators. Pass an empty string or omit for the cheapest available country.",
+      optional: true,
+      async options() {
+        const { countries = [] } = await this.listCountries();
+        return countries
+          .map((c) => ({
+            label: `${c.country_name ?? c.name ?? c.id} (${c.country_id ?? c.id ?? c.iso})`,
+            value: String(c.country_id ?? c.id ?? c.iso),
+          }))
+          .filter((opt) => opt.value);
+      },
+    },
+    orderId: {
+      type: "string",
+      label: "Order ID",
+      description: "The ID of an existing rental/activation order. Returned by the **Rent Number** action and surfaced by the **New SMS Received** trigger.",
+      async options() {
+        const orders = await this.listOrders();
+        return orders
+          .map((o) => ({
+            label: `${o.phone_number ?? "no number"} — ${o.service ?? o.service_id ?? "?"}/${o.country ?? o.country_id ?? "?"} (${o.status})`,
+            value: String(o.order_id ?? o.id),
+          }))
+          .filter((opt) => opt.value);
+      },
+    },
+  },
   methods: {
-    // this.$auth contains connected account data
-    authKeys() {
-      console.log(Object.keys(this.$auth));
+    _baseUrl() {
+      return "https://virtualsms.io/api/v1";
+    },
+    _headers() {
+      return {
+        "X-API-Key": `${this.$auth.api_key}`,
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+      };
+    },
+    _makeRequest(opts = {}) {
+      const {
+        $ = this,
+        path,
+        ...otherOpts
+      } = opts;
+      return axios($, {
+        ...otherOpts,
+        url: `${this._baseUrl()}${path}`,
+        headers: {
+          ...this._headers(),
+          ...(otherOpts.headers ?? {}),
+        },
+      });
+    },
+    listServices(args = {}) {
+      // GET /customer/services — returns { services: [...], success: true }
+      return this._makeRequest({
+        path: "/customer/services",
+        ...args,
+      });
+    },
+    listCountries(args = {}) {
+      // GET /customer/countries — returns { countries: [...], success: true }
+      return this._makeRequest({
+        path: "/customer/countries",
+        ...args,
+      });
+    },
+    getBalance(args = {}) {
+      // GET /customer/balance — returns { balance_usd, ... }
+      return this._makeRequest({
+        path: "/customer/balance",
+        ...args,
+      });
+    },
+    rentNumber({
+      service, country, ...args
+    } = {}) {
+      // POST /customer/purchase — body { service, country }
+      return this._makeRequest({
+        method: "POST",
+        path: "/customer/purchase",
+        data: {
+          service,
+          ...(country
+            ? { country }
+            : {}),
+        },
+        ...args,
+      });
+    },
+    getOrder({
+      orderId, ...args
+    } = {}) {
+      // GET /customer/order/{orderId}
+      return this._makeRequest({
+        path: `/customer/order/${encodeURIComponent(orderId)}`,
+        ...args,
+      });
+    },
+    cancelOrder({
+      orderId, ...args
+    } = {}) {
+      // POST /customer/cancel/{orderId}
+      return this._makeRequest({
+        method: "POST",
+        path: `/customer/cancel/${encodeURIComponent(orderId)}`,
+        ...args,
+      });
+    },
+    async listOrders(args = {}) {
+      // GET /customer/orders — returns { orders: [...] } or [] on 404
+      try {
+        const res = await this._makeRequest({
+          path: "/customer/orders",
+          ...args,
+        });
+        if (Array.isArray(res)) {
+          return res;
+        }
+        return res?.orders ?? [];
+      } catch (err) {
+        // Endpoint may be unavailable on some plans
+        if (err?.response?.status === 404) {
+          return [];
+        }
+        throw err;
+      }
     },
   },
 };

--- a/components/virtualsms/virtualsms.app.mjs
+++ b/components/virtualsms/virtualsms.app.mjs
@@ -105,7 +105,9 @@ export default {
         data: {
           service,
           ...(country
-            ? { country }
+            ? {
+              country,
+            }
             : {}),
         },
         ...args,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -534,8 +534,7 @@ importers:
         specifier: ^3.1.1
         version: 3.1.1
 
-  components/agify:
-    specifiers: {}
+  components/agify: {}
 
   components/agile_crm:
     dependencies:
@@ -10245,8 +10244,7 @@ importers:
         specifier: ^3.1.1
         version: 3.1.1
 
-  components/nationalize:
-    specifiers: {}
+  components/nationalize: {}
 
   components/nationbuilder:
     dependencies:
@@ -10708,8 +10706,7 @@ importers:
 
   components/oauth_app_demo_1: {}
 
-  components/obolus:
-    specifiers: {}
+  components/obolus: {}
 
   components/occasion:
     dependencies:
@@ -16561,8 +16558,7 @@ importers:
         specifier: ^3.1.1
         version: 3.1.1
 
-  components/unirateapi:
-    specifiers: {}
+  components/unirateapi: {}
 
   components/unisender:
     dependencies:
@@ -16964,7 +16960,10 @@ importers:
   components/virifi: {}
 
   components/virtualsms:
-    specifiers: {}
+    dependencies:
+      '@pipedream/platform':
+        specifier: ^3.2.5
+        version: 3.3.1
 
   components/virustotal: {}
 


### PR DESCRIPTION
## Summary

Adds [VirtualSMS](https://virtualsms.io) — an SMS-verification provider backed by real, physical SIM cards in Europe — as a new Pipedream app with 6 actions and 1 polling trigger.

VirtualSMS is **not** an A2P / sender platform like Twilio; it's the receiver side: you rent a number, point a third-party signup at it, and harvest the verification SMS. Common workflows are headless account creation, multi-region testing, and OTP-based bot authentication. There's currently no SMS-verification provider in the marketplace, so this fills a documented gap.

Closes #20717.

## What's included

`components/virtualsms/`

- `virtualsms.app.mjs` — app definition, `X-API-Key` auth, helper methods (`listServices`, `listCountries`, `rentNumber`, `getOrder`, `cancelOrder`, `listOrders`, `getBalance`)
- Actions:
  - `rent-number` — rent a number for a service / country
  - `check-messages` — poll a single order for the received SMS
  - `cancel-rental` — cancel + refund an unused rental
  - `list-services` — enumerate 2500+ services
  - `list-countries` — enumerate 145+ countries with current stock
  - `get-balance` — account balance in USD
- Source:
  - `new-sms-received` — polling trigger (60s default via `DEFAULT_POLLING_SOURCE_TIMER_INTERVAL`), de-duplicated per `order_id:sms_code`
- `README.md` — overview, use cases, getting-started, troubleshooting (error codes 401 / 402 / 404 / 429 / 5xx)
- `package.json` — `@pipedream/virtualsms@0.1.0`, only depends on `@pipedream/platform`

## Patterns matched

- App auth + helper methods: `components/airparser/airparser.app.mjs` (closest analog — single `X-API-Key` header on every request, axios via `@pipedream/platform`)
- Action shape & `propDefinition` reuse: `components/airparser/actions/extract-data-document`
- Polling source with `db` deduplication + `dedupe: "unique"` + `DEFAULT_POLLING_SOURCE_TIMER_INTERVAL`: `components/airparser/sources/new-document-parsed` and `components/sendgrid/sources/new-contact`
- README structure (Overview / Use Cases / Getting Started / Troubleshooting): `components/sendgrid/README.md`

## API findings

- Base URL: `https://virtualsms.io/api/v1`
- Auth: `X-API-Key: <key>` header (the public docs intro says `x-api-key` and the live API confirms; an older `api-docs` README mentions Bearer — that's stale, the running server returns `{"error":"Missing X-API-Key header"}` without it).
- Rate limit: 60 req/min per key (429 on excess) — surfaced in README.
- `/customer/orders` may 404 on legacy plans; `listOrders()` swallows that and returns `[]` so the polling trigger doesn't crash for those users.
- The `country` arg is optional on **Rent Number** — omit for cheapest-available routing.

## Test plan

- [ ] Pipedream review of file structure + naming
- [ ] Connected-account test with a real VirtualSMS API key against `Get Balance` (zero side-effects)
- [ ] End-to-end smoke: `Rent Number` → wait for `New SMS Received` → verify single emission per code → `Cancel Rental`
- [ ] Verify the `service` / `country` / `orderId` `async options()` populate correctly in the Pipedream UI

## Open questions for review

1. The polling source uses an in-memory dedupe map keyed by `order_id` and `sms_code`. Happy to switch to Pipedream's per-event dedupe alone if reviewers prefer — kept the explicit map because the same code can legitimately re-arrive on a different rental, and `dedupe: "unique"` on `id = orderId:code` already handles that case.
2. `Cancel Rental` is marked `destructiveHint: true`. Open to renaming `Cancel Order` if that matches the platform's vocabulary better.
3. Versioning starts at `0.0.1` per existing components and `0.1.0` for the package, matching airparser. Happy to bump if Pipedream prefers higher initial versions for new apps.

We commit to ongoing maintenance of this integration — happy to address review feedback and ship follow-up triggers (`rental-expired`, `low-balance-alert`, `stock-back-in-stock`) once this v1 lands.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VirtualSMS integration for SIM-backed, pay-per-SMS verification across 145+ countries
  * Rent temporary phone numbers, cancel rentals (with refund reporting), check messages, get balance, and list countries/services
  * New event source that polls for incoming SMS and emits deduplicated message events

* **Documentation**
  * Added setup, getting-started, example automations, and troubleshooting guide with status-code and retry guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
