### PR TITLE
Add Zenfulfillment order return read actions

### DIFF
--- a/components/zenfulfillment/actions/get-fulfillment/get-fulfillment.mjs
+++ b/components/zenfulfillment/actions/get-fulfillment/get-fulfillment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "zenfulfillment-get-fulfillment",
   name: "Get Fulfillment",
   description: "Get a fulfillment by ID. [See the documentation](https://partner.alaiko.com/docs#tag/Fulfillment/operation/api_partnerfulfillment_id_get)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/zenfulfillment/actions/get-order-return/get-order-return.mjs
+++ b/components/zenfulfillment/actions/get-order-return/get-order-return.mjs
@@ -1,0 +1,31 @@
+import zenfulfillment from "../../zenfulfillment.app.mjs";
+
+export default {
+  key: "zenfulfillment-get-order-return",
+  name: "Get Order Return",
+  description: "Get an order return by ID. [See the documentation](https://partner.alaiko.com/docs#tag/OrderReturn/operation/api_partnerorder-return_id_get)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    zenfulfillment,
+    orderReturnId: {
+      propDefinition: [
+        zenfulfillment,
+        "orderReturnId",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.zenfulfillment.getOrderReturn({
+      $,
+      orderReturnId: this.orderReturnId,
+    });
+    $.export("$summary", `Successfully retrieved order return with ID \`${this.orderReturnId}\`.`);
+    return response;
+  },
+};

--- a/components/zenfulfillment/actions/get-order/get-order.mjs
+++ b/components/zenfulfillment/actions/get-order/get-order.mjs
@@ -4,7 +4,7 @@ export default {
   key: "zenfulfillment-get-order",
   name: "Get Order",
   description: "Get an order by ID. [See the documentation](https://partner.alaiko.com/docs#tag/Order/operation/api_partnerorder_id_get)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/zenfulfillment/actions/list-fulfillments/list-fulfillments.mjs
+++ b/components/zenfulfillment/actions/list-fulfillments/list-fulfillments.mjs
@@ -4,7 +4,7 @@ export default {
   key: "zenfulfillment-list-fulfillments",
   name: "List Fulfillments",
   description: "List all fulfillments. [See the documentation](https://partner.alaiko.com/docs#tag/Fulfillment/operation/api_partnerfulfillment_get_collection)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/zenfulfillment/actions/list-order-returns/list-order-returns.mjs
+++ b/components/zenfulfillment/actions/list-order-returns/list-order-returns.mjs
@@ -1,0 +1,109 @@
+import zenfulfillment from "../../zenfulfillment.app.mjs";
+
+export default {
+  key: "zenfulfillment-list-order-returns",
+  name: "List Order Returns",
+  description: "List all order returns. [See the documentation](https://partner.alaiko.com/docs#tag/OrderReturn/operation/api_partnerorder-return_get_collection)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    zenfulfillment,
+    createdAtMin: {
+      type: "string",
+      label: "Created At Minimum",
+      description: "The minimum creation date of the order return (ISO format). Eg. `2025-01-01`",
+      optional: true,
+    },
+    createdAtMax: {
+      type: "string",
+      label: "Created At Maximum",
+      description: "The maximum creation date of the order return (ISO format). Eg. `2025-01-01`",
+      optional: true,
+    },
+    updatedAtMin: {
+      type: "string",
+      label: "Updated At Minimum",
+      description: "The minimum update date of the order return (ISO format). Eg. `2025-01-01`",
+      optional: true,
+    },
+    updatedAtMax: {
+      type: "string",
+      label: "Updated At Maximum",
+      description: "The maximum update date of the order return (ISO format). Eg. `2025-01-01`",
+      optional: true,
+    },
+    sortCreatedAt: {
+      type: "string",
+      label: "Sort by created at",
+      description: "Sort either ascending or descending by the creation date of the order return.",
+      options: [
+        "asc",
+        "desc",
+      ],
+      optional: true,
+    },
+    sortUpdatedAt: {
+      type: "string",
+      label: "Sort by updated at",
+      description: "Sort either ascending or descending by the update date of the order return.",
+      options: [
+        "asc",
+        "desc",
+      ],
+      optional: true,
+    },
+    warehouseLocation: {
+      type: "string",
+      label: "Warehouse Location",
+      description: "Filter by warehouse location.",
+      optional: true,
+    },
+    orderName: {
+      type: "string",
+      label: "Order Name",
+      description: "Filter by order name.",
+      optional: true,
+    },
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page number to return. Default is `1`",
+      optional: true,
+      default: 1,
+    },
+    itemsPerPage: {
+      type: "integer",
+      label: "Items per page",
+      description: "The number of items to return. Default is `50`. Maximum is `200`.",
+      optional: true,
+      default: 50,
+      max: 200,
+    },
+  },
+  async run({ $ }) {
+    const response = await this.zenfulfillment.listOrderReturns({
+      $,
+      params: {
+        "createdAtMin": this.createdAtMin,
+        "createdAtMax": this.createdAtMax,
+        "updatedAtMin": this.updatedAtMin,
+        "updatedAtMax": this.updatedAtMax,
+        "order[createdAt]": this.sortCreatedAt,
+        "order[updatedAt]": this.sortUpdatedAt,
+        "warehouseLocation": this.warehouseLocation,
+        "orderName": this.orderName,
+        "page": this.page,
+        "itemsPerPage": this.itemsPerPage,
+      },
+    });
+    $.export("$summary", `Successfully retrieved ${response.length} order return${response.length === 1
+      ? ""
+      : "s"}.`);
+    return response;
+  },
+};

--- a/components/zenfulfillment/actions/search-orders/search-orders.mjs
+++ b/components/zenfulfillment/actions/search-orders/search-orders.mjs
@@ -4,7 +4,7 @@ export default {
   key: "zenfulfillment-search-orders",
   name: "Search Orders",
   description: "Search for orders in Zenfulfillment. [See the documentation](https://partner.alaiko.com/docs#tag/Order/operation/api_partnerorder_get_collection)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/zenfulfillment/package.json
+++ b/components/zenfulfillment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/zenfulfillment",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Zenfulfillment Components",
   "main": "zenfulfillment.app.mjs",
   "keywords": [

--- a/components/zenfulfillment/package.json
+++ b/components/zenfulfillment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/zenfulfillment",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Pipedream Zenfulfillment Components",
   "main": "zenfulfillment.app.mjs",
   "keywords": [

--- a/components/zenfulfillment/package.json
+++ b/components/zenfulfillment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/zenfulfillment",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Pipedream Zenfulfillment Components",
   "main": "zenfulfillment.app.mjs",
   "keywords": [

--- a/components/zenfulfillment/zenfulfillment.app.mjs
+++ b/components/zenfulfillment/zenfulfillment.app.mjs
@@ -53,6 +53,22 @@ export default {
         })) || [];
       },
     },
+    orderReturnId: {
+      type: "string",
+      label: "Order Return ID",
+      description: "The ID of the order return.",
+      async options({ page }) {
+        const returns = await this.listOrderReturns({
+          params: {
+            page: page + 1,
+          },
+        });
+        return returns?.map((item) => ({
+          label: item.orders?.[0]?.name || item.externalId || item.id,
+          value: item.id,
+        })) || [];
+      },
+    },
   },
   methods: {
     _baseUrl() {
@@ -95,6 +111,18 @@ export default {
     listOrders(opts = {}) {
       return this._makeRequest({
         path: "/order",
+        ...opts,
+      });
+    },
+    listOrderReturns(opts = {}) {
+      return this._makeRequest({
+        path: "/order-return",
+        ...opts,
+      });
+    },
+    getOrderReturn({ orderReturnId, ...opts }) {
+      return this._makeRequest({
+        path: `/order-return/${orderReturnId}`,
         ...opts,
       });
     },

--- a/components/zenfulfillment/zenfulfillment.app.mjs
+++ b/components/zenfulfillment/zenfulfillment.app.mjs
@@ -121,12 +121,11 @@ export default {
       });
     },
     getOrderReturn({
-      orderReturnId,
-      ...opts
+      orderReturnId, ...opts
     }) {
       return this._makeRequest({
         path: `/order-return/${orderReturnId}`,
-        ...opts,
+        ...opts
       });
     },
   },

