### PR TITLE
Confluence - List Post ID Options bug fix

### DIFF
--- a/components/confluence/actions/list-post-id-options/list-post-id-options.mjs
+++ b/components/confluence/actions/list-post-id-options/list-post-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "confluence-list-post-id-options",
   name: "List Post ID Options",
   description: "Retrieves available options for the Post ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -22,9 +22,11 @@ export default {
   },
   async run({ $ }) {
     const options = await confluence.propDefinitions.postId.options.call(this.confluence, {
-      cursor: this.cursor,
+      prevContext: {
+        cursor: this.cursor,
+      },
     });
-    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+    $.export("$summary", `Successfully retrieved ${options.options.length} option${options.options.length === 1
       ? ""
       : "s"}`);
     return options;

--- a/components/confluence/package.json
+++ b/components/confluence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/confluence",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Pipedream Confluence Components",
   "main": "confluence.app.mjs",
   "keywords": [


### PR DESCRIPTION
Fixes a bug in the way `cursor` is passed to `options`, and updates `$summary` to display correct number of options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Confluence API response handling to correctly retrieve option counts in list operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PipedreamHQ/pipedream/pull/20899?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->