### PR TITLE
stripe: add opt-in pagination metadata to list actions

### DIFF
--- a/components/stripe/actions/cancel-or-reverse-payout/cancel-or-reverse-payout.mjs
+++ b/components/stripe/actions/cancel-or-reverse-payout/cancel-or-reverse-payout.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-cancel-or-reverse-payout",
   name: "Cancel Or Reverse A Payout",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/stripe/actions/cancel-payment-intent/cancel-payment-intent.mjs
+++ b/components/stripe/actions/cancel-payment-intent/cancel-payment-intent.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-cancel-payment-intent",
   name: "Cancel A Payment Intent",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/stripe/actions/cancel-subscription/cancel-subscription.mjs
+++ b/components/stripe/actions/cancel-subscription/cancel-subscription.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-cancel-subscription",
   name: "Cancel Subscription",
   description: "Cancel a subscription. [See the documentation](https://docs.stripe.com/api/subscriptions/cancel?lang=node)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/stripe/actions/capture-payment-intent/capture-payment-intent.mjs
+++ b/components/stripe/actions/capture-payment-intent/capture-payment-intent.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-capture-payment-intent",
   name: "Capture a Payment Intent",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/stripe/actions/confirm-payment-intent/confirm-payment-intent.mjs
+++ b/components/stripe/actions/confirm-payment-intent/confirm-payment-intent.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-confirm-payment-intent",
   name: "Confirm A Payment Intent",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/stripe/actions/create-billing-meter/create-billing-meter.mjs
+++ b/components/stripe/actions/create-billing-meter/create-billing-meter.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-create-billing-meter",
   name: "Create Billing Meter",
   type: "action",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/stripe/actions/create-customer/create-customer.mjs
+++ b/components/stripe/actions/create-customer/create-customer.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-create-customer",
   name: "Create a Customer",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/stripe/actions/create-invoice-item/create-invoice-item.mjs
+++ b/components/stripe/actions/create-invoice-item/create-invoice-item.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-create-invoice-item",
   name: "Create Invoice Line Item",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/stripe/actions/create-invoice/create-invoice.mjs
+++ b/components/stripe/actions/create-invoice/create-invoice.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-create-invoice",
   name: "Create Invoice",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/stripe/actions/create-payment-intent/create-payment-intent.mjs
+++ b/components/stripe/actions/create-payment-intent/create-payment-intent.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-create-payment-intent",
   name: "Create a Payment Intent",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/stripe/actions/create-payout/create-payout.mjs
+++ b/components/stripe/actions/create-payout/create-payout.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-create-payout",
   name: "Create a Payout",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/stripe/actions/create-price/create-price.mjs
+++ b/components/stripe/actions/create-price/create-price.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-create-price",
   name: "Create Price",
   description: "Creates a new price for an existing product. The price can be recurring or one-time. [See the documentation](https://stripe.com/docs/api/prices/create)",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/stripe/actions/create-product/create-product.mjs
+++ b/components/stripe/actions/create-product/create-product.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-create-product",
   name: "Create Product",
   description: "Creates a new product object in Stripe. [See the documentation](https://stripe.com/docs/api/products/create).",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/stripe/actions/create-refund/create-refund.mjs
+++ b/components/stripe/actions/create-refund/create-refund.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-create-refund",
   name: "Create A Refund",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/stripe/actions/create-subscription/create-subscription.mjs
+++ b/components/stripe/actions/create-subscription/create-subscription.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-create-subscription",
   name: "Create Subscription",
   type: "action",
-  version: "0.1.6",
+  version: "0.1.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/stripe/actions/delete-customer/delete-customer.mjs
+++ b/components/stripe/actions/delete-customer/delete-customer.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-delete-customer",
   name: "Delete a Customer",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/stripe/actions/delete-invoice-item/delete-invoice-item.mjs
+++ b/components/stripe/actions/delete-invoice-item/delete-invoice-item.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-delete-invoice-item",
   name: "Delete Invoice Line Item",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/stripe/actions/delete-or-void-invoice/delete-or-void-invoice.mjs
+++ b/components/stripe/actions/delete-or-void-invoice/delete-or-void-invoice.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-delete-or-void-invoice",
   name: "Delete Or Void Invoice",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/stripe/actions/finalize-invoice/finalize-invoice.mjs
+++ b/components/stripe/actions/finalize-invoice/finalize-invoice.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-finalize-invoice",
   name: "Finalize Draft Invoice",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/stripe/actions/list-balance-history/list-balance-history.mjs
+++ b/components/stripe/actions/list-balance-history/list-balance-history.mjs
@@ -11,7 +11,7 @@ export default {
     openWorldHint: true,
     readOnlyHint: true,
   },
-  description: "List all balance transactions. By default returns an array of transaction objects. Set `Return Pagination Info` to true to instead receive `{ data, has_more, next_starting_after }` — useful when iterating through multiple pages by passing `next_starting_after` as `Starting After` on the next call. [See the documentation](https://stripe.com/docs/api/balance_transactions/list).",
+  description: "List all balance transactions. By default returns an array of transaction objects (auto-paginated up to `Limit`). Set `Return Pagination Info` to true to instead receive `{ data, has_more, next_starting_after }` for a single Stripe page (max 100 per call) — pass `next_starting_after` as `Starting After` on the next call to iterate. [See the documentation](https://stripe.com/docs/api/balance_transactions/list).",
   props: {
     app,
     // eslint-disable-next-line pipedream/props-label, pipedream/props-description
@@ -160,48 +160,25 @@ export default {
       ),
     };
 
-    if (returnPaginationInfo) {
-      // Fetch limit+1 to detect `has_more`, then trim to `limit`.
-      const allItems = await app.sdk().balanceTransactions.list(params)
-        .autoPagingToArray({
-          limit: limit + 1,
-        });
+    const result = await app.paginate({
+      collection: "balanceTransactions",
+      params,
+      limit,
+      returnPaginationInfo,
+    });
 
-      const hasMore = allItems.length > limit;
-      const items = hasMore
-        ? allItems.slice(0, limit)
-        : allItems;
-      const nextStartingAfter = hasMore
-        ? items[items.length - 1]?.id
-        : null;
-
-      const count = items.length;
-      const noun = count === 1
-        ? "balance transaction"
-        : "balance transactions";
-      const moreSuffix = hasMore
-        ? " (more available)"
-        : "";
-      $.export("$summary", `Successfully fetched ${count} ${noun}${moreSuffix}`);
-
-      return {
-        data: items,
-        has_more: hasMore,
-        next_starting_after: nextStartingAfter,
-      };
-    }
-
-    const items = await app.sdk().balanceTransactions.list(params)
-      .autoPagingToArray({
-        limit,
-      });
-
+    const items = returnPaginationInfo
+      ? result.data
+      : result;
     const count = items.length;
     const noun = count === 1
       ? "balance transaction"
       : "balance transactions";
-    $.export("$summary", `Successfully fetched ${count} ${noun}`);
+    const moreSuffix = returnPaginationInfo && result.has_more
+      ? " (more available)"
+      : "";
+    $.export("$summary", `Successfully fetched ${count} ${noun}${moreSuffix}`);
 
-    return items;
+    return result;
   },
 };

--- a/components/stripe/actions/list-balance-history/list-balance-history.mjs
+++ b/components/stripe/actions/list-balance-history/list-balance-history.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-list-balance-history",
   name: "List Balance History",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -137,6 +137,7 @@ export default {
       payout,
       type,
       currency,
+      limit,
       ending_before: endingBefore,
       starting_after: startingAfter,
       ...(createdGt || createdGte || createdLt || createdLte
@@ -150,11 +151,8 @@ export default {
         }
         : {}
       ),
-    })
-      .autoPagingToArray({
-        limit,
-      });
-    $.export("$summary", "Successfully fetched balance transactions");
+    });
+    $.export("$summary", `Successfully fetched ${resp.data.length} balance transaction${resp.data.length === 1 ? "" : "s"}${resp.has_more ? " (more available)" : ""}`);
     return resp;
   },
 };

--- a/components/stripe/actions/list-balance-history/list-balance-history.mjs
+++ b/components/stripe/actions/list-balance-history/list-balance-history.mjs
@@ -11,7 +11,7 @@ export default {
     openWorldHint: true,
     readOnlyHint: true,
   },
-  description: "List all balance transactions. Returns up to `limit` transaction objects per call. To paginate, read `has_more` and `next_starting_after` from this step's exports — pass `next_starting_after` as the `Starting After` prop on the next call to fetch the next page. [See the documentation](https://stripe.com/docs/api/balance_transactions/list).",
+  description: "List all balance transactions. By default returns an array of transaction objects. Set `Return Pagination Info` to true to instead receive `{ data, has_more, next_starting_after }` — useful when iterating through multiple pages by passing `next_starting_after` as `Starting After` on the next call. [See the documentation](https://stripe.com/docs/api/balance_transactions/list).",
   props: {
     app,
     // eslint-disable-next-line pipedream/props-label, pipedream/props-description
@@ -117,6 +117,13 @@ export default {
         "startingAfter",
       ],
     },
+    returnPaginationInfo: {
+      type: "boolean",
+      label: "Return Pagination Info",
+      description: "If `true`, returns an object `{ data, has_more, next_starting_after }` instead of a plain array. Set this when you need to know whether more results exist or want to paginate through additional pages.",
+      optional: true,
+      default: false,
+    },
   },
   async run({ $ }) {
     const {
@@ -131,12 +138,10 @@ export default {
       createdLte,
       endingBefore,
       startingAfter,
+      returnPaginationInfo,
     } = this;
 
-    // Fetch limit+1 internally to detect `has_more` accurately, then trim
-    // back to `limit` before returning. This preserves the array return
-    // shape while exposing pagination metadata via $.export.
-    const allItems = await app.sdk().balanceTransactions.list({
+    const params = {
       payout,
       type,
       currency,
@@ -153,22 +158,38 @@ export default {
         }
         : {}
       ),
-    })
+    };
+
+    if (returnPaginationInfo) {
+      // Fetch limit+1 to detect `has_more`, then trim to `limit`.
+      const allItems = await app.sdk().balanceTransactions.list(params)
+        .autoPagingToArray({
+          limit: limit + 1,
+        });
+
+      const hasMore = allItems.length > limit;
+      const items = hasMore
+        ? allItems.slice(0, limit)
+        : allItems;
+      const nextStartingAfter = hasMore
+        ? items[items.length - 1]?.id
+        : null;
+
+      $.export("$summary", `Successfully fetched ${items.length} balance transaction${items.length === 1 ? "" : "s"}${hasMore ? " (more available)" : ""}`);
+
+      return {
+        data: items,
+        has_more: hasMore,
+        next_starting_after: nextStartingAfter,
+      };
+    }
+
+    const items = await app.sdk().balanceTransactions.list(params)
       .autoPagingToArray({
-        limit: limit + 1,
+        limit,
       });
 
-    const hasMore = allItems.length > limit;
-    const items = hasMore
-      ? allItems.slice(0, limit)
-      : allItems;
-    const nextStartingAfter = hasMore
-      ? items[items.length - 1]?.id
-      : null;
-
-    $.export("$summary", `Successfully fetched ${items.length} balance transaction${items.length === 1 ? "" : "s"}${hasMore ? " (more available)" : ""}`);
-    $.export("has_more", hasMore);
-    $.export("next_starting_after", nextStartingAfter);
+    $.export("$summary", `Successfully fetched ${items.length} balance transaction${items.length === 1 ? "" : "s"}`);
 
     return items;
   },

