### PR TITLE
Actions for page only prop options batch 5

### DIFF
--- a/components/fortnox/actions/list-article-number-options/list-article-number-options.mjs
+++ b/components/fortnox/actions/list-article-number-options/list-article-number-options.mjs
@@ -1,0 +1,33 @@
+import fortnox from "../../fortnox.app.mjs";
+
+export default {
+  key: "fortnox-list-article-number-options",
+  name: "List Article Number Options",
+  description: "Retrieves available options for the Article Number field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    fortnox,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await fortnox.propDefinitions.articleNumber.options.call(this.fortnox, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/fortnox/actions/list-customer-number-options/list-customer-number-options.mjs
+++ b/components/fortnox/actions/list-customer-number-options/list-customer-number-options.mjs
@@ -1,0 +1,33 @@
+import fortnox from "../../fortnox.app.mjs";
+
+export default {
+  key: "fortnox-list-customer-number-options",
+  name: "List Customer Number Options",
+  description: "Retrieves available options for the Customer Number field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    fortnox,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await fortnox.propDefinitions.customerNumber.options.call(this.fortnox, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/fortnox/actions/list-invoice-number-options/list-invoice-number-options.mjs
+++ b/components/fortnox/actions/list-invoice-number-options/list-invoice-number-options.mjs
@@ -1,0 +1,33 @@
+import fortnox from "../../fortnox.app.mjs";
+
+export default {
+  key: "fortnox-list-invoice-number-options",
+  name: "List Invoice Number Options",
+  description: "Retrieves available options for the Invoice Number field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    fortnox,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await fortnox.propDefinitions.invoiceNumber.options.call(this.fortnox, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/fortnox/actions/list-supplier-number-options/list-supplier-number-options.mjs
+++ b/components/fortnox/actions/list-supplier-number-options/list-supplier-number-options.mjs
@@ -1,0 +1,33 @@
+import fortnox from "../../fortnox.app.mjs";
+
+export default {
+  key: "fortnox-list-supplier-number-options",
+  name: "List Supplier Number Options",
+  description: "Retrieves available options for the Supplier Number field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    fortnox,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await fortnox.propDefinitions.supplierNumber.options.call(this.fortnox, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/fortnox/actions/list-voucher-number-options/list-voucher-number-options.mjs
+++ b/components/fortnox/actions/list-voucher-number-options/list-voucher-number-options.mjs
@@ -1,0 +1,33 @@
+import fortnox from "../../fortnox.app.mjs";
+
+export default {
+  key: "fortnox-list-voucher-number-options",
+  name: "List Voucher Number Options",
+  description: "Retrieves available options for the Voucher Number field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    fortnox,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await fortnox.propDefinitions.voucherNumber.options.call(this.fortnox, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/fortnox/package.json
+++ b/components/fortnox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/fortnox",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Pipedream Fortnox Components",
   "main": "fortnox.app.mjs",
   "keywords": [

--- a/components/freeagent/actions/list-project-id-options/list-project-id-options.mjs
+++ b/components/freeagent/actions/list-project-id-options/list-project-id-options.mjs
@@ -1,0 +1,33 @@
+import freeagent from "../../freeagent.app.mjs";
+
+export default {
+  key: "freeagent-list-project-id-options",
+  name: "List Project ID Options",
+  description: "Retrieves available options for the Project ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    freeagent,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await freeagent.propDefinitions.projectId.options.call(this.freeagent, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/freeagent/package.json
+++ b/components/freeagent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/freeagent",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream freeagent Components",
   "main": "freeagent.app.mjs",
   "keywords": [

--- a/components/freshchat/actions/list-agent-id-options/list-agent-id-options.mjs
+++ b/components/freshchat/actions/list-agent-id-options/list-agent-id-options.mjs
@@ -1,0 +1,33 @@
+import freshchat from "../../freshchat.app.mjs";
+
+export default {
+  key: "freshchat-list-agent-id-options",
+  name: "List Agent ID Options",
+  description: "Retrieves available options for the Agent ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    freshchat,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await freshchat.propDefinitions.agentId.options.call(this.freshchat, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/freshchat/actions/list-group-id-options/list-group-id-options.mjs
+++ b/components/freshchat/actions/list-group-id-options/list-group-id-options.mjs
@@ -1,0 +1,33 @@
+import freshchat from "../../freshchat.app.mjs";
+
+export default {
+  key: "freshchat-list-group-id-options",
+  name: "List Group ID Options",
+  description: "Retrieves available options for the Group ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    freshchat,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await freshchat.propDefinitions.groupId.options.call(this.freshchat, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/freshchat/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/freshchat/actions/list-user-id-options/list-user-id-options.mjs
@@ -1,0 +1,33 @@
+import freshchat from "../../freshchat.app.mjs";
+
+export default {
+  key: "freshchat-list-user-id-options",
+  name: "List User ID Options",
+  description: "Retrieves available options for the User ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    freshchat,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await freshchat.propDefinitions.userId.options.call(this.freshchat, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/freshchat/package.json
+++ b/components/freshchat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/freshchat",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Pipedream Freshchat Components",
   "main": "freshchat.app.mjs",
   "keywords": [

--- a/components/freshdesk/actions/list-agent-id-options/list-agent-id-options.mjs
+++ b/components/freshdesk/actions/list-agent-id-options/list-agent-id-options.mjs
@@ -1,0 +1,33 @@
+import freshdesk from "../../freshdesk.app.mjs";
+
+export default {
+  key: "freshdesk-list-agent-id-options",
+  name: "List Agent Options",
+  description: "Retrieves available options for the Agent field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    freshdesk,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await freshdesk.propDefinitions.agentId.options.call(this.freshdesk, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/freshdesk/actions/list-canned-response-folder-id-options/list-canned-response-folder-id-options.mjs
+++ b/components/freshdesk/actions/list-canned-response-folder-id-options/list-canned-response-folder-id-options.mjs
@@ -1,0 +1,34 @@
+import freshdesk from "../../freshdesk.app.mjs";
+
+export default {
+  key: "freshdesk-list-canned-response-folder-id-options",
+  name: "List Canned Response Folder ID Options",
+  description: "Retrieves available options for the Canned Response Folder ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    freshdesk,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await freshdesk.propDefinitions.cannedResponseFolderId.options
+      .call(this.freshdesk, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/freshdesk/actions/list-group-id-options/list-group-id-options.mjs
+++ b/components/freshdesk/actions/list-group-id-options/list-group-id-options.mjs
@@ -1,0 +1,33 @@
+import freshdesk from "../../freshdesk.app.mjs";
+
+export default {
+  key: "freshdesk-list-group-id-options",
+  name: "List Group Options",
+  description: "Retrieves available options for the Group field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    freshdesk,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await freshdesk.propDefinitions.groupId.options.call(this.freshdesk, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/freshdesk/actions/list-skill-ids-options/list-skill-ids-options.mjs
+++ b/components/freshdesk/actions/list-skill-ids-options/list-skill-ids-options.mjs
@@ -1,0 +1,33 @@
+import freshdesk from "../../freshdesk.app.mjs";
+
+export default {
+  key: "freshdesk-list-skill-ids-options",
+  name: "List Skill IDs Options",
+  description: "Retrieves available options for the Skill IDs field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    freshdesk,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await freshdesk.propDefinitions.skillIds.options.call(this.freshdesk, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/freshdesk/actions/list-ticket-field-id-options/list-ticket-field-id-options.mjs
+++ b/components/freshdesk/actions/list-ticket-field-id-options/list-ticket-field-id-options.mjs
@@ -1,0 +1,33 @@
+import freshdesk from "../../freshdesk.app.mjs";
+
+export default {
+  key: "freshdesk-list-ticket-field-id-options",
+  name: "List Ticket Field ID Options",
+  description: "Retrieves available options for the Ticket Field ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    freshdesk,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await freshdesk.propDefinitions.ticketFieldId.options.call(this.freshdesk, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/freshdesk/actions/list-ticket-id-options/list-ticket-id-options.mjs
+++ b/components/freshdesk/actions/list-ticket-id-options/list-ticket-id-options.mjs
@@ -1,0 +1,33 @@
+import freshdesk from "../../freshdesk.app.mjs";
+
+export default {
+  key: "freshdesk-list-ticket-id-options",
+  name: "List Ticket ID Options",
+  description: "Retrieves available options for the Ticket ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    freshdesk,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await freshdesk.propDefinitions.ticketId.options.call(this.freshdesk, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/freshdesk/package.json
+++ b/components/freshdesk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/freshdesk",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Pipedream Freshdesk Components",
   "main": "freshdesk.app.mjs",
   "keywords": [

--- a/components/freshmarketer/actions/list-lead-source-id-options/list-lead-source-id-options.mjs
+++ b/components/freshmarketer/actions/list-lead-source-id-options/list-lead-source-id-options.mjs
@@ -1,0 +1,34 @@
+import freshmarketer from "../../freshmarketer.app.mjs";
+
+export default {
+  key: "freshmarketer-list-lead-source-id-options",
+  name: "List Lead Source ID Options",
+  description: "Retrieves available options for the Lead Source ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    freshmarketer,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await freshmarketer.propDefinitions.leadSourceId.options
+      .call(this.freshmarketer, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/freshmarketer/actions/list-list-id-options/list-list-id-options.mjs
+++ b/components/freshmarketer/actions/list-list-id-options/list-list-id-options.mjs
@@ -1,0 +1,33 @@
+import freshmarketer from "../../freshmarketer.app.mjs";
+
+export default {
+  key: "freshmarketer-list-list-id-options",
+  name: "List List ID Options",
+  description: "Retrieves available options for the List ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    freshmarketer,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await freshmarketer.propDefinitions.listId.options.call(this.freshmarketer, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/freshmarketer/actions/list-owner-id-options/list-owner-id-options.mjs
+++ b/components/freshmarketer/actions/list-owner-id-options/list-owner-id-options.mjs
@@ -1,0 +1,33 @@
+import freshmarketer from "../../freshmarketer.app.mjs";
+
+export default {
+  key: "freshmarketer-list-owner-id-options",
+  name: "List Owner ID Options",
+  description: "Retrieves available options for the Owner ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    freshmarketer,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await freshmarketer.propDefinitions.ownerId.options.call(this.freshmarketer, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/freshmarketer/actions/list-territory-id-options/list-territory-id-options.mjs
+++ b/components/freshmarketer/actions/list-territory-id-options/list-territory-id-options.mjs
@@ -1,0 +1,34 @@
+import freshmarketer from "../../freshmarketer.app.mjs";
+
+export default {
+  key: "freshmarketer-list-territory-id-options",
+  name: "List Territory ID Options",
+  description: "Retrieves available options for the Territory ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    freshmarketer,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await freshmarketer.propDefinitions.territoryId.options
+      .call(this.freshmarketer, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/freshmarketer/package.json
+++ b/components/freshmarketer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/freshmarketer",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Freshmarketer Components",
   "main": "freshmarketer.app.mjs",
   "keywords": [
@@ -16,4 +16,3 @@
     "@pipedream/platform": "^1.6.8"
   }
 }
-

--- a/components/freshservice/actions/list-ticket-id-options/list-ticket-id-options.mjs
+++ b/components/freshservice/actions/list-ticket-id-options/list-ticket-id-options.mjs
@@ -1,0 +1,33 @@
+import freshservice from "../../freshservice.app.mjs";
+
+export default {
+  key: "freshservice-list-ticket-id-options",
+  name: "List Ticket ID Options",
+  description: "Retrieves available options for the Ticket ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    freshservice,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await freshservice.propDefinitions.ticketId.options.call(this.freshservice, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/freshservice/package.json
+++ b/components/freshservice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/freshservice",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Freshservice Components",
   "main": "freshservice.app.mjs",
   "keywords": [

--- a/components/fynk/actions/list-document-uuid-options/list-document-uuid-options.mjs
+++ b/components/fynk/actions/list-document-uuid-options/list-document-uuid-options.mjs
@@ -1,0 +1,33 @@
+import fynk from "../../fynk.app.mjs";
+
+export default {
+  key: "fynk-list-document-uuid-options",
+  name: "List Document Options",
+  description: "Retrieves available options for the Document field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    fynk,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await fynk.propDefinitions.documentUuid.options.call(this.fynk, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/fynk/actions/list-tag-uuids-options/list-tag-uuids-options.mjs
+++ b/components/fynk/actions/list-tag-uuids-options/list-tag-uuids-options.mjs
@@ -1,0 +1,33 @@
+import fynk from "../../fynk.app.mjs";
+
+export default {
+  key: "fynk-list-tag-uuids-options",
+  name: "List Tags Options",
+  description: "Retrieves available options for the Tags field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    fynk,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await fynk.propDefinitions.tagUuids.options.call(this.fynk, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/fynk/actions/list-template-uuid-options/list-template-uuid-options.mjs
+++ b/components/fynk/actions/list-template-uuid-options/list-template-uuid-options.mjs
@@ -1,0 +1,33 @@
+import fynk from "../../fynk.app.mjs";
+
+export default {
+  key: "fynk-list-template-uuid-options",
+  name: "List Template Options",
+  description: "Retrieves available options for the Template field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    fynk,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await fynk.propDefinitions.templateUuid.options.call(this.fynk, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/fynk/package.json
+++ b/components/fynk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/fynk",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream fynk Components",
   "main": "fynk.app.mjs",
   "keywords": [

--- a/components/gagelist/actions/list-gage-id-options/list-gage-id-options.mjs
+++ b/components/gagelist/actions/list-gage-id-options/list-gage-id-options.mjs
@@ -1,0 +1,33 @@
+import gagelist from "../../gagelist.app.mjs";
+
+export default {
+  key: "gagelist-list-gage-id-options",
+  name: "List Gage ID Options",
+  description: "Retrieves available options for the Gage ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    gagelist,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await gagelist.propDefinitions.gageId.options.call(this.gagelist, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/gagelist/package.json
+++ b/components/gagelist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/gagelist",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream GageList Components",
   "main": "gagelist.app.mjs",
   "keywords": [

--- a/components/gatherup/actions/list-business-id-options/list-business-id-options.mjs
+++ b/components/gatherup/actions/list-business-id-options/list-business-id-options.mjs
@@ -1,0 +1,33 @@
+import gatherup from "../../gatherup.app.mjs";
+
+export default {
+  key: "gatherup-list-business-id-options",
+  name: "List Business ID Options",
+  description: "Retrieves available options for the Business ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    gatherup,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await gatherup.propDefinitions.businessId.options.call(this.gatherup, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/gatherup/package.json
+++ b/components/gatherup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/gatherup",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "Pipedream Gatherup Components",
   "main": "gatherup.app.mjs",
   "keywords": [

--- a/components/gem/actions/list-created-by-options/list-created-by-options.mjs
+++ b/components/gem/actions/list-created-by-options/list-created-by-options.mjs
@@ -1,0 +1,33 @@
+import gem from "../../gem.app.mjs";
+
+export default {
+  key: "gem-list-created-by-options",
+  name: "List Created By Options",
+  description: "Retrieves available options for the Created By field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    gem,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await gem.propDefinitions.createdBy.options.call(this.gem, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/gem/actions/list-project-ids-options/list-project-ids-options.mjs
+++ b/components/gem/actions/list-project-ids-options/list-project-ids-options.mjs
@@ -1,0 +1,33 @@
+import gem from "../../gem.app.mjs";
+
+export default {
+  key: "gem-list-project-ids-options",
+  name: "List Project IDs Options",
+  description: "Retrieves available options for the Project IDs field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    gem,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await gem.propDefinitions.projectIds.options.call(this.gem, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/gem/package.json
+++ b/components/gem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/gem",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Gem Components",
   "main": "gem.app.mjs",
   "keywords": [

--- a/components/getaccept/actions/list-document-id-options/list-document-id-options.mjs
+++ b/components/getaccept/actions/list-document-id-options/list-document-id-options.mjs
@@ -1,0 +1,33 @@
+import getaccept from "../../getaccept.app.mjs";
+
+export default {
+  key: "getaccept-list-document-id-options",
+  name: "List Document Id Options",
+  description: "Retrieves available options for the Document Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    getaccept,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await getaccept.propDefinitions.documentId.options.call(this.getaccept, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/getaccept/package.json
+++ b/components/getaccept/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/getaccept",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream GetAccept Components",
   "main": "getaccept.app.mjs",
   "keywords": [

--- a/components/getprospect/actions/list-list-ids-options/list-list-ids-options.mjs
+++ b/components/getprospect/actions/list-list-ids-options/list-list-ids-options.mjs
@@ -1,0 +1,33 @@
+import getprospect from "../../getprospect.app.mjs";
+
+export default {
+  key: "getprospect-list-list-ids-options",
+  name: "List List IDs Options",
+  description: "Retrieves available options for the List IDs field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    getprospect,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await getprospect.propDefinitions.listIds.options.call(this.getprospect, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/getprospect/package.json
+++ b/components/getprospect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/getprospect",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream GetProspect Components",
   "main": "getprospect.app.mjs",
   "keywords": [

--- a/components/getresponse/actions/list-from-field-id-options/list-from-field-id-options.mjs
+++ b/components/getresponse/actions/list-from-field-id-options/list-from-field-id-options.mjs
@@ -1,0 +1,33 @@
+import getresponse from "../../getresponse.app.mjs";
+
+export default {
+  key: "getresponse-list-from-field-id-options",
+  name: "List From Field ID Options",
+  description: "Retrieves available options for the From Field ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    getresponse,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await getresponse.propDefinitions.fromFieldId.options.call(this.getresponse, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/getresponse/package.json
+++ b/components/getresponse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/getresponse",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "Pipedream Getresponse Components",
   "main": "getresponse.app.mjs",
   "keywords": [

--- a/components/ghost_org_admin_api/actions/list-member-options/list-member-options.mjs
+++ b/components/ghost_org_admin_api/actions/list-member-options/list-member-options.mjs
@@ -1,0 +1,34 @@
+import ghost_org_admin_api from "../../ghost_org_admin_api.app.mjs";
+
+export default {
+  key: "ghost_org_admin_api-list-member-options",
+  name: "List Member Options",
+  description: "Retrieves available options for the Member field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    ghost_org_admin_api,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await ghost_org_admin_api.propDefinitions.member.options
+      .call(this.ghost_org_admin_api, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/ghost_org_admin_api/package.json
+++ b/components/ghost_org_admin_api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/ghost_org_admin_api",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "description": "Pipedream Ghost_org_admin_api Components",
   "main": "ghost_org_admin_api.app.mjs",
   "keywords": [

--- a/components/giantcampaign/actions/list-list-uid-options/list-list-uid-options.mjs
+++ b/components/giantcampaign/actions/list-list-uid-options/list-list-uid-options.mjs
@@ -1,0 +1,33 @@
+import giantcampaign from "../../giantcampaign.app.mjs";
+
+export default {
+  key: "giantcampaign-list-list-uid-options",
+  name: "List List UID Options",
+  description: "Retrieves available options for the List UID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    giantcampaign,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await giantcampaign.propDefinitions.listUid.options.call(this.giantcampaign, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/giantcampaign/package.json
+++ b/components/giantcampaign/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/giantcampaign",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream GiantCampaign Components",
   "main": "giantcampaign.app.mjs",
   "keywords": [

--- a/components/gist/actions/list-campaign-id-options/list-campaign-id-options.mjs
+++ b/components/gist/actions/list-campaign-id-options/list-campaign-id-options.mjs
@@ -1,0 +1,33 @@
+import gist from "../../gist.app.mjs";
+
+export default {
+  key: "gist-list-campaign-id-options",
+  name: "List Campaign Id Options",
+  description: "Retrieves available options for the Campaign Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    gist,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await gist.propDefinitions.campaignId.options.call(this.gist, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/gist/actions/list-tag-id-options/list-tag-id-options.mjs
+++ b/components/gist/actions/list-tag-id-options/list-tag-id-options.mjs
@@ -1,0 +1,33 @@
+import gist from "../../gist.app.mjs";
+
+export default {
+  key: "gist-list-tag-id-options",
+  name: "List Tag Options",
+  description: "Retrieves available options for the Tag field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    gist,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await gist.propDefinitions.tagId.options.call(this.gist, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/gist/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/gist/actions/list-user-id-options/list-user-id-options.mjs
@@ -1,0 +1,33 @@
+import gist from "../../gist.app.mjs";
+
+export default {
+  key: "gist-list-user-id-options",
+  name: "List User Id Options",
+  description: "Retrieves available options for the User Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    gist,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await gist.propDefinitions.userId.options.call(this.gist, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/gist/package.json
+++ b/components/gist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/gist",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Gist Components",
   "main": "gist.app.mjs",
   "keywords": [
@@ -16,4 +16,3 @@
     "@pipedream/platform": "^1.6.8"
   }
 }
-

--- a/components/github/actions/list-gist-id-options/list-gist-id-options.mjs
+++ b/components/github/actions/list-gist-id-options/list-gist-id-options.mjs
@@ -1,0 +1,33 @@
+import github from "../../github.app.mjs";
+
+export default {
+  key: "github-list-gist-id-options",
+  name: "List Gist Id Options",
+  description: "Retrieves available options for the Gist Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    github,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await github.propDefinitions.gistId.options.call(this.github, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/github/package.json
+++ b/components/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/github",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Pipedream GitHub Components",
   "main": "github.app.mjs",
   "keywords": [

--- a/components/gitlab/actions/list-group-id-options/list-group-id-options.mjs
+++ b/components/gitlab/actions/list-group-id-options/list-group-id-options.mjs
@@ -1,0 +1,33 @@
+import gitlab from "../../gitlab.app.mjs";
+
+export default {
+  key: "gitlab-list-group-id-options",
+  name: "List Group ID Options",
+  description: "Retrieves available options for the Group ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    gitlab,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await gitlab.propDefinitions.groupId.options.call(this.gitlab, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/gitlab/actions/list-group-path-options/list-group-path-options.mjs
+++ b/components/gitlab/actions/list-group-path-options/list-group-path-options.mjs
@@ -1,0 +1,33 @@
+import gitlab from "../../gitlab.app.mjs";
+
+export default {
+  key: "gitlab-list-group-path-options",
+  name: "List Group Path Options",
+  description: "Retrieves available options for the Group Path field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    gitlab,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await gitlab.propDefinitions.groupPath.options.call(this.gitlab, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/gitlab/actions/list-project-id-options/list-project-id-options.mjs
+++ b/components/gitlab/actions/list-project-id-options/list-project-id-options.mjs
@@ -1,0 +1,33 @@
+import gitlab from "../../gitlab.app.mjs";
+
+export default {
+  key: "gitlab-list-project-id-options",
+  name: "List Project ID Options",
+  description: "Retrieves available options for the Project ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    gitlab,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await gitlab.propDefinitions.projectId.options.call(this.gitlab, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/gitlab/package.json
+++ b/components/gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/gitlab",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Pipedream Gitlab Components",
   "main": "gitlab.app.mjs",
   "keywords": [

--- a/components/goformz/actions/list-group-id-options/list-group-id-options.mjs
+++ b/components/goformz/actions/list-group-id-options/list-group-id-options.mjs
@@ -1,0 +1,33 @@
+import goformz from "../../goformz.app.mjs";
+
+export default {
+  key: "goformz-list-group-id-options",
+  name: "List Group ID Options",
+  description: "Retrieves available options for the Group ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    goformz,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await goformz.propDefinitions.groupId.options.call(this.goformz, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/goformz/actions/list-template-id-options/list-template-id-options.mjs
+++ b/components/goformz/actions/list-template-id-options/list-template-id-options.mjs
@@ -1,0 +1,33 @@
+import goformz from "../../goformz.app.mjs";
+
+export default {
+  key: "goformz-list-template-id-options",
+  name: "List Template ID Options",
+  description: "Retrieves available options for the Template ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    goformz,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await goformz.propDefinitions.templateId.options.call(this.goformz, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/goformz/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/goformz/actions/list-user-id-options/list-user-id-options.mjs
@@ -1,0 +1,33 @@
+import goformz from "../../goformz.app.mjs";
+
+export default {
+  key: "goformz-list-user-id-options",
+  name: "List User ID Options",
+  description: "Retrieves available options for the User ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    goformz,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await goformz.propDefinitions.userId.options.call(this.goformz, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/goformz/package.json
+++ b/components/goformz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/goformz",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream GoFormz Components",
   "main": "goformz.app.mjs",
   "keywords": [

--- a/components/goody/actions/list-order-batch-id-options/list-order-batch-id-options.mjs
+++ b/components/goody/actions/list-order-batch-id-options/list-order-batch-id-options.mjs
@@ -1,0 +1,33 @@
+import goody from "../../goody.app.mjs";
+
+export default {
+  key: "goody-list-order-batch-id-options",
+  name: "List Order Batch Options",
+  description: "Retrieves available options for the Order Batch field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    goody,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await goody.propDefinitions.orderBatchId.options.call(this.goody, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/goody/actions/list-product-id-options/list-product-id-options.mjs
+++ b/components/goody/actions/list-product-id-options/list-product-id-options.mjs
@@ -1,0 +1,33 @@
+import goody from "../../goody.app.mjs";
+
+export default {
+  key: "goody-list-product-id-options",
+  name: "List Product Options",
+  description: "Retrieves available options for the Product field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    goody,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await goody.propDefinitions.productId.options.call(this.goody, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/goody/package.json
+++ b/components/goody/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/goody",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Goody Components",
   "main": "goody.app.mjs",
   "keywords": [

--- a/components/google_cloud/actions/list-dataset-id-options/list-dataset-id-options.mjs
+++ b/components/google_cloud/actions/list-dataset-id-options/list-dataset-id-options.mjs
@@ -1,0 +1,33 @@
+import google_cloud from "../../google_cloud.app.mjs";
+
+export default {
+  key: "google_cloud-list-dataset-id-options",
+  name: "List Dataset ID Options",
+  description: "Retrieves available options for the Dataset ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    google_cloud,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await google_cloud.propDefinitions.datasetId.options.call(this.google_cloud, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/google_cloud/package.json
+++ b/components/google_cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_cloud",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Pipedream Google_cloud Components",
   "main": "google_cloud.app.mjs",
   "keywords": [

--- a/components/google_drive/actions/list-mime-type-options/list-mime-type-options.mjs
+++ b/components/google_drive/actions/list-mime-type-options/list-mime-type-options.mjs
@@ -1,0 +1,33 @@
+import google_drive from "../../google_drive.app.mjs";
+
+export default {
+  key: "google_drive-list-mime-type-options",
+  name: "List Mime Type Options",
+  description: "Retrieves available options for the Mime Type field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    google_drive,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await google_drive.propDefinitions.mimeType.options.call(this.google_drive, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/google_drive/package.json
+++ b/components/google_drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_drive",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Pipedream Google_drive Components",
   "main": "google_drive.app.mjs",
   "keywords": [

--- a/components/gotowebinar/actions/list-organizer-key-options/list-organizer-key-options.mjs
+++ b/components/gotowebinar/actions/list-organizer-key-options/list-organizer-key-options.mjs
@@ -1,0 +1,33 @@
+import gotowebinar from "../../gotowebinar.app.mjs";
+
+export default {
+  key: "gotowebinar-list-organizer-key-options",
+  name: "List Organizer Key Options",
+  description: "Retrieves available options for the Organizer Key field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    gotowebinar,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await gotowebinar.propDefinitions.organizerKey.options.call(this.gotowebinar, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/gotowebinar/actions/list-webinar-key-options/list-webinar-key-options.mjs
+++ b/components/gotowebinar/actions/list-webinar-key-options/list-webinar-key-options.mjs
@@ -1,0 +1,33 @@
+import gotowebinar from "../../gotowebinar.app.mjs";
+
+export default {
+  key: "gotowebinar-list-webinar-key-options",
+  name: "List Webinar Key Options",
+  description: "Retrieves available options for the Webinar Key field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    gotowebinar,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await gotowebinar.propDefinitions.webinarKey.options.call(this.gotowebinar, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/gotowebinar/package.json
+++ b/components/gotowebinar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/gotowebinar",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream GoToWebinar Components",
   "main": "gotowebinar.app.mjs",
   "keywords": [

--- a/components/graceblocks/actions/list-record-id-options/list-record-id-options.mjs
+++ b/components/graceblocks/actions/list-record-id-options/list-record-id-options.mjs
@@ -1,0 +1,33 @@
+import graceblocks from "../../graceblocks.app.mjs";
+
+export default {
+  key: "graceblocks-list-record-id-options",
+  name: "List Record ID Options",
+  description: "Retrieves available options for the Record ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    graceblocks,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await graceblocks.propDefinitions.recordId.options.call(this.graceblocks, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/graceblocks/package.json
+++ b/components/graceblocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/graceblocks",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Graceblocks Components",
   "main": "graceblocks.app.mjs",
   "keywords": [

--- a/components/greenhouse/actions/list-candidate-id-options/list-candidate-id-options.mjs
+++ b/components/greenhouse/actions/list-candidate-id-options/list-candidate-id-options.mjs
@@ -1,0 +1,33 @@
+import greenhouse from "../../greenhouse.app.mjs";
+
+export default {
+  key: "greenhouse-list-candidate-id-options",
+  name: "List Candidate ID Options",
+  description: "Retrieves available options for the Candidate ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    greenhouse,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await greenhouse.propDefinitions.candidateId.options.call(this.greenhouse, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/greenhouse/actions/list-job-ids-options/list-job-ids-options.mjs
+++ b/components/greenhouse/actions/list-job-ids-options/list-job-ids-options.mjs
@@ -2,8 +2,8 @@ import greenhouse from "../../greenhouse.app.mjs";
 
 export default {
   key: "greenhouse-list-job-ids-options",
-  name: "List Job Ids Options",
-  description: "Retrieves available options for the Job Ids field.",
+  name: "List Job IDs Options",
+  description: "Retrieves available options for the Job IDs field.",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/greenhouse/actions/list-job-ids-options/list-job-ids-options.mjs
+++ b/components/greenhouse/actions/list-job-ids-options/list-job-ids-options.mjs
@@ -1,0 +1,33 @@
+import greenhouse from "../../greenhouse.app.mjs";
+
+export default {
+  key: "greenhouse-list-job-ids-options",
+  name: "List Job Ids Options",
+  description: "Retrieves available options for the Job Ids field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    greenhouse,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await greenhouse.propDefinitions.jobIds.options.call(this.greenhouse, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/greenhouse/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/greenhouse/actions/list-user-id-options/list-user-id-options.mjs
@@ -1,0 +1,33 @@
+import greenhouse from "../../greenhouse.app.mjs";
+
+export default {
+  key: "greenhouse-list-user-id-options",
+  name: "List User Id Options",
+  description: "Retrieves available options for the User Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    greenhouse,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await greenhouse.propDefinitions.userId.options.call(this.greenhouse, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/greenhouse/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/greenhouse/actions/list-user-id-options/list-user-id-options.mjs
@@ -2,8 +2,8 @@ import greenhouse from "../../greenhouse.app.mjs";
 
 export default {
   key: "greenhouse-list-user-id-options",
-  name: "List User Id Options",
-  description: "Retrieves available options for the User Id field.",
+  name: "List User ID Options",
+  description: "Retrieves available options for the User ID field.",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/greenhouse/package.json
+++ b/components/greenhouse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/greenhouse",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Pipedream Greenhouse Components",
   "main": "greenhouse.app.mjs",
   "keywords": [

--- a/components/griptape/actions/list-assistant-id-options/list-assistant-id-options.mjs
+++ b/components/griptape/actions/list-assistant-id-options/list-assistant-id-options.mjs
@@ -1,0 +1,33 @@
+import griptape from "../../griptape.app.mjs";
+
+export default {
+  key: "griptape-list-assistant-id-options",
+  name: "List Assistant ID Options",
+  description: "Retrieves available options for the Assistant ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    griptape,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await griptape.propDefinitions.assistantId.options.call(this.griptape, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/griptape/actions/list-knowledge-base-id-options/list-knowledge-base-id-options.mjs
+++ b/components/griptape/actions/list-knowledge-base-id-options/list-knowledge-base-id-options.mjs
@@ -1,0 +1,33 @@
+import griptape from "../../griptape.app.mjs";
+
+export default {
+  key: "griptape-list-knowledge-base-id-options",
+  name: "List Knowledge Base ID Options",
+  description: "Retrieves available options for the Knowledge Base ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    griptape,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await griptape.propDefinitions.knowledgeBaseId.options.call(this.griptape, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/griptape/actions/list-ruleset-id-options/list-ruleset-id-options.mjs
+++ b/components/griptape/actions/list-ruleset-id-options/list-ruleset-id-options.mjs
@@ -1,0 +1,33 @@
+import griptape from "../../griptape.app.mjs";
+
+export default {
+  key: "griptape-list-ruleset-id-options",
+  name: "List Ruleset ID Options",
+  description: "Retrieves available options for the Ruleset ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    griptape,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await griptape.propDefinitions.rulesetId.options.call(this.griptape, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/griptape/actions/list-structure-id-options/list-structure-id-options.mjs
+++ b/components/griptape/actions/list-structure-id-options/list-structure-id-options.mjs
@@ -1,0 +1,33 @@
+import griptape from "../../griptape.app.mjs";
+
+export default {
+  key: "griptape-list-structure-id-options",
+  name: "List Structure ID Options",
+  description: "Retrieves available options for the Structure ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    griptape,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await griptape.propDefinitions.structureId.options.call(this.griptape, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/griptape/actions/list-tool-id-options/list-tool-id-options.mjs
+++ b/components/griptape/actions/list-tool-id-options/list-tool-id-options.mjs
@@ -1,0 +1,33 @@
+import griptape from "../../griptape.app.mjs";
+
+export default {
+  key: "griptape-list-tool-id-options",
+  name: "List Tool ID Options",
+  description: "Retrieves available options for the Tool ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    griptape,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await griptape.propDefinitions.toolId.options.call(this.griptape, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/griptape/package.json
+++ b/components/griptape/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/griptape",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Griptape Components",
   "main": "griptape.app.mjs",
   "keywords": [

--- a/components/gtmetrix/actions/list-page-id-options/list-page-id-options.mjs
+++ b/components/gtmetrix/actions/list-page-id-options/list-page-id-options.mjs
@@ -1,0 +1,33 @@
+import gtmetrix from "../../gtmetrix.app.mjs";
+
+export default {
+  key: "gtmetrix-list-page-id-options",
+  name: "List Page Options",
+  description: "Retrieves available options for the Page field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    gtmetrix,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await gtmetrix.propDefinitions.pageId.options.call(this.gtmetrix, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/gtmetrix/package.json
+++ b/components/gtmetrix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/gtmetrix",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream GTmetrix Components",
   "main": "gtmetrix.app.mjs",
   "keywords": [

--- a/components/gupshup/actions/list-template-id-options/list-template-id-options.mjs
+++ b/components/gupshup/actions/list-template-id-options/list-template-id-options.mjs
@@ -1,0 +1,33 @@
+import gupshup from "../../gupshup.app.mjs";
+
+export default {
+  key: "gupshup-list-template-id-options",
+  name: "List Template ID Options",
+  description: "Retrieves available options for the Template ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    gupshup,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await gupshup.propDefinitions.templateId.options.call(this.gupshup, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/gupshup/package.json
+++ b/components/gupshup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/gupshup",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Gupshup Components",
   "main": "gupshup.app.mjs",
   "keywords": [

--- a/components/h_supertools_analytics_tool/actions/list-report-id-options/list-report-id-options.mjs
+++ b/components/h_supertools_analytics_tool/actions/list-report-id-options/list-report-id-options.mjs
@@ -1,0 +1,34 @@
+import h_supertools_analytics_tool from "../../h_supertools_analytics_tool.app.mjs";
+
+export default {
+  key: "h_supertools_analytics_tool-list-report-id-options",
+  name: "List Report Id Options",
+  description: "Retrieves available options for the Report Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    h_supertools_analytics_tool,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await h_supertools_analytics_tool.propDefinitions.reportId.options
+      .call(this.h_supertools_analytics_tool, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/h_supertools_analytics_tool/package.json
+++ b/components/h_supertools_analytics_tool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/h_supertools_analytics_tool",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream H-supertools Analytics Tool Components",
   "main": "h_supertools_analytics_tool.app.mjs",
   "keywords": [

--- a/components/habitica/actions/list-challenge-id-options/list-challenge-id-options.mjs
+++ b/components/habitica/actions/list-challenge-id-options/list-challenge-id-options.mjs
@@ -1,0 +1,33 @@
+import habitica from "../../habitica.app.mjs";
+
+export default {
+  key: "habitica-list-challenge-id-options",
+  name: "List Challenge ID Options",
+  description: "Retrieves available options for the Challenge ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    habitica,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await habitica.propDefinitions.challengeId.options.call(this.habitica, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/habitica/package.json
+++ b/components/habitica/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/habitica",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Habitica Components",
   "main": "habitica.app.mjs",
   "keywords": [

--- a/components/hamsa/actions/list-job-id-options/list-job-id-options.mjs
+++ b/components/hamsa/actions/list-job-id-options/list-job-id-options.mjs
@@ -1,0 +1,33 @@
+import hamsa from "../../hamsa.app.mjs";
+
+export default {
+  key: "hamsa-list-job-id-options",
+  name: "List Job Id Options",
+  description: "Retrieves available options for the Job Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    hamsa,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await hamsa.propDefinitions.jobId.options.call(this.hamsa, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/hamsa/actions/list-voice-id-options/list-voice-id-options.mjs
+++ b/components/hamsa/actions/list-voice-id-options/list-voice-id-options.mjs
@@ -1,0 +1,33 @@
+import hamsa from "../../hamsa.app.mjs";
+
+export default {
+  key: "hamsa-list-voice-id-options",
+  name: "List Voice ID Options",
+  description: "Retrieves available options for the Voice ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    hamsa,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await hamsa.propDefinitions.voiceId.options.call(this.hamsa, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/hamsa/package.json
+++ b/components/hamsa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/hamsa",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Hamsa Components",
   "main": "hamsa.app.mjs",
   "keywords": [

--- a/components/helloleads/actions/list-list-key-options/list-list-key-options.mjs
+++ b/components/helloleads/actions/list-list-key-options/list-list-key-options.mjs
@@ -1,0 +1,33 @@
+import helloleads from "../../helloleads.app.mjs";
+
+export default {
+  key: "helloleads-list-list-key-options",
+  name: "List List Key Options",
+  description: "Retrieves available options for the List Key field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    helloleads,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await helloleads.propDefinitions.listKey.options.call(this.helloleads, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/helloleads/package.json
+++ b/components/helloleads/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/helloleads",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream HelloLeads Components",
   "main": "helloleads.app.mjs",
   "keywords": [

--- a/components/hellosign/actions/list-template-id-options/list-template-id-options.mjs
+++ b/components/hellosign/actions/list-template-id-options/list-template-id-options.mjs
@@ -1,0 +1,33 @@
+import hellosign from "../../hellosign.app.mjs";
+
+export default {
+  key: "hellosign-list-template-id-options",
+  name: "List Template Options",
+  description: "Retrieves available options for the Template field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    hellosign,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await hellosign.propDefinitions.templateId.options.call(this.hellosign, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/hellosign/package.json
+++ b/components/hellosign/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/hellosign",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Pipedream Hellosign Components",
   "main": "hellosign.app.mjs",
   "keywords": [

--- a/components/help_scout/actions/add-note/add-note.mjs
+++ b/components/help_scout/actions/add-note/add-note.mjs
@@ -4,7 +4,7 @@ export default {
   key: "help_scout-add-note",
   name: "Add Note to Conversation",
   description: "Adds a note to an existing conversation in Help Scout. [See the documentation](https://developer.helpscout.com/mailbox-api/endpoints/conversations/threads/note/)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/help_scout/actions/create-customer/create-customer.mjs
+++ b/components/help_scout/actions/create-customer/create-customer.mjs
@@ -13,7 +13,7 @@ export default {
   key: "help_scout-create-customer",
   name: "Create Customer",
   description: "Creates a new customer record in Help Scout. [See the documentation](https://developer.helpscout.com/mailbox-api/endpoints/customers/create/)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/help_scout/actions/get-conversation-details/get-conversation-details.mjs
+++ b/components/help_scout/actions/get-conversation-details/get-conversation-details.mjs
@@ -4,7 +4,7 @@ export default {
   key: "help_scout-get-conversation-details",
   name: "Get Conversation Details",
   description: "Retrieves the details of a specific conversation. [See the documentation](https://developer.helpscout.com/mailbox-api/endpoints/conversations/get/)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/help_scout/actions/get-conversation-threads/get-conversation-threads.mjs
+++ b/components/help_scout/actions/get-conversation-threads/get-conversation-threads.mjs
@@ -4,7 +4,7 @@ export default {
   key: "help_scout-get-conversation-threads",
   name: "Get Conversation Threads",
   description: "Retrieves the threads of a specific conversation. [See the documentation](https://developer.helpscout.com/mailbox-api/endpoints/conversations/threads/list/)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/help_scout/actions/get-tag-by-id/get-tag-by-id.mjs
+++ b/components/help_scout/actions/get-tag-by-id/get-tag-by-id.mjs
@@ -4,7 +4,7 @@ export default {
   key: "help_scout-get-tag-by-id",
   name: "Get Tag by ID",
   description: "Gets a tag by its ID. [See the documentation](https://developer.helpscout.com/mailbox-api/endpoints/tags/get/)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/help_scout/actions/list-conversation-id-options/list-conversation-id-options.mjs
+++ b/components/help_scout/actions/list-conversation-id-options/list-conversation-id-options.mjs
@@ -1,0 +1,33 @@
+import help_scout from "../../help_scout.app.mjs";
+
+export default {
+  key: "help_scout-list-conversation-id-options",
+  name: "List Conversation ID Options",
+  description: "Retrieves available options for the Conversation ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    help_scout,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await help_scout.propDefinitions.conversationId.options.call(this.help_scout, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/help_scout/actions/list-conversation-id-options/list-conversation-id-options.mjs
+++ b/components/help_scout/actions/list-conversation-id-options/list-conversation-id-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     help_scout,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        help_scout,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/help_scout/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/help_scout/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -1,0 +1,33 @@
+import help_scout from "../../help_scout.app.mjs";
+
+export default {
+  key: "help_scout-list-customer-id-options",
+  name: "List Customer ID Options",
+  description: "Retrieves available options for the Customer ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    help_scout,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await help_scout.propDefinitions.customerId.options.call(this.help_scout, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/help_scout/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/help_scout/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     help_scout,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        help_scout,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/help_scout/actions/list-tag-id-options/list-tag-id-options.mjs
+++ b/components/help_scout/actions/list-tag-id-options/list-tag-id-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     help_scout,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        help_scout,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/help_scout/actions/list-tag-id-options/list-tag-id-options.mjs
+++ b/components/help_scout/actions/list-tag-id-options/list-tag-id-options.mjs
@@ -1,0 +1,33 @@
+import help_scout from "../../help_scout.app.mjs";
+
+export default {
+  key: "help_scout-list-tag-id-options",
+  name: "List Tag ID Options",
+  description: "Retrieves available options for the Tag ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    help_scout,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await help_scout.propDefinitions.tagId.options.call(this.help_scout, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/help_scout/actions/list-tags/list-tags.mjs
+++ b/components/help_scout/actions/list-tags/list-tags.mjs
@@ -4,7 +4,7 @@ export default {
   key: "help_scout-list-tags",
   name: "List Tags",
   description: "Lists all tags in Help Scout. [See the documentation](https://developer.helpscout.com/mailbox-api/endpoints/tags/list/)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/help_scout/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/help_scout/actions/list-user-id-options/list-user-id-options.mjs
@@ -1,0 +1,33 @@
+import help_scout from "../../help_scout.app.mjs";
+
+export default {
+  key: "help_scout-list-user-id-options",
+  name: "List User ID Options",
+  description: "Retrieves available options for the User ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    help_scout,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await help_scout.propDefinitions.userId.options.call(this.help_scout, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/help_scout/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/help_scout/actions/list-user-id-options/list-user-id-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     help_scout,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        help_scout,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/help_scout/actions/send-reply/send-reply.mjs
+++ b/components/help_scout/actions/send-reply/send-reply.mjs
@@ -4,7 +4,7 @@ export default {
   key: "help_scout-send-reply",
   name: "Send Reply",
   description: "Sends a reply to a conversation. Be careful as this sends an actual email to the customer. [See the documentation](https://developer.helpscout.com/mailbox-api/endpoints/conversations/threads/reply/)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/help_scout/actions/update-conversation/update-conversation.mjs
+++ b/components/help_scout/actions/update-conversation/update-conversation.mjs
@@ -5,7 +5,7 @@ export default {
   key: "help_scout-update-conversation",
   name: "Update Conversation",
   description: "Updates a conversation. [See the documentation](https://developer.helpscout.com/mailbox-api/endpoints/conversations/update/)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: true,

--- a/components/help_scout/help_scout.app.mjs
+++ b/components/help_scout/help_scout.app.mjs
@@ -4,6 +4,13 @@ export default {
   type: "app",
   app: "help_scout",
   propDefinitions: {
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve, zero-based.",
+      min: 0,
+      default: 0,
+    },
     agentId: {
       type: "string",
       label: "Agent ID",

--- a/components/help_scout/package.json
+++ b/components/help_scout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/help_scout",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Pipedream Help Scout Components",
   "main": "help_scout.app.mjs",
   "keywords": [

--- a/components/help_scout/sources/conversation-status-updated-instant/conversation-status-updated-instant.mjs
+++ b/components/help_scout/sources/conversation-status-updated-instant/conversation-status-updated-instant.mjs
@@ -6,7 +6,7 @@ export default {
   key: "help_scout-conversation-status-updated-instant",
   name: "Conversation Status Updated (Instant)",
   description: "Emit new event when a conversation has its status updated. [See the documentation](https://developer.helpscout.com/webhooks/)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/help_scout/sources/new-agent-reply-instant/new-agent-reply-instant.mjs
+++ b/components/help_scout/sources/new-agent-reply-instant/new-agent-reply-instant.mjs
@@ -5,7 +5,7 @@ export default {
   key: "help_scout-new-agent-reply-instant",
   name: "New Agent Reply (Instant)",
   description: "Emit new event when an agent replies to a conversation.",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/help_scout/sources/new-conversation-assigned-instant/new-conversation-assigned-instant.mjs
+++ b/components/help_scout/sources/new-conversation-assigned-instant/new-conversation-assigned-instant.mjs
@@ -6,7 +6,7 @@ export default {
   key: "help_scout-new-conversation-assigned-instant",
   name: "New Conversation Assigned (Instant)",
   description: "Emit new event when a conversation is assigned to an agent. [See the documentation](https://developer.helpscout.com/)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/help_scout/sources/new-conversation-created-instant/new-conversation-created-instant.mjs
+++ b/components/help_scout/sources/new-conversation-created-instant/new-conversation-created-instant.mjs
@@ -6,7 +6,7 @@ export default {
   key: "help_scout-new-conversation-created-instant",
   name: "New Conversation Created (Instant)",
   description: "Emit new event when a new conversation is created.",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/help_scout/sources/new-customer-instant/new-customer-instant.mjs
+++ b/components/help_scout/sources/new-customer-instant/new-customer-instant.mjs
@@ -6,7 +6,7 @@ export default {
   key: "help_scout-new-customer-instant",
   name: "New Customer Added (Instant)",
   description: "Emit new event when a new customer is added.",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/help_scout/sources/new-customer-reply-instant/new-customer-reply-instant.mjs
+++ b/components/help_scout/sources/new-customer-reply-instant/new-customer-reply-instant.mjs
@@ -5,7 +5,7 @@ export default {
   key: "help_scout-new-customer-reply-instant",
   name: "New Customer Reply (Instant)",
   description: "Emit new event when a customer replies to a conversation.",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/help_scout/sources/new-note-created-instant/new-note-created-instant.mjs
+++ b/components/help_scout/sources/new-note-created-instant/new-note-created-instant.mjs
@@ -5,7 +5,7 @@ export default {
   key: "help_scout-new-note-created-instant",
   name: "New Note Created (Instant)",
   description: "Emit new event when a note is added to a conversation.",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/help_scout_api_keys/actions/list-collection-id-options/list-collection-id-options.mjs
+++ b/components/help_scout_api_keys/actions/list-collection-id-options/list-collection-id-options.mjs
@@ -1,0 +1,34 @@
+import help_scout_api_keys from "../../help_scout_api_keys.app.mjs";
+
+export default {
+  key: "help_scout_api_keys-list-collection-id-options",
+  name: "List Collection ID Options",
+  description: "Retrieves available options for the Collection ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    help_scout_api_keys,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await help_scout_api_keys.propDefinitions.collectionId.options
+      .call(this.help_scout_api_keys, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/help_scout_api_keys/actions/list-site-id-options/list-site-id-options.mjs
+++ b/components/help_scout_api_keys/actions/list-site-id-options/list-site-id-options.mjs
@@ -1,0 +1,34 @@
+import help_scout_api_keys from "../../help_scout_api_keys.app.mjs";
+
+export default {
+  key: "help_scout_api_keys-list-site-id-options",
+  name: "List Site ID Options",
+  description: "Retrieves available options for the Site ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    help_scout_api_keys,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await help_scout_api_keys.propDefinitions.siteId.options
+      .call(this.help_scout_api_keys, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/help_scout_api_keys/package.json
+++ b/components/help_scout_api_keys/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/help_scout_api_keys",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Help Scout (API Keys) Components",
   "main": "help_scout_api_keys.app.mjs",
   "keywords": [

--- a/components/helpdocs/actions/list-article-id-options/list-article-id-options.mjs
+++ b/components/helpdocs/actions/list-article-id-options/list-article-id-options.mjs
@@ -1,0 +1,33 @@
+import helpdocs from "../../helpdocs.app.mjs";
+
+export default {
+  key: "helpdocs-list-article-id-options",
+  name: "List Article ID Options",
+  description: "Retrieves available options for the Article ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    helpdocs,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await helpdocs.propDefinitions.articleId.options.call(this.helpdocs, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/helpdocs/package.json
+++ b/components/helpdocs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/helpdocs",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream HelpDocs Components",
   "main": "helpdocs.app.mjs",
   "keywords": [

--- a/components/helpspace/actions/list-customer-email-options/list-customer-email-options.mjs
+++ b/components/helpspace/actions/list-customer-email-options/list-customer-email-options.mjs
@@ -1,0 +1,33 @@
+import helpspace from "../../helpspace.app.mjs";
+
+export default {
+  key: "helpspace-list-customer-email-options",
+  name: "List Customer Email Options",
+  description: "Retrieves available options for the Customer Email field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    helpspace,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await helpspace.propDefinitions.customerEmail.options.call(this.helpspace, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/helpspace/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/helpspace/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -1,0 +1,33 @@
+import helpspace from "../../helpspace.app.mjs";
+
+export default {
+  key: "helpspace-list-customer-id-options",
+  name: "List Customer ID Options",
+  description: "Retrieves available options for the Customer ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    helpspace,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await helpspace.propDefinitions.customerId.options.call(this.helpspace, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/helpspace/package.json
+++ b/components/helpspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/helpspace",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Helpspace Components",
   "main": "helpspace.app.mjs",
   "keywords": [


### PR DESCRIPTION
Adds a batch of 74 new actions for retrieving prop options that accept the page parameter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added list options actions across 30+ integrations (Fortnox, Freshdesk, Freeagent, GitHub, GitLab, and more), enabling users to browse and select from paginated lists of field options like customers, tickets, documents, and projects.

* **Chores**
  * Updated package versions for all affected integrations to reflect new functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PipedreamHQ/pipedream/pull/20911?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->