### PR TITLE
HubSpot - Get Engagements action

### DIFF
--- a/components/hubspot/actions/get-engagements/get-engagements.mjs
+++ b/components/hubspot/actions/get-engagements/get-engagements.mjs
@@ -58,6 +58,7 @@ export default {
     const properties = this.properties?.length
       ? this.properties
       : (await this.hubspot.getProperties({
+        $,
         objectType: this.engagementType,
       }))?.results.map((property) => property.name);
 

--- a/components/hubspot/actions/get-engagements/get-engagements.mjs
+++ b/components/hubspot/actions/get-engagements/get-engagements.mjs
@@ -1,0 +1,97 @@
+import hubspot from "../../hubspot.app.mjs";
+import { ENGAGEMENT_TYPE_OPTIONS } from "../../common/constants.mjs";
+
+export default {
+  key: "hubspot-get-engagements",
+  name: "Get Engagements",
+  description: "Retrieves one or more engagements by their IDs. Use this action to fetch details about multiple engagements, such as their types, timestamps, and associated CRM objects. Requires engagement IDs, which you can obtain from the **List CRM Objects** action. [See the documentation](https://developers.hubspot.com/docs/api-reference/legacy/crm/objects/objects/batch/get-objects)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  type: "action",
+  props: {
+    hubspot,
+    engagementType: {
+      type: "string",
+      label: "Engagement Type",
+      description:
+        "One of: `notes`, `tasks`, `meetings`, `emails`, or `calls`. "
+        + "Defines the CRM object type listed and which properties belong in **Object Properties**.",
+      async options() {
+        return ENGAGEMENT_TYPE_OPTIONS;
+      },
+    },
+    engagementIds: {
+      propDefinition: [
+        hubspot,
+        "objectIds",
+        (c) => ({
+          objectType: c.engagementType,
+        }),
+      ],
+      label: "Engagement IDs",
+      description: "The IDs of the engagements to retrieve",
+    },
+    properties: {
+      type: "string[]",
+      label: "Properties",
+      description:
+        "Property names to include in results."
+        + " Use **Search Properties** to discover available property names."
+        + " If not specified, returns default properties.",
+      optional: true,
+      async options() {
+        const { results: properties } = await this.hubspot.getProperties({
+          objectType: this.engagementType,
+        });
+        return properties?.map((property) => ({
+          label: property.label,
+          value: property.name,
+        })) || [];
+      },
+    },
+    propertiesWithHistory: {
+      type: "string[]",
+      label: "Properties with History",
+      description: "Key-value pairs for setting properties for the new object and their histories",
+      optional: true,
+    },
+    archived: {
+      type: "boolean",
+      label: "Archived",
+      description: "Whether to return only results that have been archived",
+      optional: true,
+    },
+    idProperty: {
+      type: "string",
+      label: "ID Property",
+      description: "When using a custom unique value property to retrieve records, the name of the property. Do not include this parameter if retrieving by record ID.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const response = await this.hubspot.batchGetObjects({
+      $,
+      objectType: this.engagementType,
+      params: {
+        archived: this.archived,
+      },
+      data: {
+        inputs: this.engagementIds.map((id) => ({
+          id,
+        })),
+        properties: this.properties,
+        propertiesWithHistory: this.propertiesWithHistory,
+        idProperty: this.idProperty,
+      },
+    });
+    const count = response?.results?.length ?? 0;
+    $.export("$summary", `Retrieved ${count} ${this.engagementType} engagement${count === 1
+      ? ""
+      : "s"}`);
+    return response;
+  },
+};

--- a/components/hubspot/actions/get-engagements/get-engagements.mjs
+++ b/components/hubspot/actions/get-engagements/get-engagements.mjs
@@ -33,15 +33,15 @@ export default {
         }),
       ],
       label: "Engagement IDs",
