### PR TITLE
shopify: add AI-optimized MCP actions for OAuth app

### DIFF
--- a/components/shopify/actions/create-customer/create-customer.mjs
+++ b/components/shopify/actions/create-customer/create-customer.mjs
@@ -1,0 +1,117 @@
+import shopify from "../../shopify.app.mjs";
+
+export default {
+  key: "shopify-create-customer",
+  name: "Create Customer",
+  description:
+    "Create a new customer in Shopify."
+    + " Use when an agent needs to onboard a new buyer, add a contact, or register a customer account."
+    + " Either **Email** or **Phone** is required by Shopify."
+    + " To update an existing customer, use **Update Customer** instead."
+    + " Returns the new customer object including `id`, `email`, `phone`, `firstName`, and `lastName`."
+    + " [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/customercreate)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    shopify,
+    // eslint-disable-next-line pipedream/props-label, pipedream/props-description
+    info: {
+      type: "alert",
+      alertType: "info",
+      content: "Please verify that the Shopify shop has customer data properly defined and that your API credentials have been granted this access scope. [See the documentation](https://shopify.dev/docs/apps/launch/protected-customer-data)",
+    },
+    firstName: {
+      type: "string",
+      label: "First Name",
+      description: "The customer's first name",
+      optional: true,
+    },
+    lastName: {
+      type: "string",
+      label: "Last Name",
+      description: "The customer's last name",
+      optional: true,
+    },
+    email: {
+      type: "string",
+      label: "Email",
+      description: "The customer's email address. Either email or phone is required.",
+      optional: true,
+    },
+    phone: {
+      type: "string",
+      label: "Phone",
+      description: "The customer's phone number in E.164 format. Example: `+15555551234`",
+      optional: true,
+    },
+    address: {
+      type: "string",
+      label: "Address",
+      description: "Street address for the customer's default address",
+      optional: true,
+    },
+    company: {
+      type: "string",
+      label: "Company",
+      description: "The company the customer is associated with",
+      optional: true,
+    },
+    city: {
+      type: "string",
+      label: "City",
+      description: "City for the customer's default address",
+      optional: true,
+    },
+    province: {
+      type: "string",
+      label: "Province/State",
+      description: "Province or state for the customer's default address",
+      optional: true,
+    },
+    country: {
+      type: "string",
+      label: "Country",
+      description: "Country code for the customer's default address. Example: `US`",
+      optional: true,
+    },
+    zip: {
+      type: "string",
+      label: "ZIP/Postal Code",
+      description: "ZIP or postal code for the customer's default address",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const hasAddress = this.address || this.city || this.country;
+    const response = await this.shopify.createCustomer({
+      input: {
+        firstName: this.firstName,
+        lastName: this.lastName,
+        email: this.email,
+        phone: this.phone,
+        addresses: hasAddress
+          ? [
+            {
+              address1: this.address,
+              company: this.company,
+              city: this.city,
+              province: this.province,
+              country: this.country,
+              zip: this.zip,
+            },
+          ]
+          : undefined,
+      },
+    });
+    if (response.customerCreate.userErrors.length > 0) {
+      throw new Error(response.customerCreate.userErrors[0].message);
+    }
+    $.export("$summary", `Successfully created customer \`${response.customerCreate.customer.id}\``);
+    return response.customerCreate.customer;
+  },
+};

