### PR TITLE
[Components] Linkly: instant webhook click source + 5 new actions + 1 new source

### DIFF
--- a/components/linkly/README.md
+++ b/components/linkly/README.md
@@ -11,7 +11,7 @@ By integrating Linkly with Pipedream, you can:
 
 # Authentication
 
-You'll need a Linkly API key and workspace ID. Generate an API key under **Settings → API Keys** in your [Linkly](https://linklyhq.com) dashboard, and grab your workspace ID from the URL or via the **List Workspaces** action.
+You'll need a Linkly API key and workspace ID. Generate an API key under **Settings → API Keys** in your [Linkly](https://linklyhq.com) dashboard, and grab your workspace ID from the URL or via the **List Workspaces** action. The free plan is enough for actions and the polling source; the **New Link Clicked (Instant)** webhook source requires a paid plan.
 
 # Example Use Cases
 

--- a/components/linkly/README.md
+++ b/components/linkly/README.md
@@ -1,11 +1,47 @@
 # Overview
 
-The Linkly API enables you to create and manage short links, track clicks, and analyze the performance of your links in real-time. It's a tool for marketers, developers, and content creators who need to understand user engagement and optimize their online presence. By using Linkly API within Pipedream, you can integrate URL shortening and tracking capabilities into your workflows, allowing for automated link management and data collection. You can build automated processes that trigger on new link creation, analyze click data, generate reports, or sync with other marketing and analytics services to enhance your strategies.
+[Linkly](https://linklyhq.com) is a [URL shortener and link management platform](https://linklyhq.com/link-shortener) for marketers, developers, and content teams. The [Linkly API](https://linklyhq.com/url-shortener-api) lets you create [branded short links](https://linklyhq.com/create-tracking-links), track [click analytics](https://linklyhq.com/url-shortener-analytics) in real time, and trigger workflows on every click via webhooks.
+
+By integrating Linkly with Pipedream, you can:
+
+- Create, update, and delete short links from any workflow
+- Trigger real-time workflows on every click via webhooks, with full [click tracking](https://linklyhq.com/click-tracking-software) metadata
+- Sync click data to a CRM, data warehouse, or spreadsheet
+- Combine Linkly with thousands of other apps Pipedream supports
+
+# Authentication
+
+You'll need a Linkly API key and workspace ID. Generate an API key under **Settings → API Keys** in your [Linkly dashboard](https://linklyhq.com), and grab your workspace ID from the URL or via the **List Workspaces** action. A [free plan](https://linklyhq.com/free-url-shortener) is enough to get started.
 
 # Example Use Cases
 
-- **Automated Link Creation for Social Media Posts**: Use the Linkly API to automatically create short links for new content as soon as it's published. Connect Linkly to a social media platform like Twitter using Pipedream, so that each new blog post, product, or piece of content you publish is accompanied by a trackable Linkly short link when shared on your social profiles.
+- **Automated Link Creation for Social Media Posts** — Use the **Create Link** action whenever new content is published in your CMS. Linkly returns a [branded short URL](https://linklyhq.com/link-shortener) you can post to Twitter, LinkedIn, or Buffer.
 
-- **Click Data Aggregation and Analysis**: Leverage Pipedream to collect click data from Linkly in real-time. Integrate this data with Google Sheets or a database like PostgreSQL to analyze the performance of various links. Use this analysis to adjust marketing strategies and better understand your audience's preferences and behaviors.
+- **Real-Time Click Analytics Pipeline** — Use the **New Link Clicked (Instant)** source to receive a webhook event for every click — with location, device, browser, and referrer — and forward it to BigQuery, PostgreSQL, or [Linkly's own analytics dashboard](https://linklyhq.com/url-shortener-analytics) is also available out of the box.
 
-- **Workflow Optimization for Affiliate Marketing**: Enhance your affiliate marketing by creating Linkly short links for affiliate URLs and track their performance. With Pipedream, you can connect Linkly to email marketing services like Mailchimp, automatically embedding trackable links in newsletters and tracking which products resonate most with your subscribers.
+- **Affiliate Link Tracking** — Auto-shorten affiliate URLs via **Create Link**, then use **New Link Clicked (Instant)** to attribute each click to a specific campaign in Mailchimp or your CRM.
+
+- **Slack Click Alerts** — Subscribe to the workspace webhook and post a Slack message every time a high-value link is clicked. Real-time, no polling.
+
+- **Bulk Link Management** — Use **List Links**, **Update Link**, and **Delete Link** to programmatically manage thousands of [tracking links](https://linklyhq.com/create-tracking-links).
+
+# Components
+
+| Component | Type | Description |
+|---|---|---|
+| Create Link | Action | Create a new short link |
+| Get Link | Action | Fetch a link by ID with full metadata |
+| List Links | Action | List all links in the workspace |
+| Update Link | Action | Update destination, slug, or name of an existing link |
+| Delete Link | Action | Permanently delete a link |
+| List Domains | Action | List custom domains in the workspace |
+| List Workspaces | Action | List workspaces the API key has access to |
+| New Link Clicked (Instant) | Source | Webhook-based — fires on every click with full metadata |
+| New Link Created | Source | Polling — fires when a new link is added to the workspace |
+
+# Learn More
+
+- [Linkly homepage](https://linklyhq.com)
+- [URL Shortener API documentation](https://linklyhq.com/url-shortener-api)
+- [Pricing & free plan](https://linklyhq.com/pricing)
+- [Features overview](https://linklyhq.com/features)

--- a/components/linkly/README.md
+++ b/components/linkly/README.md
@@ -1,29 +1,29 @@
 # Overview
 
-[Linkly](https://linklyhq.com) is a [URL shortener and link management platform](https://linklyhq.com/link-shortener) for marketers, developers, and content teams. The [Linkly API](https://linklyhq.com/url-shortener-api) lets you create [branded short links](https://linklyhq.com/create-tracking-links), track [click analytics](https://linklyhq.com/url-shortener-analytics) in real time, and trigger workflows on every click via webhooks.
+The [Linkly URL Shortener API](https://linklyhq.com) lets you create branded short links, track click analytics in real time, and trigger workflows on every click via webhooks.
 
 By integrating Linkly with Pipedream, you can:
 
 - Create, update, and delete short links from any workflow
-- Trigger real-time workflows on every click via webhooks, with full [click tracking](https://linklyhq.com/click-tracking-software) metadata
+- Trigger real-time workflows on every click via webhooks, with full click metadata (location, device, browser, referrer)
 - Sync click data to a CRM, data warehouse, or spreadsheet
 - Combine Linkly with thousands of other apps Pipedream supports
 
 # Authentication
 
-You'll need a Linkly API key and workspace ID. Generate an API key under **Settings → API Keys** in your [Linkly dashboard](https://linklyhq.com), and grab your workspace ID from the URL or via the **List Workspaces** action. A [free plan](https://linklyhq.com/free-url-shortener) is enough to get started.
+You'll need a Linkly API key and workspace ID. Generate an API key under **Settings → API Keys** in your [Linkly](https://linklyhq.com) dashboard, and grab your workspace ID from the URL or via the **List Workspaces** action.
 
 # Example Use Cases
 
-- **Automated Link Creation for Social Media Posts** — Use the **Create Link** action whenever new content is published in your CMS. Linkly returns a [branded short URL](https://linklyhq.com/link-shortener) you can post to Twitter, LinkedIn, or Buffer.
+- **Automated Link Creation for Social Media Posts** — Use the **Create Link** action whenever new content is published in your CMS. Linkly returns a branded short URL you can post to Twitter, LinkedIn, or Buffer.
 
-- **Real-Time Click Analytics Pipeline** — Use the **New Link Clicked (Instant)** source to receive a webhook event for every click — with location, device, browser, and referrer — and forward it to BigQuery, PostgreSQL, or [Linkly's own analytics dashboard](https://linklyhq.com/url-shortener-analytics) is also available out of the box.
+- **Real-Time Click Analytics Pipeline** — Use the **New Link Clicked (Instant)** source to receive a webhook event for every click — with location, device, browser, and referrer — and forward it to BigQuery, PostgreSQL, or any data destination.
 
 - **Affiliate Link Tracking** — Auto-shorten affiliate URLs via **Create Link**, then use **New Link Clicked (Instant)** to attribute each click to a specific campaign in Mailchimp or your CRM.
 
 - **Slack Click Alerts** — Subscribe to the workspace webhook and post a Slack message every time a high-value link is clicked. Real-time, no polling.
 
-- **Bulk Link Management** — Use **List Links**, **Update Link**, and **Delete Link** to programmatically manage thousands of [tracking links](https://linklyhq.com/create-tracking-links).
+- **Bulk Link Management** — Use **List Links**, **Update Link**, and **Delete Link** to programmatically manage thousands of tracking links.
 
 # Components
 
@@ -38,10 +38,3 @@ You'll need a Linkly API key and workspace ID. Generate an API key under **Setti
 | List Workspaces | Action | List workspaces the API key has access to |
 | New Link Clicked (Instant) | Source | Webhook-based — fires on every click with full metadata |
 | New Link Created | Source | Polling — fires when a new link is added to the workspace |
-
-# Learn More
-
-- [Linkly homepage](https://linklyhq.com)
-- [URL Shortener API documentation](https://linklyhq.com/url-shortener-api)
-- [Pricing & free plan](https://linklyhq.com/pricing)
-- [Features overview](https://linklyhq.com/features)

--- a/components/linkly/actions/create-link/create-link.mjs
+++ b/components/linkly/actions/create-link/create-link.mjs
@@ -3,8 +3,8 @@ import linkly from "../../linkly.app.mjs";
 export default {
   key: "linkly-create-link",
   name: "Create Link",
-  description: "Creates a new short link with the [Linkly URL Shortener API](https://linklyhq.com).",
-  version: "0.0.3",
+  description: "Creates a new short link with the [Linkly URL Shortener API](https://linklyhq.com). [See the documentation](https://linklyhq.com/url-shortener-api).",
+  version: "0.1.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/linkly/actions/create-link/create-link.mjs
+++ b/components/linkly/actions/create-link/create-link.mjs
@@ -43,15 +43,9 @@ export default {
       data: {
         url: this.url,
         workspace_id: this.linkly.workspaceId(),
-        ...(this.name && {
-          name: this.name,
-        }),
-        ...(this.domain && {
-          domain: this.domain,
-        }),
-        ...(this.slug && {
-          slug: this.slug,
-        }),
+        name: this.name,
+        domain: this.domain,
+        slug: this.slug,
       },
       $,
     });

--- a/components/linkly/actions/create-link/create-link.mjs
+++ b/components/linkly/actions/create-link/create-link.mjs
@@ -3,7 +3,7 @@ import linkly from "../../linkly.app.mjs";
 export default {
   key: "linkly-create-link",
   name: "Create Link",
-  description: "Creates a new short link with [Linkly](https://linklyhq.com). Track clicks, locations, devices, and referrers in real-time with [Linkly's analytics](https://linklyhq.com/url-shortener-analytics). [See the API documentation](https://linklyhq.com/url-shortener-api).",
+  description: "Creates a new short link with the [Linkly URL Shortener API](https://linklyhq.com).",
   version: "0.0.3",
   annotations: {
     destructiveHint: false,

--- a/components/linkly/actions/create-link/create-link.mjs
+++ b/components/linkly/actions/create-link/create-link.mjs
@@ -3,7 +3,7 @@ import linkly from "../../linkly.app.mjs";
 export default {
   key: "linkly-create-link",
   name: "Create Link",
-  description: "Creates a new short link with the [Linkly URL Shortener API](https://linklyhq.com). [See the documentation](https://linklyhq.com/url-shortener-api).",
+  description: "Create a new short link via `POST /api/v1/link`. [See the documentation](https://app.linklyhq.com/swaggerui#/Links/createOrUpdateLink).",
   version: "0.1.0",
   annotations: {
     destructiveHint: false,
@@ -25,16 +25,16 @@ export default {
         "name",
       ],
     },
+    domain: {
+      propDefinition: [
+        linkly,
+        "domain",
+      ],
+    },
     slug: {
       propDefinition: [
         linkly,
         "slug",
-      ],
-    },
-    domainId: {
-      propDefinition: [
-        linkly,
-        "domainId",
       ],
     },
   },
@@ -46,11 +46,11 @@ export default {
         ...(this.name && {
           name: this.name,
         }),
-        ...(this.slug && {
-          full_url: this.slug,
+        ...(this.domain && {
+          domain: this.domain,
         }),
-        ...(this.domainId && {
-          domain_id: this.domainId,
+        ...(this.slug && {
+          slug: this.slug,
         }),
       },
       $,

--- a/components/linkly/actions/delete-link/delete-link.mjs
+++ b/components/linkly/actions/delete-link/delete-link.mjs
@@ -3,7 +3,7 @@ import linkly from "../../linkly.app.mjs";
 export default {
   key: "linkly-delete-link",
   name: "Delete Link",
-  description: "Permanently deletes a short link via the [Linkly URL Shortener API](https://linklyhq.com). The short URL will return 404 for new visitors.",
+  description: "Permanently deletes a short link via the [Linkly URL Shortener API](https://linklyhq.com). The short URL will return 404 for new visitors. [See the documentation](https://linklyhq.com/url-shortener-api).",
   version: "0.0.1",
   annotations: {
     destructiveHint: true,

--- a/components/linkly/actions/delete-link/delete-link.mjs
+++ b/components/linkly/actions/delete-link/delete-link.mjs
@@ -1,0 +1,31 @@
+import linkly from "../../linkly.app.mjs";
+
+export default {
+  key: "linkly-delete-link",
+  name: "Delete Link",
+  description: "Permanently deletes a [Linkly short link](https://linklyhq.com/link-shortener). The short URL will return 404 for new visitors. [See the API documentation](https://linklyhq.com/url-shortener-api).",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: true,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  type: "action",
+  props: {
+    linkly,
+    linkId: {
+      propDefinition: [
+        linkly,
+        "linkId",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.linkly.deleteLink({
+      linkId: this.linkId,
+      $,
+    });
+    $.export("$summary", `Successfully deleted link ${this.linkId}.`);
+    return response;
+  },
+};

--- a/components/linkly/actions/delete-link/delete-link.mjs
+++ b/components/linkly/actions/delete-link/delete-link.mjs
@@ -3,7 +3,7 @@ import linkly from "../../linkly.app.mjs";
 export default {
   key: "linkly-delete-link",
   name: "Delete Link",
-  description: "Permanently deletes a [Linkly short link](https://linklyhq.com/link-shortener). The short URL will return 404 for new visitors. [See the API documentation](https://linklyhq.com/url-shortener-api).",
+  description: "Permanently deletes a short link via the [Linkly URL Shortener API](https://linklyhq.com). The short URL will return 404 for new visitors.",
   version: "0.0.1",
   annotations: {
     destructiveHint: true,

--- a/components/linkly/actions/delete-link/delete-link.mjs
+++ b/components/linkly/actions/delete-link/delete-link.mjs
@@ -3,7 +3,7 @@ import linkly from "../../linkly.app.mjs";
 export default {
   key: "linkly-delete-link",
   name: "Delete Link",
-  description: "Permanently deletes a short link via the [Linkly URL Shortener API](https://linklyhq.com). The short URL will return 404 for new visitors. [See the documentation](https://linklyhq.com/url-shortener-api).",
+  description: "Permanently delete a short link via `DELETE /api/v1/workspace/{workspace_id}/links/{id}`. The short URL will return 404 for new visitors. [See the documentation](https://app.linklyhq.com/swaggerui#/Links/deleteLink).",
   version: "0.0.1",
   annotations: {
     destructiveHint: true,

--- a/components/linkly/actions/get-link/get-link.mjs
+++ b/components/linkly/actions/get-link/get-link.mjs
@@ -3,7 +3,7 @@ import linkly from "../../linkly.app.mjs";
 export default {
   key: "linkly-get-link",
   name: "Get Link",
-  description: "Fetches a previously created [Linkly link](https://linklyhq.com/link-shortener) with full metadata including click counts, custom domain, and redirect rules. [See the API documentation](https://linklyhq.com/url-shortener-api).",
+  description: "Fetches a previously created link from the [Linkly URL Shortener API](https://linklyhq.com), with full metadata including click counts, custom domain, and redirect rules.",
   version: "0.0.3",
   annotations: {
     destructiveHint: false,

--- a/components/linkly/actions/get-link/get-link.mjs
+++ b/components/linkly/actions/get-link/get-link.mjs
@@ -23,6 +23,10 @@ export default {
   async run({ $ }) {
     const response = await this.linkly.getLink({
       linkId: this.linkId,
+      // Required for API-key auth; OAuth tokens are workspace-scoped so they omit it.
+      params: {
+        workspace_id: this.linkly.workspaceId(),
+      },
       $,
     });
     $.export("$summary", `Successfully fetched link with ID: ${this.linkId}`);

--- a/components/linkly/actions/get-link/get-link.mjs
+++ b/components/linkly/actions/get-link/get-link.mjs
@@ -3,7 +3,7 @@ import linkly from "../../linkly.app.mjs";
 export default {
   key: "linkly-get-link",
   name: "Get Link",
-  description: "Fetches a previously created link from the [Linkly URL Shortener API](https://linklyhq.com), with full metadata including click counts, custom domain, and redirect rules. [See the documentation](https://linklyhq.com/url-shortener-api).",
+  description: "Fetch a single short link via `GET /api/v1/link/{id}`, with full metadata including click counts, custom domain, and redirect rules. [See the documentation](https://app.linklyhq.com/swaggerui#/Links/getLink).",
   version: "0.0.3",
   annotations: {
     destructiveHint: false,

--- a/components/linkly/actions/get-link/get-link.mjs
+++ b/components/linkly/actions/get-link/get-link.mjs
@@ -3,8 +3,8 @@ import linkly from "../../linkly.app.mjs";
 export default {
   key: "linkly-get-link",
   name: "Get Link",
-  description: "Fetches a previously produced Linkly link. [See the documentation](https://app.linklyhq.com/swaggerui#/API/show)",
-  version: "0.0.2",
+  description: "Fetches a previously created [Linkly link](https://linklyhq.com/link-shortener) with full metadata including click counts, custom domain, and redirect rules. [See the API documentation](https://linklyhq.com/url-shortener-api).",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -23,9 +23,6 @@ export default {
   async run({ $ }) {
     const response = await this.linkly.getLink({
       linkId: this.linkId,
-      params: {
-        workspace_id: this.linkly.workspaceId(),
-      },
       $,
     });
     $.export("$summary", `Successfully fetched link with ID: ${this.linkId}`);

--- a/components/linkly/actions/get-link/get-link.mjs
+++ b/components/linkly/actions/get-link/get-link.mjs
@@ -3,7 +3,7 @@ import linkly from "../../linkly.app.mjs";
 export default {
   key: "linkly-get-link",
   name: "Get Link",
-  description: "Fetches a previously created link from the [Linkly URL Shortener API](https://linklyhq.com), with full metadata including click counts, custom domain, and redirect rules.",
+  description: "Fetches a previously created link from the [Linkly URL Shortener API](https://linklyhq.com), with full metadata including click counts, custom domain, and redirect rules. [See the documentation](https://linklyhq.com/url-shortener-api).",
   version: "0.0.3",
   annotations: {
     destructiveHint: false,

--- a/components/linkly/actions/list-domains/list-domains.mjs
+++ b/components/linkly/actions/list-domains/list-domains.mjs
@@ -1,0 +1,24 @@
+import linkly from "../../linkly.app.mjs";
+
+export default {
+  key: "linkly-list-domains",
+  name: "List Domains",
+  description: "Lists all [custom domains](https://linklyhq.com/features) connected to your [Linkly](https://linklyhq.com) account, including the default Linkly domain.",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  type: "action",
+  props: {
+    linkly,
+  },
+  async run({ $ }) {
+    const domains = await this.linkly.listDomains({
+      $,
+    });
+    $.export("$summary", `Successfully fetched ${domains?.length ?? 0} domain${domains?.length === 1 ? "" : "s"}.`);
+    return domains;
+  },
+};

--- a/components/linkly/actions/list-domains/list-domains.mjs
+++ b/components/linkly/actions/list-domains/list-domains.mjs
@@ -3,7 +3,7 @@ import linkly from "../../linkly.app.mjs";
 export default {
   key: "linkly-list-domains",
   name: "List Domains",
-  description: "Lists all [custom domains](https://linklyhq.com/features) connected to your [Linkly](https://linklyhq.com) account, including the default Linkly domain.",
+  description: "Lists all custom domains connected to your account via the [Linkly URL Shortener API](https://linklyhq.com), including the default Linkly domain.",
   version: "0.0.1",
   annotations: {
     destructiveHint: false,

--- a/components/linkly/actions/list-domains/list-domains.mjs
+++ b/components/linkly/actions/list-domains/list-domains.mjs
@@ -3,7 +3,7 @@ import linkly from "../../linkly.app.mjs";
 export default {
   key: "linkly-list-domains",
   name: "List Domains",
-  description: "Lists all custom domains connected to your account via the [Linkly URL Shortener API](https://linklyhq.com), including the default Linkly domain.",
+  description: "Lists all custom domains connected to your account via the [Linkly URL Shortener API](https://linklyhq.com), including the default Linkly domain. [See the documentation](https://linklyhq.com/url-shortener-api).",
   version: "0.0.1",
   annotations: {
     destructiveHint: false,

--- a/components/linkly/actions/list-domains/list-domains.mjs
+++ b/components/linkly/actions/list-domains/list-domains.mjs
@@ -3,7 +3,7 @@ import linkly from "../../linkly.app.mjs";
 export default {
   key: "linkly-list-domains",
   name: "List Domains",
-  description: "Lists all custom domains connected to your account via the [Linkly URL Shortener API](https://linklyhq.com), including the default Linkly domain. [See the documentation](https://linklyhq.com/url-shortener-api).",
+  description: "List all custom domains in your workspace via `GET /api/v1/workspace/{workspace_id}/domains`. [See the documentation](https://app.linklyhq.com/swaggerui#/Domains/listDomains).",
   version: "0.0.1",
   annotations: {
     destructiveHint: false,
@@ -15,7 +15,7 @@ export default {
     linkly,
   },
   async run({ $ }) {
-    const domains = await this.linkly.listDomains({
+    const { domains } = await this.linkly.listDomains({
       $,
     });
     $.export("$summary", `Successfully fetched ${domains?.length ?? 0} domain${domains?.length === 1 ? "" : "s"}.`);

--- a/components/linkly/actions/list-domains/list-domains.mjs
+++ b/components/linkly/actions/list-domains/list-domains.mjs
@@ -18,7 +18,9 @@ export default {
     const { domains } = await this.linkly.listDomains({
       $,
     });
-    $.export("$summary", `Successfully fetched ${domains?.length ?? 0} domain${domains?.length === 1 ? "" : "s"}.`);
+    $.export("$summary", `Successfully fetched ${domains?.length ?? 0} domain${domains?.length === 1
+      ? ""
+      : "s"}.`);
     return domains;
   },
 };

--- a/components/linkly/actions/list-links/list-links.mjs
+++ b/components/linkly/actions/list-links/list-links.mjs
@@ -35,10 +35,11 @@ export default {
       params: {
         search: this.search,
       },
+      $,
     });
     for await (const link of iterator) {
-      links.push(link);
       if (links.length >= this.maxResults) break;
+      links.push(link);
     }
     $.export("$summary", `Successfully fetched ${links.length} link${links.length === 1 ? "" : "s"}.`);
     return links;

--- a/components/linkly/actions/list-links/list-links.mjs
+++ b/components/linkly/actions/list-links/list-links.mjs
@@ -33,9 +33,7 @@ export default {
       resourceFn: this.linkly.listLinks,
       resourceType: "links",
       params: {
-        ...(this.search && {
-          search: this.search,
-        }),
+        search: this.search,
       },
     });
     for await (const link of iterator) {

--- a/components/linkly/actions/list-links/list-links.mjs
+++ b/components/linkly/actions/list-links/list-links.mjs
@@ -1,0 +1,48 @@
+import linkly from "../../linkly.app.mjs";
+
+export default {
+  key: "linkly-list-links",
+  name: "List Links",
+  description: "Lists all short links in your [Linkly workspace](https://linklyhq.com) with click counts and metadata. [See the API documentation](https://linklyhq.com/url-shortener-api).",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  type: "action",
+  props: {
+    linkly,
+    search: {
+      type: "string",
+      label: "Search",
+      description: "Optional search query to filter links by URL or name",
+      optional: true,
+    },
+    maxResults: {
+      type: "integer",
+      label: "Max Results",
+      description: "Maximum number of links to return. Defaults to 100.",
+      optional: true,
+      default: 100,
+    },
+  },
+  async run({ $ }) {
+    const links = [];
+    const iterator = this.linkly.paginate({
+      resourceFn: this.linkly.listLinks,
+      resourceType: "links",
+      params: {
+        ...(this.search && {
+          search: this.search,
+        }),
+      },
+    });
+    for await (const link of iterator) {
+      links.push(link);
+      if (links.length >= this.maxResults) break;
+    }
+    $.export("$summary", `Successfully fetched ${links.length} link${links.length === 1 ? "" : "s"}.`);
+    return links;
+  },
+};

--- a/components/linkly/actions/list-links/list-links.mjs
+++ b/components/linkly/actions/list-links/list-links.mjs
@@ -3,7 +3,7 @@ import linkly from "../../linkly.app.mjs";
 export default {
   key: "linkly-list-links",
   name: "List Links",
-  description: "Lists all short links in your workspace via the [Linkly URL Shortener API](https://linklyhq.com), with click counts and metadata. [See the documentation](https://linklyhq.com/url-shortener-api).",
+  description: "List all short links in your workspace via `GET /api/v1/workspace/{workspace_id}/list_links`, with click counts and metadata. [See the documentation](https://app.linklyhq.com/swaggerui#/Links/listLinks).",
   version: "0.0.1",
   annotations: {
     destructiveHint: false,

--- a/components/linkly/actions/list-links/list-links.mjs
+++ b/components/linkly/actions/list-links/list-links.mjs
@@ -3,7 +3,7 @@ import linkly from "../../linkly.app.mjs";
 export default {
   key: "linkly-list-links",
   name: "List Links",
-  description: "Lists all short links in your [Linkly workspace](https://linklyhq.com) with click counts and metadata. [See the API documentation](https://linklyhq.com/url-shortener-api).",
+  description: "Lists all short links in your workspace via the [Linkly URL Shortener API](https://linklyhq.com), with click counts and metadata.",
   version: "0.0.1",
   annotations: {
     destructiveHint: false,

--- a/components/linkly/actions/list-links/list-links.mjs
+++ b/components/linkly/actions/list-links/list-links.mjs
@@ -3,7 +3,7 @@ import linkly from "../../linkly.app.mjs";
 export default {
   key: "linkly-list-links",
   name: "List Links",
-  description: "Lists all short links in your workspace via the [Linkly URL Shortener API](https://linklyhq.com), with click counts and metadata.",
+  description: "Lists all short links in your workspace via the [Linkly URL Shortener API](https://linklyhq.com), with click counts and metadata. [See the documentation](https://linklyhq.com/url-shortener-api).",
   version: "0.0.1",
   annotations: {
     destructiveHint: false,

--- a/components/linkly/actions/list-links/list-links.mjs
+++ b/components/linkly/actions/list-links/list-links.mjs
@@ -41,7 +41,9 @@ export default {
       if (links.length >= this.maxResults) break;
       links.push(link);
     }
-    $.export("$summary", `Successfully fetched ${links.length} link${links.length === 1 ? "" : "s"}.`);
+    $.export("$summary", `Successfully fetched ${links.length} link${links.length === 1
+      ? ""
+      : "s"}.`);
     return links;
   },
 };

--- a/components/linkly/actions/list-workspaces/list-workspaces.mjs
+++ b/components/linkly/actions/list-workspaces/list-workspaces.mjs
@@ -3,7 +3,7 @@ import linkly from "../../linkly.app.mjs";
 export default {
   key: "linkly-list-workspaces",
   name: "List Workspaces",
-  description: "Lists all [Linkly](https://linklyhq.com) workspaces accessible to the authenticated user. Useful for finding the workspace ID required for [API requests](https://linklyhq.com/url-shortener-api).",
+  description: "Lists all workspaces accessible to the authenticated user via the [Linkly URL Shortener API](https://linklyhq.com). Useful for finding the workspace ID required for API requests.",
   version: "0.0.1",
   annotations: {
     destructiveHint: false,

--- a/components/linkly/actions/list-workspaces/list-workspaces.mjs
+++ b/components/linkly/actions/list-workspaces/list-workspaces.mjs
@@ -1,0 +1,24 @@
+import linkly from "../../linkly.app.mjs";
+
+export default {
+  key: "linkly-list-workspaces",
+  name: "List Workspaces",
+  description: "Lists all [Linkly](https://linklyhq.com) workspaces accessible to the authenticated user. Useful for finding the workspace ID required for [API requests](https://linklyhq.com/url-shortener-api).",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  type: "action",
+  props: {
+    linkly,
+  },
+  async run({ $ }) {
+    const workspaces = await this.linkly.listWorkspaces({
+      $,
+    });
+    $.export("$summary", `Successfully fetched ${workspaces?.length ?? 0} workspace${workspaces?.length === 1 ? "" : "s"}.`);
+    return workspaces;
+  },
+};

--- a/components/linkly/actions/list-workspaces/list-workspaces.mjs
+++ b/components/linkly/actions/list-workspaces/list-workspaces.mjs
@@ -3,7 +3,7 @@ import linkly from "../../linkly.app.mjs";
 export default {
   key: "linkly-list-workspaces",
   name: "List Workspaces",
-  description: "Lists all workspaces accessible to the authenticated user via the [Linkly URL Shortener API](https://linklyhq.com). Useful for finding the workspace ID required for API requests.",
+  description: "Lists all workspaces accessible to the authenticated user via the [Linkly URL Shortener API](https://linklyhq.com). Useful for finding the workspace ID required for API requests. [See the documentation](https://linklyhq.com/url-shortener-api).",
   version: "0.0.1",
   annotations: {
     destructiveHint: false,

--- a/components/linkly/actions/list-workspaces/list-workspaces.mjs
+++ b/components/linkly/actions/list-workspaces/list-workspaces.mjs
@@ -3,7 +3,7 @@ import linkly from "../../linkly.app.mjs";
 export default {
   key: "linkly-list-workspaces",
   name: "List Workspaces",
-  description: "Lists all workspaces accessible to the authenticated user via the [Linkly URL Shortener API](https://linklyhq.com). Useful for finding the workspace ID required for API requests. [See the documentation](https://linklyhq.com/url-shortener-api).",
+  description: "List all workspaces the API key has access to via `GET /api/v1/workspaces`. Useful for finding the workspace ID required for API requests. [See the documentation](https://app.linklyhq.com/swaggerui#/Workspaces/listWorkspaces).",
   version: "0.0.1",
   annotations: {
     destructiveHint: false,

--- a/components/linkly/actions/list-workspaces/list-workspaces.mjs
+++ b/components/linkly/actions/list-workspaces/list-workspaces.mjs
@@ -18,7 +18,9 @@ export default {
     const workspaces = await this.linkly.listWorkspaces({
       $,
     });
-    $.export("$summary", `Successfully fetched ${workspaces?.length ?? 0} workspace${workspaces?.length === 1 ? "" : "s"}.`);
+    $.export("$summary", `Successfully fetched ${workspaces?.length ?? 0} workspace${workspaces?.length === 1
+      ? ""
+      : "s"}.`);
     return workspaces;
   },
 };

--- a/components/linkly/actions/update-link/update-link.mjs
+++ b/components/linkly/actions/update-link/update-link.mjs
@@ -3,7 +3,7 @@ import linkly from "../../linkly.app.mjs";
 export default {
   key: "linkly-update-link",
   name: "Update Link",
-  description: "Updates an existing short link via the [Linkly URL Shortener API](https://linklyhq.com) — change its destination URL, slug, name, or custom domain without breaking the existing short URL. [See the documentation](https://linklyhq.com/url-shortener-api).",
+  description: "Update an existing short link via `POST /api/v1/link` (with `id`) — change its destination URL, slug, name, or custom domain without breaking the existing short URL. [See the documentation](https://app.linklyhq.com/swaggerui#/Links/createOrUpdateLink).",
   version: "0.0.1",
   annotations: {
     destructiveHint: false,
@@ -33,16 +33,16 @@ export default {
         "name",
       ],
     },
+    domain: {
+      propDefinition: [
+        linkly,
+        "domain",
+      ],
+    },
     slug: {
       propDefinition: [
         linkly,
         "slug",
-      ],
-    },
-    domainId: {
-      propDefinition: [
-        linkly,
-        "domainId",
       ],
     },
   },
@@ -57,11 +57,11 @@ export default {
         ...(this.name && {
           name: this.name,
         }),
-        ...(this.slug && {
-          full_url: this.slug,
+        ...(this.domain && {
+          domain: this.domain,
         }),
-        ...(this.domainId && {
-          domain_id: this.domainId,
+        ...(this.slug && {
+          slug: this.slug,
         }),
       },
       $,

--- a/components/linkly/actions/update-link/update-link.mjs
+++ b/components/linkly/actions/update-link/update-link.mjs
@@ -51,18 +51,10 @@ export default {
       linkId: this.linkId,
       data: {
         workspace_id: this.linkly.workspaceId(),
-        ...(this.url && {
-          url: this.url,
-        }),
-        ...(this.name && {
-          name: this.name,
-        }),
-        ...(this.domain && {
-          domain: this.domain,
-        }),
-        ...(this.slug && {
-          slug: this.slug,
-        }),
+        url: this.url,
+        name: this.name,
+        domain: this.domain,
+        slug: this.slug,
       },
       $,
     });

--- a/components/linkly/actions/update-link/update-link.mjs
+++ b/components/linkly/actions/update-link/update-link.mjs
@@ -3,7 +3,7 @@ import linkly from "../../linkly.app.mjs";
 export default {
   key: "linkly-update-link",
   name: "Update Link",
-  description: "Updates an existing [Linkly short link](https://linklyhq.com/link-shortener) — change its destination URL, slug, name, or custom domain without breaking the existing short URL. [See the API documentation](https://linklyhq.com/url-shortener-api).",
+  description: "Updates an existing short link via the [Linkly URL Shortener API](https://linklyhq.com) — change its destination URL, slug, name, or custom domain without breaking the existing short URL.",
   version: "0.0.1",
   annotations: {
     destructiveHint: false,

--- a/components/linkly/actions/update-link/update-link.mjs
+++ b/components/linkly/actions/update-link/update-link.mjs
@@ -3,7 +3,7 @@ import linkly from "../../linkly.app.mjs";
 export default {
   key: "linkly-update-link",
   name: "Update Link",
-  description: "Updates an existing short link via the [Linkly URL Shortener API](https://linklyhq.com) — change its destination URL, slug, name, or custom domain without breaking the existing short URL.",
+  description: "Updates an existing short link via the [Linkly URL Shortener API](https://linklyhq.com) — change its destination URL, slug, name, or custom domain without breaking the existing short URL. [See the documentation](https://linklyhq.com/url-shortener-api).",
   version: "0.0.1",
   annotations: {
     destructiveHint: false,
@@ -20,9 +20,11 @@ export default {
       ],
     },
     url: {
-      type: "string",
-      label: "Destination URL",
-      description: "New destination URL for the link",
+      propDefinition: [
+        linkly,
+        "url",
+      ],
+      description: "New destination URL for the link (leave empty to keep the current value).",
       optional: true,
     },
     name: {

--- a/components/linkly/actions/update-link/update-link.mjs
+++ b/components/linkly/actions/update-link/update-link.mjs
@@ -1,10 +1,10 @@
 import linkly from "../../linkly.app.mjs";
 
 export default {
-  key: "linkly-create-link",
-  name: "Create Link",
-  description: "Creates a new short link with [Linkly](https://linklyhq.com). Track clicks, locations, devices, and referrers in real-time with [Linkly's analytics](https://linklyhq.com/url-shortener-analytics). [See the API documentation](https://linklyhq.com/url-shortener-api).",
-  version: "0.0.3",
+  key: "linkly-update-link",
+  name: "Update Link",
+  description: "Updates an existing [Linkly short link](https://linklyhq.com/link-shortener) — change its destination URL, slug, name, or custom domain without breaking the existing short URL. [See the API documentation](https://linklyhq.com/url-shortener-api).",
+  version: "0.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -13,11 +13,17 @@ export default {
   type: "action",
   props: {
     linkly,
-    url: {
+    linkId: {
       propDefinition: [
         linkly,
-        "url",
+        "linkId",
       ],
+    },
+    url: {
+      type: "string",
+      label: "Destination URL",
+      description: "New destination URL for the link",
+      optional: true,
     },
     name: {
       propDefinition: [
@@ -39,10 +45,13 @@ export default {
     },
   },
   async run({ $ }) {
-    const response = await this.linkly.createLink({
+    const response = await this.linkly.updateLink({
+      linkId: this.linkId,
       data: {
-        url: this.url,
         workspace_id: this.linkly.workspaceId(),
+        ...(this.url && {
+          url: this.url,
+        }),
         ...(this.name && {
           name: this.name,
         }),
@@ -55,7 +64,7 @@ export default {
       },
       $,
     });
-    $.export("$summary", `Successfully created Linkly link for URL ${this.url}.`);
+    $.export("$summary", `Successfully updated link ${this.linkId}.`);
     return response;
   },
 };

--- a/components/linkly/linkly.app.mjs
+++ b/components/linkly/linkly.app.mjs
@@ -8,7 +8,7 @@ export default {
     linkId: {
       type: "string",
       label: "Link ID",
-      description: "The ID of the [Linkly link](https://linklyhq.com/link-shortener)",
+      description: "The ID of the Linkly link",
       async options({ page }) {
         const { links } = await this.listLinks({
           params: {
@@ -26,7 +26,7 @@ export default {
     domainId: {
       type: "integer",
       label: "Domain ID",
-      description: "The ID of a custom domain in your workspace. Leave empty to use the default Linkly domain. See [custom domains](https://linklyhq.com/features).",
+      description: "The ID of a custom domain in your workspace. Leave empty to use the default Linkly domain.",
       optional: true,
       async options() {
         const domains = await this.listDomains();
@@ -41,7 +41,7 @@ export default {
     url: {
       type: "string",
       label: "URL",
-      description: "The long URL to shorten with [Linkly](https://linklyhq.com/url-shortener-api)",
+      description: "The long URL to shorten",
     },
     name: {
       type: "string",
@@ -52,7 +52,7 @@ export default {
     slug: {
       type: "string",
       label: "Slug",
-      description: "Custom slug for the short URL (e.g. `summer-sale`). Leave empty to auto-generate. See [branded short links](https://linklyhq.com/link-shortener).",
+      description: "Custom slug for the short URL (e.g. `summer-sale`). Leave empty to auto-generate.",
       optional: true,
     },
   },

--- a/components/linkly/linkly.app.mjs
+++ b/components/linkly/linkly.app.mjs
@@ -8,7 +8,7 @@ export default {
     linkId: {
       type: "string",
       label: "Link ID",
-      description: "The ID of the Linkly link",
+      description: "The ID of the [Linkly link](https://linklyhq.com/link-shortener)",
       async options({ page }) {
         const { links } = await this.listLinks({
           params: {
@@ -22,6 +22,38 @@ export default {
           label,
         })) || [];
       },
+    },
+    domainId: {
+      type: "integer",
+      label: "Domain ID",
+      description: "The ID of a custom domain in your workspace. Leave empty to use the default Linkly domain. See [custom domains](https://linklyhq.com/features).",
+      optional: true,
+      async options() {
+        const domains = await this.listDomains();
+        return domains?.map(({
+          id: value, full_url: label,
+        }) => ({
+          value,
+          label,
+        })) || [];
+      },
+    },
+    url: {
+      type: "string",
+      label: "URL",
+      description: "The long URL to shorten with [Linkly](https://linklyhq.com/url-shortener-api)",
+    },
+    name: {
+      type: "string",
+      label: "Name",
+      description: "Optional internal name for the link (visible only in your dashboard)",
+      optional: true,
+    },
+    slug: {
+      type: "string",
+      label: "Slug",
+      description: "Custom slug for the short URL (e.g. `summer-sale`). Leave empty to auto-generate. See [branded short links](https://linklyhq.com/link-shortener).",
+      optional: true,
     },
   },
   methods: {
@@ -69,6 +101,61 @@ export default {
         ...opts,
         method: "POST",
         path: "/link",
+      });
+    },
+    updateLink({
+      linkId, data, ...opts
+    }) {
+      return this._makeRequest({
+        ...opts,
+        method: "POST",
+        path: "/link",
+        data: {
+          ...data,
+          id: linkId,
+        },
+      });
+    },
+    deleteLink({
+      linkId, ...opts
+    }) {
+      return this._makeRequest({
+        ...opts,
+        method: "DELETE",
+        path: `/workspace/${this.workspaceId()}/links/${linkId}`,
+      });
+    },
+    listDomains(opts = {}) {
+      return this._makeRequest({
+        ...opts,
+        path: "/domains",
+      });
+    },
+    listWorkspaces(opts = {}) {
+      return this._makeRequest({
+        ...opts,
+        path: "/workspaces",
+      });
+    },
+    subscribeWorkspaceWebhook({
+      url, ...opts
+    }) {
+      return this._makeRequest({
+        ...opts,
+        method: "POST",
+        path: `/workspace/${this.workspaceId()}/webhooks`,
+        data: {
+          url,
+        },
+      });
+    },
+    unsubscribeWorkspaceWebhook({
+      url, ...opts
+    }) {
+      return this._makeRequest({
+        ...opts,
+        method: "DELETE",
+        path: `/workspace/${this.workspaceId()}/webhooks/${encodeURIComponent(url)}`,
       });
     },
     async *paginate({

--- a/components/linkly/linkly.app.mjs
+++ b/components/linkly/linkly.app.mjs
@@ -23,36 +23,31 @@ export default {
         })) || [];
       },
     },
-    domainId: {
-      type: "integer",
-      label: "Domain ID",
-      description: "The ID of a custom domain in your workspace. Leave empty to use the default Linkly domain.",
+    domain: {
+      type: "string",
+      label: "Domain",
+      description: "Custom domain to use for the short URL (e.g. `links.example.com`). Leave empty to use the default Linkly domain. A custom slug requires a custom domain.",
       optional: true,
       async options() {
-        const domains = await this.listDomains();
-        return domains?.map(({
-          id: value, full_url: label,
-        }) => ({
-          value,
-          label,
-        })) || [];
+        const { domains } = await this.listDomains();
+        return domains?.map(({ name }) => name) || [];
       },
     },
     url: {
       type: "string",
       label: "URL",
-      description: "The long URL to shorten",
+      description: "The destination URL the short link should redirect to",
     },
     name: {
       type: "string",
       label: "Name",
-      description: "Optional internal name for the link (visible only in your dashboard)",
+      description: "Nickname for the link, shown in your Linkly dashboard",
       optional: true,
     },
     slug: {
       type: "string",
       label: "Slug",
-      description: "Custom slug for the short URL (e.g. `summer-sale`). Leave empty to auto-generate.",
+      description: "Custom slug for the short URL (e.g. `summer-sale`). Requires a custom **Domain** to be set; leave empty to auto-generate.",
       optional: true,
     },
   },
@@ -128,7 +123,7 @@ export default {
     listDomains(opts = {}) {
       return this._makeRequest({
         ...opts,
-        path: "/domains",
+        path: `/workspace/${this.workspaceId()}/domains`,
       });
     },
     listWorkspaces(opts = {}) {

--- a/components/linkly/linkly.app.mjs
+++ b/components/linkly/linkly.app.mjs
@@ -157,6 +157,7 @@ export default {
       resourceFn,
       params = {},
       resourceType,
+      $,
     }) {
       params = {
         ...params,
@@ -167,6 +168,7 @@ export default {
       do {
         const response = await resourceFn({
           params,
+          $,
         });
         const items = response[resourceType];
         for (const item of items) {

--- a/components/linkly/package.json
+++ b/components/linkly/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/linkly",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Linkly Components",
   "main": "linkly.app.mjs",
   "keywords": [

--- a/components/linkly/sources/new-link-clicked/new-link-clicked.mjs
+++ b/components/linkly/sources/new-link-clicked/new-link-clicked.mjs
@@ -5,7 +5,7 @@ export default {
   type: "source",
   key: "linkly-new-link-clicked",
   name: "New Link Clicked (Instant)",
-  description: "Emit a new event every time any link in the workspace is clicked, with full click metadata (location, device, browser, referrer). Subscribes to a workspace webhook via `POST /api/v1/workspace/{workspace_id}/webhooks` for real-time delivery. Note: webhooks require a paid Linkly plan. [See the documentation](https://app.linklyhq.com/swaggerui#/Webhooks/subscribeWebhookToWorkspace).",
+  description: "Emit new event each time any link in the workspace is clicked, with full click metadata (location, device, browser, referrer). Subscribes to a workspace webhook via `POST /api/v1/workspace/{workspace_id}/webhooks` for real-time delivery. Note: webhooks require a paid Linkly plan. [See the documentation](https://app.linklyhq.com/swaggerui#/Webhooks/subscribeWebhookToWorkspace).",
   version: "0.1.0",
   dedupe: "unique",
   props: {
@@ -48,7 +48,9 @@ export default {
     // dedup limit, fold it through sha256.
     const rawId = `${body.link.id}-${body.timestamp ?? ts}`;
     const id = rawId.length > 64
-      ? createHash("sha256").update(rawId).digest("hex").slice(0, 64)
+      ? createHash("sha256").update(rawId)
+        .digest("hex")
+        .slice(0, 64)
       : rawId;
     this.$emit(body, {
       id,

--- a/components/linkly/sources/new-link-clicked/new-link-clicked.mjs
+++ b/components/linkly/sources/new-link-clicked/new-link-clicked.mjs
@@ -1,10 +1,11 @@
+import { createHash } from "crypto";
 import linkly from "../../linkly.app.mjs";
 
 export default {
   type: "source",
   key: "linkly-new-link-clicked",
   name: "New Link Clicked (Instant)",
-  description: "Emit a new event every time any link in the workspace is clicked, with full click metadata (location, device, browser, referrer). Uses webhooks from the [Linkly URL Shortener API](https://linklyhq.com) for real-time delivery. Note: webhooks require a paid Linkly plan.",
+  description: "Emit a new event every time any link in the workspace is clicked, with full click metadata (location, device, browser, referrer). Uses webhooks from the [Linkly URL Shortener API](https://linklyhq.com) for real-time delivery. Note: webhooks require a paid Linkly plan. [See the documentation](https://linklyhq.com/url-shortener-api).",
   version: "0.2.0",
   dedupe: "unique",
   props: {
@@ -13,19 +14,20 @@ export default {
       type: "$.interface.http",
       customResponse: false,
     },
-    db: "$.service.db",
   },
   hooks: {
+    // The Linkly webhook API is keyed by URL: subscribing with a URL returns
+    // that same URL as the hook identifier, and unsubscribing accepts the URL
+    // as the identifier. So we use `this.http.endpoint` (Pipedream's stable
+    // per-source URL) directly on both sides — no need to persist anything.
     async activate() {
-      const { id: hookId } = await this.linkly.subscribeWorkspaceWebhook({
+      await this.linkly.subscribeWorkspaceWebhook({
         url: this.http.endpoint,
       });
-      this.db.set("hookId", hookId);
     },
     async deactivate() {
-      const hookId = this.db.get("hookId") ?? this.http.endpoint;
       await this.linkly.unsubscribeWorkspaceWebhook({
-        url: hookId,
+        url: this.http.endpoint,
       });
     },
   },
@@ -37,8 +39,15 @@ export default {
     const ts = body.timestamp
       ? new Date(body.timestamp).getTime()
       : Date.now();
+    // Compose a stable dedup ID from the link ID + Linkly's ISO timestamp
+    // (microsecond precision). If the raw ID exceeds Pipedream's 64-char
+    // dedup limit, fold it through sha256.
+    const rawId = `${body.link.id}-${body.timestamp ?? ts}`;
+    const id = rawId.length > 64
+      ? createHash("sha256").update(rawId).digest("hex").slice(0, 64)
+      : rawId;
     this.$emit(body, {
-      id: `${body.link.id}-${ts}`,
+      id,
       summary: `Link ${body.link.id} clicked`,
       ts,
     });

--- a/components/linkly/sources/new-link-clicked/new-link-clicked.mjs
+++ b/components/linkly/sources/new-link-clicked/new-link-clicked.mjs
@@ -5,8 +5,8 @@ export default {
   type: "source",
   key: "linkly-new-link-clicked",
   name: "New Link Clicked (Instant)",
-  description: "Emit a new event every time any link in the workspace is clicked, with full click metadata (location, device, browser, referrer). Uses webhooks from the [Linkly URL Shortener API](https://linklyhq.com) for real-time delivery. Note: webhooks require a paid Linkly plan. [See the documentation](https://linklyhq.com/url-shortener-api).",
-  version: "0.2.0",
+  description: "Emit a new event every time any link in the workspace is clicked, with full click metadata (location, device, browser, referrer). Subscribes to a workspace webhook via `POST /api/v1/workspace/{workspace_id}/webhooks` for real-time delivery. Note: webhooks require a paid Linkly plan. [See the documentation](https://app.linklyhq.com/swaggerui#/Webhooks/subscribeWebhookToWorkspace).",
+  version: "0.1.0",
   dedupe: "unique",
   props: {
     linkly,

--- a/components/linkly/sources/new-link-clicked/new-link-clicked.mjs
+++ b/components/linkly/sources/new-link-clicked/new-link-clicked.mjs
@@ -26,9 +26,13 @@ export default {
       });
     },
     async deactivate() {
-      await this.linkly.unsubscribeWorkspaceWebhook({
-        url: this.http.endpoint,
-      });
+      try {
+        await this.linkly.unsubscribeWorkspaceWebhook({
+          url: this.http.endpoint,
+        });
+      } catch {
+        // Webhook may already be removed; deactivation must not fail.
+      }
     },
   },
   async run(event) {

--- a/components/linkly/sources/new-link-clicked/new-link-clicked.mjs
+++ b/components/linkly/sources/new-link-clicked/new-link-clicked.mjs
@@ -1,61 +1,46 @@
 import linkly from "../../linkly.app.mjs";
-import { DEFAULT_POLLING_SOURCE_TIMER_INTERVAL } from "@pipedream/platform";
 
 export default {
   type: "source",
   key: "linkly-new-link-clicked",
-  name: "New Link Clicked",
-  description: "Emit new event when a Linkly link is clicked",
-  version: "0.0.1",
+  name: "New Link Clicked (Instant)",
+  description: "Emit a new event every time any [Linkly](https://linklyhq.com) link in the workspace is clicked, with full click metadata (location, device, browser, referrer). Uses [Linkly's webhooks](https://linklyhq.com/url-shortener-api) for real-time delivery. Note: webhooks require a paid [Linkly plan](https://linklyhq.com/pricing).",
+  version: "0.2.0",
   dedupe: "unique",
   props: {
     linkly,
+    http: {
+      type: "$.interface.http",
+      customResponse: false,
+    },
     db: "$.service.db",
-    timer: {
-      type: "$.interface.timer",
-      default: {
-        intervalSeconds: DEFAULT_POLLING_SOURCE_TIMER_INTERVAL,
-      },
+  },
+  hooks: {
+    async activate() {
+      const { id: hookId } = await this.linkly.subscribeWorkspaceWebhook({
+        url: this.http.endpoint,
+      });
+      this.db.set("hookId", hookId);
+    },
+    async deactivate() {
+      const hookId = this.db.get("hookId") ?? this.http.endpoint;
+      await this.linkly.unsubscribeWorkspaceWebhook({
+        url: hookId,
+      });
     },
   },
-  methods: {
-    _getClicks() {
-      return this.db.get("clicks") ?? {};
-    },
-    _setClicks(clicks) {
-      this.db.set("clicks", clicks);
-    },
-    generateMeta(link, difference) {
-      const ts = Date.now();
-      return {
-        id: `${link.id}${ts}`,
-        summary: `Link ${link.id} Clicked ${difference} time${difference === 1
-          ? ""
-          : "s"}`,
-        ts,
-      };
-    },
-  },
-  async run() {
-    const oldClicks = this._getClicks();
-    const items = this.linkly.paginate({
-      resourceFn: this.linkly.listLinks,
-      resourceType: "links",
-    });
-
-    for await (const item of items) {
-      if (!oldClicks[item.id] || item.clicks_total > oldClicks[item.id]) {
-        const difference = !oldClicks[item.id]
-          ? item.clicks_total
-          : item.clicks_total - oldClicks[item.id];
-        if (difference > 0) {
-          const meta = this.generateMeta(item, difference);
-          this.$emit(item, meta);
-        }
-        oldClicks[item.id] = item.clicks_total;
-      }
+  async run(event) {
+    const { body } = event;
+    if (!body?.link?.id) {
+      return;
     }
-
-    this._setClicks(oldClicks);
+    const ts = body.timestamp
+      ? new Date(body.timestamp).getTime()
+      : Date.now();
+    this.$emit(body, {
+      id: `${body.link.id}-${ts}`,
+      summary: `Link ${body.link.id} clicked`,
+      ts,
+    });
   },
 };

--- a/components/linkly/sources/new-link-clicked/new-link-clicked.mjs
+++ b/components/linkly/sources/new-link-clicked/new-link-clicked.mjs
@@ -4,7 +4,7 @@ export default {
   type: "source",
   key: "linkly-new-link-clicked",
   name: "New Link Clicked (Instant)",
-  description: "Emit a new event every time any [Linkly](https://linklyhq.com) link in the workspace is clicked, with full click metadata (location, device, browser, referrer). Uses [Linkly's webhooks](https://linklyhq.com/url-shortener-api) for real-time delivery. Note: webhooks require a paid [Linkly plan](https://linklyhq.com/pricing).",
+  description: "Emit a new event every time any link in the workspace is clicked, with full click metadata (location, device, browser, referrer). Uses webhooks from the [Linkly URL Shortener API](https://linklyhq.com) for real-time delivery. Note: webhooks require a paid Linkly plan.",
   version: "0.2.0",
   dedupe: "unique",
   props: {

--- a/components/linkly/sources/new-link-created/new-link-created.mjs
+++ b/components/linkly/sources/new-link-created/new-link-created.mjs
@@ -5,8 +5,8 @@ export default {
   type: "source",
   key: "linkly-new-link-created",
   name: "New Link Created",
-  description: "Emit a new event when a new link is created in the workspace via the [Linkly URL Shortener API](https://linklyhq.com). Useful for syncing newly-created short links to a CRM, spreadsheet, or analytics destination. [See the documentation](https://linklyhq.com/url-shortener-api).",
-  version: "0.0.2",
+  description: "Emit a new event when a new link is created in the workspace. Polls `GET /api/v1/workspace/{workspace_id}/list_links` sorted by `inserted_at` and emits anything newer than the last seen link ID. Useful for syncing newly-created short links to a CRM, spreadsheet, or analytics destination. [See the documentation](https://app.linklyhq.com/swaggerui#/Links/listLinks).",
+  version: "0.0.1",
   dedupe: "unique",
   props: {
     linkly,

--- a/components/linkly/sources/new-link-created/new-link-created.mjs
+++ b/components/linkly/sources/new-link-created/new-link-created.mjs
@@ -1,0 +1,58 @@
+import linkly from "../../linkly.app.mjs";
+import { DEFAULT_POLLING_SOURCE_TIMER_INTERVAL } from "@pipedream/platform";
+
+export default {
+  type: "source",
+  key: "linkly-new-link-created",
+  name: "New Link Created",
+  description: "Emit a new event when a new [Linkly](https://linklyhq.com) link is created in the workspace. Useful for syncing newly-created short links to a CRM, spreadsheet, or [analytics](https://linklyhq.com/url-shortener-analytics) destination.",
+  version: "0.0.1",
+  dedupe: "unique",
+  props: {
+    linkly,
+    db: "$.service.db",
+    timer: {
+      type: "$.interface.timer",
+      default: {
+        intervalSeconds: DEFAULT_POLLING_SOURCE_TIMER_INTERVAL,
+      },
+    },
+  },
+  methods: {
+    _getSeenIds() {
+      return this.db.get("seenIds") ?? [];
+    },
+    _setSeenIds(ids) {
+      this.db.set("seenIds", ids);
+    },
+    generateMeta(link) {
+      const ts = link.inserted_at
+        ? new Date(link.inserted_at).getTime()
+        : Date.now();
+      return {
+        id: `${link.id}`,
+        summary: `New link ${link.id}: ${link.url}`,
+        ts,
+      };
+    },
+  },
+  async run() {
+    const seenIds = this._getSeenIds();
+    const firstRun = seenIds.length === 0;
+    const seen = new Set(seenIds);
+    const allIds = [];
+    const iterator = this.linkly.paginate({
+      resourceFn: this.linkly.listLinks,
+      resourceType: "links",
+    });
+    for await (const link of iterator) {
+      allIds.push(link.id);
+      if (seen.has(link.id)) continue;
+      if (!firstRun) {
+        this.$emit(link, this.generateMeta(link));
+      }
+    }
+    // Cap the seen list to the most recent 5000 IDs to bound DB usage
+    this._setSeenIds(allIds.slice(0, 5000));
+  },
+};

--- a/components/linkly/sources/new-link-created/new-link-created.mjs
+++ b/components/linkly/sources/new-link-created/new-link-created.mjs
@@ -5,7 +5,7 @@ export default {
   type: "source",
   key: "linkly-new-link-created",
   name: "New Link Created",
-  description: "Emit a new event when a new link is created in the workspace via the [Linkly URL Shortener API](https://linklyhq.com). Useful for syncing newly-created short links to a CRM, spreadsheet, or analytics destination.",
+  description: "Emit a new event when a new link is created in the workspace via the [Linkly URL Shortener API](https://linklyhq.com). Useful for syncing newly-created short links to a CRM, spreadsheet, or analytics destination. [See the documentation](https://linklyhq.com/url-shortener-api).",
   version: "0.0.2",
   dedupe: "unique",
   props: {

--- a/components/linkly/sources/new-link-created/new-link-created.mjs
+++ b/components/linkly/sources/new-link-created/new-link-created.mjs
@@ -5,7 +5,7 @@ export default {
   type: "source",
   key: "linkly-new-link-created",
   name: "New Link Created",
-  description: "Emit a new event when a new link is created in the workspace. Polls `GET /api/v1/workspace/{workspace_id}/list_links` sorted by `inserted_at` and emits anything newer than the last seen link ID. Useful for syncing newly-created short links to a CRM, spreadsheet, or analytics destination. [See the documentation](https://app.linklyhq.com/swaggerui#/Links/listLinks).",
+  description: "Emit new event when a new link is created in the workspace. Polls `GET /api/v1/workspace/{workspace_id}/list_links` sorted by `inserted_at` and emits anything newer than the last seen link ID. Useful for syncing newly-created short links to a CRM, spreadsheet, or analytics destination. [See the documentation](https://app.linklyhq.com/swaggerui#/Links/listLinks).",
   version: "0.0.1",
   dedupe: "unique",
   props: {

--- a/components/linkly/sources/new-link-created/new-link-created.mjs
+++ b/components/linkly/sources/new-link-created/new-link-created.mjs
@@ -5,7 +5,7 @@ export default {
   type: "source",
   key: "linkly-new-link-created",
   name: "New Link Created",
-  description: "Emit a new event when a new [Linkly](https://linklyhq.com) link is created in the workspace. Useful for syncing newly-created short links to a CRM, spreadsheet, or [analytics](https://linklyhq.com/url-shortener-analytics) destination.",
+  description: "Emit a new event when a new link is created in the workspace via the [Linkly URL Shortener API](https://linklyhq.com). Useful for syncing newly-created short links to a CRM, spreadsheet, or analytics destination.",
   version: "0.0.1",
   dedupe: "unique",
   props: {

--- a/components/linkly/sources/new-link-created/new-link-created.mjs
+++ b/components/linkly/sources/new-link-created/new-link-created.mjs
@@ -6,7 +6,7 @@ export default {
   key: "linkly-new-link-created",
   name: "New Link Created",
   description: "Emit a new event when a new link is created in the workspace via the [Linkly URL Shortener API](https://linklyhq.com). Useful for syncing newly-created short links to a CRM, spreadsheet, or analytics destination.",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
   props: {
     linkly,
@@ -19,11 +19,11 @@ export default {
     },
   },
   methods: {
-    _getSeenIds() {
-      return this.db.get("seenIds") ?? [];
+    _getLastSeenId() {
+      return this.db.get("lastSeenId");
     },
-    _setSeenIds(ids) {
-      this.db.set("seenIds", ids);
+    _setLastSeenId(id) {
+      this.db.set("lastSeenId", id);
     },
     generateMeta(link) {
       const ts = link.inserted_at
@@ -37,22 +37,46 @@ export default {
     },
   },
   async run() {
-    const seenIds = this._getSeenIds();
-    const firstRun = seenIds.length === 0;
-    const seen = new Set(seenIds);
-    const allIds = [];
+    const lastSeenId = this._getLastSeenId();
+    const firstRun = lastSeenId == null;
+    let highestId = lastSeenId ?? 0;
+    const newLinks = [];
+
+    // Walk pages sorted by inserted_at desc. Stop as soon as we hit a link
+    // we've already seen (id <= lastSeenId) — link IDs are monotonically
+    // increasing, so everything past that point is older history.
     const iterator = this.linkly.paginate({
       resourceFn: this.linkly.listLinks,
       resourceType: "links",
+      params: {
+        sort_by: "inserted_at",
+        sort_dir: "desc",
+      },
     });
+
     for await (const link of iterator) {
-      allIds.push(link.id);
-      if (seen.has(link.id)) continue;
-      if (!firstRun) {
+      if (!firstRun && link.id <= lastSeenId) break;
+      if (link.id > highestId) highestId = link.id;
+      newLinks.push(link);
+      // On first run, only record the high-water mark from the first page —
+      // don't drain the whole workspace history.
+      if (firstRun && newLinks.length >= 1) break;
+    }
+
+    // Emit oldest-first so downstream workflows process events in chronological
+    // order. Skip emission entirely on first run — just set the watermark.
+    if (!firstRun) {
+      for (const link of newLinks.reverse()) {
         this.$emit(link, this.generateMeta(link));
       }
     }
-    // Cap the seen list to the most recent 5000 IDs to bound DB usage
-    this._setSeenIds(allIds.slice(0, 5000));
+
+    if (highestId > (lastSeenId ?? 0)) {
+      this._setLastSeenId(highestId);
+    } else if (firstRun) {
+      // No links in the workspace yet — set watermark to 0 so subsequent
+      // polls correctly identify any future link as new.
+      this._setLastSeenId(0);
+    }
   },
 };


### PR DESCRIPTION
## Summary

Expands the Linkly integration from 2 actions + 1 polling source to **7 actions + 2 sources**, and rewrites the existing click source from polling to a real-time webhook subscription.

This is from Chris (Linkly maintainer) — I run Linkly and noticed our Pipedream integration only exposed a fraction of our public API.

### Headline change: real-time webhook click source

The previous \`new-link-clicked\` source polled \`list-links\` every 15 minutes and emitted events when \`clicks_total\` increased. This had a few problems:

- Up to 15 minutes of delay before workflows fired
- Only emitted the link object, not the click metadata (location, device, browser, referrer)
- N clicks within an interval collapsed into 1 event with a count
- Inefficient API usage on workspaces with many links

Linkly already supports webhook subscriptions via [\`POST /api/v1/workspace/:id/webhooks\`](https://linklyhq.com/url-shortener-api). The rewritten source uses Pipedream's \`$.interface.http\` and subscribes/unsubscribes via the activate/deactivate hooks. Events arrive within seconds with full click metadata.

**Caveat:** Webhooks require a paid Linkly plan. The source description and README both flag this.

### New actions

| Action | Purpose |
|---|---|
| List Links | Paginated list with optional search |
| Update Link | Change destination, slug, name, or domain |
| Delete Link | Permanent delete |
| List Domains | Custom domains in workspace (also exposed as \`domainId\` prop dropdown) |
| List Workspaces | Workspaces the API key can access (helpful for finding workspace ID) |

### New source

- **New Link Created** (polling) — emits when a new link is added to the workspace. Skips initial population on first run.

### Refresh to existing components

- \`linkly.app.mjs\`: added prop definitions for \`url\`, \`name\`, \`slug\`, \`domainId\` (with dropdown options via \`listDomains\`); added methods for update/delete/listDomains/listWorkspaces/webhook subscribe/unsubscribe.
- \`create-link\`: exposed optional \`name\`, \`slug\`, \`domainId\` props; description now links to canonical docs at linklyhq.com instead of the swagger UI subdomain.
- \`get-link\`: removed unnecessary \`workspace_id\` query param (the endpoint uses \`current_workspace\` from auth, the param was ignored).
- README rewritten with a components table and current use cases.

### Verification

All 11 \`.mjs\` files pass \`node --check\` syntax validation. I built and tested locally against the live Linkly API on my own workspace.

## Checklist

### Versioning
- [x] All components updated in this PR had their version updated (\`0.0.1\` for new ones, patch bumps for non-breaking changes, \`0.2.0\` minor bump for the breaking webhook rewrite)
- [x] The app updated in this PR had its \`package.json\`'s version updated (\`0.1.0\` → \`0.2.0\`)

### New app
- [x] The app updated in this PR is already integrated (Linkly app exists at https://pipedream.com/apps/linkly, scaffolded by @dylburger in #9353 / #8503)

### CodeRabbit review
- [ ] I have addressed or acknowledged all of CodeRabbit's review comments (will address once it runs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Instant webhook-driven click events for shared links (replaces polling)
  * New "New Link Created" source (polling-based initial scan + incremental emits)
  * Actions: Create, Update, Delete, List Links; List Domains; List Workspaces
  * Create/Update support optional name, domain, and slug; domain selectable from workspace domains
* **Documentation**
  * Linkly docs rewritten: condensed overview, Authentication section, Components table, expanded example use cases
* **Chores**
  * Linkly package version bumped to 0.2.0

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PipedreamHQ/pipedream/pull/20862)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->