### PR TITLE
onenote: add get-page-content action and improve search-pages

### DIFF
--- a/components/onenote/actions/create-notebook/create-notebook.mjs
+++ b/components/onenote/actions/create-notebook/create-notebook.mjs
@@ -2,7 +2,7 @@ import app from "../../onenote.app.mjs";
 
 export default {
   name: "Create Notebook",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/onenote/actions/create-page/create-page.mjs
+++ b/components/onenote/actions/create-page/create-page.mjs
@@ -2,7 +2,7 @@ import app from "../../onenote.app.mjs";
 
 export default {
   name: "Create Page",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/onenote/actions/create-section/create-section.mjs
+++ b/components/onenote/actions/create-section/create-section.mjs
@@ -2,7 +2,7 @@ import app from "../../onenote.app.mjs";
 
 export default {
   name: "Create Section",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/onenote/actions/get-page-content/get-page-content.mjs
+++ b/components/onenote/actions/get-page-content/get-page-content.mjs
@@ -1,0 +1,64 @@
+import TurndownService from "turndown";
+import app from "../../onenote.app.mjs";
+
+const turndownService = new TurndownService({
+  headingStyle: "atx",
+  codeBlockStyle: "fenced",
+});
+
+export default {
+  key: "onenote-get-page-content",
+  name: "Get Page Content",
+  description: "Retrieve the body content of a OneNote page as HTML or Markdown."
+    + " Use **Get Page** for the page's metadata (title, parent section, URLs, timestamps); use this action when you need the actual page content."
+    + " Use **Search Pages** first to resolve a page name to a `pageId`."
+    + " Set `convertToMarkdown` to `true` for cleaner, more compact output (recommended when the consumer is an LLM)."
+    + " Set `includeIDs` to `true` if you need element IDs for a later update operation. Note: combining `includeIDs` with `convertToMarkdown` may strip `data-id` attributes during conversion."
+    + " [See the documentation](https://learn.microsoft.com/en-us/graph/api/onenote-input-output-html?view=graph-rest-1.0)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    app,
+    pageId: {
+      propDefinition: [
+        app,
+        "pageId",
+      ],
+    },
+    includeIDs: {
+      type: "boolean",
+      label: "Include Element IDs",
+      description: "When true, the returned HTML includes `data-id` attributes on elements. Required for later update operations targeting specific elements on the page. Default false.",
+      optional: true,
+      default: false,
+    },
+    convertToMarkdown: {
+      type: "boolean",
+      label: "Convert to Markdown",
+      description: "When true, the HTML content is converted to Markdown before being returned. Recommended when the consumer is an LLM. Default false (returns raw HTML).",
+      optional: true,
+      default: false,
+    },
+  },
+  async run({ $ }) {
+    const html = await this.app.getPageContent({
+      $,
+      pageId: this.pageId,
+      includeIDs: this.includeIDs,
+    });
+
+    if (this.convertToMarkdown) {
+      const markdown = turndownService.turndown(html);
+      $.export("$summary", `Retrieved page ${this.pageId} content as Markdown (${markdown.length} chars)`);
+      return markdown;
+    }
+
+    $.export("$summary", `Retrieved page ${this.pageId} content as HTML (${html.length} chars)`);
+    return html;
+  },
+};

--- a/components/onenote/actions/get-page-content/get-page-content.mjs
+++ b/components/onenote/actions/get-page-content/get-page-content.mjs
@@ -14,7 +14,7 @@ export default {
     + " Use **Search Pages** first to resolve a page name to a `pageId`."
     + " Set `convertToMarkdown` to `true` for cleaner, more compact output (recommended when the consumer is an LLM)."
     + " Set `includeIDs` to `true` if you need element IDs for a later update operation. Note: combining `includeIDs` with `convertToMarkdown` may strip `data-id` attributes during conversion."
-    + " [See the documentation](https://learn.microsoft.com/en-us/graph/api/onenote-input-output-html?view=graph-rest-1.0)",
+    + " [See the documentation](https://learn.microsoft.com/en-us/graph/api/page-get?view=graph-rest-1.0&tabs=http)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/onenote/actions/get-page/get-page.mjs
+++ b/components/onenote/actions/get-page/get-page.mjs
@@ -5,7 +5,7 @@ export default {
   description: "Gets a page. [See the documentation](https://learn.microsoft.com/en-us/graph/api/page-get?view=graph-rest-1.0&tabs=http)",
   key: "onenote-get-page",
   type: "action",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/onenote/actions/search-notebooks/search-notebooks.mjs
+++ b/components/onenote/actions/search-notebooks/search-notebooks.mjs
@@ -6,7 +6,7 @@ export default {
   description: "Searches for notebooks. [See the documentation](https://learn.microsoft.com/en-us/graph/api/onenote-list-notebooks?view=graph-rest-1.0&tabs=http)",
   key: "onenote-search-notebooks",
   type: "action",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/onenote/actions/search-pages/search-pages.mjs
+++ b/components/onenote/actions/search-pages/search-pages.mjs
@@ -50,7 +50,7 @@ export default {
     + " Use **Get Page Content** to retrieve the body of a specific page after locating it here. Use **Get Page** for page metadata only."
     + " Returns the array of matching pages and a `nextLink` URL for pagination when more results are available."
     + " [See the documentation](https://learn.microsoft.com/en-us/graph/api/onenote-list-pages?view=graph-rest-1.0&tabs=http)",
-  version: "0.1.0",
+  version: "1.0.0",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/onenote/actions/search-pages/search-pages.mjs
+++ b/components/onenote/actions/search-pages/search-pages.mjs
@@ -1,12 +1,57 @@
+import { ConfigurationError } from "@pipedream/platform";
 import { EXPAND_PAGE_OPTIONS } from "../../common/constants.mjs";
 import app from "../../onenote.app.mjs";
 
+// OData $filter requires at least one comparison operator or filter function.
+// Free-text like "dinner" or "title:dinner" has neither and will 400 at Graph.
+const ODATA_OPERATORS = [
+  " eq ",
+  " ne ",
+  " gt ",
+  " ge ",
+  " lt ",
+  " le ",
+  " and ",
+  " or ",
+  " not ",
+  " has ",
+];
+
+const ODATA_FUNCTIONS = [
+  "startswith(",
+  "endswith(",
+  "contains(",
+  "tolower(",
+  "toupper(",
+  "length(",
+  "indexof(",
+  "substring(",
+];
+
+function looksLikeOData(filter) {
+  const lower = ` ${filter.toLowerCase()} `;
+  if (ODATA_OPERATORS.some((op) => lower.includes(op))) return true;
+  if (ODATA_FUNCTIONS.some((fn) => lower.includes(fn))) return true;
+  return false;
+}
+
+// Escape single quotes for safe embedding in OData string literals.
+function escapeOData(str) {
+  return str.replace(/'/g, "''");
+}
+
 export default {
-  name: "Search Pages",
-  description: "Searches for pages. [See the documentation](https://learn.microsoft.com/en-us/graph/api/onenote-list-pages?view=graph-rest-1.0&tabs=http)",
   key: "onenote-search-pages",
+  name: "Search Pages",
+  description: "Search and list OneNote pages. Supports free-text title search, OData filtering, expansion of related resources, and pagination."
+    + " Use `search` for natural-language queries against page titles (e.g., `weekly notes`, `feeding schedule`). Translated server-side to a case-insensitive `contains` filter on the page title."
+    + " Use `filter` for structured OData queries (e.g., `createdDateTime gt 2026-01-01T00:00:00Z`). `search` and `filter` can be combined and are joined with `and`."
+    + " Limitation: Microsoft Graph does not support searching OneNote page **body content** via this endpoint. To match on content, retrieve a candidate set by title and then call **Get Page Content** for each."
+    + " Use **Get Page Content** to retrieve the body of a specific page after locating it here. Use **Get Page** for page metadata only."
+    + " Returns the array of matching pages and a `nextLink` URL for pagination when more results are available."
+    + " [See the documentation](https://learn.microsoft.com/en-us/graph/api/onenote-list-pages?view=graph-rest-1.0&tabs=http)",
+  version: "0.1.0",
   type: "action",
-  version: "0.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -14,12 +59,19 @@ export default {
   },
   props: {
     app,
+    search: {
+      propDefinition: [
+        app,
+        "search",
+      ],
+      description: "Free-text search against page titles. Case-insensitive substring match. Example: `weekly notes`, `feeding schedule`. Translated server-side to `contains(tolower(title), '<value>')`.",
+    },
     filter: {
       propDefinition: [
         app,
         "filter",
       ],
-      description: "Filter for pages. [See the documentation](https://learn.microsoft.com/en-us/graph/query-parameters?tabs=http#filter)",
+      description: "OData filter expression for structured queries. Example: `createdDateTime gt 2026-01-01T00:00:00Z`, `title eq 'Weekly Notes'`. Combined with `search` via `and` when both are set. [See the documentation](https://learn.microsoft.com/en-us/graph/query-parameters?tabs=http#filter)",
     },
     expand: {
       propDefinition: [
@@ -28,20 +80,55 @@ export default {
       ],
       options: EXPAND_PAGE_OPTIONS,
     },
+    top: {
+      type: "integer",
+      label: "Top",
+      description: "Number of pages to return (max 100). Defaults to the Graph API's standard page size when omitted.",
+      optional: true,
+    },
   },
   async run({ $ }) {
-    const { value: response } = await this.app.getPages({
+    if (this.filter && !looksLikeOData(this.filter)) {
+      throw new ConfigurationError(
+        `The Filter field expects OData $filter syntax, but received "${this.filter}".`
+        + " For natural-language queries, use the **Search** field instead"
+        + ` (e.g., set Search to "${this.filter}" and leave Filter empty).`
+        + " For OData filtering, use syntax like: `title eq 'My Page'`,"
+        + " `startswith(title, 'Daily')`, or `createdDateTime gt 2026-01-01T00:00:00Z`."
+        + " [See OData filter docs](https://learn.microsoft.com/en-us/graph/query-parameters?tabs=http#filter).",
+      );
+    }
+
+    // Translate `search` to a title contains filter, then combine with user filter.
+    const filterParts = [];
+    if (this.search) {
+      filterParts.push(`contains(tolower(title), '${escapeOData(this.search.toLowerCase())}')`);
+    }
+    if (this.filter) {
+      filterParts.push(`(${this.filter})`);
+    }
+    const combinedFilter = filterParts.length
+      ? filterParts.join(" and ")
+      : undefined;
+
+    const response = await this.app.getPages({
       $,
       params: {
-        "$filter": this.filter,
+        "$filter": combinedFilter,
         "$expand": this.expand,
+        "$top": this.top,
       },
     });
 
-    $.export("$summary", `Successfully found ${response.length} page${response.length === 1
+    const pages = response.value ?? [];
+
+    $.export("$summary", `Found ${pages.length} page${pages.length === 1
       ? ""
       : "s"}`);
 
-    return response;
+    return {
+      pages,
+      nextLink: response["@odata.nextLink"] ?? null,
+    };
   },
 };

--- a/components/onenote/actions/search-sections/search-sections.mjs
+++ b/components/onenote/actions/search-sections/search-sections.mjs
@@ -6,7 +6,7 @@ export default {
   description: "Searches for sections. [See the documentation](https://learn.microsoft.com/en-us/graph/api/onenote-list-sections?view=graph-rest-1.0&tabs=http)",
   key: "onenote-search-sections",
   type: "action",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/onenote/onenote.app.mjs
+++ b/components/onenote/onenote.app.mjs
@@ -122,6 +122,23 @@ export default {
         ...args,
       });
     },
+    async getPageContent({
+      pageId, includeIDs, ...args
+    }) {
+      return this._makeRequest({
+        path: `/me/onenote/pages/${pageId}/content`,
+        responseType: "text",
+        ...args,
+        params: {
+          ...(args.params ?? {}),
+          ...(includeIDs
+            ? {
+              includeIDs: "true",
+            }
+            : {}),
+        },
+      });
+    },
     async createPage({
       sectionId, ...args
     }) {

--- a/components/onenote/package.json
+++ b/components/onenote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/onenote",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "Pipedream Microsoft 365 OneNote Components",
   "main": "onenote.app.mjs",
   "keywords": [

--- a/components/onenote/package.json
+++ b/components/onenote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/onenote",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Microsoft 365 OneNote Components",
   "main": "onenote.app.mjs",
   "keywords": [
@@ -13,6 +13,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@pipedream/platform": "^3.3.0"
+    "@pipedream/platform": "^3.3.0",
+    "turndown": "^7.2.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5251,8 +5251,7 @@ importers:
 
   components/exact_mails: {}
 
-  components/excalidraw:
-    specifiers: {}
+  components/excalidraw: {}
 
   components/exhibitday:
     dependencies:
@@ -7360,8 +7359,7 @@ importers:
 
   components/hiver: {}
 
-  components/hiver_omni:
-    specifiers: {}
+  components/hiver_omni: {}
 
   components/hogia: {}
 
@@ -9172,8 +9170,7 @@ importers:
         specifier: ^3.1.1
         version: 3.1.1
 
-  components/luma:
-    specifiers: {}
+  components/luma: {}
 
   components/lumin_pdf:
     dependencies:
@@ -10892,6 +10889,9 @@ importers:
       '@pipedream/platform':
         specifier: ^3.3.0
         version: 3.3.0
+      turndown:
+        specifier: ^7.2.0
+        version: 7.2.2
 
   components/onepage: {}
 
@@ -12858,8 +12858,7 @@ importers:
         specifier: ^1.6.8
         version: 1.6.8
 
-  components/read_ai:
-    specifiers: {}
+  components/read_ai: {}
 
   components/readwise:
     dependencies:
@@ -20109,16 +20108,16 @@ packages:
   '@daytonaio/toolbox-api-client@0.138.0':
     resolution: {integrity: sha512-unM9e7MOQiyDXdY8hCW1uTctYbxpo/TGZ6L71ZXyS/j2Cnz9/ud4VWBLcQP2VzlC+lrBP2YMrhT90zSSvcNfmA==}
 
-  '@definitelytyped/header-parser@0.2.27':
-    resolution: {integrity: sha512-5NJMixxngpGSnGMRRmObDPTNJzNBh/glT2BDniFNXhKnE8c9/vI46nrb3YvfVJA4KGMLjf738Z91Cu7q18sKvg==}
+  '@definitelytyped/header-parser@0.2.28':
+    resolution: {integrity: sha512-JONMU+bw65y1EHtJggxMM9LdFUuvjFY1SXdSH038HcfYceRKiVHvWnMa8/cCKTAj/X696UqND8MVa5s7cJZwfg==}
     engines: {node: '>=20.17.0'}
 
   '@definitelytyped/typescript-versions@0.1.11':
     resolution: {integrity: sha512-hkO3A+ZyjeiLEXLTYe561uv9hnTvHM15+JTi3RgetfuB/+/Rp4Im1y/m+SehSi6D3iwdnbPckupv5TZ4PnlKPg==}
     engines: {node: '>=20.17.0'}
 
-  '@definitelytyped/utils@0.1.13':
-    resolution: {integrity: sha512-B9+yLpGZbNHXofccDGOKujBimXrrKTK7NO41QhRwmRar/Z9/t5HdG5IpwdEpiioAbYd1Fju/FCLrI/3KzGweQw==}
+  '@definitelytyped/utils@0.1.14':
+    resolution: {integrity: sha512-dh6J1DPR2WbczPP5/eFeeVh0tXiYTnfM0FTl6NzVqpummcqSzbo9gB2ySXQaK7Xr4bJskz/lszSBuDrz9bFWcw==}
     engines: {node: '>=20.17.0'}
 
   '@dependents/detective-less@5.0.1':
@@ -38487,10 +38486,10 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@definitelytyped/header-parser@0.2.27':
+  '@definitelytyped/header-parser@0.2.28':
     dependencies:
       '@definitelytyped/typescript-versions': 0.1.11
-      '@definitelytyped/utils': 0.1.13
+      '@definitelytyped/utils': 0.1.14
       semver: 7.7.4
     transitivePeerDependencies:
       - bare-abort-controller
@@ -38500,7 +38499,7 @@ snapshots:
 
   '@definitelytyped/typescript-versions@0.1.11': {}
 
-  '@definitelytyped/utils@0.1.13':
+  '@definitelytyped/utils@0.1.14':
     dependencies:
       '@types/node': 25.6.0
       cachedir: 2.4.0
@@ -41739,6 +41738,7 @@ snapshots:
     transitivePeerDependencies:
       - rolldown
       - rollup
+      - supports-color
 
   '@putout/operator-parens@2.0.0(rolldown@1.0.0-beta.60(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1))(rollup@4.53.2)':
     dependencies:
@@ -47069,7 +47069,7 @@ snapshots:
 
   dts-critic@3.3.11(typescript@5.6.3):
     dependencies:
-      '@definitelytyped/header-parser': 0.2.27
+      '@definitelytyped/header-parser': 0.2.28
       command-exists: 1.2.9
       rimraf: 3.0.2
       semver: 6.3.1
@@ -47084,7 +47084,7 @@ snapshots:
 
   dts-critic@3.3.11(typescript@5.9.3):
     dependencies:
-      '@definitelytyped/header-parser': 0.2.27
+      '@definitelytyped/header-parser': 0.2.28
       command-exists: 1.2.9
       rimraf: 3.0.2
       semver: 6.3.1
@@ -47101,9 +47101,9 @@ snapshots:
 
   dtslint@4.2.1(typescript@5.6.3):
     dependencies:
-      '@definitelytyped/header-parser': 0.2.27
+      '@definitelytyped/header-parser': 0.2.28
       '@definitelytyped/typescript-versions': 0.1.11
-      '@definitelytyped/utils': 0.1.13
+      '@definitelytyped/utils': 0.1.14
       dts-critic: 3.3.11(typescript@5.6.3)
       fs-extra: 6.0.1
       json-stable-stringify: 1.3.0
@@ -47120,9 +47120,9 @@ snapshots:
 
   dtslint@4.2.1(typescript@5.9.3):
     dependencies:
-      '@definitelytyped/header-parser': 0.2.27
+      '@definitelytyped/header-parser': 0.2.28
       '@definitelytyped/typescript-versions': 0.1.11
-      '@definitelytyped/utils': 0.1.13
+      '@definitelytyped/utils': 0.1.14
       dts-critic: 3.3.11(typescript@5.9.3)
       fs-extra: 6.0.1
       json-stable-stringify: 1.3.0


### PR DESCRIPTION
## Summary

- **New action `onenote-get-page-content`** fetches a OneNote page's HTML body (which `onenote-get-page` does not return — that returns metadata only). Supports `includeIDs` for later element-update flows and `convertToMarkdown` for LLM-friendly Markdown output via `turndown`.
- **Rewrites `onenote-search-pages`**:
  - Adds free-text `search` prop, translated server-side to `contains(tolower(title), '<value>')`. Microsoft Graph's standard `$search` is **not supported** on this endpoint, so this is the only way to do title-based search via the API.
  - Adds `top` for page size, returns `nextLink` for cursor-based pagination.
  - Keeps existing `filter` (OData) and `expand`, combined via `and` with the translated search filter when both are set.
  - Pre-flight validation: throws a `ConfigurationError` with corrective guidance when `filter` receives non-OData input (e.g. `title:dinner`). The error echoes the user's input back and points them to the `search` field instead, so both LLMs and humans get a useful redirect.
- **App file**: adds `getPageContent(pageId, includeIDs)` method that returns HTML as text (`responseType: "text"`).
- **Package**: bumps `@pipedream/onenote` to `0.3.0`; adds `turndown@^7.2.0`.

## Test plan

- [x] Lint clean: `pnpm eslint 'components/onenote/**/*.mjs'` exit 0
- [x] Published to a private workspace and validated end-to-end:
  - Free-text "dinosaur care" search returns the seeded page by title (case-insensitive contains match)
  - Get Page Content returns HTML for a known page ID
  - Get Page Content with `convertToMarkdown: true` returns clean Markdown (no HTML tags) preserving body text
- [x] Verified the OData validation error message dynamically echoes the user's input, including the example value in the suggested Search field
- [x] No regressions on existing OneNote actions — none were modified
- [x] Eval suite for these two actions passing 3/3 (free-text search, get content as HTML, get content as Markdown)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retrieve OneNote page content with optional Markdown conversion and an option to include element IDs.

* **Improvements**
  * Natural-language page search combined with structured filters, pagination, and clearer validation/error messages.

* **Chores**
  * Component version bumps, package version update, and added Markdown conversion dependency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PipedreamHQ/pipedream/pull/20838)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->