--- a/components/shopify/actions/create-fulfillment/create-fulfillment.mjs
+++ b/components/shopify/actions/create-fulfillment/create-fulfillment.mjs
@@ -1,0 +1,74 @@
+import shopify from "../../shopify.app.mjs";
+
+export default {
+  key: "shopify-create-fulfillment",
+  name: "Create Fulfillment",
+  description:
+    "Create a fulfillment for items in a fulfillment order."
+    + " Use when items are ready to ship and you need to mark them as fulfilled."
+    + " Use **Get Fulfillment Orders** to find the fulfillment order ID and its line item IDs."
+    + " The `fulfillmentOrderLineItems` param is a JSON array with `id` (FulfillmentOrderLineItem GID) and `quantity`."
+    + " Example: `[{\"id\": \"gid://shopify/FulfillmentOrderLineItem/123\", \"quantity\": 1}]`"
+    + " Returns the fulfillment object including `id`, `status`, `trackingInfo`, and `fulfillmentLineItems`."
+    + " [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/fulfillmentcreate)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    shopify,
+    // eslint-disable-next-line pipedream/props-label, pipedream/props-description
+    info: {
+      type: "alert",
+      alertType: "info",
+      content: "Fulfillment actions require one of the following access scopes: `write_assigned_fulfillment_orders`, `write_merchant_managed_fulfillment_orders`, or `write_third_party_fulfillment_orders`. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/objects/fulfillmentorder#api-access-scopes)",
+    },
+    fulfillmentOrderId: {
+      propDefinition: [
+        shopify,
+        "fulfillmentOrderId",
+      ],
+      description: "The GID of the fulfillment order to fulfill. Example: `gid://shopify/FulfillmentOrder/123456789`. Use **Get Fulfillment Orders** to find fulfillment order IDs and their line item IDs.",
+    },
+    fulfillmentOrderLineItems: {
+      type: "string",
+      label: "Fulfillment Order Line Items",
+      description: "JSON array of line items to fulfill. Each must include `id` (FulfillmentOrderLineItem GID) and `quantity`. Example: `[{\"id\": \"gid://shopify/FulfillmentOrderLineItem/123\", \"quantity\": 1}]`",
+    },
+    notifyCustomer: {
+      type: "boolean",
+      label: "Notify Customer",
+      description: "Whether to send a shipment notification to the customer",
+      optional: true,
+    },
+    message: {
+      type: "string",
+      label: "Message",
+      description: "An optional message for the fulfillment",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const lineItems = JSON.parse(this.fulfillmentOrderLineItems);
+    const response = await this.shopify.createFulfillment({
+      fulfillment: {
+        lineItemsByFulfillmentOrder: [
+          {
+            fulfillmentOrderId: this.fulfillmentOrderId,
+            fulfillmentOrderLineItems: lineItems,
+          },
+        ],
+        notifyCustomer: this.notifyCustomer,
+      },
+      message: this.message,
+    });
+    if (response.fulfillmentCreate.userErrors.length > 0) {
+      throw new Error(response.fulfillmentCreate.userErrors[0].message);
+    }
+    $.export("$summary", `Successfully created fulfillment \`${response.fulfillmentCreate.fulfillment.id}\``);
+    return response.fulfillmentCreate.fulfillment;
+  },
+};

--- a/components/shopify/actions/create-order/create-order.mjs
+++ b/components/shopify/actions/create-order/create-order.mjs
@@ -1,0 +1,136 @@
+import shopify from "../../shopify.app.mjs";
+
+export default {
+  key: "shopify-create-order",
+  name: "Create Order",
+  description:
+    "Create a new order in Shopify programmatically."
+    + " Use for B2B, manual order entry, or importing orders from external systems."
+    + " Requires at least one line item with a `variantId` and `quantity`."
+    + " Use **Search for Products** and **Search Product Variant** to find variant IDs."
+    + " Returns the created order object including `id`, `name`, `lineItems`, and `financialStatus`."
+    + " [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/ordercreate)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    shopify,
+    // eslint-disable-next-line pipedream/props-label, pipedream/props-description
+    info: {
+      type: "alert",
+      alertType: "info",
+      content: "Please verify that the Shopify shop has order data properly defined and that your API credentials have been granted the required access scopes. [See the documentation](https://shopify.dev/docs/apps/launch/protected-customer-data)",
+    },
+    lineItems: {
+      type: "string",
+      label: "Line Items",
+      description: "JSON array of line items. Each must include `variantId` and `quantity`. Example: `[{\"variantId\": \"gid://shopify/ProductVariant/12345\", \"quantity\": 2}]`",
+    },
+    customerId: {
+      propDefinition: [
+        shopify,
+        "customerId",
+      ],
+      description: "The GID of the customer to associate with this order. Example: `gid://shopify/Customer/123456789`. Use **Search for Customers** to find customer IDs. Optional — omit to create a guest order.",
+      optional: true,
+    },
+    billingAddress: {
+      type: "string",
+      label: "Billing Address",
+      description: "JSON object for the billing address. Example: `{\"firstName\": \"Alan\", \"lastName\": \"Grant\", \"address1\": \"123 Main St\", \"city\": \"Malibu\", \"province\": \"CA\", \"country\": \"US\", \"zip\": \"90210\"}`",
+      optional: true,
+    },
+    shippingAddress: {
+      type: "string",
+      label: "Shipping Address",
+      description: "JSON object for the shipping address (same structure as Billing Address)",
+      optional: true,
+    },
+    financialStatus: {
+      type: "string",
+      label: "Financial Status",
+      description: "The payment status of the order",
+      options: [
+        "PENDING",
+        "AUTHORIZED",
+        "PARTIALLY_PAID",
+        "PAID",
+        "PARTIALLY_REFUNDED",
+        "REFUNDED",
+        "VOIDED",
+      ],
+      optional: true,
+    },
+    note: {
+      type: "string",
+      label: "Note",
+      description: "An optional note to attach to the order",
+      optional: true,
+    },
+    sendReceipt: {
+      type: "boolean",
+      label: "Send Receipt",
+      description: "Whether to send an order confirmation email to the customer",
+      optional: true,
+    },
+    inventoryBehavior: {
+      type: "string",
+      label: "Inventory Behavior",
+      description: "How to handle inventory when creating the order",
+      options: [
+        {
+          value: "BYPASS",
+          label: "Do not claim inventory",
+        },
+        {
+          value: "DECREMENT_IGNORING_POLICY",
+          label: "Claim inventory, ignoring inventory policy",
+        },
+        {
+          value: "DECREMENT_OBEYING_POLICY",
+          label: "Claim inventory, following inventory policy",
+        },
+      ],
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const lineItems = JSON.parse(this.lineItems);
+    const billingAddress = this.billingAddress
+      ? JSON.parse(this.billingAddress)
+      : undefined;
+    const shippingAddress = this.shippingAddress
+      ? JSON.parse(this.shippingAddress)
+      : undefined;
+
+    const response = await this.shopify.createOrder({
+      order: {
+        lineItems,
+        billingAddress,
+        shippingAddress,
+        financialStatus: this.financialStatus,
+        note: this.note,
+        customer: this.customerId
+          ? {
+            toAssociate: {
+              id: this.customerId,
+            },
+          }
+          : undefined,
+      },
+      options: {
+        sendReceipt: this.sendReceipt,
+        inventoryBehaviour: this.inventoryBehavior,
+      },
+    });
+    if (response.orderCreate.userErrors.length > 0) {
+      throw new Error(response.orderCreate.userErrors[0].message);
+    }
+    $.export("$summary", `Successfully created order \`${response.orderCreate.order.name ?? response.orderCreate.order.id}\``);
+    return response.orderCreate.order;
+  },
+};

