### PR TITLE
Actions for page only prop options batch 1

### DIFF
--- a/components/accelo/accelo.app.mjs
+++ b/components/accelo/accelo.app.mjs
@@ -4,6 +4,13 @@ export default {
   type: "app",
   app: "accelo",
   propDefinitions: {
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve, zero-based.",
+      min: 0,
+      default: 0,
+    },
     companyId: {
       label: "Company ID",
       description: "The company ID",

--- a/components/accelo/actions/create-contact/create-contact.mjs
+++ b/components/accelo/actions/create-contact/create-contact.mjs
@@ -2,7 +2,7 @@ import accelo from "../../accelo.app.mjs";
 
 export default {
   name: "Create Contact",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/accelo/actions/create-prospect/create-prospect.mjs
+++ b/components/accelo/actions/create-prospect/create-prospect.mjs
@@ -2,7 +2,7 @@ import accelo from "../../accelo.app.mjs";
 
 export default {
   name: "Create Prospect",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/accelo/actions/create-request/create-request.mjs
+++ b/components/accelo/actions/create-request/create-request.mjs
@@ -2,7 +2,7 @@ import accelo from "../../accelo.app.mjs";
 
 export default {
   name: "Create Request",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/accelo/actions/list-affiliation-id-options/list-affiliation-id-options.mjs
+++ b/components/accelo/actions/list-affiliation-id-options/list-affiliation-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "accelo-list-affiliation-id-options",
   name: "List Affiliation ID Options",
   description: "Retrieves available options for the Affiliation ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/accelo/actions/list-affiliation-id-options/list-affiliation-id-options.mjs
+++ b/components/accelo/actions/list-affiliation-id-options/list-affiliation-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "accelo-list-affiliation-id-options",
   name: "List Affiliation ID Options",
   description: "Retrieves available options for the Affiliation ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     accelo,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await accelo.propDefinitions.affiliationId.options
-        .call(this.accelo, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await accelo.propDefinitions.affiliationId.options
+      .call(this.accelo, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/accelo/actions/list-affiliation-id-options/list-affiliation-id-options.mjs
+++ b/components/accelo/actions/list-affiliation-id-options/list-affiliation-id-options.mjs
@@ -1,0 +1,34 @@
+import accelo from "../../accelo.app.mjs";
+
+export default {
+  key: "accelo-list-affiliation-id-options",
+  name: "List Affiliation ID Options",
+  description: "Retrieves available options for the Affiliation ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    accelo,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await accelo.propDefinitions.affiliationId.options
+        .call(this.accelo, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/accelo/actions/list-affiliation-id-options/list-affiliation-id-options.mjs
+++ b/components/accelo/actions/list-affiliation-id-options/list-affiliation-id-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     accelo,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        accelo,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/accelo/actions/list-affiliation-id-options/list-affiliation-id-options.mjs
+++ b/components/accelo/actions/list-affiliation-id-options/list-affiliation-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/accelo/actions/list-company-id-options/list-company-id-options.mjs
+++ b/components/accelo/actions/list-company-id-options/list-company-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "accelo-list-company-id-options",
   name: "List Company ID Options",
   description: "Retrieves available options for the Company ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/accelo/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/accelo/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "accelo-list-contact-id-options",
   name: "List Contact ID Options",
   description: "Retrieves available options for the Contact ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     accelo,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await accelo.propDefinitions.contactId.options
-        .call(this.accelo, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await accelo.propDefinitions.contactId.options
+      .call(this.accelo, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/accelo/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/accelo/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "accelo-list-contact-id-options",
   name: "List Contact ID Options",
   description: "Retrieves available options for the Contact ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/accelo/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/accelo/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     accelo,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        accelo,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/accelo/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/accelo/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -1,0 +1,34 @@
+import accelo from "../../accelo.app.mjs";
+
+export default {
+  key: "accelo-list-contact-id-options",
+  name: "List Contact ID Options",
+  description: "Retrieves available options for the Contact ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    accelo,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await accelo.propDefinitions.contactId.options
+        .call(this.accelo, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/accelo/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/accelo/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/accelo/actions/list-prospect-type-id-options/list-prospect-type-id-options.mjs
+++ b/components/accelo/actions/list-prospect-type-id-options/list-prospect-type-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "accelo-list-prospect-type-id-options",
   name: "List Prospect Type ID Options",
   description: "Retrieves available options for the Prospect Type ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/accelo/actions/list-prospect-type-id-options/list-prospect-type-id-options.mjs
+++ b/components/accelo/actions/list-prospect-type-id-options/list-prospect-type-id-options.mjs
@@ -1,0 +1,34 @@
+import accelo from "../../accelo.app.mjs";
+
+export default {
+  key: "accelo-list-prospect-type-id-options",
+  name: "List Prospect Type ID Options",
+  description: "Retrieves available options for the Prospect Type ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    accelo,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await accelo.propDefinitions.prospectTypeId.options
+        .call(this.accelo, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/accelo/actions/list-prospect-type-id-options/list-prospect-type-id-options.mjs
+++ b/components/accelo/actions/list-prospect-type-id-options/list-prospect-type-id-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     accelo,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        accelo,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/accelo/actions/list-prospect-type-id-options/list-prospect-type-id-options.mjs
+++ b/components/accelo/actions/list-prospect-type-id-options/list-prospect-type-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/accelo/actions/list-prospect-type-id-options/list-prospect-type-id-options.mjs
+++ b/components/accelo/actions/list-prospect-type-id-options/list-prospect-type-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "accelo-list-prospect-type-id-options",
   name: "List Prospect Type ID Options",
   description: "Retrieves available options for the Prospect Type ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     accelo,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await accelo.propDefinitions.prospectTypeId.options
-        .call(this.accelo, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await accelo.propDefinitions.prospectTypeId.options
+      .call(this.accelo, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/accelo/actions/list-request-type-id-options/list-request-type-id-options.mjs
+++ b/components/accelo/actions/list-request-type-id-options/list-request-type-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "accelo-list-request-type-id-options",
   name: "List Request Type ID Options",
   description: "Retrieves available options for the Request Type ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     accelo,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await accelo.propDefinitions.requestTypeId.options
-        .call(this.accelo, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await accelo.propDefinitions.requestTypeId.options
+      .call(this.accelo, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/accelo/actions/list-request-type-id-options/list-request-type-id-options.mjs
+++ b/components/accelo/actions/list-request-type-id-options/list-request-type-id-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     accelo,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        accelo,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/accelo/actions/list-request-type-id-options/list-request-type-id-options.mjs
+++ b/components/accelo/actions/list-request-type-id-options/list-request-type-id-options.mjs
@@ -1,0 +1,34 @@
+import accelo from "../../accelo.app.mjs";
+
+export default {
+  key: "accelo-list-request-type-id-options",
+  name: "List Request Type ID Options",
+  description: "Retrieves available options for the Request Type ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    accelo,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await accelo.propDefinitions.requestTypeId.options
+        .call(this.accelo, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/accelo/actions/list-request-type-id-options/list-request-type-id-options.mjs
+++ b/components/accelo/actions/list-request-type-id-options/list-request-type-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "accelo-list-request-type-id-options",
   name: "List Request Type ID Options",
   description: "Retrieves available options for the Request Type ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/accelo/actions/list-request-type-id-options/list-request-type-id-options.mjs
+++ b/components/accelo/actions/list-request-type-id-options/list-request-type-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/accelo/actions/update-contact/update-contact.mjs
+++ b/components/accelo/actions/update-contact/update-contact.mjs
@@ -2,7 +2,7 @@ import accelo from "../../accelo.app.mjs";
 
 export default {
   name: "Update Contact",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/accelo/package.json
+++ b/components/accelo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/accelo",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Accelo Components",
   "main": "accelo.app.mjs",
   "keywords": [

--- a/components/accelo/sources/new-request-created/new-request-created.mjs
+++ b/components/accelo/sources/new-request-created/new-request-created.mjs
@@ -3,7 +3,7 @@ import common from "../common/common.mjs";
 export default {
   ...common,
   name: "New Request Created (Instant)",
-  version: "0.0.1",
+  version: "0.0.2",
   key: "accelo-new-request-created",
   description: "Emit new event on each new request created.",
   type: "source",

--- a/components/accelo/sources/new-task-assigned/new-task-assigned.mjs
+++ b/components/accelo/sources/new-task-assigned/new-task-assigned.mjs
@@ -3,7 +3,7 @@ import common from "../common/common.mjs";
 export default {
   ...common,
   name: "New Task Assigned (Instant)",
-  version: "0.0.1",
+  version: "0.0.2",
   key: "accelo-new-task-assigned",
   description: "Emit new event on each new task assigned.",
   type: "source",

--- a/components/accredible/accredible.app.mjs
+++ b/components/accredible/accredible.app.mjs
@@ -6,6 +6,13 @@ export default {
   type: "app",
   app: "accredible",
   propDefinitions: {
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve, zero-based.",
+      min: 0,
+      default: 0,
+    },
     credentialId: {
       type: "string",
       label: "Credential ID",

--- a/components/accredible/actions/create-credential/create-credential.mjs
+++ b/components/accredible/actions/create-credential/create-credential.mjs
@@ -4,7 +4,7 @@ export default {
   key: "accredible-create-credential",
   name: "Create Credential",
   description: "Issue a new credential to a given recipient. [See the documentation](https://accrediblecredentialapi.docs.apiary.io/#reference/credentials/credentials/create-a-new-credential)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/accredible/actions/delete-credential/delete-credential.mjs
+++ b/components/accredible/actions/delete-credential/delete-credential.mjs
@@ -4,7 +4,7 @@ export default {
   key: "accredible-delete-credential",
   name: "Delete Credential",
   description: "Remove a specific credential from the system. [See the documentation](https://accrediblecredentialapi.docs.apiary.io/#reference/credentials/credential/delete-a-credential)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/accredible/actions/list-credential-id-options/list-credential-id-options.mjs
+++ b/components/accredible/actions/list-credential-id-options/list-credential-id-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     accredible,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        accredible,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/accredible/actions/list-credential-id-options/list-credential-id-options.mjs
+++ b/components/accredible/actions/list-credential-id-options/list-credential-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "accredible-list-credential-id-options",
   name: "List Credential ID Options",
   description: "Retrieves available options for the Credential ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/accredible/actions/list-credential-id-options/list-credential-id-options.mjs
+++ b/components/accredible/actions/list-credential-id-options/list-credential-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "accredible-list-credential-id-options",
   name: "List Credential ID Options",
   description: "Retrieves available options for the Credential ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     accredible,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await accredible.propDefinitions.credentialId.options
-        .call(this.accredible, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await accredible.propDefinitions.credentialId.options
+      .call(this.accredible, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/accredible/actions/list-credential-id-options/list-credential-id-options.mjs
+++ b/components/accredible/actions/list-credential-id-options/list-credential-id-options.mjs
@@ -1,0 +1,34 @@
+import accredible from "../../accredible.app.mjs";
+
+export default {
+  key: "accredible-list-credential-id-options",
+  name: "List Credential ID Options",
+  description: "Retrieves available options for the Credential ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    accredible,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await accredible.propDefinitions.credentialId.options
+        .call(this.accredible, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/accredible/actions/list-credential-id-options/list-credential-id-options.mjs
+++ b/components/accredible/actions/list-credential-id-options/list-credential-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/accredible/actions/list-group-id-options/list-group-id-options.mjs
+++ b/components/accredible/actions/list-group-id-options/list-group-id-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     accredible,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        accredible,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/accredible/actions/list-group-id-options/list-group-id-options.mjs
+++ b/components/accredible/actions/list-group-id-options/list-group-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "accredible-list-group-id-options",
   name: "List Group ID Options",
   description: "Retrieves available options for the Group ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     accredible,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await accredible.propDefinitions.groupId.options
-        .call(this.accredible, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await accredible.propDefinitions.groupId.options
+      .call(this.accredible, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/accredible/actions/list-group-id-options/list-group-id-options.mjs
+++ b/components/accredible/actions/list-group-id-options/list-group-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "accredible-list-group-id-options",
   name: "List Group ID Options",
   description: "Retrieves available options for the Group ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/accredible/actions/list-group-id-options/list-group-id-options.mjs
+++ b/components/accredible/actions/list-group-id-options/list-group-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/accredible/actions/list-group-id-options/list-group-id-options.mjs
+++ b/components/accredible/actions/list-group-id-options/list-group-id-options.mjs
@@ -1,0 +1,34 @@
+import accredible from "../../accredible.app.mjs";
+
+export default {
+  key: "accredible-list-group-id-options",
+  name: "List Group ID Options",
+  description: "Retrieves available options for the Group ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    accredible,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await accredible.propDefinitions.groupId.options
+        .call(this.accredible, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/accredible/actions/update-credential/update-credential.mjs
+++ b/components/accredible/actions/update-credential/update-credential.mjs
@@ -4,7 +4,7 @@ export default {
   key: "accredible-update-credential",
   name: "Update Credential",
   description: "Modify the details of an existing credential. [See the documentation](https://accrediblecredentialapi.docs.apiary.io/#reference/credentials/credential/update-a-credential)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/accredible/package.json
+++ b/components/accredible/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/accredible",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Accredible Components",
   "main": "accredible.app.mjs",
   "keywords": [

--- a/components/accredible/sources/issued-credential/issued-credential.mjs
+++ b/components/accredible/sources/issued-credential/issued-credential.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Issued Credential",
   description: "This source triggers when a new credential is issued to a recipient. [See the documentation](https://accrediblecredentialapi.docs.apiary.io/#reference/credentials/search-credentials-v2/search-for-credentials).",
   type: "source",
-  version: "0.0.1",
+  version: "0.0.2",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/accredible/sources/updated-credential/updated-credential.mjs
+++ b/components/accredible/sources/updated-credential/updated-credential.mjs
@@ -6,7 +6,7 @@ export default {
   key: "accredible-updated-credential",
   name: "Updated Credential",
   description: "Emit new event when an existing credential's details are updated or modified. [See the documentation](https://accrediblecredentialapi.docs.apiary.io/#reference/credentials/search-credentials-v2/search-for-credentials).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/accuranker/actions/list-domain-id-options/list-domain-id-options.mjs
+++ b/components/accuranker/actions/list-domain-id-options/list-domain-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "accuranker-list-domain-id-options",
   name: "List Domain ID Options",
   description: "Retrieves available options for the Domain ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/accuranker/actions/list-domain-id-options/list-domain-id-options.mjs
+++ b/components/accuranker/actions/list-domain-id-options/list-domain-id-options.mjs
@@ -1,0 +1,34 @@
+import accuranker from "../../accuranker.app.mjs";
+
+export default {
+  key: "accuranker-list-domain-id-options",
+  name: "List Domain ID Options",
+  description: "Retrieves available options for the Domain ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    accuranker,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await accuranker.propDefinitions.domainId.options
+        .call(this.accuranker, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/accuranker/actions/list-domain-id-options/list-domain-id-options.mjs
+++ b/components/accuranker/actions/list-domain-id-options/list-domain-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "accuranker-list-domain-id-options",
   name: "List Domain ID Options",
   description: "Retrieves available options for the Domain ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     accuranker,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await accuranker.propDefinitions.domainId.options
-        .call(this.accuranker, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await accuranker.propDefinitions.domainId.options
+      .call(this.accuranker, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/accuranker/actions/list-domain-id-options/list-domain-id-options.mjs
+++ b/components/accuranker/actions/list-domain-id-options/list-domain-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/accuranker/package.json
+++ b/components/accuranker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/accuranker",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Pipedream accuranker Components",
   "main": "accuranker.app.mjs",
   "keywords": [

--- a/components/acelle_mail/acelle_mail.app.mjs
+++ b/components/acelle_mail/acelle_mail.app.mjs
@@ -4,6 +4,13 @@ export default {
   type: "app",
   app: "acelle_mail",
   propDefinitions: {
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve, zero-based.",
+      min: 0,
+      default: 0,
+    },
     subscriberId: {
       type: "string",
       label: "Subscriber ID",

--- a/components/acelle_mail/actions/create-customer/create-customer.mjs
+++ b/components/acelle_mail/actions/create-customer/create-customer.mjs
@@ -3,7 +3,7 @@ import constants from "../common/constants.mjs";
 
 export default {
   name: "Create Customer",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/acelle_mail/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/acelle_mail/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "acelle_mail-list-customer-id-options",
   name: "List Customer ID Options",
   description: "Retrieves available options for the Customer ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/acelle_mail/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/acelle_mail/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "acelle_mail-list-customer-id-options",
   name: "List Customer ID Options",
   description: "Retrieves available options for the Customer ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     acelle_mail,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await acelle_mail.propDefinitions.customerId.options
-        .call(this.acelle_mail, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await acelle_mail.propDefinitions.customerId.options
+      .call(this.acelle_mail, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/acelle_mail/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/acelle_mail/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -1,0 +1,34 @@
+import acelle_mail from "../../acelle_mail.app.mjs";
+
+export default {
+  key: "acelle_mail-list-customer-id-options",
+  name: "List Customer ID Options",
+  description: "Retrieves available options for the Customer ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    acelle_mail,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await acelle_mail.propDefinitions.customerId.options
+        .call(this.acelle_mail, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/acelle_mail/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/acelle_mail/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/acelle_mail/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/acelle_mail/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     acelle_mail,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        acelle_mail,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/acelle_mail/actions/list-plan-id-options/list-plan-id-options.mjs
+++ b/components/acelle_mail/actions/list-plan-id-options/list-plan-id-options.mjs
@@ -1,0 +1,34 @@
+import acelle_mail from "../../acelle_mail.app.mjs";
+
+export default {
+  key: "acelle_mail-list-plan-id-options",
+  name: "List Plan ID Options",
+  description: "Retrieves available options for the Plan ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    acelle_mail,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await acelle_mail.propDefinitions.planId.options
+        .call(this.acelle_mail, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/acelle_mail/actions/list-plan-id-options/list-plan-id-options.mjs
+++ b/components/acelle_mail/actions/list-plan-id-options/list-plan-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "acelle_mail-list-plan-id-options",
   name: "List Plan ID Options",
   description: "Retrieves available options for the Plan ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     acelle_mail,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await acelle_mail.propDefinitions.planId.options
-        .call(this.acelle_mail, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await acelle_mail.propDefinitions.planId.options
+      .call(this.acelle_mail, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/acelle_mail/actions/list-plan-id-options/list-plan-id-options.mjs
+++ b/components/acelle_mail/actions/list-plan-id-options/list-plan-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "acelle_mail-list-plan-id-options",
   name: "List Plan ID Options",
   description: "Retrieves available options for the Plan ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/acelle_mail/actions/list-plan-id-options/list-plan-id-options.mjs
+++ b/components/acelle_mail/actions/list-plan-id-options/list-plan-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/acelle_mail/actions/list-plan-id-options/list-plan-id-options.mjs
+++ b/components/acelle_mail/actions/list-plan-id-options/list-plan-id-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     acelle_mail,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        acelle_mail,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/acelle_mail/actions/list-subscriber-id-options/list-subscriber-id-options.mjs
+++ b/components/acelle_mail/actions/list-subscriber-id-options/list-subscriber-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "acelle_mail-list-subscriber-id-options",
   name: "List Subscriber ID Options",
   description: "Retrieves available options for the Subscriber ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     acelle_mail,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await acelle_mail.propDefinitions.subscriberId.options
-        .call(this.acelle_mail, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await acelle_mail.propDefinitions.subscriberId.options
+      .call(this.acelle_mail, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/acelle_mail/actions/list-subscriber-id-options/list-subscriber-id-options.mjs
+++ b/components/acelle_mail/actions/list-subscriber-id-options/list-subscriber-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "acelle_mail-list-subscriber-id-options",
   name: "List Subscriber ID Options",
   description: "Retrieves available options for the Subscriber ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/acelle_mail/actions/list-subscriber-id-options/list-subscriber-id-options.mjs
+++ b/components/acelle_mail/actions/list-subscriber-id-options/list-subscriber-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/acelle_mail/actions/list-subscriber-id-options/list-subscriber-id-options.mjs
+++ b/components/acelle_mail/actions/list-subscriber-id-options/list-subscriber-id-options.mjs
@@ -1,0 +1,34 @@
+import acelle_mail from "../../acelle_mail.app.mjs";
+
+export default {
+  key: "acelle_mail-list-subscriber-id-options",
+  name: "List Subscriber ID Options",
+  description: "Retrieves available options for the Subscriber ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    acelle_mail,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await acelle_mail.propDefinitions.subscriberId.options
+        .call(this.acelle_mail, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/acelle_mail/actions/list-subscriber-id-options/list-subscriber-id-options.mjs
+++ b/components/acelle_mail/actions/list-subscriber-id-options/list-subscriber-id-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     acelle_mail,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        acelle_mail,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/acelle_mail/actions/subscribe-customer-to-plan/subscribe-customer-to-plan.mjs
+++ b/components/acelle_mail/actions/subscribe-customer-to-plan/subscribe-customer-to-plan.mjs
@@ -2,7 +2,7 @@ import app from "../../acelle_mail.app.mjs";
 
 export default {
   name: "Subscribe Customer To Plan",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/acelle_mail/package.json
+++ b/components/acelle_mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/acelle_mail",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream Acelle Mail Components",
   "main": "acelle_mail.app.mjs",
   "keywords": [

--- a/components/activecalculator/actions/list-calculator-ids-options/list-calculator-ids-options.mjs
+++ b/components/activecalculator/actions/list-calculator-ids-options/list-calculator-ids-options.mjs
@@ -1,0 +1,34 @@
+import activecalculator from "../../activecalculator.app.mjs";
+
+export default {
+  key: "activecalculator-list-calculator-ids-options",
+  name: "List Calculator Ids Options",
+  description: "Retrieves available options for the Calculator Ids field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    activecalculator,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await activecalculator.propDefinitions.calculatorIds.options
+        .call(this.activecalculator, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/activecalculator/actions/list-calculator-ids-options/list-calculator-ids-options.mjs
+++ b/components/activecalculator/actions/list-calculator-ids-options/list-calculator-ids-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "activecalculator-list-calculator-ids-options",
   name: "List Calculator Ids Options",
   description: "Retrieves available options for the Calculator Ids field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     activecalculator,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await activecalculator.propDefinitions.calculatorIds.options
-        .call(this.activecalculator, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await activecalculator.propDefinitions.calculatorIds.options
+      .call(this.activecalculator, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/activecalculator/actions/list-calculator-ids-options/list-calculator-ids-options.mjs
+++ b/components/activecalculator/actions/list-calculator-ids-options/list-calculator-ids-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "activecalculator-list-calculator-ids-options",
   name: "List Calculator Ids Options",
   description: "Retrieves available options for the Calculator Ids field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/activecalculator/actions/list-calculator-ids-options/list-calculator-ids-options.mjs
+++ b/components/activecalculator/actions/list-calculator-ids-options/list-calculator-ids-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/activecalculator/package.json
+++ b/components/activecalculator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/activecalculator",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream ActiveCalculator Components",
   "main": "activecalculator.app.mjs",
   "keywords": [
@@ -16,4 +16,3 @@
     "@pipedream/platform": "^3.1.1"
   }
 }
-

--- a/components/acymailing/actions/list-emails-options/list-emails-options.mjs
+++ b/components/acymailing/actions/list-emails-options/list-emails-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "acymailing-list-emails-options",
   name: "List Emails Options",
   description: "Retrieves available options for the Emails field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     acymailing,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await acymailing.propDefinitions.emails.options
-        .call(this.acymailing, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await acymailing.propDefinitions.emails.options
+      .call(this.acymailing, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/acymailing/actions/list-emails-options/list-emails-options.mjs
+++ b/components/acymailing/actions/list-emails-options/list-emails-options.mjs
@@ -1,0 +1,34 @@
+import acymailing from "../../acymailing.app.mjs";
+
+export default {
+  key: "acymailing-list-emails-options",
+  name: "List Emails Options",
+  description: "Retrieves available options for the Emails field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    acymailing,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await acymailing.propDefinitions.emails.options
+        .call(this.acymailing, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/acymailing/actions/list-emails-options/list-emails-options.mjs
+++ b/components/acymailing/actions/list-emails-options/list-emails-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "acymailing-list-emails-options",
   name: "List Emails Options",
   description: "Retrieves available options for the Emails field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/acymailing/actions/list-emails-options/list-emails-options.mjs
+++ b/components/acymailing/actions/list-emails-options/list-emails-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/acymailing/actions/list-list-ids-options/list-list-ids-options.mjs
+++ b/components/acymailing/actions/list-list-ids-options/list-list-ids-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "acymailing-list-list-ids-options",
   name: "List List Ids Options",
   description: "Retrieves available options for the List Ids field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/acymailing/actions/list-list-ids-options/list-list-ids-options.mjs
+++ b/components/acymailing/actions/list-list-ids-options/list-list-ids-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "acymailing-list-list-ids-options",
   name: "List List Ids Options",
   description: "Retrieves available options for the List Ids field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     acymailing,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await acymailing.propDefinitions.listIds.options
-        .call(this.acymailing, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await acymailing.propDefinitions.listIds.options
+      .call(this.acymailing, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/acymailing/actions/list-list-ids-options/list-list-ids-options.mjs
+++ b/components/acymailing/actions/list-list-ids-options/list-list-ids-options.mjs
@@ -1,0 +1,34 @@
+import acymailing from "../../acymailing.app.mjs";
+
+export default {
+  key: "acymailing-list-list-ids-options",
+  name: "List List Ids Options",
+  description: "Retrieves available options for the List Ids field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    acymailing,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await acymailing.propDefinitions.listIds.options
+        .call(this.acymailing, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/acymailing/actions/list-list-ids-options/list-list-ids-options.mjs
+++ b/components/acymailing/actions/list-list-ids-options/list-list-ids-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/acymailing/package.json
+++ b/components/acymailing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/acymailing",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream AcyMailing Components",
   "main": "acymailing.app.mjs",
   "keywords": [
@@ -16,4 +16,3 @@
     "@pipedream/platform": "^2.0.2"
   }
 }
-

--- a/components/addevent/actions/list-calendar-id-options/list-calendar-id-options.mjs
+++ b/components/addevent/actions/list-calendar-id-options/list-calendar-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "addevent-list-calendar-id-options",
   name: "List Calendar ID Options",
   description: "Retrieves available options for the Calendar ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     addevent,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await addevent.propDefinitions.calendarId.options
-        .call(this.addevent, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await addevent.propDefinitions.calendarId.options
+      .call(this.addevent, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/addevent/actions/list-calendar-id-options/list-calendar-id-options.mjs
+++ b/components/addevent/actions/list-calendar-id-options/list-calendar-id-options.mjs
@@ -1,0 +1,34 @@
+import addevent from "../../addevent.app.mjs";
+
+export default {
+  key: "addevent-list-calendar-id-options",
+  name: "List Calendar ID Options",
+  description: "Retrieves available options for the Calendar ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    addevent,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await addevent.propDefinitions.calendarId.options
+        .call(this.addevent, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/addevent/actions/list-calendar-id-options/list-calendar-id-options.mjs
+++ b/components/addevent/actions/list-calendar-id-options/list-calendar-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/addevent/actions/list-calendar-id-options/list-calendar-id-options.mjs
+++ b/components/addevent/actions/list-calendar-id-options/list-calendar-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "addevent-list-calendar-id-options",
   name: "List Calendar ID Options",
   description: "Retrieves available options for the Calendar ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/addevent/actions/list-event-id-options/list-event-id-options.mjs
+++ b/components/addevent/actions/list-event-id-options/list-event-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "addevent-list-event-id-options",
   name: "List Event ID Options",
   description: "Retrieves available options for the Event ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/addevent/actions/list-event-id-options/list-event-id-options.mjs
+++ b/components/addevent/actions/list-event-id-options/list-event-id-options.mjs
@@ -1,0 +1,34 @@
+import addevent from "../../addevent.app.mjs";
+
+export default {
+  key: "addevent-list-event-id-options",
+  name: "List Event ID Options",
+  description: "Retrieves available options for the Event ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    addevent,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await addevent.propDefinitions.eventId.options
+        .call(this.addevent, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/addevent/actions/list-event-id-options/list-event-id-options.mjs
+++ b/components/addevent/actions/list-event-id-options/list-event-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "addevent-list-event-id-options",
   name: "List Event ID Options",
   description: "Retrieves available options for the Event ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     addevent,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await addevent.propDefinitions.eventId.options
-        .call(this.addevent, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await addevent.propDefinitions.eventId.options
+      .call(this.addevent, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/addevent/actions/list-event-id-options/list-event-id-options.mjs
+++ b/components/addevent/actions/list-event-id-options/list-event-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/addevent/package.json
+++ b/components/addevent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/addevent",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream addevent Components",
   "main": "addevent.app.mjs",
   "keywords": [

--- a/components/adhook/actions/list-post-id-options/list-post-id-options.mjs
+++ b/components/adhook/actions/list-post-id-options/list-post-id-options.mjs
@@ -1,0 +1,34 @@
+import adhook from "../../adhook.app.mjs";
+
+export default {
+  key: "adhook-list-post-id-options",
+  name: "List Post ID Options",
+  description: "Retrieves available options for the Post ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    adhook,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await adhook.propDefinitions.postId.options
+        .call(this.adhook, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/adhook/actions/list-post-id-options/list-post-id-options.mjs
+++ b/components/adhook/actions/list-post-id-options/list-post-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "adhook-list-post-id-options",
   name: "List Post ID Options",
   description: "Retrieves available options for the Post ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/adhook/actions/list-post-id-options/list-post-id-options.mjs
+++ b/components/adhook/actions/list-post-id-options/list-post-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "adhook-list-post-id-options",
   name: "List Post ID Options",
   description: "Retrieves available options for the Post ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     adhook,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await adhook.propDefinitions.postId.options
-        .call(this.adhook, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await adhook.propDefinitions.postId.options
+      .call(this.adhook, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/adhook/actions/list-post-id-options/list-post-id-options.mjs
+++ b/components/adhook/actions/list-post-id-options/list-post-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/adhook/package.json
+++ b/components/adhook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/adhook",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Adhook Components",
   "main": "adhook.app.mjs",
   "keywords": [

--- a/components/adrapid/actions/list-banner-id-options/list-banner-id-options.mjs
+++ b/components/adrapid/actions/list-banner-id-options/list-banner-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "adrapid-list-banner-id-options",
   name: "List Banner Id Options",
   description: "Retrieves available options for the Banner Id field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/adrapid/actions/list-banner-id-options/list-banner-id-options.mjs
+++ b/components/adrapid/actions/list-banner-id-options/list-banner-id-options.mjs
@@ -1,0 +1,34 @@
+import adrapid from "../../adrapid.app.mjs";
+
+export default {
+  key: "adrapid-list-banner-id-options",
+  name: "List Banner Id Options",
+  description: "Retrieves available options for the Banner Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    adrapid,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await adrapid.propDefinitions.bannerId.options
+        .call(this.adrapid, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/adrapid/actions/list-banner-id-options/list-banner-id-options.mjs
+++ b/components/adrapid/actions/list-banner-id-options/list-banner-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "adrapid-list-banner-id-options",
   name: "List Banner Id Options",
   description: "Retrieves available options for the Banner Id field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     adrapid,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await adrapid.propDefinitions.bannerId.options
-        .call(this.adrapid, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await adrapid.propDefinitions.bannerId.options
+      .call(this.adrapid, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/adrapid/actions/list-banner-id-options/list-banner-id-options.mjs
+++ b/components/adrapid/actions/list-banner-id-options/list-banner-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/adrapid/actions/list-template-id-options/list-template-id-options.mjs
+++ b/components/adrapid/actions/list-template-id-options/list-template-id-options.mjs
@@ -1,0 +1,34 @@
+import adrapid from "../../adrapid.app.mjs";
+
+export default {
+  key: "adrapid-list-template-id-options",
+  name: "List Template Id Options",
+  description: "Retrieves available options for the Template Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    adrapid,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await adrapid.propDefinitions.templateId.options
+        .call(this.adrapid, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/adrapid/actions/list-template-id-options/list-template-id-options.mjs
+++ b/components/adrapid/actions/list-template-id-options/list-template-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "adrapid-list-template-id-options",
   name: "List Template Id Options",
   description: "Retrieves available options for the Template Id field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/adrapid/actions/list-template-id-options/list-template-id-options.mjs
+++ b/components/adrapid/actions/list-template-id-options/list-template-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "adrapid-list-template-id-options",
   name: "List Template Id Options",
   description: "Retrieves available options for the Template Id field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     adrapid,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await adrapid.propDefinitions.templateId.options
-        .call(this.adrapid, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await adrapid.propDefinitions.templateId.options
+      .call(this.adrapid, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/adrapid/actions/list-template-id-options/list-template-id-options.mjs
+++ b/components/adrapid/actions/list-template-id-options/list-template-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/adrapid/package.json
+++ b/components/adrapid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/adrapid",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Adrapid Components",
   "main": "adrapid.app.mjs",
   "keywords": [

--- a/components/aftership/actions/list-tracking-id-options/list-tracking-id-options.mjs
+++ b/components/aftership/actions/list-tracking-id-options/list-tracking-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "aftership-list-tracking-id-options",
   name: "List Tracking ID Options",
   description: "Retrieves available options for the Tracking ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     aftership,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await aftership.propDefinitions.trackingId.options
-        .call(this.aftership, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await aftership.propDefinitions.trackingId.options
+      .call(this.aftership, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/aftership/actions/list-tracking-id-options/list-tracking-id-options.mjs
+++ b/components/aftership/actions/list-tracking-id-options/list-tracking-id-options.mjs
@@ -1,0 +1,34 @@
+import aftership from "../../aftership.app.mjs";
+
+export default {
+  key: "aftership-list-tracking-id-options",
+  name: "List Tracking ID Options",
+  description: "Retrieves available options for the Tracking ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    aftership,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await aftership.propDefinitions.trackingId.options
+        .call(this.aftership, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/aftership/actions/list-tracking-id-options/list-tracking-id-options.mjs
+++ b/components/aftership/actions/list-tracking-id-options/list-tracking-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "aftership-list-tracking-id-options",
   name: "List Tracking ID Options",
   description: "Retrieves available options for the Tracking ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/aftership/actions/list-tracking-id-options/list-tracking-id-options.mjs
+++ b/components/aftership/actions/list-tracking-id-options/list-tracking-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/aftership/package.json
+++ b/components/aftership/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/aftership",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Pipedream AfterShip Components",
   "main": "aftership.app.mjs",
   "keywords": [

--- a/components/agiliron/actions/list-contact-name-options/list-contact-name-options.mjs
+++ b/components/agiliron/actions/list-contact-name-options/list-contact-name-options.mjs
@@ -1,0 +1,34 @@
+import agiliron from "../../agiliron.app.mjs";
+
+export default {
+  key: "agiliron-list-contact-name-options",
+  name: "List Contact Name Options",
+  description: "Retrieves available options for the Contact Name field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    agiliron,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await agiliron.propDefinitions.contactName.options
+        .call(this.agiliron, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/agiliron/actions/list-contact-name-options/list-contact-name-options.mjs
+++ b/components/agiliron/actions/list-contact-name-options/list-contact-name-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "agiliron-list-contact-name-options",
   name: "List Contact Name Options",
   description: "Retrieves available options for the Contact Name field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     agiliron,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await agiliron.propDefinitions.contactName.options
-        .call(this.agiliron, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await agiliron.propDefinitions.contactName.options
+      .call(this.agiliron, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/agiliron/actions/list-contact-name-options/list-contact-name-options.mjs
+++ b/components/agiliron/actions/list-contact-name-options/list-contact-name-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "agiliron-list-contact-name-options",
   name: "List Contact Name Options",
   description: "Retrieves available options for the Contact Name field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/agiliron/actions/list-contact-name-options/list-contact-name-options.mjs
+++ b/components/agiliron/actions/list-contact-name-options/list-contact-name-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/agiliron/package.json
+++ b/components/agiliron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/agiliron",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Agiliron Components",
   "main": "agiliron.app.mjs",
   "keywords": [

--- a/components/agrello/actions/list-folder-id-options/list-folder-id-options.mjs
+++ b/components/agrello/actions/list-folder-id-options/list-folder-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "agrello-list-folder-id-options",
   name: "List Folder ID Options",
   description: "Retrieves available options for the Folder ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/agrello/actions/list-folder-id-options/list-folder-id-options.mjs
+++ b/components/agrello/actions/list-folder-id-options/list-folder-id-options.mjs
@@ -1,0 +1,34 @@
+import agrello from "../../agrello.app.mjs";
+
+export default {
+  key: "agrello-list-folder-id-options",
+  name: "List Folder ID Options",
+  description: "Retrieves available options for the Folder ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    agrello,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await agrello.propDefinitions.folderId.options
+        .call(this.agrello, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/agrello/actions/list-folder-id-options/list-folder-id-options.mjs
+++ b/components/agrello/actions/list-folder-id-options/list-folder-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "agrello-list-folder-id-options",
   name: "List Folder ID Options",
   description: "Retrieves available options for the Folder ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     agrello,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await agrello.propDefinitions.folderId.options
-        .call(this.agrello, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await agrello.propDefinitions.folderId.options
+      .call(this.agrello, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/agrello/actions/list-folder-id-options/list-folder-id-options.mjs
+++ b/components/agrello/actions/list-folder-id-options/list-folder-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/agrello/package.json
+++ b/components/agrello/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/agrello",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Agrello Components",
   "main": "agrello.app.mjs",
   "keywords": [
@@ -16,4 +16,3 @@
     "@pipedream/platform": "^3.1.1"
   }
 }
-

--- a/components/airbrake/actions/list-project-id-options/list-project-id-options.mjs
+++ b/components/airbrake/actions/list-project-id-options/list-project-id-options.mjs
@@ -1,0 +1,34 @@
+import airbrake from "../../airbrake.app.mjs";
+
+export default {
+  key: "airbrake-list-project-id-options",
+  name: "List Project ID Options",
+  description: "Retrieves available options for the Project ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    airbrake,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await airbrake.propDefinitions.projectId.options
+        .call(this.airbrake, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/airbrake/actions/list-project-id-options/list-project-id-options.mjs
+++ b/components/airbrake/actions/list-project-id-options/list-project-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "airbrake-list-project-id-options",
   name: "List Project ID Options",
   description: "Retrieves available options for the Project ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/airbrake/actions/list-project-id-options/list-project-id-options.mjs
+++ b/components/airbrake/actions/list-project-id-options/list-project-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "airbrake-list-project-id-options",
   name: "List Project ID Options",
   description: "Retrieves available options for the Project ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     airbrake,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await airbrake.propDefinitions.projectId.options
-        .call(this.airbrake, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await airbrake.propDefinitions.projectId.options
+      .call(this.airbrake, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/airbrake/actions/list-project-id-options/list-project-id-options.mjs
+++ b/components/airbrake/actions/list-project-id-options/list-project-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/airbrake/package.json
+++ b/components/airbrake/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/airbrake",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "Pipedream Airbrake Components",
   "main": "airbrake.app.mjs",
   "keywords": [

--- a/components/aircall/actions/list-call-options/list-call-options.mjs
+++ b/components/aircall/actions/list-call-options/list-call-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "aircall-list-call-options",
   name: "List Call Options",
   description: "Retrieves available options for the Call field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/aircall/actions/list-call-options/list-call-options.mjs
+++ b/components/aircall/actions/list-call-options/list-call-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "aircall-list-call-options",
   name: "List Call Options",
   description: "Retrieves available options for the Call field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     aircall,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await aircall.propDefinitions.call.options
-        .call(this.aircall, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await aircall.propDefinitions.call.options
+      .call(this.aircall, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/aircall/actions/list-call-options/list-call-options.mjs
+++ b/components/aircall/actions/list-call-options/list-call-options.mjs
@@ -1,0 +1,34 @@
+import aircall from "../../aircall.app.mjs";
+
+export default {
+  key: "aircall-list-call-options",
+  name: "List Call Options",
+  description: "Retrieves available options for the Call field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    aircall,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await aircall.propDefinitions.call.options
+        .call(this.aircall, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/aircall/actions/list-call-options/list-call-options.mjs
+++ b/components/aircall/actions/list-call-options/list-call-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/aircall/package.json
+++ b/components/aircall/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/aircall",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Pipedream Aircall Components",
   "main": "aircall.app.mjs",
   "keywords": [

--- a/components/airtop/actions/list-session-id-options/list-session-id-options.mjs
+++ b/components/airtop/actions/list-session-id-options/list-session-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "airtop-list-session-id-options",
   name: "List Session ID Options",
   description: "Retrieves available options for the Session ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/airtop/actions/list-session-id-options/list-session-id-options.mjs
+++ b/components/airtop/actions/list-session-id-options/list-session-id-options.mjs
@@ -1,0 +1,34 @@
+import airtop from "../../airtop.app.mjs";
+
+export default {
+  key: "airtop-list-session-id-options",
+  name: "List Session ID Options",
+  description: "Retrieves available options for the Session ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    airtop,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await airtop.propDefinitions.sessionId.options
+        .call(this.airtop, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/airtop/actions/list-session-id-options/list-session-id-options.mjs
+++ b/components/airtop/actions/list-session-id-options/list-session-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "airtop-list-session-id-options",
   name: "List Session ID Options",
   description: "Retrieves available options for the Session ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     airtop,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await airtop.propDefinitions.sessionId.options
-        .call(this.airtop, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await airtop.propDefinitions.sessionId.options
+      .call(this.airtop, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/airtop/actions/list-session-id-options/list-session-id-options.mjs
+++ b/components/airtop/actions/list-session-id-options/list-session-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/airtop/package.json
+++ b/components/airtop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/airtop",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream Airtop Components",
   "main": "airtop.app.mjs",
   "keywords": [

--- a/components/akeneo/actions/create-a-new-product-media-file/create-a-new-product-media-file.mjs
+++ b/components/akeneo/actions/create-a-new-product-media-file/create-a-new-product-media-file.mjs
@@ -7,7 +7,7 @@ import app from "../../akeneo.app.mjs";
 export default {
   type: "action",
   key: "akeneo-create-a-new-product-media-file",
-  version: "0.2.1",
+  version: "0.2.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/akeneo/actions/delete-product/delete-product.mjs
+++ b/components/akeneo/actions/delete-product/delete-product.mjs
@@ -4,7 +4,7 @@ export default {
   key: "akeneo-delete-product",
   name: "Delete Product",
   description: "Delete a product from Akeneo. [See the documentation](https://api.akeneo.com/api-reference.html#delete_products__code_)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/akeneo/actions/get-draft/get-draft.mjs
+++ b/components/akeneo/actions/get-draft/get-draft.mjs
@@ -4,7 +4,7 @@ export default {
   key: "akeneo-get-draft",
   name: "Get Draft",
   description: "Get a product draft from Akeneo. [See the documentation](https://api.akeneo.com/api-reference.html#get_draft__code_)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/akeneo/actions/get-product/get-product.mjs
+++ b/components/akeneo/actions/get-product/get-product.mjs
@@ -4,7 +4,7 @@ export default {
   key: "akeneo-get-product",
   name: "Get Product",
   description: "Get a product from Akeneo. [See the documentation](https://api.akeneo.com/api-reference.html#get_products__code_)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/akeneo/actions/list-attribute-options/list-attribute-options.mjs
+++ b/components/akeneo/actions/list-attribute-options/list-attribute-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "akeneo-list-attribute-options",
   name: "List Attribute Options",
   description: "Retrieves available options for the Attribute field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     akeneo,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await akeneo.propDefinitions.attribute.options
-        .call(this.akeneo, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await akeneo.propDefinitions.attribute.options
+      .call(this.akeneo, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/akeneo/actions/list-attribute-options/list-attribute-options.mjs
+++ b/components/akeneo/actions/list-attribute-options/list-attribute-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     akeneo,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        akeneo,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/akeneo/actions/list-attribute-options/list-attribute-options.mjs
+++ b/components/akeneo/actions/list-attribute-options/list-attribute-options.mjs
@@ -1,0 +1,34 @@
+import akeneo from "../../akeneo.app.mjs";
+
+export default {
+  key: "akeneo-list-attribute-options",
+  name: "List Attribute Options",
+  description: "Retrieves available options for the Attribute field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    akeneo,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await akeneo.propDefinitions.attribute.options
+        .call(this.akeneo, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/akeneo/actions/list-attribute-options/list-attribute-options.mjs
+++ b/components/akeneo/actions/list-attribute-options/list-attribute-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/akeneo/actions/list-attribute-options/list-attribute-options.mjs
+++ b/components/akeneo/actions/list-attribute-options/list-attribute-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "akeneo-list-attribute-options",
   name: "List Attribute Options",
   description: "Retrieves available options for the Attribute field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/akeneo/actions/list-channel-code-options/list-channel-code-options.mjs
+++ b/components/akeneo/actions/list-channel-code-options/list-channel-code-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     akeneo,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        akeneo,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/akeneo/actions/list-channel-code-options/list-channel-code-options.mjs
+++ b/components/akeneo/actions/list-channel-code-options/list-channel-code-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "akeneo-list-channel-code-options",
   name: "List Channel Code Options",
   description: "Retrieves available options for the Channel Code field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/akeneo/actions/list-channel-code-options/list-channel-code-options.mjs
+++ b/components/akeneo/actions/list-channel-code-options/list-channel-code-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "akeneo-list-channel-code-options",
   name: "List Channel Code Options",
   description: "Retrieves available options for the Channel Code field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     akeneo,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await akeneo.propDefinitions.channelCode.options
-        .call(this.akeneo, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await akeneo.propDefinitions.channelCode.options
+      .call(this.akeneo, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/akeneo/actions/list-channel-code-options/list-channel-code-options.mjs
+++ b/components/akeneo/actions/list-channel-code-options/list-channel-code-options.mjs
@@ -1,0 +1,34 @@
+import akeneo from "../../akeneo.app.mjs";
+
+export default {
+  key: "akeneo-list-channel-code-options",
+  name: "List Channel Code Options",
+  description: "Retrieves available options for the Channel Code field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    akeneo,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await akeneo.propDefinitions.channelCode.options
+        .call(this.akeneo, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/akeneo/actions/list-channel-code-options/list-channel-code-options.mjs
+++ b/components/akeneo/actions/list-channel-code-options/list-channel-code-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/akeneo/actions/list-locale-options/list-locale-options.mjs
+++ b/components/akeneo/actions/list-locale-options/list-locale-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "akeneo-list-locale-options",
   name: "List Locale Options",
   description: "Retrieves available options for the Locale field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/akeneo/actions/list-media-file-attribute-code-options/list-media-file-attribute-code-options.mjs
+++ b/components/akeneo/actions/list-media-file-attribute-code-options/list-media-file-attribute-code-options.mjs
@@ -1,0 +1,34 @@
+import akeneo from "../../akeneo.app.mjs";
+
+export default {
+  key: "akeneo-list-media-file-attribute-code-options",
+  name: "List Attribute Code Options",
+  description: "Retrieves available options for the Attribute Code field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    akeneo,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await akeneo.propDefinitions.mediaFileAttributeCode.options
+        .call(this.akeneo, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/akeneo/actions/list-media-file-attribute-code-options/list-media-file-attribute-code-options.mjs
+++ b/components/akeneo/actions/list-media-file-attribute-code-options/list-media-file-attribute-code-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     akeneo,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        akeneo,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/akeneo/actions/list-media-file-attribute-code-options/list-media-file-attribute-code-options.mjs
+++ b/components/akeneo/actions/list-media-file-attribute-code-options/list-media-file-attribute-code-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "akeneo-list-media-file-attribute-code-options",
   name: "List Attribute Code Options",
   description: "Retrieves available options for the Attribute Code field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     akeneo,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await akeneo.propDefinitions.mediaFileAttributeCode.options
-        .call(this.akeneo, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await akeneo.propDefinitions.mediaFileAttributeCode.options
+      .call(this.akeneo, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/akeneo/actions/list-media-file-attribute-code-options/list-media-file-attribute-code-options.mjs
+++ b/components/akeneo/actions/list-media-file-attribute-code-options/list-media-file-attribute-code-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "akeneo-list-media-file-attribute-code-options",
   name: "List Attribute Code Options",
   description: "Retrieves available options for the Attribute Code field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/akeneo/actions/list-media-file-attribute-code-options/list-media-file-attribute-code-options.mjs
+++ b/components/akeneo/actions/list-media-file-attribute-code-options/list-media-file-attribute-code-options.mjs
@@ -2,8 +2,8 @@ import akeneo from "../../akeneo.app.mjs";
 
 export default {
   key: "akeneo-list-media-file-attribute-code-options",
-  name: "List Attribute Code Options",
-  description: "Retrieves available options for the Attribute Code field.",
+  name: "List Media File Attribute Code Options",
+  description: "Retrieves available options for the Media File Attribute Code field.",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/akeneo/actions/list-media-file-attribute-code-options/list-media-file-attribute-code-options.mjs
+++ b/components/akeneo/actions/list-media-file-attribute-code-options/list-media-file-attribute-code-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/akeneo/actions/list-product-id-options/list-product-id-options.mjs
+++ b/components/akeneo/actions/list-product-id-options/list-product-id-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     akeneo,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        akeneo,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/akeneo/actions/list-product-id-options/list-product-id-options.mjs
+++ b/components/akeneo/actions/list-product-id-options/list-product-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "akeneo-list-product-id-options",
   name: "List Product Identifier Options",
   description: "Retrieves available options for the Product Identifier field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/akeneo/actions/list-product-id-options/list-product-id-options.mjs
+++ b/components/akeneo/actions/list-product-id-options/list-product-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "akeneo-list-product-id-options",
   name: "List Product Identifier Options",
   description: "Retrieves available options for the Product Identifier field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     akeneo,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await akeneo.propDefinitions.productId.options
-        .call(this.akeneo, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await akeneo.propDefinitions.productId.options
+      .call(this.akeneo, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/akeneo/actions/list-product-id-options/list-product-id-options.mjs
+++ b/components/akeneo/actions/list-product-id-options/list-product-id-options.mjs
@@ -1,0 +1,34 @@
+import akeneo from "../../akeneo.app.mjs";
+
+export default {
+  key: "akeneo-list-product-id-options",
+  name: "List Product Identifier Options",
+  description: "Retrieves available options for the Product Identifier field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    akeneo,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await akeneo.propDefinitions.productId.options
+        .call(this.akeneo, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/akeneo/actions/list-product-id-options/list-product-id-options.mjs
+++ b/components/akeneo/actions/list-product-id-options/list-product-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/akeneo/actions/list-product-model-code-options/list-product-model-code-options.mjs
+++ b/components/akeneo/actions/list-product-model-code-options/list-product-model-code-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "akeneo-list-product-model-code-options",
   name: "List Product Model Code Options",
   description: "Retrieves available options for the Product Model Code field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     akeneo,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await akeneo.propDefinitions.productModelCode.options
-        .call(this.akeneo, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await akeneo.propDefinitions.productModelCode.options
+      .call(this.akeneo, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/akeneo/actions/list-product-model-code-options/list-product-model-code-options.mjs
+++ b/components/akeneo/actions/list-product-model-code-options/list-product-model-code-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     akeneo,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        akeneo,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/akeneo/actions/list-product-model-code-options/list-product-model-code-options.mjs
+++ b/components/akeneo/actions/list-product-model-code-options/list-product-model-code-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "akeneo-list-product-model-code-options",
   name: "List Product Model Code Options",
   description: "Retrieves available options for the Product Model Code field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/akeneo/actions/list-product-model-code-options/list-product-model-code-options.mjs
+++ b/components/akeneo/actions/list-product-model-code-options/list-product-model-code-options.mjs
@@ -1,0 +1,34 @@
+import akeneo from "../../akeneo.app.mjs";
+
+export default {
+  key: "akeneo-list-product-model-code-options",
+  name: "List Product Model Code Options",
+  description: "Retrieves available options for the Product Model Code field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    akeneo,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await akeneo.propDefinitions.productModelCode.options
+        .call(this.akeneo, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/akeneo/actions/list-product-model-code-options/list-product-model-code-options.mjs
+++ b/components/akeneo/actions/list-product-model-code-options/list-product-model-code-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/akeneo/actions/search-products/search-products.mjs
+++ b/components/akeneo/actions/search-products/search-products.mjs
@@ -5,7 +5,7 @@ export default {
   key: "akeneo-search-products",
   name: "Search Products",
   description: "Search products from Akeneo. [See the documentation](https://api.akeneo.com/api-reference.html#get_products)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/akeneo/actions/submit-product-for-approval/submit-product-for-approval.mjs
+++ b/components/akeneo/actions/submit-product-for-approval/submit-product-for-approval.mjs
@@ -4,7 +4,7 @@ export default {
   key: "akeneo-submit-product-for-approval",
   name: "Submit Product For Approval",
   description: "Submit a product for approval. [See the documentation](https://api.akeneo.com/api-reference.html#post_proposal)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/akeneo/akeneo.app.mjs
+++ b/components/akeneo/akeneo.app.mjs
@@ -6,6 +6,13 @@ export default {
   type: "app",
   app: "akeneo",
   propDefinitions: {
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve, zero-based.",
+      min: 0,
+      default: 0,
+    },
     productId: {
       type: "string",
       label: "Product Identifier",

--- a/components/akeneo/package.json
+++ b/components/akeneo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/akeneo",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Pipedream Akeneo Components",
   "main": "akeneo.app.mjs",
   "keywords": [

--- a/components/alegra/actions/list-client-options/list-client-options.mjs
+++ b/components/alegra/actions/list-client-options/list-client-options.mjs
@@ -1,0 +1,34 @@
+import alegra from "../../alegra.app.mjs";
+
+export default {
+  key: "alegra-list-client-options",
+  name: "List Client Options",
+  description: "Retrieves available options for the Client field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    alegra,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await alegra.propDefinitions.client.options
+        .call(this.alegra, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/alegra/actions/list-client-options/list-client-options.mjs
+++ b/components/alegra/actions/list-client-options/list-client-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "alegra-list-client-options",
   name: "List Client Options",
   description: "Retrieves available options for the Client field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/alegra/actions/list-client-options/list-client-options.mjs
+++ b/components/alegra/actions/list-client-options/list-client-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "alegra-list-client-options",
   name: "List Client Options",
   description: "Retrieves available options for the Client field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     alegra,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await alegra.propDefinitions.client.options
-        .call(this.alegra, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await alegra.propDefinitions.client.options
+      .call(this.alegra, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/alegra/actions/list-client-options/list-client-options.mjs
+++ b/components/alegra/actions/list-client-options/list-client-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/alegra/actions/list-cost-center-options/list-cost-center-options.mjs
+++ b/components/alegra/actions/list-cost-center-options/list-cost-center-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "alegra-list-cost-center-options",
   name: "List Cost Center Options",
   description: "Retrieves available options for the Cost Center field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/alegra/actions/list-cost-center-options/list-cost-center-options.mjs
+++ b/components/alegra/actions/list-cost-center-options/list-cost-center-options.mjs
@@ -1,0 +1,34 @@
+import alegra from "../../alegra.app.mjs";
+
+export default {
+  key: "alegra-list-cost-center-options",
+  name: "List Cost Center Options",
+  description: "Retrieves available options for the Cost Center field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    alegra,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await alegra.propDefinitions.costCenter.options
+        .call(this.alegra, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/alegra/actions/list-cost-center-options/list-cost-center-options.mjs
+++ b/components/alegra/actions/list-cost-center-options/list-cost-center-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "alegra-list-cost-center-options",
   name: "List Cost Center Options",
   description: "Retrieves available options for the Cost Center field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     alegra,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await alegra.propDefinitions.costCenter.options
-        .call(this.alegra, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await alegra.propDefinitions.costCenter.options
+      .call(this.alegra, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/alegra/actions/list-cost-center-options/list-cost-center-options.mjs
+++ b/components/alegra/actions/list-cost-center-options/list-cost-center-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/alegra/actions/list-debt-to-pay-options/list-debt-to-pay-options.mjs
+++ b/components/alegra/actions/list-debt-to-pay-options/list-debt-to-pay-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "alegra-list-debt-to-pay-options",
   name: "List Debt to Pay Options",
   description: "Retrieves available options for the Debt to Pay field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/alegra/actions/list-debt-to-pay-options/list-debt-to-pay-options.mjs
+++ b/components/alegra/actions/list-debt-to-pay-options/list-debt-to-pay-options.mjs
@@ -1,0 +1,34 @@
+import alegra from "../../alegra.app.mjs";
+
+export default {
+  key: "alegra-list-debt-to-pay-options",
+  name: "List Debt to Pay Options",
+  description: "Retrieves available options for the Debt to Pay field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    alegra,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await alegra.propDefinitions.debtToPay.options
+        .call(this.alegra, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/alegra/actions/list-debt-to-pay-options/list-debt-to-pay-options.mjs
+++ b/components/alegra/actions/list-debt-to-pay-options/list-debt-to-pay-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "alegra-list-debt-to-pay-options",
   name: "List Debt to Pay Options",
   description: "Retrieves available options for the Debt to Pay field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     alegra,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await alegra.propDefinitions.debtToPay.options
-        .call(this.alegra, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await alegra.propDefinitions.debtToPay.options
+      .call(this.alegra, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/alegra/actions/list-debt-to-pay-options/list-debt-to-pay-options.mjs
+++ b/components/alegra/actions/list-debt-to-pay-options/list-debt-to-pay-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/alegra/actions/list-price-list-options/list-price-list-options.mjs
+++ b/components/alegra/actions/list-price-list-options/list-price-list-options.mjs
@@ -1,0 +1,34 @@
+import alegra from "../../alegra.app.mjs";
+
+export default {
+  key: "alegra-list-price-list-options",
+  name: "List Price List Options",
+  description: "Retrieves available options for the Price List field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    alegra,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await alegra.propDefinitions.priceList.options
+        .call(this.alegra, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/alegra/actions/list-price-list-options/list-price-list-options.mjs
+++ b/components/alegra/actions/list-price-list-options/list-price-list-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "alegra-list-price-list-options",
   name: "List Price List Options",
   description: "Retrieves available options for the Price List field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     alegra,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await alegra.propDefinitions.priceList.options
-        .call(this.alegra, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await alegra.propDefinitions.priceList.options
+      .call(this.alegra, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/alegra/actions/list-price-list-options/list-price-list-options.mjs
+++ b/components/alegra/actions/list-price-list-options/list-price-list-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "alegra-list-price-list-options",
   name: "List Price List Options",
   description: "Retrieves available options for the Price List field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/alegra/actions/list-price-list-options/list-price-list-options.mjs
+++ b/components/alegra/actions/list-price-list-options/list-price-list-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/alegra/actions/list-seller-options/list-seller-options.mjs
+++ b/components/alegra/actions/list-seller-options/list-seller-options.mjs
@@ -1,0 +1,34 @@
+import alegra from "../../alegra.app.mjs";
+
+export default {
+  key: "alegra-list-seller-options",
+  name: "List Seller Options",
+  description: "Retrieves available options for the Seller field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    alegra,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await alegra.propDefinitions.seller.options
+        .call(this.alegra, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/alegra/actions/list-seller-options/list-seller-options.mjs
+++ b/components/alegra/actions/list-seller-options/list-seller-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "alegra-list-seller-options",
   name: "List Seller Options",
   description: "Retrieves available options for the Seller field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     alegra,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await alegra.propDefinitions.seller.options
-        .call(this.alegra, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await alegra.propDefinitions.seller.options
+      .call(this.alegra, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/alegra/actions/list-seller-options/list-seller-options.mjs
+++ b/components/alegra/actions/list-seller-options/list-seller-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/alegra/actions/list-seller-options/list-seller-options.mjs
+++ b/components/alegra/actions/list-seller-options/list-seller-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "alegra-list-seller-options",
   name: "List Seller Options",
   description: "Retrieves available options for the Seller field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/alegra/actions/list-term-options/list-term-options.mjs
+++ b/components/alegra/actions/list-term-options/list-term-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "alegra-list-term-options",
   name: "List Term Options",
   description: "Retrieves available options for the Term field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/alegra/actions/list-term-options/list-term-options.mjs
+++ b/components/alegra/actions/list-term-options/list-term-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "alegra-list-term-options",
   name: "List Term Options",
   description: "Retrieves available options for the Term field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     alegra,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await alegra.propDefinitions.term.options
-        .call(this.alegra, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await alegra.propDefinitions.term.options
+      .call(this.alegra, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/alegra/actions/list-term-options/list-term-options.mjs
+++ b/components/alegra/actions/list-term-options/list-term-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/alegra/actions/list-term-options/list-term-options.mjs
+++ b/components/alegra/actions/list-term-options/list-term-options.mjs
@@ -1,0 +1,34 @@
+import alegra from "../../alegra.app.mjs";
+
+export default {
+  key: "alegra-list-term-options",
+  name: "List Term Options",
+  description: "Retrieves available options for the Term field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    alegra,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await alegra.propDefinitions.term.options
+        .call(this.alegra, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/alegra/actions/list-warehouse-options/list-warehouse-options.mjs
+++ b/components/alegra/actions/list-warehouse-options/list-warehouse-options.mjs
@@ -1,0 +1,34 @@
+import alegra from "../../alegra.app.mjs";
+
+export default {
+  key: "alegra-list-warehouse-options",
+  name: "List Warehouse Options",
+  description: "Retrieves available options for the Warehouse field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    alegra,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await alegra.propDefinitions.warehouse.options
+        .call(this.alegra, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/alegra/actions/list-warehouse-options/list-warehouse-options.mjs
+++ b/components/alegra/actions/list-warehouse-options/list-warehouse-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "alegra-list-warehouse-options",
   name: "List Warehouse Options",
   description: "Retrieves available options for the Warehouse field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/alegra/actions/list-warehouse-options/list-warehouse-options.mjs
+++ b/components/alegra/actions/list-warehouse-options/list-warehouse-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "alegra-list-warehouse-options",
   name: "List Warehouse Options",
   description: "Retrieves available options for the Warehouse field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     alegra,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await alegra.propDefinitions.warehouse.options
-        .call(this.alegra, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await alegra.propDefinitions.warehouse.options
+      .call(this.alegra, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/alegra/actions/list-warehouse-options/list-warehouse-options.mjs
+++ b/components/alegra/actions/list-warehouse-options/list-warehouse-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/alegra/package.json
+++ b/components/alegra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/alegra",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Alegra Components",
   "main": "alegra.app.mjs",
   "keywords": [

--- a/components/all_images_ai/actions/list-image-generation-id-options/list-image-generation-id-options.mjs
+++ b/components/all_images_ai/actions/list-image-generation-id-options/list-image-generation-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "all_images_ai-list-image-generation-id-options",
   name: "List Image Generation Id Options",
   description: "Retrieves available options for the Image Generation Id field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     all_images_ai,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await all_images_ai.propDefinitions.imageGenerationId.options
-        .call(this.all_images_ai, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await all_images_ai.propDefinitions.imageGenerationId.options
+      .call(this.all_images_ai, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/all_images_ai/actions/list-image-generation-id-options/list-image-generation-id-options.mjs
+++ b/components/all_images_ai/actions/list-image-generation-id-options/list-image-generation-id-options.mjs
@@ -1,0 +1,34 @@
+import all_images_ai from "../../all_images_ai.app.mjs";
+
+export default {
+  key: "all_images_ai-list-image-generation-id-options",
+  name: "List Image Generation Id Options",
+  description: "Retrieves available options for the Image Generation Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    all_images_ai,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await all_images_ai.propDefinitions.imageGenerationId.options
+        .call(this.all_images_ai, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/all_images_ai/actions/list-image-generation-id-options/list-image-generation-id-options.mjs
+++ b/components/all_images_ai/actions/list-image-generation-id-options/list-image-generation-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "all_images_ai-list-image-generation-id-options",
   name: "List Image Generation Id Options",
   description: "Retrieves available options for the Image Generation Id field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/all_images_ai/actions/list-image-generation-id-options/list-image-generation-id-options.mjs
+++ b/components/all_images_ai/actions/list-image-generation-id-options/list-image-generation-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/all_images_ai/actions/list-image-id-options/list-image-id-options.mjs
+++ b/components/all_images_ai/actions/list-image-id-options/list-image-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "all_images_ai-list-image-id-options",
   name: "List Image Id Options",
   description: "Retrieves available options for the Image Id field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/all_images_ai/actions/list-image-id-options/list-image-id-options.mjs
+++ b/components/all_images_ai/actions/list-image-id-options/list-image-id-options.mjs
@@ -1,0 +1,34 @@
+import all_images_ai from "../../all_images_ai.app.mjs";
+
+export default {
+  key: "all_images_ai-list-image-id-options",
+  name: "List Image Id Options",
+  description: "Retrieves available options for the Image Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    all_images_ai,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await all_images_ai.propDefinitions.imageId.options
+        .call(this.all_images_ai, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/all_images_ai/actions/list-image-id-options/list-image-id-options.mjs
+++ b/components/all_images_ai/actions/list-image-id-options/list-image-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "all_images_ai-list-image-id-options",
   name: "List Image Id Options",
   description: "Retrieves available options for the Image Id field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     all_images_ai,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await all_images_ai.propDefinitions.imageId.options
-        .call(this.all_images_ai, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await all_images_ai.propDefinitions.imageId.options
+      .call(this.all_images_ai, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/all_images_ai/actions/list-image-id-options/list-image-id-options.mjs
+++ b/components/all_images_ai/actions/list-image-id-options/list-image-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/all_images_ai/package.json
+++ b/components/all_images_ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/all_images_ai",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream All-Images.ai Components",
   "main": "all_images_ai.app.mjs",
   "keywords": [

--- a/components/altoviz/actions/list-invoice-id-options/list-invoice-id-options.mjs
+++ b/components/altoviz/actions/list-invoice-id-options/list-invoice-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "altoviz-list-invoice-id-options",
   name: "List Invoice ID Options",
   description: "Retrieves available options for the Invoice ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     altoviz,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await altoviz.propDefinitions.invoiceId.options
-        .call(this.altoviz, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await altoviz.propDefinitions.invoiceId.options
+      .call(this.altoviz, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/altoviz/actions/list-invoice-id-options/list-invoice-id-options.mjs
+++ b/components/altoviz/actions/list-invoice-id-options/list-invoice-id-options.mjs
@@ -1,0 +1,34 @@
+import altoviz from "../../altoviz.app.mjs";
+
+export default {
+  key: "altoviz-list-invoice-id-options",
+  name: "List Invoice ID Options",
+  description: "Retrieves available options for the Invoice ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    altoviz,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await altoviz.propDefinitions.invoiceId.options
+        .call(this.altoviz, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/altoviz/actions/list-invoice-id-options/list-invoice-id-options.mjs
+++ b/components/altoviz/actions/list-invoice-id-options/list-invoice-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "altoviz-list-invoice-id-options",
   name: "List Invoice ID Options",
   description: "Retrieves available options for the Invoice ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/altoviz/actions/list-invoice-id-options/list-invoice-id-options.mjs
+++ b/components/altoviz/actions/list-invoice-id-options/list-invoice-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/altoviz/package.json
+++ b/components/altoviz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/altoviz",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Altoviz Components",
   "main": "altoviz.app.mjs",
   "keywords": [

--- a/components/alttextify/actions/list-asset-id-options/list-asset-id-options.mjs
+++ b/components/alttextify/actions/list-asset-id-options/list-asset-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "alttextify-list-asset-id-options",
   name: "List Asset ID Options",
   description: "Retrieves available options for the Asset ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     alttextify,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await alttextify.propDefinitions.assetId.options
-        .call(this.alttextify, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await alttextify.propDefinitions.assetId.options
+      .call(this.alttextify, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/alttextify/actions/list-asset-id-options/list-asset-id-options.mjs
+++ b/components/alttextify/actions/list-asset-id-options/list-asset-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "alttextify-list-asset-id-options",
   name: "List Asset ID Options",
   description: "Retrieves available options for the Asset ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/alttextify/actions/list-asset-id-options/list-asset-id-options.mjs
+++ b/components/alttextify/actions/list-asset-id-options/list-asset-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/alttextify/actions/list-asset-id-options/list-asset-id-options.mjs
+++ b/components/alttextify/actions/list-asset-id-options/list-asset-id-options.mjs
@@ -1,0 +1,34 @@
+import alttextify from "../../alttextify.app.mjs";
+
+export default {
+  key: "alttextify-list-asset-id-options",
+  name: "List Asset ID Options",
+  description: "Retrieves available options for the Asset ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    alttextify,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await alttextify.propDefinitions.assetId.options
+        .call(this.alttextify, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/alttextify/package.json
+++ b/components/alttextify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/alttextify",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Pipedream AltTextify Components",
   "main": "alttextify.app.mjs",
   "keywords": [

--- a/components/amilia/actions/list-account-options/list-account-options.mjs
+++ b/components/amilia/actions/list-account-options/list-account-options.mjs
@@ -1,0 +1,34 @@
+import amilia from "../../amilia.app.mjs";
+
+export default {
+  key: "amilia-list-account-options",
+  name: "List Account Options",
+  description: "Retrieves available options for the Account field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    amilia,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await amilia.propDefinitions.account.options
+        .call(this.amilia, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/amilia/actions/list-account-options/list-account-options.mjs
+++ b/components/amilia/actions/list-account-options/list-account-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "amilia-list-account-options",
   name: "List Account Options",
   description: "Retrieves available options for the Account field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/amilia/actions/list-account-options/list-account-options.mjs
+++ b/components/amilia/actions/list-account-options/list-account-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "amilia-list-account-options",
   name: "List Account Options",
   description: "Retrieves available options for the Account field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     amilia,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await amilia.propDefinitions.account.options
-        .call(this.amilia, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await amilia.propDefinitions.account.options
+      .call(this.amilia, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/amilia/actions/list-account-options/list-account-options.mjs
+++ b/components/amilia/actions/list-account-options/list-account-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/amilia/package.json
+++ b/components/amilia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/amilia",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "Pipedream Amilia Components",
   "main": "amilia.app.mjs",
   "keywords": [

--- a/components/apify/actions/list-dataset-id-options/list-dataset-id-options.mjs
+++ b/components/apify/actions/list-dataset-id-options/list-dataset-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "apify-list-dataset-id-options",
   name: "List Dataset ID Options",
   description: "Retrieves available options for the Dataset ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     apify,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await apify.propDefinitions.datasetId.options
-        .call(this.apify, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await apify.propDefinitions.datasetId.options
+      .call(this.apify, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/apify/actions/list-dataset-id-options/list-dataset-id-options.mjs
+++ b/components/apify/actions/list-dataset-id-options/list-dataset-id-options.mjs
@@ -1,0 +1,34 @@
+import apify from "../../apify.app.mjs";
+
+export default {
+  key: "apify-list-dataset-id-options",
+  name: "List Dataset ID Options",
+  description: "Retrieves available options for the Dataset ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    apify,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await apify.propDefinitions.datasetId.options
+        .call(this.apify, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/apify/actions/list-dataset-id-options/list-dataset-id-options.mjs
+++ b/components/apify/actions/list-dataset-id-options/list-dataset-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "apify-list-dataset-id-options",
   name: "List Dataset ID Options",
   description: "Retrieves available options for the Dataset ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/apify/actions/list-dataset-id-options/list-dataset-id-options.mjs
+++ b/components/apify/actions/list-dataset-id-options/list-dataset-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/apify/package.json
+++ b/components/apify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/apify",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Pipedream Apify Components",
   "main": "apify.app.mjs",
   "keywords": [

--- a/components/apollo_io/actions/list-account-id-options/list-account-id-options.mjs
+++ b/components/apollo_io/actions/list-account-id-options/list-account-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "apollo_io-list-account-id-options",
   name: "List Account ID Options",
   description: "Retrieves available options for the Account ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/apollo_io/actions/list-account-id-options/list-account-id-options.mjs
+++ b/components/apollo_io/actions/list-account-id-options/list-account-id-options.mjs
@@ -1,0 +1,34 @@
+import apollo_io from "../../apollo_io.app.mjs";
+
+export default {
+  key: "apollo_io-list-account-id-options",
+  name: "List Account ID Options",
+  description: "Retrieves available options for the Account ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    apollo_io,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await apollo_io.propDefinitions.accountId.options
+        .call(this.apollo_io, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/apollo_io/actions/list-account-id-options/list-account-id-options.mjs
+++ b/components/apollo_io/actions/list-account-id-options/list-account-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/apollo_io/actions/list-account-id-options/list-account-id-options.mjs
+++ b/components/apollo_io/actions/list-account-id-options/list-account-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "apollo_io-list-account-id-options",
   name: "List Account ID Options",
   description: "Retrieves available options for the Account ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     apollo_io,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await apollo_io.propDefinitions.accountId.options
-        .call(this.apollo_io, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await apollo_io.propDefinitions.accountId.options
+      .call(this.apollo_io, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/apollo_io/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/apollo_io/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -1,0 +1,34 @@
+import apollo_io from "../../apollo_io.app.mjs";
+
+export default {
+  key: "apollo_io-list-contact-id-options",
+  name: "List Contact ID Options",
+  description: "Retrieves available options for the Contact ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    apollo_io,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await apollo_io.propDefinitions.contactId.options
+        .call(this.apollo_io, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/apollo_io/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/apollo_io/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "apollo_io-list-contact-id-options",
   name: "List Contact ID Options",
   description: "Retrieves available options for the Contact ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     apollo_io,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await apollo_io.propDefinitions.contactId.options
-        .call(this.apollo_io, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await apollo_io.propDefinitions.contactId.options
+      .call(this.apollo_io, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/apollo_io/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/apollo_io/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "apollo_io-list-contact-id-options",
   name: "List Contact ID Options",
   description: "Retrieves available options for the Contact ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/apollo_io/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/apollo_io/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/apollo_io/actions/list-opportunity-id-options/list-opportunity-id-options.mjs
+++ b/components/apollo_io/actions/list-opportunity-id-options/list-opportunity-id-options.mjs
@@ -1,0 +1,34 @@
+import apollo_io from "../../apollo_io.app.mjs";
+
+export default {
+  key: "apollo_io-list-opportunity-id-options",
+  name: "List Opportunity ID Options",
+  description: "Retrieves available options for the Opportunity ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    apollo_io,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await apollo_io.propDefinitions.opportunityId.options
+        .call(this.apollo_io, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/apollo_io/actions/list-opportunity-id-options/list-opportunity-id-options.mjs
+++ b/components/apollo_io/actions/list-opportunity-id-options/list-opportunity-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/apollo_io/actions/list-opportunity-id-options/list-opportunity-id-options.mjs
+++ b/components/apollo_io/actions/list-opportunity-id-options/list-opportunity-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "apollo_io-list-opportunity-id-options",
   name: "List Opportunity ID Options",
   description: "Retrieves available options for the Opportunity ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/apollo_io/actions/list-opportunity-id-options/list-opportunity-id-options.mjs
+++ b/components/apollo_io/actions/list-opportunity-id-options/list-opportunity-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "apollo_io-list-opportunity-id-options",
   name: "List Opportunity ID Options",
   description: "Retrieves available options for the Opportunity ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     apollo_io,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await apollo_io.propDefinitions.opportunityId.options
-        .call(this.apollo_io, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await apollo_io.propDefinitions.opportunityId.options
+      .call(this.apollo_io, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/apollo_io/package.json
+++ b/components/apollo_io/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/apollo_io",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Pipedream Apollo.io Components",
   "main": "apollo_io.app.mjs",
   "keywords": [

--- a/components/ascora/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/ascora/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "ascora-list-customer-id-options",
   name: "List Customer ID Options",
   description: "Retrieves available options for the Customer ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/ascora/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/ascora/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "ascora-list-customer-id-options",
   name: "List Customer ID Options",
   description: "Retrieves available options for the Customer ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     ascora,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await ascora.propDefinitions.customerId.options
-        .call(this.ascora, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await ascora.propDefinitions.customerId.options
+      .call(this.ascora, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/ascora/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/ascora/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -1,0 +1,34 @@
+import ascora from "../../ascora.app.mjs";
+
+export default {
+  key: "ascora-list-customer-id-options",
+  name: "List Customer ID Options",
+  description: "Retrieves available options for the Customer ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    ascora,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await ascora.propDefinitions.customerId.options
+        .call(this.ascora, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/ascora/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/ascora/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/ascora/package.json
+++ b/components/ascora/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/ascora",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Ascora Components",
   "main": "ascora.app.mjs",
   "keywords": [

--- a/components/attractwell/actions/list-class-id-options/list-class-id-options.mjs
+++ b/components/attractwell/actions/list-class-id-options/list-class-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "attractwell-list-class-id-options",
   name: "List Class ID Options",
   description: "Retrieves available options for the Class ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/attractwell/actions/list-class-id-options/list-class-id-options.mjs
+++ b/components/attractwell/actions/list-class-id-options/list-class-id-options.mjs
@@ -1,0 +1,34 @@
+import attractwell from "../../attractwell.app.mjs";
+
+export default {
+  key: "attractwell-list-class-id-options",
+  name: "List Class ID Options",
+  description: "Retrieves available options for the Class ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    attractwell,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await attractwell.propDefinitions.classId.options
+        .call(this.attractwell, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/attractwell/actions/list-class-id-options/list-class-id-options.mjs
+++ b/components/attractwell/actions/list-class-id-options/list-class-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "attractwell-list-class-id-options",
   name: "List Class ID Options",
   description: "Retrieves available options for the Class ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     attractwell,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await attractwell.propDefinitions.classId.options
-        .call(this.attractwell, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await attractwell.propDefinitions.classId.options
+      .call(this.attractwell, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/attractwell/actions/list-class-id-options/list-class-id-options.mjs
+++ b/components/attractwell/actions/list-class-id-options/list-class-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/attractwell/actions/list-lesson-id-options/list-lesson-id-options.mjs
+++ b/components/attractwell/actions/list-lesson-id-options/list-lesson-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "attractwell-list-lesson-id-options",
   name: "List Lesson ID Options",
   description: "Retrieves available options for the Lesson ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/attractwell/actions/list-lesson-id-options/list-lesson-id-options.mjs
+++ b/components/attractwell/actions/list-lesson-id-options/list-lesson-id-options.mjs
@@ -1,0 +1,34 @@
+import attractwell from "../../attractwell.app.mjs";
+
+export default {
+  key: "attractwell-list-lesson-id-options",
+  name: "List Lesson ID Options",
+  description: "Retrieves available options for the Lesson ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    attractwell,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await attractwell.propDefinitions.lessonId.options
+        .call(this.attractwell, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/attractwell/actions/list-lesson-id-options/list-lesson-id-options.mjs
+++ b/components/attractwell/actions/list-lesson-id-options/list-lesson-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "attractwell-list-lesson-id-options",
   name: "List Lesson ID Options",
   description: "Retrieves available options for the Lesson ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     attractwell,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await attractwell.propDefinitions.lessonId.options
-        .call(this.attractwell, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await attractwell.propDefinitions.lessonId.options
+      .call(this.attractwell, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/attractwell/actions/list-lesson-id-options/list-lesson-id-options.mjs
+++ b/components/attractwell/actions/list-lesson-id-options/list-lesson-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/attractwell/package.json
+++ b/components/attractwell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/attractwell",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream AttractWell Components",
   "main": "attractwell.app.mjs",
   "keywords": [

--- a/components/bamboohr/actions/list-application-id-options/list-application-id-options.mjs
+++ b/components/bamboohr/actions/list-application-id-options/list-application-id-options.mjs
@@ -1,0 +1,34 @@
+import bamboohr from "../../bamboohr.app.mjs";
+
+export default {
+  key: "bamboohr-list-application-id-options",
+  name: "List Application ID Options",
+  description: "Retrieves available options for the Application ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    bamboohr,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await bamboohr.propDefinitions.applicationId.options
+        .call(this.bamboohr, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/bamboohr/actions/list-application-id-options/list-application-id-options.mjs
+++ b/components/bamboohr/actions/list-application-id-options/list-application-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "bamboohr-list-application-id-options",
   name: "List Application ID Options",
   description: "Retrieves available options for the Application ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/bamboohr/actions/list-application-id-options/list-application-id-options.mjs
+++ b/components/bamboohr/actions/list-application-id-options/list-application-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "bamboohr-list-application-id-options",
   name: "List Application ID Options",
   description: "Retrieves available options for the Application ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     bamboohr,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await bamboohr.propDefinitions.applicationId.options
-        .call(this.bamboohr, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await bamboohr.propDefinitions.applicationId.options
+      .call(this.bamboohr, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/bamboohr/actions/list-application-id-options/list-application-id-options.mjs
+++ b/components/bamboohr/actions/list-application-id-options/list-application-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/bamboohr/package.json
+++ b/components/bamboohr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/bamboohr",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Pipedream bamboohr Components",
   "main": "bamboohr.app.mjs",
   "keywords": [

--- a/components/beanstalkapp/actions/list-repository-id-options/list-repository-id-options.mjs
+++ b/components/beanstalkapp/actions/list-repository-id-options/list-repository-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "beanstalkapp-list-repository-id-options",
   name: "List Repository ID Options",
   description: "Retrieves available options for the Repository ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/beanstalkapp/actions/list-repository-id-options/list-repository-id-options.mjs
+++ b/components/beanstalkapp/actions/list-repository-id-options/list-repository-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "beanstalkapp-list-repository-id-options",
   name: "List Repository ID Options",
   description: "Retrieves available options for the Repository ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     beanstalkapp,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await beanstalkapp.propDefinitions.repositoryId.options
-        .call(this.beanstalkapp, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await beanstalkapp.propDefinitions.repositoryId.options
+      .call(this.beanstalkapp, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/beanstalkapp/actions/list-repository-id-options/list-repository-id-options.mjs
+++ b/components/beanstalkapp/actions/list-repository-id-options/list-repository-id-options.mjs
@@ -1,0 +1,34 @@
+import beanstalkapp from "../../beanstalkapp.app.mjs";
+
+export default {
+  key: "beanstalkapp-list-repository-id-options",
+  name: "List Repository ID Options",
+  description: "Retrieves available options for the Repository ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    beanstalkapp,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await beanstalkapp.propDefinitions.repositoryId.options
+        .call(this.beanstalkapp, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/beanstalkapp/actions/list-repository-id-options/list-repository-id-options.mjs
+++ b/components/beanstalkapp/actions/list-repository-id-options/list-repository-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/beanstalkapp/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/beanstalkapp/actions/list-user-id-options/list-user-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "beanstalkapp-list-user-id-options",
   name: "List User ID Options",
   description: "Retrieves available options for the User ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     beanstalkapp,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await beanstalkapp.propDefinitions.userId.options
-        .call(this.beanstalkapp, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await beanstalkapp.propDefinitions.userId.options
+      .call(this.beanstalkapp, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/beanstalkapp/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/beanstalkapp/actions/list-user-id-options/list-user-id-options.mjs
@@ -1,0 +1,34 @@
+import beanstalkapp from "../../beanstalkapp.app.mjs";
+
+export default {
+  key: "beanstalkapp-list-user-id-options",
+  name: "List User ID Options",
+  description: "Retrieves available options for the User ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    beanstalkapp,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await beanstalkapp.propDefinitions.userId.options
+        .call(this.beanstalkapp, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/beanstalkapp/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/beanstalkapp/actions/list-user-id-options/list-user-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "beanstalkapp-list-user-id-options",
   name: "List User ID Options",
   description: "Retrieves available options for the User ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/beanstalkapp/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/beanstalkapp/actions/list-user-id-options/list-user-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/beanstalkapp/package.json
+++ b/components/beanstalkapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/beanstalkapp",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "Pipedream Beanstalk Components",
   "main": "beanstalkapp.app.mjs",
   "keywords": [

--- a/components/beekeeper/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/beekeeper/actions/list-user-id-options/list-user-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "beekeeper-list-user-id-options",
   name: "List User ID Options",
   description: "Retrieves available options for the User ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     beekeeper,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await beekeeper.propDefinitions.userId.options
-        .call(this.beekeeper, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await beekeeper.propDefinitions.userId.options
+      .call(this.beekeeper, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/beekeeper/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/beekeeper/actions/list-user-id-options/list-user-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "beekeeper-list-user-id-options",
   name: "List User ID Options",
   description: "Retrieves available options for the User ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/beekeeper/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/beekeeper/actions/list-user-id-options/list-user-id-options.mjs
@@ -1,0 +1,34 @@
+import beekeeper from "../../beekeeper.app.mjs";
+
+export default {
+  key: "beekeeper-list-user-id-options",
+  name: "List User ID Options",
+  description: "Retrieves available options for the User ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    beekeeper,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await beekeeper.propDefinitions.userId.options
+        .call(this.beekeeper, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/beekeeper/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/beekeeper/actions/list-user-id-options/list-user-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/beekeeper/package.json
+++ b/components/beekeeper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/beekeeper",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Pipedream beekeeper Components",
   "main": "beekeeper.app.mjs",
   "keywords": [

--- a/components/bigcommerce/actions/list-category-id-options/list-category-id-options.mjs
+++ b/components/bigcommerce/actions/list-category-id-options/list-category-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "bigcommerce-list-category-id-options",
   name: "List Category Id Options",
   description: "Retrieves available options for the Category Id field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/bigcommerce/actions/list-category-id-options/list-category-id-options.mjs
+++ b/components/bigcommerce/actions/list-category-id-options/list-category-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "bigcommerce-list-category-id-options",
   name: "List Category Id Options",
   description: "Retrieves available options for the Category Id field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     bigcommerce,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await bigcommerce.propDefinitions.categoryId.options
-        .call(this.bigcommerce, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await bigcommerce.propDefinitions.categoryId.options
+      .call(this.bigcommerce, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/bigcommerce/actions/list-category-id-options/list-category-id-options.mjs
+++ b/components/bigcommerce/actions/list-category-id-options/list-category-id-options.mjs
@@ -1,0 +1,34 @@
+import bigcommerce from "../../bigcommerce.app.mjs";
+
+export default {
+  key: "bigcommerce-list-category-id-options",
+  name: "List Category Id Options",
+  description: "Retrieves available options for the Category Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    bigcommerce,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await bigcommerce.propDefinitions.categoryId.options
+        .call(this.bigcommerce, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/bigcommerce/actions/list-category-id-options/list-category-id-options.mjs
+++ b/components/bigcommerce/actions/list-category-id-options/list-category-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/bigcommerce/package.json
+++ b/components/bigcommerce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/bigcommerce",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "Pipedream BigCommerce Components",
   "main": "bigcommerce.app.mjs",
   "keywords": [

--- a/components/billbee/actions/add-shipment-to-order/add-shipment-to-order.mjs
+++ b/components/billbee/actions/add-shipment-to-order/add-shipment-to-order.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Add Shipment To Order",
   description: "Add a shipment to an existing order. [See the documentation](https://app.billbee.io//swagger/ui/index#/Orders/OrderApi_AddShipment)",
   type: "action",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/billbee/actions/change-order-state/change-order-state.mjs
+++ b/components/billbee/actions/change-order-state/change-order-state.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Change Order State",
   description: "Change the state of an order. [See the documentation](https://app.billbee.io//swagger/ui/index#/Orders/OrderApi_UpdateState)",
   type: "action",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/billbee/actions/create-invoice-for-order/create-invoice-for-order.mjs
+++ b/components/billbee/actions/create-invoice-for-order/create-invoice-for-order.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Create Invoice For Order",
   description: "Create an invoice for an existing order. [See the documentation](https://app.billbee.io//swagger/ui/index#/Orders/OrderApi_CreateInvoice)",
   type: "action",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/billbee/actions/create-order/create-order.mjs
+++ b/components/billbee/actions/create-order/create-order.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Create Order",
   description: "Create a new order. [See the documentation](https://app.billbee.io//swagger/ui/index#/Orders/OrderApi_PostNewOrder)",
   type: "action",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/billbee/actions/get-order-by-id/get-order-by-id.mjs
+++ b/components/billbee/actions/get-order-by-id/get-order-by-id.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Get Order By ID",
   description: "Retrieve a specific order by its ID from Billbee. [See the documentation](https://app.billbee.io//swagger/ui/index#/Orders/OrderApi_Get)",
   type: "action",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/billbee/actions/list-carrier-id-options/list-carrier-id-options.mjs
+++ b/components/billbee/actions/list-carrier-id-options/list-carrier-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "billbee-list-carrier-id-options",
   name: "List Carrier ID Options",
   description: "Retrieves available options for the Carrier ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/billbee/actions/list-cloud-storage-id-options/list-cloud-storage-id-options.mjs
+++ b/components/billbee/actions/list-cloud-storage-id-options/list-cloud-storage-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "billbee-list-cloud-storage-id-options",
   name: "List Cloud Storage ID Options",
   description: "Retrieves available options for the Cloud Storage ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/billbee/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/billbee/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "billbee-list-customer-id-options",
   name: "List Customer ID Options",
   description: "Retrieves available options for the Customer ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     billbee,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await billbee.propDefinitions.customerId.options
-        .call(this.billbee, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await billbee.propDefinitions.customerId.options
+      .call(this.billbee, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/billbee/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/billbee/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "billbee-list-customer-id-options",
   name: "List Customer ID Options",
   description: "Retrieves available options for the Customer ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/billbee/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/billbee/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     billbee,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        billbee,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/billbee/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/billbee/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -1,0 +1,34 @@
+import billbee from "../../billbee.app.mjs";
+
+export default {
+  key: "billbee-list-customer-id-options",
+  name: "List Customer ID Options",
+  description: "Retrieves available options for the Customer ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    billbee,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await billbee.propDefinitions.customerId.options
+        .call(this.billbee, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/billbee/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/billbee/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/billbee/actions/list-customers/list-customers.mjs
+++ b/components/billbee/actions/list-customers/list-customers.mjs
@@ -5,7 +5,7 @@ export default {
   name: "List Customers",
   description: "Retrieve a list of customers. [See the documentation](https://app.billbee.io/swagger/ui/index#/Customers/Customer_GetAll)",
   type: "action",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/billbee/actions/list-order-id-options/list-order-id-options.mjs
+++ b/components/billbee/actions/list-order-id-options/list-order-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "billbee-list-order-id-options",
   name: "List Order ID Options",
   description: "Retrieves available options for the Order ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     billbee,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await billbee.propDefinitions.orderId.options
-        .call(this.billbee, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await billbee.propDefinitions.orderId.options
+      .call(this.billbee, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/billbee/actions/list-order-id-options/list-order-id-options.mjs
+++ b/components/billbee/actions/list-order-id-options/list-order-id-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     billbee,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        billbee,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/billbee/actions/list-order-id-options/list-order-id-options.mjs
+++ b/components/billbee/actions/list-order-id-options/list-order-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "billbee-list-order-id-options",
   name: "List Order ID Options",
   description: "Retrieves available options for the Order ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/billbee/actions/list-order-id-options/list-order-id-options.mjs
+++ b/components/billbee/actions/list-order-id-options/list-order-id-options.mjs
@@ -1,0 +1,34 @@
+import billbee from "../../billbee.app.mjs";
+
+export default {
+  key: "billbee-list-order-id-options",
+  name: "List Order ID Options",
+  description: "Retrieves available options for the Order ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    billbee,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await billbee.propDefinitions.orderId.options
+        .call(this.billbee, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/billbee/actions/list-order-id-options/list-order-id-options.mjs
+++ b/components/billbee/actions/list-order-id-options/list-order-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/billbee/actions/list-order-state-id-options/list-order-state-id-options.mjs
+++ b/components/billbee/actions/list-order-state-id-options/list-order-state-id-options.mjs
@@ -1,0 +1,34 @@
+import billbee from "../../billbee.app.mjs";
+
+export default {
+  key: "billbee-list-order-state-id-options",
+  name: "List Order State ID Options",
+  description: "Retrieves available options for the Order State ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    billbee,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await billbee.propDefinitions.orderStateId.options
+        .call(this.billbee, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/billbee/actions/list-order-state-id-options/list-order-state-id-options.mjs
+++ b/components/billbee/actions/list-order-state-id-options/list-order-state-id-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     billbee,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        billbee,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/billbee/actions/list-order-state-id-options/list-order-state-id-options.mjs
+++ b/components/billbee/actions/list-order-state-id-options/list-order-state-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "billbee-list-order-state-id-options",
   name: "List Order State ID Options",
   description: "Retrieves available options for the Order State ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/billbee/actions/list-order-state-id-options/list-order-state-id-options.mjs
+++ b/components/billbee/actions/list-order-state-id-options/list-order-state-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "billbee-list-order-state-id-options",
   name: "List Order State ID Options",
   description: "Retrieves available options for the Order State ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     billbee,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await billbee.propDefinitions.orderStateId.options
-        .call(this.billbee, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await billbee.propDefinitions.orderStateId.options
+      .call(this.billbee, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/billbee/actions/list-order-state-id-options/list-order-state-id-options.mjs
+++ b/components/billbee/actions/list-order-state-id-options/list-order-state-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/billbee/actions/list-orders/list-orders.mjs
+++ b/components/billbee/actions/list-orders/list-orders.mjs
@@ -5,7 +5,7 @@ export default {
   name: "List Orders",
   description: "Retrieve a list of orders. [See the documentation](https://app.billbee.io//swagger/ui/index#/Orders/OrderApi_GetList)",
   type: "action",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/billbee/actions/list-products/list-products.mjs
+++ b/components/billbee/actions/list-products/list-products.mjs
@@ -5,7 +5,7 @@ export default {
   name: "List Products",
   description: "Retrieve a list of products. [See the documentation](https://app.billbee.io//swagger/ui/index#/Products/Article_GetList)",
   type: "action",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/billbee/actions/list-shipment-type-options/list-shipment-type-options.mjs
+++ b/components/billbee/actions/list-shipment-type-options/list-shipment-type-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "billbee-list-shipment-type-options",
   name: "List Shipment Type Options",
   description: "Retrieves available options for the Shipment Type field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/billbee/actions/list-shipping-provider-id-options/list-shipping-provider-id-options.mjs
+++ b/components/billbee/actions/list-shipping-provider-id-options/list-shipping-provider-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "billbee-list-shipping-provider-id-options",
   name: "List Shipping Provider ID Options",
   description: "Retrieves available options for the Shipping Provider ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/billbee/actions/list-shop-id-options/list-shop-id-options.mjs
+++ b/components/billbee/actions/list-shop-id-options/list-shop-id-options.mjs
@@ -1,0 +1,34 @@
+import billbee from "../../billbee.app.mjs";
+
+export default {
+  key: "billbee-list-shop-id-options",
+  name: "List Shop ID Options",
+  description: "Retrieves available options for the Shop ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    billbee,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await billbee.propDefinitions.shopId.options
+        .call(this.billbee, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/billbee/actions/list-shop-id-options/list-shop-id-options.mjs
+++ b/components/billbee/actions/list-shop-id-options/list-shop-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "billbee-list-shop-id-options",
   name: "List Shop ID Options",
   description: "Retrieves available options for the Shop ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     billbee,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await billbee.propDefinitions.shopId.options
-        .call(this.billbee, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await billbee.propDefinitions.shopId.options
+      .call(this.billbee, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/billbee/actions/list-shop-id-options/list-shop-id-options.mjs
+++ b/components/billbee/actions/list-shop-id-options/list-shop-id-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     billbee,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        billbee,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/billbee/actions/list-shop-id-options/list-shop-id-options.mjs
+++ b/components/billbee/actions/list-shop-id-options/list-shop-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "billbee-list-shop-id-options",
   name: "List Shop ID Options",
   description: "Retrieves available options for the Shop ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/billbee/actions/list-shop-id-options/list-shop-id-options.mjs
+++ b/components/billbee/actions/list-shop-id-options/list-shop-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/billbee/actions/list-stock-id-options/list-stock-id-options.mjs
+++ b/components/billbee/actions/list-stock-id-options/list-stock-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "billbee-list-stock-id-options",
   name: "List Stock ID Options",
   description: "Retrieves available options for the Stock ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/billbee/actions/list-stock-id-options/list-stock-id-options.mjs
+++ b/components/billbee/actions/list-stock-id-options/list-stock-id-options.mjs
@@ -1,0 +1,34 @@
+import billbee from "../../billbee.app.mjs";
+
+export default {
+  key: "billbee-list-stock-id-options",
+  name: "List Stock ID Options",
+  description: "Retrieves available options for the Stock ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    billbee,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await billbee.propDefinitions.stockId.options
+        .call(this.billbee, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/billbee/actions/list-stock-id-options/list-stock-id-options.mjs
+++ b/components/billbee/actions/list-stock-id-options/list-stock-id-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     billbee,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        billbee,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/billbee/actions/list-stock-id-options/list-stock-id-options.mjs
+++ b/components/billbee/actions/list-stock-id-options/list-stock-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "billbee-list-stock-id-options",
   name: "List Stock ID Options",
   description: "Retrieves available options for the Stock ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     billbee,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await billbee.propDefinitions.stockId.options
-        .call(this.billbee, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await billbee.propDefinitions.stockId.options
+      .call(this.billbee, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/billbee/actions/list-stock-id-options/list-stock-id-options.mjs
+++ b/components/billbee/actions/list-stock-id-options/list-stock-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/billbee/actions/update-order/update-order.mjs
+++ b/components/billbee/actions/update-order/update-order.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Update Order",
   description: "Partially update an existing order. [See the documentation](https://app.billbee.io//swagger/ui/index#/Orders/OrderApi_PatchOrder)",
   type: "action",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/billbee/actions/update-stock/update-stock.mjs
+++ b/components/billbee/actions/update-stock/update-stock.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Update Stock",
   description: "Update the stock level for a single product. [See the documentation](https://app.billbee.io//swagger/ui/index#/Products/Article_UpdateStock)",
   type: "action",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/billbee/billbee.app.mjs
+++ b/components/billbee/billbee.app.mjs
@@ -6,6 +6,13 @@ export default {
   type: "app",
   app: "billbee",
   propDefinitions: {
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve, zero-based.",
+      min: 0,
+      default: 0,
+    },
     orderId: {
       type: "string",
       label: "Order ID",

--- a/components/billbee/package.json
+++ b/components/billbee/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/billbee",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Billbee Components",
   "main": "billbee.app.mjs",
   "keywords": [

--- a/components/billsby/actions/list-subscription-ids-options/list-subscription-ids-options.mjs
+++ b/components/billsby/actions/list-subscription-ids-options/list-subscription-ids-options.mjs
@@ -1,0 +1,34 @@
+import billsby from "../../billsby.app.mjs";
+
+export default {
+  key: "billsby-list-subscription-ids-options",
+  name: "List Subscription IDs Options",
+  description: "Retrieves available options for the Subscription IDs field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    billsby,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await billsby.propDefinitions.subscriptionIds.options
+        .call(this.billsby, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/billsby/actions/list-subscription-ids-options/list-subscription-ids-options.mjs
+++ b/components/billsby/actions/list-subscription-ids-options/list-subscription-ids-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "billsby-list-subscription-ids-options",
   name: "List Subscription IDs Options",
   description: "Retrieves available options for the Subscription IDs field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     billsby,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await billsby.propDefinitions.subscriptionIds.options
-        .call(this.billsby, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await billsby.propDefinitions.subscriptionIds.options
+      .call(this.billsby, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/billsby/actions/list-subscription-ids-options/list-subscription-ids-options.mjs
+++ b/components/billsby/actions/list-subscription-ids-options/list-subscription-ids-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "billsby-list-subscription-ids-options",
   name: "List Subscription IDs Options",
   description: "Retrieves available options for the Subscription IDs field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/billsby/actions/list-subscription-ids-options/list-subscription-ids-options.mjs
+++ b/components/billsby/actions/list-subscription-ids-options/list-subscription-ids-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/billsby/package.json
+++ b/components/billsby/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/billsby",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Billsby Components",
   "main": "billsby.app.mjs",
   "keywords": [

--- a/components/bitbucket/actions/list-workspace-options/list-workspace-options.mjs
+++ b/components/bitbucket/actions/list-workspace-options/list-workspace-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "bitbucket-list-workspace-options",
   name: "List Workspace Options",
   description: "Retrieves available options for the Workspace field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     bitbucket,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await bitbucket.propDefinitions.workspace.options
-        .call(this.bitbucket, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await bitbucket.propDefinitions.workspace.options
+      .call(this.bitbucket, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/bitbucket/actions/list-workspace-options/list-workspace-options.mjs
+++ b/components/bitbucket/actions/list-workspace-options/list-workspace-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "bitbucket-list-workspace-options",
   name: "List Workspace Options",
   description: "Retrieves available options for the Workspace field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/bitbucket/actions/list-workspace-options/list-workspace-options.mjs
+++ b/components/bitbucket/actions/list-workspace-options/list-workspace-options.mjs
@@ -1,0 +1,34 @@
+import bitbucket from "../../bitbucket.app.mjs";
+
+export default {
+  key: "bitbucket-list-workspace-options",
+  name: "List Workspace Options",
+  description: "Retrieves available options for the Workspace field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    bitbucket,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await bitbucket.propDefinitions.workspace.options
+        .call(this.bitbucket, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/bitbucket/actions/list-workspace-options/list-workspace-options.mjs
+++ b/components/bitbucket/actions/list-workspace-options/list-workspace-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/bitbucket/package.json
+++ b/components/bitbucket/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/bitbucket",
-  "version": "0.3.10",
+  "version": "0.4.0",
   "description": "Pipedream Bitbucket Components",
   "main": "bitbucket.app.mjs",
   "keywords": [

--- a/components/bitdefender_gravityzone/actions/get-policy-details/get-policy-details.mjs
+++ b/components/bitdefender_gravityzone/actions/get-policy-details/get-policy-details.mjs
@@ -4,7 +4,7 @@ export default {
   key: "bitdefender_gravityzone-get-policy-details",
   name: "Get Policy Details",
   description: "Retrieve details about a specific policy. [See the documentation](https://www.bitdefender.com/business/support/en/77209-135304-getpolicydetails.html)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/bitdefender_gravityzone/actions/get-scan-task-status/get-scan-task-status.mjs
+++ b/components/bitdefender_gravityzone/actions/get-scan-task-status/get-scan-task-status.mjs
@@ -4,7 +4,7 @@ export default {
   key: "bitdefender_gravityzone-get-scan-task-status",
   name: "Get Scan Task Status",
   description: "Get the status of a scan task. [See the documentation(https://www.bitdefender.com/business/support/en/77209-440638-gettaskstatus.html)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/bitdefender_gravityzone/actions/get-scan-task-status/get-scan-task-status.mjs
+++ b/components/bitdefender_gravityzone/actions/get-scan-task-status/get-scan-task-status.mjs
@@ -3,7 +3,7 @@ import bitdefender from "../../bitdefender_gravityzone.app.mjs";
 export default {
   key: "bitdefender_gravityzone-get-scan-task-status",
   name: "Get Scan Task Status",
-  description: "Get the status of a scan task. [See the documentation(https://www.bitdefender.com/business/support/en/77209-440638-gettaskstatus.html)",
+  description: "Get the status of a scan task. [See the documentation](https://www.bitdefender.com/business/support/en/77209-440638-gettaskstatus.html)",
   version: "0.0.3",
   annotations: {
     destructiveHint: false,

--- a/components/bitdefender_gravityzone/actions/list-endpoint-id-options/list-endpoint-id-options.mjs
+++ b/components/bitdefender_gravityzone/actions/list-endpoint-id-options/list-endpoint-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "bitdefender_gravityzone-list-endpoint-id-options",
   name: "List Endpoint ID Options",
   description: "Retrieves available options for the Endpoint ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     bitdefender_gravityzone,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await bitdefender_gravityzone.propDefinitions.endpointId.options
-        .call(this.bitdefender_gravityzone, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await bitdefender_gravityzone.propDefinitions.endpointId.options
+      .call(this.bitdefender_gravityzone, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/bitdefender_gravityzone/actions/list-endpoint-id-options/list-endpoint-id-options.mjs
+++ b/components/bitdefender_gravityzone/actions/list-endpoint-id-options/list-endpoint-id-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     bitdefender_gravityzone,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        bitdefender_gravityzone,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/bitdefender_gravityzone/actions/list-endpoint-id-options/list-endpoint-id-options.mjs
+++ b/components/bitdefender_gravityzone/actions/list-endpoint-id-options/list-endpoint-id-options.mjs
@@ -1,0 +1,34 @@
+import bitdefender_gravityzone from "../../bitdefender_gravityzone.app.mjs";
+
+export default {
+  key: "bitdefender_gravityzone-list-endpoint-id-options",
+  name: "List Endpoint ID Options",
+  description: "Retrieves available options for the Endpoint ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    bitdefender_gravityzone,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await bitdefender_gravityzone.propDefinitions.endpointId.options
+        .call(this.bitdefender_gravityzone, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/bitdefender_gravityzone/actions/list-endpoint-id-options/list-endpoint-id-options.mjs
+++ b/components/bitdefender_gravityzone/actions/list-endpoint-id-options/list-endpoint-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "bitdefender_gravityzone-list-endpoint-id-options",
   name: "List Endpoint ID Options",
   description: "Retrieves available options for the Endpoint ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/bitdefender_gravityzone/actions/list-endpoint-id-options/list-endpoint-id-options.mjs
+++ b/components/bitdefender_gravityzone/actions/list-endpoint-id-options/list-endpoint-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/bitdefender_gravityzone/actions/list-policy-id-options/list-policy-id-options.mjs
+++ b/components/bitdefender_gravityzone/actions/list-policy-id-options/list-policy-id-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     bitdefender_gravityzone,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        bitdefender_gravityzone,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/bitdefender_gravityzone/actions/list-policy-id-options/list-policy-id-options.mjs
+++ b/components/bitdefender_gravityzone/actions/list-policy-id-options/list-policy-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "bitdefender_gravityzone-list-policy-id-options",
   name: "List Policy ID Options",
   description: "Retrieves available options for the Policy ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     bitdefender_gravityzone,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await bitdefender_gravityzone.propDefinitions.policyId.options
-        .call(this.bitdefender_gravityzone, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await bitdefender_gravityzone.propDefinitions.policyId.options
+      .call(this.bitdefender_gravityzone, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/bitdefender_gravityzone/actions/list-policy-id-options/list-policy-id-options.mjs
+++ b/components/bitdefender_gravityzone/actions/list-policy-id-options/list-policy-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "bitdefender_gravityzone-list-policy-id-options",
   name: "List Policy ID Options",
   description: "Retrieves available options for the Policy ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/bitdefender_gravityzone/actions/list-policy-id-options/list-policy-id-options.mjs
+++ b/components/bitdefender_gravityzone/actions/list-policy-id-options/list-policy-id-options.mjs
@@ -1,0 +1,34 @@
+import bitdefender_gravityzone from "../../bitdefender_gravityzone.app.mjs";
+
+export default {
+  key: "bitdefender_gravityzone-list-policy-id-options",
+  name: "List Policy ID Options",
+  description: "Retrieves available options for the Policy ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    bitdefender_gravityzone,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await bitdefender_gravityzone.propDefinitions.policyId.options
+        .call(this.bitdefender_gravityzone, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/bitdefender_gravityzone/actions/list-policy-id-options/list-policy-id-options.mjs
+++ b/components/bitdefender_gravityzone/actions/list-policy-id-options/list-policy-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/bitdefender_gravityzone/actions/list-task-id-options/list-task-id-options.mjs
+++ b/components/bitdefender_gravityzone/actions/list-task-id-options/list-task-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "bitdefender_gravityzone-list-task-id-options",
   name: "List Task ID Options",
   description: "Retrieves available options for the Task ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/bitdefender_gravityzone/actions/list-task-id-options/list-task-id-options.mjs
+++ b/components/bitdefender_gravityzone/actions/list-task-id-options/list-task-id-options.mjs
@@ -1,0 +1,34 @@
+import bitdefender_gravityzone from "../../bitdefender_gravityzone.app.mjs";
+
+export default {
+  key: "bitdefender_gravityzone-list-task-id-options",
+  name: "List Task ID Options",
+  description: "Retrieves available options for the Task ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    bitdefender_gravityzone,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await bitdefender_gravityzone.propDefinitions.taskId.options
+        .call(this.bitdefender_gravityzone, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/bitdefender_gravityzone/actions/list-task-id-options/list-task-id-options.mjs
+++ b/components/bitdefender_gravityzone/actions/list-task-id-options/list-task-id-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     bitdefender_gravityzone,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        bitdefender_gravityzone,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/bitdefender_gravityzone/actions/list-task-id-options/list-task-id-options.mjs
+++ b/components/bitdefender_gravityzone/actions/list-task-id-options/list-task-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "bitdefender_gravityzone-list-task-id-options",
   name: "List Task ID Options",
   description: "Retrieves available options for the Task ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     bitdefender_gravityzone,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await bitdefender_gravityzone.propDefinitions.taskId.options
-        .call(this.bitdefender_gravityzone, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await bitdefender_gravityzone.propDefinitions.taskId.options
+      .call(this.bitdefender_gravityzone, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/bitdefender_gravityzone/actions/list-task-id-options/list-task-id-options.mjs
+++ b/components/bitdefender_gravityzone/actions/list-task-id-options/list-task-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/bitdefender_gravityzone/actions/move-endpoint-to-group/move-endpoint-to-group.mjs
+++ b/components/bitdefender_gravityzone/actions/move-endpoint-to-group/move-endpoint-to-group.mjs
@@ -4,7 +4,7 @@ export default {
   key: "bitdefender_gravityzone-move-endpoint-to-group",
   name: "Move Endpoint to Group",
   description: "Move an endpoint to a different group. [See the documentation](https://www.bitdefender.com/business/support/en/77209-128489-moveendpoints.html)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/bitdefender_gravityzone/actions/scan-endpoint/scan-endpoint.mjs
+++ b/components/bitdefender_gravityzone/actions/scan-endpoint/scan-endpoint.mjs
@@ -5,7 +5,7 @@ export default {
   key: "bitdefender_gravityzone-scan-endpoint",
   name: "Scan Endpoint",
   description: "Trigger a scan on a specific endpoint. [See the documentation](https://www.bitdefender.com/business/support/en/77209-128495-createscantask.html)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/bitdefender_gravityzone/bitdefender_gravityzone.app.mjs
+++ b/components/bitdefender_gravityzone/bitdefender_gravityzone.app.mjs
@@ -4,6 +4,13 @@ export default {
   type: "app",
   app: "bitdefender_gravityzone",
   propDefinitions: {
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve, zero-based.",
+      min: 0,
+      default: 0,
+    },
     endpointId: {
       type: "string",
       label: "Endpoint ID",

--- a/components/bitdefender_gravityzone/package.json
+++ b/components/bitdefender_gravityzone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/bitdefender_gravityzone",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Bitdefender GravityZone Components",
   "main": "bitdefender_gravityzone.app.mjs",
   "keywords": [

--- a/components/bitdefender_gravityzone/sources/new-endpoint-added-instant/new-endpoint-added-instant.mjs
+++ b/components/bitdefender_gravityzone/sources/new-endpoint-added-instant/new-endpoint-added-instant.mjs
@@ -6,7 +6,7 @@ export default {
   key: "bitdefender_gravityzone-new-endpoint-added-instant",
   name: "New Endpoint Added (Instant)",
   description: "Emit new event when a new endpoint is registered in Bitdefender GravityZone.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/bitdefender_gravityzone/sources/new-incident-instant/new-incident-instant.mjs
+++ b/components/bitdefender_gravityzone/sources/new-incident-instant/new-incident-instant.mjs
@@ -6,7 +6,7 @@ export default {
   key: "bitdefender_gravityzone-new-incident-instant",
   name: "New Incident (Instant)",
   description: "Emit new event when a new Root Cause Analysis (RCA) is displayed under the Incidents section of Control Center.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/bitdefender_gravityzone/sources/new-threat-detected-instant/new-threat-detected-instant.mjs
+++ b/components/bitdefender_gravityzone/sources/new-threat-detected-instant/new-threat-detected-instant.mjs
@@ -6,7 +6,7 @@ export default {
   key: "bitdefender_gravityzone-new-threat-detected-instant",
   name: "New Threat Detected (Instant)",
   description: "Emit new event when a potentially dangerous application is detected and blocked on an endpoint",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/bitdefender_gravityzone/sources/new-threat-detected-instant/new-threat-detected-instant.mjs
+++ b/components/bitdefender_gravityzone/sources/new-threat-detected-instant/new-threat-detected-instant.mjs
@@ -16,11 +16,14 @@ export default {
         "avc": true,  // advanced threat control
       };
     },
-    generateMeta() {
+    generateMeta(event) {
+      const ts = event?.last_blocked
+        ? new Date(event.last_blocked).getTime()
+        : Date.now();
       return {
-        id: Date.now(),
+        id: `${event?.computer_id}-${ts}`,
         summary: "New Threat Detected",
-        ts: Date.now(),
+        ts,
       };
     },
   },

--- a/components/blink/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/blink/actions/list-user-id-options/list-user-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "blink-list-user-id-options",
   name: "List User ID Options",
   description: "Retrieves available options for the User ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     blink,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await blink.propDefinitions.userId.options
-        .call(this.blink, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await blink.propDefinitions.userId.options
+      .call(this.blink, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/blink/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/blink/actions/list-user-id-options/list-user-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "blink-list-user-id-options",
   name: "List User ID Options",
   description: "Retrieves available options for the User ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/blink/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/blink/actions/list-user-id-options/list-user-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/blink/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/blink/actions/list-user-id-options/list-user-id-options.mjs
@@ -1,0 +1,34 @@
+import blink from "../../blink.app.mjs";
+
+export default {
+  key: "blink-list-user-id-options",
+  name: "List User ID Options",
+  description: "Retrieves available options for the User ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    blink,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await blink.propDefinitions.userId.options
+        .call(this.blink, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/blink/package.json
+++ b/components/blink/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/blink",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Blink Components",
   "main": "blink.app.mjs",
   "keywords": [

--- a/components/bloomerang/actions/list-appeal-id-options/list-appeal-id-options.mjs
+++ b/components/bloomerang/actions/list-appeal-id-options/list-appeal-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "bloomerang-list-appeal-id-options",
   name: "List Appeal Options",
   description: "Retrieves available options for the Appeal field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     bloomerang,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await bloomerang.propDefinitions.appealId.options
-        .call(this.bloomerang, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await bloomerang.propDefinitions.appealId.options
+      .call(this.bloomerang, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/bloomerang/actions/list-appeal-id-options/list-appeal-id-options.mjs
+++ b/components/bloomerang/actions/list-appeal-id-options/list-appeal-id-options.mjs
@@ -1,0 +1,34 @@
+import bloomerang from "../../bloomerang.app.mjs";
+
+export default {
+  key: "bloomerang-list-appeal-id-options",
+  name: "List Appeal Options",
+  description: "Retrieves available options for the Appeal field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    bloomerang,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await bloomerang.propDefinitions.appealId.options
+        .call(this.bloomerang, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/bloomerang/actions/list-appeal-id-options/list-appeal-id-options.mjs
+++ b/components/bloomerang/actions/list-appeal-id-options/list-appeal-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "bloomerang-list-appeal-id-options",
   name: "List Appeal Options",
   description: "Retrieves available options for the Appeal field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/bloomerang/actions/list-appeal-id-options/list-appeal-id-options.mjs
+++ b/components/bloomerang/actions/list-appeal-id-options/list-appeal-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/bloomerang/actions/list-campaign-id-options/list-campaign-id-options.mjs
+++ b/components/bloomerang/actions/list-campaign-id-options/list-campaign-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "bloomerang-list-campaign-id-options",
   name: "List Campaign Options",
   description: "Retrieves available options for the Campaign field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     bloomerang,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await bloomerang.propDefinitions.campaignId.options
-        .call(this.bloomerang, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await bloomerang.propDefinitions.campaignId.options
+      .call(this.bloomerang, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/bloomerang/actions/list-campaign-id-options/list-campaign-id-options.mjs
+++ b/components/bloomerang/actions/list-campaign-id-options/list-campaign-id-options.mjs
@@ -1,0 +1,34 @@
+import bloomerang from "../../bloomerang.app.mjs";
+
+export default {
+  key: "bloomerang-list-campaign-id-options",
+  name: "List Campaign Options",
+  description: "Retrieves available options for the Campaign field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    bloomerang,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await bloomerang.propDefinitions.campaignId.options
+        .call(this.bloomerang, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/bloomerang/actions/list-campaign-id-options/list-campaign-id-options.mjs
+++ b/components/bloomerang/actions/list-campaign-id-options/list-campaign-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "bloomerang-list-campaign-id-options",
   name: "List Campaign Options",
   description: "Retrieves available options for the Campaign field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/bloomerang/actions/list-campaign-id-options/list-campaign-id-options.mjs
+++ b/components/bloomerang/actions/list-campaign-id-options/list-campaign-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/bloomerang/actions/list-constituent-id-options/list-constituent-id-options.mjs
+++ b/components/bloomerang/actions/list-constituent-id-options/list-constituent-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "bloomerang-list-constituent-id-options",
   name: "List Constituent ID Options",
   description: "Retrieves available options for the Constituent ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     bloomerang,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await bloomerang.propDefinitions.constituentId.options
-        .call(this.bloomerang, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await bloomerang.propDefinitions.constituentId.options
+      .call(this.bloomerang, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/bloomerang/actions/list-constituent-id-options/list-constituent-id-options.mjs
+++ b/components/bloomerang/actions/list-constituent-id-options/list-constituent-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "bloomerang-list-constituent-id-options",
   name: "List Constituent ID Options",
   description: "Retrieves available options for the Constituent ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/bloomerang/actions/list-constituent-id-options/list-constituent-id-options.mjs
+++ b/components/bloomerang/actions/list-constituent-id-options/list-constituent-id-options.mjs
@@ -1,0 +1,34 @@
+import bloomerang from "../../bloomerang.app.mjs";
+
+export default {
+  key: "bloomerang-list-constituent-id-options",
+  name: "List Constituent ID Options",
+  description: "Retrieves available options for the Constituent ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    bloomerang,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await bloomerang.propDefinitions.constituentId.options
+        .call(this.bloomerang, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/bloomerang/actions/list-constituent-id-options/list-constituent-id-options.mjs
+++ b/components/bloomerang/actions/list-constituent-id-options/list-constituent-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/bloomerang/actions/list-fund-id-options/list-fund-id-options.mjs
+++ b/components/bloomerang/actions/list-fund-id-options/list-fund-id-options.mjs
@@ -1,0 +1,34 @@
+import bloomerang from "../../bloomerang.app.mjs";
+
+export default {
+  key: "bloomerang-list-fund-id-options",
+  name: "List Fund Options",
+  description: "Retrieves available options for the Fund field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    bloomerang,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await bloomerang.propDefinitions.fundId.options
+        .call(this.bloomerang, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/bloomerang/actions/list-fund-id-options/list-fund-id-options.mjs
+++ b/components/bloomerang/actions/list-fund-id-options/list-fund-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "bloomerang-list-fund-id-options",
   name: "List Fund Options",
   description: "Retrieves available options for the Fund field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/bloomerang/actions/list-fund-id-options/list-fund-id-options.mjs
+++ b/components/bloomerang/actions/list-fund-id-options/list-fund-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "bloomerang-list-fund-id-options",
   name: "List Fund Options",
   description: "Retrieves available options for the Fund field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     bloomerang,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await bloomerang.propDefinitions.fundId.options
-        .call(this.bloomerang, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await bloomerang.propDefinitions.fundId.options
+      .call(this.bloomerang, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/bloomerang/actions/list-fund-id-options/list-fund-id-options.mjs
+++ b/components/bloomerang/actions/list-fund-id-options/list-fund-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/bloomerang/package.json
+++ b/components/bloomerang/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/bloomerang",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream Bloomerang Components",
   "main": "bloomerang.app.mjs",
   "keywords": [

--- a/components/bol_com/actions/list-category-id-options/list-category-id-options.mjs
+++ b/components/bol_com/actions/list-category-id-options/list-category-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "bol_com-list-category-id-options",
   name: "List Category ID Options",
   description: "Retrieves available options for the Category ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     bol_com,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await bol_com.propDefinitions.categoryId.options
-        .call(this.bol_com, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await bol_com.propDefinitions.categoryId.options
+      .call(this.bol_com, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/bol_com/actions/list-category-id-options/list-category-id-options.mjs
+++ b/components/bol_com/actions/list-category-id-options/list-category-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "bol_com-list-category-id-options",
   name: "List Category ID Options",
   description: "Retrieves available options for the Category ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/bol_com/actions/list-category-id-options/list-category-id-options.mjs
+++ b/components/bol_com/actions/list-category-id-options/list-category-id-options.mjs
@@ -1,0 +1,34 @@
+import bol_com from "../../bol_com.app.mjs";
+
+export default {
+  key: "bol_com-list-category-id-options",
+  name: "List Category ID Options",
+  description: "Retrieves available options for the Category ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    bol_com,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await bol_com.propDefinitions.categoryId.options
+        .call(this.bol_com, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/bol_com/actions/list-category-id-options/list-category-id-options.mjs
+++ b/components/bol_com/actions/list-category-id-options/list-category-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/bol_com/actions/list-order-id-options/list-order-id-options.mjs
+++ b/components/bol_com/actions/list-order-id-options/list-order-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "bol_com-list-order-id-options",
   name: "List Order ID Options",
   description: "Retrieves available options for the Order ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/bol_com/actions/list-order-id-options/list-order-id-options.mjs
+++ b/components/bol_com/actions/list-order-id-options/list-order-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "bol_com-list-order-id-options",
   name: "List Order ID Options",
   description: "Retrieves available options for the Order ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     bol_com,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await bol_com.propDefinitions.orderId.options
-        .call(this.bol_com, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await bol_com.propDefinitions.orderId.options
+      .call(this.bol_com, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/bol_com/actions/list-order-id-options/list-order-id-options.mjs
+++ b/components/bol_com/actions/list-order-id-options/list-order-id-options.mjs
@@ -1,0 +1,34 @@
+import bol_com from "../../bol_com.app.mjs";
+
+export default {
+  key: "bol_com-list-order-id-options",
+  name: "List Order ID Options",
+  description: "Retrieves available options for the Order ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    bol_com,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await bol_com.propDefinitions.orderId.options
+        .call(this.bol_com, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/bol_com/actions/list-order-id-options/list-order-id-options.mjs
+++ b/components/bol_com/actions/list-order-id-options/list-order-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/bol_com/actions/list-return-id-options/list-return-id-options.mjs
+++ b/components/bol_com/actions/list-return-id-options/list-return-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "bol_com-list-return-id-options",
   name: "List Return ID Options",
   description: "Retrieves available options for the Return ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     bol_com,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await bol_com.propDefinitions.returnId.options
-        .call(this.bol_com, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await bol_com.propDefinitions.returnId.options
+      .call(this.bol_com, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/bol_com/actions/list-return-id-options/list-return-id-options.mjs
+++ b/components/bol_com/actions/list-return-id-options/list-return-id-options.mjs
@@ -1,0 +1,34 @@
+import bol_com from "../../bol_com.app.mjs";
+
+export default {
+  key: "bol_com-list-return-id-options",
+  name: "List Return ID Options",
+  description: "Retrieves available options for the Return ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    bol_com,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await bol_com.propDefinitions.returnId.options
+        .call(this.bol_com, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/bol_com/actions/list-return-id-options/list-return-id-options.mjs
+++ b/components/bol_com/actions/list-return-id-options/list-return-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "bol_com-list-return-id-options",
   name: "List Return ID Options",
   description: "Retrieves available options for the Return ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/bol_com/actions/list-return-id-options/list-return-id-options.mjs
+++ b/components/bol_com/actions/list-return-id-options/list-return-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/bol_com/actions/list-shipment-id-options/list-shipment-id-options.mjs
+++ b/components/bol_com/actions/list-shipment-id-options/list-shipment-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "bol_com-list-shipment-id-options",
   name: "List Shipment ID Options",
   description: "Retrieves available options for the Shipment ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/bol_com/actions/list-shipment-id-options/list-shipment-id-options.mjs
+++ b/components/bol_com/actions/list-shipment-id-options/list-shipment-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/bol_com/actions/list-shipment-id-options/list-shipment-id-options.mjs
+++ b/components/bol_com/actions/list-shipment-id-options/list-shipment-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "bol_com-list-shipment-id-options",
   name: "List Shipment ID Options",
   description: "Retrieves available options for the Shipment ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     bol_com,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await bol_com.propDefinitions.shipmentId.options
-        .call(this.bol_com, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await bol_com.propDefinitions.shipmentId.options
+      .call(this.bol_com, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/bol_com/actions/list-shipment-id-options/list-shipment-id-options.mjs
+++ b/components/bol_com/actions/list-shipment-id-options/list-shipment-id-options.mjs
@@ -1,0 +1,34 @@
+import bol_com from "../../bol_com.app.mjs";
+
+export default {
+  key: "bol_com-list-shipment-id-options",
+  name: "List Shipment ID Options",
+  description: "Retrieves available options for the Shipment ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    bol_com,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await bol_com.propDefinitions.shipmentId.options
+        .call(this.bol_com, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/bol_com/package.json
+++ b/components/bol_com/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/bol_com",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Bol.com Components",
   "main": "bol_com.app.mjs",
   "keywords": [

--- a/components/boldsign/actions/list-cc-options/list-cc-options.mjs
+++ b/components/boldsign/actions/list-cc-options/list-cc-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "boldsign-list-cc-options",
   name: "List CC Options",
   description: "Retrieves available options for the CC field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/boldsign/actions/list-cc-options/list-cc-options.mjs
+++ b/components/boldsign/actions/list-cc-options/list-cc-options.mjs
@@ -1,0 +1,34 @@
+import boldsign from "../../boldsign.app.mjs";
+
+export default {
+  key: "boldsign-list-cc-options",
+  name: "List CC Options",
+  description: "Retrieves available options for the CC field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    boldsign,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await boldsign.propDefinitions.cc.options
+        .call(this.boldsign, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/boldsign/actions/list-cc-options/list-cc-options.mjs
+++ b/components/boldsign/actions/list-cc-options/list-cc-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "boldsign-list-cc-options",
   name: "List CC Options",
   description: "Retrieves available options for the CC field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     boldsign,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await boldsign.propDefinitions.cc.options
-        .call(this.boldsign, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await boldsign.propDefinitions.cc.options
+      .call(this.boldsign, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/boldsign/actions/list-cc-options/list-cc-options.mjs
+++ b/components/boldsign/actions/list-cc-options/list-cc-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/boldsign/actions/list-sent-by-options/list-sent-by-options.mjs
+++ b/components/boldsign/actions/list-sent-by-options/list-sent-by-options.mjs
@@ -1,0 +1,34 @@
+import boldsign from "../../boldsign.app.mjs";
+
+export default {
+  key: "boldsign-list-sent-by-options",
+  name: "List Sent By Options",
+  description: "Retrieves available options for the Sent By field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    boldsign,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await boldsign.propDefinitions.sentBy.options
+        .call(this.boldsign, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/boldsign/actions/list-sent-by-options/list-sent-by-options.mjs
+++ b/components/boldsign/actions/list-sent-by-options/list-sent-by-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "boldsign-list-sent-by-options",
   name: "List Sent By Options",
   description: "Retrieves available options for the Sent By field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     boldsign,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await boldsign.propDefinitions.sentBy.options
-        .call(this.boldsign, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await boldsign.propDefinitions.sentBy.options
+      .call(this.boldsign, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/boldsign/actions/list-sent-by-options/list-sent-by-options.mjs
+++ b/components/boldsign/actions/list-sent-by-options/list-sent-by-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "boldsign-list-sent-by-options",
   name: "List Sent By Options",
   description: "Retrieves available options for the Sent By field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/boldsign/actions/list-sent-by-options/list-sent-by-options.mjs
+++ b/components/boldsign/actions/list-sent-by-options/list-sent-by-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/boldsign/actions/list-template-id-options/list-template-id-options.mjs
+++ b/components/boldsign/actions/list-template-id-options/list-template-id-options.mjs
@@ -1,0 +1,34 @@
+import boldsign from "../../boldsign.app.mjs";
+
+export default {
+  key: "boldsign-list-template-id-options",
+  name: "List Template ID Options",
+  description: "Retrieves available options for the Template ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    boldsign,
+  },
+  async run({ $ }) {
+    const results = [];
+    let page = 0;
+    while (true) {
+      const options = await boldsign.propDefinitions.templateId.options
+        .call(this.boldsign, {
+          page,
+        });
+      if (!options?.length) break;
+      results.push(...options);
+      page++;
+    }
+    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};

--- a/components/boldsign/actions/list-template-id-options/list-template-id-options.mjs
+++ b/components/boldsign/actions/list-template-id-options/list-template-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "boldsign-list-template-id-options",
   name: "List Template ID Options",
   description: "Retrieves available options for the Template ID field.",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/boldsign/actions/list-template-id-options/list-template-id-options.mjs
+++ b/components/boldsign/actions/list-template-id-options/list-template-id-options.mjs
@@ -17,7 +17,7 @@ export default {
       type: "integer",
       label: "Page",
       description: "The page of results to retrieve.",
-      optional: true,
+      min: 0,
       default: 0,
     },
   },

--- a/components/boldsign/actions/list-template-id-options/list-template-id-options.mjs
+++ b/components/boldsign/actions/list-template-id-options/list-template-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "boldsign-list-template-id-options",
   name: "List Template ID Options",
   description: "Retrieves available options for the Template ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,22 +13,22 @@ export default {
   },
   props: {
     boldsign,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      optional: true,
+      default: 0,
+    },
   },
   async run({ $ }) {
-    const results = [];
-    let page = 0;
-    while (true) {
-      const options = await boldsign.propDefinitions.templateId.options
-        .call(this.boldsign, {
-          page,
-        });
-      if (!options?.length) break;
-      results.push(...options);
-      page++;
-    }
-    $.export("$summary", `Successfully retrieved ${results.length} option${results.length === 1
+    const options = await boldsign.propDefinitions.templateId.options
+      .call(this.boldsign, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);
-    return results;
+    return options;
   },
 };

--- a/components/boldsign/package.json
+++ b/components/boldsign/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/boldsign",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Pipedream BoldSign Components",
   "main": "boldsign.app.mjs",
   "keywords": [


### PR DESCRIPTION
Adds a batch of 75 new actions for retrieving prop options that accept the `page` parameter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added paginated "list options" actions across 50+ integrations so dynamic dropdowns can fetch values page-by-page (improved pagination support).

* **Chores**
  * Added a standardized page input to affected app configurations.
  * Bumped component package versions (minor/patch) across the updated integrations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PipedreamHQ/pipedream/pull/20907?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->