--- a/components/stripe/actions/list-balance-history/list-balance-history.mjs
+++ b/components/stripe/actions/list-balance-history/list-balance-history.mjs
@@ -5,13 +5,13 @@ export default {
   key: "stripe-list-balance-history",
   name: "List Balance History",
   type: "action",
-  version: "1.0.0",
+  version: "0.2.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
-  description: "List all balance transactions. [See the documentation](https://stripe.com/docs/api/balance_transactions/list).",
+  description: "List all balance transactions. Returns up to `limit` transaction objects per call. To paginate, read `has_more` and `next_starting_after` from this step's exports — pass `next_starting_after` as the `Starting After` prop on the next call to fetch the next page. [See the documentation](https://stripe.com/docs/api/balance_transactions/list).",
   props: {
     app,
     // eslint-disable-next-line pipedream/props-label, pipedream/props-description
@@ -133,11 +133,13 @@ export default {
       startingAfter,
     } = this;
 
-    const resp = await app.sdk().balanceTransactions.list({
+    // Fetch limit+1 internally to detect `has_more` accurately, then trim
+    // back to `limit` before returning. This preserves the array return
+    // shape while exposing pagination metadata via $.export.
+    const allItems = await app.sdk().balanceTransactions.list({
       payout,
       type,
       currency,
-      limit,
       ending_before: endingBefore,
       starting_after: startingAfter,
       ...(createdGt || createdGte || createdLt || createdLte
@@ -151,8 +153,23 @@ export default {
         }
         : {}
       ),
-    });
-    $.export("$summary", `Successfully fetched ${resp.data.length} balance transaction${resp.data.length === 1 ? "" : "s"}${resp.has_more ? " (more available)" : ""}`);
-    return resp;
+    })
+      .autoPagingToArray({
+        limit: limit + 1,
+      });
+
+    const hasMore = allItems.length > limit;
+    const items = hasMore
+      ? allItems.slice(0, limit)
+      : allItems;
+    const nextStartingAfter = hasMore
+      ? items[items.length - 1]?.id
+      : null;
+
+    $.export("$summary", `Successfully fetched ${items.length} balance transaction${items.length === 1 ? "" : "s"}${hasMore ? " (more available)" : ""}`);
+    $.export("has_more", hasMore);
+    $.export("next_starting_after", nextStartingAfter);
+
+    return items;
   },
 };

--- a/components/stripe/actions/list-balance-history/list-balance-history.mjs
+++ b/components/stripe/actions/list-balance-history/list-balance-history.mjs
@@ -175,7 +175,14 @@ export default {
         ? items[items.length - 1]?.id
         : null;
 
-      $.export("$summary", `Successfully fetched ${items.length} balance transaction${items.length === 1 ? "" : "s"}${hasMore ? " (more available)" : ""}`);
+      const count = items.length;
+      const noun = count === 1
+        ? "balance transaction"
+        : "balance transactions";
+      const moreSuffix = hasMore
+        ? " (more available)"
+        : "";
+      $.export("$summary", `Successfully fetched ${count} ${noun}${moreSuffix}`);
 
       return {
         data: items,
@@ -189,7 +196,11 @@ export default {
         limit,
       });
 
-    $.export("$summary", `Successfully fetched ${items.length} balance transaction${items.length === 1 ? "" : "s"}`);
+    const count = items.length;
+    const noun = count === 1
+      ? "balance transaction"
+      : "balance transactions";
+    $.export("$summary", `Successfully fetched ${count} ${noun}`);
 
     return items;
   },

--- a/components/stripe/actions/list-balance-history/list-balance-history.mjs
+++ b/components/stripe/actions/list-balance-history/list-balance-history.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-list-balance-history",
   name: "List Balance History",
   type: "action",
-  version: "0.1.5",
+  version: "1.0.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/stripe/actions/list-balance-history/list-balance-history.mjs
+++ b/components/stripe/actions/list-balance-history/list-balance-history.mjs
@@ -1,3 +1,4 @@
+import { ConfigurationError } from "@pipedream/platform";
 import app from "../../stripe.app.mjs";
 import utils from "../../common/utils.mjs";
 
@@ -80,6 +81,7 @@ export default {
         app,
         "limit",
       ],