--- a/components/zenfulfillment/zenfulfillment.app.mjs
+++ b/components/zenfulfillment/zenfulfillment.app.mjs
@@ -120,7 +120,10 @@ export default {
         ...opts,
       });
     },
-    getOrderReturn({ orderReturnId, ...opts }) {
+    getOrderReturn({
+      orderReturnId,
+      ...opts
+    }) {
       return this._makeRequest({
         path: `/order-return/${orderReturnId}`,
         ...opts,

--- a/components/zenfulfillment/zenfulfillment.app.mjs
+++ b/components/zenfulfillment/zenfulfillment.app.mjs
@@ -125,7 +125,7 @@ export default {
     }) {
       return this._makeRequest({
         path: `/order-return/${orderReturnId}`,
-        ...opts
+        ...opts,
       });
     },
   },


### PR DESCRIPTION
## Summary

Adds two read-only Zenfulfillment actions for order returns:
- List Order Returns
- Get Order Return

These actions cover the READ order return endpoints requested in #20754:
- `GET /order-return`
- `GET /order-return/{id}`

This PR also adds a reusable `orderReturnId` prop definition and app helper methods for the new read endpoints.

Note: The issue also references the return label endpoint, but the last maintainer comment said to test only READ endpoints. Since `POST /return-label` is not a read endpoint, it is intentionally left out of this PR.

## Validation
- `node --check` passed for changed/created files.
- `pnpm validate:package --package=components/zenfulfillment` was attempted, but the local repo has a broader dependency issue: `Cannot find module 'delayed-stream'`, affecting many components and not specific to this change.

## Checklist
Please check the following items before your PR can be reviewed:

### Versioning
- [x] All components updated in this PR had their version updated (`0.0.1` for new ones)
- [x] The app updated in this PR had its `package.json`'s version updated

### New app
If this is a new app, please submit [an app integration request](https://github.com/PipedreamHQ/pipedream/issues/new?template=app---service-integration.md) - the PR will only be reviewed after the app is integrated.
- [x] The app updated in this PR is already integrated

### CodeRabbit review
After the PR is opened, and if new changes are pushed, CodeRabbit will automatically review it. Do not 'mark as resolved' CodeRabbit's comments, but reply to them instead, whether you agree (and update the PR accordingly) or disagree.
- [ ] I have addressed or acknowledged all of CodeRabbit's review comments



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Get Order Return" action to retrieve individual order return details.
  * Added "List Order Returns" action with optional filters (created/updated date ranges, sort direction, warehouse, order name) and pagination.
  * Added an order-return selector for simpler input selection.

* **Maintenance**
  * Package version bumped to v0.3.1 and several action metadata versions incremented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->