### PR TITLE
Actions for page only prop options batch 8

### DIFF
--- a/components/miestro/actions/list-course-id-options/list-course-id-options.mjs
+++ b/components/miestro/actions/list-course-id-options/list-course-id-options.mjs
@@ -1,0 +1,33 @@
+import miestro from "../../miestro.app.mjs";
+
+export default {
+  key: "miestro-list-course-id-options",
+  name: "List Course ID Options",
+  description: "Retrieves available options for the Course ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    miestro,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await miestro.propDefinitions.courseId.options.call(this.miestro, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/miestro/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/miestro/actions/list-user-id-options/list-user-id-options.mjs
@@ -1,0 +1,33 @@
+import miestro from "../../miestro.app.mjs";
+
+export default {
+  key: "miestro-list-user-id-options",
+  name: "List User ID Options",
+  description: "Retrieves available options for the User ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    miestro,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await miestro.propDefinitions.userId.options.call(this.miestro, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/miestro/package.json
+++ b/components/miestro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/miestro",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "Pipedream Miestro Components",
   "main": "miestro.app.mjs",
   "keywords": [

--- a/components/mistral_ai/actions/list-batch-job-id-options/list-batch-job-id-options.mjs
+++ b/components/mistral_ai/actions/list-batch-job-id-options/list-batch-job-id-options.mjs
@@ -1,0 +1,33 @@
+import mistral_ai from "../../mistral_ai.app.mjs";
+
+export default {
+  key: "mistral_ai-list-batch-job-id-options",
+  name: "List Batch Job ID Options",
+  description: "Retrieves available options for the Batch Job ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    mistral_ai,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await mistral_ai.propDefinitions.batchJobId.options.call(this.mistral_ai, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/mistral_ai/package.json
+++ b/components/mistral_ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/mistral_ai",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "Pipedream Mistral AI Components",
   "main": "mistral_ai.app.mjs",
   "keywords": [

--- a/components/moaform/actions/list-form-id-options/list-form-id-options.mjs
+++ b/components/moaform/actions/list-form-id-options/list-form-id-options.mjs
@@ -1,0 +1,33 @@
+import moaform from "../../moaform.app.mjs";
+
+export default {
+  key: "moaform-list-form-id-options",
+  name: "List Form ID Options",
+  description: "Retrieves available options for the Form ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    moaform,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await moaform.propDefinitions.formId.options.call(this.moaform, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/moaform/package.json
+++ b/components/moaform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/moaform",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Moaform Components",
   "main": "moaform.app.mjs",
   "keywords": [

--- a/components/moco/actions/list-invoice-id-options/list-invoice-id-options.mjs
+++ b/components/moco/actions/list-invoice-id-options/list-invoice-id-options.mjs
@@ -1,0 +1,33 @@
+import moco from "../../moco.app.mjs";
+
+export default {
+  key: "moco-list-invoice-id-options",
+  name: "List Invoice ID Options",
+  description: "Retrieves available options for the Invoice ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    moco,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await moco.propDefinitions.invoiceId.options.call(this.moco, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/moco/actions/list-project-id-options/list-project-id-options.mjs
+++ b/components/moco/actions/list-project-id-options/list-project-id-options.mjs
@@ -1,0 +1,33 @@
+import moco from "../../moco.app.mjs";
+
+export default {
+  key: "moco-list-project-id-options",
+  name: "List Project ID Options",
+  description: "Retrieves available options for the Project ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    moco,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await moco.propDefinitions.projectId.options.call(this.moco, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/moco/package.json
+++ b/components/moco/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/moco",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream MOCO Components",
   "main": "moco.app.mjs",
   "keywords": [

--- a/components/mojo_helpdesk/actions/list-ticket-queue-id-options/list-ticket-queue-id-options.mjs
+++ b/components/mojo_helpdesk/actions/list-ticket-queue-id-options/list-ticket-queue-id-options.mjs
@@ -1,0 +1,34 @@
+import mojo_helpdesk from "../../mojo_helpdesk.app.mjs";
+
+export default {
+  key: "mojo_helpdesk-list-ticket-queue-id-options",
+  name: "List Ticket Queue Options",
+  description: "Retrieves available options for the Ticket Queue field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    mojo_helpdesk,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await mojo_helpdesk.propDefinitions.ticketQueueId.options
+      .call(this.mojo_helpdesk, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/mojo_helpdesk/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/mojo_helpdesk/actions/list-user-id-options/list-user-id-options.mjs
@@ -1,0 +1,33 @@
+import mojo_helpdesk from "../../mojo_helpdesk.app.mjs";
+
+export default {
+  key: "mojo_helpdesk-list-user-id-options",
+  name: "List User Options",
+  description: "Retrieves available options for the User field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    mojo_helpdesk,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await mojo_helpdesk.propDefinitions.userId.options.call(this.mojo_helpdesk, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/mojo_helpdesk/package.json
+++ b/components/mojo_helpdesk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/mojo_helpdesk",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Pipedream Mojo Helpdesk Components",
   "main": "mojo_helpdesk.app.mjs",
   "keywords": [

--- a/components/momentum_ams/actions/list-id-options/list-id-options.mjs
+++ b/components/momentum_ams/actions/list-id-options/list-id-options.mjs
@@ -1,0 +1,33 @@
+import momentum_ams from "../../momentum_ams.app.mjs";
+
+export default {
+  key: "momentum_ams-list-id-options",
+  name: "List Client ID Options",
+  description: "Retrieves available options for the Client ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    momentum_ams,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await momentum_ams.propDefinitions.id.options.call(this.momentum_ams, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/momentum_ams/package.json
+++ b/components/momentum_ams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/momentum_ams",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Momentum AMS Components",
   "main": "momentum_ams.app.mjs",
   "keywords": [

--- a/components/monday/actions/list-board-id-options/list-board-id-options.mjs
+++ b/components/monday/actions/list-board-id-options/list-board-id-options.mjs
@@ -1,0 +1,33 @@
+import monday from "../../monday.app.mjs";
+
+export default {
+  key: "monday-list-board-id-options",
+  name: "List Board ID Options",
+  description: "Retrieves available options for the Board ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    monday,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await monday.propDefinitions.boardId.options.call(this.monday, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/monday/actions/list-board-ids-options/list-board-ids-options.mjs
+++ b/components/monday/actions/list-board-ids-options/list-board-ids-options.mjs
@@ -1,0 +1,33 @@
+import monday from "../../monday.app.mjs";
+
+export default {
+  key: "monday-list-board-ids-options",
+  name: "List Board IDs Options",
+  description: "Retrieves available options for the Board IDs field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    monday,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await monday.propDefinitions.boardIds.options.call(this.monday, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/monday/package.json
+++ b/components/monday/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/monday",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Pipedream Monday Components",
   "main": "monday.app.mjs",
   "keywords": [

--- a/components/moneybird/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/moneybird/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -1,0 +1,33 @@
+import moneybird from "../../moneybird.app.mjs";
+
+export default {
+  key: "moneybird-list-contact-id-options",
+  name: "List Contact ID Options",
+  description: "Retrieves available options for the Contact ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    moneybird,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await moneybird.propDefinitions.contactId.options.call(this.moneybird, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/moneybird/actions/list-product-id-options/list-product-id-options.mjs
+++ b/components/moneybird/actions/list-product-id-options/list-product-id-options.mjs
@@ -1,0 +1,33 @@
+import moneybird from "../../moneybird.app.mjs";
+
+export default {
+  key: "moneybird-list-product-id-options",
+  name: "List Product ID Options",
+  description: "Retrieves available options for the Product ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    moneybird,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await moneybird.propDefinitions.productId.options.call(this.moneybird, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/moneybird/actions/list-project-id-options/list-project-id-options.mjs
+++ b/components/moneybird/actions/list-project-id-options/list-project-id-options.mjs
@@ -1,0 +1,33 @@
+import moneybird from "../../moneybird.app.mjs";
+
+export default {
+  key: "moneybird-list-project-id-options",
+  name: "List Project ID Options",
+  description: "Retrieves available options for the Project ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    moneybird,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await moneybird.propDefinitions.projectId.options.call(this.moneybird, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/moneybird/package.json
+++ b/components/moneybird/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/moneybird",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "Pipedream Moneybird Components",
   "main": "moneybird.app.mjs",
   "keywords": [

--- a/components/monta/actions/list-order-id-options/list-order-id-options.mjs
+++ b/components/monta/actions/list-order-id-options/list-order-id-options.mjs
@@ -1,0 +1,33 @@
+import monta from "../../monta.app.mjs";
+
+export default {
+  key: "monta-list-order-id-options",
+  name: "List Order ID Options",
+  description: "Retrieves available options for the Order ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    monta,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await monta.propDefinitions.orderId.options.call(this.monta, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/monta/package.json
+++ b/components/monta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/monta",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream Monta Components",
   "main": "monta.app.mjs",
   "keywords": [

--- a/components/moosend/actions/list-mailing-list-id-options/list-mailing-list-id-options.mjs
+++ b/components/moosend/actions/list-mailing-list-id-options/list-mailing-list-id-options.mjs
@@ -1,0 +1,33 @@
+import moosend from "../../moosend.app.mjs";
+
+export default {
+  key: "moosend-list-mailing-list-id-options",
+  name: "List Mailing List ID Options",
+  description: "Retrieves available options for the Mailing List ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    moosend,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await moosend.propDefinitions.mailingListId.options.call(this.moosend, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/moosend/package.json
+++ b/components/moosend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/moosend",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Pipedream Moosend Components",
   "main": "moosend.app.mjs",
   "keywords": [

--- a/components/motive/actions/list-driver-company-id-options/list-driver-company-id-options.mjs
+++ b/components/motive/actions/list-driver-company-id-options/list-driver-company-id-options.mjs
@@ -1,0 +1,33 @@
+import motive from "../../motive.app.mjs";
+
+export default {
+  key: "motive-list-driver-company-id-options",
+  name: "List Driver Company ID Options",
+  description: "Retrieves available options for the Driver Company ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    motive,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await motive.propDefinitions.driverCompanyId.options.call(this.motive, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/motive/package.json
+++ b/components/motive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/motive",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Motive Components",
   "main": "motive.app.mjs",
   "keywords": [

--- a/components/mux/actions/list-asset-id-options/list-asset-id-options.mjs
+++ b/components/mux/actions/list-asset-id-options/list-asset-id-options.mjs
@@ -1,0 +1,33 @@
+import mux from "../../mux.app.mjs";
+
+export default {
+  key: "mux-list-asset-id-options",
+  name: "List Asset Options",
+  description: "Retrieves available options for the Asset field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    mux,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await mux.propDefinitions.assetId.options.call(this.mux, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/mux/package.json
+++ b/components/mux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/mux",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Pipedream Mux Components",
   "main": "mux.app.mjs",
   "keywords": [

--- a/components/mx_technologies/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/mx_technologies/actions/list-user-id-options/list-user-id-options.mjs
@@ -1,0 +1,34 @@
+import mx_technologies from "../../mx_technologies.app.mjs";
+
+export default {
+  key: "mx_technologies-list-user-id-options",
+  name: "List User ID Options",
+  description: "Retrieves available options for the User ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    mx_technologies,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await mx_technologies.propDefinitions.userId.options
+      .call(this.mx_technologies, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/mx_technologies/package.json
+++ b/components/mx_technologies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/mx_technologies",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream MX Technologies Components",
   "main": "mx_technologies.app.mjs",
   "keywords": [

--- a/components/navan/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/navan/actions/list-user-id-options/list-user-id-options.mjs
@@ -1,0 +1,33 @@
+import navan from "../../navan.app.mjs";
+
+export default {
+  key: "navan-list-user-id-options",
+  name: "List User ID Options",
+  description: "Retrieves available options for the User ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    navan,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await navan.propDefinitions.userId.options.call(this.navan, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/navan/package.json
+++ b/components/navan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/navan",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Navan Components",
   "main": "navan.app.mjs",
   "keywords": [

--- a/components/netsuite/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/netsuite/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -1,0 +1,33 @@
+import netsuite from "../../netsuite.app.mjs";
+
+export default {
+  key: "netsuite-list-customer-id-options",
+  name: "List Customer ID Options",
+  description: "Retrieves available options for the Customer ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    netsuite,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await netsuite.propDefinitions.customerId.options.call(this.netsuite, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/netsuite/actions/list-invoice-id-options/list-invoice-id-options.mjs
+++ b/components/netsuite/actions/list-invoice-id-options/list-invoice-id-options.mjs
@@ -1,0 +1,33 @@
+import netsuite from "../../netsuite.app.mjs";
+
+export default {
+  key: "netsuite-list-invoice-id-options",
+  name: "List Invoice ID Options",
+  description: "Retrieves available options for the Invoice ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    netsuite,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await netsuite.propDefinitions.invoiceId.options.call(this.netsuite, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/netsuite/actions/list-sales-order-id-options/list-sales-order-id-options.mjs
+++ b/components/netsuite/actions/list-sales-order-id-options/list-sales-order-id-options.mjs
@@ -1,0 +1,33 @@
+import netsuite from "../../netsuite.app.mjs";
+
+export default {
+  key: "netsuite-list-sales-order-id-options",
+  name: "List Sales Order ID Options",
+  description: "Retrieves available options for the Sales Order ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    netsuite,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await netsuite.propDefinitions.salesOrderId.options.call(this.netsuite, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/netsuite/actions/list-subsidiary-id-options/list-subsidiary-id-options.mjs
+++ b/components/netsuite/actions/list-subsidiary-id-options/list-subsidiary-id-options.mjs
@@ -1,0 +1,33 @@
+import netsuite from "../../netsuite.app.mjs";
+
+export default {
+  key: "netsuite-list-subsidiary-id-options",
+  name: "List Subsidiary ID Options",
+  description: "Retrieves available options for the Subsidiary ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    netsuite,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await netsuite.propDefinitions.subsidiaryId.options.call(this.netsuite, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/netsuite/package.json
+++ b/components/netsuite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/netsuite",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream NetSuite Components",
   "main": "netsuite.app.mjs",
   "keywords": [

--- a/components/new_relic/actions/list-application-options/list-application-options.mjs
+++ b/components/new_relic/actions/list-application-options/list-application-options.mjs
@@ -1,0 +1,33 @@
+import new_relic from "../../new_relic.app.mjs";
+
+export default {
+  key: "new_relic-list-application-options",
+  name: "List Application ID Options",
+  description: "Retrieves available options for the Application ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    new_relic,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await new_relic.propDefinitions.application.options.call(this.new_relic, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/new_relic/package.json
+++ b/components/new_relic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/new-relic",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "description": "Pipedream New Relic Components",
   "main": "new_relic.app.mjs",
   "keywords": [

--- a/components/newscatcher/actions/list-job-id-options/list-job-id-options.mjs
+++ b/components/newscatcher/actions/list-job-id-options/list-job-id-options.mjs
@@ -1,0 +1,33 @@
+import newscatcher from "../../newscatcher.app.mjs";
+
+export default {
+  key: "newscatcher-list-job-id-options",
+  name: "List Job ID Options",
+  description: "Retrieves available options for the Job ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    newscatcher,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await newscatcher.propDefinitions.jobId.options.call(this.newscatcher, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/newscatcher/package.json
+++ b/components/newscatcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/newscatcher",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream NewsCatcher Components",
   "main": "newscatcher.app.mjs",
   "keywords": [

--- a/components/nifty/actions/list-app-id-options/list-app-id-options.mjs
+++ b/components/nifty/actions/list-app-id-options/list-app-id-options.mjs
@@ -1,0 +1,33 @@
+import nifty from "../../nifty.app.mjs";
+
+export default {
+  key: "nifty-list-app-id-options",
+  name: "List App ID Options",
+  description: "Retrieves available options for the App ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    nifty,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await nifty.propDefinitions.appId.options.call(this.nifty, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/nifty/actions/list-label-ids-options/list-label-ids-options.mjs
+++ b/components/nifty/actions/list-label-ids-options/list-label-ids-options.mjs
@@ -1,0 +1,33 @@
+import nifty from "../../nifty.app.mjs";
+
+export default {
+  key: "nifty-list-label-ids-options",
+  name: "List Label IDs Options",
+  description: "Retrieves available options for the Label IDs field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    nifty,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await nifty.propDefinitions.labelIds.options.call(this.nifty, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/nifty/actions/list-project-id-options/list-project-id-options.mjs
+++ b/components/nifty/actions/list-project-id-options/list-project-id-options.mjs
@@ -1,0 +1,33 @@
+import nifty from "../../nifty.app.mjs";
+
+export default {
+  key: "nifty-list-project-id-options",
+  name: "List Project ID Options",
+  description: "Retrieves available options for the Project ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    nifty,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await nifty.propDefinitions.projectId.options.call(this.nifty, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/nifty/actions/list-template-id-options/list-template-id-options.mjs
+++ b/components/nifty/actions/list-template-id-options/list-template-id-options.mjs
@@ -1,0 +1,33 @@
+import nifty from "../../nifty.app.mjs";
+
+export default {
+  key: "nifty-list-template-id-options",
+  name: "List Template ID Options",
+  description: "Retrieves available options for the Template ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    nifty,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await nifty.propDefinitions.templateId.options.call(this.nifty, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/nifty/package.json
+++ b/components/nifty/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/nifty",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Pipedream Nifty Components",
   "main": "nifty.app.mjs",
   "keywords": [

--- a/components/nimble/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/nimble/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -1,0 +1,33 @@
+import nimble from "../../nimble.app.mjs";
+
+export default {
+  key: "nimble-list-contact-id-options",
+  name: "List Contact ID Options",
+  description: "Retrieves available options for the Contact ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    nimble,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await nimble.propDefinitions.contactId.options.call(this.nimble, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/nimble/package.json
+++ b/components/nimble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/nimble",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Nimble Components",
   "main": "nimble.app.mjs",
   "keywords": [

--- a/components/nocrm_io/actions/list-lead-id-options/list-lead-id-options.mjs
+++ b/components/nocrm_io/actions/list-lead-id-options/list-lead-id-options.mjs
@@ -1,0 +1,33 @@
+import nocrm_io from "../../nocrm_io.app.mjs";
+
+export default {
+  key: "nocrm_io-list-lead-id-options",
+  name: "List Lead ID Options",
+  description: "Retrieves available options for the Lead ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    nocrm_io,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await nocrm_io.propDefinitions.leadId.options.call(this.nocrm_io, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/nocrm_io/package.json
+++ b/components/nocrm_io/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/nocrm_io",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream noCRM.io Components",
   "main": "nocrm_io.app.mjs",
   "keywords": [

--- a/components/nordigen/actions/list-requisition-id-options/list-requisition-id-options.mjs
+++ b/components/nordigen/actions/list-requisition-id-options/list-requisition-id-options.mjs
@@ -1,0 +1,33 @@
+import nordigen from "../../nordigen.app.mjs";
+
+export default {
+  key: "nordigen-list-requisition-id-options",
+  name: "List Requisition Id Options",
+  description: "Retrieves available options for the Requisition Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    nordigen,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await nordigen.propDefinitions.requisitionId.options.call(this.nordigen, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/nordigen/package.json
+++ b/components/nordigen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/nordigen",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Pipedream Nordigen Components",
   "main": "nordigen.app.mjs",
   "keywords": [

--- a/components/nutshell/actions/list-account-type-id-options/list-account-type-id-options.mjs
+++ b/components/nutshell/actions/list-account-type-id-options/list-account-type-id-options.mjs
@@ -1,0 +1,33 @@
+import nutshell from "../../nutshell.app.mjs";
+
+export default {
+  key: "nutshell-list-account-type-id-options",
+  name: "List Account Type Id Options",
+  description: "Retrieves available options for the Account Type Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    nutshell,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await nutshell.propDefinitions.accountTypeId.options.call(this.nutshell, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/nutshell/actions/list-audience-id-options/list-audience-id-options.mjs
+++ b/components/nutshell/actions/list-audience-id-options/list-audience-id-options.mjs
@@ -1,0 +1,33 @@
+import nutshell from "../../nutshell.app.mjs";
+
+export default {
+  key: "nutshell-list-audience-id-options",
+  name: "List Audience Id Options",
+  description: "Retrieves available options for the Audience Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    nutshell,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await nutshell.propDefinitions.audienceId.options.call(this.nutshell, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/nutshell/actions/list-company-id-options/list-company-id-options.mjs
+++ b/components/nutshell/actions/list-company-id-options/list-company-id-options.mjs
@@ -1,0 +1,33 @@
+import nutshell from "../../nutshell.app.mjs";
+
+export default {
+  key: "nutshell-list-company-id-options",
+  name: "List Company ID Options",
+  description: "Retrieves available options for the Company ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    nutshell,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await nutshell.propDefinitions.companyId.options.call(this.nutshell, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/nutshell/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/nutshell/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -1,0 +1,33 @@
+import nutshell from "../../nutshell.app.mjs";
+
+export default {
+  key: "nutshell-list-contact-id-options",
+  name: "List Contact Id Options",
+  description: "Retrieves available options for the Contact Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    nutshell,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await nutshell.propDefinitions.contactId.options.call(this.nutshell, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/nutshell/actions/list-industry-id-options/list-industry-id-options.mjs
+++ b/components/nutshell/actions/list-industry-id-options/list-industry-id-options.mjs
@@ -1,0 +1,33 @@
+import nutshell from "../../nutshell.app.mjs";
+
+export default {
+  key: "nutshell-list-industry-id-options",
+  name: "List Industry Id Options",
+  description: "Retrieves available options for the Industry Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    nutshell,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await nutshell.propDefinitions.industryId.options.call(this.nutshell, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/nutshell/actions/list-lead-id-options/list-lead-id-options.mjs
+++ b/components/nutshell/actions/list-lead-id-options/list-lead-id-options.mjs
@@ -1,0 +1,33 @@
+import nutshell from "../../nutshell.app.mjs";
+
+export default {
+  key: "nutshell-list-lead-id-options",
+  name: "List Lead ID Options",
+  description: "Retrieves available options for the Lead ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    nutshell,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await nutshell.propDefinitions.leadId.options.call(this.nutshell, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/nutshell/actions/list-market-id-options/list-market-id-options.mjs
+++ b/components/nutshell/actions/list-market-id-options/list-market-id-options.mjs
@@ -1,0 +1,33 @@
+import nutshell from "../../nutshell.app.mjs";
+
+export default {
+  key: "nutshell-list-market-id-options",
+  name: "List Market Id Options",
+  description: "Retrieves available options for the Market Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    nutshell,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await nutshell.propDefinitions.marketId.options.call(this.nutshell, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/nutshell/actions/list-territory-id-options/list-territory-id-options.mjs
+++ b/components/nutshell/actions/list-territory-id-options/list-territory-id-options.mjs
@@ -1,0 +1,33 @@
+import nutshell from "../../nutshell.app.mjs";
+
+export default {
+  key: "nutshell-list-territory-id-options",
+  name: "List Territory Id Options",
+  description: "Retrieves available options for the Territory Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    nutshell,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await nutshell.propDefinitions.territoryId.options.call(this.nutshell, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/nutshell/package.json
+++ b/components/nutshell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/nutshell",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Pipedream Nutshell Components",
   "main": "nutshell.app.mjs",
   "keywords": [
@@ -16,4 +16,3 @@
     "@pipedream/platform": "^3.2.5"
   }
 }
-

--- a/components/omise/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/omise/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -1,0 +1,33 @@
+import omise from "../../omise.app.mjs";
+
+export default {
+  key: "omise-list-customer-id-options",
+  name: "List Customer ID Options",
+  description: "Retrieves available options for the Customer ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    omise,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await omise.propDefinitions.customerId.options.call(this.omise, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/omise/package.json
+++ b/components/omise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/omise",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream OPN (formerly Omise) Components",
   "main": "omise.app.mjs",
   "keywords": [
@@ -16,4 +16,3 @@
     "@pipedream/platform": "^1.6.8"
   }
 }
-

--- a/components/omnisend/actions/list-campaign-id-options/list-campaign-id-options.mjs
+++ b/components/omnisend/actions/list-campaign-id-options/list-campaign-id-options.mjs
@@ -1,0 +1,33 @@
+import omnisend from "../../omnisend.app.mjs";
+
+export default {
+  key: "omnisend-list-campaign-id-options",
+  name: "List Campaign ID Options",
+  description: "Retrieves available options for the Campaign ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    omnisend,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await omnisend.propDefinitions.campaignId.options.call(this.omnisend, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/omnisend/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/omnisend/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -1,0 +1,33 @@
+import omnisend from "../../omnisend.app.mjs";
+
+export default {
+  key: "omnisend-list-contact-id-options",
+  name: "List Contact ID Options",
+  description: "Retrieves available options for the Contact ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    omnisend,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await omnisend.propDefinitions.contactId.options.call(this.omnisend, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/omnisend/actions/list-event-id-options/list-event-id-options.mjs
+++ b/components/omnisend/actions/list-event-id-options/list-event-id-options.mjs
@@ -1,0 +1,33 @@
+import omnisend from "../../omnisend.app.mjs";
+
+export default {
+  key: "omnisend-list-event-id-options",
+  name: "List Event ID Options",
+  description: "Retrieves available options for the Event ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    omnisend,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await omnisend.propDefinitions.eventId.options.call(this.omnisend, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/omnisend/package.json
+++ b/components/omnisend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/omnisend",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Omnisend Components",
   "main": "omnisend.app.mjs",
   "keywords": [
@@ -16,4 +16,3 @@
     "@pipedream/platform": "^1.6.8"
   }
 }
-

--- a/components/onelogin/actions/list-event-type-options/list-event-type-options.mjs
+++ b/components/onelogin/actions/list-event-type-options/list-event-type-options.mjs
@@ -1,0 +1,33 @@
+import onelogin from "../../onelogin.app.mjs";
+
+export default {
+  key: "onelogin-list-event-type-options",
+  name: "List Event Type Options",
+  description: "Retrieves available options for the Event Type field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    onelogin,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await onelogin.propDefinitions.eventType.options.call(this.onelogin, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/onelogin/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/onelogin/actions/list-user-id-options/list-user-id-options.mjs
@@ -1,0 +1,33 @@
+import onelogin from "../../onelogin.app.mjs";
+
+export default {
+  key: "onelogin-list-user-id-options",
+  name: "List User ID Options",
+  description: "Retrieves available options for the User ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    onelogin,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await onelogin.propDefinitions.userId.options.call(this.onelogin, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/onelogin/package.json
+++ b/components/onelogin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/onelogin",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream OneLogin Components",
   "main": "onelogin.app.mjs",
   "keywords": [

--- a/components/onepagecrm/actions/list-company-id-options/list-company-id-options.mjs
+++ b/components/onepagecrm/actions/list-company-id-options/list-company-id-options.mjs
@@ -1,0 +1,33 @@
+import onepagecrm from "../../onepagecrm.app.mjs";
+
+export default {
+  key: "onepagecrm-list-company-id-options",
+  name: "List Company ID Options",
+  description: "Retrieves available options for the Company ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    onepagecrm,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await onepagecrm.propDefinitions.companyId.options.call(this.onepagecrm, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/onepagecrm/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/onepagecrm/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -1,0 +1,33 @@
+import onepagecrm from "../../onepagecrm.app.mjs";
+
+export default {
+  key: "onepagecrm-list-contact-id-options",
+  name: "List Contact ID Options",
+  description: "Retrieves available options for the Contact ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    onepagecrm,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await onepagecrm.propDefinitions.contactId.options.call(this.onepagecrm, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/onepagecrm/actions/list-deal-id-options/list-deal-id-options.mjs
+++ b/components/onepagecrm/actions/list-deal-id-options/list-deal-id-options.mjs
@@ -1,0 +1,33 @@
+import onepagecrm from "../../onepagecrm.app.mjs";
+
+export default {
+  key: "onepagecrm-list-deal-id-options",
+  name: "List Deal ID Options",
+  description: "Retrieves available options for the Deal ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    onepagecrm,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await onepagecrm.propDefinitions.dealId.options.call(this.onepagecrm, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/onepagecrm/actions/list-lead-source-id-options/list-lead-source-id-options.mjs
+++ b/components/onepagecrm/actions/list-lead-source-id-options/list-lead-source-id-options.mjs
@@ -1,0 +1,33 @@
+import onepagecrm from "../../onepagecrm.app.mjs";
+
+export default {
+  key: "onepagecrm-list-lead-source-id-options",
+  name: "List Lead Source ID Options",
+  description: "Retrieves available options for the Lead Source ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    onepagecrm,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await onepagecrm.propDefinitions.leadSourceId.options.call(this.onepagecrm, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/onepagecrm/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/onepagecrm/actions/list-user-id-options/list-user-id-options.mjs
@@ -1,0 +1,33 @@
+import onepagecrm from "../../onepagecrm.app.mjs";
+
+export default {
+  key: "onepagecrm-list-user-id-options",
+  name: "List User ID Options",
+  description: "Retrieves available options for the User ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    onepagecrm,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await onepagecrm.propDefinitions.userId.options.call(this.onepagecrm, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/onepagecrm/package.json
+++ b/components/onepagecrm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/onepagecrm",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream OnePageCRM Components",
   "main": "onepagecrm.app.mjs",
   "keywords": [

--- a/components/onlinecheckwriter/actions/list-bank-account-id-options/list-bank-account-id-options.mjs
+++ b/components/onlinecheckwriter/actions/list-bank-account-id-options/list-bank-account-id-options.mjs
@@ -1,0 +1,34 @@
+import onlinecheckwriter from "../../onlinecheckwriter.app.mjs";
+
+export default {
+  key: "onlinecheckwriter-list-bank-account-id-options",
+  name: "List Bank Account ID Options",
+  description: "Retrieves available options for the Bank Account ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    onlinecheckwriter,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await onlinecheckwriter.propDefinitions.bankAccountId.options
+      .call(this.onlinecheckwriter, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/onlinecheckwriter/actions/list-category-id-options/list-category-id-options.mjs
+++ b/components/onlinecheckwriter/actions/list-category-id-options/list-category-id-options.mjs
@@ -1,0 +1,34 @@
+import onlinecheckwriter from "../../onlinecheckwriter.app.mjs";
+
+export default {
+  key: "onlinecheckwriter-list-category-id-options",
+  name: "List Category ID Options",
+  description: "Retrieves available options for the Category ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    onlinecheckwriter,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await onlinecheckwriter.propDefinitions.categoryId.options
+      .call(this.onlinecheckwriter, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/onlinecheckwriter/actions/list-custom-from-address-id-options/list-custom-from-address-id-options.mjs
+++ b/components/onlinecheckwriter/actions/list-custom-from-address-id-options/list-custom-from-address-id-options.mjs
@@ -1,0 +1,34 @@
+import onlinecheckwriter from "../../onlinecheckwriter.app.mjs";
+
+export default {
+  key: "onlinecheckwriter-list-custom-from-address-id-options",
+  name: "List Custom From Address ID Options",
+  description: "Retrieves available options for the Custom From Address ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    onlinecheckwriter,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await onlinecheckwriter.propDefinitions.customFromAddressId.options
+      .call(this.onlinecheckwriter, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/onlinecheckwriter/actions/list-custom-to-address-id-options/list-custom-to-address-id-options.mjs
+++ b/components/onlinecheckwriter/actions/list-custom-to-address-id-options/list-custom-to-address-id-options.mjs
@@ -1,0 +1,34 @@
+import onlinecheckwriter from "../../onlinecheckwriter.app.mjs";
+
+export default {
+  key: "onlinecheckwriter-list-custom-to-address-id-options",
+  name: "List Custom To Address ID Options",
+  description: "Retrieves available options for the Custom To Address ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    onlinecheckwriter,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await onlinecheckwriter.propDefinitions.customToAddressId.options
+      .call(this.onlinecheckwriter, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/onlinecheckwriter/actions/list-payee-id-options/list-payee-id-options.mjs
+++ b/components/onlinecheckwriter/actions/list-payee-id-options/list-payee-id-options.mjs
@@ -1,0 +1,34 @@
+import onlinecheckwriter from "../../onlinecheckwriter.app.mjs";
+
+export default {
+  key: "onlinecheckwriter-list-payee-id-options",
+  name: "List Payee ID Options",
+  description: "Retrieves available options for the Payee ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    onlinecheckwriter,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await onlinecheckwriter.propDefinitions.payeeId.options
+      .call(this.onlinecheckwriter, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/onlinecheckwriter/package.json
+++ b/components/onlinecheckwriter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/onlinecheckwriter",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "Pipedream OnlineCheckWriter Components",
   "main": "onlinecheckwriter.app.mjs",
   "keywords": [

--- a/components/ontraport/actions/list-form-id-options/list-form-id-options.mjs
+++ b/components/ontraport/actions/list-form-id-options/list-form-id-options.mjs
@@ -1,0 +1,33 @@
+import ontraport from "../../ontraport.app.mjs";
+
+export default {
+  key: "ontraport-list-form-id-options",
+  name: "List Form ID Options",
+  description: "Retrieves available options for the Form ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    ontraport,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await ontraport.propDefinitions.formId.options.call(this.ontraport, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/ontraport/actions/list-product-id-options/list-product-id-options.mjs
+++ b/components/ontraport/actions/list-product-id-options/list-product-id-options.mjs
@@ -1,0 +1,33 @@
+import ontraport from "../../ontraport.app.mjs";
+
+export default {
+  key: "ontraport-list-product-id-options",
+  name: "List Product ID Options",
+  description: "Retrieves available options for the Product ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    ontraport,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await ontraport.propDefinitions.productId.options.call(this.ontraport, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/ontraport/actions/list-tag-id-options/list-tag-id-options.mjs
+++ b/components/ontraport/actions/list-tag-id-options/list-tag-id-options.mjs
@@ -1,0 +1,33 @@
+import ontraport from "../../ontraport.app.mjs";
+
+export default {
+  key: "ontraport-list-tag-id-options",
+  name: "List Tag ID Options",
+  description: "Retrieves available options for the Tag ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    ontraport,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await ontraport.propDefinitions.tagId.options.call(this.ontraport, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/ontraport/package.json
+++ b/components/ontraport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/ontraport",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "Pipedream Ontraport Components",
   "main": "ontraport.app.mjs",
   "keywords": [

--- a/components/opinion_stage/actions/list-item-id-options/list-item-id-options.mjs
+++ b/components/opinion_stage/actions/list-item-id-options/list-item-id-options.mjs
@@ -1,0 +1,33 @@
+import opinion_stage from "../../opinion_stage.app.mjs";
+
+export default {
+  key: "opinion_stage-list-item-id-options",
+  name: "List Item ID Options",
+  description: "Retrieves available options for the Item ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    opinion_stage,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await opinion_stage.propDefinitions.itemId.options.call(this.opinion_stage, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/opinion_stage/package.json
+++ b/components/opinion_stage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/opinion_stage",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Opinion Stage Components",
   "main": "opinion_stage.app.mjs",
   "keywords": [

--- a/components/opsgenie/actions/list-alert-id-options/list-alert-id-options.mjs
+++ b/components/opsgenie/actions/list-alert-id-options/list-alert-id-options.mjs
@@ -1,0 +1,33 @@
+import opsgenie from "../../opsgenie.app.mjs";
+
+export default {
+  key: "opsgenie-list-alert-id-options",
+  name: "List Alert ID Options",
+  description: "Retrieves available options for the Alert ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    opsgenie,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await opsgenie.propDefinitions.alertId.options.call(this.opsgenie, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/opsgenie/package.json
+++ b/components/opsgenie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/opsgenie",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Pipedream Opsgenie Components",
   "main": "opsgenie.app.mjs",
   "keywords": [

--- a/components/orca_scan/actions/list-sheet-id-options/list-sheet-id-options.mjs
+++ b/components/orca_scan/actions/list-sheet-id-options/list-sheet-id-options.mjs
@@ -1,0 +1,33 @@
+import orca_scan from "../../orca_scan.app.mjs";
+
+export default {
+  key: "orca_scan-list-sheet-id-options",
+  name: "List Sheet ID Options",
+  description: "Retrieves available options for the Sheet ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    orca_scan,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await orca_scan.propDefinitions.sheetId.options.call(this.orca_scan, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/orca_scan/package.json
+++ b/components/orca_scan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/orca_scan",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Orca Scan Components",
   "main": "orca_scan.app.mjs",
   "keywords": [
@@ -16,4 +16,3 @@
     "@pipedream/platform": "^1.6.8"
   }
 }
-

--- a/components/order_desk/actions/list-order-id-options/list-order-id-options.mjs
+++ b/components/order_desk/actions/list-order-id-options/list-order-id-options.mjs
@@ -1,0 +1,33 @@
+import order_desk from "../../order_desk.app.mjs";
+
+export default {
+  key: "order_desk-list-order-id-options",
+  name: "List Order ID Options",
+  description: "Retrieves available options for the Order ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    order_desk,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await order_desk.propDefinitions.order_id.options.call(this.order_desk, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/order_desk/package.json
+++ b/components/order_desk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/order_desk",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream Order Desk Components",
   "main": "order_desk.app.mjs",
   "keywords": [

--- a/components/ortto/actions/list-user-email-options/list-user-email-options.mjs
+++ b/components/ortto/actions/list-user-email-options/list-user-email-options.mjs
@@ -1,0 +1,33 @@
+import ortto from "../../ortto.app.mjs";
+
+export default {
+  key: "ortto-list-user-email-options",
+  name: "List User Email Options",
+  description: "Retrieves available options for the User Email field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    ortto,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await ortto.propDefinitions.userEmail.options.call(this.ortto, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/ortto/package.json
+++ b/components/ortto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/ortto",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Ortto  Components",
   "main": "ortto.app.mjs",
   "keywords": [

--- a/components/oto/actions/list-order-id-options/list-order-id-options.mjs
+++ b/components/oto/actions/list-order-id-options/list-order-id-options.mjs
@@ -1,0 +1,33 @@
+import oto from "../../oto.app.mjs";
+
+export default {
+  key: "oto-list-order-id-options",
+  name: "List Order ID Options",
+  description: "Retrieves available options for the Order ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    oto,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await oto.propDefinitions.orderId.options.call(this.oto, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/oto/package.json
+++ b/components/oto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/oto",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream OTO Components",
   "main": "oto.app.mjs",
   "keywords": [

--- a/components/overloop/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/overloop/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -1,0 +1,33 @@
+import overloop from "../../overloop.app.mjs";
+
+export default {
+  key: "overloop-list-contact-id-options",
+  name: "List Contact ID Options",
+  description: "Retrieves available options for the Contact ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    overloop,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await overloop.propDefinitions.contactId.options.call(this.overloop, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/overloop/actions/list-deal-id-options/list-deal-id-options.mjs
+++ b/components/overloop/actions/list-deal-id-options/list-deal-id-options.mjs
@@ -1,0 +1,33 @@
+import overloop from "../../overloop.app.mjs";
+
+export default {
+  key: "overloop-list-deal-id-options",
+  name: "List Deal ID Options",
+  description: "Retrieves available options for the Deal ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    overloop,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await overloop.propDefinitions.dealId.options.call(this.overloop, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/overloop/actions/list-list-names-options/list-list-names-options.mjs
+++ b/components/overloop/actions/list-list-names-options/list-list-names-options.mjs
@@ -1,0 +1,33 @@
+import overloop from "../../overloop.app.mjs";
+
+export default {
+  key: "overloop-list-list-names-options",
+  name: "List List Names Options",
+  description: "Retrieves available options for the List Names field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    overloop,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await overloop.propDefinitions.listNames.options.call(this.overloop, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/overloop/actions/list-organization-id-options/list-organization-id-options.mjs
+++ b/components/overloop/actions/list-organization-id-options/list-organization-id-options.mjs
@@ -1,0 +1,33 @@
+import overloop from "../../overloop.app.mjs";
+
+export default {
+  key: "overloop-list-organization-id-options",
+  name: "List Organization ID Options",
+  description: "Retrieves available options for the Organization ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    overloop,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await overloop.propDefinitions.organizationId.options.call(this.overloop, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/overloop/actions/list-stage-id-options/list-stage-id-options.mjs
+++ b/components/overloop/actions/list-stage-id-options/list-stage-id-options.mjs
@@ -1,0 +1,33 @@
+import overloop from "../../overloop.app.mjs";
+
+export default {
+  key: "overloop-list-stage-id-options",
+  name: "List Stage ID Options",
+  description: "Retrieves available options for the Stage ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    overloop,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await overloop.propDefinitions.stageId.options.call(this.overloop, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/overloop/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/overloop/actions/list-user-id-options/list-user-id-options.mjs
@@ -1,0 +1,33 @@
+import overloop from "../../overloop.app.mjs";
+
+export default {
+  key: "overloop-list-user-id-options",
+  name: "List User ID Options",
+  description: "Retrieves available options for the User ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    overloop,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await overloop.propDefinitions.userId.options.call(this.overloop, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/overloop/package.json
+++ b/components/overloop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/overloop",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Pipedream Overloop Components",
   "main": "overloop.app.mjs",
   "keywords": [


### PR DESCRIPTION
Adds a batch of 72 new actions for retrieving prop options that accept the page parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added pagination support to option listings across multiple integrations, allowing users to browse through large datasets of available options
  * New action modules added for list options in Miestro, Mistral AI, Moaform, Moco, Mojo Helpdesk, and 40+ additional integrations

* **Updates**
  * Version bumps across component packages to support new pagination capabilities

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PipedreamHQ/pipedream/pull/20914?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->