### PR TITLE
Actions for page only prop options batch 4

### DIFF
--- a/components/drata/actions/list-control-id-options/list-control-id-options.mjs
+++ b/components/drata/actions/list-control-id-options/list-control-id-options.mjs
@@ -1,0 +1,33 @@
+import drata from "../../drata.app.mjs";
+
+export default {
+  key: "drata-list-control-id-options",
+  name: "List Control ID Options",
+  description: "Retrieves available options for the Control ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    drata,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await drata.propDefinitions.controlId.options.call(this.drata, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/drata/actions/list-vendor-id-options/list-vendor-id-options.mjs
+++ b/components/drata/actions/list-vendor-id-options/list-vendor-id-options.mjs
@@ -1,0 +1,33 @@
+import drata from "../../drata.app.mjs";
+
+export default {
+  key: "drata-list-vendor-id-options",
+  name: "List Vendor ID Options",
+  description: "Retrieves available options for the Vendor ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    drata,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await drata.propDefinitions.vendorId.options.call(this.drata, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/drata/actions/list-workspace-id-options/list-workspace-id-options.mjs
+++ b/components/drata/actions/list-workspace-id-options/list-workspace-id-options.mjs
@@ -1,0 +1,33 @@
+import drata from "../../drata.app.mjs";
+
+export default {
+  key: "drata-list-workspace-id-options",
+  name: "List Workspace ID Options",
+  description: "Retrieves available options for the Workspace ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    drata,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await drata.propDefinitions.workspaceId.options.call(this.drata, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/drata/package.json
+++ b/components/drata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/drata",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "description": "Pipedream Drata Components",
   "main": "drata.app.mjs",
   "keywords": [

--- a/components/dreamstudio/actions/list-organization-id-options/list-organization-id-options.mjs
+++ b/components/dreamstudio/actions/list-organization-id-options/list-organization-id-options.mjs
@@ -1,0 +1,34 @@
+import dreamstudio from "../../dreamstudio.app.mjs";
+
+export default {
+  key: "dreamstudio-list-organization-id-options",
+  name: "List Organization Id Options",
+  description: "Retrieves available options for the Organization Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    dreamstudio,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await dreamstudio.propDefinitions.organizationId.options
+      .call(this.dreamstudio, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/dreamstudio/package.json
+++ b/components/dreamstudio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/dreamstudio",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Pipedream DreamStudio (Stable Diffusion) Components",
   "main": "dreamstudio.app.mjs",
   "keywords": [

--- a/components/drip/actions/list-campaign-options/list-campaign-options.mjs
+++ b/components/drip/actions/list-campaign-options/list-campaign-options.mjs
@@ -1,0 +1,33 @@
+import drip from "../../drip.app.mjs";
+
+export default {
+  key: "drip-list-campaign-options",
+  name: "List Campaign Options",
+  description: "Retrieves available options for the Campaign field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    drip,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await drip.propDefinitions.campaign.options.call(this.drip, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/drip/actions/list-email-options/list-email-options.mjs
+++ b/components/drip/actions/list-email-options/list-email-options.mjs
@@ -1,0 +1,33 @@
+import drip from "../../drip.app.mjs";
+
+export default {
+  key: "drip-list-email-options",
+  name: "List Email Options",
+  description: "Retrieves available options for the Email field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    drip,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await drip.propDefinitions.email.options.call(this.drip, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/drip/actions/list-workflow-id-options/list-workflow-id-options.mjs
+++ b/components/drip/actions/list-workflow-id-options/list-workflow-id-options.mjs
@@ -1,0 +1,33 @@
+import drip from "../../drip.app.mjs";
+
+export default {
+  key: "drip-list-workflow-id-options",
+  name: "List Workflow Id Options",
+  description: "Retrieves available options for the Workflow Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    drip,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await drip.propDefinitions.workflowId.options.call(this.drip, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/drip/package.json
+++ b/components/drip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/drip",
-  "version": "0.0.6",
+  "version": "0.1.0",
   "description": "Pipedream Drip Components",
   "main": "drip.app.mjs",
   "keywords": [

--- a/components/dropboard/actions/list-client-id-options/list-client-id-options.mjs
+++ b/components/dropboard/actions/list-client-id-options/list-client-id-options.mjs
@@ -1,0 +1,33 @@
+import dropboard from "../../dropboard.app.mjs";
+
+export default {
+  key: "dropboard-list-client-id-options",
+  name: "List Client ID Options",
+  description: "Retrieves available options for the Client ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    dropboard,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await dropboard.propDefinitions.clientId.options.call(this.dropboard, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/dropboard/actions/list-client-plan-id-options/list-client-plan-id-options.mjs
+++ b/components/dropboard/actions/list-client-plan-id-options/list-client-plan-id-options.mjs
@@ -1,0 +1,33 @@
+import dropboard from "../../dropboard.app.mjs";
+
+export default {
+  key: "dropboard-list-client-plan-id-options",
+  name: "List Client Plan ID Options",
+  description: "Retrieves available options for the Client Plan ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    dropboard,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await dropboard.propDefinitions.clientPlanId.options.call(this.dropboard, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/dropboard/actions/list-job-id-options/list-job-id-options.mjs
+++ b/components/dropboard/actions/list-job-id-options/list-job-id-options.mjs
@@ -1,0 +1,33 @@
+import dropboard from "../../dropboard.app.mjs";
+
+export default {
+  key: "dropboard-list-job-id-options",
+  name: "List Job ID Options",
+  description: "Retrieves available options for the Job ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    dropboard,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await dropboard.propDefinitions.jobId.options.call(this.dropboard, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/dropboard/package.json
+++ b/components/dropboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/dropboard",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream Dropboard Components",
   "main": "dropboard.app.mjs",
   "keywords": [
@@ -16,4 +16,3 @@
     "@pipedream/platform": "^3.1.1"
   }
 }
-

--- a/components/e_conomic/actions/list-currency-code-options/list-currency-code-options.mjs
+++ b/components/e_conomic/actions/list-currency-code-options/list-currency-code-options.mjs
@@ -1,0 +1,33 @@
+import e_conomic from "../../e_conomic.app.mjs";
+
+export default {
+  key: "e_conomic-list-currency-code-options",
+  name: "List Currency Code Options",
+  description: "Retrieves available options for the Currency Code field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    e_conomic,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await e_conomic.propDefinitions.currencyCode.options.call(this.e_conomic, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/e_conomic/actions/list-customer-group-number-options/list-customer-group-number-options.mjs
+++ b/components/e_conomic/actions/list-customer-group-number-options/list-customer-group-number-options.mjs
@@ -1,0 +1,34 @@
+import e_conomic from "../../e_conomic.app.mjs";
+
+export default {
+  key: "e_conomic-list-customer-group-number-options",
+  name: "List Customer Group Number Options",
+  description: "Retrieves available options for the Customer Group Number field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    e_conomic,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await e_conomic.propDefinitions.customerGroupNumber.options
+      .call(this.e_conomic, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/e_conomic/actions/list-customer-number-options/list-customer-number-options.mjs
+++ b/components/e_conomic/actions/list-customer-number-options/list-customer-number-options.mjs
@@ -1,0 +1,33 @@
+import e_conomic from "../../e_conomic.app.mjs";
+
+export default {
+  key: "e_conomic-list-customer-number-options",
+  name: "List Customer Number Options",
+  description: "Retrieves available options for the Customer Number field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    e_conomic,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await e_conomic.propDefinitions.customerNumber.options.call(this.e_conomic, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/e_conomic/actions/list-draft-invoice-number-options/list-draft-invoice-number-options.mjs
+++ b/components/e_conomic/actions/list-draft-invoice-number-options/list-draft-invoice-number-options.mjs
@@ -1,0 +1,34 @@
+import e_conomic from "../../e_conomic.app.mjs";
+
+export default {
+  key: "e_conomic-list-draft-invoice-number-options",
+  name: "List Draft Invoice Number Options",
+  description: "Retrieves available options for the Draft Invoice Number field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    e_conomic,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await e_conomic.propDefinitions.draftInvoiceNumber.options
+      .call(this.e_conomic, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/e_conomic/actions/list-journal-number-options/list-journal-number-options.mjs
+++ b/components/e_conomic/actions/list-journal-number-options/list-journal-number-options.mjs
@@ -1,0 +1,33 @@
+import e_conomic from "../../e_conomic.app.mjs";
+
+export default {
+  key: "e_conomic-list-journal-number-options",
+  name: "List Journal Number Options",
+  description: "Retrieves available options for the Journal Number field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    e_conomic,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await e_conomic.propDefinitions.journalNumber.options.call(this.e_conomic, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/e_conomic/actions/list-layout-number-options/list-layout-number-options.mjs
+++ b/components/e_conomic/actions/list-layout-number-options/list-layout-number-options.mjs
@@ -1,0 +1,33 @@
+import e_conomic from "../../e_conomic.app.mjs";
+
+export default {
+  key: "e_conomic-list-layout-number-options",
+  name: "List Layout Number Options",
+  description: "Retrieves available options for the Layout Number field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    e_conomic,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await e_conomic.propDefinitions.layoutNumber.options.call(this.e_conomic, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/e_conomic/actions/list-payment-term-number-options/list-payment-term-number-options.mjs
+++ b/components/e_conomic/actions/list-payment-term-number-options/list-payment-term-number-options.mjs
@@ -1,0 +1,33 @@
+import e_conomic from "../../e_conomic.app.mjs";
+
+export default {
+  key: "e_conomic-list-payment-term-number-options",
+  name: "List Payment Term Number Options",
+  description: "Retrieves available options for the Payment Term Number field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    e_conomic,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await e_conomic.propDefinitions.paymentTermNumber.options.call(this.e_conomic, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/e_conomic/actions/list-product-numbers-options/list-product-numbers-options.mjs
+++ b/components/e_conomic/actions/list-product-numbers-options/list-product-numbers-options.mjs
@@ -1,0 +1,33 @@
+import e_conomic from "../../e_conomic.app.mjs";
+
+export default {
+  key: "e_conomic-list-product-numbers-options",
+  name: "List Product Numbers Options",
+  description: "Retrieves available options for the Product Numbers field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    e_conomic,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await e_conomic.propDefinitions.productNumbers.options.call(this.e_conomic, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/e_conomic/actions/list-supplier-number-options/list-supplier-number-options.mjs
+++ b/components/e_conomic/actions/list-supplier-number-options/list-supplier-number-options.mjs
@@ -1,0 +1,33 @@
+import e_conomic from "../../e_conomic.app.mjs";
+
+export default {
+  key: "e_conomic-list-supplier-number-options",
+  name: "List Supplier Number Options",
+  description: "Retrieves available options for the Supplier Number field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    e_conomic,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await e_conomic.propDefinitions.supplierNumber.options.call(this.e_conomic, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/e_conomic/actions/list-vat-zone-number-options/list-vat-zone-number-options.mjs
+++ b/components/e_conomic/actions/list-vat-zone-number-options/list-vat-zone-number-options.mjs
@@ -1,0 +1,33 @@
+import e_conomic from "../../e_conomic.app.mjs";
+
+export default {
+  key: "e_conomic-list-vat-zone-number-options",
+  name: "List VAT Zone Number Options",
+  description: "Retrieves available options for the VAT Zone Number field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    e_conomic,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await e_conomic.propDefinitions.vatZoneNumber.options.call(this.e_conomic, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/e_conomic/package.json
+++ b/components/e_conomic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/e_conomic",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream E-conomic Components",
   "main": "e_conomic.app.mjs",
   "keywords": [

--- a/components/easybroker/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/easybroker/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -1,0 +1,33 @@
+import easybroker from "../../easybroker.app.mjs";
+
+export default {
+  key: "easybroker-list-contact-id-options",
+  name: "List Contact ID Options",
+  description: "Retrieves available options for the Contact ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    easybroker,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await easybroker.propDefinitions.contactId.options.call(this.easybroker, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/easybroker/actions/list-property-id-options/list-property-id-options.mjs
+++ b/components/easybroker/actions/list-property-id-options/list-property-id-options.mjs
@@ -1,0 +1,33 @@
+import easybroker from "../../easybroker.app.mjs";
+
+export default {
+  key: "easybroker-list-property-id-options",
+  name: "List Property ID Options",
+  description: "Retrieves available options for the Property ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    easybroker,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await easybroker.propDefinitions.propertyId.options.call(this.easybroker, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/easybroker/package.json
+++ b/components/easybroker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/easybroker",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream EasyBroker Components",
   "main": "easybroker.app.mjs",
   "keywords": [

--- a/components/easysendy/actions/list-list-id-options/list-list-id-options.mjs
+++ b/components/easysendy/actions/list-list-id-options/list-list-id-options.mjs
@@ -1,0 +1,33 @@
+import easysendy from "../../easysendy.app.mjs";
+
+export default {
+  key: "easysendy-list-list-id-options",
+  name: "List List ID Options",
+  description: "Retrieves available options for the List ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    easysendy,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await easysendy.propDefinitions.listId.options.call(this.easysendy, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/easysendy/package.json
+++ b/components/easysendy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/easysendy",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream EasySendy Components",
   "main": "easysendy.app.mjs",
   "keywords": [

--- a/components/easyship/actions/list-shipment-id-options/list-shipment-id-options.mjs
+++ b/components/easyship/actions/list-shipment-id-options/list-shipment-id-options.mjs
@@ -1,0 +1,33 @@
+import easyship from "../../easyship.app.mjs";
+
+export default {
+  key: "easyship-list-shipment-id-options",
+  name: "List Shipment ID Options",
+  description: "Retrieves available options for the Shipment ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    easyship,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await easyship.propDefinitions.shipmentId.options.call(this.easyship, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/easyship/package.json
+++ b/components/easyship/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/easyship",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Easyship Components",
   "main": "easyship.app.mjs",
   "keywords": [

--- a/components/edusign/actions/list-course-id-options/list-course-id-options.mjs
+++ b/components/edusign/actions/list-course-id-options/list-course-id-options.mjs
@@ -1,0 +1,33 @@
+import edusign from "../../edusign.app.mjs";
+
+export default {
+  key: "edusign-list-course-id-options",
+  name: "List Course ID Options",
+  description: "Retrieves available options for the Course ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    edusign,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await edusign.propDefinitions.courseId.options.call(this.edusign, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/edusign/actions/list-group-id-options/list-group-id-options.mjs
+++ b/components/edusign/actions/list-group-id-options/list-group-id-options.mjs
@@ -1,0 +1,33 @@
+import edusign from "../../edusign.app.mjs";
+
+export default {
+  key: "edusign-list-group-id-options",
+  name: "List Group ID Options",
+  description: "Retrieves available options for the Group ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    edusign,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await edusign.propDefinitions.groupId.options.call(this.edusign, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/edusign/actions/list-professor-id-options/list-professor-id-options.mjs
+++ b/components/edusign/actions/list-professor-id-options/list-professor-id-options.mjs
@@ -1,0 +1,33 @@
+import edusign from "../../edusign.app.mjs";
+
+export default {
+  key: "edusign-list-professor-id-options",
+  name: "List Professor ID Options",
+  description: "Retrieves available options for the Professor ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    edusign,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await edusign.propDefinitions.professorId.options.call(this.edusign, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/edusign/actions/list-student-id-options/list-student-id-options.mjs
+++ b/components/edusign/actions/list-student-id-options/list-student-id-options.mjs
@@ -1,0 +1,33 @@
+import edusign from "../../edusign.app.mjs";
+
+export default {
+  key: "edusign-list-student-id-options",
+  name: "List Student ID Options",
+  description: "Retrieves available options for the Student ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    edusign,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await edusign.propDefinitions.studentId.options.call(this.edusign, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/edusign/package.json
+++ b/components/edusign/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/edusign",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Edusign Components",
   "main": "edusign.app.mjs",
   "keywords": [

--- a/components/elastic_email/actions/list-campaign-options/list-campaign-options.mjs
+++ b/components/elastic_email/actions/list-campaign-options/list-campaign-options.mjs
@@ -1,0 +1,33 @@
+import elastic_email from "../../elastic_email.app.mjs";
+
+export default {
+  key: "elastic_email-list-campaign-options",
+  name: "List Campaign Options",
+  description: "Retrieves available options for the Campaign field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    elastic_email,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await elastic_email.propDefinitions.campaign.options.call(this.elastic_email, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/elastic_email/actions/list-contact-options/list-contact-options.mjs
+++ b/components/elastic_email/actions/list-contact-options/list-contact-options.mjs
@@ -1,0 +1,33 @@
+import elastic_email from "../../elastic_email.app.mjs";
+
+export default {
+  key: "elastic_email-list-contact-options",
+  name: "List Contact Options",
+  description: "Retrieves available options for the Contact field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    elastic_email,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await elastic_email.propDefinitions.contact.options.call(this.elastic_email, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/elastic_email/actions/list-list-names-options/list-list-names-options.mjs
+++ b/components/elastic_email/actions/list-list-names-options/list-list-names-options.mjs
@@ -1,0 +1,33 @@
+import elastic_email from "../../elastic_email.app.mjs";
+
+export default {
+  key: "elastic_email-list-list-names-options",
+  name: "List List Names Options",
+  description: "Retrieves available options for the List Names field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    elastic_email,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await elastic_email.propDefinitions.listNames.options.call(this.elastic_email, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/elastic_email/actions/list-segment-names-options/list-segment-names-options.mjs
+++ b/components/elastic_email/actions/list-segment-names-options/list-segment-names-options.mjs
@@ -1,0 +1,34 @@
+import elastic_email from "../../elastic_email.app.mjs";
+
+export default {
+  key: "elastic_email-list-segment-names-options",
+  name: "List Segment Names Options",
+  description: "Retrieves available options for the Segment Names field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    elastic_email,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await elastic_email.propDefinitions.segmentNames.options
+      .call(this.elastic_email, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/elastic_email/actions/list-template-name-options/list-template-name-options.mjs
+++ b/components/elastic_email/actions/list-template-name-options/list-template-name-options.mjs
@@ -1,0 +1,34 @@
+import elastic_email from "../../elastic_email.app.mjs";
+
+export default {
+  key: "elastic_email-list-template-name-options",
+  name: "List Template Name Options",
+  description: "Retrieves available options for the Template Name field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    elastic_email,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await elastic_email.propDefinitions.templateName.options
+      .call(this.elastic_email, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/elastic_email/package.json
+++ b/components/elastic_email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/elastic_email",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Elastic Email Components",
   "main": "elastic_email.app.mjs",
   "keywords": [

--- a/components/elevio/actions/list-article-id-options/list-article-id-options.mjs
+++ b/components/elevio/actions/list-article-id-options/list-article-id-options.mjs
@@ -1,0 +1,33 @@
+import elevio from "../../elevio.app.mjs";
+
+export default {
+  key: "elevio-list-article-id-options",
+  name: "List Article ID Options",
+  description: "Retrieves available options for the Article ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    elevio,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await elevio.propDefinitions.articleId.options.call(this.elevio, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/elevio/package.json
+++ b/components/elevio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/elevio",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Elevio Components",
   "main": "elevio.app.mjs",
   "keywords": [

--- a/components/elorus/actions/list-task-id-options/list-task-id-options.mjs
+++ b/components/elorus/actions/list-task-id-options/list-task-id-options.mjs
@@ -1,0 +1,33 @@
+import elorus from "../../elorus.app.mjs";
+
+export default {
+  key: "elorus-list-task-id-options",
+  name: "List Task Id Options",
+  description: "Retrieves available options for the Task Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    elorus,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await elorus.propDefinitions.taskId.options.call(this.elorus, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/elorus/package.json
+++ b/components/elorus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/elorus",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Elorus Components",
   "main": "elorus.app.mjs",
   "keywords": [

--- a/components/emailoctopus/actions/list-list-id-options/list-list-id-options.mjs
+++ b/components/emailoctopus/actions/list-list-id-options/list-list-id-options.mjs
@@ -1,0 +1,33 @@
+import emailoctopus from "../../emailoctopus.app.mjs";
+
+export default {
+  key: "emailoctopus-list-list-id-options",
+  name: "List List Options",
+  description: "Retrieves available options for the List field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    emailoctopus,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await emailoctopus.propDefinitions.listId.options.call(this.emailoctopus, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/emailoctopus/package.json
+++ b/components/emailoctopus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/emailoctopus",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Pipedream Emailoctopus Components",
   "main": "emailoctopus.app.mjs",
   "keywords": [

--- a/components/encharge/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/encharge/actions/list-user-id-options/list-user-id-options.mjs
@@ -1,0 +1,33 @@
+import encharge from "../../encharge.app.mjs";
+
+export default {
+  key: "encharge-list-user-id-options",
+  name: "List User ID Options",
+  description: "Retrieves available options for the User ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    encharge,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await encharge.propDefinitions.userId.options.call(this.encharge, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/encharge/package.json
+++ b/components/encharge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/encharge",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Encharge Components",
   "main": "encharge.app.mjs",
   "keywords": [

--- a/components/espocrm/actions/list-assignee-id-options/list-assignee-id-options.mjs
+++ b/components/espocrm/actions/list-assignee-id-options/list-assignee-id-options.mjs
@@ -1,0 +1,33 @@
+import espocrm from "../../espocrm.app.mjs";
+
+export default {
+  key: "espocrm-list-assignee-id-options",
+  name: "List Assigned User Options",
+  description: "Retrieves available options for the Assigned User field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    espocrm,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await espocrm.propDefinitions.assigneeId.options.call(this.espocrm, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/espocrm/package.json
+++ b/components/espocrm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/espocrm",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream EspoCRM Components",
   "main": "espocrm.app.mjs",
   "keywords": [

--- a/components/evenium/actions/list-event-id-options/list-event-id-options.mjs
+++ b/components/evenium/actions/list-event-id-options/list-event-id-options.mjs
@@ -1,0 +1,33 @@
+import evenium from "../../evenium.app.mjs";
+
+export default {
+  key: "evenium-list-event-id-options",
+  name: "List Event ID Options",
+  description: "Retrieves available options for the Event ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    evenium,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await evenium.propDefinitions.eventId.options.call(this.evenium, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/evenium/package.json
+++ b/components/evenium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/evenium",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Pipedream evenium Components",
   "main": "evenium.app.mjs",
   "keywords": [

--- a/components/eventzilla/actions/list-event-id-options/list-event-id-options.mjs
+++ b/components/eventzilla/actions/list-event-id-options/list-event-id-options.mjs
@@ -1,0 +1,33 @@
+import eventzilla from "../../eventzilla.app.mjs";
+
+export default {
+  key: "eventzilla-list-event-id-options",
+  name: "List Event ID Options",
+  description: "Retrieves available options for the Event ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    eventzilla,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await eventzilla.propDefinitions.eventId.options.call(this.eventzilla, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/eventzilla/package.json
+++ b/components/eventzilla/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/eventzilla",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Pipedream eventzilla Components",
   "main": "eventzilla.app.mjs",
   "keywords": [

--- a/components/everhour/actions/list-project-id-options/list-project-id-options.mjs
+++ b/components/everhour/actions/list-project-id-options/list-project-id-options.mjs
@@ -1,0 +1,33 @@
+import everhour from "../../everhour.app.mjs";
+
+export default {
+  key: "everhour-list-project-id-options",
+  name: "List Project ID Options",
+  description: "Retrieves available options for the Project ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    everhour,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await everhour.propDefinitions.projectId.options.call(this.everhour, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/everhour/package.json
+++ b/components/everhour/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/everhour",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Everhour Components",
   "main": "everhour.app.mjs",
   "keywords": [

--- a/components/evernote/actions/list-note-id-options/list-note-id-options.mjs
+++ b/components/evernote/actions/list-note-id-options/list-note-id-options.mjs
@@ -1,0 +1,33 @@
+import evernote from "../../evernote.app.mjs";
+
+export default {
+  key: "evernote-list-note-id-options",
+  name: "List Note ID Options",
+  description: "Retrieves available options for the Note ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    evernote,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await evernote.propDefinitions.noteId.options.call(this.evernote, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/evernote/package.json
+++ b/components/evernote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/evernote",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Pipedream Evernote Components",
   "main": "evernote.app.mjs",
   "keywords": [

--- a/components/everstox/actions/list-order-id-options/list-order-id-options.mjs
+++ b/components/everstox/actions/list-order-id-options/list-order-id-options.mjs
@@ -1,0 +1,33 @@
+import everstox from "../../everstox.app.mjs";
+
+export default {
+  key: "everstox-list-order-id-options",
+  name: "List Order ID Options",
+  description: "Retrieves available options for the Order ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    everstox,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await everstox.propDefinitions.orderId.options.call(this.everstox, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/everstox/actions/list-order-number-options/list-order-number-options.mjs
+++ b/components/everstox/actions/list-order-number-options/list-order-number-options.mjs
@@ -1,0 +1,33 @@
+import everstox from "../../everstox.app.mjs";
+
+export default {
+  key: "everstox-list-order-number-options",
+  name: "List Order Number Options",
+  description: "Retrieves available options for the Order Number field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    everstox,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await everstox.propDefinitions.orderNumber.options.call(this.everstox, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/everstox/actions/list-return-id-options/list-return-id-options.mjs
+++ b/components/everstox/actions/list-return-id-options/list-return-id-options.mjs
@@ -1,0 +1,33 @@
+import everstox from "../../everstox.app.mjs";
+
+export default {
+  key: "everstox-list-return-id-options",
+  name: "List Return ID Options",
+  description: "Retrieves available options for the Return ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    everstox,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await everstox.propDefinitions.returnId.options.call(this.everstox, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/everstox/actions/list-warehouse-ids-options/list-warehouse-ids-options.mjs
+++ b/components/everstox/actions/list-warehouse-ids-options/list-warehouse-ids-options.mjs
@@ -1,0 +1,33 @@
+import everstox from "../../everstox.app.mjs";
+
+export default {
+  key: "everstox-list-warehouse-ids-options",
+  name: "List Warehouse IDs Options",
+  description: "Retrieves available options for the Warehouse IDs field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    everstox,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await everstox.propDefinitions.warehouseIds.options.call(this.everstox, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/everstox/package.json
+++ b/components/everstox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/everstox",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Everstox Components",
   "main": "everstox.app.mjs",
   "keywords": [

--- a/components/ezeep_blue/actions/list-printer-id-options/list-printer-id-options.mjs
+++ b/components/ezeep_blue/actions/list-printer-id-options/list-printer-id-options.mjs
@@ -1,0 +1,33 @@
+import ezeep_blue from "../../ezeep_blue.app.mjs";
+
+export default {
+  key: "ezeep_blue-list-printer-id-options",
+  name: "List Printer ID Options",
+  description: "Retrieves available options for the Printer ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    ezeep_blue,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await ezeep_blue.propDefinitions.printerId.options.call(this.ezeep_blue, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/ezeep_blue/package.json
+++ b/components/ezeep_blue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/ezeep_blue",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Pipedream ezeep Blue Components",
   "main": "ezeep_blue.app.mjs",
   "keywords": [

--- a/components/f15five/actions/list-user-options/list-user-options.mjs
+++ b/components/f15five/actions/list-user-options/list-user-options.mjs
@@ -1,0 +1,33 @@
+import f15five from "../../f15five.app.mjs";
+
+export default {
+  key: "f15five-list-user-options",
+  name: "List User Options",
+  description: "Retrieves available options for the User field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    f15five,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await f15five.propDefinitions.user.options.call(this.f15five, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/f15five/package.json
+++ b/components/f15five/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/f15five",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream 15Five Components",
   "main": "f15five.app.mjs",
   "keywords": [

--- a/components/filepost/actions/list-file-id-options/list-file-id-options.mjs
+++ b/components/filepost/actions/list-file-id-options/list-file-id-options.mjs
@@ -1,0 +1,33 @@
+import filepost from "../../filepost.app.mjs";
+
+export default {
+  key: "filepost-list-file-id-options",
+  name: "List File ID Options",
+  description: "Retrieves available options for the File ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    filepost,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await filepost.propDefinitions.fileId.options.call(this.filepost, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/filepost/package.json
+++ b/components/filepost/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/filepost",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream FilePost Components",
   "main": "filepost.app.mjs",
   "keywords": [

--- a/components/fireflies/actions/list-meeting-id-options/list-meeting-id-options.mjs
+++ b/components/fireflies/actions/list-meeting-id-options/list-meeting-id-options.mjs
@@ -1,0 +1,33 @@
+import fireflies from "../../fireflies.app.mjs";
+
+export default {
+  key: "fireflies-list-meeting-id-options",
+  name: "List Meeting ID Options",
+  description: "Retrieves available options for the Meeting ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    fireflies,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await fireflies.propDefinitions.meetingId.options.call(this.fireflies, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/fireflies/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/fireflies/actions/list-user-id-options/list-user-id-options.mjs
@@ -1,0 +1,33 @@
+import fireflies from "../../fireflies.app.mjs";
+
+export default {
+  key: "fireflies-list-user-id-options",
+  name: "List User ID Options",
+  description: "Retrieves available options for the User ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    fireflies,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await fireflies.propDefinitions.userId.options.call(this.fireflies, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/fireflies/package.json
+++ b/components/fireflies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/fireflies",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "Pipedream Fireflies Components",
   "main": "fireflies.app.mjs",
   "keywords": [

--- a/components/flexmail/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/flexmail/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -1,0 +1,33 @@
+import flexmail from "../../flexmail.app.mjs";
+
+export default {
+  key: "flexmail-list-contact-id-options",
+  name: "List Contact ID Options",
+  description: "Retrieves available options for the Contact ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    flexmail,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await flexmail.propDefinitions.contactId.options.call(this.flexmail, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/flexmail/actions/list-interest-options/list-interest-options.mjs
+++ b/components/flexmail/actions/list-interest-options/list-interest-options.mjs
@@ -1,0 +1,33 @@
+import flexmail from "../../flexmail.app.mjs";
+
+export default {
+  key: "flexmail-list-interest-options",
+  name: "List Interest Options",
+  description: "Retrieves available options for the Interest field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    flexmail,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await flexmail.propDefinitions.interest.options.call(this.flexmail, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/flexmail/actions/list-source-options/list-source-options.mjs
+++ b/components/flexmail/actions/list-source-options/list-source-options.mjs
@@ -1,0 +1,33 @@
+import flexmail from "../../flexmail.app.mjs";
+
+export default {
+  key: "flexmail-list-source-options",
+  name: "List Source Options",
+  description: "Retrieves available options for the Source field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    flexmail,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await flexmail.propDefinitions.source.options.call(this.flexmail, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/flexmail/package.json
+++ b/components/flexmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/flexmail",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Flexmail Components",
   "main": "flexmail.app.mjs",
   "keywords": [

--- a/components/flippingbook/actions/list-flipbook-id-options/list-flipbook-id-options.mjs
+++ b/components/flippingbook/actions/list-flipbook-id-options/list-flipbook-id-options.mjs
@@ -1,0 +1,33 @@
+import flippingbook from "../../flippingbook.app.mjs";
+
+export default {
+  key: "flippingbook-list-flipbook-id-options",
+  name: "List Flipbook ID Options",
+  description: "Retrieves available options for the Flipbook ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    flippingbook,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await flippingbook.propDefinitions.flipbookId.options.call(this.flippingbook, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/flippingbook/package.json
+++ b/components/flippingbook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/flippingbook",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Pipedream FlippingBook Components",
   "main": "flippingbook.app.mjs",
   "keywords": [

--- a/components/float/actions/list-account-id-options/list-account-id-options.mjs
+++ b/components/float/actions/list-account-id-options/list-account-id-options.mjs
@@ -1,0 +1,33 @@
+import float from "../../float.app.mjs";
+
+export default {
+  key: "float-list-account-id-options",
+  name: "List Account Options",
+  description: "Retrieves available options for the Account field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    float,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await float.propDefinitions.accountId.options.call(this.float, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/float/actions/list-client-id-options/list-client-id-options.mjs
+++ b/components/float/actions/list-client-id-options/list-client-id-options.mjs
@@ -1,0 +1,33 @@
+import float from "../../float.app.mjs";
+
+export default {
+  key: "float-list-client-id-options",
+  name: "List Client Options",
+  description: "Retrieves available options for the Client field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    float,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await float.propDefinitions.clientId.options.call(this.float, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/float/actions/list-people-id-options/list-people-id-options.mjs
+++ b/components/float/actions/list-people-id-options/list-people-id-options.mjs
@@ -1,0 +1,33 @@
+import float from "../../float.app.mjs";
+
+export default {
+  key: "float-list-people-id-options",
+  name: "List Person Options",
+  description: "Retrieves available options for the Person field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    float,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await float.propDefinitions.peopleId.options.call(this.float, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/float/actions/list-project-id-options/list-project-id-options.mjs
+++ b/components/float/actions/list-project-id-options/list-project-id-options.mjs
@@ -1,0 +1,33 @@
+import float from "../../float.app.mjs";
+
+export default {
+  key: "float-list-project-id-options",
+  name: "List Project Options",
+  description: "Retrieves available options for the Project field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    float,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await float.propDefinitions.projectId.options.call(this.float, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/float/actions/list-stage-id-options/list-stage-id-options.mjs
+++ b/components/float/actions/list-stage-id-options/list-stage-id-options.mjs
@@ -1,0 +1,33 @@
+import float from "../../float.app.mjs";
+
+export default {
+  key: "float-list-stage-id-options",
+  name: "List Stage ID Options",
+  description: "Retrieves available options for the Stage ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    float,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await float.propDefinitions.stageId.options.call(this.float, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/float/actions/list-tags-options/list-tags-options.mjs
+++ b/components/float/actions/list-tags-options/list-tags-options.mjs
@@ -1,0 +1,33 @@
+import float from "../../float.app.mjs";
+
+export default {
+  key: "float-list-tags-options",
+  name: "List Tags Options",
+  description: "Retrieves available options for the Tags field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    float,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await float.propDefinitions.tags.options.call(this.float, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/float/actions/list-task-id-options/list-task-id-options.mjs
+++ b/components/float/actions/list-task-id-options/list-task-id-options.mjs
@@ -1,0 +1,33 @@
+import float from "../../float.app.mjs";
+
+export default {
+  key: "float-list-task-id-options",
+  name: "List Task Options",
+  description: "Retrieves available options for the Task field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    float,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await float.propDefinitions.taskId.options.call(this.float, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/float/package.json
+++ b/components/float/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/float",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Float Components",
   "main": "float.app.mjs",
   "keywords": [

--- a/components/flodesk/actions/list-custom-fields-options/list-custom-fields-options.mjs
+++ b/components/flodesk/actions/list-custom-fields-options/list-custom-fields-options.mjs
@@ -1,0 +1,33 @@
+import flodesk from "../../flodesk.app.mjs";
+
+export default {
+  key: "flodesk-list-custom-fields-options",
+  name: "List Custom Fields Options",
+  description: "Retrieves available options for the Custom Fields field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    flodesk,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await flodesk.propDefinitions.customFields.options.call(this.flodesk, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/flodesk/actions/list-segment-ids-options/list-segment-ids-options.mjs
+++ b/components/flodesk/actions/list-segment-ids-options/list-segment-ids-options.mjs
@@ -1,0 +1,33 @@
+import flodesk from "../../flodesk.app.mjs";
+
+export default {
+  key: "flodesk-list-segment-ids-options",
+  name: "List Segments Options",
+  description: "Retrieves available options for the Segments field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    flodesk,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await flodesk.propDefinitions.segmentIds.options.call(this.flodesk, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/flodesk/actions/list-subscriber-id-options/list-subscriber-id-options.mjs
+++ b/components/flodesk/actions/list-subscriber-id-options/list-subscriber-id-options.mjs
@@ -1,0 +1,33 @@
+import flodesk from "../../flodesk.app.mjs";
+
+export default {
+  key: "flodesk-list-subscriber-id-options",
+  name: "List Subscriber Options",
+  description: "Retrieves available options for the Subscriber field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    flodesk,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await flodesk.propDefinitions.subscriberId.options.call(this.flodesk, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/flodesk/package.json
+++ b/components/flodesk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/flodesk",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream Flodesk Components",
   "main": "flodesk.app.mjs",
   "keywords": [

--- a/components/flowla/actions/list-company-id-options/list-company-id-options.mjs
+++ b/components/flowla/actions/list-company-id-options/list-company-id-options.mjs
@@ -1,0 +1,33 @@
+import flowla from "../../flowla.app.mjs";
+
+export default {
+  key: "flowla-list-company-id-options",
+  name: "List Company ID Options",
+  description: "Retrieves available options for the Company ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    flowla,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await flowla.propDefinitions.companyId.options.call(this.flowla, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/flowla/actions/list-label-id-options/list-label-id-options.mjs
+++ b/components/flowla/actions/list-label-id-options/list-label-id-options.mjs
@@ -1,0 +1,33 @@
+import flowla from "../../flowla.app.mjs";
+
+export default {
+  key: "flowla-list-label-id-options",
+  name: "List Label ID Options",
+  description: "Retrieves available options for the Label ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    flowla,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await flowla.propDefinitions.labelId.options.call(this.flowla, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/flowla/actions/list-status-id-options/list-status-id-options.mjs
+++ b/components/flowla/actions/list-status-id-options/list-status-id-options.mjs
@@ -1,0 +1,33 @@
+import flowla from "../../flowla.app.mjs";
+
+export default {
+  key: "flowla-list-status-id-options",
+  name: "List Status ID Options",
+  description: "Retrieves available options for the Status ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    flowla,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await flowla.propDefinitions.statusId.options.call(this.flowla, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/flowla/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/flowla/actions/list-user-id-options/list-user-id-options.mjs
@@ -1,0 +1,33 @@
+import flowla from "../../flowla.app.mjs";
+
+export default {
+  key: "flowla-list-user-id-options",
+  name: "List User ID Options",
+  description: "Retrieves available options for the User ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    flowla,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await flowla.propDefinitions.userId.options.call(this.flowla, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/flowla/package.json
+++ b/components/flowla/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/flowla",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Flowla Components",
   "main": "flowla.app.mjs",
   "keywords": [

--- a/components/flutterwave/actions/list-transaction-options/list-transaction-options.mjs
+++ b/components/flutterwave/actions/list-transaction-options/list-transaction-options.mjs
@@ -1,0 +1,33 @@
+import flutterwave from "../../flutterwave.app.mjs";
+
+export default {
+  key: "flutterwave-list-transaction-options",
+  name: "List Transaction Options",
+  description: "Retrieves available options for the Transaction field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    flutterwave,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await flutterwave.propDefinitions.transaction.options.call(this.flutterwave, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/flutterwave/package.json
+++ b/components/flutterwave/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/flutterwave",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Flutterwave Components",
   "main": "flutterwave.app.mjs",
   "keywords": [

--- a/components/forcemanager/actions/list-account-id-options/list-account-id-options.mjs
+++ b/components/forcemanager/actions/list-account-id-options/list-account-id-options.mjs
@@ -1,0 +1,33 @@
+import forcemanager from "../../forcemanager.app.mjs";
+
+export default {
+  key: "forcemanager-list-account-id-options",
+  name: "List Account ID Options",
+  description: "Retrieves available options for the Account ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    forcemanager,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await forcemanager.propDefinitions.accountId.options.call(this.forcemanager, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/forcemanager/actions/list-sales-rep-id-options/list-sales-rep-id-options.mjs
+++ b/components/forcemanager/actions/list-sales-rep-id-options/list-sales-rep-id-options.mjs
@@ -1,0 +1,33 @@
+import forcemanager from "../../forcemanager.app.mjs";
+
+export default {
+  key: "forcemanager-list-sales-rep-id-options",
+  name: "List Sales Rep ID Options",
+  description: "Retrieves available options for the Sales Rep ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    forcemanager,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await forcemanager.propDefinitions.salesRepId.options.call(this.forcemanager, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/forcemanager/package.json
+++ b/components/forcemanager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/forcemanager",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream ForceManager Components",
   "main": "forcemanager.app.mjs",
   "keywords": [

--- a/components/formaloo/actions/list-form-slug-options/list-form-slug-options.mjs
+++ b/components/formaloo/actions/list-form-slug-options/list-form-slug-options.mjs
@@ -1,0 +1,33 @@
+import formaloo from "../../formaloo.app.mjs";
+
+export default {
+  key: "formaloo-list-form-slug-options",
+  name: "List Form Slug Options",
+  description: "Retrieves available options for the Form Slug field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    formaloo,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await formaloo.propDefinitions.formSlug.options.call(this.formaloo, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/formaloo/package.json
+++ b/components/formaloo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/formaloo",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Formaloo Components",
   "main": "formaloo.app.mjs",
   "keywords": [

--- a/components/formstack/actions/list-form-id-options/list-form-id-options.mjs
+++ b/components/formstack/actions/list-form-id-options/list-form-id-options.mjs
@@ -1,0 +1,33 @@
+import formstack from "../../formstack.app.mjs";
+
+export default {
+  key: "formstack-list-form-id-options",
+  name: "List Forms Options",
+  description: "Retrieves available options for the Forms field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    formstack,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await formstack.propDefinitions.formId.options.call(this.formstack, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/formstack/package.json
+++ b/components/formstack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/formstack",
-  "version": "0.3.7",
+  "version": "0.4.0",
   "description": "Pipedream Formstack Components",
   "main": "formstack.app.mjs",
   "keywords": [


### PR DESCRIPTION
Adds a batch of 74 new actions for retrieving prop options that accept the page parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added list field options actions across 40+ integrations (Drata, DreamStudio, Drip, Dropboard, E-conomic, EasyBroker, Easysendy, Easyship, Edusign, Elastic Email, Elevio, Elorus, EmailOctopus, Encharge, EspoCRM, Evenium, EventZilla, Everhour, Evernote, Everstox, Ezeep Blue, F15Five, FilePost, Fireflies, Flexmail, FlippingBook, Float, Flodesk, Flowla, Flutterwave, ForceManager, Formaloo, FormStack) enabling paginated retrieval of field option values.

* **Chores**
  * Updated package versions across multiple components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PipedreamHQ/pipedream/pull/20910?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->