### PR TITLE
Actions for page only prop options batch 2

### DIFF
--- a/components/boloforms/actions/list-form-id-options/list-form-id-options.mjs
+++ b/components/boloforms/actions/list-form-id-options/list-form-id-options.mjs
@@ -1,0 +1,33 @@
+import boloforms from "../../boloforms.app.mjs";
+
+export default {
+  key: "boloforms-list-form-id-options",
+  name: "List Form ID Options",
+  description: "Retrieves available options for the Form ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    boloforms,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await boloforms.propDefinitions.formId.options.call(this.boloforms, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/boloforms/package.json
+++ b/components/boloforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/boloforms",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream Boloforms Components",
   "main": "boloforms.app.mjs",
   "keywords": [

--- a/components/booking_experts/actions/list-administration-id-options/list-administration-id-options.mjs
+++ b/components/booking_experts/actions/list-administration-id-options/list-administration-id-options.mjs
@@ -1,0 +1,34 @@
+import booking_experts from "../../booking_experts.app.mjs";
+
+export default {
+  key: "booking_experts-list-administration-id-options",
+  name: "List Administration ID Options",
+  description: "Retrieves available options for the Administration ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    booking_experts,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await booking_experts.propDefinitions.administrationId.options
+      .call(this.booking_experts, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/booking_experts/actions/list-amenity-group-id-options/list-amenity-group-id-options.mjs
+++ b/components/booking_experts/actions/list-amenity-group-id-options/list-amenity-group-id-options.mjs
@@ -1,0 +1,34 @@
+import booking_experts from "../../booking_experts.app.mjs";
+
+export default {
+  key: "booking_experts-list-amenity-group-id-options",
+  name: "List Amenity Group ID Options",
+  description: "Retrieves available options for the Amenity Group ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    booking_experts,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await booking_experts.propDefinitions.amenityGroupId.options
+      .call(this.booking_experts, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/booking_experts/actions/list-amenity-id-options/list-amenity-id-options.mjs
+++ b/components/booking_experts/actions/list-amenity-id-options/list-amenity-id-options.mjs
@@ -1,0 +1,34 @@
+import booking_experts from "../../booking_experts.app.mjs";
+
+export default {
+  key: "booking_experts-list-amenity-id-options",
+  name: "List Amenity ID Options",
+  description: "Retrieves available options for the Amenity ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    booking_experts,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await booking_experts.propDefinitions.amenityId.options
+      .call(this.booking_experts, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/booking_experts/actions/list-channel-id-options/list-channel-id-options.mjs
+++ b/components/booking_experts/actions/list-channel-id-options/list-channel-id-options.mjs
@@ -1,0 +1,34 @@
+import booking_experts from "../../booking_experts.app.mjs";
+
+export default {
+  key: "booking_experts-list-channel-id-options",
+  name: "List Channel ID Options",
+  description: "Retrieves available options for the Channel ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    booking_experts,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await booking_experts.propDefinitions.channelId.options
+      .call(this.booking_experts, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/booking_experts/actions/list-rentable-segment-id-options/list-rentable-segment-id-options.mjs
+++ b/components/booking_experts/actions/list-rentable-segment-id-options/list-rentable-segment-id-options.mjs
@@ -1,0 +1,34 @@
+import booking_experts from "../../booking_experts.app.mjs";
+
+export default {
+  key: "booking_experts-list-rentable-segment-id-options",
+  name: "List Rentable Segment ID Options",
+  description: "Retrieves available options for the Rentable Segment ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    booking_experts,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await booking_experts.propDefinitions.rentableSegmentId.options
+      .call(this.booking_experts, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/booking_experts/package.json
+++ b/components/booking_experts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/booking_experts",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Pipedream Booking Experts Components",
   "main": "booking_experts.app.mjs",
   "keywords": [

--- a/components/booqable/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/booqable/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -1,0 +1,33 @@
+import booqable from "../../booqable.app.mjs";
+
+export default {
+  key: "booqable-list-customer-id-options",
+  name: "List Customer ID Options",
+  description: "Retrieves available options for the Customer ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    booqable,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await booqable.propDefinitions.customerId.options.call(this.booqable, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/booqable/package.json
+++ b/components/booqable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/booqable",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Booqable Components",
   "main": "booqable.app.mjs",
   "keywords": [

--- a/components/botconversa/actions/list-subscriber-id-options/list-subscriber-id-options.mjs
+++ b/components/botconversa/actions/list-subscriber-id-options/list-subscriber-id-options.mjs
@@ -1,0 +1,33 @@
+import botconversa from "../../botconversa.app.mjs";
+
+export default {
+  key: "botconversa-list-subscriber-id-options",
+  name: "List Subscriber Id Options",
+  description: "Retrieves available options for the Subscriber Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    botconversa,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await botconversa.propDefinitions.subscriberId.options.call(this.botconversa, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/botconversa/package.json
+++ b/components/botconversa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/botconversa",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream BotConversa Components",
   "main": "botconversa.app.mjs",
   "keywords": [

--- a/components/botpenguin/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/botpenguin/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -1,0 +1,33 @@
+import botpenguin from "../../botpenguin.app.mjs";
+
+export default {
+  key: "botpenguin-list-contact-id-options",
+  name: "List Contact ID Options",
+  description: "Retrieves available options for the Contact ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    botpenguin,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await botpenguin.propDefinitions.contactId.options.call(this.botpenguin, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/botpenguin/package.json
+++ b/components/botpenguin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/botpenguin",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream BotPenguin Components",
   "main": "botpenguin.app.mjs",
   "keywords": [
@@ -16,4 +16,3 @@
     "@pipedream/platform": "^2.0.2"
   }
 }
-

--- a/components/breathe/actions/list-department-id-options/list-department-id-options.mjs
+++ b/components/breathe/actions/list-department-id-options/list-department-id-options.mjs
@@ -1,0 +1,33 @@
+import breathe from "../../breathe.app.mjs";
+
+export default {
+  key: "breathe-list-department-id-options",
+  name: "List Department ID Options",
+  description: "Retrieves available options for the Department ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    breathe,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await breathe.propDefinitions.departmentId.options.call(this.breathe, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/breathe/actions/list-employee-id-options/list-employee-id-options.mjs
+++ b/components/breathe/actions/list-employee-id-options/list-employee-id-options.mjs
@@ -1,0 +1,33 @@
+import breathe from "../../breathe.app.mjs";
+
+export default {
+  key: "breathe-list-employee-id-options",
+  name: "List Employee ID Options",
+  description: "Retrieves available options for the Employee ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    breathe,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await breathe.propDefinitions.employeeId.options.call(this.breathe, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/breathe/package.json
+++ b/components/breathe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/breathe",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Breathe Components",
   "main": "breathe.app.mjs",
   "keywords": [

--- a/components/brillium/actions/list-account-id-options/list-account-id-options.mjs
+++ b/components/brillium/actions/list-account-id-options/list-account-id-options.mjs
@@ -1,0 +1,33 @@
+import brillium from "../../brillium.app.mjs";
+
+export default {
+  key: "brillium-list-account-id-options",
+  name: "List Account ID Options",
+  description: "Retrieves available options for the Account ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    brillium,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await brillium.propDefinitions.accountId.options.call(this.brillium, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/brillium/package.json
+++ b/components/brillium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/brillium",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream Brillium Components",
   "main": "brillium.app.mjs",
   "keywords": [

--- a/components/browserhub/actions/list-scraper-id-options/list-scraper-id-options.mjs
+++ b/components/browserhub/actions/list-scraper-id-options/list-scraper-id-options.mjs
@@ -1,0 +1,33 @@
+import browserhub from "../../browserhub.app.mjs";
+
+export default {
+  key: "browserhub-list-scraper-id-options",
+  name: "List Scraper ID Options",
+  description: "Retrieves available options for the Scraper ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    browserhub,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await browserhub.propDefinitions.scraperId.options.call(this.browserhub, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/browserhub/package.json
+++ b/components/browserhub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/browserhub",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Browserhub Components",
   "main": "browserhub.app.mjs",
   "keywords": [
@@ -16,4 +16,3 @@
     "@pipedream/platform": "^1.6.8"
   }
 }
-

--- a/components/buddee/actions/list-company-id-options/list-company-id-options.mjs
+++ b/components/buddee/actions/list-company-id-options/list-company-id-options.mjs
@@ -1,0 +1,33 @@
+import buddee from "../../buddee.app.mjs";
+
+export default {
+  key: "buddee-list-company-id-options",
+  name: "List Company ID Options",
+  description: "Retrieves available options for the Company ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    buddee,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await buddee.propDefinitions.companyId.options.call(this.buddee, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/buddee/actions/list-cost-center-id-options/list-cost-center-id-options.mjs
+++ b/components/buddee/actions/list-cost-center-id-options/list-cost-center-id-options.mjs
@@ -1,0 +1,33 @@
+import buddee from "../../buddee.app.mjs";
+
+export default {
+  key: "buddee-list-cost-center-id-options",
+  name: "List Cost Center ID Options",
+  description: "Retrieves available options for the Cost Center ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    buddee,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await buddee.propDefinitions.costCenterId.options.call(this.buddee, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/buddee/actions/list-cost-unit-id-options/list-cost-unit-id-options.mjs
+++ b/components/buddee/actions/list-cost-unit-id-options/list-cost-unit-id-options.mjs
@@ -1,0 +1,33 @@
+import buddee from "../../buddee.app.mjs";
+
+export default {
+  key: "buddee-list-cost-unit-id-options",
+  name: "List Cost Unit ID Options",
+  description: "Retrieves available options for the Cost Unit ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    buddee,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await buddee.propDefinitions.costUnitId.options.call(this.buddee, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/buddee/actions/list-department-id-options/list-department-id-options.mjs
+++ b/components/buddee/actions/list-department-id-options/list-department-id-options.mjs
@@ -1,0 +1,33 @@
+import buddee from "../../buddee.app.mjs";
+
+export default {
+  key: "buddee-list-department-id-options",
+  name: "List Department ID Options",
+  description: "Retrieves available options for the Department ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    buddee,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await buddee.propDefinitions.departmentId.options.call(this.buddee, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/buddee/actions/list-employee-id-options/list-employee-id-options.mjs
+++ b/components/buddee/actions/list-employee-id-options/list-employee-id-options.mjs
@@ -1,0 +1,33 @@
+import buddee from "../../buddee.app.mjs";
+
+export default {
+  key: "buddee-list-employee-id-options",
+  name: "List Employee ID Options",
+  description: "Retrieves available options for the Employee ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    buddee,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await buddee.propDefinitions.employeeId.options.call(this.buddee, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/buddee/actions/list-job-id-options/list-job-id-options.mjs
+++ b/components/buddee/actions/list-job-id-options/list-job-id-options.mjs
@@ -1,0 +1,33 @@
+import buddee from "../../buddee.app.mjs";
+
+export default {
+  key: "buddee-list-job-id-options",
+  name: "List Job ID Options",
+  description: "Retrieves available options for the Job ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    buddee,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await buddee.propDefinitions.jobId.options.call(this.buddee, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/buddee/actions/list-leave-type-id-options/list-leave-type-id-options.mjs
+++ b/components/buddee/actions/list-leave-type-id-options/list-leave-type-id-options.mjs
@@ -1,0 +1,33 @@
+import buddee from "../../buddee.app.mjs";
+
+export default {
+  key: "buddee-list-leave-type-id-options",
+  name: "List Leave Type ID Options",
+  description: "Retrieves available options for the Leave Type ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    buddee,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await buddee.propDefinitions.leaveTypeId.options.call(this.buddee, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/buddee/actions/list-location-id-options/list-location-id-options.mjs
+++ b/components/buddee/actions/list-location-id-options/list-location-id-options.mjs
@@ -1,0 +1,33 @@
+import buddee from "../../buddee.app.mjs";
+
+export default {
+  key: "buddee-list-location-id-options",
+  name: "List Location ID Options",
+  description: "Retrieves available options for the Location ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    buddee,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await buddee.propDefinitions.locationId.options.call(this.buddee, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/buddee/actions/list-project-id-options/list-project-id-options.mjs
+++ b/components/buddee/actions/list-project-id-options/list-project-id-options.mjs
@@ -1,0 +1,33 @@
+import buddee from "../../buddee.app.mjs";
+
+export default {
+  key: "buddee-list-project-id-options",
+  name: "List Project ID Options",
+  description: "Retrieves available options for the Project ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    buddee,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await buddee.propDefinitions.projectId.options.call(this.buddee, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/buddee/actions/list-time-registration-type-id-options/list-time-registration-type-id-options.mjs
+++ b/components/buddee/actions/list-time-registration-type-id-options/list-time-registration-type-id-options.mjs
@@ -1,0 +1,33 @@
+import buddee from "../../buddee.app.mjs";
+
+export default {
+  key: "buddee-list-time-registration-type-id-options",
+  name: "List Time Registration Type ID Options",
+  description: "Retrieves available options for the Time Registration Type ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    buddee,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await buddee.propDefinitions.timeRegistrationTypeId.options.call(this.buddee, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/buddee/package.json
+++ b/components/buddee/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/buddee",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Buddee Components - HR and employee management platform integration",
   "main": "buddee.app.mjs",
   "keywords": [

--- a/components/bugbug/actions/list-suite-options/list-suite-options.mjs
+++ b/components/bugbug/actions/list-suite-options/list-suite-options.mjs
@@ -1,0 +1,33 @@
+import bugbug from "../../bugbug.app.mjs";
+
+export default {
+  key: "bugbug-list-suite-options",
+  name: "List Suite Options",
+  description: "Retrieves available options for the Suite field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    bugbug,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await bugbug.propDefinitions.suite.options.call(this.bugbug, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/bugbug/actions/list-test-options/list-test-options.mjs
+++ b/components/bugbug/actions/list-test-options/list-test-options.mjs
@@ -1,0 +1,33 @@
+import bugbug from "../../bugbug.app.mjs";
+
+export default {
+  key: "bugbug-list-test-options",
+  name: "List Test Options",
+  description: "Retrieves available options for the Test field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    bugbug,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await bugbug.propDefinitions.test.options.call(this.bugbug, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/bugbug/package.json
+++ b/components/bugbug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/bugbug",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream BugBug Components",
   "main": "bugbug.app.mjs",
   "keywords": [

--- a/components/buildchatbot/actions/list-chatbot-id-options/list-chatbot-id-options.mjs
+++ b/components/buildchatbot/actions/list-chatbot-id-options/list-chatbot-id-options.mjs
@@ -1,0 +1,33 @@
+import buildchatbot from "../../buildchatbot.app.mjs";
+
+export default {
+  key: "buildchatbot-list-chatbot-id-options",
+  name: "List Chatbot ID Options",
+  description: "Retrieves available options for the Chatbot ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    buildchatbot,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await buildchatbot.propDefinitions.chatbotId.options.call(this.buildchatbot, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/buildchatbot/package.json
+++ b/components/buildchatbot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/buildchatbot",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream BuildChatbot Components",
   "main": "buildchatbot.app.mjs",
   "keywords": [

--- a/components/bytenite/actions/list-template-id-options/list-template-id-options.mjs
+++ b/components/bytenite/actions/list-template-id-options/list-template-id-options.mjs
@@ -1,0 +1,33 @@
+import bytenite from "../../bytenite.app.mjs";
+
+export default {
+  key: "bytenite-list-template-id-options",
+  name: "List Template ID Options",
+  description: "Retrieves available options for the Template ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    bytenite,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await bytenite.propDefinitions.templateId.options.call(this.bytenite, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/bytenite/package.json
+++ b/components/bytenite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/bytenite",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream ByteNite Components",
   "main": "bytenite.app.mjs",
   "keywords": [

--- a/components/callpage/actions/list-widget-id-options/list-widget-id-options.mjs
+++ b/components/callpage/actions/list-widget-id-options/list-widget-id-options.mjs
@@ -1,0 +1,33 @@
+import callpage from "../../callpage.app.mjs";
+
+export default {
+  key: "callpage-list-widget-id-options",
+  name: "List Widget Options",
+  description: "Retrieves available options for the Widget field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    callpage,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await callpage.propDefinitions.widgetId.options.call(this.callpage, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/callpage/package.json
+++ b/components/callpage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/callpage",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream CallPage Components",
   "main": "callpage.app.mjs",
   "keywords": [
@@ -16,4 +16,3 @@
     "@pipedream/platform": "^1.6.8"
   }
 }
-

--- a/components/callrail/actions/list-account-id-options/list-account-id-options.mjs
+++ b/components/callrail/actions/list-account-id-options/list-account-id-options.mjs
@@ -1,0 +1,33 @@
+import callrail from "../../callrail.app.mjs";
+
+export default {
+  key: "callrail-list-account-id-options",
+  name: "List Account ID Options",
+  description: "Retrieves available options for the Account ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    callrail,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await callrail.propDefinitions.accountId.options.call(this.callrail, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/callrail/package.json
+++ b/components/callrail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/callrail",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream CallRail Components",
   "main": "callrail.app.mjs",
   "keywords": [

--- a/components/canny/actions/list-category-id-options/list-category-id-options.mjs
+++ b/components/canny/actions/list-category-id-options/list-category-id-options.mjs
@@ -1,0 +1,33 @@
+import canny from "../../canny.app.mjs";
+
+export default {
+  key: "canny-list-category-id-options",
+  name: "List Category ID Options",
+  description: "Retrieves available options for the Category ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    canny,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await canny.propDefinitions.categoryId.options.call(this.canny, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/canny/actions/list-comment-id-options/list-comment-id-options.mjs
+++ b/components/canny/actions/list-comment-id-options/list-comment-id-options.mjs
@@ -1,0 +1,33 @@
+import canny from "../../canny.app.mjs";
+
+export default {
+  key: "canny-list-comment-id-options",
+  name: "List Comment ID Options",
+  description: "Retrieves available options for the Comment ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    canny,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await canny.propDefinitions.commentId.options.call(this.canny, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/canny/actions/list-company-id-options/list-company-id-options.mjs
+++ b/components/canny/actions/list-company-id-options/list-company-id-options.mjs
@@ -1,0 +1,33 @@
+import canny from "../../canny.app.mjs";
+
+export default {
+  key: "canny-list-company-id-options",
+  name: "List Company ID Options",
+  description: "Retrieves available options for the Company ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    canny,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await canny.propDefinitions.companyId.options.call(this.canny, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/canny/actions/list-tag-id-options/list-tag-id-options.mjs
+++ b/components/canny/actions/list-tag-id-options/list-tag-id-options.mjs
@@ -1,0 +1,33 @@
+import canny from "../../canny.app.mjs";
+
+export default {
+  key: "canny-list-tag-id-options",
+  name: "List Tag ID Options",
+  description: "Retrieves available options for the Tag ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    canny,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await canny.propDefinitions.tagId.options.call(this.canny, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/canny/package.json
+++ b/components/canny/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/canny",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Pipedream canny Components",
   "main": "canny.app.mjs",
   "keywords": [

--- a/components/cardly/actions/list-art-id-options/list-art-id-options.mjs
+++ b/components/cardly/actions/list-art-id-options/list-art-id-options.mjs
@@ -1,0 +1,33 @@
+import cardly from "../../cardly.app.mjs";
+
+export default {
+  key: "cardly-list-art-id-options",
+  name: "List Art Options",
+  description: "Retrieves available options for the Art field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    cardly,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await cardly.propDefinitions.artId.options.call(this.cardly, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/cardly/actions/list-list-id-options/list-list-id-options.mjs
+++ b/components/cardly/actions/list-list-id-options/list-list-id-options.mjs
@@ -1,0 +1,33 @@
+import cardly from "../../cardly.app.mjs";
+
+export default {
+  key: "cardly-list-list-id-options",
+  name: "List List Options",
+  description: "Retrieves available options for the List field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    cardly,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await cardly.propDefinitions.listId.options.call(this.cardly, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/cardly/actions/list-template-id-options/list-template-id-options.mjs
+++ b/components/cardly/actions/list-template-id-options/list-template-id-options.mjs
@@ -1,0 +1,33 @@
+import cardly from "../../cardly.app.mjs";
+
+export default {
+  key: "cardly-list-template-id-options",
+  name: "List Template Options",
+  description: "Retrieves available options for the Template field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    cardly,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await cardly.propDefinitions.templateId.options.call(this.cardly, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/cardly/package.json
+++ b/components/cardly/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/cardly",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Cardly Components",
   "main": "cardly.app.mjs",
   "keywords": [

--- a/components/cats/actions/list-candidate-id-options/list-candidate-id-options.mjs
+++ b/components/cats/actions/list-candidate-id-options/list-candidate-id-options.mjs
@@ -1,0 +1,33 @@
+import cats from "../../cats.app.mjs";
+
+export default {
+  key: "cats-list-candidate-id-options",
+  name: "List Candidate ID Options",
+  description: "Retrieves available options for the Candidate ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    cats,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await cats.propDefinitions.candidateId.options.call(this.cats, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/cats/actions/list-company-id-options/list-company-id-options.mjs
+++ b/components/cats/actions/list-company-id-options/list-company-id-options.mjs
@@ -1,0 +1,33 @@
+import cats from "../../cats.app.mjs";
+
+export default {
+  key: "cats-list-company-id-options",
+  name: "List Company ID Options",
+  description: "Retrieves available options for the Company ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    cats,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await cats.propDefinitions.companyId.options.call(this.cats, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/cats/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/cats/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -1,0 +1,33 @@
+import cats from "../../cats.app.mjs";
+
+export default {
+  key: "cats-list-contact-id-options",
+  name: "List Contact Id Options",
+  description: "Retrieves available options for the Contact Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    cats,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await cats.propDefinitions.contactId.options.call(this.cats, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/cats/actions/list-custom-fields-options/list-custom-fields-options.mjs
+++ b/components/cats/actions/list-custom-fields-options/list-custom-fields-options.mjs
@@ -1,0 +1,33 @@
+import cats from "../../cats.app.mjs";
+
+export default {
+  key: "cats-list-custom-fields-options",
+  name: "List Custom Fields Options",
+  description: "Retrieves available options for the Custom Fields field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    cats,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await cats.propDefinitions.customFields.options.call(this.cats, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/cats/actions/list-job-id-options/list-job-id-options.mjs
+++ b/components/cats/actions/list-job-id-options/list-job-id-options.mjs
@@ -1,0 +1,33 @@
+import cats from "../../cats.app.mjs";
+
+export default {
+  key: "cats-list-job-id-options",
+  name: "List Job ID Options",
+  description: "Retrieves available options for the Job ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    cats,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await cats.propDefinitions.jobId.options.call(this.cats, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/cats/actions/list-owner-id-options/list-owner-id-options.mjs
+++ b/components/cats/actions/list-owner-id-options/list-owner-id-options.mjs
@@ -1,0 +1,33 @@
+import cats from "../../cats.app.mjs";
+
+export default {
+  key: "cats-list-owner-id-options",
+  name: "List Owner ID Options",
+  description: "Retrieves available options for the Owner ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    cats,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await cats.propDefinitions.ownerId.options.call(this.cats, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/cats/package.json
+++ b/components/cats/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/cats",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream CATS Components",
   "main": "cats.app.mjs",
   "keywords": [

--- a/components/centralstationcrm/actions/list-responsible-user-id-options/list-responsible-user-id-options.mjs
+++ b/components/centralstationcrm/actions/list-responsible-user-id-options/list-responsible-user-id-options.mjs
@@ -1,0 +1,34 @@
+import centralstationcrm from "../../centralstationcrm.app.mjs";
+
+export default {
+  key: "centralstationcrm-list-responsible-user-id-options",
+  name: "List Responsible User Options",
+  description: "Retrieves available options for the Responsible User field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    centralstationcrm,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await centralstationcrm.propDefinitions.responsibleUserId.options
+      .call(this.centralstationcrm, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/centralstationcrm/package.json
+++ b/components/centralstationcrm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/centralstationcrm",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream CentralStationCRM  Components",
   "main": "centralstationcrm.app.mjs",
   "keywords": [

--- a/components/changes_page/actions/list-post-id-options/list-post-id-options.mjs
+++ b/components/changes_page/actions/list-post-id-options/list-post-id-options.mjs
@@ -1,0 +1,33 @@
+import changes_page from "../../changes_page.app.mjs";
+
+export default {
+  key: "changes_page-list-post-id-options",
+  name: "List Post ID Options",
+  description: "Retrieves available options for the Post ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    changes_page,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await changes_page.propDefinitions.postId.options.call(this.changes_page, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/changes_page/package.json
+++ b/components/changes_page/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/changes_page",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream changes.page Components",
   "main": "changes_page.app.mjs",
   "keywords": [

--- a/components/channable/actions/list-stock-update-id-options/list-stock-update-id-options.mjs
+++ b/components/channable/actions/list-stock-update-id-options/list-stock-update-id-options.mjs
@@ -1,0 +1,33 @@
+import channable from "../../channable.app.mjs";
+
+export default {
+  key: "channable-list-stock-update-id-options",
+  name: "List Stock Update ID Options",
+  description: "Retrieves available options for the Stock Update ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    channable,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await channable.propDefinitions.stockUpdateId.options.call(this.channable, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/channable/package.json
+++ b/components/channable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/channable",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Channable Components",
   "main": "channable.app.mjs",
   "keywords": [

--- a/components/chargify/actions/list-coupon-code-options/list-coupon-code-options.mjs
+++ b/components/chargify/actions/list-coupon-code-options/list-coupon-code-options.mjs
@@ -1,0 +1,33 @@
+import chargify from "../../chargify.app.mjs";
+
+export default {
+  key: "chargify-list-coupon-code-options",
+  name: "List Coupon Code Options",
+  description: "Retrieves available options for the Coupon Code field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    chargify,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await chargify.propDefinitions.couponCode.options.call(this.chargify, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/chargify/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/chargify/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -1,0 +1,33 @@
+import chargify from "../../chargify.app.mjs";
+
+export default {
+  key: "chargify-list-customer-id-options",
+  name: "List Customer ID Options",
+  description: "Retrieves available options for the Customer ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    chargify,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await chargify.propDefinitions.customerId.options.call(this.chargify, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/chargify/actions/list-product-id-options/list-product-id-options.mjs
+++ b/components/chargify/actions/list-product-id-options/list-product-id-options.mjs
@@ -1,0 +1,33 @@
+import chargify from "../../chargify.app.mjs";
+
+export default {
+  key: "chargify-list-product-id-options",
+  name: "List Product ID Options",
+  description: "Retrieves available options for the Product ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    chargify,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await chargify.propDefinitions.productId.options.call(this.chargify, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/chargify/actions/list-subscription-id-options/list-subscription-id-options.mjs
+++ b/components/chargify/actions/list-subscription-id-options/list-subscription-id-options.mjs
@@ -1,0 +1,33 @@
+import chargify from "../../chargify.app.mjs";
+
+export default {
+  key: "chargify-list-subscription-id-options",
+  name: "List Subscription ID Options",
+  description: "Retrieves available options for the Subscription ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    chargify,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await chargify.propDefinitions.subscriptionId.options.call(this.chargify, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/chargify/package.json
+++ b/components/chargify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/chargify",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Pipedream Chargify Components",
   "main": "chargify.app.mjs",
   "keywords": [

--- a/components/chartmogul/actions/list-customer-email-options/list-customer-email-options.mjs
+++ b/components/chartmogul/actions/list-customer-email-options/list-customer-email-options.mjs
@@ -1,0 +1,33 @@
+import chartmogul from "../../chartmogul.app.mjs";
+
+export default {
+  key: "chartmogul-list-customer-email-options",
+  name: "List Customer Email Options",
+  description: "Retrieves available options for the Customer Email field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    chartmogul,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await chartmogul.propDefinitions.customerEmail.options.call(this.chartmogul, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/chartmogul/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/chartmogul/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -1,0 +1,33 @@
+import chartmogul from "../../chartmogul.app.mjs";
+
+export default {
+  key: "chartmogul-list-customer-id-options",
+  name: "List Customer UUID Options",
+  description: "Retrieves available options for the Customer UUID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    chartmogul,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await chartmogul.propDefinitions.customerId.options.call(this.chartmogul, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/chartmogul/actions/list-data-source-id-options/list-data-source-id-options.mjs
+++ b/components/chartmogul/actions/list-data-source-id-options/list-data-source-id-options.mjs
@@ -1,0 +1,33 @@
+import chartmogul from "../../chartmogul.app.mjs";
+
+export default {
+  key: "chartmogul-list-data-source-id-options",
+  name: "List Data Source UUID Options",
+  description: "Retrieves available options for the Data Source UUID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    chartmogul,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await chartmogul.propDefinitions.dataSourceId.options.call(this.chartmogul, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/chartmogul/package.json
+++ b/components/chartmogul/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/chartmogul",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "Pipedream ChartMogul Components",
   "main": "chartmogul.app.mjs",
   "keywords": [

--- a/components/chaser/actions/list-customer-external-id-options/list-customer-external-id-options.mjs
+++ b/components/chaser/actions/list-customer-external-id-options/list-customer-external-id-options.mjs
@@ -1,0 +1,33 @@
+import chaser from "../../chaser.app.mjs";
+
+export default {
+  key: "chaser-list-customer-external-id-options",
+  name: "List Customer External ID Options",
+  description: "Retrieves available options for the Customer External ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    chaser,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await chaser.propDefinitions.customerExternalId.options.call(this.chaser, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/chaser/package.json
+++ b/components/chaser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/chaser",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Chaser Components",
   "main": "chaser.app.mjs",
   "keywords": [

--- a/components/cinc/actions/list-lead-id-options/list-lead-id-options.mjs
+++ b/components/cinc/actions/list-lead-id-options/list-lead-id-options.mjs
@@ -1,0 +1,33 @@
+import cinc from "../../cinc.app.mjs";
+
+export default {
+  key: "cinc-list-lead-id-options",
+  name: "List Lead Identifier Options",
+  description: "Retrieves available options for the Lead Identifier field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    cinc,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await cinc.propDefinitions.leadId.options.call(this.cinc, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/cinc/package.json
+++ b/components/cinc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/cinc",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream CINC Components",
   "main": "cinc.app.mjs",
   "keywords": [

--- a/components/cincopa/actions/list-fid-options/list-fid-options.mjs
+++ b/components/cincopa/actions/list-fid-options/list-fid-options.mjs
@@ -1,0 +1,33 @@
+import cincopa from "../../cincopa.app.mjs";
+
+export default {
+  key: "cincopa-list-fid-options",
+  name: "List Gallery FID Options",
+  description: "Retrieves available options for the Gallery FID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    cincopa,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await cincopa.propDefinitions.fid.options.call(this.cincopa, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/cincopa/package.json
+++ b/components/cincopa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/cincopa",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Pipedream Cincopa Components",
   "main": "cincopa.app.mjs",
   "keywords": [

--- a/components/circle/actions/list-user-email-options/list-user-email-options.mjs
+++ b/components/circle/actions/list-user-email-options/list-user-email-options.mjs
@@ -1,0 +1,33 @@
+import circle from "../../circle.app.mjs";
+
+export default {
+  key: "circle-list-user-email-options",
+  name: "List User Email Options",
+  description: "Retrieves available options for the User Email field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    circle,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await circle.propDefinitions.userEmail.options.call(this.circle, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/circle/package.json
+++ b/components/circle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/circle",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Circle Components",
   "main": "circle.app.mjs",
   "keywords": [

--- a/components/clear_books/actions/list-supplier-id-options/list-supplier-id-options.mjs
+++ b/components/clear_books/actions/list-supplier-id-options/list-supplier-id-options.mjs
@@ -1,0 +1,33 @@
+import clear_books from "../../clear_books.app.mjs";
+
+export default {
+  key: "clear_books-list-supplier-id-options",
+  name: "List Supplier ID Options",
+  description: "Retrieves available options for the Supplier ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    clear_books,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await clear_books.propDefinitions.supplierId.options.call(this.clear_books, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/clear_books/package.json
+++ b/components/clear_books/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/clear_books",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Clear Books Components",
   "main": "clear_books.app.mjs",
   "keywords": [

--- a/components/clerk/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/clerk/actions/list-user-id-options/list-user-id-options.mjs
@@ -1,0 +1,33 @@
+import clerk from "../../clerk.app.mjs";
+
+export default {
+  key: "clerk-list-user-id-options",
+  name: "List User Id Options",
+  description: "Retrieves available options for the User Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    clerk,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await clerk.propDefinitions.userId.options.call(this.clerk, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/clerk/package.json
+++ b/components/clerk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/clerk",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream Clerk Components",
   "main": "clerk.app.mjs",
   "keywords": [

--- a/components/click2mail2/actions/list-address-id-options/list-address-id-options.mjs
+++ b/components/click2mail2/actions/list-address-id-options/list-address-id-options.mjs
@@ -1,0 +1,33 @@
+import click2mail2 from "../../click2mail2.app.mjs";
+
+export default {
+  key: "click2mail2-list-address-id-options",
+  name: "List Address Id Options",
+  description: "Retrieves available options for the Address Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    click2mail2,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await click2mail2.propDefinitions.addressId.options.call(this.click2mail2, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/click2mail2/actions/list-document-id-options/list-document-id-options.mjs
+++ b/components/click2mail2/actions/list-document-id-options/list-document-id-options.mjs
@@ -1,0 +1,33 @@
+import click2mail2 from "../../click2mail2.app.mjs";
+
+export default {
+  key: "click2mail2-list-document-id-options",
+  name: "List Document Id Options",
+  description: "Retrieves available options for the Document Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    click2mail2,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await click2mail2.propDefinitions.documentId.options.call(this.click2mail2, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/click2mail2/actions/list-project-id-options/list-project-id-options.mjs
+++ b/components/click2mail2/actions/list-project-id-options/list-project-id-options.mjs
@@ -1,0 +1,33 @@
+import click2mail2 from "../../click2mail2.app.mjs";
+
+export default {
+  key: "click2mail2-list-project-id-options",
+  name: "List Project Id Options",
+  description: "Retrieves available options for the Project Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    click2mail2,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await click2mail2.propDefinitions.projectId.options.call(this.click2mail2, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/click2mail2/actions/list-project-id-options/list-project-id-options.mjs
+++ b/components/click2mail2/actions/list-project-id-options/list-project-id-options.mjs
@@ -2,8 +2,8 @@ import click2mail2 from "../../click2mail2.app.mjs";
 
 export default {
   key: "click2mail2-list-project-id-options",
-  name: "List Project Id Options",
-  description: "Retrieves available options for the Project Id field.",
+  name: "List Project ID Options",
+  description: "Retrieves available options for the Project ID field.",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/click2mail2/package.json
+++ b/components/click2mail2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/click2mail2",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "Pipedream Click2Mail Components",
   "main": "click2mail2.app.mjs",
   "keywords": [

--- a/components/clicktime/actions/list-client-id-options/list-client-id-options.mjs
+++ b/components/clicktime/actions/list-client-id-options/list-client-id-options.mjs
@@ -1,0 +1,33 @@
+import clicktime from "../../clicktime.app.mjs";
+
+export default {
+  key: "clicktime-list-client-id-options",
+  name: "List Client ID Options",
+  description: "Retrieves available options for the Client ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    clicktime,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await clicktime.propDefinitions.clientId.options.call(this.clicktime, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/clicktime/actions/list-employment-type-id-options/list-employment-type-id-options.mjs
+++ b/components/clicktime/actions/list-employment-type-id-options/list-employment-type-id-options.mjs
@@ -1,0 +1,33 @@
+import clicktime from "../../clicktime.app.mjs";
+
+export default {
+  key: "clicktime-list-employment-type-id-options",
+  name: "List Employment Type ID Options",
+  description: "Retrieves available options for the Employment Type ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    clicktime,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await clicktime.propDefinitions.employmentTypeId.options.call(this.clicktime, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/clicktime/package.json
+++ b/components/clicktime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/clicktime",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream ClickTime Components",
   "main": "clicktime.app.mjs",
   "keywords": [

--- a/components/clinchpad/actions/list-pipeline-id-options/list-pipeline-id-options.mjs
+++ b/components/clinchpad/actions/list-pipeline-id-options/list-pipeline-id-options.mjs
@@ -1,0 +1,33 @@
+import clinchpad from "../../clinchpad.app.mjs";
+
+export default {
+  key: "clinchpad-list-pipeline-id-options",
+  name: "List Pipeline ID Options",
+  description: "Retrieves available options for the Pipeline ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    clinchpad,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await clinchpad.propDefinitions.pipelineId.options.call(this.clinchpad, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/clinchpad/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/clinchpad/actions/list-user-id-options/list-user-id-options.mjs
@@ -1,0 +1,33 @@
+import clinchpad from "../../clinchpad.app.mjs";
+
+export default {
+  key: "clinchpad-list-user-id-options",
+  name: "List User ID Options",
+  description: "Retrieves available options for the User ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    clinchpad,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await clinchpad.propDefinitions.userId.options.call(this.clinchpad, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/clinchpad/package.json
+++ b/components/clinchpad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/clinchpad",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "Pipedream Clinchpad Components",
   "main": "clinchpad.app.mjs",
   "keywords": [

--- a/components/clockwork_recruiting/actions/list-company-id-options/list-company-id-options.mjs
+++ b/components/clockwork_recruiting/actions/list-company-id-options/list-company-id-options.mjs
@@ -1,0 +1,34 @@
+import clockwork_recruiting from "../../clockwork_recruiting.app.mjs";
+
+export default {
+  key: "clockwork_recruiting-list-company-id-options",
+  name: "List Company Id Options",
+  description: "Retrieves available options for the Company Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    clockwork_recruiting,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await clockwork_recruiting.propDefinitions.companyId.options
+      .call(this.clockwork_recruiting, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/clockwork_recruiting/actions/list-person-id-options/list-person-id-options.mjs
+++ b/components/clockwork_recruiting/actions/list-person-id-options/list-person-id-options.mjs
@@ -1,0 +1,34 @@
+import clockwork_recruiting from "../../clockwork_recruiting.app.mjs";
+
+export default {
+  key: "clockwork_recruiting-list-person-id-options",
+  name: "List Person Id Options",
+  description: "Retrieves available options for the Person Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    clockwork_recruiting,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await clockwork_recruiting.propDefinitions.personId.options
+      .call(this.clockwork_recruiting, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/clockwork_recruiting/actions/list-region-id-options/list-region-id-options.mjs
+++ b/components/clockwork_recruiting/actions/list-region-id-options/list-region-id-options.mjs
@@ -1,0 +1,34 @@
+import clockwork_recruiting from "../../clockwork_recruiting.app.mjs";
+
+export default {
+  key: "clockwork_recruiting-list-region-id-options",
+  name: "List Region Id Options",
+  description: "Retrieves available options for the Region Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    clockwork_recruiting,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await clockwork_recruiting.propDefinitions.regionId.options
+      .call(this.clockwork_recruiting, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/clockwork_recruiting/actions/list-tag-ids-options/list-tag-ids-options.mjs
+++ b/components/clockwork_recruiting/actions/list-tag-ids-options/list-tag-ids-options.mjs
@@ -1,0 +1,34 @@
+import clockwork_recruiting from "../../clockwork_recruiting.app.mjs";
+
+export default {
+  key: "clockwork_recruiting-list-tag-ids-options",
+  name: "List Tag Ids Options",
+  description: "Retrieves available options for the Tag Ids field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    clockwork_recruiting,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await clockwork_recruiting.propDefinitions.tagIds.options
+      .call(this.clockwork_recruiting, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/clockwork_recruiting/actions/list-tag-names-options/list-tag-names-options.mjs
+++ b/components/clockwork_recruiting/actions/list-tag-names-options/list-tag-names-options.mjs
@@ -1,0 +1,34 @@
+import clockwork_recruiting from "../../clockwork_recruiting.app.mjs";
+
+export default {
+  key: "clockwork_recruiting-list-tag-names-options",
+  name: "List Tag Names Options",
+  description: "Retrieves available options for the Tag Names field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    clockwork_recruiting,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await clockwork_recruiting.propDefinitions.tagNames.options
+      .call(this.clockwork_recruiting, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/clockwork_recruiting/package.json
+++ b/components/clockwork_recruiting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/clockwork_recruiting",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Clockwork Recruiting Components",
   "main": "clockwork_recruiting.app.mjs",
   "keywords": [

--- a/components/close/actions/list-lead-options/list-lead-options.mjs
+++ b/components/close/actions/list-lead-options/list-lead-options.mjs
@@ -1,0 +1,33 @@
+import close from "../../close.app.mjs";
+
+export default {
+  key: "close-list-lead-options",
+  name: "List Lead ID Options",
+  description: "Retrieves available options for the Lead ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    close,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await close.propDefinitions.lead.options.call(this.close, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/close/package.json
+++ b/components/close/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/close",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Close Components",
   "main": "close.app.mjs",
   "keywords": [

--- a/components/cloudflare_api_key/actions/list-account-identifier-options/list-account-identifier-options.mjs
+++ b/components/cloudflare_api_key/actions/list-account-identifier-options/list-account-identifier-options.mjs
@@ -1,0 +1,34 @@
+import cloudflare_api_key from "../../cloudflare_api_key.app.mjs";
+
+export default {
+  key: "cloudflare_api_key-list-account-identifier-options",
+  name: "List Account ID Options",
+  description: "Retrieves available options for the Account ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    cloudflare_api_key,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await cloudflare_api_key.propDefinitions.accountIdentifier.options
+      .call(this.cloudflare_api_key, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/cloudflare_api_key/package.json
+++ b/components/cloudflare_api_key/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/cloudflare_api_key",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Pipedream Cloudflare Components",
   "main": "cloudflare_api_key.app.mjs",
   "keywords": [

--- a/components/cloudpresenter/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/cloudpresenter/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -1,0 +1,34 @@
+import cloudpresenter from "../../cloudpresenter.app.mjs";
+
+export default {
+  key: "cloudpresenter-list-contact-id-options",
+  name: "List Contact UUID Options",
+  description: "Retrieves available options for the Contact UUID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    cloudpresenter,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await cloudpresenter.propDefinitions.contactId.options
+      .call(this.cloudpresenter, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/cloudpresenter/actions/list-tag-ids-options/list-tag-ids-options.mjs
+++ b/components/cloudpresenter/actions/list-tag-ids-options/list-tag-ids-options.mjs
@@ -1,0 +1,33 @@
+import cloudpresenter from "../../cloudpresenter.app.mjs";
+
+export default {
+  key: "cloudpresenter-list-tag-ids-options",
+  name: "List Tag IDs Options",
+  description: "Retrieves available options for the Tag IDs field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    cloudpresenter,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await cloudpresenter.propDefinitions.tagIds.options.call(this.cloudpresenter, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/cloudpresenter/package.json
+++ b/components/cloudpresenter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/cloudpresenter",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Cloudpresenter Components",
   "main": "cloudpresenter.app.mjs",
   "keywords": [


### PR DESCRIPTION
Adds a batch of 74 new actions for retrieving prop options that accept the page parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added paginated listing of available field options across 50+ integrations (e.g., Boloforms, Booking Experts, Booqable, Buddee, Canny, Chargify, ChartMogul, Click2Mail2, and many others) so users can dynamically discover and select ID/reference values.

* **Chores**
  * Bumped package versions across affected components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->