### PR TITLE
Canva - List Designs

### DIFF
--- a/components/canva/actions/create-design/create-design.mjs
+++ b/components/canva/actions/create-design/create-design.mjs
@@ -5,7 +5,7 @@ export default {
   key: "canva-create-design",
   name: "Create Design",
   description: "Creates a new Canva design. [See the documentation](https://www.canva.dev/docs/connect/api-reference/designs/create-design/)",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/canva/actions/export-design/export-design.mjs
+++ b/components/canva/actions/export-design/export-design.mjs
@@ -8,7 +8,7 @@ export default {
   key: "canva-export-design",
   name: "Export Design",
   description: "Starts a new job to export a file from Canva. [See the documentation](https://www.canva.dev/docs/connect/api-reference/exports/create-design-export-job/)",
-  version: "0.1.0",
+  version: "0.1.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/canva/actions/list-designs/list-designs.mjs
+++ b/components/canva/actions/list-designs/list-designs.mjs
@@ -1,0 +1,74 @@
+import canva from "../../canva.app.mjs";
+import constants from "../../common/constants.mjs";
+
+export default {
+  key: "canva-list-designs",
+  name: "List Designs",
+  description: "List all designs in Canva. [See the documentation](https://www.canva.dev/docs/connect/api-reference/designs/list-designs/)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    canva,
+    query: {
+      type: "string",
+      label: "Query",
+      description: "Keyword or phrase to search across designs owned by or shared with the user. Maximum 255 characters. Example: `\"Q4 marketing banner\"`",
+      optional: true,
+    },
+    continuation: {
+      type: "string",
+      label: "Continuation",
+      description: "Pagination cursor returned in a previous response. Pass this value to retrieve the next page of results. Leave blank to start from the beginning. Example: `\"eyJhbGciOiJIUzI1NiJ9...\"`",
+      optional: true,
+    },
+    ownership: {
+      type: "string",
+      label: "Ownership",
+      description: "Filter designs by ownership. Use `owned` to see only designs you created, `shared` to see only designs others shared with you, or `any` to see both. Example: `\"owned\"`",
+      optional: true,
+      default: "any",
+      options: constants.OWNERSHIP_OPTIONS,
+    },
+    sortBy: {
+      type: "string",
+      label: "Sort By",
+      description: "Order of the returned designs. Use `relevance` when searching by query, or a date/title option to browse all designs. Example: `\"modified_descending\"`",
+      optional: true,
+      default: "relevance",
+      options: constants.SORT_BY_OPTIONS,
+    },
+    limit: {
+      type: "integer",
+      label: "Limit",
+      description: "Maximum number of designs to return per request (1–100). Use with `Continuation` to page through large result sets. Example: `25`",
+      optional: true,
+      default: 25,
+      min: 1,
+      max: 100,
+    },
+  },
+  async run({ $ }) {
+    const designs = await this.canva.listDesigns({
+      $,
+      debug: true,
+      params: {
+        query: this.query?.length
+          ? this.query.slice(0, 255)
+          : undefined,
+        continuation: this.continuation,
+        ownership: this.ownership ?? "any",
+        sort_by: this.sortBy ?? "relevance",
+        limit: this.limit ?? 25,
+      },
+    });
+    $.export("$summary", `Successfully retrieved ${designs.items?.length} design${designs.items?.length === 1
+      ? ""
+      : "s"}`);
+    return designs;
+  },
+};

--- a/components/canva/actions/list-designs/list-designs.mjs
+++ b/components/canva/actions/list-designs/list-designs.mjs
@@ -55,7 +55,6 @@ export default {
   async run({ $ }) {
     const designs = await this.canva.listDesigns({
       $,
-      debug: true,
       params: {
         query: this.query?.length
           ? this.query.slice(0, 255)

--- a/components/canva/common/constants.mjs
+++ b/components/canva/common/constants.mjs
@@ -56,6 +56,44 @@ const PAPER_SIZE = [
   "legal",
 ];
 
+const OWNERSHIP_OPTIONS = [
+  {
+    label: "Any (owned by and shared with the user)",
+    value: "any",
+  },
+  {
+    label: "Owned (owned by the user)",
+    value: "owned",
+  },
+  {
+    label: "Shared (shared with the user)",
+    value: "shared",
+  },
+];
+
+const SORT_BY_OPTIONS = [
+  {
+    label: "Relevance",
+    value: "relevance",
+  },
+  {
+    label: "Modified (newest first)",
+    value: "modified_descending",
+  },
+  {
+    label: "Modified (oldest first)",
+    value: "modified_ascending",
+  },
+  {
+    label: "Title (Z to A)",
+    value: "title_descending",
+  },
+  {
+    label: "Title (A to Z)",
+    value: "title_ascending",
+  },
+];
+
 export default {
   DESIGN_TYPE_OPTIONS,
   DESIGN_TYPE_NAME_OPTIONS,
@@ -63,4 +101,6 @@ export default {
   MP4_QUALITY,
   EXPORT_QUALITY,
   PAPER_SIZE,
+  OWNERSHIP_OPTIONS,
+  SORT_BY_OPTIONS,
 };

--- a/components/canva/package.json
+++ b/components/canva/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/canva",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "Pipedream Canva Components",
   "main": "canva.app.mjs",
   "keywords": [


### PR DESCRIPTION
Resolves #20728 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced "List Designs" action to search and filter Canva designs by ownership (default: any), sort by relevance/date/title (default: relevance), and control pagination limits (1–100, default: 25). Returns full results and a brief summary of matched designs.

* **Chores**
  * Updated component package and action definition versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->