--- a/components/shopify/actions/get-fulfillment-orders/get-fulfillment-orders.mjs
+++ b/components/shopify/actions/get-fulfillment-orders/get-fulfillment-orders.mjs
@@ -3,8 +3,13 @@ import shopify from "../../shopify.app.mjs";
 export default {
   key: "shopify-get-fulfillment-orders",
   name: "Get Fulfillment Orders",
-  description: "Retrieve a list of fulfillment orders. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/queries/fulfillmentorders)",
-  version: "0.0.7",
+  description:
+    "Retrieve and search fulfillment orders in Shopify."
+    + " Use to discover fulfillment order IDs and line item IDs needed for **Create Fulfillment** or **Update Fulfillment Tracking Info**."
+    + " Filter by `status:open` to find orders ready to ship, or `assigned_location_id:{id}` for a specific location."
+    + " Returns an array of fulfillment order objects including `id`, `status`, `lineItems` (with `id` for each line item), and `assignedLocation`."
+    + " [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/queries/fulfillmentorders)",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify/actions/get-order/get-order.mjs
+++ b/components/shopify/actions/get-order/get-order.mjs
@@ -1,0 +1,52 @@
+import { MAX_LIMIT } from "../../common/constants.mjs";
+import shopify from "../../shopify.app.mjs";
+
+export default {
+  key: "shopify-get-order",
+  name: "Get Order Details",
+  description:
+    "Retrieve the complete details of a single Shopify order by ID — line items with GIDs, fulfillments with GIDs, and customer info."
+    + " **Search Orders** returns summary data only and does NOT include line item GIDs or fulfillment GIDs."
+    + " Use this tool after **Search Orders** whenever you need to: refund items (**Refund Order** requires line item GIDs from `lineItems`), update tracking (**Update Fulfillment Tracking Info** requires fulfillment GIDs from `fulfillments`), or inspect the complete order."
+    + " Accepts both numeric IDs (e.g. `12345`) and GID format (e.g. `gid://shopify/Order/12345`)."
+    + " Returns the order object including `id`, `name`, `lineItems` (each with GID), `fulfillments` (each with GID), `customer`, and `financialStatus`."
+    + " [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/queries/order)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    shopify,
+    // eslint-disable-next-line pipedream/props-label, pipedream/props-description
+    info: {
+      type: "alert",
+      alertType: "info",
+      content: "Please verify that the Shopify shop has order data properly defined and that your API credentials have been granted the required access scopes. [See the documentation](https://shopify.dev/docs/apps/launch/protected-customer-data)",
+    },
+    orderId: {
+      propDefinition: [
+        shopify,
+        "orderId",
+      ],
+      description: "The ID of the order to retrieve. Accepts a GID (`gid://shopify/Order/123`) or a plain numeric ID (`123`). Use **Search Orders** to find order IDs.",
+    },
+  },
+  async run({ $ }) {
+    const raw = String(this.orderId).trim();
+    const orderId = raw.startsWith("gid://shopify/Order/")
+      ? raw
+      : /^\d+$/.test(raw)
+        ? `gid://shopify/Order/${raw}`
+        : raw;
+
+    const response = await this.shopify.getOrder({
+      id: orderId,
+      first: MAX_LIMIT,
+    });
+    $.export("$summary", `Successfully retrieved order \`${response.order?.name ?? orderId}\``);
+    return response.order;
+  },
+};