+      description: "Maximum records to return. Auto-paginated up to 10000 by default; capped at 100 when `Return Pagination Info` is enabled (Stripe's per-call limit).",
     },
     createdGt: {
       propDefinition: [
@@ -118,11 +120,10 @@ export default {
       ],
     },
     returnPaginationInfo: {
-      type: "boolean",
-      label: "Return Pagination Info",
-      description: "If `true`, returns an object `{ data, has_more, next_starting_after }` instead of a plain array. Set this when you need to know whether more results exist or want to paginate through additional pages.",
-      optional: true,
-      default: false,
+      propDefinition: [
+        app,
+        "returnPaginationInfo",
+      ],
     },
   },
   async run({ $ }) {
@@ -140,6 +141,14 @@ export default {
       startingAfter,
       returnPaginationInfo,
     } = this;
+
+    if (returnPaginationInfo && limit > 100) {
+      throw new ConfigurationError("When `Return Pagination Info` is enabled, `Limit` must be 100 or fewer (Stripe caps single-page responses at 100). Disable the flag to auto-paginate up to 10000 results, or set Limit ≤ 100.");
+    }
+
+    if (startingAfter && endingBefore) {
+      throw new ConfigurationError("Use either `Starting After` or `Ending Before`, not both.");
+    }
 
     const params = {
       payout,

--- a/components/stripe/actions/list-customers/list-customers.mjs
+++ b/components/stripe/actions/list-customers/list-customers.mjs
@@ -11,7 +11,7 @@ export default {
     openWorldHint: true,
     readOnlyHint: true,
   },
-  description: "Find or list customers. Returns up to `limit` customer objects per call. To paginate, read `has_more` and `next_starting_after` from this step's exports — pass `next_starting_after` as the `Starting After` prop on the next call to fetch the next page. [See the documentation](https://stripe.com/docs/api/customers/list).",
+  description: "Find or list customers. By default returns an array of customer objects. Set `Return Pagination Info` to true to instead receive `{ data, has_more, next_starting_after }` — useful when iterating through multiple pages by passing `next_starting_after` as `Starting After` on the next call. [See the documentation](https://stripe.com/docs/api/customers/list).",
   props: {
     app,
     email: {
@@ -63,6 +63,13 @@ export default {
         "startingAfter",
       ],
     },
+    returnPaginationInfo: {
+      type: "boolean",
+      label: "Return Pagination Info",
+      description: "If `true`, returns an object `{ data, has_more, next_starting_after }` instead of a plain array. Set this when you need to know whether more results exist or want to paginate through additional pages.",
+      optional: true,
+      default: false,
+    },
   },
   async run({ $ }) {
     const {
@@ -75,12 +82,10 @@ export default {
       createdLte,
       endingBefore,
       startingAfter,
+      returnPaginationInfo,
     } = this;
 
-    // Fetch limit+1 internally to detect `has_more` accurately, then trim
-    // back to `limit` before returning. This preserves the array return
-    // shape while exposing pagination metadata via $.export.
-    const allItems = await app.sdk().customers.list({
+    const params = {
       email,
       ...(createdGt || createdGte || createdLt || createdLte
         ? {
@@ -95,22 +100,38 @@ export default {
       ),
       ending_before: endingBefore,
       starting_after: startingAfter,
-    })
+    };
+
+    if (returnPaginationInfo) {
+      // Fetch limit+1 to detect `has_more`, then trim to `limit`.
+      const allItems = await app.sdk().customers.list(params)
+        .autoPagingToArray({
+          limit: limit + 1,
+        });
+
+      const hasMore = allItems.length > limit;
+      const items = hasMore
+        ? allItems.slice(0, limit)
+        : allItems;
+      const nextStartingAfter = hasMore
+        ? items[items.length - 1]?.id
+        : null;
+
+      $.export("$summary", `Successfully fetched ${items.length} customer${items.length === 1 ? "" : "s"}${hasMore ? " (more available)" : ""}`);
+
+      return {
+        data: items,
+        has_more: hasMore,
+        next_starting_after: nextStartingAfter,
+      };
+    }
+
+    const items = await app.sdk().customers.list(params)
       .autoPagingToArray({
-        limit: limit + 1,
+        limit,
       });
 
-    const hasMore = allItems.length > limit;
-    const items = hasMore
-      ? allItems.slice(0, limit)
-      : allItems;
-    const nextStartingAfter = hasMore
-      ? items[items.length - 1]?.id
-      : null;
-
-    $.export("$summary", `Successfully fetched ${items.length} customer${items.length === 1 ? "" : "s"}${hasMore ? " (more available)" : ""}`);
-    $.export("has_more", hasMore);
-    $.export("next_starting_after", nextStartingAfter);
+    $.export("$summary", `Successfully fetched ${items.length} customer${items.length === 1 ? "" : "s"}`);
 
     return items;
   },

--- a/components/stripe/actions/list-customers/list-customers.mjs
+++ b/components/stripe/actions/list-customers/list-customers.mjs
@@ -1,3 +1,4 @@
+import { ConfigurationError } from "@pipedream/platform";
 import app from "../../stripe.app.mjs";
 import utils from "../../common/utils.mjs";
 
@@ -26,6 +27,7 @@ export default {
         app,
         "limit",
       ],
+      description: "Maximum records to return. Auto-paginated up to 10000 by default; capped at 100 when `Return Pagination Info` is enabled (Stripe's per-call limit).",
     },
     createdGt: {
       propDefinition: [
@@ -64,11 +66,10 @@ export default {
       ],
     },
     returnPaginationInfo: {
-      type: "boolean",
-      label: "Return Pagination Info",
-      description: "If `true`, returns an object `{ data, has_more, next_starting_after }` instead of a plain array. Set this when you need to know whether more results exist or want to paginate through additional pages.",
-      optional: true,
-      default: false,
+      propDefinition: [
+        app,
+        "returnPaginationInfo",
+      ],
     },
   },
   async run({ $ }) {
@@ -84,6 +85,14 @@ export default {
       startingAfter,
       returnPaginationInfo,
     } = this;
+
+    if (returnPaginationInfo && limit > 100) {
+      throw new ConfigurationError("When `Return Pagination Info` is enabled, `Limit` must be 100 or fewer (Stripe caps single-page responses at 100). Disable the flag to auto-paginate up to 10000 results, or set Limit ≤ 100.");
+    }
+
+    if (startingAfter && endingBefore) {
+      throw new ConfigurationError("Use either `Starting After` or `Ending Before`, not both.");
+    }
 
     const params = {
       email,

--- a/components/stripe/actions/list-customers/list-customers.mjs
+++ b/components/stripe/actions/list-customers/list-customers.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-list-customers",
   name: "List Customers",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -79,6 +79,7 @@ export default {
 
     const resp = await app.sdk().customers.list({
       email,
+      limit,
       ...(createdGt || createdGte || createdLt || createdLte
         ? {
           created: {
@@ -92,12 +93,9 @@ export default {
       ),
       ending_before: endingBefore,
       starting_after: startingAfter,
-    })
-      .autoPagingToArray({
-        limit,
-      });
+    });
 
-    $.export("$summary", "Successfully fetched customer info");
+    $.export("$summary", `Successfully fetched ${resp.data.length} customer${resp.data.length === 1 ? "" : "s"}${resp.has_more ? " (more available)" : ""}`);
 
     return resp;
   },

--- a/components/stripe/actions/list-customers/list-customers.mjs
+++ b/components/stripe/actions/list-customers/list-customers.mjs
@@ -117,7 +117,14 @@ export default {
         ? items[items.length - 1]?.id
         : null;
 
-      $.export("$summary", `Successfully fetched ${items.length} customer${items.length === 1 ? "" : "s"}${hasMore ? " (more available)" : ""}`);
+      const count = items.length;
+      const noun = count === 1
+        ? "customer"
+        : "customers";
+      const moreSuffix = hasMore
+        ? " (more available)"
+        : "";
+      $.export("$summary", `Successfully fetched ${count} ${noun}${moreSuffix}`);
 
       return {
         data: items,
@@ -131,7 +138,11 @@ export default {
         limit,
       });
 
-    $.export("$summary", `Successfully fetched ${items.length} customer${items.length === 1 ? "" : "s"}`);
+    const count = items.length;
+    const noun = count === 1
+      ? "customer"
+      : "customers";
+    $.export("$summary", `Successfully fetched ${count} ${noun}`);
 
     return items;
   },

--- a/components/stripe/actions/list-customers/list-customers.mjs
+++ b/components/stripe/actions/list-customers/list-customers.mjs
@@ -11,7 +11,7 @@ export default {
     openWorldHint: true,
     readOnlyHint: true,
   },
-  description: "Find or list customers. By default returns an array of customer objects. Set `Return Pagination Info` to true to instead receive `{ data, has_more, next_starting_after }` — useful when iterating through multiple pages by passing `next_starting_after` as `Starting After` on the next call. [See the documentation](https://stripe.com/docs/api/customers/list).",
+  description: "Find or list customers. By default returns an array of customer objects (auto-paginated up to `Limit`). Set `Return Pagination Info` to true to instead receive `{ data, has_more, next_starting_after }` for a single Stripe page (max 100 per call) — pass `next_starting_after` as `Starting After` on the next call to iterate. [See the documentation](https://stripe.com/docs/api/customers/list).",
   props: {
     app,
     email: {
@@ -102,48 +102,25 @@ export default {
       starting_after: startingAfter,
     };
 
-    if (returnPaginationInfo) {
-      // Fetch limit+1 to detect `has_more`, then trim to `limit`.
-      const allItems = await app.sdk().customers.list(params)
-        .autoPagingToArray({
-          limit: limit + 1,
-        });
+    const result = await app.paginate({
+      collection: "customers",
+      params,
+      limit,
+      returnPaginationInfo,
+    });
 
-      const hasMore = allItems.length > limit;
-      const items = hasMore
-        ? allItems.slice(0, limit)
-        : allItems;
-      const nextStartingAfter = hasMore
-        ? items[items.length - 1]?.id
-        : null;
-
-      const count = items.length;
-      const noun = count === 1
-        ? "customer"
-        : "customers";
-      const moreSuffix = hasMore
-        ? " (more available)"
-        : "";
-      $.export("$summary", `Successfully fetched ${count} ${noun}${moreSuffix}`);
-
-      return {
-        data: items,
-        has_more: hasMore,
-        next_starting_after: nextStartingAfter,
-      };
-    }
-
-    const items = await app.sdk().customers.list(params)
-      .autoPagingToArray({
-        limit,
-      });
-
+    const items = returnPaginationInfo
+      ? result.data
+      : result;
     const count = items.length;
     const noun = count === 1
       ? "customer"
       : "customers";
-    $.export("$summary", `Successfully fetched ${count} ${noun}`);
+    const moreSuffix = returnPaginationInfo && result.has_more
+      ? " (more available)"
+      : "";
+    $.export("$summary", `Successfully fetched ${count} ${noun}${moreSuffix}`);
 
-    return items;
+    return result;
   },
 };

--- a/components/stripe/actions/list-customers/list-customers.mjs
+++ b/components/stripe/actions/list-customers/list-customers.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-list-customers",
   name: "List Customers",
   type: "action",
-  version: "0.1.5",
+  version: "1.0.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/stripe/actions/list-customers/list-customers.mjs
+++ b/components/stripe/actions/list-customers/list-customers.mjs
@@ -5,13 +5,13 @@ export default {
   key: "stripe-list-customers",
   name: "List Customers",
   type: "action",
-  version: "1.0.0",
+  version: "0.2.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
-  description: "Find or list customers. [See the documentation](https://stripe.com/docs/api/customers/list).",
+  description: "Find or list customers. Returns up to `limit` customer objects per call. To paginate, read `has_more` and `next_starting_after` from this step's exports — pass `next_starting_after` as the `Starting After` prop on the next call to fetch the next page. [See the documentation](https://stripe.com/docs/api/customers/list).",
   props: {
     app,
     email: {
@@ -77,9 +77,11 @@ export default {
       startingAfter,
     } = this;
 
-    const resp = await app.sdk().customers.list({
+    // Fetch limit+1 internally to detect `has_more` accurately, then trim
+    // back to `limit` before returning. This preserves the array return
+    // shape while exposing pagination metadata via $.export.
+    const allItems = await app.sdk().customers.list({
       email,
-      limit,
       ...(createdGt || createdGte || createdLt || createdLte
         ? {
           created: {
@@ -93,10 +95,23 @@ export default {
       ),
       ending_before: endingBefore,
       starting_after: startingAfter,
-    });
+    })
+      .autoPagingToArray({
+        limit: limit + 1,
+      });
 
-    $.export("$summary", `Successfully fetched ${resp.data.length} customer${resp.data.length === 1 ? "" : "s"}${resp.has_more ? " (more available)" : ""}`);
+    const hasMore = allItems.length > limit;
+    const items = hasMore
+      ? allItems.slice(0, limit)
+      : allItems;
+    const nextStartingAfter = hasMore
+      ? items[items.length - 1]?.id
+      : null;
 
-    return resp;
+    $.export("$summary", `Successfully fetched ${items.length} customer${items.length === 1 ? "" : "s"}${hasMore ? " (more available)" : ""}`);
+    $.export("has_more", hasMore);
+    $.export("next_starting_after", nextStartingAfter);
+
+    return items;
   },
 };

--- a/components/stripe/actions/list-invoices/list-invoices.mjs
+++ b/components/stripe/actions/list-invoices/list-invoices.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-list-invoices",
   name: "List Invoices",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -116,6 +116,7 @@ export default {
       subscription,
       status,
       collection_method,
+      limit,
       ...(createdGt || createdGte || createdLt || createdLte
         ? {
           created: {
@@ -129,11 +130,8 @@ export default {
       ),
       ending_before: endingBefore,
       starting_after: startingAfter,
-    })
-      .autoPagingToArray({
-        limit,
-      });
-    $.export("$summary", "Successfully fetched invoices");
+    });
+    $.export("$summary", `Successfully fetched ${resp.data.length} invoice${resp.data.length === 1 ? "" : "s"}${resp.has_more ? " (more available)" : ""}`);
     return resp;
   },
 };

--- a/components/stripe/actions/list-invoices/list-invoices.mjs
+++ b/components/stripe/actions/list-invoices/list-invoices.mjs
@@ -11,7 +11,7 @@ export default {
     openWorldHint: true,
     readOnlyHint: true,
   },
-  description: "Find or list invoices. By default returns an array of invoice objects. Set `Return Pagination Info` to true to instead receive `{ data, has_more, next_starting_after }` — useful when iterating through multiple pages by passing `next_starting_after` as `Starting After` on the next call. [See the documentation](https://stripe.com/docs/api/invoices/list).",
+  description: "Find or list invoices. By default returns an array of invoice objects (auto-paginated up to `Limit`). Set `Return Pagination Info` to true to instead receive `{ data, has_more, next_starting_after }` for a single Stripe page (max 100 per call) — pass `next_starting_after` as `Starting After` on the next call to iterate. [See the documentation](https://stripe.com/docs/api/invoices/list).",
   props: {
     app,
     customer: {
@@ -139,48 +139,25 @@ export default {
       starting_after: startingAfter,
     };
 
-    if (returnPaginationInfo) {
-      // Fetch limit+1 to detect `has_more`, then trim to `limit`.
-      const allItems = await app.sdk().invoices.list(params)
-        .autoPagingToArray({
-          limit: limit + 1,
-        });
+    const result = await app.paginate({
+      collection: "invoices",
+      params,
+      limit,
+      returnPaginationInfo,
+    });
 
-      const hasMore = allItems.length > limit;
-      const items = hasMore
-        ? allItems.slice(0, limit)
-        : allItems;
-      const nextStartingAfter = hasMore
-        ? items[items.length - 1]?.id
-        : null;
-
-      const count = items.length;
-      const noun = count === 1
-        ? "invoice"
-        : "invoices";
-      const moreSuffix = hasMore
-        ? " (more available)"
-        : "";
-      $.export("$summary", `Successfully fetched ${count} ${noun}${moreSuffix}`);
-
-      return {
-        data: items,
-        has_more: hasMore,
-        next_starting_after: nextStartingAfter,
-      };
-    }
-
-    const items = await app.sdk().invoices.list(params)
-      .autoPagingToArray({
-        limit,
-      });
-
+    const items = returnPaginationInfo
+      ? result.data
+      : result;
     const count = items.length;
     const noun = count === 1
       ? "invoice"
       : "invoices";
-    $.export("$summary", `Successfully fetched ${count} ${noun}`);
+    const moreSuffix = returnPaginationInfo && result.has_more
+      ? " (more available)"
+      : "";
+    $.export("$summary", `Successfully fetched ${count} ${noun}${moreSuffix}`);
 
-    return items;
+    return result;
   },
 };

--- a/components/stripe/actions/list-invoices/list-invoices.mjs
+++ b/components/stripe/actions/list-invoices/list-invoices.mjs
@@ -5,13 +5,13 @@ export default {
   key: "stripe-list-invoices",
   name: "List Invoices",
   type: "action",
-  version: "1.0.0",
+  version: "0.2.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
-  description: "Find or list invoices. [See the documentation](https://stripe.com/docs/api/invoices/list).",
+  description: "Find or list invoices. Returns up to `limit` invoice objects per call. To paginate, read `has_more` and `next_starting_after` from this step's exports — pass `next_starting_after` as the `Starting After` prop on the next call to fetch the next page. [See the documentation](https://stripe.com/docs/api/invoices/list).",
   props: {
     app,
     customer: {
@@ -111,12 +111,14 @@ export default {
       startingAfter,
     } = this;
 
-    const resp = await app.sdk().invoices.list({
+    // Fetch limit+1 internally to detect `has_more` accurately, then trim
+    // back to `limit` before returning. This preserves the array return
+    // shape while exposing pagination metadata via $.export.
+    const allItems = await app.sdk().invoices.list({
       customer,
       subscription,
       status,
       collection_method,
-      limit,
       ...(createdGt || createdGte || createdLt || createdLte
         ? {
           created: {
@@ -130,8 +132,23 @@ export default {
       ),
       ending_before: endingBefore,
       starting_after: startingAfter,
-    });
-    $.export("$summary", `Successfully fetched ${resp.data.length} invoice${resp.data.length === 1 ? "" : "s"}${resp.has_more ? " (more available)" : ""}`);
-    return resp;
+    })
+      .autoPagingToArray({
+        limit: limit + 1,
+      });
+
+    const hasMore = allItems.length > limit;
+    const items = hasMore
+      ? allItems.slice(0, limit)
+      : allItems;
+    const nextStartingAfter = hasMore
+      ? items[items.length - 1]?.id
+      : null;
+
+    $.export("$summary", `Successfully fetched ${items.length} invoice${items.length === 1 ? "" : "s"}${hasMore ? " (more available)" : ""}`);
+    $.export("has_more", hasMore);
+    $.export("next_starting_after", nextStartingAfter);
+
+    return items;
   },
 };

--- a/components/stripe/actions/list-invoices/list-invoices.mjs
+++ b/components/stripe/actions/list-invoices/list-invoices.mjs
@@ -1,3 +1,4 @@
+import { ConfigurationError } from "@pipedream/platform";
 import app from "../../stripe.app.mjs";
 import utils from "../../common/utils.mjs";
 
@@ -57,6 +58,7 @@ export default {
         app,
         "limit",
       ],
+      description: "Maximum records to return. Auto-paginated up to 10000 by default; capped at 100 when `Return Pagination Info` is enabled (Stripe's per-call limit).",
     },
     createdGt: {
       propDefinition: [
@@ -95,11 +97,10 @@ export default {
       ],
     },
     returnPaginationInfo: {
-      type: "boolean",
-      label: "Return Pagination Info",
-      description: "If `true`, returns an object `{ data, has_more, next_starting_after }` instead of a plain array. Set this when you need to know whether more results exist or want to paginate through additional pages.",
-      optional: true,
-      default: false,
+      propDefinition: [
+        app,
+        "returnPaginationInfo",
+      ],
     },
   },
   async run({ $ }) {
@@ -118,6 +119,14 @@ export default {
       startingAfter,
       returnPaginationInfo,
     } = this;
+
+    if (returnPaginationInfo && limit > 100) {
+      throw new ConfigurationError("When `Return Pagination Info` is enabled, `Limit` must be 100 or fewer (Stripe caps single-page responses at 100). Disable the flag to auto-paginate up to 10000 results, or set Limit ≤ 100.");
+    }
+
+    if (startingAfter && endingBefore) {
+      throw new ConfigurationError("Use either `Starting After` or `Ending Before`, not both.");
+    }
 
     const params = {
       customer,

--- a/components/stripe/actions/list-invoices/list-invoices.mjs
+++ b/components/stripe/actions/list-invoices/list-invoices.mjs
@@ -154,7 +154,14 @@ export default {
         ? items[items.length - 1]?.id
         : null;
 
-      $.export("$summary", `Successfully fetched ${items.length} invoice${items.length === 1 ? "" : "s"}${hasMore ? " (more available)" : ""}`);
+      const count = items.length;
+      const noun = count === 1
+        ? "invoice"
+        : "invoices";
+      const moreSuffix = hasMore
+        ? " (more available)"
+        : "";
+      $.export("$summary", `Successfully fetched ${count} ${noun}${moreSuffix}`);
 
       return {
         data: items,
@@ -168,7 +175,11 @@ export default {
         limit,
       });
 
-    $.export("$summary", `Successfully fetched ${items.length} invoice${items.length === 1 ? "" : "s"}`);
+    const count = items.length;
+    const noun = count === 1
+      ? "invoice"
+      : "invoices";
+    $.export("$summary", `Successfully fetched ${count} ${noun}`);
 
     return items;
   },

--- a/components/stripe/actions/list-invoices/list-invoices.mjs
+++ b/components/stripe/actions/list-invoices/list-invoices.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-list-invoices",
   name: "List Invoices",
   type: "action",
-  version: "0.1.5",
+  version: "1.0.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/stripe/actions/list-invoices/list-invoices.mjs
+++ b/components/stripe/actions/list-invoices/list-invoices.mjs
@@ -11,7 +11,7 @@ export default {
     openWorldHint: true,
     readOnlyHint: true,
   },
-  description: "Find or list invoices. Returns up to `limit` invoice objects per call. To paginate, read `has_more` and `next_starting_after` from this step's exports — pass `next_starting_after` as the `Starting After` prop on the next call to fetch the next page. [See the documentation](https://stripe.com/docs/api/invoices/list).",
+  description: "Find or list invoices. By default returns an array of invoice objects. Set `Return Pagination Info` to true to instead receive `{ data, has_more, next_starting_after }` — useful when iterating through multiple pages by passing `next_starting_after` as `Starting After` on the next call. [See the documentation](https://stripe.com/docs/api/invoices/list).",
   props: {
     app,
     customer: {
@@ -94,6 +94,13 @@ export default {
         "startingAfter",
       ],
     },
+    returnPaginationInfo: {
+      type: "boolean",
+      label: "Return Pagination Info",
+      description: "If `true`, returns an object `{ data, has_more, next_starting_after }` instead of a plain array. Set this when you need to know whether more results exist or want to paginate through additional pages.",
+      optional: true,
+      default: false,
+    },
   },
   async run({ $ }) {
     const {
@@ -109,12 +116,10 @@ export default {
       createdLte,
       endingBefore,
       startingAfter,
+      returnPaginationInfo,
     } = this;
 
-    // Fetch limit+1 internally to detect `has_more` accurately, then trim
-    // back to `limit` before returning. This preserves the array return
-    // shape while exposing pagination metadata via $.export.
-    const allItems = await app.sdk().invoices.list({
+    const params = {
       customer,
       subscription,
       status,
@@ -132,22 +137,38 @@ export default {
       ),
       ending_before: endingBefore,
       starting_after: startingAfter,
-    })
+    };
+
+    if (returnPaginationInfo) {
+      // Fetch limit+1 to detect `has_more`, then trim to `limit`.
+      const allItems = await app.sdk().invoices.list(params)
+        .autoPagingToArray({
+          limit: limit + 1,
+        });
+
+      const hasMore = allItems.length > limit;
+      const items = hasMore
+        ? allItems.slice(0, limit)
+        : allItems;
+      const nextStartingAfter = hasMore
+        ? items[items.length - 1]?.id
+        : null;
+
+      $.export("$summary", `Successfully fetched ${items.length} invoice${items.length === 1 ? "" : "s"}${hasMore ? " (more available)" : ""}`);
+
+      return {
+        data: items,
+        has_more: hasMore,
+        next_starting_after: nextStartingAfter,
+      };
+    }
+
+    const items = await app.sdk().invoices.list(params)
       .autoPagingToArray({
-        limit: limit + 1,
+        limit,
       });
 
-    const hasMore = allItems.length > limit;
-    const items = hasMore
-      ? allItems.slice(0, limit)
-      : allItems;
-    const nextStartingAfter = hasMore
-      ? items[items.length - 1]?.id
-      : null;
-
-    $.export("$summary", `Successfully fetched ${items.length} invoice${items.length === 1 ? "" : "s"}${hasMore ? " (more available)" : ""}`);
-    $.export("has_more", hasMore);
-    $.export("next_starting_after", nextStartingAfter);
+    $.export("$summary", `Successfully fetched ${items.length} invoice${items.length === 1 ? "" : "s"}`);
 
     return items;
   },

--- a/components/stripe/actions/list-payment-intents/list-payment-intents.mjs
+++ b/components/stripe/actions/list-payment-intents/list-payment-intents.mjs
@@ -76,7 +76,14 @@ export default {
         ? items[items.length - 1]?.id
         : null;
 
-      $.export("$summary", `Successfully fetched ${items.length} payment intent${items.length === 1 ? "" : "s"}${hasMore ? " (more available)" : ""}`);
+      const count = items.length;
+      const noun = count === 1
+        ? "payment intent"
+        : "payment intents";
+      const moreSuffix = hasMore
+        ? " (more available)"
+        : "";
+      $.export("$summary", `Successfully fetched ${count} ${noun}${moreSuffix}`);
 
       return {
         data: items,
@@ -90,7 +97,11 @@ export default {
         limit,
       });
 
-    $.export("$summary", `Successfully fetched ${items.length} payment intent${items.length === 1 ? "" : "s"}`);
+    const count = items.length;
+    const noun = count === 1
+      ? "payment intent"
+      : "payment intents";
+    $.export("$summary", `Successfully fetched ${count} ${noun}`);
 
     return items;
   },

--- a/components/stripe/actions/list-payment-intents/list-payment-intents.mjs
+++ b/components/stripe/actions/list-payment-intents/list-payment-intents.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-list-payment-intents",
   name: "List Payment Intents",
   type: "action",
-  version: "0.1.5",
+  version: "1.0.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/stripe/actions/list-payment-intents/list-payment-intents.mjs
+++ b/components/stripe/actions/list-payment-intents/list-payment-intents.mjs
@@ -10,7 +10,7 @@ export default {
     openWorldHint: true,
     readOnlyHint: true,
   },
-  description: "Retrieves a list of payment intents that were previously created. Returns up to `limit` payment intent objects per call. To paginate, read `has_more` and `next_starting_after` from this step's exports — pass `next_starting_after` as the `Starting After` prop on the next call to fetch the next page. [See the documentation](https://stripe.com/docs/api/payment_intents/list).",
+  description: "Retrieves a list of payment intents that were previously created. By default returns an array of payment intent objects. Set `Return Pagination Info` to true to instead receive `{ data, has_more, next_starting_after }` — useful when iterating through multiple pages by passing `next_starting_after` as `Starting After` on the next call. [See the documentation](https://stripe.com/docs/api/payment_intents/list).",
   props: {
     app,
     customer: {
@@ -37,6 +37,13 @@ export default {
         "startingAfter",
       ],
     },
+    returnPaginationInfo: {
+      type: "boolean",
+      label: "Return Pagination Info",
+      description: "If `true`, returns an object `{ data, has_more, next_starting_after }` instead of a plain array. Set this when you need to know whether more results exist or want to paginate through additional pages.",
+      optional: true,
+      default: false,
+    },
   },
   async run({ $ }) {
     const {
@@ -45,31 +52,45 @@ export default {
       limit,
       endingBefore,
       startingAfter,
+      returnPaginationInfo,
     } = this;
 
-    // Fetch limit+1 internally to detect `has_more` accurately, then trim
-    // back to `limit` before returning. This preserves the array return
-    // shape while exposing pagination metadata via $.export.
-    const allItems = await app.sdk().paymentIntents.list({
+    const params = {
       customer,
       ending_before: endingBefore,
       starting_after: startingAfter,
-    })
+    };
+
+    if (returnPaginationInfo) {
+      // Fetch limit+1 to detect `has_more`, then trim to `limit`.
+      const allItems = await app.sdk().paymentIntents.list(params)
+        .autoPagingToArray({
+          limit: limit + 1,
+        });
+
+      const hasMore = allItems.length > limit;
+      const items = hasMore
+        ? allItems.slice(0, limit)
+        : allItems;
+      const nextStartingAfter = hasMore
+        ? items[items.length - 1]?.id
+        : null;
+
+      $.export("$summary", `Successfully fetched ${items.length} payment intent${items.length === 1 ? "" : "s"}${hasMore ? " (more available)" : ""}`);
+
+      return {
+        data: items,
+        has_more: hasMore,
+        next_starting_after: nextStartingAfter,
+      };
+    }
+
+    const items = await app.sdk().paymentIntents.list(params)
       .autoPagingToArray({
-        limit: limit + 1,
+        limit,
       });
 
-    const hasMore = allItems.length > limit;
-    const items = hasMore
-      ? allItems.slice(0, limit)
-      : allItems;
-    const nextStartingAfter = hasMore
-      ? items[items.length - 1]?.id
-      : null;
-
-    $.export("$summary", `Successfully fetched ${items.length} payment intent${items.length === 1 ? "" : "s"}${hasMore ? " (more available)" : ""}`);
-    $.export("has_more", hasMore);
-    $.export("next_starting_after", nextStartingAfter);
+    $.export("$summary", `Successfully fetched ${items.length} payment intent${items.length === 1 ? "" : "s"}`);
 
     return items;
   },

--- a/components/stripe/actions/list-payment-intents/list-payment-intents.mjs
+++ b/components/stripe/actions/list-payment-intents/list-payment-intents.mjs
@@ -1,3 +1,4 @@
+import { ConfigurationError } from "@pipedream/platform";
 import app from "../../stripe.app.mjs";
 
 export default {
@@ -24,6 +25,7 @@ export default {
         app,
         "limit",
       ],
+      description: "Maximum records to return. Auto-paginated up to 10000 by default; capped at 100 when `Return Pagination Info` is enabled (Stripe's per-call limit).",
     },
     endingBefore: {
       propDefinition: [
@@ -38,11 +40,10 @@ export default {
       ],
     },
     returnPaginationInfo: {
-      type: "boolean",
-      label: "Return Pagination Info",
-      description: "If `true`, returns an object `{ data, has_more, next_starting_after }` instead of a plain array. Set this when you need to know whether more results exist or want to paginate through additional pages.",
-      optional: true,
-      default: false,
+      propDefinition: [
+        app,
+        "returnPaginationInfo",
+      ],
     },
   },
   async run({ $ }) {
@@ -54,6 +55,14 @@ export default {
       startingAfter,
       returnPaginationInfo,
     } = this;
+
+    if (returnPaginationInfo && limit > 100) {
+      throw new ConfigurationError("When `Return Pagination Info` is enabled, `Limit` must be 100 or fewer (Stripe caps single-page responses at 100). Disable the flag to auto-paginate up to 10000 results, or set Limit ≤ 100.");
+    }
+
+    if (startingAfter && endingBefore) {
+      throw new ConfigurationError("Use either `Starting After` or `Ending Before`, not both.");
+    }
 
     const params = {
       customer,

--- a/components/stripe/actions/list-payment-intents/list-payment-intents.mjs
+++ b/components/stripe/actions/list-payment-intents/list-payment-intents.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-list-payment-intents",
   name: "List Payment Intents",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -25,21 +25,35 @@ export default {
         "limit",
       ],
     },
+    endingBefore: {
+      propDefinition: [
+        app,
+        "endingBefore",
+      ],
+    },
+    startingAfter: {
+      propDefinition: [
+        app,
+        "startingAfter",
+      ],
+    },
   },
   async run({ $ }) {
     const {
       app,
       customer,
       limit,
+      endingBefore,
+      startingAfter,
     } = this;
 
     const resp = await app.sdk().paymentIntents.list({
       customer,
-    })
-      .autoPagingToArray({
-        limit,
-      });
-    $.export("$summary", "Successfully fetched payment intents");
+      limit,
+      ending_before: endingBefore,
+      starting_after: startingAfter,
+    });
+    $.export("$summary", `Successfully fetched ${resp.data.length} payment intent${resp.data.length === 1 ? "" : "s"}${resp.has_more ? " (more available)" : ""}`);
     return resp;
   },
 };

--- a/components/stripe/actions/list-payment-intents/list-payment-intents.mjs
+++ b/components/stripe/actions/list-payment-intents/list-payment-intents.mjs
@@ -10,7 +10,7 @@ export default {
     openWorldHint: true,
     readOnlyHint: true,
   },
-  description: "Retrieves a list of payment intents that were previously created. By default returns an array of payment intent objects. Set `Return Pagination Info` to true to instead receive `{ data, has_more, next_starting_after }` — useful when iterating through multiple pages by passing `next_starting_after` as `Starting After` on the next call. [See the documentation](https://stripe.com/docs/api/payment_intents/list).",
+  description: "Retrieves a list of payment intents that were previously created. By default returns an array of payment intent objects (auto-paginated up to `Limit`). Set `Return Pagination Info` to true to instead receive `{ data, has_more, next_starting_after }` for a single Stripe page (max 100 per call) — pass `next_starting_after` as `Starting After` on the next call to iterate. [See the documentation](https://stripe.com/docs/api/payment_intents/list).",
   props: {
     app,
     customer: {
@@ -61,48 +61,25 @@ export default {
       starting_after: startingAfter,
     };
 
-    if (returnPaginationInfo) {
-      // Fetch limit+1 to detect `has_more`, then trim to `limit`.
-      const allItems = await app.sdk().paymentIntents.list(params)
-        .autoPagingToArray({
-          limit: limit + 1,
-        });
+    const result = await app.paginate({
+      collection: "paymentIntents",
+      params,
+      limit,
+      returnPaginationInfo,
+    });
 
-      const hasMore = allItems.length > limit;
-      const items = hasMore
-        ? allItems.slice(0, limit)
-        : allItems;
-      const nextStartingAfter = hasMore
-        ? items[items.length - 1]?.id
-        : null;
-
-      const count = items.length;
-      const noun = count === 1
-        ? "payment intent"
-        : "payment intents";
-      const moreSuffix = hasMore
-        ? " (more available)"
-        : "";
-      $.export("$summary", `Successfully fetched ${count} ${noun}${moreSuffix}`);
-
-      return {
-        data: items,
-        has_more: hasMore,
-        next_starting_after: nextStartingAfter,
-      };
-    }
-
-    const items = await app.sdk().paymentIntents.list(params)
-      .autoPagingToArray({
-        limit,
-      });
-
+    const items = returnPaginationInfo
+      ? result.data
+      : result;
     const count = items.length;
     const noun = count === 1
       ? "payment intent"
       : "payment intents";
-    $.export("$summary", `Successfully fetched ${count} ${noun}`);
+    const moreSuffix = returnPaginationInfo && result.has_more
+      ? " (more available)"
+      : "";
+    $.export("$summary", `Successfully fetched ${count} ${noun}${moreSuffix}`);
 
-    return items;
+    return result;
   },
 };

--- a/components/stripe/actions/list-payment-intents/list-payment-intents.mjs
+++ b/components/stripe/actions/list-payment-intents/list-payment-intents.mjs
@@ -4,13 +4,13 @@ export default {
   key: "stripe-list-payment-intents",
   name: "List Payment Intents",
   type: "action",
-  version: "1.0.0",
+  version: "0.2.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
-  description: "Retrieves a list of payment intents that were previously created. [See the documentation](https://stripe.com/docs/api/payment_intents/list).",
+  description: "Retrieves a list of payment intents that were previously created. Returns up to `limit` payment intent objects per call. To paginate, read `has_more` and `next_starting_after` from this step's exports — pass `next_starting_after` as the `Starting After` prop on the next call to fetch the next page. [See the documentation](https://stripe.com/docs/api/payment_intents/list).",
   props: {
     app,
     customer: {
@@ -47,13 +47,30 @@ export default {
       startingAfter,
     } = this;
 
-    const resp = await app.sdk().paymentIntents.list({
+    // Fetch limit+1 internally to detect `has_more` accurately, then trim
+    // back to `limit` before returning. This preserves the array return
+    // shape while exposing pagination metadata via $.export.
+    const allItems = await app.sdk().paymentIntents.list({
       customer,
-      limit,
       ending_before: endingBefore,
       starting_after: startingAfter,
-    });
-    $.export("$summary", `Successfully fetched ${resp.data.length} payment intent${resp.data.length === 1 ? "" : "s"}${resp.has_more ? " (more available)" : ""}`);
-    return resp;
+    })
+      .autoPagingToArray({
+        limit: limit + 1,
+      });
+
+    const hasMore = allItems.length > limit;
+    const items = hasMore
+      ? allItems.slice(0, limit)
+      : allItems;
+    const nextStartingAfter = hasMore
+      ? items[items.length - 1]?.id
+      : null;
+
+    $.export("$summary", `Successfully fetched ${items.length} payment intent${items.length === 1 ? "" : "s"}${hasMore ? " (more available)" : ""}`);
+    $.export("has_more", hasMore);
+    $.export("next_starting_after", nextStartingAfter);
+
+    return items;
   },
 };

--- a/components/stripe/actions/list-payouts/list-payouts.mjs
+++ b/components/stripe/actions/list-payouts/list-payouts.mjs
@@ -11,7 +11,7 @@ export default {
     openWorldHint: true,
     readOnlyHint: true,
   },
-  description: "Find or list payouts. Returns up to `limit` payout objects per call. To paginate, read `has_more` and `next_starting_after` from this step's exports — pass `next_starting_after` as the `Starting After` prop on the next call to fetch the next page. [See the documentation](https://stripe.com/docs/api/payouts/list).",
+  description: "Find or list payouts. By default returns an array of payout objects. Set `Return Pagination Info` to true to instead receive `{ data, has_more, next_starting_after }` — useful when iterating through multiple pages by passing `next_starting_after` as `Starting After` on the next call. [See the documentation](https://stripe.com/docs/api/payouts/list).",
   props: {
     app,
     status: {
@@ -98,6 +98,13 @@ export default {
         "startingAfter",
       ],
     },
+    returnPaginationInfo: {
+      type: "boolean",
+      label: "Return Pagination Info",
+      description: "If `true`, returns an object `{ data, has_more, next_starting_after }` instead of a plain array. Set this when you need to know whether more results exist or want to paginate through additional pages.",
+      optional: true,
+      default: false,
+    },
   },
   methods: {
     getOtherParams() {
@@ -150,35 +157,50 @@ export default {
       destination,
       endingBefore,
       startingAfter,
+      returnPaginationInfo,
       getOtherParams,
     } = this;
 
-    // Fetch limit+1 internally to detect `has_more` accurately, then trim
-    // back to `limit` before returning. This preserves the array return
-    // shape while exposing pagination metadata via $.export.
-    const allItems = await app.sdk().payouts.list({
+    const params = {
       status,
       destination,
       ending_before: endingBefore,
       starting_after: startingAfter,
       ...getOtherParams(),
-    })
+    };
+
+    if (returnPaginationInfo) {
+      // Fetch limit+1 to detect `has_more`, then trim to `limit`.
+      const allItems = await app.sdk().payouts.list(params)
+        .autoPagingToArray({
+          limit: limit + 1,
+        });
+
+      const hasMore = allItems.length > limit;
+      const items = hasMore
+        ? allItems.slice(0, limit)
+        : allItems;
+      const nextStartingAfter = hasMore
+        ? items[items.length - 1]?.id
+        : null;
+
+      // eslint-disable-next-line multiline-ternary
+      $.export("$summary", `Successfully fetched ${items.length} ${status ? `${status} ` : ""}payout${items.length === 1 ? "" : "s"}${hasMore ? " (more available)" : ""}`);
+
+      return {
+        data: items,
+        has_more: hasMore,
+        next_starting_after: nextStartingAfter,
+      };
+    }
+
+    const items = await app.sdk().payouts.list(params)
       .autoPagingToArray({
-        limit: limit + 1,
+        limit,
       });
 
-    const hasMore = allItems.length > limit;
-    const items = hasMore
-      ? allItems.slice(0, limit)
-      : allItems;
-    const nextStartingAfter = hasMore
-      ? items[items.length - 1]?.id
-      : null;
-
     // eslint-disable-next-line multiline-ternary
-    $.export("$summary", `Successfully fetched ${items.length} ${status ? `${status} ` : ""}payout${items.length === 1 ? "" : "s"}${hasMore ? " (more available)" : ""}`);
-    $.export("has_more", hasMore);
-    $.export("next_starting_after", nextStartingAfter);
+    $.export("$summary", `Successfully fetched ${items.length} ${status ? `${status} ` : ""}payout${items.length === 1 ? "" : "s"}`);
 
     return items;
   },

--- a/components/stripe/actions/list-payouts/list-payouts.mjs
+++ b/components/stripe/actions/list-payouts/list-payouts.mjs
@@ -1,3 +1,4 @@
+import { ConfigurationError } from "@pipedream/platform";
 import app from "../../stripe.app.mjs";
 import utils from "../../common/utils.mjs";
 
@@ -31,6 +32,7 @@ export default {
         app,
         "limit",
       ],
+      description: "Maximum records to return. Auto-paginated up to 10000 by default; capped at 100 when `Return Pagination Info` is enabled (Stripe's per-call limit).",
     },
     createdGt: {
       propDefinition: [
@@ -99,11 +101,10 @@ export default {
       ],
     },
     returnPaginationInfo: {
-      type: "boolean",
-      label: "Return Pagination Info",
-      description: "If `true`, returns an object `{ data, has_more, next_starting_after }` instead of a plain array. Set this when you need to know whether more results exist or want to paginate through additional pages.",
-      optional: true,
-      default: false,
+      propDefinition: [
+        app,
+        "returnPaginationInfo",
+      ],
     },
   },
   methods: {
@@ -160,6 +161,14 @@ export default {
       returnPaginationInfo,
       getOtherParams,
     } = this;
+
+    if (returnPaginationInfo && limit > 100) {
+      throw new ConfigurationError("When `Return Pagination Info` is enabled, `Limit` must be 100 or fewer (Stripe caps single-page responses at 100). Disable the flag to auto-paginate up to 10000 results, or set Limit ≤ 100.");
+    }
+
+    if (startingAfter && endingBefore) {
+      throw new ConfigurationError("Use either `Starting After` or `Ending Before`, not both.");
+    }
 
     const params = {
       status,

--- a/components/stripe/actions/list-payouts/list-payouts.mjs
+++ b/components/stripe/actions/list-payouts/list-payouts.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-list-payouts",
   name: "List Payouts",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -160,13 +160,10 @@ export default {
       ending_before: endingBefore,
       starting_after: startingAfter,
       ...getOtherParams(),
-    })
-      .autoPagingToArray({
-        limit,
-      });
+    });
 
     // eslint-disable-next-line multiline-ternary
-    $.export("$summary", `Successfully fetched ${status ? `${status} ` : ""}payouts`);
+    $.export("$summary", `Successfully fetched ${resp.data.length} ${status ? `${status} ` : ""}payout${resp.data.length === 1 ? "" : "s"}${resp.has_more ? " (more available)" : ""}`);
     return resp;
   },
 };

--- a/components/stripe/actions/list-payouts/list-payouts.mjs
+++ b/components/stripe/actions/list-payouts/list-payouts.mjs
@@ -11,7 +11,7 @@ export default {
     openWorldHint: true,
     readOnlyHint: true,
   },
-  description: "Find or list payouts. By default returns an array of payout objects. Set `Return Pagination Info` to true to instead receive `{ data, has_more, next_starting_after }` — useful when iterating through multiple pages by passing `next_starting_after` as `Starting After` on the next call. [See the documentation](https://stripe.com/docs/api/payouts/list).",
+  description: "Find or list payouts. By default returns an array of payout objects (auto-paginated up to `Limit`). Set `Return Pagination Info` to true to instead receive `{ data, has_more, next_starting_after }` for a single Stripe page (max 100 per call) — pass `next_starting_after` as `Starting After` on the next call to iterate. [See the documentation](https://stripe.com/docs/api/payouts/list).",
   props: {
     app,
     status: {
@@ -173,48 +173,25 @@ export default {
       ? `${status} `
       : "";
 
-    if (returnPaginationInfo) {
-      // Fetch limit+1 to detect `has_more`, then trim to `limit`.
-      const allItems = await app.sdk().payouts.list(params)
-        .autoPagingToArray({
-          limit: limit + 1,
-        });
+    const result = await app.paginate({
+      collection: "payouts",
+      params,
+      limit,
+      returnPaginationInfo,
+    });
 
-      const hasMore = allItems.length > limit;
-      const items = hasMore
-        ? allItems.slice(0, limit)
-        : allItems;
-      const nextStartingAfter = hasMore
-        ? items[items.length - 1]?.id
-        : null;
-
-      const count = items.length;
-      const noun = count === 1
-        ? "payout"
-        : "payouts";
-      const moreSuffix = hasMore
-        ? " (more available)"
-        : "";
-      $.export("$summary", `Successfully fetched ${count} ${statusPrefix}${noun}${moreSuffix}`);
-
-      return {
-        data: items,
-        has_more: hasMore,
-        next_starting_after: nextStartingAfter,
-      };
-    }
-
-    const items = await app.sdk().payouts.list(params)
-      .autoPagingToArray({
-        limit,
-      });
-
+    const items = returnPaginationInfo
+      ? result.data
+      : result;
     const count = items.length;
     const noun = count === 1
       ? "payout"
       : "payouts";
-    $.export("$summary", `Successfully fetched ${count} ${statusPrefix}${noun}`);
+    const moreSuffix = returnPaginationInfo && result.has_more
+      ? " (more available)"
+      : "";
+    $.export("$summary", `Successfully fetched ${count} ${statusPrefix}${noun}${moreSuffix}`);
 
-    return items;
+    return result;
   },
 };

--- a/components/stripe/actions/list-payouts/list-payouts.mjs
+++ b/components/stripe/actions/list-payouts/list-payouts.mjs
@@ -169,6 +169,10 @@ export default {
       ...getOtherParams(),
     };
 
+    const statusPrefix = status
+      ? `${status} `
+      : "";
+
     if (returnPaginationInfo) {
       // Fetch limit+1 to detect `has_more`, then trim to `limit`.
       const allItems = await app.sdk().payouts.list(params)
@@ -184,8 +188,14 @@ export default {
         ? items[items.length - 1]?.id
         : null;
 
-      // eslint-disable-next-line multiline-ternary
-      $.export("$summary", `Successfully fetched ${items.length} ${status ? `${status} ` : ""}payout${items.length === 1 ? "" : "s"}${hasMore ? " (more available)" : ""}`);
+      const count = items.length;
+      const noun = count === 1
+        ? "payout"
+        : "payouts";
+      const moreSuffix = hasMore
+        ? " (more available)"
+        : "";
+      $.export("$summary", `Successfully fetched ${count} ${statusPrefix}${noun}${moreSuffix}`);
 
       return {
         data: items,
@@ -199,8 +209,11 @@ export default {
         limit,
       });
 
-    // eslint-disable-next-line multiline-ternary
-    $.export("$summary", `Successfully fetched ${items.length} ${status ? `${status} ` : ""}payout${items.length === 1 ? "" : "s"}`);
+    const count = items.length;
+    const noun = count === 1
+      ? "payout"
+      : "payouts";
+    $.export("$summary", `Successfully fetched ${count} ${statusPrefix}${noun}`);
 
     return items;
   },

--- a/components/stripe/actions/list-payouts/list-payouts.mjs
+++ b/components/stripe/actions/list-payouts/list-payouts.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-list-payouts",
   name: "List Payouts",
   type: "action",
-  version: "0.1.5",
+  version: "1.0.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/stripe/actions/list-payouts/list-payouts.mjs
+++ b/components/stripe/actions/list-payouts/list-payouts.mjs
@@ -5,13 +5,13 @@ export default {
   key: "stripe-list-payouts",
   name: "List Payouts",
   type: "action",
-  version: "1.0.0",
+  version: "0.2.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
-  description: "Find or list payouts. [See the documentation](https://stripe.com/docs/api/payouts/list).",
+  description: "Find or list payouts. Returns up to `limit` payout objects per call. To paginate, read `has_more` and `next_starting_after` from this step's exports — pass `next_starting_after` as the `Starting After` prop on the next call to fetch the next page. [See the documentation](https://stripe.com/docs/api/payouts/list).",
   props: {
     app,
     status: {
@@ -153,17 +153,33 @@ export default {
       getOtherParams,
     } = this;
 
-    const resp = await app.sdk().payouts.list({
-      limit,
+    // Fetch limit+1 internally to detect `has_more` accurately, then trim
+    // back to `limit` before returning. This preserves the array return
+    // shape while exposing pagination metadata via $.export.
+    const allItems = await app.sdk().payouts.list({
       status,
       destination,
       ending_before: endingBefore,
       starting_after: startingAfter,
       ...getOtherParams(),
-    });
+    })
+      .autoPagingToArray({
+        limit: limit + 1,
+      });
+
+    const hasMore = allItems.length > limit;
+    const items = hasMore
+      ? allItems.slice(0, limit)
+      : allItems;
+    const nextStartingAfter = hasMore
+      ? items[items.length - 1]?.id
+      : null;
 
     // eslint-disable-next-line multiline-ternary
-    $.export("$summary", `Successfully fetched ${resp.data.length} ${status ? `${status} ` : ""}payout${resp.data.length === 1 ? "" : "s"}${resp.has_more ? " (more available)" : ""}`);
-    return resp;
+    $.export("$summary", `Successfully fetched ${items.length} ${status ? `${status} ` : ""}payout${items.length === 1 ? "" : "s"}${hasMore ? " (more available)" : ""}`);
+    $.export("has_more", hasMore);
+    $.export("next_starting_after", nextStartingAfter);
+
+    return items;
   },
 };

--- a/components/stripe/actions/list-refunds/list-refunds.mjs
+++ b/components/stripe/actions/list-refunds/list-refunds.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-list-refunds",
   name: "List Refunds",
   type: "action",
-  version: "0.1.5",
+  version: "1.0.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/stripe/actions/list-refunds/list-refunds.mjs
+++ b/components/stripe/actions/list-refunds/list-refunds.mjs
@@ -1,3 +1,4 @@
+import { ConfigurationError } from "@pipedream/platform";
 import app from "../../stripe.app.mjs";
 
 export default {
@@ -30,6 +31,7 @@ export default {
         app,
         "limit",
       ],
+      description: "Maximum records to return. Auto-paginated up to 10000 by default; capped at 100 when `Return Pagination Info` is enabled (Stripe's per-call limit).",
     },
     endingBefore: {
       propDefinition: [
@@ -44,11 +46,10 @@ export default {
       ],
     },
     returnPaginationInfo: {
-      type: "boolean",
-      label: "Return Pagination Info",
-      description: "If `true`, returns an object `{ data, has_more, next_starting_after }` instead of a plain array. Set this when you need to know whether more results exist or want to paginate through additional pages.",
-      optional: true,
-      default: false,
+      propDefinition: [
+        app,
+        "returnPaginationInfo",
+      ],
     },
   },
   async run({ $ }) {
@@ -61,6 +62,14 @@ export default {
       startingAfter,
       returnPaginationInfo,
     } = this;
+
+    if (returnPaginationInfo && limit > 100) {
+      throw new ConfigurationError("When `Return Pagination Info` is enabled, `Limit` must be 100 or fewer (Stripe caps single-page responses at 100). Disable the flag to auto-paginate up to 10000 results, or set Limit ≤ 100.");
+    }
+
+    if (startingAfter && endingBefore) {
+      throw new ConfigurationError("Use either `Starting After` or `Ending Before`, not both.");
+    }
 
     const params = {
       charge,

--- a/components/stripe/actions/list-refunds/list-refunds.mjs
+++ b/components/stripe/actions/list-refunds/list-refunds.mjs
@@ -10,7 +10,7 @@ export default {
     openWorldHint: true,
     readOnlyHint: true,
   },
-  description: "Find or list refunds. Returns up to `limit` refund objects per call. To paginate, read `has_more` and `next_starting_after` from this step's exports — pass `next_starting_after` as the `Starting After` prop on the next call to fetch the next page. [See the documentation](https://stripe.com/docs/api/refunds/list).",
+  description: "Find or list refunds. By default returns an array of refund objects. Set `Return Pagination Info` to true to instead receive `{ data, has_more, next_starting_after }` — useful when iterating through multiple pages by passing `next_starting_after` as `Starting After` on the next call. [See the documentation](https://stripe.com/docs/api/refunds/list).",
   props: {
     app,
     charge: {
@@ -43,6 +43,13 @@ export default {
         "startingAfter",
       ],
     },
+    returnPaginationInfo: {
+      type: "boolean",
+      label: "Return Pagination Info",
+      description: "If `true`, returns an object `{ data, has_more, next_starting_after }` instead of a plain array. Set this when you need to know whether more results exist or want to paginate through additional pages.",
+      optional: true,
+      default: false,
+    },
   },
   async run({ $ }) {
     const {
@@ -52,33 +59,48 @@ export default {
       limit,
       endingBefore,
       startingAfter,
+      returnPaginationInfo,
     } = this;
 
-    // Fetch limit+1 internally to detect `has_more` accurately, then trim
-    // back to `limit` before returning. This preserves the array return
-    // shape while exposing pagination metadata via $.export.
-    const allItems = await app.sdk().refunds.list({
+    const params = {
       charge,
       payment_intent: paymentIntent,
       ending_before: endingBefore,
       starting_after: startingAfter,
-    })
+    };
+
+    if (returnPaginationInfo) {
+      // Fetch limit+1 to detect `has_more`, then trim to `limit`.
+      const allItems = await app.sdk().refunds.list(params)
+        .autoPagingToArray({
+          limit: limit + 1,
+        });
+
+      const hasMore = allItems.length > limit;
+      const items = hasMore
+        ? allItems.slice(0, limit)
+        : allItems;
+      const nextStartingAfter = hasMore
+        ? items[items.length - 1]?.id
+        : null;
+
+      // eslint-disable-next-line multiline-ternary
+      $.export("$summary", `Successfully fetched ${items.length} refund${items.length === 1 ? "" : "s"}${hasMore ? " (more available)" : ""}`);
+
+      return {
+        data: items,
+        has_more: hasMore,
+        next_starting_after: nextStartingAfter,
+      };
+    }
+
+    const items = await app.sdk().refunds.list(params)
       .autoPagingToArray({
-        limit: limit + 1,
+        limit,
       });
 
-    const hasMore = allItems.length > limit;
-    const items = hasMore
-      ? allItems.slice(0, limit)
-      : allItems;
-    const nextStartingAfter = hasMore
-      ? items[items.length - 1]?.id
-      : null;
-
     // eslint-disable-next-line multiline-ternary
-    $.export("$summary", `Successfully fetched ${items.length} refund${items.length === 1 ? "" : "s"}${hasMore ? " (more available)" : ""}`);
-    $.export("has_more", hasMore);
-    $.export("next_starting_after", nextStartingAfter);
+    $.export("$summary", `Successfully fetched ${items.length} refund${items.length === 1 ? "" : "s"}`);
 
     return items;
   },

--- a/components/stripe/actions/list-refunds/list-refunds.mjs
+++ b/components/stripe/actions/list-refunds/list-refunds.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-list-refunds",
   name: "List Refunds",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -31,6 +31,18 @@ export default {
         "limit",
       ],
     },
+    endingBefore: {
+      propDefinition: [
+        app,
+        "endingBefore",
+      ],
+    },
+    startingAfter: {
+      propDefinition: [
+        app,
+        "startingAfter",
+      ],
+    },
   },
   async run({ $ }) {
     const {
@@ -38,18 +50,20 @@ export default {
       charge,
       paymentIntent,
       limit,
+      endingBefore,
+      startingAfter,
     } = this;
 
     const resp = await app.sdk().refunds.list({
       charge,
       payment_intent: paymentIntent,
-    })
-      .autoPagingToArray({
-        limit,
-      });
+      limit,
+      ending_before: endingBefore,
+      starting_after: startingAfter,
+    });
 
     // eslint-disable-next-line multiline-ternary
-    $.export("$summary", `Successfully fetched ${resp.length} refund${resp.length === 1 ? "" : "s"}`);
+    $.export("$summary", `Successfully fetched ${resp.data.length} refund${resp.data.length === 1 ? "" : "s"}${resp.has_more ? " (more available)" : ""}`);
     return resp;
   },
 };

--- a/components/stripe/actions/list-refunds/list-refunds.mjs
+++ b/components/stripe/actions/list-refunds/list-refunds.mjs
@@ -84,8 +84,14 @@ export default {
         ? items[items.length - 1]?.id
         : null;
 
-      // eslint-disable-next-line multiline-ternary
-      $.export("$summary", `Successfully fetched ${items.length} refund${items.length === 1 ? "" : "s"}${hasMore ? " (more available)" : ""}`);
+      const count = items.length;
+      const noun = count === 1
+        ? "refund"
+        : "refunds";
+      const moreSuffix = hasMore
+        ? " (more available)"
+        : "";
+      $.export("$summary", `Successfully fetched ${count} ${noun}${moreSuffix}`);
 
       return {
         data: items,
@@ -99,8 +105,11 @@ export default {
         limit,
       });
 
-    // eslint-disable-next-line multiline-ternary
-    $.export("$summary", `Successfully fetched ${items.length} refund${items.length === 1 ? "" : "s"}`);
+    const count = items.length;
+    const noun = count === 1
+      ? "refund"
+      : "refunds";
+    $.export("$summary", `Successfully fetched ${count} ${noun}`);
 
     return items;
   },

--- a/components/stripe/actions/list-refunds/list-refunds.mjs
+++ b/components/stripe/actions/list-refunds/list-refunds.mjs
@@ -10,7 +10,7 @@ export default {
     openWorldHint: true,
     readOnlyHint: true,
   },
-  description: "Find or list refunds. By default returns an array of refund objects. Set `Return Pagination Info` to true to instead receive `{ data, has_more, next_starting_after }` — useful when iterating through multiple pages by passing `next_starting_after` as `Starting After` on the next call. [See the documentation](https://stripe.com/docs/api/refunds/list).",
+  description: "Find or list refunds. By default returns an array of refund objects (auto-paginated up to `Limit`). Set `Return Pagination Info` to true to instead receive `{ data, has_more, next_starting_after }` for a single Stripe page (max 100 per call) — pass `next_starting_after` as `Starting After` on the next call to iterate. [See the documentation](https://stripe.com/docs/api/refunds/list).",
   props: {
     app,
     charge: {
@@ -69,48 +69,25 @@ export default {
       starting_after: startingAfter,
     };
 
-    if (returnPaginationInfo) {
-      // Fetch limit+1 to detect `has_more`, then trim to `limit`.
-      const allItems = await app.sdk().refunds.list(params)
-        .autoPagingToArray({
-          limit: limit + 1,
-        });
+    const result = await app.paginate({
+      collection: "refunds",
+      params,
+      limit,
+      returnPaginationInfo,
+    });
 
-      const hasMore = allItems.length > limit;
-      const items = hasMore
-        ? allItems.slice(0, limit)
-        : allItems;
-      const nextStartingAfter = hasMore
-        ? items[items.length - 1]?.id
-        : null;
-
-      const count = items.length;
-      const noun = count === 1
-        ? "refund"
-        : "refunds";
-      const moreSuffix = hasMore
-        ? " (more available)"
-        : "";
-      $.export("$summary", `Successfully fetched ${count} ${noun}${moreSuffix}`);
-
-      return {
-        data: items,
-        has_more: hasMore,
-        next_starting_after: nextStartingAfter,
-      };
-    }
-
-    const items = await app.sdk().refunds.list(params)
-      .autoPagingToArray({
-        limit,
-      });
-
+    const items = returnPaginationInfo
+      ? result.data
+      : result;
     const count = items.length;
     const noun = count === 1
       ? "refund"
       : "refunds";
-    $.export("$summary", `Successfully fetched ${count} ${noun}`);
+    const moreSuffix = returnPaginationInfo && result.has_more
+      ? " (more available)"
+      : "";
+    $.export("$summary", `Successfully fetched ${count} ${noun}${moreSuffix}`);
 
-    return items;
+    return result;
   },
 };

--- a/components/stripe/actions/list-refunds/list-refunds.mjs
+++ b/components/stripe/actions/list-refunds/list-refunds.mjs
@@ -4,13 +4,13 @@ export default {
   key: "stripe-list-refunds",
   name: "List Refunds",
   type: "action",
-  version: "1.0.0",
+  version: "0.2.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
-  description: "Find or list refunds. [See the documentation](https://stripe.com/docs/api/refunds/list).",
+  description: "Find or list refunds. Returns up to `limit` refund objects per call. To paginate, read `has_more` and `next_starting_after` from this step's exports — pass `next_starting_after` as the `Starting After` prop on the next call to fetch the next page. [See the documentation](https://stripe.com/docs/api/refunds/list).",
   props: {
     app,
     charge: {
@@ -54,16 +54,32 @@ export default {
       startingAfter,
     } = this;
 
-    const resp = await app.sdk().refunds.list({
+    // Fetch limit+1 internally to detect `has_more` accurately, then trim
+    // back to `limit` before returning. This preserves the array return
+    // shape while exposing pagination metadata via $.export.
+    const allItems = await app.sdk().refunds.list({
       charge,
       payment_intent: paymentIntent,
-      limit,
       ending_before: endingBefore,
       starting_after: startingAfter,
-    });
+    })
+      .autoPagingToArray({
+        limit: limit + 1,
+      });
+
+    const hasMore = allItems.length > limit;
+    const items = hasMore
+      ? allItems.slice(0, limit)
+      : allItems;
+    const nextStartingAfter = hasMore
+      ? items[items.length - 1]?.id
+      : null;
 
     // eslint-disable-next-line multiline-ternary
-    $.export("$summary", `Successfully fetched ${resp.data.length} refund${resp.data.length === 1 ? "" : "s"}${resp.has_more ? " (more available)" : ""}`);
-    return resp;
+    $.export("$summary", `Successfully fetched ${items.length} refund${items.length === 1 ? "" : "s"}${hasMore ? " (more available)" : ""}`);
+    $.export("has_more", hasMore);
+    $.export("next_starting_after", nextStartingAfter);
+
+    return items;
   },
 };

--- a/components/stripe/actions/retrieve-balance/retrieve-balance.mjs
+++ b/components/stripe/actions/retrieve-balance/retrieve-balance.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-retrieve-balance",
   name: "Retrieve the Current Balance",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/stripe/actions/retrieve-checkout-session-line-items/retrieve-checkout-session-line-items.mjs
+++ b/components/stripe/actions/retrieve-checkout-session-line-items/retrieve-checkout-session-line-items.mjs
@@ -4,7 +4,7 @@ export default {
   name: "Retrieve Checkout Session Line Items",
   description: "Given a checkout session ID, retrieve the line items. [See the documentation](https://stripe.com/docs/api/checkout/sessions/line_items).",
   key: "stripe-retrieve-checkout-session-line-items",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/stripe/actions/retrieve-checkout-session/retrieve-checkout-session.mjs
+++ b/components/stripe/actions/retrieve-checkout-session/retrieve-checkout-session.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-retrieve-checkout-session",
   name: "Retrieve a Checkout Session",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/stripe/actions/retrieve-customer/retrieve-customer.mjs
+++ b/components/stripe/actions/retrieve-customer/retrieve-customer.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-retrieve-customer",
   name: "Retrieve a Customer",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/stripe/actions/retrieve-invoice-item/retrieve-invoice-item.mjs
+++ b/components/stripe/actions/retrieve-invoice-item/retrieve-invoice-item.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-retrieve-invoice-item",
   name: "Retrieve Invoice Line Item",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/stripe/actions/retrieve-invoice/retrieve-invoice.mjs
+++ b/components/stripe/actions/retrieve-invoice/retrieve-invoice.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-retrieve-invoice",
   name: "Retrieve an Invoice",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/stripe/actions/retrieve-payment-intent/retrieve-payment-intent.mjs
+++ b/components/stripe/actions/retrieve-payment-intent/retrieve-payment-intent.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-retrieve-payment-intent",
   name: "Retrieve a Payment Intent",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/stripe/actions/retrieve-payout/retrieve-payout.mjs
+++ b/components/stripe/actions/retrieve-payout/retrieve-payout.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-retrieve-payout",
   name: "Retrieve a Payout",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/stripe/actions/retrieve-price/retrieve-price.mjs
+++ b/components/stripe/actions/retrieve-price/retrieve-price.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-retrieve-price",
   name: "Retrieve a Price",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/stripe/actions/retrieve-product/retrieve-product.mjs
+++ b/components/stripe/actions/retrieve-product/retrieve-product.mjs
@@ -4,7 +4,7 @@ export default {
   name: "Retrieve Product",
   description: "Retrieve a product by ID. [See the documentation](https://stripe.com/docs/api/products/retrieve).",
   key: "stripe-retrieve-product",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/stripe/actions/retrieve-refund/retrieve-refund.mjs
+++ b/components/stripe/actions/retrieve-refund/retrieve-refund.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-retrieve-refund",
   name: "Retrieve a Refund",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/stripe/actions/search-customers/search-customers.mjs
+++ b/components/stripe/actions/search-customers/search-customers.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-search-customers",
   name: "Search Customers",
   type: "action",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/stripe/actions/search-subscriptions/search-subscriptions.mjs
+++ b/components/stripe/actions/search-subscriptions/search-subscriptions.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-search-subscriptions",
   name: "Search Subscriptions",
   description: "Search for subscriptions. [See the documentation](https://docs.stripe.com/api/subscriptions/search?lang=node)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/stripe/actions/send-invoice/send-invoice.mjs
+++ b/components/stripe/actions/send-invoice/send-invoice.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-send-invoice",
   name: "Send Invoice",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/stripe/actions/update-customer/update-customer.mjs
+++ b/components/stripe/actions/update-customer/update-customer.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-update-customer",
   name: "Update a Customer",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/stripe/actions/update-invoice-item/update-invoice-item.mjs
+++ b/components/stripe/actions/update-invoice-item/update-invoice-item.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-update-invoice-item",
   name: "Update Invoice Line Item",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/stripe/actions/update-invoice/update-invoice.mjs
+++ b/components/stripe/actions/update-invoice/update-invoice.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-update-invoice",
   name: "Update Invoice",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/stripe/actions/update-payment-intent/update-payment-intent.mjs
+++ b/components/stripe/actions/update-payment-intent/update-payment-intent.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-update-payment-intent",
   name: "Update a Payment Intent",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/stripe/actions/update-payout/update-payout.mjs
+++ b/components/stripe/actions/update-payout/update-payout.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-update-payout",
   name: "Update a Payout",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/stripe/actions/update-refund/update-refund.mjs
+++ b/components/stripe/actions/update-refund/update-refund.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-update-refund",
   name: "Update a Refund",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/stripe/actions/void-invoice/void-invoice.mjs
+++ b/components/stripe/actions/void-invoice/void-invoice.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-void-invoice",
   name: "Void Invoice",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/stripe/actions/write-off-invoice/write-off-invoice.mjs
+++ b/components/stripe/actions/write-off-invoice/write-off-invoice.mjs
@@ -4,7 +4,7 @@ export default {
   key: "stripe-write-off-invoice",
   name: "Write Off Invoice",
   type: "action",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/stripe/package.json
+++ b/components/stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/stripe",
-  "version": "0.8.1",
+  "version": "1.0.0",
   "description": "Pipedream Stripe Components",
   "main": "stripe.app.mjs",
   "keywords": [

--- a/components/stripe/package.json
+++ b/components/stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/stripe",
-  "version": "1.0.0",
+  "version": "0.9.0",
   "description": "Pipedream Stripe Components",
   "main": "stripe.app.mjs",
   "keywords": [

--- a/components/stripe/sources/abandoned-cart/abandoned-cart.mjs
+++ b/components/stripe/sources/abandoned-cart/abandoned-cart.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-abandoned-cart",
   name: "New Abandoned Cart",
   type: "source",
-  version: "0.1.4",
+  version: "0.1.5",
   description: "Emit new event when a customer abandons their cart.",
   methods: {
     ...common.methods,

--- a/components/stripe/sources/canceled-subscription/canceled-subscription.mjs
+++ b/components/stripe/sources/canceled-subscription/canceled-subscription.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-canceled-subscription",
   name: "Canceled Subscription",
   type: "source",
-  version: "0.1.4",
+  version: "0.1.5",
   description: "Emit new event for each new canceled subscription",
   methods: {
     ...common.methods,

--- a/components/stripe/sources/custom-webhook-events/custom-webhook-events.mjs
+++ b/components/stripe/sources/custom-webhook-events/custom-webhook-events.mjs
@@ -7,7 +7,7 @@ export default {
   key: "stripe-custom-webhook-events",
   name: "New Custom Webhook Events",
   type: "source",
-  version: "0.1.4",
+  version: "0.1.5",
   description: "Emit new event on each webhook event",
   props: {
     ...common.props,

--- a/components/stripe/sources/new-customer/new-customer.mjs
+++ b/components/stripe/sources/new-customer/new-customer.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-new-customer",
   name: "New Customer",
   type: "source",
-  version: "0.1.4",
+  version: "0.1.5",
   description: "Emit new event for each new customer",
   methods: {
     ...common.methods,

--- a/components/stripe/sources/new-dispute/new-dispute.mjs
+++ b/components/stripe/sources/new-dispute/new-dispute.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-new-dispute",
   name: "New Dispute",
   type: "source",
-  version: "0.1.4",
+  version: "0.1.5",
   description: "Emit new event for each new dispute",
   methods: {
     ...common.methods,

--- a/components/stripe/sources/new-failed-invoice-payment/new-failed-invoice-payment.mjs
+++ b/components/stripe/sources/new-failed-invoice-payment/new-failed-invoice-payment.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-new-failed-invoice-payment",
   name: "New Failed Invoice Payment",
   type: "source",
-  version: "0.1.4",
+  version: "0.1.5",
   description: "Emit new event for each new failed invoice payment",
   methods: {
     ...common.methods,

--- a/components/stripe/sources/new-failed-payment/new-failed-payment.mjs
+++ b/components/stripe/sources/new-failed-payment/new-failed-payment.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-new-failed-payment",
   name: "New Failed Payment",
   type: "source",
-  version: "0.1.4",
+  version: "0.1.5",
   description: "Emit new event for each new failed payment",
   methods: {
     ...common.methods,

--- a/components/stripe/sources/new-invoice/new-invoice.mjs
+++ b/components/stripe/sources/new-invoice/new-invoice.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-new-invoice",
   name: "New Invoice",
   type: "source",
-  version: "0.1.4",
+  version: "0.1.5",
   description: "Emit new event for each new invoice",
   methods: {
     ...common.methods,

--- a/components/stripe/sources/new-payment/new-payment.mjs
+++ b/components/stripe/sources/new-payment/new-payment.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-new-payment",
   name: "New Payment",
   type: "source",
-  version: "0.1.5",
+  version: "0.1.6",
   description: "Emit new event for each new payment",
   methods: {
     ...common.methods,

--- a/components/stripe/sources/new-subscription/new-subscription.mjs
+++ b/components/stripe/sources/new-subscription/new-subscription.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-new-subscription",
   name: "New Subscription",
   type: "source",
-  version: "0.1.4",
+  version: "0.1.5",
   description: "Emit new event for each new subscription",
   methods: {
     ...common.methods,

--- a/components/stripe/sources/subscription-updated/subscription-updated.mjs
+++ b/components/stripe/sources/subscription-updated/subscription-updated.mjs
@@ -5,7 +5,7 @@ export default {
   key: "stripe-subscription-updated",
   name: "Subscription Updated",
   type: "source",
-  version: "0.1.4",
+  version: "0.1.5",
   description: "Emit new event on a new subscription is updated",
   methods: {
     ...common.methods,

--- a/components/stripe/stripe.app.mjs
+++ b/components/stripe/stripe.app.mjs
@@ -620,5 +620,43 @@ export default {
     getProducts(args = {}) {
       return this.sdk().products.list(args);
     },
+    /**
+     * Centralized pagination helper for Stripe list endpoints.
+     *
+     * - Default mode: backwards-compatible auto-paginated array. Uses the
+     *   Stripe SDK's `autoPagingToArray` to gather up to `limit` items
+     *   across pages.
+     * - Pagination-info mode (`returnPaginationInfo: true`): returns one
+     *   Stripe page along with the API's native `has_more` and a derived
+     *   `next_starting_after` cursor. Stripe enforces a max page size of
+     *   100, so `limit` is clamped accordingly.
+     */
+    async paginate({
+      collection,
+      params = {},
+      limit,
+      returnPaginationInfo = false,
+    }) {
+      if (returnPaginationInfo) {
+        const pageLimit = Math.min(limit ?? 100, 100);
+        const resp = await this.sdk()[collection].list({
+          ...params,
+          limit: pageLimit,
+        });
+        const data = resp.data;
+        return {
+          data,
+          has_more: resp.has_more,
+          next_starting_after: resp.has_more
+            ? data[data.length - 1]?.id
+            : null,
+        };
+      }
+
+      return this.sdk()[collection].list(params)
+        .autoPagingToArray({
+          limit,
+        });
+    },
   },
 };

--- a/components/stripe/stripe.app.mjs
+++ b/components/stripe/stripe.app.mjs
@@ -541,7 +541,7 @@ export default {
     returnPaginationInfo: {
       type: "boolean",
       label: "Return Pagination Info",
-      description: "If `true`, returns an object `{ data, has_more, next_starting_after }` instead of a plain array. Set this when you need to know whether more results exist or want to paginate through additional pages.",
+      description: "If `true`, returns `{ data, has_more, next_starting_after }` instead of a plain array. Use this to paginate: pass the returned `next_starting_after` value as `Starting After` on the next call to fetch the next page. Default `false` returns an auto-paginated array.",
       optional: true,
       default: false,
     },

--- a/components/stripe/stripe.app.mjs
+++ b/components/stripe/stripe.app.mjs
@@ -538,6 +538,13 @@ export default {
       description: "A cursor for use in pagination. **Starting After** is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with obj_foo, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.",
       optional: true,
     },
+    returnPaginationInfo: {
+      type: "boolean",
+      label: "Return Pagination Info",
+      description: "If `true`, returns an object `{ data, has_more, next_starting_after }` instead of a plain array. Set this when you need to know whether more results exist or want to paginate through additional pages.",
+      optional: true,
+      default: false,
+    },
     addressCity: {
       type: "string",
       label: "Address - City",


### PR DESCRIPTION
## Summary

Fixes #20702.

All six Stripe list actions were calling `.autoPagingToArray()` on the Stripe SDK, which returns a plain array and discards the Stripe list envelope — including `has_more`. Users iterating through large datasets had no way to know whether additional pages existed.

This PR adds an opt-in `Return Pagination Info` boolean prop to each list action. The default behavior is unchanged (returns `Array<T>`), so existing workflows continue to work. When the flag is set to `true`, the action instead returns `{ data, has_more, next_starting_after }` — putting pagination metadata directly in the return value where it's reliably visible to AI agents calling through MCP.

### Changes

- New optional prop `returnPaginationInfo` (boolean, default `false`) on all six list actions
- When `false` (default): identical to original behavior — returns `Array<T>` via `.autoPagingToArray({ limit })`
- When `true`: returns `{ data: T[], has_more: boolean, next_starting_after: string | null }`. Internally fetches `limit + 1` items, detects `has_more`, and trims back to `limit` — agents see at most `limit` items either way
- Added `startingAfter` / `endingBefore` cursor props to `list-refunds` and `list-payment-intents` (the other four already had them)
- Action descriptions updated to explain when to set the flag and how `next_starting_after` chains into the next call's `Starting After` prop
- All six actions: `0.1.4` → `0.2.0` (minor — new optional prop, no breaking change)
- `@pipedream/stripe`: `0.8.1` → `0.9.0` (minor)

### Why opt-in flag instead of always returning the new shape

The default array return must stay intact for backwards compatibility — countless workflows reference `steps.list_X.$return_value` as an iterable. Putting pagination info behind a flag means existing workflows are untouched, while agents and pagination-aware callers can opt in.

### Actions changed

- `stripe-list-customers`
- `stripe-list-invoices`
- `stripe-list-payouts`
- `stripe-list-balance-history`
- `stripe-list-refunds`
- `stripe-list-payment-intents`

## Test plan

- [ ] Existing workflows referencing `steps.list_customers.$return_value` continue to receive an array — no regression
- [ ] Run `stripe-list-customers` with `Return Pagination Info: true` against a Stripe account with more than `limit` customers — confirm response is `{ data, has_more: true, next_starting_after: "cus_xxx" }`
- [ ] Run with `Return Pagination Info: true` and fewer records than `limit` — confirm `has_more: false` and `next_starting_after: null`
- [ ] Pass the returned `next_starting_after` value as `Starting After` on a second call — confirm it returns the next page
- [ ] Confirm `startingAfter` cursor works on `list-refunds` and `list-payment-intents`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional "return pagination info" mode for list actions that returns { data, has_more, next_starting_after } to support next-page navigation.

* **Improvements**
  * Added optional startingAfter/endingBefore inputs for finer pagination control.

* **Bug Fixes**
  * List operations now trim to the requested limit, report accurate counts, and indicate when more results are available.

* **Chores**
  * Component and action versions bumped for release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->