### PR TITLE
Actions for page only prop options batch 6

### DIFF
--- a/components/helpspot/actions/list-email-from-options/list-email-from-options.mjs
+++ b/components/helpspot/actions/list-email-from-options/list-email-from-options.mjs
@@ -1,0 +1,33 @@
+import helpspot from "../../helpspot.app.mjs";
+
+export default {
+  key: "helpspot-list-email-from-options",
+  name: "List Send Email From Options",
+  description: "Retrieves available options for the Send Email From field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    helpspot,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await helpspot.propDefinitions.emailFrom.options.call(this.helpspot, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/helpspot/actions/list-email-staff-options/list-email-staff-options.mjs
+++ b/components/helpspot/actions/list-email-staff-options/list-email-staff-options.mjs
@@ -1,0 +1,33 @@
+import helpspot from "../../helpspot.app.mjs";
+
+export default {
+  key: "helpspot-list-email-staff-options",
+  name: "List Email Staff Options",
+  description: "Retrieves available options for the Email Staff field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    helpspot,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await helpspot.propDefinitions.emailStaff.options.call(this.helpspot, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/helpspot/actions/list-x-category-options/list-x-category-options.mjs
+++ b/components/helpspot/actions/list-x-category-options/list-x-category-options.mjs
@@ -1,0 +1,33 @@
+import helpspot from "../../helpspot.app.mjs";
+
+export default {
+  key: "helpspot-list-x-category-options",
+  name: "List Category Options",
+  description: "Retrieves available options for the Category field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    helpspot,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await helpspot.propDefinitions.xCategory.options.call(this.helpspot, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/helpspot/actions/list-x-request-options/list-x-request-options.mjs
+++ b/components/helpspot/actions/list-x-request-options/list-x-request-options.mjs
@@ -1,0 +1,33 @@
+import helpspot from "../../helpspot.app.mjs";
+
+export default {
+  key: "helpspot-list-x-request-options",
+  name: "List Request Id Options",
+  description: "Retrieves available options for the Request Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    helpspot,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await helpspot.propDefinitions.xRequest.options.call(this.helpspot, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/helpspot/actions/list-x-status-options/list-x-status-options.mjs
+++ b/components/helpspot/actions/list-x-status-options/list-x-status-options.mjs
@@ -1,0 +1,33 @@
+import helpspot from "../../helpspot.app.mjs";
+
+export default {
+  key: "helpspot-list-x-status-options",
+  name: "List Status Options",
+  description: "Retrieves available options for the Status field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    helpspot,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await helpspot.propDefinitions.xStatus.options.call(this.helpspot, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/helpspot/package.json
+++ b/components/helpspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/helpspot",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream HelpSpot Components",
   "main": "helpspot.app.mjs",
   "keywords": [
@@ -16,4 +16,3 @@
     "@pipedream/platform": "^3.1.1"
   }
 }
-

--- a/components/helpwise/actions/list-mailbox-id-options/list-mailbox-id-options.mjs
+++ b/components/helpwise/actions/list-mailbox-id-options/list-mailbox-id-options.mjs
@@ -1,0 +1,33 @@
+import helpwise from "../../helpwise.app.mjs";
+
+export default {
+  key: "helpwise-list-mailbox-id-options",
+  name: "List Mailbox ID Options",
+  description: "Retrieves available options for the Mailbox ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    helpwise,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await helpwise.propDefinitions.mailboxId.options.call(this.helpwise, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/helpwise/actions/list-to-options/list-to-options.mjs
+++ b/components/helpwise/actions/list-to-options/list-to-options.mjs
@@ -1,0 +1,33 @@
+import helpwise from "../../helpwise.app.mjs";
+
+export default {
+  key: "helpwise-list-to-options",
+  name: "List To Options",
+  description: "Retrieves available options for the To field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    helpwise,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await helpwise.propDefinitions.to.options.call(this.helpwise, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/helpwise/package.json
+++ b/components/helpwise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/helpwise",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Helpwise Components",
   "main": "helpwise.app.mjs",
   "keywords": [

--- a/components/herobot_chatbot_marketing/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/herobot_chatbot_marketing/actions/list-user-id-options/list-user-id-options.mjs
@@ -1,0 +1,34 @@
+import herobot_chatbot_marketing from "../../herobot_chatbot_marketing.app.mjs";
+
+export default {
+  key: "herobot_chatbot_marketing-list-user-id-options",
+  name: "List User ID Options",
+  description: "Retrieves available options for the User ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    herobot_chatbot_marketing,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await herobot_chatbot_marketing.propDefinitions.userId.options
+      .call(this.herobot_chatbot_marketing, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/herobot_chatbot_marketing/package.json
+++ b/components/herobot_chatbot_marketing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/herobot_chatbot_marketing",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream HeroBot Chatbot Marketing Components",
   "main": "herobot_chatbot_marketing.app.mjs",
   "keywords": [
@@ -16,4 +16,3 @@
     "@pipedream/platform": "^1.6.8"
   }
 }
-

--- a/components/hippo_video/actions/list-list-ids-options/list-list-ids-options.mjs
+++ b/components/hippo_video/actions/list-list-ids-options/list-list-ids-options.mjs
@@ -1,0 +1,33 @@
+import hippo_video from "../../hippo_video.app.mjs";
+
+export default {
+  key: "hippo_video-list-list-ids-options",
+  name: "List List Ids Options",
+  description: "Retrieves available options for the List Ids field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    hippo_video,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await hippo_video.propDefinitions.listIds.options.call(this.hippo_video, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/hippo_video/actions/list-video-id-options/list-video-id-options.mjs
+++ b/components/hippo_video/actions/list-video-id-options/list-video-id-options.mjs
@@ -1,0 +1,33 @@
+import hippo_video from "../../hippo_video.app.mjs";
+
+export default {
+  key: "hippo_video-list-video-id-options",
+  name: "List Video ID Options",
+  description: "Retrieves available options for the Video ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    hippo_video,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await hippo_video.propDefinitions.videoId.options.call(this.hippo_video, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/hippo_video/package.json
+++ b/components/hippo_video/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/hippo_video",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Pipedream Hippo Video Components",
   "main": "hippo_video.app.mjs",
   "keywords": [

--- a/components/hive/actions/list-workspace-id-options/list-workspace-id-options.mjs
+++ b/components/hive/actions/list-workspace-id-options/list-workspace-id-options.mjs
@@ -1,0 +1,33 @@
+import hive from "../../hive.app.mjs";
+
+export default {
+  key: "hive-list-workspace-id-options",
+  name: "List Workspace Id Options",
+  description: "Retrieves available options for the Workspace Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    hive,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await hive.propDefinitions.workspaceId.options.call(this.hive, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/hive/package.json
+++ b/components/hive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/hive",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Hive Components",
   "main": "hive.app.mjs",
   "keywords": [

--- a/components/homerun/actions/list-job-application-id-options/list-job-application-id-options.mjs
+++ b/components/homerun/actions/list-job-application-id-options/list-job-application-id-options.mjs
@@ -1,0 +1,33 @@
+import homerun from "../../homerun.app.mjs";
+
+export default {
+  key: "homerun-list-job-application-id-options",
+  name: "List Job Application ID Options",
+  description: "Retrieves available options for the Job Application ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    homerun,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await homerun.propDefinitions.jobApplicationId.options.call(this.homerun, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/homerun/actions/list-vacancy-id-options/list-vacancy-id-options.mjs
+++ b/components/homerun/actions/list-vacancy-id-options/list-vacancy-id-options.mjs
@@ -1,0 +1,33 @@
+import homerun from "../../homerun.app.mjs";
+
+export default {
+  key: "homerun-list-vacancy-id-options",
+  name: "List Vacancy ID Options",
+  description: "Retrieves available options for the Vacancy ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    homerun,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await homerun.propDefinitions.vacancyId.options.call(this.homerun, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/homerun/package.json
+++ b/components/homerun/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/homerun",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Homerun Components",
   "main": "homerun.app.mjs",
   "keywords": [

--- a/components/hostaway/actions/list-listing-id-options/list-listing-id-options.mjs
+++ b/components/hostaway/actions/list-listing-id-options/list-listing-id-options.mjs
@@ -1,0 +1,33 @@
+import hostaway from "../../hostaway.app.mjs";
+
+export default {
+  key: "hostaway-list-listing-id-options",
+  name: "List Listing Options",
+  description: "Retrieves available options for the Listing field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    hostaway,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await hostaway.propDefinitions.listingId.options.call(this.hostaway, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/hostaway/actions/list-task-id-options/list-task-id-options.mjs
+++ b/components/hostaway/actions/list-task-id-options/list-task-id-options.mjs
@@ -1,0 +1,33 @@
+import hostaway from "../../hostaway.app.mjs";
+
+export default {
+  key: "hostaway-list-task-id-options",
+  name: "List Task Options",
+  description: "Retrieves available options for the Task field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    hostaway,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await hostaway.propDefinitions.taskId.options.call(this.hostaway, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/hostaway/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/hostaway/actions/list-user-id-options/list-user-id-options.mjs
@@ -1,0 +1,33 @@
+import hostaway from "../../hostaway.app.mjs";
+
+export default {
+  key: "hostaway-list-user-id-options",
+  name: "List User Options",
+  description: "Retrieves available options for the User field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    hostaway,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await hostaway.propDefinitions.userId.options.call(this.hostaway, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/hostaway/package.json
+++ b/components/hostaway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/hostaway",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Hostaway Components",
   "main": "hostaway.app.mjs",
   "keywords": [

--- a/components/hr_cloud/actions/list-department-id-options/list-department-id-options.mjs
+++ b/components/hr_cloud/actions/list-department-id-options/list-department-id-options.mjs
@@ -1,0 +1,33 @@
+import hr_cloud from "../../hr_cloud.app.mjs";
+
+export default {
+  key: "hr_cloud-list-department-id-options",
+  name: "List Department Options",
+  description: "Retrieves available options for the Department field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    hr_cloud,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await hr_cloud.propDefinitions.departmentId.options.call(this.hr_cloud, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/hr_cloud/actions/list-employee-id-options/list-employee-id-options.mjs
+++ b/components/hr_cloud/actions/list-employee-id-options/list-employee-id-options.mjs
@@ -1,0 +1,33 @@
+import hr_cloud from "../../hr_cloud.app.mjs";
+
+export default {
+  key: "hr_cloud-list-employee-id-options",
+  name: "List Employee Options",
+  description: "Retrieves available options for the Employee field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    hr_cloud,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await hr_cloud.propDefinitions.employeeId.options.call(this.hr_cloud, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/hr_cloud/actions/list-employment-status-id-options/list-employment-status-id-options.mjs
+++ b/components/hr_cloud/actions/list-employment-status-id-options/list-employment-status-id-options.mjs
@@ -1,0 +1,33 @@
+import hr_cloud from "../../hr_cloud.app.mjs";
+
+export default {
+  key: "hr_cloud-list-employment-status-id-options",
+  name: "List Employment Status ID Options",
+  description: "Retrieves available options for the Employment Status ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    hr_cloud,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await hr_cloud.propDefinitions.employmentStatusId.options.call(this.hr_cloud, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/hr_cloud/actions/list-job-title-options/list-job-title-options.mjs
+++ b/components/hr_cloud/actions/list-job-title-options/list-job-title-options.mjs
@@ -1,0 +1,33 @@
+import hr_cloud from "../../hr_cloud.app.mjs";
+
+export default {
+  key: "hr_cloud-list-job-title-options",
+  name: "List Job Title Options",
+  description: "Retrieves available options for the Job Title field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    hr_cloud,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await hr_cloud.propDefinitions.jobTitle.options.call(this.hr_cloud, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/hr_cloud/actions/list-location-id-options/list-location-id-options.mjs
+++ b/components/hr_cloud/actions/list-location-id-options/list-location-id-options.mjs
@@ -1,0 +1,33 @@
+import hr_cloud from "../../hr_cloud.app.mjs";
+
+export default {
+  key: "hr_cloud-list-location-id-options",
+  name: "List Location ID Options",
+  description: "Retrieves available options for the Location ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    hr_cloud,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await hr_cloud.propDefinitions.locationId.options.call(this.hr_cloud, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/hr_cloud/package.json
+++ b/components/hr_cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/hr_cloud",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream HR Cloud Components",
   "main": "hr_cloud.app.mjs",
   "keywords": [

--- a/components/https_airbyte_com/actions/list-workspace-id-options/list-workspace-id-options.mjs
+++ b/components/https_airbyte_com/actions/list-workspace-id-options/list-workspace-id-options.mjs
@@ -1,0 +1,34 @@
+import https_airbyte_com from "../../https_airbyte_com.app.mjs";
+
+export default {
+  key: "https_airbyte_com-list-workspace-id-options",
+  name: "List Workspace ID Options",
+  description: "Retrieves available options for the Workspace ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    https_airbyte_com,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await https_airbyte_com.propDefinitions.workspaceId.options
+      .call(this.https_airbyte_com, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/https_airbyte_com/package.json
+++ b/components/https_airbyte_com/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/https_airbyte_com",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Airbyte Components",
   "main": "https_airbyte_com.app.mjs",
   "keywords": [

--- a/components/hubspot/actions/list-forms-options/list-forms-options.mjs
+++ b/components/hubspot/actions/list-forms-options/list-forms-options.mjs
@@ -1,0 +1,33 @@
+import hubspot from "../../hubspot.app.mjs";
+
+export default {
+  key: "hubspot-list-forms-options",
+  name: "List Form Options",
+  description: "Retrieves available options for the Form field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    hubspot,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await hubspot.propDefinitions.forms.options.call(this.hubspot, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/hubspot/actions/list-template-path-options/list-template-path-options.mjs
+++ b/components/hubspot/actions/list-template-path-options/list-template-path-options.mjs
@@ -1,0 +1,33 @@
+import hubspot from "../../hubspot.app.mjs";
+
+export default {
+  key: "hubspot-list-template-path-options",
+  name: "List Template Path Options",
+  description: "Retrieves available options for the Template Path field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    hubspot,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await hubspot.propDefinitions.templatePath.options.call(this.hubspot, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/hubspot/package.json
+++ b/components/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/hubspot",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Pipedream Hubspot Components",
   "main": "hubspot.app.mjs",
   "keywords": [

--- a/components/humanitix/actions/list-event-id-options/list-event-id-options.mjs
+++ b/components/humanitix/actions/list-event-id-options/list-event-id-options.mjs
@@ -1,0 +1,33 @@
+import humanitix from "../../humanitix.app.mjs";
+
+export default {
+  key: "humanitix-list-event-id-options",
+  name: "List Event ID Options",
+  description: "Retrieves available options for the Event ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    humanitix,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await humanitix.propDefinitions.eventId.options.call(this.humanitix, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/humanitix/package.json
+++ b/components/humanitix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/humanitix",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Humanitix Components",
   "main": "humanitix.app.mjs",
   "keywords": [

--- a/components/ignisign/actions/list-signature-request-id-options/list-signature-request-id-options.mjs
+++ b/components/ignisign/actions/list-signature-request-id-options/list-signature-request-id-options.mjs
@@ -1,0 +1,33 @@
+import ignisign from "../../ignisign.app.mjs";
+
+export default {
+  key: "ignisign-list-signature-request-id-options",
+  name: "List Signature Request ID Options",
+  description: "Retrieves available options for the Signature Request ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    ignisign,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await ignisign.propDefinitions.signatureRequestId.options.call(this.ignisign, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/ignisign/actions/list-signer-ids-options/list-signer-ids-options.mjs
+++ b/components/ignisign/actions/list-signer-ids-options/list-signer-ids-options.mjs
@@ -1,0 +1,33 @@
+import ignisign from "../../ignisign.app.mjs";
+
+export default {
+  key: "ignisign-list-signer-ids-options",
+  name: "List Signer IDs Options",
+  description: "Retrieves available options for the Signer IDs field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    ignisign,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await ignisign.propDefinitions.signerIds.options.call(this.ignisign, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/ignisign/package.json
+++ b/components/ignisign/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/ignisign",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Pipedream IgniSign Components",
   "main": "ignisign.app.mjs",
   "keywords": [

--- a/components/imagekit_io/actions/list-file-id-options/list-file-id-options.mjs
+++ b/components/imagekit_io/actions/list-file-id-options/list-file-id-options.mjs
@@ -1,0 +1,33 @@
+import imagekit_io from "../../imagekit_io.app.mjs";
+
+export default {
+  key: "imagekit_io-list-file-id-options",
+  name: "List File Id Options",
+  description: "Retrieves available options for the File Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    imagekit_io,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await imagekit_io.propDefinitions.fileId.options.call(this.imagekit_io, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/imagekit_io/package.json
+++ b/components/imagekit_io/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/imagekit_io",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Pipedream ImageKit.io Components",
   "main": "imagekit_io.app.mjs",
   "keywords": [

--- a/components/indiefunnels/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/indiefunnels/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -1,0 +1,33 @@
+import indiefunnels from "../../indiefunnels.app.mjs";
+
+export default {
+  key: "indiefunnels-list-contact-id-options",
+  name: "List Contact ID Options",
+  description: "Retrieves available options for the Contact ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    indiefunnels,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await indiefunnels.propDefinitions.contactId.options.call(this.indiefunnels, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/indiefunnels/actions/list-member-id-options/list-member-id-options.mjs
+++ b/components/indiefunnels/actions/list-member-id-options/list-member-id-options.mjs
@@ -1,0 +1,33 @@
+import indiefunnels from "../../indiefunnels.app.mjs";
+
+export default {
+  key: "indiefunnels-list-member-id-options",
+  name: "List Member ID Options",
+  description: "Retrieves available options for the Member ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    indiefunnels,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await indiefunnels.propDefinitions.memberId.options.call(this.indiefunnels, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/indiefunnels/package.json
+++ b/components/indiefunnels/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/indiefunnels",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream INDIEFUNNELS Components",
   "main": "indiefunnels.app.mjs",
   "keywords": [

--- a/components/influxdb_cloud/actions/list-bucket-id-options/list-bucket-id-options.mjs
+++ b/components/influxdb_cloud/actions/list-bucket-id-options/list-bucket-id-options.mjs
@@ -1,0 +1,34 @@
+import influxdb_cloud from "../../influxdb_cloud.app.mjs";
+
+export default {
+  key: "influxdb_cloud-list-bucket-id-options",
+  name: "List Bucket ID Options",
+  description: "Retrieves available options for the Bucket ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    influxdb_cloud,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await influxdb_cloud.propDefinitions.bucketId.options
+      .call(this.influxdb_cloud, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/influxdb_cloud/actions/list-script-id-options/list-script-id-options.mjs
+++ b/components/influxdb_cloud/actions/list-script-id-options/list-script-id-options.mjs
@@ -1,0 +1,34 @@
+import influxdb_cloud from "../../influxdb_cloud.app.mjs";
+
+export default {
+  key: "influxdb_cloud-list-script-id-options",
+  name: "List Script ID Options",
+  description: "Retrieves available options for the Script ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    influxdb_cloud,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await influxdb_cloud.propDefinitions.scriptId.options
+      .call(this.influxdb_cloud, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/influxdb_cloud/package.json
+++ b/components/influxdb_cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/influxdb_cloud",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Pipedream influxdb_cloud Components",
   "main": "influxdb_cloud.app.mjs",
   "keywords": [

--- a/components/infobip/actions/list-application-id-options/list-application-id-options.mjs
+++ b/components/infobip/actions/list-application-id-options/list-application-id-options.mjs
@@ -1,0 +1,33 @@
+import infobip from "../../infobip.app.mjs";
+
+export default {
+  key: "infobip-list-application-id-options",
+  name: "List Application ID Options",
+  description: "Retrieves available options for the Application ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    infobip,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await infobip.propDefinitions.applicationId.options.call(this.infobip, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/infobip/actions/list-entity-id-options/list-entity-id-options.mjs
+++ b/components/infobip/actions/list-entity-id-options/list-entity-id-options.mjs
@@ -1,0 +1,33 @@
+import infobip from "../../infobip.app.mjs";
+
+export default {
+  key: "infobip-list-entity-id-options",
+  name: "List Entity Id Options",
+  description: "Retrieves available options for the Entity Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    infobip,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await infobip.propDefinitions.entityId.options.call(this.infobip, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/infobip/package.json
+++ b/components/infobip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/infobip",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream Infobip Components",
   "main": "infobip.app.mjs",
   "keywords": [

--- a/components/insertchat/actions/list-chatbot-id-options/list-chatbot-id-options.mjs
+++ b/components/insertchat/actions/list-chatbot-id-options/list-chatbot-id-options.mjs
@@ -1,0 +1,33 @@
+import insertchat from "../../insertchat.app.mjs";
+
+export default {
+  key: "insertchat-list-chatbot-id-options",
+  name: "List Chatbot ID Options",
+  description: "Retrieves available options for the Chatbot ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    insertchat,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await insertchat.propDefinitions.chatbotId.options.call(this.insertchat, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/insertchat/actions/list-lead-id-options/list-lead-id-options.mjs
+++ b/components/insertchat/actions/list-lead-id-options/list-lead-id-options.mjs
@@ -1,0 +1,33 @@
+import insertchat from "../../insertchat.app.mjs";
+
+export default {
+  key: "insertchat-list-lead-id-options",
+  name: "List Lead ID Options",
+  description: "Retrieves available options for the Lead ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    insertchat,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await insertchat.propDefinitions.leadId.options.call(this.insertchat, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/insertchat/package.json
+++ b/components/insertchat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/insertchat",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream InsertChat Components",
   "main": "insertchat.app.mjs",
   "keywords": [

--- a/components/insightly/actions/list-category-id-options/list-category-id-options.mjs
+++ b/components/insightly/actions/list-category-id-options/list-category-id-options.mjs
@@ -1,0 +1,33 @@
+import insightly from "../../insightly.app.mjs";
+
+export default {
+  key: "insightly-list-category-id-options",
+  name: "List Category Options",
+  description: "Retrieves available options for the Category field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    insightly,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await insightly.propDefinitions.categoryId.options.call(this.insightly, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/insightly/package.json
+++ b/components/insightly/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/insightly",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream Insightly Components",
   "main": "insightly.app.mjs",
   "keywords": [

--- a/components/insighto_ai/actions/list-assistant-id-options/list-assistant-id-options.mjs
+++ b/components/insighto_ai/actions/list-assistant-id-options/list-assistant-id-options.mjs
@@ -1,0 +1,33 @@
+import insighto_ai from "../../insighto_ai.app.mjs";
+
+export default {
+  key: "insighto_ai-list-assistant-id-options",
+  name: "List Assistant ID Options",
+  description: "Retrieves available options for the Assistant ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    insighto_ai,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await insighto_ai.propDefinitions.assistantId.options.call(this.insighto_ai, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/insighto_ai/actions/list-data-source-id-options/list-data-source-id-options.mjs
+++ b/components/insighto_ai/actions/list-data-source-id-options/list-data-source-id-options.mjs
@@ -1,0 +1,33 @@
+import insighto_ai from "../../insighto_ai.app.mjs";
+
+export default {
+  key: "insighto_ai-list-data-source-id-options",
+  name: "List Data Source ID Options",
+  description: "Retrieves available options for the Data Source ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    insighto_ai,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await insighto_ai.propDefinitions.dataSourceId.options.call(this.insighto_ai, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/insighto_ai/actions/list-org-id-options/list-org-id-options.mjs
+++ b/components/insighto_ai/actions/list-org-id-options/list-org-id-options.mjs
@@ -1,0 +1,33 @@
+import insighto_ai from "../../insighto_ai.app.mjs";
+
+export default {
+  key: "insighto_ai-list-org-id-options",
+  name: "List Organization ID Options",
+  description: "Retrieves available options for the Organization ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    insighto_ai,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await insighto_ai.propDefinitions.orgId.options.call(this.insighto_ai, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/insighto_ai/actions/list-widget-id-options/list-widget-id-options.mjs
+++ b/components/insighto_ai/actions/list-widget-id-options/list-widget-id-options.mjs
@@ -1,0 +1,33 @@
+import insighto_ai from "../../insighto_ai.app.mjs";
+
+export default {
+  key: "insighto_ai-list-widget-id-options",
+  name: "List Widget ID Options",
+  description: "Retrieves available options for the Widget ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    insighto_ai,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await insighto_ai.propDefinitions.widgetId.options.call(this.insighto_ai, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/insighto_ai/package.json
+++ b/components/insighto_ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/insighto_ai",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Insighto.ai Components",
   "main": "insighto_ai.app.mjs",
   "keywords": [

--- a/components/intellihr/actions/list-job-id-options/list-job-id-options.mjs
+++ b/components/intellihr/actions/list-job-id-options/list-job-id-options.mjs
@@ -1,0 +1,33 @@
+import intellihr from "../../intellihr.app.mjs";
+
+export default {
+  key: "intellihr-list-job-id-options",
+  name: "List Job ID Options",
+  description: "Retrieves available options for the Job ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    intellihr,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await intellihr.propDefinitions.jobId.options.call(this.intellihr, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/intellihr/actions/list-work-right-id-options/list-work-right-id-options.mjs
+++ b/components/intellihr/actions/list-work-right-id-options/list-work-right-id-options.mjs
@@ -1,0 +1,33 @@
+import intellihr from "../../intellihr.app.mjs";
+
+export default {
+  key: "intellihr-list-work-right-id-options",
+  name: "List Work Right ID Options",
+  description: "Retrieves available options for the Work Right ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    intellihr,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await intellihr.propDefinitions.workRightId.options.call(this.intellihr, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/intellihr/package.json
+++ b/components/intellihr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/intellihr",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream IntelliHR Components",
   "main": "intellihr.app.mjs",
   "keywords": [

--- a/components/interseller/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/interseller/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -1,0 +1,33 @@
+import interseller from "../../interseller.app.mjs";
+
+export default {
+  key: "interseller-list-contact-id-options",
+  name: "List Contact ID Options",
+  description: "Retrieves available options for the Contact ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    interseller,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await interseller.propDefinitions.contactId.options.call(this.interseller, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/interseller/package.json
+++ b/components/interseller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/interseller",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Interseller Components",
   "main": "interseller.app.mjs",
   "keywords": [
@@ -16,4 +16,3 @@
     "@pipedream/platform": "^1.6.8"
   }
 }
-

--- a/components/invision_community/actions/list-author-id-options/list-author-id-options.mjs
+++ b/components/invision_community/actions/list-author-id-options/list-author-id-options.mjs
@@ -1,0 +1,34 @@
+import invision_community from "../../invision_community.app.mjs";
+
+export default {
+  key: "invision_community-list-author-id-options",
+  name: "List Author Id Options",
+  description: "Retrieves available options for the Author Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    invision_community,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await invision_community.propDefinitions.authorId.options
+      .call(this.invision_community, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/invision_community/actions/list-forum-id-options/list-forum-id-options.mjs
+++ b/components/invision_community/actions/list-forum-id-options/list-forum-id-options.mjs
@@ -1,0 +1,34 @@
+import invision_community from "../../invision_community.app.mjs";
+
+export default {
+  key: "invision_community-list-forum-id-options",
+  name: "List Forum ID Options",
+  description: "Retrieves available options for the Forum ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    invision_community,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await invision_community.propDefinitions.forumId.options
+      .call(this.invision_community, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/invision_community/actions/list-group-id-options/list-group-id-options.mjs
+++ b/components/invision_community/actions/list-group-id-options/list-group-id-options.mjs
@@ -1,0 +1,34 @@
+import invision_community from "../../invision_community.app.mjs";
+
+export default {
+  key: "invision_community-list-group-id-options",
+  name: "List Group ID Options",
+  description: "Retrieves available options for the Group ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    invision_community,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await invision_community.propDefinitions.groupId.options
+      .call(this.invision_community, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/invision_community/actions/list-member-id-options/list-member-id-options.mjs
+++ b/components/invision_community/actions/list-member-id-options/list-member-id-options.mjs
@@ -1,0 +1,34 @@
+import invision_community from "../../invision_community.app.mjs";
+
+export default {
+  key: "invision_community-list-member-id-options",
+  name: "List Member ID Options",
+  description: "Retrieves available options for the Member ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    invision_community,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await invision_community.propDefinitions.memberId.options
+      .call(this.invision_community, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/invision_community/package.json
+++ b/components/invision_community/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/invision_community",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Invision Community Components",
   "main": "invision_community.app.mjs",
   "keywords": [
@@ -16,4 +16,3 @@
     "@pipedream/platform": "^3.1.1"
   }
 }
-

--- a/components/invoiced/actions/list-chasing-cadence-id-options/list-chasing-cadence-id-options.mjs
+++ b/components/invoiced/actions/list-chasing-cadence-id-options/list-chasing-cadence-id-options.mjs
@@ -1,0 +1,33 @@
+import invoiced from "../../invoiced.app.mjs";
+
+export default {
+  key: "invoiced-list-chasing-cadence-id-options",
+  name: "List Chasing Cadence Options",
+  description: "Retrieves available options for the Chasing Cadence field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    invoiced,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await invoiced.propDefinitions.chasingCadenceId.options.call(this.invoiced, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/invoiced/actions/list-coupon-id-options/list-coupon-id-options.mjs
+++ b/components/invoiced/actions/list-coupon-id-options/list-coupon-id-options.mjs
@@ -1,0 +1,33 @@
+import invoiced from "../../invoiced.app.mjs";
+
+export default {
+  key: "invoiced-list-coupon-id-options",
+  name: "List Coupon ID Options",
+  description: "Retrieves available options for the Coupon ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    invoiced,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await invoiced.propDefinitions.couponId.options.call(this.invoiced, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/invoiced/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/invoiced/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -1,0 +1,33 @@
+import invoiced from "../../invoiced.app.mjs";
+
+export default {
+  key: "invoiced-list-customer-id-options",
+  name: "List Customer ID Options",
+  description: "Retrieves available options for the Customer ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    invoiced,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await invoiced.propDefinitions.customerId.options.call(this.invoiced, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/invoiced/actions/list-member-id-options/list-member-id-options.mjs
+++ b/components/invoiced/actions/list-member-id-options/list-member-id-options.mjs
@@ -1,0 +1,33 @@
+import invoiced from "../../invoiced.app.mjs";
+
+export default {
+  key: "invoiced-list-member-id-options",
+  name: "List Member ID Options",
+  description: "Retrieves available options for the Member ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    invoiced,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await invoiced.propDefinitions.memberId.options.call(this.invoiced, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/invoiced/actions/list-tax-id-options/list-tax-id-options.mjs
+++ b/components/invoiced/actions/list-tax-id-options/list-tax-id-options.mjs
@@ -1,0 +1,33 @@
+import invoiced from "../../invoiced.app.mjs";
+
+export default {
+  key: "invoiced-list-tax-id-options",
+  name: "List Tax ID Options",
+  description: "Retrieves available options for the Tax ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    invoiced,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await invoiced.propDefinitions.taxId.options.call(this.invoiced, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/invoiced/package.json
+++ b/components/invoiced/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/invoiced",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Pipedream invoiced Components",
   "main": "invoiced.app.mjs",
   "keywords": [

--- a/components/ironclad/actions/list-record-id-options/list-record-id-options.mjs
+++ b/components/ironclad/actions/list-record-id-options/list-record-id-options.mjs
@@ -1,0 +1,33 @@
+import ironclad from "../../ironclad.app.mjs";
+
+export default {
+  key: "ironclad-list-record-id-options",
+  name: "List Record ID Options",
+  description: "Retrieves available options for the Record ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    ironclad,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await ironclad.propDefinitions.recordId.options.call(this.ironclad, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/ironclad/actions/list-workflow-id-options/list-workflow-id-options.mjs
+++ b/components/ironclad/actions/list-workflow-id-options/list-workflow-id-options.mjs
@@ -1,0 +1,33 @@
+import ironclad from "../../ironclad.app.mjs";
+
+export default {
+  key: "ironclad-list-workflow-id-options",
+  name: "List Workflow ID Options",
+  description: "Retrieves available options for the Workflow ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    ironclad,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await ironclad.propDefinitions.workflowId.options.call(this.ironclad, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/ironclad/package.json
+++ b/components/ironclad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/ironclad",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Ironclad Components",
   "main": "ironclad.app.mjs",
   "keywords": [

--- a/components/jo4/actions/list-url-slug-options/list-url-slug-options.mjs
+++ b/components/jo4/actions/list-url-slug-options/list-url-slug-options.mjs
@@ -1,0 +1,33 @@
+import jo4 from "../../jo4.app.mjs";
+
+export default {
+  key: "jo4-list-url-slug-options",
+  name: "List URL Options",
+  description: "Retrieves available options for the URL field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    jo4,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await jo4.propDefinitions.urlSlug.options.call(this.jo4, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/jo4/package.json
+++ b/components/jo4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/jo4",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream jo4 Components",
   "main": "jo4.app.mjs",
   "keywords": [

--- a/components/jobnimbus/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/jobnimbus/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -1,0 +1,33 @@
+import jobnimbus from "../../jobnimbus.app.mjs";
+
+export default {
+  key: "jobnimbus-list-contact-id-options",
+  name: "List Contact ID Options",
+  description: "Retrieves available options for the Contact ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    jobnimbus,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await jobnimbus.propDefinitions.contactId.options.call(this.jobnimbus, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/jobnimbus/actions/list-customer-id-from-contacts-options/list-customer-id-from-contacts-options.mjs
+++ b/components/jobnimbus/actions/list-customer-id-from-contacts-options/list-customer-id-from-contacts-options.mjs
@@ -1,0 +1,34 @@
+import jobnimbus from "../../jobnimbus.app.mjs";
+
+export default {
+  key: "jobnimbus-list-customer-id-from-contacts-options",
+  name: "List Customer ID Options",
+  description: "Retrieves available options for the Customer ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    jobnimbus,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await jobnimbus.propDefinitions.customerIdFromContacts.options
+      .call(this.jobnimbus, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/jobnimbus/package.json
+++ b/components/jobnimbus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/jobnimbus",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Pipedream Jobnimbus Components",
   "main": "jobnimbus.app.mjs",
   "keywords": [

--- a/components/jotform/actions/list-team-id-options/list-team-id-options.mjs
+++ b/components/jotform/actions/list-team-id-options/list-team-id-options.mjs
@@ -1,0 +1,33 @@
+import jotform from "../../jotform.app.mjs";
+
+export default {
+  key: "jotform-list-team-id-options",
+  name: "List Team Options",
+  description: "Retrieves available options for the Team field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    jotform,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await jotform.propDefinitions.teamId.options.call(this.jotform, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/jotform/package.json
+++ b/components/jotform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/jotform",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Pipedream Jotform Components",
   "main": "jotform.app.mjs",
   "keywords": [

--- a/components/jumpseller/actions/list-product-id-options/list-product-id-options.mjs
+++ b/components/jumpseller/actions/list-product-id-options/list-product-id-options.mjs
@@ -1,0 +1,33 @@
+import jumpseller from "../../jumpseller.app.mjs";
+
+export default {
+  key: "jumpseller-list-product-id-options",
+  name: "List Product Options",
+  description: "Retrieves available options for the Product field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    jumpseller,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await jumpseller.propDefinitions.productId.options.call(this.jumpseller, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/jumpseller/package.json
+++ b/components/jumpseller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/jumpseller",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream Jumpseller Components",
   "main": "jumpseller.app.mjs",
   "keywords": [

--- a/components/keysender/actions/list-database-id-options/list-database-id-options.mjs
+++ b/components/keysender/actions/list-database-id-options/list-database-id-options.mjs
@@ -1,0 +1,33 @@
+import keysender from "../../keysender.app.mjs";
+
+export default {
+  key: "keysender-list-database-id-options",
+  name: "List Database ID Options",
+  description: "Retrieves available options for the Database ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    keysender,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await keysender.propDefinitions.databaseId.options.call(this.keysender, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/keysender/package.json
+++ b/components/keysender/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/keysender",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Keysender Components",
   "main": "keysender.app.mjs",
   "keywords": [

--- a/components/kingsumo/actions/list-giveaway-id-options/list-giveaway-id-options.mjs
+++ b/components/kingsumo/actions/list-giveaway-id-options/list-giveaway-id-options.mjs
@@ -1,0 +1,33 @@
+import kingsumo from "../../kingsumo.app.mjs";
+
+export default {
+  key: "kingsumo-list-giveaway-id-options",
+  name: "List Giveaway Id Options",
+  description: "Retrieves available options for the Giveaway Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    kingsumo,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await kingsumo.propDefinitions.giveawayId.options.call(this.kingsumo, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/kingsumo/package.json
+++ b/components/kingsumo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/kingsumo",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream KingSumo Components",
   "main": "kingsumo.app.mjs",
   "keywords": [

--- a/components/kintone/actions/list-app-id-options/list-app-id-options.mjs
+++ b/components/kintone/actions/list-app-id-options/list-app-id-options.mjs
@@ -1,0 +1,33 @@
+import kintone from "../../kintone.app.mjs";
+
+export default {
+  key: "kintone-list-app-id-options",
+  name: "List App ID Options",
+  description: "Retrieves available options for the App ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    kintone,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await kintone.propDefinitions.appId.options.call(this.kintone, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/kintone/package.json
+++ b/components/kintone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/kintone",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Kintone Components",
   "main": "kintone.app.mjs",
   "keywords": [

--- a/components/kiwihr/actions/list-employee-id-options/list-employee-id-options.mjs
+++ b/components/kiwihr/actions/list-employee-id-options/list-employee-id-options.mjs
@@ -1,0 +1,33 @@
+import kiwihr from "../../kiwihr.app.mjs";
+
+export default {
+  key: "kiwihr-list-employee-id-options",
+  name: "List Employee ID Options",
+  description: "Retrieves available options for the Employee ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    kiwihr,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await kiwihr.propDefinitions.employeeId.options.call(this.kiwihr, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/kiwihr/actions/list-location-id-options/list-location-id-options.mjs
+++ b/components/kiwihr/actions/list-location-id-options/list-location-id-options.mjs
@@ -1,0 +1,33 @@
+import kiwihr from "../../kiwihr.app.mjs";
+
+export default {
+  key: "kiwihr-list-location-id-options",
+  name: "List Location ID Options",
+  description: "Retrieves available options for the Location ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    kiwihr,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await kiwihr.propDefinitions.locationId.options.call(this.kiwihr, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/kiwihr/actions/list-manager-id-options/list-manager-id-options.mjs
+++ b/components/kiwihr/actions/list-manager-id-options/list-manager-id-options.mjs
@@ -1,0 +1,33 @@
+import kiwihr from "../../kiwihr.app.mjs";
+
+export default {
+  key: "kiwihr-list-manager-id-options",
+  name: "List Manager ID Options",
+  description: "Retrieves available options for the Manager ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    kiwihr,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await kiwihr.propDefinitions.managerId.options.call(this.kiwihr, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/kiwihr/actions/list-position-id-options/list-position-id-options.mjs
+++ b/components/kiwihr/actions/list-position-id-options/list-position-id-options.mjs
@@ -1,0 +1,33 @@
+import kiwihr from "../../kiwihr.app.mjs";
+
+export default {
+  key: "kiwihr-list-position-id-options",
+  name: "List Position ID Options",
+  description: "Retrieves available options for the Position ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    kiwihr,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await kiwihr.propDefinitions.positionId.options.call(this.kiwihr, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/kiwihr/actions/list-team-ids-options/list-team-ids-options.mjs
+++ b/components/kiwihr/actions/list-team-ids-options/list-team-ids-options.mjs
@@ -1,0 +1,33 @@
+import kiwihr from "../../kiwihr.app.mjs";
+
+export default {
+  key: "kiwihr-list-team-ids-options",
+  name: "List Team IDs Options",
+  description: "Retrieves available options for the Team IDs field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    kiwihr,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await kiwihr.propDefinitions.teamIds.options.call(this.kiwihr, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/kiwihr/package.json
+++ b/components/kiwihr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/kiwihr",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Pipedream kiwiHR Components",
   "main": "kiwihr.app.mjs",
   "keywords": [

--- a/components/kiyoh/actions/list-location-id-options/list-location-id-options.mjs
+++ b/components/kiyoh/actions/list-location-id-options/list-location-id-options.mjs
@@ -1,0 +1,33 @@
+import kiyoh from "../../kiyoh.app.mjs";
+
+export default {
+  key: "kiyoh-list-location-id-options",
+  name: "List Location ID Options",
+  description: "Retrieves available options for the Location ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    kiyoh,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await kiyoh.propDefinitions.locationId.options.call(this.kiyoh, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/kiyoh/package.json
+++ b/components/kiyoh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/kiyoh",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Kiyoh (& Klantenvertellen) Components",
   "main": "kiyoh.app.mjs",
   "keywords": [

--- a/components/klaxoon/actions/list-board-id-options/list-board-id-options.mjs
+++ b/components/klaxoon/actions/list-board-id-options/list-board-id-options.mjs
@@ -1,0 +1,33 @@
+import klaxoon from "../../klaxoon.app.mjs";
+
+export default {
+  key: "klaxoon-list-board-id-options",
+  name: "List Board ID Options",
+  description: "Retrieves available options for the Board ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    klaxoon,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await klaxoon.propDefinitions.boardId.options.call(this.klaxoon, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/klaxoon/package.json
+++ b/components/klaxoon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/klaxoon",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream Klaxoon Components",
   "main": "klaxoon.app.mjs",
   "keywords": [

--- a/components/knorish/actions/list-bundle-id-options/list-bundle-id-options.mjs
+++ b/components/knorish/actions/list-bundle-id-options/list-bundle-id-options.mjs
@@ -1,0 +1,33 @@
+import knorish from "../../knorish.app.mjs";
+
+export default {
+  key: "knorish-list-bundle-id-options",
+  name: "List Bundle Id Options",
+  description: "Retrieves available options for the Bundle Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    knorish,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await knorish.propDefinitions.bundleId.options.call(this.knorish, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/knorish/actions/list-course-id-options/list-course-id-options.mjs
+++ b/components/knorish/actions/list-course-id-options/list-course-id-options.mjs
@@ -1,0 +1,33 @@
+import knorish from "../../knorish.app.mjs";
+
+export default {
+  key: "knorish-list-course-id-options",
+  name: "List Course ID Options",
+  description: "Retrieves available options for the Course ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    knorish,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await knorish.propDefinitions.courseId.options.call(this.knorish, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/knorish/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/knorish/actions/list-user-id-options/list-user-id-options.mjs
@@ -1,0 +1,33 @@
+import knorish from "../../knorish.app.mjs";
+
+export default {
+  key: "knorish-list-user-id-options",
+  name: "List User ID Options",
+  description: "Retrieves available options for the User ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    knorish,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await knorish.propDefinitions.userId.options.call(this.knorish, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/knorish/package.json
+++ b/components/knorish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/knorish",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Knorish Components",
   "main": "knorish.app.mjs",
   "keywords": [

--- a/components/kontent_ai/actions/list-type-id-options/list-type-id-options.mjs
+++ b/components/kontent_ai/actions/list-type-id-options/list-type-id-options.mjs
@@ -1,0 +1,33 @@
+import kontent_ai from "../../kontent_ai.app.mjs";
+
+export default {
+  key: "kontent_ai-list-type-id-options",
+  name: "List Type Id Options",
+  description: "Retrieves available options for the Type Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    kontent_ai,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await kontent_ai.propDefinitions.typeId.options.call(this.kontent_ai, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/kontent_ai/package.json
+++ b/components/kontent_ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/kontent_ai",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Kontent.ai Components",
   "main": "kontent_ai.app.mjs",
   "keywords": [


### PR DESCRIPTION
Adds a batch of 74 new actions for retrieving prop options that accept the page parameter.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added new "List [Field] Options" actions across 40+ integrations (including Helpspot, HubSpot, HR Cloud, Airbyte, IntelliHR, JobNimbus, KiwiHR, Klaxoon, Knorish, and others). These actions retrieve available options for various fields with pagination support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PipedreamHQ/pipedream/pull/20912?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->