--- a/components/shopify/actions/refund-order/refund-order.mjs
+++ b/components/shopify/actions/refund-order/refund-order.mjs
@@ -1,0 +1,69 @@
+import shopify from "../../shopify.app.mjs";
+
+export default {
+  key: "shopify-refund-order",
+  name: "Refund Order",
+  description:
+    "Issue a refund for line items on a Shopify order."
+    + " Requires line item GIDs — use **Search Orders** to find the order ID, then **Get Order Details** to retrieve line item GIDs from the `lineItems` array. **Search Orders** alone does NOT return line item GIDs."
+    + " The `refundLineItems` param is a JSON array — each entry needs `lineItemId` (line item GID), `quantity`, and `restockType` (`CANCEL`, `NO_RESTOCK`, or `RETURN`)."
+    + " Example: `[{\"lineItemId\": \"gid://shopify/LineItem/123\", \"quantity\": 1, \"restockType\": \"RETURN\"}]`"
+    + " Returns the refund object including `id`, refunded amounts, and line item details."
+    + " [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/refundcreate)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    shopify,
+    // eslint-disable-next-line pipedream/props-label, pipedream/props-description
+    info: {
+      type: "alert",
+      alertType: "info",
+      content: "Please verify that the Shopify shop has order data properly defined and that your API credentials have been granted the required access scopes. [See the documentation](https://shopify.dev/docs/apps/launch/protected-customer-data)",
+    },
+    orderId: {
+      propDefinition: [
+        shopify,
+        "orderId",
+      ],
+      description: "The GID of the order to refund. Example: `gid://shopify/Order/123456789`. Accepts plain numeric IDs too. Use **Search Orders** then **Get Order Details** to find the order ID and its line item GIDs.",
+    },
+    refundLineItems: {
+      type: "string",
+      label: "Refund Line Items",
+      description: "JSON array of line items to refund. Each must include `lineItemId`, `quantity`, and `restockType` (`CANCEL`, `NO_RESTOCK`, or `RETURN`). Optionally include `locationId`. Example: `[{\"lineItemId\": \"gid://shopify/LineItem/123\", \"quantity\": 1, \"restockType\": \"RETURN\"}]`",
+    },
+    note: {
+      type: "string",
+      label: "Note",
+      description: "An optional note to attach to the refund",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const raw = String(this.orderId).trim();
+    const orderId = raw.startsWith("gid://shopify/Order/")
+      ? raw
+      : /^\d+$/.test(raw)
+        ? `gid://shopify/Order/${raw}`
+        : raw;
+
+    const refundLineItems = JSON.parse(this.refundLineItems);
+    const response = await this.shopify.refundOrder({
+      input: {
+        orderId,
+        note: this.note,
+        refundLineItems,
+      },
+    });
+    if (response.refundCreate.userErrors.length > 0) {
+      throw new Error(response.refundCreate.userErrors[0].message);
+    }
+    $.export("$summary", `Successfully refunded order \`${orderId}\``);
+    return response.refundCreate.refund;
+  },
+};

