### PR TITLE
Actions for page only prop options batch 7

### DIFF
--- a/components/kustomer/actions/list-assigned-teams-options/list-assigned-teams-options.mjs
+++ b/components/kustomer/actions/list-assigned-teams-options/list-assigned-teams-options.mjs
@@ -1,0 +1,33 @@
+import kustomer from "../../kustomer.app.mjs";
+
+export default {
+  key: "kustomer-list-assigned-teams-options",
+  name: "List Assigned Teams Options",
+  description: "Retrieves available options for the Assigned Teams field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    kustomer,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await kustomer.propDefinitions.assignedTeams.options.call(this.kustomer, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/kustomer/actions/list-assigned-users-options/list-assigned-users-options.mjs
+++ b/components/kustomer/actions/list-assigned-users-options/list-assigned-users-options.mjs
@@ -1,0 +1,33 @@
+import kustomer from "../../kustomer.app.mjs";
+
+export default {
+  key: "kustomer-list-assigned-users-options",
+  name: "List Assigned Users Options",
+  description: "Retrieves available options for the Assigned Users field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    kustomer,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await kustomer.propDefinitions.assignedUsers.options.call(this.kustomer, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/kustomer/actions/list-conversation-id-options/list-conversation-id-options.mjs
+++ b/components/kustomer/actions/list-conversation-id-options/list-conversation-id-options.mjs
@@ -1,0 +1,33 @@
+import kustomer from "../../kustomer.app.mjs";
+
+export default {
+  key: "kustomer-list-conversation-id-options",
+  name: "List Conversation ID Options",
+  description: "Retrieves available options for the Conversation ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    kustomer,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await kustomer.propDefinitions.conversationId.options.call(this.kustomer, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/kustomer/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/kustomer/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -1,0 +1,33 @@
+import kustomer from "../../kustomer.app.mjs";
+
+export default {
+  key: "kustomer-list-customer-id-options",
+  name: "List Customer ID Options",
+  description: "Retrieves available options for the Customer ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    kustomer,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await kustomer.propDefinitions.customerId.options.call(this.kustomer, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/kustomer/actions/list-klass-name-options/list-klass-name-options.mjs
+++ b/components/kustomer/actions/list-klass-name-options/list-klass-name-options.mjs
@@ -1,0 +1,33 @@
+import kustomer from "../../kustomer.app.mjs";
+
+export default {
+  key: "kustomer-list-klass-name-options",
+  name: "List Klass Name Options",
+  description: "Retrieves available options for the Klass Name field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    kustomer,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await kustomer.propDefinitions.klassName.options.call(this.kustomer, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/kustomer/actions/list-queue-id-options/list-queue-id-options.mjs
+++ b/components/kustomer/actions/list-queue-id-options/list-queue-id-options.mjs
@@ -1,0 +1,33 @@
+import kustomer from "../../kustomer.app.mjs";
+
+export default {
+  key: "kustomer-list-queue-id-options",
+  name: "List Queue Id Options",
+  description: "Retrieves available options for the Queue Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    kustomer,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await kustomer.propDefinitions.queueId.options.call(this.kustomer, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/kustomer/actions/list-tags-options/list-tags-options.mjs
+++ b/components/kustomer/actions/list-tags-options/list-tags-options.mjs
@@ -1,0 +1,33 @@
+import kustomer from "../../kustomer.app.mjs";
+
+export default {
+  key: "kustomer-list-tags-options",
+  name: "List Tags Options",
+  description: "Retrieves available options for the Tags field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    kustomer,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await kustomer.propDefinitions.tags.options.call(this.kustomer, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/kustomer/package.json
+++ b/components/kustomer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/kustomer",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Kustomer Components",
   "main": "kustomer.app.mjs",
   "keywords": [

--- a/components/landbot/actions/list-channel-id-options/list-channel-id-options.mjs
+++ b/components/landbot/actions/list-channel-id-options/list-channel-id-options.mjs
@@ -1,0 +1,33 @@
+import landbot from "../../landbot.app.mjs";
+
+export default {
+  key: "landbot-list-channel-id-options",
+  name: "List Channel ID Options",
+  description: "Retrieves available options for the Channel ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    landbot,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await landbot.propDefinitions.channelId.options.call(this.landbot, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/landbot/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/landbot/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -1,0 +1,33 @@
+import landbot from "../../landbot.app.mjs";
+
+export default {
+  key: "landbot-list-customer-id-options",
+  name: "List Customer ID Options",
+  description: "Retrieves available options for the Customer ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    landbot,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await landbot.propDefinitions.customerId.options.call(this.landbot, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/landbot/package.json
+++ b/components/landbot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/landbot",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Pipedream Landbot Components",
   "main": "landbot.app.mjs",
   "keywords": [

--- a/components/lastpass/actions/list-username-options/list-username-options.mjs
+++ b/components/lastpass/actions/list-username-options/list-username-options.mjs
@@ -1,0 +1,33 @@
+import lastpass from "../../lastpass.app.mjs";
+
+export default {
+  key: "lastpass-list-username-options",
+  name: "List Username Options",
+  description: "Retrieves available options for the Username field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    lastpass,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await lastpass.propDefinitions.username.options.call(this.lastpass, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/lastpass/package.json
+++ b/components/lastpass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/lastpass",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream LastPass Enterprise API Components",
   "main": "lastpass.app.mjs",
   "keywords": [

--- a/components/lawmatics/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/lawmatics/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -1,0 +1,33 @@
+import lawmatics from "../../lawmatics.app.mjs";
+
+export default {
+  key: "lawmatics-list-contact-id-options",
+  name: "List Contact ID Options",
+  description: "Retrieves available options for the Contact ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    lawmatics,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await lawmatics.propDefinitions.contactId.options.call(this.lawmatics, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/lawmatics/package.json
+++ b/components/lawmatics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/lawmatics",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Pipedream lawmatics Components",
   "main": "lawmatics.app.mjs",
   "keywords": [

--- a/components/leaddyno/actions/list-affiliate-code-options/list-affiliate-code-options.mjs
+++ b/components/leaddyno/actions/list-affiliate-code-options/list-affiliate-code-options.mjs
@@ -1,0 +1,33 @@
+import leaddyno from "../../leaddyno.app.mjs";
+
+export default {
+  key: "leaddyno-list-affiliate-code-options",
+  name: "List Affiliate Code Options",
+  description: "Retrieves available options for the Affiliate Code field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    leaddyno,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await leaddyno.propDefinitions.affiliateCode.options.call(this.leaddyno, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/leaddyno/actions/list-affiliate-options/list-affiliate-options.mjs
+++ b/components/leaddyno/actions/list-affiliate-options/list-affiliate-options.mjs
@@ -1,0 +1,33 @@
+import leaddyno from "../../leaddyno.app.mjs";
+
+export default {
+  key: "leaddyno-list-affiliate-options",
+  name: "List Affiliate Options",
+  description: "Retrieves available options for the Affiliate field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    leaddyno,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await leaddyno.propDefinitions.affiliate.options.call(this.leaddyno, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/leaddyno/actions/list-lead-email-options/list-lead-email-options.mjs
+++ b/components/leaddyno/actions/list-lead-email-options/list-lead-email-options.mjs
@@ -1,0 +1,33 @@
+import leaddyno from "../../leaddyno.app.mjs";
+
+export default {
+  key: "leaddyno-list-lead-email-options",
+  name: "List Lead Email Options",
+  description: "Retrieves available options for the Lead Email field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    leaddyno,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await leaddyno.propDefinitions.leadEmail.options.call(this.leaddyno, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/leaddyno/actions/list-lead-id-options/list-lead-id-options.mjs
+++ b/components/leaddyno/actions/list-lead-id-options/list-lead-id-options.mjs
@@ -1,0 +1,33 @@
+import leaddyno from "../../leaddyno.app.mjs";
+
+export default {
+  key: "leaddyno-list-lead-id-options",
+  name: "List Lead ID Options",
+  description: "Retrieves available options for the Lead ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    leaddyno,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await leaddyno.propDefinitions.leadId.options.call(this.leaddyno, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/leaddyno/package.json
+++ b/components/leaddyno/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/leaddyno",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream LeadDyno Components",
   "main": "leaddyno.app.mjs",
   "keywords": [

--- a/components/learnworlds/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/learnworlds/actions/list-user-id-options/list-user-id-options.mjs
@@ -1,0 +1,33 @@
+import learnworlds from "../../learnworlds.app.mjs";
+
+export default {
+  key: "learnworlds-list-user-id-options",
+  name: "List User Id Options",
+  description: "Retrieves available options for the User Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    learnworlds,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await learnworlds.propDefinitions.userId.options.call(this.learnworlds, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/learnworlds/package.json
+++ b/components/learnworlds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/learnworlds",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream LearnWorlds Components",
   "main": "learnworlds.app.mjs",
   "keywords": [

--- a/components/leexi/actions/list-call-id-options/list-call-id-options.mjs
+++ b/components/leexi/actions/list-call-id-options/list-call-id-options.mjs
@@ -1,0 +1,33 @@
+import leexi from "../../leexi.app.mjs";
+
+export default {
+  key: "leexi-list-call-id-options",
+  name: "List Call ID Options",
+  description: "Retrieves available options for the Call ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    leexi,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await leexi.propDefinitions.callId.options.call(this.leexi, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/leexi/package.json
+++ b/components/leexi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/leexi",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream Leexi Components",
   "main": "leexi.app.mjs",
   "keywords": [

--- a/components/lemlist/actions/list-campaign-id-options/list-campaign-id-options.mjs
+++ b/components/lemlist/actions/list-campaign-id-options/list-campaign-id-options.mjs
@@ -1,0 +1,33 @@
+import lemlist from "../../lemlist.app.mjs";
+
+export default {
+  key: "lemlist-list-campaign-id-options",
+  name: "List Campaign Id Options",
+  description: "Retrieves available options for the Campaign Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    lemlist,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await lemlist.propDefinitions.campaignId.options.call(this.lemlist, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/lemlist/package.json
+++ b/components/lemlist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/lemlist",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "Pipedream Lemlist Components",
   "main": "lemlist.app.mjs",
   "keywords": [

--- a/components/lexoffice/actions/list-voucher-id-options/list-voucher-id-options.mjs
+++ b/components/lexoffice/actions/list-voucher-id-options/list-voucher-id-options.mjs
@@ -1,0 +1,33 @@
+import lexoffice from "../../lexoffice.app.mjs";
+
+export default {
+  key: "lexoffice-list-voucher-id-options",
+  name: "List Voucher ID Options",
+  description: "Retrieves available options for the Voucher ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    lexoffice,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await lexoffice.propDefinitions.voucherId.options.call(this.lexoffice, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/lexoffice/package.json
+++ b/components/lexoffice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/lexoffice",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream Lexoffice Components",
   "main": "lexoffice.app.mjs",
   "keywords": [

--- a/components/lightspeed_ecom_c_series/actions/list-brand-id-options/list-brand-id-options.mjs
+++ b/components/lightspeed_ecom_c_series/actions/list-brand-id-options/list-brand-id-options.mjs
@@ -1,0 +1,34 @@
+import lightspeed_ecom_c_series from "../../lightspeed_ecom_c_series.app.mjs";
+
+export default {
+  key: "lightspeed_ecom_c_series-list-brand-id-options",
+  name: "List Brand ID Options",
+  description: "Retrieves available options for the Brand ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    lightspeed_ecom_c_series,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await lightspeed_ecom_c_series.propDefinitions.brandId.options
+      .call(this.lightspeed_ecom_c_series, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/lightspeed_ecom_c_series/actions/list-customer-email-options/list-customer-email-options.mjs
+++ b/components/lightspeed_ecom_c_series/actions/list-customer-email-options/list-customer-email-options.mjs
@@ -1,0 +1,34 @@
+import lightspeed_ecom_c_series from "../../lightspeed_ecom_c_series.app.mjs";
+
+export default {
+  key: "lightspeed_ecom_c_series-list-customer-email-options",
+  name: "List Customer Email Options",
+  description: "Retrieves available options for the Customer Email field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    lightspeed_ecom_c_series,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await lightspeed_ecom_c_series.propDefinitions.customerEmail.options
+      .call(this.lightspeed_ecom_c_series, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/lightspeed_ecom_c_series/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/lightspeed_ecom_c_series/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -1,0 +1,34 @@
+import lightspeed_ecom_c_series from "../../lightspeed_ecom_c_series.app.mjs";
+
+export default {
+  key: "lightspeed_ecom_c_series-list-customer-id-options",
+  name: "List Customer ID Options",
+  description: "Retrieves available options for the Customer ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    lightspeed_ecom_c_series,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await lightspeed_ecom_c_series.propDefinitions.customerId.options
+      .call(this.lightspeed_ecom_c_series, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/lightspeed_ecom_c_series/actions/list-invoice-number-options/list-invoice-number-options.mjs
+++ b/components/lightspeed_ecom_c_series/actions/list-invoice-number-options/list-invoice-number-options.mjs
@@ -1,0 +1,34 @@
+import lightspeed_ecom_c_series from "../../lightspeed_ecom_c_series.app.mjs";
+
+export default {
+  key: "lightspeed_ecom_c_series-list-invoice-number-options",
+  name: "List Invoice Number Options",
+  description: "Retrieves available options for the Invoice Number field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    lightspeed_ecom_c_series,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await lightspeed_ecom_c_series.propDefinitions.invoiceNumber.options
+      .call(this.lightspeed_ecom_c_series, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/lightspeed_ecom_c_series/actions/list-order-id-options/list-order-id-options.mjs
+++ b/components/lightspeed_ecom_c_series/actions/list-order-id-options/list-order-id-options.mjs
@@ -1,0 +1,34 @@
+import lightspeed_ecom_c_series from "../../lightspeed_ecom_c_series.app.mjs";
+
+export default {
+  key: "lightspeed_ecom_c_series-list-order-id-options",
+  name: "List Order ID Options",
+  description: "Retrieves available options for the Order ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    lightspeed_ecom_c_series,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await lightspeed_ecom_c_series.propDefinitions.orderId.options
+      .call(this.lightspeed_ecom_c_series, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/lightspeed_ecom_c_series/actions/list-order-number-options/list-order-number-options.mjs
+++ b/components/lightspeed_ecom_c_series/actions/list-order-number-options/list-order-number-options.mjs
@@ -1,0 +1,34 @@
+import lightspeed_ecom_c_series from "../../lightspeed_ecom_c_series.app.mjs";
+
+export default {
+  key: "lightspeed_ecom_c_series-list-order-number-options",
+  name: "List Order Number Options",
+  description: "Retrieves available options for the Order Number field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    lightspeed_ecom_c_series,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await lightspeed_ecom_c_series.propDefinitions.orderNumber.options
+      .call(this.lightspeed_ecom_c_series, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/lightspeed_ecom_c_series/actions/list-product-id-options/list-product-id-options.mjs
+++ b/components/lightspeed_ecom_c_series/actions/list-product-id-options/list-product-id-options.mjs
@@ -1,0 +1,34 @@
+import lightspeed_ecom_c_series from "../../lightspeed_ecom_c_series.app.mjs";
+
+export default {
+  key: "lightspeed_ecom_c_series-list-product-id-options",
+  name: "List Product ID Options",
+  description: "Retrieves available options for the Product ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    lightspeed_ecom_c_series,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await lightspeed_ecom_c_series.propDefinitions.productId.options
+      .call(this.lightspeed_ecom_c_series, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/lightspeed_ecom_c_series/actions/list-shipment-id-options/list-shipment-id-options.mjs
+++ b/components/lightspeed_ecom_c_series/actions/list-shipment-id-options/list-shipment-id-options.mjs
@@ -1,0 +1,34 @@
+import lightspeed_ecom_c_series from "../../lightspeed_ecom_c_series.app.mjs";
+
+export default {
+  key: "lightspeed_ecom_c_series-list-shipment-id-options",
+  name: "List Shipment ID Options",
+  description: "Retrieves available options for the Shipment ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    lightspeed_ecom_c_series,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await lightspeed_ecom_c_series.propDefinitions.shipmentId.options
+      .call(this.lightspeed_ecom_c_series, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/lightspeed_ecom_c_series/actions/list-shipment-number-options/list-shipment-number-options.mjs
+++ b/components/lightspeed_ecom_c_series/actions/list-shipment-number-options/list-shipment-number-options.mjs
@@ -1,0 +1,34 @@
+import lightspeed_ecom_c_series from "../../lightspeed_ecom_c_series.app.mjs";
+
+export default {
+  key: "lightspeed_ecom_c_series-list-shipment-number-options",
+  name: "List Shipment Number Options",
+  description: "Retrieves available options for the Shipment Number field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    lightspeed_ecom_c_series,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await lightspeed_ecom_c_series.propDefinitions.shipmentNumber.options
+      .call(this.lightspeed_ecom_c_series, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/lightspeed_ecom_c_series/package.json
+++ b/components/lightspeed_ecom_c_series/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/lightspeed_ecom_c_series",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Lightspeed eCom (C-Series) Components",
   "main": "lightspeed_ecom_c_series.app.mjs",
   "keywords": [

--- a/components/lightspeed_vt/actions/list-content-role-options/list-content-role-options.mjs
+++ b/components/lightspeed_vt/actions/list-content-role-options/list-content-role-options.mjs
@@ -1,0 +1,34 @@
+import lightspeed_vt from "../../lightspeed_vt.app.mjs";
+
+export default {
+  key: "lightspeed_vt-list-content-role-options",
+  name: "List Content Role Id Options",
+  description: "Retrieves available options for the Content Role Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    lightspeed_vt,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await lightspeed_vt.propDefinitions.contentRole.options
+      .call(this.lightspeed_vt, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/lightspeed_vt/actions/list-job-position-id-options/list-job-position-id-options.mjs
+++ b/components/lightspeed_vt/actions/list-job-position-id-options/list-job-position-id-options.mjs
@@ -1,0 +1,34 @@
+import lightspeed_vt from "../../lightspeed_vt.app.mjs";
+
+export default {
+  key: "lightspeed_vt-list-job-position-id-options",
+  name: "List Job Position Id Options",
+  description: "Retrieves available options for the Job Position Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    lightspeed_vt,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await lightspeed_vt.propDefinitions.jobPositionId.options
+      .call(this.lightspeed_vt, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/lightspeed_vt/actions/list-location-id-options/list-location-id-options.mjs
+++ b/components/lightspeed_vt/actions/list-location-id-options/list-location-id-options.mjs
@@ -1,0 +1,34 @@
+import lightspeed_vt from "../../lightspeed_vt.app.mjs";
+
+export default {
+  key: "lightspeed_vt-list-location-id-options",
+  name: "List Location Id Options",
+  description: "Retrieves available options for the Location Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    lightspeed_vt,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await lightspeed_vt.propDefinitions.locationId.options
+      .call(this.lightspeed_vt, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/lightspeed_vt/actions/list-team-id-options/list-team-id-options.mjs
+++ b/components/lightspeed_vt/actions/list-team-id-options/list-team-id-options.mjs
@@ -1,0 +1,33 @@
+import lightspeed_vt from "../../lightspeed_vt.app.mjs";
+
+export default {
+  key: "lightspeed_vt-list-team-id-options",
+  name: "List Team Id Options",
+  description: "Retrieves available options for the Team Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    lightspeed_vt,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await lightspeed_vt.propDefinitions.teamId.options.call(this.lightspeed_vt, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/lightspeed_vt/package.json
+++ b/components/lightspeed_vt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/lightspeed_vt",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream LightSpeed VT Components",
   "main": "lightspeed_vt.app.mjs",
   "keywords": [
@@ -16,4 +16,3 @@
     "@pipedream/platform": "^1.6.8"
   }
 }
-

--- a/components/limoexpress/actions/list-client-id-options/list-client-id-options.mjs
+++ b/components/limoexpress/actions/list-client-id-options/list-client-id-options.mjs
@@ -1,0 +1,33 @@
+import limoexpress from "../../limoexpress.app.mjs";
+
+export default {
+  key: "limoexpress-list-client-id-options",
+  name: "List Client ID Options",
+  description: "Retrieves available options for the Client ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    limoexpress,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await limoexpress.propDefinitions.clientId.options.call(this.limoexpress, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/limoexpress/actions/list-invoice-id-options/list-invoice-id-options.mjs
+++ b/components/limoexpress/actions/list-invoice-id-options/list-invoice-id-options.mjs
@@ -1,0 +1,33 @@
+import limoexpress from "../../limoexpress.app.mjs";
+
+export default {
+  key: "limoexpress-list-invoice-id-options",
+  name: "List Invoice ID Options",
+  description: "Retrieves available options for the Invoice ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    limoexpress,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await limoexpress.propDefinitions.invoiceId.options.call(this.limoexpress, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/limoexpress/actions/list-payment-method-id-options/list-payment-method-id-options.mjs
+++ b/components/limoexpress/actions/list-payment-method-id-options/list-payment-method-id-options.mjs
@@ -1,0 +1,34 @@
+import limoexpress from "../../limoexpress.app.mjs";
+
+export default {
+  key: "limoexpress-list-payment-method-id-options",
+  name: "List Payment Method ID Options",
+  description: "Retrieves available options for the Payment Method ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    limoexpress,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await limoexpress.propDefinitions.paymentMethodId.options
+      .call(this.limoexpress, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/limoexpress/actions/list-vehicle-class-id-options/list-vehicle-class-id-options.mjs
+++ b/components/limoexpress/actions/list-vehicle-class-id-options/list-vehicle-class-id-options.mjs
@@ -1,0 +1,34 @@
+import limoexpress from "../../limoexpress.app.mjs";
+
+export default {
+  key: "limoexpress-list-vehicle-class-id-options",
+  name: "List Vehicle Class ID Options",
+  description: "Retrieves available options for the Vehicle Class ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    limoexpress,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await limoexpress.propDefinitions.vehicleClassId.options
+      .call(this.limoexpress, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/limoexpress/package.json
+++ b/components/limoexpress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/limoexpress",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream LimoExpress Components",
   "main": "limoexpress.app.mjs",
   "keywords": [

--- a/components/linearb/actions/list-services-options/list-services-options.mjs
+++ b/components/linearb/actions/list-services-options/list-services-options.mjs
@@ -1,0 +1,33 @@
+import linearb from "../../linearb.app.mjs";
+
+export default {
+  key: "linearb-list-services-options",
+  name: "List Services Options",
+  description: "Retrieves available options for the Services field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    linearb,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await linearb.propDefinitions.services.options.call(this.linearb, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/linearb/actions/list-teams-options/list-teams-options.mjs
+++ b/components/linearb/actions/list-teams-options/list-teams-options.mjs
@@ -1,0 +1,33 @@
+import linearb from "../../linearb.app.mjs";
+
+export default {
+  key: "linearb-list-teams-options",
+  name: "List Teams Options",
+  description: "Retrieves available options for the Teams field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    linearb,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await linearb.propDefinitions.teams.options.call(this.linearb, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/linearb/package.json
+++ b/components/linearb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/linearb",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream LinearB Components",
   "main": "linearb.app.mjs",
   "keywords": [

--- a/components/linkedin/actions/list-ad-account-id-options/list-ad-account-id-options.mjs
+++ b/components/linkedin/actions/list-ad-account-id-options/list-ad-account-id-options.mjs
@@ -1,0 +1,33 @@
+import linkedin from "../../linkedin.app.mjs";
+
+export default {
+  key: "linkedin-list-ad-account-id-options",
+  name: "List Ad Account Id Options",
+  description: "Retrieves available options for the Ad Account Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    linkedin,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await linkedin.propDefinitions.adAccountId.options.call(this.linkedin, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/linkedin/actions/list-campaign-id-options/list-campaign-id-options.mjs
+++ b/components/linkedin/actions/list-campaign-id-options/list-campaign-id-options.mjs
@@ -1,0 +1,33 @@
+import linkedin from "../../linkedin.app.mjs";
+
+export default {
+  key: "linkedin-list-campaign-id-options",
+  name: "List Campaign Id Options",
+  description: "Retrieves available options for the Campaign Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    linkedin,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await linkedin.propDefinitions.campaignId.options.call(this.linkedin, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/linkedin/actions/list-organization-id-options/list-organization-id-options.mjs
+++ b/components/linkedin/actions/list-organization-id-options/list-organization-id-options.mjs
@@ -1,0 +1,33 @@
+import linkedin from "../../linkedin.app.mjs";
+
+export default {
+  key: "linkedin-list-organization-id-options",
+  name: "List Organization Id Options",
+  description: "Retrieves available options for the Organization Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    linkedin,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await linkedin.propDefinitions.organizationId.options.call(this.linkedin, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/linkedin/package.json
+++ b/components/linkedin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/linkedin",
-  "version": "1.2.7",
+  "version": "1.3.0",
   "description": "Pipedream Linkedin Components",
   "main": "linkedin.app.mjs",
   "keywords": [

--- a/components/linkly/actions/list-link-id-options/list-link-id-options.mjs
+++ b/components/linkly/actions/list-link-id-options/list-link-id-options.mjs
@@ -1,0 +1,33 @@
+import linkly from "../../linkly.app.mjs";
+
+export default {
+  key: "linkly-list-link-id-options",
+  name: "List Link ID Options",
+  description: "Retrieves available options for the Link ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    linkly,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await linkly.propDefinitions.linkId.options.call(this.linkly, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/linkly/package.json
+++ b/components/linkly/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/linkly",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Linkly Components",
   "main": "linkly.app.mjs",
   "keywords": [

--- a/components/listmonk/actions/list-list-ids-options/list-list-ids-options.mjs
+++ b/components/listmonk/actions/list-list-ids-options/list-list-ids-options.mjs
@@ -1,0 +1,33 @@
+import listmonk from "../../listmonk.app.mjs";
+
+export default {
+  key: "listmonk-list-list-ids-options",
+  name: "List Lists Options",
+  description: "Retrieves available options for the Lists field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    listmonk,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await listmonk.propDefinitions.listIds.options.call(this.listmonk, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/listmonk/package.json
+++ b/components/listmonk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/listmonk",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream listmonk Components",
   "main": "listmonk.app.mjs",
   "keywords": [

--- a/components/little_green_light/actions/list-appeal-id-options/list-appeal-id-options.mjs
+++ b/components/little_green_light/actions/list-appeal-id-options/list-appeal-id-options.mjs
@@ -1,0 +1,34 @@
+import little_green_light from "../../little_green_light.app.mjs";
+
+export default {
+  key: "little_green_light-list-appeal-id-options",
+  name: "List Appeal ID Options",
+  description: "Retrieves available options for the Appeal ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    little_green_light,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await little_green_light.propDefinitions.appealId.options
+      .call(this.little_green_light, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/little_green_light/actions/list-constituent-id-options/list-constituent-id-options.mjs
+++ b/components/little_green_light/actions/list-constituent-id-options/list-constituent-id-options.mjs
@@ -1,0 +1,34 @@
+import little_green_light from "../../little_green_light.app.mjs";
+
+export default {
+  key: "little_green_light-list-constituent-id-options",
+  name: "List Constituent ID Options",
+  description: "Retrieves available options for the Constituent ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    little_green_light,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await little_green_light.propDefinitions.constituentId.options
+      .call(this.little_green_light, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/little_green_light/actions/list-fund-id-options/list-fund-id-options.mjs
+++ b/components/little_green_light/actions/list-fund-id-options/list-fund-id-options.mjs
@@ -1,0 +1,34 @@
+import little_green_light from "../../little_green_light.app.mjs";
+
+export default {
+  key: "little_green_light-list-fund-id-options",
+  name: "List Fund ID Options",
+  description: "Retrieves available options for the Fund ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    little_green_light,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await little_green_light.propDefinitions.fundId.options
+      .call(this.little_green_light, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/little_green_light/actions/list-gift-category-id-options/list-gift-category-id-options.mjs
+++ b/components/little_green_light/actions/list-gift-category-id-options/list-gift-category-id-options.mjs
@@ -1,0 +1,34 @@
+import little_green_light from "../../little_green_light.app.mjs";
+
+export default {
+  key: "little_green_light-list-gift-category-id-options",
+  name: "List Gift Category ID Options",
+  description: "Retrieves available options for the Gift Category ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    little_green_light,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await little_green_light.propDefinitions.giftCategoryId.options
+      .call(this.little_green_light, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/little_green_light/actions/list-gift-type-id-options/list-gift-type-id-options.mjs
+++ b/components/little_green_light/actions/list-gift-type-id-options/list-gift-type-id-options.mjs
@@ -1,0 +1,34 @@
+import little_green_light from "../../little_green_light.app.mjs";
+
+export default {
+  key: "little_green_light-list-gift-type-id-options",
+  name: "List Gift Type ID Options",
+  description: "Retrieves available options for the Gift Type ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    little_green_light,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await little_green_light.propDefinitions.giftTypeId.options
+      .call(this.little_green_light, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/little_green_light/package.json
+++ b/components/little_green_light/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/little_green_light",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Little Green Light Components",
   "main": "little_green_light.app.mjs",
   "keywords": [
@@ -16,4 +16,3 @@
     "@pipedream/platform": "^1.6.8"
   }
 }
-

--- a/components/liveagent/actions/list-agent-id-options/list-agent-id-options.mjs
+++ b/components/liveagent/actions/list-agent-id-options/list-agent-id-options.mjs
@@ -1,0 +1,33 @@
+import liveagent from "../../liveagent.app.mjs";
+
+export default {
+  key: "liveagent-list-agent-id-options",
+  name: "List Agent ID Options",
+  description: "Retrieves available options for the Agent ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    liveagent,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await liveagent.propDefinitions.agentId.options.call(this.liveagent, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/liveagent/actions/list-group-id-options/list-group-id-options.mjs
+++ b/components/liveagent/actions/list-group-id-options/list-group-id-options.mjs
@@ -1,0 +1,33 @@
+import liveagent from "../../liveagent.app.mjs";
+
+export default {
+  key: "liveagent-list-group-id-options",
+  name: "List Group ID Options",
+  description: "Retrieves available options for the Group ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    liveagent,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await liveagent.propDefinitions.groupId.options.call(this.liveagent, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/liveagent/package.json
+++ b/components/liveagent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/liveagent",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Liveagent Components",
   "main": "liveagent.app.mjs",
   "keywords": [

--- a/components/livestorm/actions/list-event-id-options/list-event-id-options.mjs
+++ b/components/livestorm/actions/list-event-id-options/list-event-id-options.mjs
@@ -1,0 +1,33 @@
+import livestorm from "../../livestorm.app.mjs";
+
+export default {
+  key: "livestorm-list-event-id-options",
+  name: "List Event ID Options",
+  description: "Retrieves available options for the Event ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    livestorm,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await livestorm.propDefinitions.eventId.options.call(this.livestorm, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/livestorm/actions/list-session-id-options/list-session-id-options.mjs
+++ b/components/livestorm/actions/list-session-id-options/list-session-id-options.mjs
@@ -1,0 +1,33 @@
+import livestorm from "../../livestorm.app.mjs";
+
+export default {
+  key: "livestorm-list-session-id-options",
+  name: "List Session ID Options",
+  description: "Retrieves available options for the Session ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    livestorm,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await livestorm.propDefinitions.sessionId.options.call(this.livestorm, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/livestorm/package.json
+++ b/components/livestorm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/livestorm",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Livestorm Components",
   "main": "livestorm.app.mjs",
   "keywords": [

--- a/components/lokalise/actions/list-language-options/list-language-options.mjs
+++ b/components/lokalise/actions/list-language-options/list-language-options.mjs
@@ -1,0 +1,33 @@
+import lokalise from "../../lokalise.app.mjs";
+
+export default {
+  key: "lokalise-list-language-options",
+  name: "List Language Options",
+  description: "Retrieves available options for the Language field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    lokalise,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await lokalise.propDefinitions.language.options.call(this.lokalise, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/lokalise/actions/list-project-id-options/list-project-id-options.mjs
+++ b/components/lokalise/actions/list-project-id-options/list-project-id-options.mjs
@@ -1,0 +1,33 @@
+import lokalise from "../../lokalise.app.mjs";
+
+export default {
+  key: "lokalise-list-project-id-options",
+  name: "List Project ID Options",
+  description: "Retrieves available options for the Project ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    lokalise,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await lokalise.propDefinitions.projectId.options.call(this.lokalise, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/lokalise/package.json
+++ b/components/lokalise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/lokalise",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Pipedream Lokalise Components",
   "main": "lokalise.app.mjs",
   "keywords": [

--- a/components/loopify/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/loopify/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -1,0 +1,33 @@
+import loopify from "../../loopify.app.mjs";
+
+export default {
+  key: "loopify-list-contact-id-options",
+  name: "List Contact ID Options",
+  description: "Retrieves available options for the Contact ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    loopify,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await loopify.propDefinitions.contactId.options.call(this.loopify, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/loopify/package.json
+++ b/components/loopify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/loopify",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Pipedream Loopify Components",
   "main": "loopify.app.mjs",
   "keywords": [

--- a/components/lucca/actions/list-department-id-options/list-department-id-options.mjs
+++ b/components/lucca/actions/list-department-id-options/list-department-id-options.mjs
@@ -1,0 +1,33 @@
+import lucca from "../../lucca.app.mjs";
+
+export default {
+  key: "lucca-list-department-id-options",
+  name: "List Department ID Options",
+  description: "Retrieves available options for the Department ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    lucca,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await lucca.propDefinitions.departmentId.options.call(this.lucca, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/lucca/actions/list-leave-request-id-options/list-leave-request-id-options.mjs
+++ b/components/lucca/actions/list-leave-request-id-options/list-leave-request-id-options.mjs
@@ -1,0 +1,33 @@
+import lucca from "../../lucca.app.mjs";
+
+export default {
+  key: "lucca-list-leave-request-id-options",
+  name: "List Leave Request ID Options",
+  description: "Retrieves available options for the Leave Request ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    lucca,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await lucca.propDefinitions.leaveRequestId.options.call(this.lucca, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/lucca/actions/list-legal-entity-id-options/list-legal-entity-id-options.mjs
+++ b/components/lucca/actions/list-legal-entity-id-options/list-legal-entity-id-options.mjs
@@ -1,0 +1,33 @@
+import lucca from "../../lucca.app.mjs";
+
+export default {
+  key: "lucca-list-legal-entity-id-options",
+  name: "List Legal Entity ID Options",
+  description: "Retrieves available options for the Legal Entity ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    lucca,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await lucca.propDefinitions.legalEntityId.options.call(this.lucca, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/lucca/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/lucca/actions/list-user-id-options/list-user-id-options.mjs
@@ -1,0 +1,33 @@
+import lucca from "../../lucca.app.mjs";
+
+export default {
+  key: "lucca-list-user-id-options",
+  name: "List User ID Options",
+  description: "Retrieves available options for the User ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    lucca,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await lucca.propDefinitions.userId.options.call(this.lucca, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/lucca/package.json
+++ b/components/lucca/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/lucca",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Lucca Components",
   "main": "lucca.app.mjs",
   "keywords": [

--- a/components/mailblaze/actions/list-list-uid-options/list-list-uid-options.mjs
+++ b/components/mailblaze/actions/list-list-uid-options/list-list-uid-options.mjs
@@ -1,0 +1,33 @@
+import mailblaze from "../../mailblaze.app.mjs";
+
+export default {
+  key: "mailblaze-list-list-uid-options",
+  name: "List List UID Options",
+  description: "Retrieves available options for the List UID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    mailblaze,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await mailblaze.propDefinitions.listUid.options.call(this.mailblaze, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/mailblaze/package.json
+++ b/components/mailblaze/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/mailblaze",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream MailBlaze Components",
   "main": "mailblaze.app.mjs",
   "keywords": [
@@ -16,4 +16,3 @@
     "@pipedream/platform": "^3.1.1"
   }
 }
-

--- a/components/mailchimp/actions/list-campaign-id-options/list-campaign-id-options.mjs
+++ b/components/mailchimp/actions/list-campaign-id-options/list-campaign-id-options.mjs
@@ -1,0 +1,33 @@
+import mailchimp from "../../mailchimp.app.mjs";
+
+export default {
+  key: "mailchimp-list-campaign-id-options",
+  name: "List Campaign ID Options",
+  description: "Retrieves available options for the Campaign ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    mailchimp,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await mailchimp.propDefinitions.campaignId.options.call(this.mailchimp, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/mailchimp/actions/list-list-id-options/list-list-id-options.mjs
+++ b/components/mailchimp/actions/list-list-id-options/list-list-id-options.mjs
@@ -1,0 +1,33 @@
+import mailchimp from "../../mailchimp.app.mjs";
+
+export default {
+  key: "mailchimp-list-list-id-options",
+  name: "List Audience List Id Options",
+  description: "Retrieves available options for the Audience List Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    mailchimp,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await mailchimp.propDefinitions.listId.options.call(this.mailchimp, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/mailchimp/actions/list-store-id-options/list-store-id-options.mjs
+++ b/components/mailchimp/actions/list-store-id-options/list-store-id-options.mjs
@@ -1,0 +1,33 @@
+import mailchimp from "../../mailchimp.app.mjs";
+
+export default {
+  key: "mailchimp-list-store-id-options",
+  name: "List Store Id Options",
+  description: "Retrieves available options for the Store Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    mailchimp,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await mailchimp.propDefinitions.storeId.options.call(this.mailchimp, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/mailchimp/package.json
+++ b/components/mailchimp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/mailchimp",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "Pipedream Mailchimp Components",
   "main": "mailchimp.app.mjs",
   "keywords": [

--- a/components/mailercloud/actions/list-list-id-options/list-list-id-options.mjs
+++ b/components/mailercloud/actions/list-list-id-options/list-list-id-options.mjs
@@ -1,0 +1,33 @@
+import mailercloud from "../../mailercloud.app.mjs";
+
+export default {
+  key: "mailercloud-list-list-id-options",
+  name: "List List ID Options",
+  description: "Retrieves available options for the List ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    mailercloud,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await mailercloud.propDefinitions.listId.options.call(this.mailercloud, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/mailercloud/package.json
+++ b/components/mailercloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/mailercloud",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Mailercloud Components",
   "main": "mailercloud.app.mjs",
   "keywords": [

--- a/components/mailgun/actions/list-domain-options/list-domain-options.mjs
+++ b/components/mailgun/actions/list-domain-options/list-domain-options.mjs
@@ -1,0 +1,33 @@
+import mailgun from "../../mailgun.app.mjs";
+
+export default {
+  key: "mailgun-list-domain-options",
+  name: "List Domain Name Options",
+  description: "Retrieves available options for the Domain Name field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    mailgun,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await mailgun.propDefinitions.domain.options.call(this.mailgun, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/mailgun/actions/list-list-options/list-list-options.mjs
+++ b/components/mailgun/actions/list-list-options/list-list-options.mjs
@@ -1,0 +1,33 @@
+import mailgun from "../../mailgun.app.mjs";
+
+export default {
+  key: "mailgun-list-list-options",
+  name: "List Mailing List Options",
+  description: "Retrieves available options for the Mailing List field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    mailgun,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await mailgun.propDefinitions.list.options.call(this.mailgun, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/mailgun/package.json
+++ b/components/mailgun/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/mailgun",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "description": "Pipedream Mailgun Components",
   "main": "mailgun.app.mjs",
   "keywords": [

--- a/components/mailwizz/actions/list-campaign-id-options/list-campaign-id-options.mjs
+++ b/components/mailwizz/actions/list-campaign-id-options/list-campaign-id-options.mjs
@@ -1,0 +1,33 @@
+import mailwizz from "../../mailwizz.app.mjs";
+
+export default {
+  key: "mailwizz-list-campaign-id-options",
+  name: "List Campaign UID Options",
+  description: "Retrieves available options for the Campaign UID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    mailwizz,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await mailwizz.propDefinitions.campaignId.options.call(this.mailwizz, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/mailwizz/actions/list-list-id-options/list-list-id-options.mjs
+++ b/components/mailwizz/actions/list-list-id-options/list-list-id-options.mjs
@@ -1,0 +1,33 @@
+import mailwizz from "../../mailwizz.app.mjs";
+
+export default {
+  key: "mailwizz-list-list-id-options",
+  name: "List List UID Options",
+  description: "Retrieves available options for the List UID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    mailwizz,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await mailwizz.propDefinitions.listId.options.call(this.mailwizz, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/mailwizz/actions/list-template-id-options/list-template-id-options.mjs
+++ b/components/mailwizz/actions/list-template-id-options/list-template-id-options.mjs
@@ -1,0 +1,33 @@
+import mailwizz from "../../mailwizz.app.mjs";
+
+export default {
+  key: "mailwizz-list-template-id-options",
+  name: "List Template UID Options",
+  description: "Retrieves available options for the Template UID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    mailwizz,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await mailwizz.propDefinitions.templateId.options.call(this.mailwizz, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/mailwizz/package.json
+++ b/components/mailwizz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/mailwizz",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "Pipedream Mailwizz Components",
   "main": "mailwizz.app.mjs",
   "keywords": [

--- a/components/mctime/actions/list-organization-id-options/list-organization-id-options.mjs
+++ b/components/mctime/actions/list-organization-id-options/list-organization-id-options.mjs
@@ -1,0 +1,33 @@
+import mctime from "../../mctime.app.mjs";
+
+export default {
+  key: "mctime-list-organization-id-options",
+  name: "List Organization ID Options",
+  description: "Retrieves available options for the Organization ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    mctime,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await mctime.propDefinitions.organizationId.options.call(this.mctime, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/mctime/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/mctime/actions/list-user-id-options/list-user-id-options.mjs
@@ -1,0 +1,33 @@
+import mctime from "../../mctime.app.mjs";
+
+export default {
+  key: "mctime-list-user-id-options",
+  name: "List User ID Options",
+  description: "Retrieves available options for the User ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    mctime,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await mctime.propDefinitions.userId.options.call(this.mctime, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/mctime/package.json
+++ b/components/mctime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/mctime",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream McTime Components",
   "main": "mctime.app.mjs",
   "keywords": [

--- a/components/meistertask/actions/list-project-id-options/list-project-id-options.mjs
+++ b/components/meistertask/actions/list-project-id-options/list-project-id-options.mjs
@@ -1,0 +1,33 @@
+import meistertask from "../../meistertask.app.mjs";
+
+export default {
+  key: "meistertask-list-project-id-options",
+  name: "List Project Options",
+  description: "Retrieves available options for the Project field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    meistertask,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await meistertask.propDefinitions.projectId.options.call(this.meistertask, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/meistertask/package.json
+++ b/components/meistertask/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/meistertask",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Pipedream Meistertask Components",
   "main": "meistertask.app.mjs",
   "homepage": "https://pipedream.com/apps/meistertask",

--- a/components/microsoft_outlook/actions/list-contact-options/list-contact-options.mjs
+++ b/components/microsoft_outlook/actions/list-contact-options/list-contact-options.mjs
@@ -1,0 +1,34 @@
+import microsoft_outlook from "../../microsoft_outlook.app.mjs";
+
+export default {
+  key: "microsoft_outlook-list-contact-options",
+  name: "List Contact Options",
+  description: "Retrieves available options for the Contact field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    microsoft_outlook,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await microsoft_outlook.propDefinitions.contact.options
+      .call(this.microsoft_outlook, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/microsoft_outlook/actions/list-folder-ids-options/list-folder-ids-options.mjs
+++ b/components/microsoft_outlook/actions/list-folder-ids-options/list-folder-ids-options.mjs
@@ -1,0 +1,34 @@
+import microsoft_outlook from "../../microsoft_outlook.app.mjs";
+
+export default {
+  key: "microsoft_outlook-list-folder-ids-options",
+  name: "List Folder IDs to Monitor Options",
+  description: "Retrieves available options for the Folder IDs to Monitor field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    microsoft_outlook,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await microsoft_outlook.propDefinitions.folderIds.options
+      .call(this.microsoft_outlook, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/microsoft_outlook/package.json
+++ b/components/microsoft_outlook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/microsoft_outlook",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Pipedream Microsoft Outlook Components",
   "main": "microsoft_outlook.app.mjs",
   "keywords": [


### PR DESCRIPTION
Adds a batch of 74 new actions for retrieving prop options that accept the page parameter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added list options actions across 40+ integrations (Kustomer, Landbot, LastPass, Lawmatics, Leaddyno, Leexi, Lemlist, LinkedIn, Lightspeed, Lucca, Mailchimp, Mailgun, and others) for dynamic field selection in workflows.

* **Chores**
  * Updated component package versions with minor version bumps for improved compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PipedreamHQ/pipedream/pull/20913?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->