### PR TITLE
fix(google_drive): escape search term special chars and document tokenized matching

### DIFF
--- a/components/google_drive/actions/find-file/find-file.mjs
+++ b/components/google_drive/actions/find-file/find-file.mjs
@@ -5,8 +5,8 @@ import googleDrive from "../../google_drive.app.mjs";
 export default {
   key: "google_drive-find-file",
   name: "Find File",
-  description: "Search for a specific file by name. [See the documentation](https://developers.google.com/drive/api/v3/search-files) for more information",
-  version: "0.1.20",
+  description: "Search for a specific file by name. The `Search Name` field uses Google Drive's tokenized full-text matching — pass a distinctive word or short phrase rather than the full title when the name contains special characters like `&` or `'`. [See the documentation](https://developers.google.com/drive/api/v3/search-files) for more information",
+  version: "0.1.21",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/find-folder/find-folder.mjs
+++ b/components/google_drive/actions/find-folder/find-folder.mjs
@@ -6,8 +6,8 @@ import { GOOGLE_DRIVE_FOLDER_MIME_TYPE } from "../../common/constants.mjs";
 export default {
   key: "google_drive-find-folder",
   name: "Find Folder",
-  description: "Search for a specific folder by name. [See the documentation](https://developers.google.com/drive/api/v3/search-files) for more information",
-  version: "0.1.20",
+  description: "Search for a specific folder by name. The `Search Name` field uses Google Drive's tokenized full-text matching — pass a distinctive word or short phrase rather than the full title when the name contains special characters like `&` or `'`. [See the documentation](https://developers.google.com/drive/api/v3/search-files) for more information",
+  version: "0.1.21",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -39,7 +39,7 @@ export default {
     },
   },
   async run({ $ }) {
-    const escapedSearchTerm = this.nameSearchTerm?.replace(/'/g, "\\'") || "";
+    const escapedSearchTerm = this.nameSearchTerm?.replace(/\\/g, "\\\\").replace(/'/g, "\\'") || "";
     let q = `mimeType = '${GOOGLE_DRIVE_FOLDER_MIME_TYPE}' and name contains '${escapedSearchTerm}'`.trim();
     if (!this.includeTrashed) {
       q += " and trashed=false";

--- a/components/google_drive/actions/find-forms/find-forms.mjs
+++ b/components/google_drive/actions/find-forms/find-forms.mjs
@@ -5,8 +5,8 @@ import googleDrive from "../../google_drive.app.mjs";
 export default {
   key: "google_drive-find-forms",
   name: "Find Forms",
-  description: "List Google Form documents or search for a Form by name. [See the documentation](https://developers.google.com/drive/api/v3/search-files) for more information",
-  version: "0.0.21",
+  description: "List Google Form documents or search for a Form by name. The `Search Name` field uses Google Drive's tokenized full-text matching — pass a distinctive word or short phrase rather than the full title when the name contains special characters like `&` or `'`. [See the documentation](https://developers.google.com/drive/api/v3/search-files) for more information",
+  version: "0.0.22",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/find-spreadsheets/find-spreadsheets.mjs
+++ b/components/google_drive/actions/find-spreadsheets/find-spreadsheets.mjs
@@ -5,8 +5,8 @@ import googleDrive from "../../google_drive.app.mjs";
 export default {
   key: "google_drive-find-spreadsheets",
   name: "Find Spreadsheets",
-  description: "Search for a specific spreadsheet by name. [See the documentation](https://developers.google.com/drive/api/v3/search-files) for more information",
-  version: "0.1.20",
+  description: "Search for a specific spreadsheet by name. The `Search Name` field uses Google Drive's tokenized full-text matching — pass a distinctive word or short phrase rather than the full title when the name contains special characters like `&` or `'`. [See the documentation](https://developers.google.com/drive/api/v3/search-files) for more information",
+  version: "0.1.21",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/common/commonSearchQuery.mjs
+++ b/components/google_drive/common/commonSearchQuery.mjs
@@ -19,7 +19,8 @@ export default {
           : `${q} and ${searchQuery}`;
       } else {
         if (nameSearchTerm) {
-          const nameQuery = `name contains '${nameSearchTerm}'`;
+          const escapedTerm = nameSearchTerm.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+          const nameQuery = `name contains '${escapedTerm}'`;
           q = q
             ? `${q} and ${nameQuery}`
             : nameQuery;

--- a/components/google_drive/google_drive.app.mjs
+++ b/components/google_drive/google_drive.app.mjs
@@ -172,7 +172,7 @@ export default {
     fileNameSearchTerm: {
       type: "string",
       label: "Search Name",
-      description: "Search for a file by name (equivalent to the query `name contains [value]`). Uses tokenized full-text matching — punctuation like `&` and `'` acts as a word boundary, so use a distinctive word or short phrase rather than the full title when special characters are present.",
+      description: "Search for a file by name (equivalent to the query `name contains [value]`).",
       optional: true,
     },
     searchQuery: {

--- a/components/google_drive/google_drive.app.mjs
+++ b/components/google_drive/google_drive.app.mjs
@@ -172,7 +172,7 @@ export default {
     fileNameSearchTerm: {
       type: "string",
       label: "Search Name",
-      description: "Search for a file by name (equivalent to the query `name contains [value]`).",
+      description: "Search for a file by name (equivalent to the query `name contains [value]`). Uses tokenized full-text matching — punctuation like `&` and `'` acts as a word boundary, so use a distinctive word or short phrase rather than the full title when special characters are present.",
       optional: true,
     },
     searchQuery: {

--- a/components/google_drive/package.json
+++ b/components/google_drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_drive",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Pipedream Google_drive Components",
   "main": "google_drive.app.mjs",
   "keywords": [


### PR DESCRIPTION
## Summary

- **Bug fix**: `nameSearchTerm` was not escaped before being interpolated into the Drive query string in `commonSearchQuery.mjs`. Single quotes in file names (e.g. `O'Brien's Doc`) would generate a malformed query. Now escapes `\` and `'` per the Drive query syntax spec.
- **Bug fix**: `find-folder` had the same issue — it was escaping `'` but not `\`. Added backslash escaping to match.
- **Agent guidance**: Updated action descriptions for `find-file`, `find-folder`, `find-forms`, and `find-spreadsheets` to document that `Search Name` uses Google Drive's tokenized full-text matching. Special characters like `&` act as token boundaries, not literal characters, so agents/users should pass a distinctive word or phrase rather than the full title. Also updated the `fileNameSearchTerm` prop description in the app for the same reason.

## Context

Reported by a Connect developer: searching for files with `&` in the name (e.g. "Learn Pricing Tool & ROI calc") consistently failed on the first attempt. The `&` issue is a Google Drive API tokenization behavior (not a syntax bug), but the lack of single-quote escaping is a real correctness bug. Both are addressed here.

## Test plan

- [ ] Search for a file whose name contains a single quote — confirm it returns results instead of a Drive API error
- [ ] Search for a file whose name contains `&` using a word on one side of the `&` — confirm it finds the file
- [ ] Verify action descriptions surface the tokenization note in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced special character handling in Google Drive search operations for improved search reliability.

* **Documentation**
  * Updated search action descriptions with guidance on tokenized full-text matching and special character escaping in search queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->