--- a/components/shopify/actions/search-customers/search-customers.mjs
+++ b/components/shopify/actions/search-customers/search-customers.mjs
@@ -1,0 +1,64 @@
+import shopify from "../../shopify.app.mjs";
+
+export default {
+  key: "shopify-search-customers",
+  name: "Search for Customers",
+  description:
+    "Filter customers in Shopify by a specific attribute — preferred over **Get Customers** when you know what you're looking for."
+    + " **Get Customers** lists all customers without filtering; use this tool instead when you have a specific email, name, phone, tag, or state to match."
+    + " Requires a query in Shopify filter syntax. Examples: `email:alan@ingen.com`, `first_name:Ellie last_name:Sattler`, `tag:vip`, `state:ENABLED`, `phone:+15555551234`."
+    + " Use **Get Customer** (with the `id` from results) if you need the full customer record."
+    + " Returns an array of customer objects including `id`, `email`, `phone`, `firstName`, and `lastName`."
+    + " [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/queries/customers)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    shopify,
+    // eslint-disable-next-line pipedream/props-label, pipedream/props-description
+    info: {
+      type: "alert",
+      alertType: "info",
+      content: "Please verify that the Shopify shop has customer data properly defined and that your API credentials have been granted this access scope. [See the documentation](https://shopify.dev/docs/apps/launch/protected-customer-data)",
+    },
+    query: {
+      type: "string",
+      label: "Query",
+      description: "Search query using Shopify filter syntax. Examples: `email:alan@ingen.com`, `first_name:Ellie last_name:Sattler`, `tag:vip`, `state:ENABLED`",
+    },
+    sortKey: {
+      propDefinition: [
+        shopify,
+        "sortKey",
+      ],
+      description: "The key to sort results by. Options: `CREATED_AT`, `ID`, `NAME`, `ORDERS_COUNT`, `STATE`, `TOTAL_SPENT`, `UPDATED_AT`",
+    },
+    maxResults: {
+      propDefinition: [
+        shopify,
+        "maxResults",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const customers = await this.shopify.getPaginated({
+      resourceFn: this.shopify.listCustomers,
+      resourceKeys: [
+        "customers",
+      ],
+      variables: {
+        query: this.query,
+        sortKey: this.sortKey,
+      },
+      max: this.maxResults,
+    });
+    $.export("$summary", `Successfully retrieved ${customers.length} customer${customers.length === 1
+      ? ""
+      : "s"}`);
+    return customers;
+  },
+};

--- a/components/shopify/actions/send-order-invoice/send-order-invoice.mjs
+++ b/components/shopify/actions/send-order-invoice/send-order-invoice.mjs
@@ -1,0 +1,93 @@
+import shopify from "../../shopify.app.mjs";
+
+export default {
+  key: "shopify-send-order-invoice",
+  name: "Send Order Invoice",
+  description:
+    "Send an invoice email for a Shopify order."
+    + " Use to send or resend a payment link or order summary to a customer."
+    + " Use **Search Orders** to find the order ID."
+    + " All email fields are optional — omit them to use the store's default invoice template."
+    + " Returns the order object including `id` and `name` confirming the invoice was sent."
+    + " [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/orderinvoicesend)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    shopify,
+    // eslint-disable-next-line pipedream/props-label, pipedream/props-description
+    info: {
+      type: "alert",
+      alertType: "info",
+      content: "Please verify that the Shopify shop has order data properly defined and that your API credentials have been granted the required access scopes. [See the documentation](https://shopify.dev/docs/apps/launch/protected-customer-data)",
+    },
+    orderId: {
+      propDefinition: [
+        shopify,
+        "orderId",
+      ],
+      description: "The ID of the order to invoice. Accepts a GID (`gid://shopify/Order/123`) or a plain numeric ID (`123`). Use **Search Orders** to find order IDs.",
+    },
+    to: {
+      type: "string",
+      label: "To Email",
+      description: "Recipient email address. Defaults to the customer's email if omitted.",
+      optional: true,
+    },
+    from: {
+      type: "string",
+      label: "From Email",
+      description: "Sender email address. Must be a store or staff account email.",
+      optional: true,
+    },
+    bcc: {
+      type: "string[]",
+      label: "BCC Emails",
+      description: "Blind carbon copy email addresses. Must be store or staff account emails.",
+      optional: true,
+    },
+    subject: {
+      type: "string",
+      label: "Subject",
+      description: "Custom subject line for the invoice email",
+      optional: true,
+    },
+    customMessage: {
+      type: "string",
+      label: "Custom Message",
+      description: "Optional custom message to include in the invoice email body",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const raw = String(this.orderId).trim();
+    const orderId = raw.startsWith("gid://shopify/Order/")
+      ? raw
+      : /^\d+$/.test(raw)
+        ? `gid://shopify/Order/${raw}`
+        : raw;
+
+    const email = {};
+    if (this.to) email.to = this.to;
+    if (this.from) email.from = this.from;
+    if (this.bcc?.length) email.bcc = this.bcc;
+    if (this.subject) email.subject = this.subject;
+    if (this.customMessage) email.customMessage = this.customMessage;
+
+    const response = await this.shopify.sendOrderInvoice({
+      id: orderId,
+      ...(Object.keys(email).length > 0 && {
+        email,
+      }),
+    });
+    if (response.orderInvoiceSend.userErrors.length > 0) {
+      throw new Error(response.orderInvoiceSend.userErrors[0].message);
+    }
+    $.export("$summary", `Successfully sent invoice for order \`${response.orderInvoiceSend.order.name}\``);
+    return response.orderInvoiceSend.order;
+  },
+};

--- a/components/shopify/actions/update-customer/update-customer.mjs
+++ b/components/shopify/actions/update-customer/update-customer.mjs
@@ -1,0 +1,124 @@
+import shopify from "../../shopify.app.mjs";
+
+export default {
+  key: "shopify-update-customer",
+  name: "Update Customer",
+  description:
+    "Update an existing customer's details in Shopify."
+    + " Use when an agent needs to change a customer's name, email, phone, or address."
+    + " Use **Search for Customers** to find the customer by email, name, or tag — or **Get Customers** to browse all customers — then pass the customer `id` here."
+    + " Returns the updated customer object including `id`, `email`, `firstName`, and `lastName`."
+    + " [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/customerupdate)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: true,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    shopify,
+    // eslint-disable-next-line pipedream/props-label, pipedream/props-description
+    info: {
+      type: "alert",
+      alertType: "info",
+      content: "Please verify that the Shopify shop has customer data properly defined and that your API credentials have been granted this access scope. [See the documentation](https://shopify.dev/docs/apps/launch/protected-customer-data)",
+    },
+    customerId: {
+      propDefinition: [
+        shopify,
+        "customerId",
+      ],
+      description: "The GID of the customer to update. Example: `gid://shopify/Customer/123456789`. Use **Search for Customers** or **Get Customers** to find customer IDs.",
+    },
+    firstName: {
+      type: "string",
+      label: "First Name",
+      description: "Updated first name",
+      optional: true,
+    },
+    lastName: {
+      type: "string",
+      label: "Last Name",
+      description: "Updated last name",
+      optional: true,
+    },
+    email: {
+      type: "string",
+      label: "Email",
+      description: "Updated email address",
+      optional: true,
+    },
+    phone: {
+      type: "string",
+      label: "Phone",
+      description: "Updated phone number in E.164 format. Example: `+15555551234`",
+      optional: true,
+    },
+    address: {
+      type: "string",
+      label: "Address",
+      description: "Updated street address",
+      optional: true,
+    },
+    company: {
+      type: "string",
+      label: "Company",
+      description: "Updated company name",
+      optional: true,
+    },
+    city: {
+      type: "string",
+      label: "City",
+      description: "Updated city",
+      optional: true,
+    },
+    province: {
+      type: "string",
+      label: "Province/State",
+      description: "Updated province or state",
+      optional: true,
+    },
+    country: {
+      type: "string",
+      label: "Country",
+      description: "Updated country code. Example: `US`",
+      optional: true,
+    },
+    zip: {
+      type: "string",
+      label: "ZIP/Postal Code",
+      description: "Updated ZIP or postal code",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const hasAddress = this.address || this.city || this.country;
+    const response = await this.shopify.updateCustomer({
+      input: {
+        id: this.customerId,
+        firstName: this.firstName,
+        lastName: this.lastName,
+        email: this.email,
+        phone: this.phone,
+        addresses: hasAddress
+          ? [
+            {
+              address1: this.address,
+              company: this.company,
+              city: this.city,
+              province: this.province,
+              country: this.country,
+              zip: this.zip,
+            },
+          ]
+          : undefined,
+      },
+    });
+    if (response.customerUpdate.userErrors.length > 0) {
+      throw new Error(response.customerUpdate.userErrors[0].message);
+    }
+    $.export("$summary", `Successfully updated customer \`${response.customerUpdate.customer.email ?? response.customerUpdate.customer.id}\``);
+    return response.customerUpdate.customer;
+  },
+};

--- a/components/shopify/actions/update-fulfillment-tracking-info/update-fulfillment-tracking-info.mjs
+++ b/components/shopify/actions/update-fulfillment-tracking-info/update-fulfillment-tracking-info.mjs
@@ -1,0 +1,74 @@
+import shopify from "../../shopify.app.mjs";
+
+export default {
+  key: "shopify-update-fulfillment-tracking-info",
+  name: "Update Fulfillment Tracking Info",
+  description:
+    "Update the tracking information for a fulfillment in Shopify."
+    + " Use when you have a tracking number or URL to add to a fulfilled shipment."
+    + " Requires a fulfillment GID — use **Search Orders** to find the order, then **Get Order Details** to retrieve fulfillment GIDs from the `fulfillments` array. **Search Orders** alone does NOT return fulfillment GIDs."
+    + " Fulfillment GIDs are in the format: `gid://shopify/Fulfillment/123456789`."
+    + " Returns the updated fulfillment object including `id`, `status`, and `trackingInfo`."
+    + " [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/fulfillmenttrackinginfoupdate)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: true,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    shopify,
+    // eslint-disable-next-line pipedream/props-label, pipedream/props-description
+    info: {
+      type: "alert",
+      alertType: "info",
+      content: "Fulfillment actions require one of the following access scopes: `write_assigned_fulfillment_orders`, `write_merchant_managed_fulfillment_orders`, or `write_third_party_fulfillment_orders`. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/objects/fulfillmentorder#api-access-scopes)",
+    },
+    fulfillmentId: {
+      type: "string",
+      label: "Fulfillment ID",
+      description: "The GID of the fulfillment to update. Example: `gid://shopify/Fulfillment/123456789`. Use **Get Order Details** to find fulfillment GIDs within an order's `fulfillments` array.",
+    },
+    company: {
+      type: "string",
+      label: "Tracking Company",
+      description: "The name of the shipping carrier. Example: `UPS`, `FedEx`, `USPS`",
+      optional: true,
+    },
+    number: {
+      type: "string",
+      label: "Tracking Number",
+      description: "The tracking number for the shipment",
+      optional: true,
+    },
+    url: {
+      type: "string",
+      label: "Tracking URL",
+      description: "A URL where the customer can track the shipment",
+      optional: true,
+    },
+    notifyCustomer: {
+      type: "boolean",
+      label: "Notify Customer",
+      description: "Whether to send a tracking update notification to the customer",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const response = await this.shopify.updateFulfillmentTrackingInfo({
+      fulfillmentId: this.fulfillmentId,
+      trackingInfoInput: {
+        company: this.company,
+        number: this.number,
+        url: this.url,
+      },
+      notifyCustomer: this.notifyCustomer,
+    });
+    if (response.fulfillmentTrackingInfoUpdate.userErrors.length > 0) {
+      throw new Error(response.fulfillmentTrackingInfoUpdate.userErrors[0].message);
+    }
+    $.export("$summary", `Successfully updated tracking info for fulfillment \`${this.fulfillmentId}\``);
+    return response.fulfillmentTrackingInfoUpdate.fulfillment;
+  },
+};

--- a/components/shopify/common/mutations.mjs
+++ b/components/shopify/common/mutations.mjs
@@ -433,6 +433,158 @@ const UPDATE_ORDER = `
   }
 `;
 
+const CREATE_CUSTOMER = `
+  mutation customerCreate($input: CustomerInput!) {
+    customerCreate(input: $input) {
+      userErrors {
+        field
+        message
+      }
+      customer {
+        id
+        email
+        phone
+        firstName
+        lastName
+        taxExempt
+        amountSpent {
+          amount
+          currencyCode
+        }
+      }
+    }
+  }
+`;
+
+const UPDATE_CUSTOMER = `
+  mutation customerUpdate($input: CustomerInput!) {
+    customerUpdate(input: $input) {
+      customer {
+        id
+        email
+        firstName
+        lastName
+      }
+      userErrors {
+        message
+        field
+      }
+    }
+  }
+`;
+
+const CREATE_ORDER = `
+  mutation OrderCreate($order: OrderCreateOrderInput!, $options: OrderCreateOptionsInput) {
+    orderCreate(order: $order, options: $options) {
+      userErrors {
+        field
+        message
+      }
+      order {
+        id
+        name
+        totalTaxSet {
+          shopMoney {
+            amount
+            currencyCode
+          }
+        }
+        lineItems(first: 10) {
+          nodes {
+            id
+            title
+            quantity
+          }
+        }
+      }
+    }
+  }
+`;
+
+const REFUND_ORDER = `
+  mutation RefundCreate($input: RefundInput!) {
+    refundCreate(input: $input) {
+      refund {
+        id
+        totalRefundedSet {
+          presentmentMoney {
+            amount
+            currencyCode
+          }
+        }
+        order {
+          id
+          name
+        }
+      }
+      userErrors {
+        field
+        message
+      }
+    }
+  }
+`;
+
+const CREATE_FULFILLMENT = `
+  mutation FulfillmentCreate($fulfillment: FulfillmentInput!, $message: String) {
+    fulfillmentCreate(fulfillment: $fulfillment, message: $message) {
+      fulfillment {
+        id
+        name
+        status
+        createdAt
+      }
+      userErrors {
+        field
+        message
+      }
+    }
+  }
+`;
+
+const UPDATE_FULFILLMENT_TRACKING_INFO = `
+  mutation FulfillmentTrackingInfoUpdate(
+    $fulfillmentId: ID!
+    $trackingInfoInput: FulfillmentTrackingInput!
+    $notifyCustomer: Boolean
+  ) {
+    fulfillmentTrackingInfoUpdate(
+      fulfillmentId: $fulfillmentId
+      trackingInfoInput: $trackingInfoInput
+      notifyCustomer: $notifyCustomer
+    ) {
+      fulfillment {
+        id
+        status
+        trackingInfo {
+          company
+          number
+          url
+        }
+      }
+      userErrors {
+        field
+        message
+      }
+    }
+  }
+`;
+
+const SEND_ORDER_INVOICE = `
+  mutation OrderInvoiceSend($id: ID!, $email: EmailInput) {
+    orderInvoiceSend(id: $id, email: $email) {
+      order {
+        id
+        name
+      }
+      userErrors {
+        field
+        message
+      }
+    }
+  }
+`;
+
 export default {
   CREATE_WEBHOOK,
   DELETE_WEBHOOK,
@@ -458,4 +610,11 @@ export default {
   DELETE_PAGE,
   DELETE_METAFIELD,
   UPDATE_ORDER,
+  CREATE_CUSTOMER,
+  UPDATE_CUSTOMER,
+  CREATE_ORDER,
+  REFUND_ORDER,
+  CREATE_FULFILLMENT,
+  UPDATE_FULFILLMENT_TRACKING_INFO,
+  SEND_ORDER_INVOICE,
 };

--- a/components/shopify/common/queries.mjs
+++ b/components/shopify/common/queries.mjs
@@ -1102,6 +1102,90 @@ const GET_FULFILLMENT_ORDER = `
   }
 `;
 
+const GET_ORDER = `
+  query GetOrder($id: ID!, $first: Int) {
+    order(id: $id) {
+      id
+      name
+      createdAt
+      updatedAt
+      processedAt
+      currencyCode
+      displayFinancialStatus
+      displayFulfillmentStatus
+      closed
+      confirmed
+      note
+      tags
+      totalPriceSet {
+        shopMoney {
+          amount
+          currencyCode
+        }
+      }
+      subtotalPriceSet {
+        shopMoney {
+          amount
+          currencyCode
+        }
+      }
+      customer {
+        id
+        displayName
+        firstName
+        lastName
+        email
+        phone
+        defaultAddress {
+          address1
+          city
+          province
+          zip
+          country
+        }
+      }
+      shippingAddress {
+        address1
+        city
+        province
+        zip
+        country
+        firstName
+        lastName
+      }
+      lineItems(first: $first) {
+        edges {
+          node {
+            id
+            title
+            quantity
+            variantTitle
+            vendor
+            fulfillmentStatus
+            originalUnitPriceSet {
+              shopMoney {
+                amount
+                currencyCode
+              }
+            }
+          }
+        }
+      }
+      fulfillments {
+        id
+        status
+        displayStatus
+        createdAt
+        trackingInfo {
+          number
+          url
+          company
+        }
+      }
+    }
+  }
+`;
+
 const LIST_FULFILLMENT_ORDERS = `
   query ($first: Int, $after: String, $reverse: Boolean, $sortKey: FulfillmentOrderSortKeys, $query: String) {
     fulfillmentOrders(first: $first, after: $after, reverse: $reverse, sortKey: $sortKey, query: $query) {
@@ -1179,4 +1263,5 @@ export default {
   LIST_ASSIGNED_FULFILLMENT_ORDERS,
   GET_FULFILLMENT_ORDER,
   LIST_FULFILLMENT_ORDERS,
+  GET_ORDER,
 };

--- a/components/shopify/shopify.app.mjs
+++ b/components/shopify/shopify.app.mjs
@@ -544,6 +544,30 @@ export default {
     listFulfillmentOrders(variables) {
       return this._makeGraphQlRequest(queries.LIST_FULFILLMENT_ORDERS, variables);
     },
+    getOrder(variables) {
+      return this._makeGraphQlRequest(queries.GET_ORDER, variables);
+    },
+    createCustomer(variables) {
+      return this._makeGraphQlRequest(mutations.CREATE_CUSTOMER, variables);
+    },
+    updateCustomer(variables) {
+      return this._makeGraphQlRequest(mutations.UPDATE_CUSTOMER, variables);
+    },
+    createOrder(variables) {
+      return this._makeGraphQlRequest(mutations.CREATE_ORDER, variables);
+    },
+    refundOrder(variables) {
+      return this._makeGraphQlRequest(mutations.REFUND_ORDER, variables);
+    },
+    createFulfillment(variables) {
+      return this._makeGraphQlRequest(mutations.CREATE_FULFILLMENT, variables);
+    },
+    updateFulfillmentTrackingInfo(variables) {
+      return this._makeGraphQlRequest(mutations.UPDATE_FULFILLMENT_TRACKING_INFO, variables);
+    },
+    sendOrderInvoice(variables) {
+      return this._makeGraphQlRequest(mutations.SEND_ORDER_INVOICE, variables);
+    },
     async *paginate({
       resourceFn, resourceKeys = [], variables = {}, max,
     }) {


### PR DESCRIPTION
## Summary

Brings the `shopify` (OAuth) app to feature parity with `shopify_developer_app` for agentic / MCP use cases. Adds 9 new AI-optimized actions and updates existing tooling for better agent tool selection.

### New actions

| Key | Name | Category |
|---|---|---|
| `shopify-create-customer` | Create Customer | write |
| `shopify-search-customers` | Search for Customers | read |
| `shopify-update-customer` | Update Customer | write |
| `shopify-get-order` | Get Order Details | read |
| `shopify-create-order` | Create Order | write |
| `shopify-refund-order` | Refund Order | write |
| `shopify-send-order-invoice` | Send Order Invoice | write |
| `shopify-create-fulfillment` | Create Fulfillment | write |
| `shopify-update-fulfillment-tracking-info` | Update Fulfillment Tracking Info | write |

### Also updated

- `shopify-get-fulfillment-orders` — improved description with cross-references and scope guidance (v0.0.7 → v0.0.8)
- `shopify.app.mjs` — added 8 new GraphQL methods (`getOrder`, `createCustomer`, `updateCustomer`, `createOrder`, `refundOrder`, `createFulfillment`, `updateFulfillmentTrackingInfo`, `sendOrderInvoice`)
- `common/mutations.mjs` — added 7 new GraphQL mutations
- `common/queries.mjs` — added `GET_ORDER` query

### AI-optimization highlights

- All descriptions follow Purpose → When to use → Cross-references → Returns format
- JSON string inputs for dynamic arrays (line items, refund items, addresses) — no `additionalProps` or `reloadProps`
- ID normalization: accepts both plain numeric IDs and GID format for order/customer props
- Explicit disambiguation in descriptions: e.g. "Search Orders does NOT return line item GIDs — use Get Order Details first"
- `destructiveHint`, `readOnlyHint`, `openWorldHint` set correctly on all actions