-      description: "The IDs of the engagements to retrieve",
+      description: "Array of engagement record IDs to retrieve. Example: `[\"191980186487\", \"191980186488\"]`.",
     },
     properties: {
       type: "string[]",
       label: "Properties",
       description:
-        "Property names to include in results."
+        "Property names to include in results. Example: `[\"hs_note_body\"]` for notes or `[\"hs_task_subject\", \"hs_task_body\"]` for tasks."
         + " Use **Search Properties** to discover available property names."
-        + " If not specified, returns all properties.",
+        + " If not specified, engagement-type defaults should be returned.",
       optional: true,
       async options() {
         const { results: properties } = await this.hubspot.getProperties({

--- a/components/hubspot/actions/get-engagements/get-engagements.mjs
+++ b/components/hubspot/actions/get-engagements/get-engagements.mjs
@@ -53,39 +53,16 @@ export default {
         })) || [];
       },
     },
-    propertiesWithHistory: {
-      type: "string[]",
-      label: "Properties with History",
-      description: "Key-value pairs for setting properties for the new object and their histories",
-      optional: true,
-    },
-    archived: {
-      type: "boolean",
-      label: "Archived",
-      description: "Whether to return only results that have been archived",
-      optional: true,
-    },
-    idProperty: {
-      type: "string",
-      label: "ID Property",
-      description: "When using a custom unique value property to retrieve records, the name of the property. Do not include this parameter if retrieving by record ID.",
-      optional: true,
-    },
   },
   async run({ $ }) {
     const response = await this.hubspot.batchGetObjects({
       $,
       objectType: this.engagementType,
-      params: {
-        archived: this.archived,
-      },
       data: {
         inputs: this.engagementIds.map((id) => ({
           id,
         })),
         properties: this.properties,
-        propertiesWithHistory: this.propertiesWithHistory,
-        idProperty: this.idProperty,
       },
     });
     const count = response?.results?.length ?? 0;

--- a/components/hubspot/actions/get-engagements/get-engagements.mjs
+++ b/components/hubspot/actions/get-engagements/get-engagements.mjs
@@ -41,7 +41,7 @@ export default {
       description:
         "Property names to include in results."
         + " Use **Search Properties** to discover available property names."
-        + " If not specified, returns default properties.",
+        + " If not specified, returns all properties.",
       optional: true,
       async options() {
         const { results: properties } = await this.hubspot.getProperties({
@@ -55,6 +55,12 @@ export default {
     },
   },
   async run({ $ }) {
+    const properties = this.properties?.length
+      ? this.properties
+      : (await this.hubspot.getProperties({
+        objectType: this.engagementType,
+      }))?.results.map((property) => property.name);
+
     const response = await this.hubspot.batchGetObjects({
       $,
       objectType: this.engagementType,
@@ -62,7 +68,7 @@ export default {
         inputs: this.engagementIds.map((id) => ({
           id,
         })),
-        properties: this.properties,
+        properties,
       },
     });
     const count = response?.results?.length ?? 0;

--- a/components/hubspot/actions/get-engagements/get-engagements.mjs
+++ b/components/hubspot/actions/get-engagements/get-engagements.mjs
@@ -44,6 +44,9 @@ export default {
         + " If not specified, engagement-type defaults should be returned.",
       optional: true,
       async options() {
+        if (!this.engagementType) {
+          return [];
+        }
         const { results: properties } = await this.hubspot.getProperties({
           objectType: this.engagementType,
         });

--- a/components/hubspot/package.json
+++ b/components/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/hubspot",
-  "version": "1.12.1",
+  "version": "1.13.0",
   "description": "Pipedream Hubspot Components",
   "main": "hubspot.app.mjs",
   "keywords": [


### PR DESCRIPTION
Resolves #20727 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a HubSpot action to retrieve multiple engagements by ID with selectable engagement type, optional property selection (auto-populates properties if omitted), and a concise result summary showing the retrieved count with correct singular/plural wording.

* **Chores**
  * HubSpot component package version bumped to 1.13.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->