### PR TITLE
Actions for page only prop options batch 3

### DIFF
--- a/components/cloudpress/actions/list-collection-id-options/list-collection-id-options.mjs
+++ b/components/cloudpress/actions/list-collection-id-options/list-collection-id-options.mjs
@@ -1,0 +1,33 @@
+import cloudpress from "../../cloudpress.app.mjs";
+
+export default {
+  key: "cloudpress-list-collection-id-options",
+  name: "List Collection ID Options",
+  description: "Retrieves available options for the Collection ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    cloudpress,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await cloudpress.propDefinitions.collectionId.options.call(this.cloudpress, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/cloudpress/actions/list-document-reference-options/list-document-reference-options.mjs
+++ b/components/cloudpress/actions/list-document-reference-options/list-document-reference-options.mjs
@@ -1,0 +1,34 @@
+import cloudpress from "../../cloudpress.app.mjs";
+
+export default {
+  key: "cloudpress-list-document-reference-options",
+  name: "List Document Reference Options",
+  description: "Retrieves available options for the Document Reference field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    cloudpress,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await cloudpress.propDefinitions.documentReference.options
+      .call(this.cloudpress, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/cloudpress/package.json
+++ b/components/cloudpress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/cloudpress",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Cloudpress Components",
   "main": "cloudpress.app.mjs",
   "keywords": [

--- a/components/codat/actions/list-company-id-options/list-company-id-options.mjs
+++ b/components/codat/actions/list-company-id-options/list-company-id-options.mjs
@@ -1,0 +1,33 @@
+import codat from "../../codat.app.mjs";
+
+export default {
+  key: "codat-list-company-id-options",
+  name: "List Company ID Options",
+  description: "Retrieves available options for the Company ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    codat,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await codat.propDefinitions.companyId.options.call(this.codat, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/codat/package.json
+++ b/components/codat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/codat",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Codat Components",
   "main": "codat.app.mjs",
   "keywords": [

--- a/components/codeqr/actions/list-link-id-options/list-link-id-options.mjs
+++ b/components/codeqr/actions/list-link-id-options/list-link-id-options.mjs
@@ -1,0 +1,33 @@
+import codeqr from "../../codeqr.app.mjs";
+
+export default {
+  key: "codeqr-list-link-id-options",
+  name: "List Link ID Options",
+  description: "Retrieves available options for the Link ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    codeqr,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await codeqr.propDefinitions.linkId.options.call(this.codeqr, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/codeqr/actions/list-qrcode-id-options/list-qrcode-id-options.mjs
+++ b/components/codeqr/actions/list-qrcode-id-options/list-qrcode-id-options.mjs
@@ -1,0 +1,33 @@
+import codeqr from "../../codeqr.app.mjs";
+
+export default {
+  key: "codeqr-list-qrcode-id-options",
+  name: "List QR Code ID Options",
+  description: "Retrieves available options for the QR Code ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    codeqr,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await codeqr.propDefinitions.qrcodeId.options.call(this.codeqr, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/codeqr/package.json
+++ b/components/codeqr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/codeqr",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Pipedream CodeQR Components",
   "main": "codeqr.app.mjs",
   "keywords": [

--- a/components/cody/actions/list-bot-id-options/list-bot-id-options.mjs
+++ b/components/cody/actions/list-bot-id-options/list-bot-id-options.mjs
@@ -1,0 +1,33 @@
+import cody from "../../cody.app.mjs";
+
+export default {
+  key: "cody-list-bot-id-options",
+  name: "List Bot ID Options",
+  description: "Retrieves available options for the Bot ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    cody,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await cody.propDefinitions.botId.options.call(this.cody, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/cody/actions/list-folder-id-options/list-folder-id-options.mjs
+++ b/components/cody/actions/list-folder-id-options/list-folder-id-options.mjs
@@ -1,0 +1,33 @@
+import cody from "../../cody.app.mjs";
+
+export default {
+  key: "cody-list-folder-id-options",
+  name: "List Folder Id Options",
+  description: "Retrieves available options for the Folder Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    cody,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await cody.propDefinitions.folderId.options.call(this.cody, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/cody/package.json
+++ b/components/cody/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/cody",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Cody Components",
   "main": "cody.app.mjs",
   "keywords": [

--- a/components/cogmento/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/cogmento/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -1,0 +1,33 @@
+import cogmento from "../../cogmento.app.mjs";
+
+export default {
+  key: "cogmento-list-contact-id-options",
+  name: "List Contact ID Options",
+  description: "Retrieves available options for the Contact ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    cogmento,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await cogmento.propDefinitions.contactId.options.call(this.cogmento, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/cogmento/actions/list-deal-id-options/list-deal-id-options.mjs
+++ b/components/cogmento/actions/list-deal-id-options/list-deal-id-options.mjs
@@ -1,0 +1,33 @@
+import cogmento from "../../cogmento.app.mjs";
+
+export default {
+  key: "cogmento-list-deal-id-options",
+  name: "List Deal ID Options",
+  description: "Retrieves available options for the Deal ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    cogmento,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await cogmento.propDefinitions.dealId.options.call(this.cogmento, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/cogmento/actions/list-product-ids-options/list-product-ids-options.mjs
+++ b/components/cogmento/actions/list-product-ids-options/list-product-ids-options.mjs
@@ -1,0 +1,33 @@
+import cogmento from "../../cogmento.app.mjs";
+
+export default {
+  key: "cogmento-list-product-ids-options",
+  name: "List Product IDs Options",
+  description: "Retrieves available options for the Product IDs field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    cogmento,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await cogmento.propDefinitions.productIds.options.call(this.cogmento, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/cogmento/package.json
+++ b/components/cogmento/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/cogmento",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Cogmento Components",
   "main": "cogmento.app.mjs",
   "keywords": [

--- a/components/companyhub/actions/list-company-id-options/list-company-id-options.mjs
+++ b/components/companyhub/actions/list-company-id-options/list-company-id-options.mjs
@@ -1,0 +1,33 @@
+import companyhub from "../../companyhub.app.mjs";
+
+export default {
+  key: "companyhub-list-company-id-options",
+  name: "List Company ID Options",
+  description: "Retrieves available options for the Company ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    companyhub,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await companyhub.propDefinitions.companyId.options.call(this.companyhub, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/companyhub/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/companyhub/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -1,0 +1,33 @@
+import companyhub from "../../companyhub.app.mjs";
+
+export default {
+  key: "companyhub-list-contact-id-options",
+  name: "List Contact ID Options",
+  description: "Retrieves available options for the Contact ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    companyhub,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await companyhub.propDefinitions.contactId.options.call(this.companyhub, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/companyhub/package.json
+++ b/components/companyhub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/companyhub",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Pipedream companyhub Components",
   "main": "companyhub.app.mjs",
   "keywords": [

--- a/components/confluence_data_center/actions/list-space-key-options/list-space-key-options.mjs
+++ b/components/confluence_data_center/actions/list-space-key-options/list-space-key-options.mjs
@@ -1,0 +1,34 @@
+import confluence_data_center from "../../confluence_data_center.app.mjs";
+
+export default {
+  key: "confluence_data_center-list-space-key-options",
+  name: "List Space Key Options",
+  description: "Retrieves available options for the Space Key field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    confluence_data_center,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await confluence_data_center.propDefinitions.spaceKey.options
+      .call(this.confluence_data_center, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/confluence_data_center/package.json
+++ b/components/confluence_data_center/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/confluence_data_center",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Confluence Data Center Components",
   "main": "confluence_data_center.app.mjs",
   "keywords": [

--- a/components/connecteam/actions/list-assigned-user-id-options/list-assigned-user-id-options.mjs
+++ b/components/connecteam/actions/list-assigned-user-id-options/list-assigned-user-id-options.mjs
@@ -1,0 +1,33 @@
+import connecteam from "../../connecteam.app.mjs";
+
+export default {
+  key: "connecteam-list-assigned-user-id-options",
+  name: "List Assigned User ID Options",
+  description: "Retrieves available options for the Assigned User ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    connecteam,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await connecteam.propDefinitions.assignedUserId.options.call(this.connecteam, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/connecteam/actions/list-form-id-options/list-form-id-options.mjs
+++ b/components/connecteam/actions/list-form-id-options/list-form-id-options.mjs
@@ -1,0 +1,33 @@
+import connecteam from "../../connecteam.app.mjs";
+
+export default {
+  key: "connecteam-list-form-id-options",
+  name: "List Form ID Options",
+  description: "Retrieves available options for the Form ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    connecteam,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await connecteam.propDefinitions.formId.options.call(this.connecteam, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/connecteam/actions/list-job-id-options/list-job-id-options.mjs
+++ b/components/connecteam/actions/list-job-id-options/list-job-id-options.mjs
@@ -1,0 +1,33 @@
+import connecteam from "../../connecteam.app.mjs";
+
+export default {
+  key: "connecteam-list-job-id-options",
+  name: "List Job ID Options",
+  description: "Retrieves available options for the Job ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    connecteam,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await connecteam.propDefinitions.jobId.options.call(this.connecteam, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/connecteam/package.json
+++ b/components/connecteam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/connecteam",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Connecteam Components",
   "main": "connecteam.app.mjs",
   "keywords": [

--- a/components/connectwise_psa/actions/list-company-options/list-company-options.mjs
+++ b/components/connectwise_psa/actions/list-company-options/list-company-options.mjs
@@ -1,0 +1,34 @@
+import connectwise_psa from "../../connectwise_psa.app.mjs";
+
+export default {
+  key: "connectwise_psa-list-company-options",
+  name: "List Company Options",
+  description: "Retrieves available options for the Company field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    connectwise_psa,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await connectwise_psa.propDefinitions.company.options
+      .call(this.connectwise_psa, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/connectwise_psa/actions/list-company-types-options/list-company-types-options.mjs
+++ b/components/connectwise_psa/actions/list-company-types-options/list-company-types-options.mjs
@@ -1,0 +1,34 @@
+import connectwise_psa from "../../connectwise_psa.app.mjs";
+
+export default {
+  key: "connectwise_psa-list-company-types-options",
+  name: "List Types Options",
+  description: "Retrieves available options for the Types field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    connectwise_psa,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await connectwise_psa.propDefinitions.companyTypes.options
+      .call(this.connectwise_psa, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/connectwise_psa/actions/list-contact-options/list-contact-options.mjs
+++ b/components/connectwise_psa/actions/list-contact-options/list-contact-options.mjs
@@ -1,0 +1,34 @@
+import connectwise_psa from "../../connectwise_psa.app.mjs";
+
+export default {
+  key: "connectwise_psa-list-contact-options",
+  name: "List Contact Options",
+  description: "Retrieves available options for the Contact field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    connectwise_psa,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await connectwise_psa.propDefinitions.contact.options
+      .call(this.connectwise_psa, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/connectwise_psa/actions/list-contact-types-options/list-contact-types-options.mjs
+++ b/components/connectwise_psa/actions/list-contact-types-options/list-contact-types-options.mjs
@@ -1,0 +1,34 @@
+import connectwise_psa from "../../connectwise_psa.app.mjs";
+
+export default {
+  key: "connectwise_psa-list-contact-types-options",
+  name: "List Types Options",
+  description: "Retrieves available options for the Types field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    connectwise_psa,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await connectwise_psa.propDefinitions.contactTypes.options
+      .call(this.connectwise_psa, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/connectwise_psa/actions/list-country-options/list-country-options.mjs
+++ b/components/connectwise_psa/actions/list-country-options/list-country-options.mjs
@@ -1,0 +1,34 @@
+import connectwise_psa from "../../connectwise_psa.app.mjs";
+
+export default {
+  key: "connectwise_psa-list-country-options",
+  name: "List Country Options",
+  description: "Retrieves available options for the Country field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    connectwise_psa,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await connectwise_psa.propDefinitions.country.options
+      .call(this.connectwise_psa, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/connectwise_psa/actions/list-department-options/list-department-options.mjs
+++ b/components/connectwise_psa/actions/list-department-options/list-department-options.mjs
@@ -1,0 +1,34 @@
+import connectwise_psa from "../../connectwise_psa.app.mjs";
+
+export default {
+  key: "connectwise_psa-list-department-options",
+  name: "List Department Options",
+  description: "Retrieves available options for the Department field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    connectwise_psa,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await connectwise_psa.propDefinitions.department.options
+      .call(this.connectwise_psa, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/connectwise_psa/actions/list-market-options/list-market-options.mjs
+++ b/components/connectwise_psa/actions/list-market-options/list-market-options.mjs
@@ -1,0 +1,34 @@
+import connectwise_psa from "../../connectwise_psa.app.mjs";
+
+export default {
+  key: "connectwise_psa-list-market-options",
+  name: "List Market Options",
+  description: "Retrieves available options for the Market field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    connectwise_psa,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await connectwise_psa.propDefinitions.market.options
+      .call(this.connectwise_psa, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/connectwise_psa/actions/list-priority-options/list-priority-options.mjs
+++ b/components/connectwise_psa/actions/list-priority-options/list-priority-options.mjs
@@ -1,0 +1,34 @@
+import connectwise_psa from "../../connectwise_psa.app.mjs";
+
+export default {
+  key: "connectwise_psa-list-priority-options",
+  name: "List Priority Options",
+  description: "Retrieves available options for the Priority field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    connectwise_psa,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await connectwise_psa.propDefinitions.priority.options
+      .call(this.connectwise_psa, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/connectwise_psa/actions/list-relationship-options/list-relationship-options.mjs
+++ b/components/connectwise_psa/actions/list-relationship-options/list-relationship-options.mjs
@@ -1,0 +1,34 @@
+import connectwise_psa from "../../connectwise_psa.app.mjs";
+
+export default {
+  key: "connectwise_psa-list-relationship-options",
+  name: "List Relationship Options",
+  description: "Retrieves available options for the Relationship field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    connectwise_psa,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await connectwise_psa.propDefinitions.relationship.options
+      .call(this.connectwise_psa, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/connectwise_psa/actions/list-status-options/list-status-options.mjs
+++ b/components/connectwise_psa/actions/list-status-options/list-status-options.mjs
@@ -1,0 +1,34 @@
+import connectwise_psa from "../../connectwise_psa.app.mjs";
+
+export default {
+  key: "connectwise_psa-list-status-options",
+  name: "List Status Options",
+  description: "Retrieves available options for the Status field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    connectwise_psa,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await connectwise_psa.propDefinitions.status.options
+      .call(this.connectwise_psa, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/connectwise_psa/actions/list-territory-options/list-territory-options.mjs
+++ b/components/connectwise_psa/actions/list-territory-options/list-territory-options.mjs
@@ -1,0 +1,34 @@
+import connectwise_psa from "../../connectwise_psa.app.mjs";
+
+export default {
+  key: "connectwise_psa-list-territory-options",
+  name: "List Territory Options",
+  description: "Retrieves available options for the Territory field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    connectwise_psa,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await connectwise_psa.propDefinitions.territory.options
+      .call(this.connectwise_psa, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/connectwise_psa/actions/list-ticket-id-options/list-ticket-id-options.mjs
+++ b/components/connectwise_psa/actions/list-ticket-id-options/list-ticket-id-options.mjs
@@ -1,0 +1,34 @@
+import connectwise_psa from "../../connectwise_psa.app.mjs";
+
+export default {
+  key: "connectwise_psa-list-ticket-id-options",
+  name: "List Ticket ID Options",
+  description: "Retrieves available options for the Ticket ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    connectwise_psa,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await connectwise_psa.propDefinitions.ticketId.options
+      .call(this.connectwise_psa, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/connectwise_psa/package.json
+++ b/components/connectwise_psa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/connectwise_psa",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Pipedream Connectwise PSA Components",
   "main": "connectwise_psa.app.mjs",
   "keywords": [

--- a/components/constant_contact/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/constant_contact/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -1,0 +1,34 @@
+import constant_contact from "../../constant_contact.app.mjs";
+
+export default {
+  key: "constant_contact-list-contact-id-options",
+  name: "List Contact Id Options",
+  description: "Retrieves available options for the Contact Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    constant_contact,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await constant_contact.propDefinitions.contactId.options
+      .call(this.constant_contact, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/constant_contact/actions/list-list-memberships-options/list-list-memberships-options.mjs
+++ b/components/constant_contact/actions/list-list-memberships-options/list-list-memberships-options.mjs
@@ -1,0 +1,34 @@
+import constant_contact from "../../constant_contact.app.mjs";
+
+export default {
+  key: "constant_contact-list-list-memberships-options",
+  name: "List List Membership Options",
+  description: "Retrieves available options for the List Membership field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    constant_contact,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await constant_contact.propDefinitions.listMemberships.options
+      .call(this.constant_contact, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/constant_contact/actions/list-taggings-options/list-taggings-options.mjs
+++ b/components/constant_contact/actions/list-taggings-options/list-taggings-options.mjs
@@ -1,0 +1,34 @@
+import constant_contact from "../../constant_contact.app.mjs";
+
+export default {
+  key: "constant_contact-list-taggings-options",
+  name: "List Taggings Options",
+  description: "Retrieves available options for the Taggings field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    constant_contact,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await constant_contact.propDefinitions.taggings.options
+      .call(this.constant_contact, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/constant_contact/package.json
+++ b/components/constant_contact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/constant_contact",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Constant Contact Components",
   "main": "constant_contact.app.mjs",
   "keywords": [

--- a/components/contentstack/actions/list-branch-ids-options/list-branch-ids-options.mjs
+++ b/components/contentstack/actions/list-branch-ids-options/list-branch-ids-options.mjs
@@ -1,0 +1,33 @@
+import contentstack from "../../contentstack.app.mjs";
+
+export default {
+  key: "contentstack-list-branch-ids-options",
+  name: "List Branches Options",
+  description: "Retrieves available options for the Branches field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    contentstack,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await contentstack.propDefinitions.branchIds.options.call(this.contentstack, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/contentstack/package.json
+++ b/components/contentstack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/contentstack",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Contentstack Components",
   "main": "contentstack.app.mjs",
   "keywords": [

--- a/components/copperx/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/copperx/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -1,0 +1,33 @@
+import copperx from "../../copperx.app.mjs";
+
+export default {
+  key: "copperx-list-customer-id-options",
+  name: "List Customer Id Options",
+  description: "Retrieves available options for the Customer Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    copperx,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await copperx.propDefinitions.customerId.options.call(this.copperx, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/copperx/package.json
+++ b/components/copperx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/copperx",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream Copperx Components",
   "main": "copperx.app.mjs",
   "keywords": [

--- a/components/craftboxx/actions/create-article/create-article.mjs
+++ b/components/craftboxx/actions/create-article/create-article.mjs
@@ -6,7 +6,7 @@ export default {
   key: "craftboxx-create-article",
   name: "Create Article",
   description: "Creates a new article in Craftboxx. [See the documentation](https://api.craftboxx.de/docs/docs.json)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/craftboxx/actions/create-customer-and-mailing-address/create-customer-and-mailing-address.mjs
+++ b/components/craftboxx/actions/create-customer-and-mailing-address/create-customer-and-mailing-address.mjs
@@ -6,7 +6,7 @@ export default {
   key: "craftboxx-create-customer-and-mailing-address",
   name: "Create Customer and Mailing Address",
   description: "Creates a new customer along with their mailing address in Craftboxx. [See the documentation](https://api.craftboxx.de/docs/docs.json)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/craftboxx/actions/list-appointment-id-options/list-appointment-id-options.mjs
+++ b/components/craftboxx/actions/list-appointment-id-options/list-appointment-id-options.mjs
@@ -1,0 +1,33 @@
+import craftboxx from "../../craftboxx.app.mjs";
+
+export default {
+  key: "craftboxx-list-appointment-id-options",
+  name: "List Appointment ID Options",
+  description: "Retrieves available options for the Appointment ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    craftboxx,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await craftboxx.propDefinitions.appointmentId.options.call(this.craftboxx, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/craftboxx/actions/list-appointment-id-options/list-appointment-id-options.mjs
+++ b/components/craftboxx/actions/list-appointment-id-options/list-appointment-id-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     craftboxx,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        craftboxx,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/craftboxx/actions/list-project-id-options/list-project-id-options.mjs
+++ b/components/craftboxx/actions/list-project-id-options/list-project-id-options.mjs
@@ -1,0 +1,33 @@
+import craftboxx from "../../craftboxx.app.mjs";
+
+export default {
+  key: "craftboxx-list-project-id-options",
+  name: "List Project ID Options",
+  description: "Retrieves available options for the Project ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    craftboxx,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await craftboxx.propDefinitions.projectId.options.call(this.craftboxx, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/craftboxx/actions/list-project-id-options/list-project-id-options.mjs
+++ b/components/craftboxx/actions/list-project-id-options/list-project-id-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     craftboxx,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        craftboxx,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/craftboxx/actions/update-project-and-appointment/update-project-and-appointment.mjs
+++ b/components/craftboxx/actions/update-project-and-appointment/update-project-and-appointment.mjs
@@ -5,7 +5,7 @@ export default {
   key: "craftboxx-update-project-and-appointment",
   name: "Update Project and Appointment",
   description: "Applies updates to a project and its corresponding appointment in Craftboxx. [See the documentation](https://api.craftboxx.de/docs/docs.json)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/craftboxx/craftboxx.app.mjs
+++ b/components/craftboxx/craftboxx.app.mjs
@@ -6,6 +6,13 @@ export default {
   type: "app",
   app: "craftboxx",
   propDefinitions: {
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve, zero-based.",
+      min: 0,
+      default: 0,
+    },
     projectId: {
       type: "string",
       label: "Project ID",

--- a/components/craftboxx/package.json
+++ b/components/craftboxx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/craftboxx",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Craftboxx Components",
   "main": "craftboxx.app.mjs",
   "keywords": [

--- a/components/craftboxx/sources/new-appointment/new-appointment.mjs
+++ b/components/craftboxx/sources/new-appointment/new-appointment.mjs
@@ -5,7 +5,7 @@ export default {
   key: "craftboxx-new-appointment",
   name: "New Appointment",
   description: "Emit new event when a new appointment is created in Craftboxx. [See the documentation](https://api.craftboxx.de/docs/docs.json)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/craftboxx/sources/new-customer/new-customer.mjs
+++ b/components/craftboxx/sources/new-customer/new-customer.mjs
@@ -5,7 +5,7 @@ export default {
   key: "craftboxx-new-customer",
   name: "New Customer",
   description: "Emit new event when a new customer is created in Craftboxx. [See the documentation](https://api.craftboxx.de/docs/docs.json)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/craftboxx/sources/new-project/new-project.mjs
+++ b/components/craftboxx/sources/new-project/new-project.mjs
@@ -5,7 +5,7 @@ export default {
   key: "craftboxx-new-project",
   name: "New Project",
   description: "Emit new event when a new project is created in Craftboxx. [See the documentation](https://api.craftboxx.de/docs/docs.json)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/craftmypdf/actions/list-template-id-options/list-template-id-options.mjs
+++ b/components/craftmypdf/actions/list-template-id-options/list-template-id-options.mjs
@@ -1,0 +1,33 @@
+import craftmypdf from "../../craftmypdf.app.mjs";
+
+export default {
+  key: "craftmypdf-list-template-id-options",
+  name: "List Template Id Options",
+  description: "Retrieves available options for the Template Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    craftmypdf,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await craftmypdf.propDefinitions.templateId.options.call(this.craftmypdf, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/craftmypdf/package.json
+++ b/components/craftmypdf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/craftmypdf",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream CraftMyPDF Components",
   "main": "craftmypdf.app.mjs",
   "keywords": [

--- a/components/crisp/actions/list-person-id-options/list-person-id-options.mjs
+++ b/components/crisp/actions/list-person-id-options/list-person-id-options.mjs
@@ -1,0 +1,33 @@
+import crisp from "../../crisp.app.mjs";
+
+export default {
+  key: "crisp-list-person-id-options",
+  name: "List Person ID Options",
+  description: "Retrieves available options for the Person ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    crisp,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await crisp.propDefinitions.personId.options.call(this.crisp, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/crisp/package.json
+++ b/components/crisp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/crisp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Crisp Components",
   "main": "crisp.app.mjs",
   "keywords": [

--- a/components/crowdin/actions/list-mt-id-options/list-mt-id-options.mjs
+++ b/components/crowdin/actions/list-mt-id-options/list-mt-id-options.mjs
@@ -1,0 +1,33 @@
+import crowdin from "../../crowdin.app.mjs";
+
+export default {
+  key: "crowdin-list-mt-id-options",
+  name: "List Machine Translation ID Options",
+  description: "Retrieves available options for the Machine Translation ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    crowdin,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await crowdin.propDefinitions.mtId.options.call(this.crowdin, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/crowdin/actions/list-project-id-options/list-project-id-options.mjs
+++ b/components/crowdin/actions/list-project-id-options/list-project-id-options.mjs
@@ -1,0 +1,33 @@
+import crowdin from "../../crowdin.app.mjs";
+
+export default {
+  key: "crowdin-list-project-id-options",
+  name: "List Project ID Options",
+  description: "Retrieves available options for the Project ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    crowdin,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await crowdin.propDefinitions.projectId.options.call(this.crowdin, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/crowdin/actions/list-source-language-id-options/list-source-language-id-options.mjs
+++ b/components/crowdin/actions/list-source-language-id-options/list-source-language-id-options.mjs
@@ -1,0 +1,33 @@
+import crowdin from "../../crowdin.app.mjs";
+
+export default {
+  key: "crowdin-list-source-language-id-options",
+  name: "List Source Language ID Options",
+  description: "Retrieves available options for the Source Language ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    crowdin,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await crowdin.propDefinitions.sourceLanguageId.options.call(this.crowdin, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/crowdin/actions/list-storage-id-options/list-storage-id-options.mjs
+++ b/components/crowdin/actions/list-storage-id-options/list-storage-id-options.mjs
@@ -1,0 +1,33 @@
+import crowdin from "../../crowdin.app.mjs";
+
+export default {
+  key: "crowdin-list-storage-id-options",
+  name: "List Storage ID Options",
+  description: "Retrieves available options for the Storage ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    crowdin,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await crowdin.propDefinitions.storageId.options.call(this.crowdin, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/crowdin/package.json
+++ b/components/crowdin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/crowdin",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Pipedream Crowdin Components",
   "main": "crowdin.app.mjs",
   "keywords": [

--- a/components/customer_fields/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/customer_fields/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -1,0 +1,34 @@
+import customer_fields from "../../customer_fields.app.mjs";
+
+export default {
+  key: "customer_fields-list-customer-id-options",
+  name: "List Customer ID Options",
+  description: "Retrieves available options for the Customer ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    customer_fields,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await customer_fields.propDefinitions.customerId.options
+      .call(this.customer_fields, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/customer_fields/package.json
+++ b/components/customer_fields/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/customer_fields",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Customer Fields Components",
   "main": "customer_fields.app.mjs",
   "keywords": [

--- a/components/customgpt/actions/list-project-id-options/list-project-id-options.mjs
+++ b/components/customgpt/actions/list-project-id-options/list-project-id-options.mjs
@@ -1,0 +1,33 @@
+import customgpt from "../../customgpt.app.mjs";
+
+export default {
+  key: "customgpt-list-project-id-options",
+  name: "List Project ID Options",
+  description: "Retrieves available options for the Project ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    customgpt,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await customgpt.propDefinitions.projectId.options.call(this.customgpt, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/customgpt/package.json
+++ b/components/customgpt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/customgpt",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream CustomGPT Components",
   "main": "customgpt.app.mjs",
   "keywords": [

--- a/components/dailybot/actions/list-target-teams-options/list-target-teams-options.mjs
+++ b/components/dailybot/actions/list-target-teams-options/list-target-teams-options.mjs
@@ -1,0 +1,33 @@
+import dailybot from "../../dailybot.app.mjs";
+
+export default {
+  key: "dailybot-list-target-teams-options",
+  name: "List Target Teams IDs Options",
+  description: "Retrieves available options for the Target Teams IDs field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    dailybot,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await dailybot.propDefinitions.targetTeams.options.call(this.dailybot, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/dailybot/actions/list-target-users-options/list-target-users-options.mjs
+++ b/components/dailybot/actions/list-target-users-options/list-target-users-options.mjs
@@ -1,0 +1,33 @@
+import dailybot from "../../dailybot.app.mjs";
+
+export default {
+  key: "dailybot-list-target-users-options",
+  name: "List Target User IDs Options",
+  description: "Retrieves available options for the Target User IDs field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    dailybot,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await dailybot.propDefinitions.targetUsers.options.call(this.dailybot, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/dailybot/package.json
+++ b/components/dailybot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/dailybot",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream DailyBot Components",
   "main": "dailybot.app.mjs",
   "keywords": [

--- a/components/dart/actions/list-assignee-ids-options/list-assignee-ids-options.mjs
+++ b/components/dart/actions/list-assignee-ids-options/list-assignee-ids-options.mjs
@@ -1,0 +1,33 @@
+import dart from "../../dart.app.mjs";
+
+export default {
+  key: "dart-list-assignee-ids-options",
+  name: "List Assigned To Options",
+  description: "Retrieves available options for the Assigned To field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    dart,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await dart.propDefinitions.assigneeIds.options.call(this.dart, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/dart/actions/list-doc-id-options/list-doc-id-options.mjs
+++ b/components/dart/actions/list-doc-id-options/list-doc-id-options.mjs
@@ -1,0 +1,33 @@
+import dart from "../../dart.app.mjs";
+
+export default {
+  key: "dart-list-doc-id-options",
+  name: "List Doc ID Options",
+  description: "Retrieves available options for the Doc ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    dart,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await dart.propDefinitions.docId.options.call(this.dart, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/dart/actions/list-task-id-options/list-task-id-options.mjs
+++ b/components/dart/actions/list-task-id-options/list-task-id-options.mjs
@@ -1,0 +1,33 @@
+import dart from "../../dart.app.mjs";
+
+export default {
+  key: "dart-list-task-id-options",
+  name: "List Task ID Options",
+  description: "Retrieves available options for the Task ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    dart,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await dart.propDefinitions.taskId.options.call(this.dart, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/dart/package.json
+++ b/components/dart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/dart",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Pipedream Dart Components",
   "main": "dart.app.mjs",
   "keywords": [

--- a/components/dayschedule/actions/list-page-options/list-page-options.mjs
+++ b/components/dayschedule/actions/list-page-options/list-page-options.mjs
@@ -1,0 +1,33 @@
+import dayschedule from "../../dayschedule.app.mjs";
+
+export default {
+  key: "dayschedule-list-page-options",
+  name: "List Page Options",
+  description: "Retrieves available options for the Page field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    dayschedule,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await dayschedule.propDefinitions.page.options.call(this.dayschedule, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/dayschedule/actions/list-schedule-options/list-schedule-options.mjs
+++ b/components/dayschedule/actions/list-schedule-options/list-schedule-options.mjs
@@ -1,0 +1,33 @@
+import dayschedule from "../../dayschedule.app.mjs";
+
+export default {
+  key: "dayschedule-list-schedule-options",
+  name: "List Schedule Options",
+  description: "Retrieves available options for the Schedule field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    dayschedule,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await dayschedule.propDefinitions.schedule.options.call(this.dayschedule, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/dayschedule/package.json
+++ b/components/dayschedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/dayschedule",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "Pipedream DaySchedule Components",
   "main": "dayschedule.app.mjs",
   "keywords": [

--- a/components/daytona/actions/list-sandbox-id-options/list-sandbox-id-options.mjs
+++ b/components/daytona/actions/list-sandbox-id-options/list-sandbox-id-options.mjs
@@ -1,0 +1,33 @@
+import daytona from "../../daytona.app.mjs";
+
+export default {
+  key: "daytona-list-sandbox-id-options",
+  name: "List Sandbox ID Options",
+  description: "Retrieves available options for the Sandbox ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    daytona,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await daytona.propDefinitions.sandboxId.options.call(this.daytona, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/daytona/actions/list-snapshot-id-options/list-snapshot-id-options.mjs
+++ b/components/daytona/actions/list-snapshot-id-options/list-snapshot-id-options.mjs
@@ -1,0 +1,33 @@
+import daytona from "../../daytona.app.mjs";
+
+export default {
+  key: "daytona-list-snapshot-id-options",
+  name: "List Snapshot ID Options",
+  description: "Retrieves available options for the Snapshot ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    daytona,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await daytona.propDefinitions.snapshotId.options.call(this.daytona, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/daytona/package.json
+++ b/components/daytona/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/daytona",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Daytona Components",
   "main": "daytona.app.mjs",
   "keywords": [

--- a/components/dealmachine/actions/list-lead-id-options/list-lead-id-options.mjs
+++ b/components/dealmachine/actions/list-lead-id-options/list-lead-id-options.mjs
@@ -1,0 +1,33 @@
+import dealmachine from "../../dealmachine.app.mjs";
+
+export default {
+  key: "dealmachine-list-lead-id-options",
+  name: "List Lead Id Options",
+  description: "Retrieves available options for the Lead Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    dealmachine,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await dealmachine.propDefinitions.leadId.options.call(this.dealmachine, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/dealmachine/package.json
+++ b/components/dealmachine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/dealmachine",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream DealMachine Components",
   "main": "dealmachine.app.mjs",
   "keywords": [
@@ -11,8 +11,8 @@
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "publishConfig": {
     "access": "public"
-	},
-	"dependencies": {
-		"@pipedream/platform": "^1.6.8"
-	}
+  },
+  "dependencies": {
+    "@pipedream/platform": "^1.6.8"
+  }
 }

--- a/components/devin/actions/list-session-id-options/list-session-id-options.mjs
+++ b/components/devin/actions/list-session-id-options/list-session-id-options.mjs
@@ -1,0 +1,33 @@
+import devin from "../../devin.app.mjs";
+
+export default {
+  key: "devin-list-session-id-options",
+  name: "List Session ID Options",
+  description: "Retrieves available options for the Session ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    devin,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await devin.propDefinitions.sessionId.options.call(this.devin, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/devin/package.json
+++ b/components/devin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/devin",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Devin Components",
   "main": "devin.app.mjs",
   "keywords": [

--- a/components/dex/actions/list-contact-ids-options/list-contact-ids-options.mjs
+++ b/components/dex/actions/list-contact-ids-options/list-contact-ids-options.mjs
@@ -1,0 +1,33 @@
+import dex from "../../dex.app.mjs";
+
+export default {
+  key: "dex-list-contact-ids-options",
+  name: "List Contact IDs Options",
+  description: "Retrieves available options for the Contact IDs field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    dex,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await dex.propDefinitions.contactIds.options.call(this.dex, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/dex/package.json
+++ b/components/dex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/dex",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Dex Components",
   "main": "dex.app.mjs",
   "keywords": [

--- a/components/discogs/actions/list-order-id-options/list-order-id-options.mjs
+++ b/components/discogs/actions/list-order-id-options/list-order-id-options.mjs
@@ -1,0 +1,33 @@
+import discogs from "../../discogs.app.mjs";
+
+export default {
+  key: "discogs-list-order-id-options",
+  name: "List Order ID Options",
+  description: "Retrieves available options for the Order ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    discogs,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await discogs.propDefinitions.orderId.options.call(this.discogs, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/discogs/package.json
+++ b/components/discogs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/discogs",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Discogs Components",
   "main": "discogs.app.mjs",
   "keywords": [
@@ -16,4 +16,3 @@
     "@pipedream/platform": "^1.6.8"
   }
 }
-

--- a/components/discourse/actions/list-categories-options/list-categories-options.mjs
+++ b/components/discourse/actions/list-categories-options/list-categories-options.mjs
@@ -1,0 +1,33 @@
+import discourse from "../../discourse.app.mjs";
+
+export default {
+  key: "discourse-list-categories-options",
+  name: "List Categories Options",
+  description: "Retrieves available options for the Categories field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    discourse,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await discourse.propDefinitions.categories.options.call(this.discourse, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/discourse/actions/list-topic-id-options/list-topic-id-options.mjs
+++ b/components/discourse/actions/list-topic-id-options/list-topic-id-options.mjs
@@ -1,0 +1,33 @@
+import discourse from "../../discourse.app.mjs";
+
+export default {
+  key: "discourse-list-topic-id-options",
+  name: "List Topic ID Options",
+  description: "Retrieves available options for the Topic ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    discourse,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await discourse.propDefinitions.topicId.options.call(this.discourse, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/discourse/package.json
+++ b/components/discourse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/discourse",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream Discourse Components",
   "main": "discourse.app.mjs",
   "keywords": [

--- a/components/dixa/actions/list-agent-id-options/list-agent-id-options.mjs
+++ b/components/dixa/actions/list-agent-id-options/list-agent-id-options.mjs
@@ -1,0 +1,33 @@
+import dixa from "../../dixa.app.mjs";
+
+export default {
+  key: "dixa-list-agent-id-options",
+  name: "List Agent Id Options",
+  description: "Retrieves available options for the Agent Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    dixa,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await dixa.propDefinitions.agentId.options.call(this.dixa, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/dixa/actions/list-end-user-id-options/list-end-user-id-options.mjs
+++ b/components/dixa/actions/list-end-user-id-options/list-end-user-id-options.mjs
@@ -1,0 +1,33 @@
+import dixa from "../../dixa.app.mjs";
+
+export default {
+  key: "dixa-list-end-user-id-options",
+  name: "List End User Id Options",
+  description: "Retrieves available options for the End User Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    dixa,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await dixa.propDefinitions.endUserId.options.call(this.dixa, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/dixa/package.json
+++ b/components/dixa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/dixa",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Pipedream Dixa Components",
   "main": "dixa.app.mjs",
   "keywords": [

--- a/components/docnify/actions/list-document-id-options/list-document-id-options.mjs
+++ b/components/docnify/actions/list-document-id-options/list-document-id-options.mjs
@@ -1,0 +1,33 @@
+import docnify from "../../docnify.app.mjs";
+
+export default {
+  key: "docnify-list-document-id-options",
+  name: "List Document ID Options",
+  description: "Retrieves available options for the Document ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    docnify,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await docnify.propDefinitions.documentId.options.call(this.docnify, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/docnify/actions/list-template-id-options/list-template-id-options.mjs
+++ b/components/docnify/actions/list-template-id-options/list-template-id-options.mjs
@@ -1,0 +1,33 @@
+import docnify from "../../docnify.app.mjs";
+
+export default {
+  key: "docnify-list-template-id-options",
+  name: "List Template ID Options",
+  description: "Retrieves available options for the Template ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    docnify,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await docnify.propDefinitions.templateId.options.call(this.docnify, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/docnify/package.json
+++ b/components/docnify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/docnify",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Docnify Components",
   "main": "docnify.app.mjs",
   "keywords": [

--- a/components/documenso/actions/list-document-id-options/list-document-id-options.mjs
+++ b/components/documenso/actions/list-document-id-options/list-document-id-options.mjs
@@ -1,0 +1,33 @@
+import documenso from "../../documenso.app.mjs";
+
+export default {
+  key: "documenso-list-document-id-options",
+  name: "List Document ID Options",
+  description: "Retrieves available options for the Document ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    documenso,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await documenso.propDefinitions.documentId.options.call(this.documenso, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/documenso/actions/list-template-id-options/list-template-id-options.mjs
+++ b/components/documenso/actions/list-template-id-options/list-template-id-options.mjs
@@ -1,0 +1,33 @@
+import documenso from "../../documenso.app.mjs";
+
+export default {
+  key: "documenso-list-template-id-options",
+  name: "List Template ID Options",
+  description: "Retrieves available options for the Template ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    documenso,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await documenso.propDefinitions.templateId.options.call(this.documenso, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/documenso/package.json
+++ b/components/documenso/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/documenso",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Documenso Components",
   "main": "documenso.app.mjs",
   "keywords": [

--- a/components/document360/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/document360/actions/list-user-id-options/list-user-id-options.mjs
@@ -1,0 +1,33 @@
+import document360 from "../../document360.app.mjs";
+
+export default {
+  key: "document360-list-user-id-options",
+  name: "List User ID Options",
+  description: "Retrieves available options for the User ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    document360,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await document360.propDefinitions.userId.options.call(this.document360, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/document360/package.json
+++ b/components/document360/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/document360",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Pipedream Document360 Components",
   "main": "document360.app.mjs",
   "keywords": [

--- a/components/documint/actions/list-template-id-options/list-template-id-options.mjs
+++ b/components/documint/actions/list-template-id-options/list-template-id-options.mjs
@@ -1,0 +1,33 @@
+import documint from "../../documint.app.mjs";
+
+export default {
+  key: "documint-list-template-id-options",
+  name: "List Template ID Options",
+  description: "Retrieves available options for the Template ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    documint,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await documint.propDefinitions.templateId.options.call(this.documint, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/documint/package.json
+++ b/components/documint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/documint",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream Documint Components",
   "main": "documint.app.mjs",
   "keywords": [

--- a/components/dolibarr/actions/create-order/create-order.mjs
+++ b/components/dolibarr/actions/create-order/create-order.mjs
@@ -5,7 +5,7 @@ export default {
   key: "dolibarr-create-order",
   name: "Create Order",
   description: "Create a new order in Dolibarr.",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/dolibarr/actions/create-thirdparty/create-thirdparty.mjs
+++ b/components/dolibarr/actions/create-thirdparty/create-thirdparty.mjs
@@ -5,7 +5,7 @@ export default {
   key: "dolibarr-create-thirdparty",
   name: "Create Third Party",
   description: "Create a new third party in Dolibarr.",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/dolibarr/actions/create-user/create-user.mjs
+++ b/components/dolibarr/actions/create-user/create-user.mjs
@@ -5,7 +5,7 @@ export default {
   key: "dolibarr-create-user",
   name: "Create User",
   description: "Create a new user in Dolibarr.",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/dolibarr/actions/list-payment-method-code-options/list-payment-method-code-options.mjs
+++ b/components/dolibarr/actions/list-payment-method-code-options/list-payment-method-code-options.mjs
@@ -1,0 +1,33 @@
+import dolibarr from "../../dolibarr.app.mjs";
+
+export default {
+  key: "dolibarr-list-payment-method-code-options",
+  name: "List Payment Method Code Options",
+  description: "Retrieves available options for the Payment Method Code field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    dolibarr,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await dolibarr.propDefinitions.paymentMethodCode.options.call(this.dolibarr, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/dolibarr/actions/list-payment-method-code-options/list-payment-method-code-options.mjs
+++ b/components/dolibarr/actions/list-payment-method-code-options/list-payment-method-code-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     dolibarr,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        dolibarr,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/dolibarr/actions/list-payment-term-code-options/list-payment-term-code-options.mjs
+++ b/components/dolibarr/actions/list-payment-term-code-options/list-payment-term-code-options.mjs
@@ -1,0 +1,33 @@
+import dolibarr from "../../dolibarr.app.mjs";
+
+export default {
+  key: "dolibarr-list-payment-term-code-options",
+  name: "List Payment Term ID Options",
+  description: "Retrieves available options for the Payment Term ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    dolibarr,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await dolibarr.propDefinitions.paymentTermCode.options.call(this.dolibarr, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/dolibarr/actions/list-payment-term-code-options/list-payment-term-code-options.mjs
+++ b/components/dolibarr/actions/list-payment-term-code-options/list-payment-term-code-options.mjs
@@ -2,8 +2,8 @@ import dolibarr from "../../dolibarr.app.mjs";
 
 export default {
   key: "dolibarr-list-payment-term-code-options",
-  name: "List Payment Term ID Options",
-  description: "Retrieves available options for the Payment Term ID field.",
+  name: "List Payment Term Code Options",
+  description: "Retrieves available options for the Payment Term Code field.",
   version: "0.0.1",
   type: "action",
   annotations: {
@@ -14,11 +14,10 @@ export default {
   props: {
     dolibarr,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        dolibarr,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/dolibarr/actions/list-third-party-id-options/list-third-party-id-options.mjs
+++ b/components/dolibarr/actions/list-third-party-id-options/list-third-party-id-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     dolibarr,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        dolibarr,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/dolibarr/actions/list-third-party-id-options/list-third-party-id-options.mjs
+++ b/components/dolibarr/actions/list-third-party-id-options/list-third-party-id-options.mjs
@@ -1,0 +1,33 @@
+import dolibarr from "../../dolibarr.app.mjs";
+
+export default {
+  key: "dolibarr-list-third-party-id-options",
+  name: "List Third Party ID Options",
+  description: "Retrieves available options for the Third Party ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    dolibarr,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await dolibarr.propDefinitions.thirdPartyId.options.call(this.dolibarr, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/dolibarr/dolibarr.app.mjs
+++ b/components/dolibarr/dolibarr.app.mjs
@@ -5,6 +5,13 @@ export default {
   type: "app",
   app: "dolibarr",
   propDefinitions: {
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve, zero-based.",
+      min: 0,
+      default: 0,
+    },
     thirdPartyId: {
       type: "string",
       label: "Third Party ID",

--- a/components/dolibarr/package.json
+++ b/components/dolibarr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/dolibarr",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Dolibarr Components",
   "main": "dolibarr.app.mjs",
   "keywords": [

--- a/components/dolibarr/sources/new-invoice-created/new-invoice-created.mjs
+++ b/components/dolibarr/sources/new-invoice-created/new-invoice-created.mjs
@@ -6,7 +6,7 @@ export default {
   key: "dolibarr-new-invoice-created",
   name: "New Invoice Created",
   description: "Emit new event when a new invoice is created",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/dolibarr/sources/new-order-created/new-order-created.mjs
+++ b/components/dolibarr/sources/new-order-created/new-order-created.mjs
@@ -6,7 +6,7 @@ export default {
   key: "dolibarr-new-order-created",
   name: "New Order Created",
   description: "Emit new event when a new order is created",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/dolibarr/sources/new-thirdparty-created/new-thirdparty-created.mjs
+++ b/components/dolibarr/sources/new-thirdparty-created/new-thirdparty-created.mjs
@@ -6,7 +6,7 @@ export default {
   key: "dolibarr-new-thirdparty-created",
   name: "New Third Party Created",
   description: "Emit new event when a new third party is created",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/doppler_marketing_automation/actions/list-list-id-options/list-list-id-options.mjs
+++ b/components/doppler_marketing_automation/actions/list-list-id-options/list-list-id-options.mjs
@@ -1,0 +1,34 @@
+import doppler_marketing_automation from "../../doppler_marketing_automation.app.mjs";
+
+export default {
+  key: "doppler_marketing_automation-list-list-id-options",
+  name: "List List ID Options",
+  description: "Retrieves available options for the List ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    doppler_marketing_automation,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await doppler_marketing_automation.propDefinitions.listId.options
+      .call(this.doppler_marketing_automation, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/doppler_marketing_automation/package.json
+++ b/components/doppler_marketing_automation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/doppler_marketing_automation",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Pipedream Doppler Marketing Automation Components",
   "main": "doppler_marketing_automation.app.mjs",
   "keywords": [

--- a/components/dopplerai/actions/list-chat-uuid-options/list-chat-uuid-options.mjs
+++ b/components/dopplerai/actions/list-chat-uuid-options/list-chat-uuid-options.mjs
@@ -1,0 +1,33 @@
+import dopplerai from "../../dopplerai.app.mjs";
+
+export default {
+  key: "dopplerai-list-chat-uuid-options",
+  name: "List Chat UUID Options",
+  description: "Retrieves available options for the Chat UUID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    dopplerai,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await dopplerai.propDefinitions.chatUuid.options.call(this.dopplerai, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/dopplerai/actions/list-collection-uuid-options/list-collection-uuid-options.mjs
+++ b/components/dopplerai/actions/list-collection-uuid-options/list-collection-uuid-options.mjs
@@ -1,0 +1,33 @@
+import dopplerai from "../../dopplerai.app.mjs";
+
+export default {
+  key: "dopplerai-list-collection-uuid-options",
+  name: "List Collection UUID Options",
+  description: "Retrieves available options for the Collection UUID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    dopplerai,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await dopplerai.propDefinitions.collectionUuid.options.call(this.dopplerai, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/dopplerai/package.json
+++ b/components/dopplerai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/dopplerai",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream DopplerAI Components",
   "main": "dopplerai.app.mjs",
   "keywords": [

--- a/components/dotsimple/actions/list-post-id-options/list-post-id-options.mjs
+++ b/components/dotsimple/actions/list-post-id-options/list-post-id-options.mjs
@@ -1,0 +1,33 @@
+import dotsimple from "../../dotsimple.app.mjs";
+
+export default {
+  key: "dotsimple-list-post-id-options",
+  name: "List Post ID Options",
+  description: "Retrieves available options for the Post ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    dotsimple,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await dotsimple.propDefinitions.postId.options.call(this.dotsimple, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/dotsimple/package.json
+++ b/components/dotsimple/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/dotsimple",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream DotSimple Components",
   "main": "dotsimple.app.mjs",
   "keywords": [


### PR DESCRIPTION
Adds a batch of 73 new actions for retrieving prop options that accept the page parameter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added paginated "list option" actions across many integrations to retrieve available field options (e.g., CloudPress, Codat, CodeQR, Cody, ConnectWise PSA, Crowdin, Dolibarr, Craftboxx, and others).
  * Enabled pagination support for option lookups.

* **Chores**
  * Bumped component package versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PipedreamHQ/pipedream/pull/20909?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->