### PR TITLE
Add hosted contents to Teams chat messages

### DIFF
--- a/components/microsoft_teams/actions/send-chat-message/send-chat-message.mjs
+++ b/components/microsoft_teams/actions/send-chat-message/send-chat-message.mjs
@@ -3,9 +3,9 @@ import microsoftTeams from "../../microsoft_teams.app.mjs";
 export default {
   key: "microsoft_teams-send-chat-message",
   name: "Send Chat Message",
-  description: "Send a message to a team&#39;s chat. [See the docs here](https://docs.microsoft.com/en-us/graph/api/chat-post-messages?view=graph-rest-1.0&tabs=http)",
+  description: "Send a message to a team's chat. Optionally include inline images via `hostedContents`. [See the docs here](https://learn.microsoft.com/en-us/graph/api/chatmessage-post?view=graph-rest-1.0&tabs=http)",
   type: "action",
-  version: "0.0.12",
+  version: "0.0.13",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -31,23 +31,41 @@ export default {
         "contentType",
       ],
     },
+    hostedContents: {
+      type: "string[]",
+      label: "Hosted Contents",
+      description: "An array of JSON strings, each representing an inline hosted image to attach. Each item must be a JSON object with `'@microsoft.graph.temporaryId'` (string), `contentBytes` (base64-encoded image data), and `contentType` (MIME type, e.g. `image/png`). Example: `{\"@microsoft.graph.temporaryId\": \"1\", \"contentBytes\": \"BASE64_STRING\", \"contentType\": \"image/png\"}`. Reference each image in your HTML message body using `<img src=\"../hostedContents/1/$value\">`. [See the docs](https://learn.microsoft.com/en-us/graph/api/chatmessage-post?view=graph-rest-1.0&tabs=http#example-6-send-inline-images-along-with-the-message)",
+      optional: true,
+    },
   },
   async run({ $ }) {
     const {
       chatId,
       message,
       contentType,
+      hostedContents,
     } = this;
+
+    const parsedHostedContents = hostedContents?.map((item) =>
+      typeof item === "string"
+        ? JSON.parse(item)
+        : item);
+
+    const content = {
+      body: {
+        content: message,
+        contentType: contentType ?? "text",
+      },
+    };
+
+    if (parsedHostedContents?.length) {
+      content.hostedContents = parsedHostedContents;
+    }
 
     const response =
       await this.microsoftTeams.sendChatMessage({
         chatId,
-        content: {
-          body: {
-            content: message,
-            contentType,
-          },
-        },
+        content,
       });
 
     $.export("$summary", `Successfully sent message to chat ${chatId}`);

--- a/components/microsoft_teams/package.json
+++ b/components/microsoft_teams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/microsoft_teams",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Pipedream Microsoft Teams Components",
   "main": "microsoft_teams.app.mjs",
   "keywords": [


### PR DESCRIPTION
This adds the optional `hostedContents` input to the Microsoft Teams Send Chat Message action so inline images can be included in chat messages, matching the existing channel message action. The action now builds the request body before sending it and attaches parsed hosted content entries when provided.

Tested with `node --check components/microsoft_teams/actions/send-chat-message/send-chat-message.mjs`.

Closes #20856


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for embedding inline hosted images in Microsoft Teams chat messages via a new optional hosted-contents input, enabling richer message content.

* **Updates**
  * Refined action description text for Microsoft Teams chat messaging for clearer intent and improved user-facing wording.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PipedreamHQ/pipedream/pull/20858)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->