### PR TITLE
Actions for page only prop options batch 9

### DIFF
--- a/components/pagerduty/actions/list-escalation-policy-id-options/list-escalation-policy-id-options.mjs
+++ b/components/pagerduty/actions/list-escalation-policy-id-options/list-escalation-policy-id-options.mjs
@@ -1,0 +1,34 @@
+import pagerduty from "../../pagerduty.app.mjs";
+
+export default {
+  key: "pagerduty-list-escalation-policy-id-options",
+  name: "List Escalation Policy ID Options",
+  description: "Retrieves available options for the Escalation Policy ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    pagerduty,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await pagerduty.propDefinitions.escalationPolicyId.options
+      .call(this.pagerduty, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/pagerduty/actions/list-oncall-schedule-id-options/list-oncall-schedule-id-options.mjs
+++ b/components/pagerduty/actions/list-oncall-schedule-id-options/list-oncall-schedule-id-options.mjs
@@ -1,0 +1,33 @@
+import pagerduty from "../../pagerduty.app.mjs";
+
+export default {
+  key: "pagerduty-list-oncall-schedule-id-options",
+  name: "List On-Call Schedule ID Options",
+  description: "Retrieves available options for the On-Call Schedule ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    pagerduty,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await pagerduty.propDefinitions.oncallScheduleId.options.call(this.pagerduty, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/pagerduty/actions/list-service-id-options/list-service-id-options.mjs
+++ b/components/pagerduty/actions/list-service-id-options/list-service-id-options.mjs
@@ -1,0 +1,33 @@
+import pagerduty from "../../pagerduty.app.mjs";
+
+export default {
+  key: "pagerduty-list-service-id-options",
+  name: "List Service ID Options",
+  description: "Retrieves available options for the Service ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    pagerduty,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await pagerduty.propDefinitions.serviceId.options.call(this.pagerduty, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/pagerduty/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/pagerduty/actions/list-user-id-options/list-user-id-options.mjs
@@ -1,0 +1,33 @@
+import pagerduty from "../../pagerduty.app.mjs";
+
+export default {
+  key: "pagerduty-list-user-id-options",
+  name: "List User ID Options",
+  description: "Retrieves available options for the User ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    pagerduty,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await pagerduty.propDefinitions.userId.options.call(this.pagerduty, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/pagerduty/package.json
+++ b/components/pagerduty/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/pagerduty",
-  "version": "0.3.9",
+  "version": "0.4.0",
   "description": "Pipedream Pagerduty Components",
   "main": "pagerduty.app.mjs",
   "keywords": [

--- a/components/pandadoc/actions/list-completed-document-id-options/list-completed-document-id-options.mjs
+++ b/components/pandadoc/actions/list-completed-document-id-options/list-completed-document-id-options.mjs
@@ -1,0 +1,33 @@
+import pandadoc from "../../pandadoc.app.mjs";
+
+export default {
+  key: "pandadoc-list-completed-document-id-options",
+  name: "List Completed Document Id Options",
+  description: "Retrieves available options for the Completed Document Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    pandadoc,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await pandadoc.propDefinitions.completedDocumentId.options.call(this.pandadoc, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/pandadoc/actions/list-document-folder-id-options/list-document-folder-id-options.mjs
+++ b/components/pandadoc/actions/list-document-folder-id-options/list-document-folder-id-options.mjs
@@ -1,0 +1,33 @@
+import pandadoc from "../../pandadoc.app.mjs";
+
+export default {
+  key: "pandadoc-list-document-folder-id-options",
+  name: "List Document Folder Id Options",
+  description: "Retrieves available options for the Document Folder Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    pandadoc,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await pandadoc.propDefinitions.documentFolderId.options.call(this.pandadoc, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/pandadoc/actions/list-document-id-options/list-document-id-options.mjs
+++ b/components/pandadoc/actions/list-document-id-options/list-document-id-options.mjs
@@ -1,0 +1,33 @@
+import pandadoc from "../../pandadoc.app.mjs";
+
+export default {
+  key: "pandadoc-list-document-id-options",
+  name: "List Document Id Options",
+  description: "Retrieves available options for the Document Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    pandadoc,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await pandadoc.propDefinitions.documentId.options.call(this.pandadoc, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/pandadoc/actions/list-template-id-options/list-template-id-options.mjs
+++ b/components/pandadoc/actions/list-template-id-options/list-template-id-options.mjs
@@ -1,0 +1,33 @@
+import pandadoc from "../../pandadoc.app.mjs";
+
+export default {
+  key: "pandadoc-list-template-id-options",
+  name: "List Template Id Options",
+  description: "Retrieves available options for the Template Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    pandadoc,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await pandadoc.propDefinitions.templateId.options.call(this.pandadoc, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/pandadoc/package.json
+++ b/components/pandadoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/pandadoc",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "Pipedream PandaDoc Components",
   "main": "pandadoc.app.mjs",
   "keywords": [

--- a/components/paperform/actions/list-form-id-options/list-form-id-options.mjs
+++ b/components/paperform/actions/list-form-id-options/list-form-id-options.mjs
@@ -1,0 +1,33 @@
+import paperform from "../../paperform.app.mjs";
+
+export default {
+  key: "paperform-list-form-id-options",
+  name: "List Form ID Options",
+  description: "Retrieves available options for the Form ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    paperform,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await paperform.propDefinitions.formId.options.call(this.paperform, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/paperform/package.json
+++ b/components/paperform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/paperform",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream PaperForm Components",
   "main": "paperform.app.mjs",
   "keywords": [

--- a/components/papersign/actions/list-document-id-options/list-document-id-options.mjs
+++ b/components/papersign/actions/list-document-id-options/list-document-id-options.mjs
@@ -1,0 +1,33 @@
+import papersign from "../../papersign.app.mjs";
+
+export default {
+  key: "papersign-list-document-id-options",
+  name: "List Document ID Options",
+  description: "Retrieves available options for the Document ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    papersign,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await papersign.propDefinitions.documentId.options.call(this.papersign, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/papersign/actions/list-folder-id-options/list-folder-id-options.mjs
+++ b/components/papersign/actions/list-folder-id-options/list-folder-id-options.mjs
@@ -1,0 +1,33 @@
+import papersign from "../../papersign.app.mjs";
+
+export default {
+  key: "papersign-list-folder-id-options",
+  name: "List Folder ID Options",
+  description: "Retrieves available options for the Folder ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    papersign,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await papersign.propDefinitions.folderId.options.call(this.papersign, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/papersign/actions/list-space-id-options/list-space-id-options.mjs
+++ b/components/papersign/actions/list-space-id-options/list-space-id-options.mjs
@@ -1,0 +1,33 @@
+import papersign from "../../papersign.app.mjs";
+
+export default {
+  key: "papersign-list-space-id-options",
+  name: "List Space ID Options",
+  description: "Retrieves available options for the Space ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    papersign,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await papersign.propDefinitions.spaceId.options.call(this.papersign, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/papersign/package.json
+++ b/components/papersign/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/papersign",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Papersign Components",
   "main": "papersign.app.mjs",
   "keywords": [

--- a/components/parma/actions/list-relationship-id-options/list-relationship-id-options.mjs
+++ b/components/parma/actions/list-relationship-id-options/list-relationship-id-options.mjs
@@ -1,0 +1,33 @@
+import parma from "../../parma.app.mjs";
+
+export default {
+  key: "parma-list-relationship-id-options",
+  name: "List Relationship ID Options",
+  description: "Retrieves available options for the Relationship ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    parma,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await parma.propDefinitions.relationshipId.options.call(this.parma, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/parma/package.json
+++ b/components/parma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/parma",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Parma Components",
   "main": "parma.app.mjs",
   "keywords": [

--- a/components/parseur/actions/list-parser-id-options/list-parser-id-options.mjs
+++ b/components/parseur/actions/list-parser-id-options/list-parser-id-options.mjs
@@ -1,0 +1,33 @@
+import parseur from "../../parseur.app.mjs";
+
+export default {
+  key: "parseur-list-parser-id-options",
+  name: "List Parser ID Options",
+  description: "Retrieves available options for the Parser ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    parseur,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await parseur.propDefinitions.parserId.options.call(this.parseur, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/parseur/package.json
+++ b/components/parseur/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/parseur",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "Pipedream Parseur Components",
   "main": "parseur.app.mjs",
   "keywords": [

--- a/components/paystack/actions/list-customer-code-options/list-customer-code-options.mjs
+++ b/components/paystack/actions/list-customer-code-options/list-customer-code-options.mjs
@@ -1,0 +1,33 @@
+import paystack from "../../paystack.app.mjs";
+
+export default {
+  key: "paystack-list-customer-code-options",
+  name: "List Customer Code Options",
+  description: "Retrieves available options for the Customer Code field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    paystack,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await paystack.propDefinitions.customerCode.options.call(this.paystack, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/paystack/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/paystack/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -1,0 +1,33 @@
+import paystack from "../../paystack.app.mjs";
+
+export default {
+  key: "paystack-list-customer-id-options",
+  name: "List Customer ID Options",
+  description: "Retrieves available options for the Customer ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    paystack,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await paystack.propDefinitions.customerID.options.call(this.paystack, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/paystack/actions/list-reference-options/list-reference-options.mjs
+++ b/components/paystack/actions/list-reference-options/list-reference-options.mjs
@@ -1,0 +1,33 @@
+import paystack from "../../paystack.app.mjs";
+
+export default {
+  key: "paystack-list-reference-options",
+  name: "List Reference Options",
+  description: "Retrieves available options for the Reference field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    paystack,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await paystack.propDefinitions.reference.options.call(this.paystack, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/paystack/actions/list-split-code-options/list-split-code-options.mjs
+++ b/components/paystack/actions/list-split-code-options/list-split-code-options.mjs
@@ -1,0 +1,33 @@
+import paystack from "../../paystack.app.mjs";
+
+export default {
+  key: "paystack-list-split-code-options",
+  name: "List Split Code Options",
+  description: "Retrieves available options for the Split Code field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    paystack,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await paystack.propDefinitions.splitCode.options.call(this.paystack, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/paystack/actions/list-transaction-id-options/list-transaction-id-options.mjs
+++ b/components/paystack/actions/list-transaction-id-options/list-transaction-id-options.mjs
@@ -1,0 +1,33 @@
+import paystack from "../../paystack.app.mjs";
+
+export default {
+  key: "paystack-list-transaction-id-options",
+  name: "List Transaction ID Options",
+  description: "Retrieves available options for the Transaction ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    paystack,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await paystack.propDefinitions.transactionID.options.call(this.paystack, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/paystack/actions/list-virtual-terminal-code-options/list-virtual-terminal-code-options.mjs
+++ b/components/paystack/actions/list-virtual-terminal-code-options/list-virtual-terminal-code-options.mjs
@@ -1,0 +1,33 @@
+import paystack from "../../paystack.app.mjs";
+
+export default {
+  key: "paystack-list-virtual-terminal-code-options",
+  name: "List Virtual Terminal Code Options",
+  description: "Retrieves available options for the Virtual Terminal Code field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    paystack,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await paystack.propDefinitions.virtualTerminalCode.options.call(this.paystack, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/paystack/package.json
+++ b/components/paystack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/paystack",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Pipedream Paystack Components",
   "main": "paystack.app.mjs",
   "keywords": [

--- a/components/pdffiller/actions/list-document-id-options/list-document-id-options.mjs
+++ b/components/pdffiller/actions/list-document-id-options/list-document-id-options.mjs
@@ -1,0 +1,33 @@
+import pdffiller from "../../pdffiller.app.mjs";
+
+export default {
+  key: "pdffiller-list-document-id-options",
+  name: "List Document ID Options",
+  description: "Retrieves available options for the Document ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    pdffiller,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await pdffiller.propDefinitions.documentId.options.call(this.pdffiller, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/pdffiller/actions/list-fillable-form-id-options/list-fillable-form-id-options.mjs
+++ b/components/pdffiller/actions/list-fillable-form-id-options/list-fillable-form-id-options.mjs
@@ -1,0 +1,33 @@
+import pdffiller from "../../pdffiller.app.mjs";
+
+export default {
+  key: "pdffiller-list-fillable-form-id-options",
+  name: "List Fillable Form ID Options",
+  description: "Retrieves available options for the Fillable Form ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    pdffiller,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await pdffiller.propDefinitions.fillableFormId.options.call(this.pdffiller, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/pdffiller/actions/list-folder-id-options/list-folder-id-options.mjs
+++ b/components/pdffiller/actions/list-folder-id-options/list-folder-id-options.mjs
@@ -1,0 +1,33 @@
+import pdffiller from "../../pdffiller.app.mjs";
+
+export default {
+  key: "pdffiller-list-folder-id-options",
+  name: "List Folder Id Options",
+  description: "Retrieves available options for the Folder Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    pdffiller,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await pdffiller.propDefinitions.folderId.options.call(this.pdffiller, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/pdffiller/package.json
+++ b/components/pdffiller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/pdffiller",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "Pipedream pdfFiller Components",
   "main": "pdffiller.app.mjs",
   "keywords": [

--- a/components/pdfless/actions/list-template-id-options/list-template-id-options.mjs
+++ b/components/pdfless/actions/list-template-id-options/list-template-id-options.mjs
@@ -1,0 +1,33 @@
+import pdfless from "../../pdfless.app.mjs";
+
+export default {
+  key: "pdfless-list-template-id-options",
+  name: "List Template ID Options",
+  description: "Retrieves available options for the Template ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    pdfless,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await pdfless.propDefinitions.templateId.options.call(this.pdfless, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/pdfless/package.json
+++ b/components/pdfless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/pdfless",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Pdfless Components",
   "main": "pdfless.app.mjs",
   "keywords": [

--- a/components/pdfmonkey/actions/list-document-id-options/list-document-id-options.mjs
+++ b/components/pdfmonkey/actions/list-document-id-options/list-document-id-options.mjs
@@ -1,0 +1,33 @@
+import pdfmonkey from "../../pdfmonkey.app.mjs";
+
+export default {
+  key: "pdfmonkey-list-document-id-options",
+  name: "List Document ID Options",
+  description: "Retrieves available options for the Document ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    pdfmonkey,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await pdfmonkey.propDefinitions.documentId.options.call(this.pdfmonkey, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/pdfmonkey/actions/list-template-id-options/list-template-id-options.mjs
+++ b/components/pdfmonkey/actions/list-template-id-options/list-template-id-options.mjs
@@ -1,0 +1,33 @@
+import pdfmonkey from "../../pdfmonkey.app.mjs";
+
+export default {
+  key: "pdfmonkey-list-template-id-options",
+  name: "List Template ID Options",
+  description: "Retrieves available options for the Template ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    pdfmonkey,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await pdfmonkey.propDefinitions.templateId.options.call(this.pdfmonkey, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/pdfmonkey/package.json
+++ b/components/pdfmonkey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/pdfmonkey",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream PDFMonkey Components",
   "main": "pdfmonkey.app.mjs",
   "keywords": [

--- a/components/pencil_spaces/actions/list-owner-id-options/list-owner-id-options.mjs
+++ b/components/pencil_spaces/actions/list-owner-id-options/list-owner-id-options.mjs
@@ -1,0 +1,33 @@
+import pencil_spaces from "../../pencil_spaces.app.mjs";
+
+export default {
+  key: "pencil_spaces-list-owner-id-options",
+  name: "List Owner Id Options",
+  description: "Retrieves available options for the Owner Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    pencil_spaces,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await pencil_spaces.propDefinitions.ownerId.options.call(this.pencil_spaces, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/pencil_spaces/actions/list-space-to-clone-id-options/list-space-to-clone-id-options.mjs
+++ b/components/pencil_spaces/actions/list-space-to-clone-id-options/list-space-to-clone-id-options.mjs
@@ -1,0 +1,34 @@
+import pencil_spaces from "../../pencil_spaces.app.mjs";
+
+export default {
+  key: "pencil_spaces-list-space-to-clone-id-options",
+  name: "List Space To Clone Id Options",
+  description: "Retrieves available options for the Space To Clone Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    pencil_spaces,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await pencil_spaces.propDefinitions.spaceToCloneId.options
+      .call(this.pencil_spaces, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/pencil_spaces/package.json
+++ b/components/pencil_spaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/pencil_spaces",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Pencil Spaces Components",
   "main": "pencil_spaces.app.mjs",
   "keywords": [

--- a/components/pennylane/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/pennylane/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -1,0 +1,33 @@
+import pennylane from "../../pennylane.app.mjs";
+
+export default {
+  key: "pennylane-list-customer-id-options",
+  name: "List Customer Id Options",
+  description: "Retrieves available options for the Customer Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    pennylane,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await pennylane.propDefinitions.customerId.options.call(this.pennylane, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/pennylane/package.json
+++ b/components/pennylane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/pennylane",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream Pennylane Components",
   "main": "pennylane.app.mjs",
   "keywords": [

--- a/components/permit_io/actions/list-proj-id-options/list-proj-id-options.mjs
+++ b/components/permit_io/actions/list-proj-id-options/list-proj-id-options.mjs
@@ -1,0 +1,33 @@
+import permit_io from "../../permit_io.app.mjs";
+
+export default {
+  key: "permit_io-list-proj-id-options",
+  name: "List Project ID Options",
+  description: "Retrieves available options for the Project ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    permit_io,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await permit_io.propDefinitions.projId.options.call(this.permit_io, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/permit_io/package.json
+++ b/components/permit_io/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/permit_io",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Permit.io Components",
   "main": "permit_io.app.mjs",
   "keywords": [

--- a/components/personio/package.json
+++ b/components/personio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/personio",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "description": "Pipedream Personio Components",
   "main": "personio.app.mjs",
   "keywords": [

--- a/components/personio/package.json
+++ b/components/personio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/personio",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Personio Components",
   "main": "personio.app.mjs",
   "keywords": [

--- a/components/php_point_of_sale/actions/list-register-id-options/list-register-id-options.mjs
+++ b/components/php_point_of_sale/actions/list-register-id-options/list-register-id-options.mjs
@@ -1,0 +1,34 @@
+import php_point_of_sale from "../../php_point_of_sale.app.mjs";
+
+export default {
+  key: "php_point_of_sale-list-register-id-options",
+  name: "List Register ID Options",
+  description: "Retrieves available options for the Register ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    php_point_of_sale,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await php_point_of_sale.propDefinitions.registerId.options
+      .call(this.php_point_of_sale, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/php_point_of_sale/package.json
+++ b/components/php_point_of_sale/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/php_point_of_sale",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream PHP Point of Sale Components",
   "main": "php_point_of_sale.app.mjs",
   "keywords": [

--- a/components/picqer/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/picqer/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -1,0 +1,33 @@
+import picqer from "../../picqer.app.mjs";
+
+export default {
+  key: "picqer-list-customer-id-options",
+  name: "List Customer ID Options",
+  description: "Retrieves available options for the Customer ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    picqer,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await picqer.propDefinitions.customerId.options.call(this.picqer, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/picqer/actions/list-fulfillment-customer-id-options/list-fulfillment-customer-id-options.mjs
+++ b/components/picqer/actions/list-fulfillment-customer-id-options/list-fulfillment-customer-id-options.mjs
@@ -1,0 +1,33 @@
+import picqer from "../../picqer.app.mjs";
+
+export default {
+  key: "picqer-list-fulfillment-customer-id-options",
+  name: "List Fulfillment Customer ID Options",
+  description: "Retrieves available options for the Fulfillment Customer ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    picqer,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await picqer.propDefinitions.fulfillmentCustomerId.options.call(this.picqer, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/picqer/actions/list-picklist-id-options/list-picklist-id-options.mjs
+++ b/components/picqer/actions/list-picklist-id-options/list-picklist-id-options.mjs
@@ -1,0 +1,33 @@
+import picqer from "../../picqer.app.mjs";
+
+export default {
+  key: "picqer-list-picklist-id-options",
+  name: "List Picklist ID Options",
+  description: "Retrieves available options for the Picklist ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    picqer,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await picqer.propDefinitions.picklistId.options.call(this.picqer, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/picqer/actions/list-product-id-options/list-product-id-options.mjs
+++ b/components/picqer/actions/list-product-id-options/list-product-id-options.mjs
@@ -1,0 +1,33 @@
+import picqer from "../../picqer.app.mjs";
+
+export default {
+  key: "picqer-list-product-id-options",
+  name: "List Product ID Options",
+  description: "Retrieves available options for the Product ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    picqer,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await picqer.propDefinitions.productId.options.call(this.picqer, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/picqer/actions/list-return-id-options/list-return-id-options.mjs
+++ b/components/picqer/actions/list-return-id-options/list-return-id-options.mjs
@@ -1,0 +1,33 @@
+import picqer from "../../picqer.app.mjs";
+
+export default {
+  key: "picqer-list-return-id-options",
+  name: "List Return ID Options",
+  description: "Retrieves available options for the Return ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    picqer,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await picqer.propDefinitions.returnId.options.call(this.picqer, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/picqer/actions/list-shipping-provider-id-options/list-shipping-provider-id-options.mjs
+++ b/components/picqer/actions/list-shipping-provider-id-options/list-shipping-provider-id-options.mjs
@@ -2,8 +2,8 @@ import picqer from "../../picqer.app.mjs";
 
 export default {
   key: "picqer-list-shipping-provider-id-options",
-  name: "List Shipping Provider Id Options",
-  description: "Retrieves available options for the Shipping Provider Id field.",
+  name: "List Shipping Provider ID Options",
+  description: "Retrieves available options for the Shipping Provider ID field.",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/picqer/actions/list-shipping-provider-id-options/list-shipping-provider-id-options.mjs
+++ b/components/picqer/actions/list-shipping-provider-id-options/list-shipping-provider-id-options.mjs
@@ -1,0 +1,33 @@
+import picqer from "../../picqer.app.mjs";
+
+export default {
+  key: "picqer-list-shipping-provider-id-options",
+  name: "List Shipping Provider Id Options",
+  description: "Retrieves available options for the Shipping Provider Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    picqer,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await picqer.propDefinitions.shippingProviderId.options.call(this.picqer, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/picqer/actions/list-tag-id-options/list-tag-id-options.mjs
+++ b/components/picqer/actions/list-tag-id-options/list-tag-id-options.mjs
@@ -1,0 +1,33 @@
+import picqer from "../../picqer.app.mjs";
+
+export default {
+  key: "picqer-list-tag-id-options",
+  name: "List Tag ID Options",
+  description: "Retrieves available options for the Tag ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    picqer,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await picqer.propDefinitions.tagId.options.call(this.picqer, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/picqer/actions/list-template-id-options/list-template-id-options.mjs
+++ b/components/picqer/actions/list-template-id-options/list-template-id-options.mjs
@@ -2,8 +2,8 @@ import picqer from "../../picqer.app.mjs";
 
 export default {
   key: "picqer-list-template-id-options",
-  name: "List Template Id Options",
-  description: "Retrieves available options for the Template Id field.",
+  name: "List Template ID Options",
+  description: "Retrieves available options for the Template ID field.",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/picqer/actions/list-template-id-options/list-template-id-options.mjs
+++ b/components/picqer/actions/list-template-id-options/list-template-id-options.mjs
@@ -1,0 +1,33 @@
+import picqer from "../../picqer.app.mjs";
+
+export default {
+  key: "picqer-list-template-id-options",
+  name: "List Template Id Options",
+  description: "Retrieves available options for the Template Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    picqer,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await picqer.propDefinitions.templateId.options.call(this.picqer, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/picqer/actions/list-warehouse-id-options/list-warehouse-id-options.mjs
+++ b/components/picqer/actions/list-warehouse-id-options/list-warehouse-id-options.mjs
@@ -1,0 +1,33 @@
+import picqer from "../../picqer.app.mjs";
+
+export default {
+  key: "picqer-list-warehouse-id-options",
+  name: "List Warehouse ID Options",
+  description: "Retrieves available options for the Warehouse ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    picqer,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await picqer.propDefinitions.warehouseId.options.call(this.picqer, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/picqer/package.json
+++ b/components/picqer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/picqer",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Picqer Components",
   "main": "picqer.app.mjs",
   "keywords": [

--- a/components/piggy/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/piggy/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -1,0 +1,33 @@
+import piggy from "../../piggy.app.mjs";
+
+export default {
+  key: "piggy-list-contact-id-options",
+  name: "List Contact ID Options",
+  description: "Retrieves available options for the Contact ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    piggy,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await piggy.propDefinitions.contactId.options.call(this.piggy, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/piggy/package.json
+++ b/components/piggy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/piggy",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream Piggy Components",
   "main": "piggy.app.mjs",
   "keywords": [

--- a/components/pipeline/actions/list-company-id-options/list-company-id-options.mjs
+++ b/components/pipeline/actions/list-company-id-options/list-company-id-options.mjs
@@ -1,0 +1,33 @@
+import pipeline from "../../pipeline.app.mjs";
+
+export default {
+  key: "pipeline-list-company-id-options",
+  name: "List Company ID Options",
+  description: "Retrieves available options for the Company ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    pipeline,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await pipeline.propDefinitions.companyId.options.call(this.pipeline, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/pipeline/actions/list-deal-id-options/list-deal-id-options.mjs
+++ b/components/pipeline/actions/list-deal-id-options/list-deal-id-options.mjs
@@ -1,0 +1,33 @@
+import pipeline from "../../pipeline.app.mjs";
+
+export default {
+  key: "pipeline-list-deal-id-options",
+  name: "List Deal ID Options",
+  description: "Retrieves available options for the Deal ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    pipeline,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await pipeline.propDefinitions.dealId.options.call(this.pipeline, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/pipeline/actions/list-deal-stage-id-options/list-deal-stage-id-options.mjs
+++ b/components/pipeline/actions/list-deal-stage-id-options/list-deal-stage-id-options.mjs
@@ -1,0 +1,33 @@
+import pipeline from "../../pipeline.app.mjs";
+
+export default {
+  key: "pipeline-list-deal-stage-id-options",
+  name: "List Deal Stage ID Options",
+  description: "Retrieves available options for the Deal Stage ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    pipeline,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await pipeline.propDefinitions.dealStageId.options.call(this.pipeline, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/pipeline/actions/list-deal-status-id-options/list-deal-status-id-options.mjs
+++ b/components/pipeline/actions/list-deal-status-id-options/list-deal-status-id-options.mjs
@@ -1,0 +1,33 @@
+import pipeline from "../../pipeline.app.mjs";
+
+export default {
+  key: "pipeline-list-deal-status-id-options",
+  name: "List Deal Status ID Options",
+  description: "Retrieves available options for the Deal Status ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    pipeline,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await pipeline.propDefinitions.dealStatusId.options.call(this.pipeline, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/pipeline/actions/list-event-category-id-options/list-event-category-id-options.mjs
+++ b/components/pipeline/actions/list-event-category-id-options/list-event-category-id-options.mjs
@@ -1,0 +1,33 @@
+import pipeline from "../../pipeline.app.mjs";
+
+export default {
+  key: "pipeline-list-event-category-id-options",
+  name: "List Event Category ID Options",
+  description: "Retrieves available options for the Event Category ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    pipeline,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await pipeline.propDefinitions.eventCategoryId.options.call(this.pipeline, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/pipeline/actions/list-note-category-id-options/list-note-category-id-options.mjs
+++ b/components/pipeline/actions/list-note-category-id-options/list-note-category-id-options.mjs
@@ -1,0 +1,33 @@
+import pipeline from "../../pipeline.app.mjs";
+
+export default {
+  key: "pipeline-list-note-category-id-options",
+  name: "List Note Category ID Options",
+  description: "Retrieves available options for the Note Category ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    pipeline,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await pipeline.propDefinitions.noteCategoryId.options.call(this.pipeline, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/pipeline/actions/list-person-id-options/list-person-id-options.mjs
+++ b/components/pipeline/actions/list-person-id-options/list-person-id-options.mjs
@@ -1,0 +1,33 @@
+import pipeline from "../../pipeline.app.mjs";
+
+export default {
+  key: "pipeline-list-person-id-options",
+  name: "List Person ID Options",
+  description: "Retrieves available options for the Person ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    pipeline,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await pipeline.propDefinitions.personId.options.call(this.pipeline, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/pipeline/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/pipeline/actions/list-user-id-options/list-user-id-options.mjs
@@ -1,0 +1,33 @@
+import pipeline from "../../pipeline.app.mjs";
+
+export default {
+  key: "pipeline-list-user-id-options",
+  name: "List User ID Options",
+  description: "Retrieves available options for the User ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    pipeline,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await pipeline.propDefinitions.userId.options.call(this.pipeline, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/pipeline/package.json
+++ b/components/pipeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/pipeline",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Pipedream Pipeline Components",
   "main": "pipeline.app.mjs",
   "keywords": [

--- a/components/pixiebrix/actions/list-organization-id-options/list-organization-id-options.mjs
+++ b/components/pixiebrix/actions/list-organization-id-options/list-organization-id-options.mjs
@@ -1,0 +1,33 @@
+import pixiebrix from "../../pixiebrix.app.mjs";
+
+export default {
+  key: "pixiebrix-list-organization-id-options",
+  name: "List Organization ID Options",
+  description: "Retrieves available options for the Organization ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    pixiebrix,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await pixiebrix.propDefinitions.organizationId.options.call(this.pixiebrix, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/pixiebrix/package.json
+++ b/components/pixiebrix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/pixiebrix",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream PixieBrix Components",
   "main": "pixiebrix.app.mjs",
   "keywords": [

--- a/components/plainly/actions/list-render-id-options/list-render-id-options.mjs
+++ b/components/plainly/actions/list-render-id-options/list-render-id-options.mjs
@@ -1,0 +1,33 @@
+import plainly from "../../plainly.app.mjs";
+
+export default {
+  key: "plainly-list-render-id-options",
+  name: "List Render ID Options",
+  description: "Retrieves available options for the Render ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    plainly,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await plainly.propDefinitions.renderId.options.call(this.plainly, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/plainly/package.json
+++ b/components/plainly/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/plainly",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Plainly Components",
   "main": "plainly.app.mjs",
   "keywords": [

--- a/components/planning_center/actions/list-list-id-options/list-list-id-options.mjs
+++ b/components/planning_center/actions/list-list-id-options/list-list-id-options.mjs
@@ -1,0 +1,34 @@
+import planning_center from "../../planning_center.app.mjs";
+
+export default {
+  key: "planning_center-list-list-id-options",
+  name: "List List ID Options",
+  description: "Retrieves available options for the List ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    planning_center,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await planning_center.propDefinitions.listId.options
+      .call(this.planning_center, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/planning_center/package.json
+++ b/components/planning_center/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/planning_center",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Planning Center Components",
   "main": "planning_center.app.mjs",
   "keywords": [

--- a/components/planview_leankit/actions/list-board-id-options/list-board-id-options.mjs
+++ b/components/planview_leankit/actions/list-board-id-options/list-board-id-options.mjs
@@ -1,0 +1,34 @@
+import planview_leankit from "../../planview_leankit.app.mjs";
+
+export default {
+  key: "planview_leankit-list-board-id-options",
+  name: "List Board ID Options",
+  description: "Retrieves available options for the Board ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    planview_leankit,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await planview_leankit.propDefinitions.boardId.options
+      .call(this.planview_leankit, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/planview_leankit/actions/list-planning-series-id-options/list-planning-series-id-options.mjs
+++ b/components/planview_leankit/actions/list-planning-series-id-options/list-planning-series-id-options.mjs
@@ -1,0 +1,34 @@
+import planview_leankit from "../../planview_leankit.app.mjs";
+
+export default {
+  key: "planview_leankit-list-planning-series-id-options",
+  name: "List Planning Series ID Options",
+  description: "Retrieves available options for the Planning Series ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    planview_leankit,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await planview_leankit.propDefinitions.planningSeriesId.options
+      .call(this.planview_leankit, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/planview_leankit/package.json
+++ b/components/planview_leankit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/planview_leankit",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Planview Leankit Components",
   "main": "planview_leankit.app.mjs",
   "keywords": [

--- a/components/planyo_online_booking/actions/list-resource-id-options/list-resource-id-options.mjs
+++ b/components/planyo_online_booking/actions/list-resource-id-options/list-resource-id-options.mjs
@@ -1,0 +1,34 @@
+import planyo_online_booking from "../../planyo_online_booking.app.mjs";
+
+export default {
+  key: "planyo_online_booking-list-resource-id-options",
+  name: "List Resource ID Options",
+  description: "Retrieves available options for the Resource ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    planyo_online_booking,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await planyo_online_booking.propDefinitions.resourceId.options
+      .call(this.planyo_online_booking, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/planyo_online_booking/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/planyo_online_booking/actions/list-user-id-options/list-user-id-options.mjs
@@ -1,0 +1,34 @@
+import planyo_online_booking from "../../planyo_online_booking.app.mjs";
+
+export default {
+  key: "planyo_online_booking-list-user-id-options",
+  name: "List User ID Options",
+  description: "Retrieves available options for the User ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    planyo_online_booking,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await planyo_online_booking.propDefinitions.userId.options
+      .call(this.planyo_online_booking, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/planyo_online_booking/package.json
+++ b/components/planyo_online_booking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/planyo_online_booking",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Pipedream Planyo Online Booking Components",
   "main": "planyo_online_booking.app.mjs",
   "keywords": [

--- a/components/plentyone/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/plentyone/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -1,0 +1,33 @@
+import plentyone from "../../plentyone.app.mjs";
+
+export default {
+  key: "plentyone-list-contact-id-options",
+  name: "List Contact ID Options",
+  description: "Retrieves available options for the Contact ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    plentyone,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await plentyone.propDefinitions.contactId.options.call(this.plentyone, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/plentyone/actions/list-country-id-options/list-country-id-options.mjs
+++ b/components/plentyone/actions/list-country-id-options/list-country-id-options.mjs
@@ -1,0 +1,33 @@
+import plentyone from "../../plentyone.app.mjs";
+
+export default {
+  key: "plentyone-list-country-id-options",
+  name: "List Country ID Options",
+  description: "Retrieves available options for the Country ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    plentyone,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await plentyone.propDefinitions.countryId.options.call(this.plentyone, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/plentyone/actions/list-order-id-options/list-order-id-options.mjs
+++ b/components/plentyone/actions/list-order-id-options/list-order-id-options.mjs
@@ -1,0 +1,33 @@
+import plentyone from "../../plentyone.app.mjs";
+
+export default {
+  key: "plentyone-list-order-id-options",
+  name: "List Order ID Options",
+  description: "Retrieves available options for the Order ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    plentyone,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await plentyone.propDefinitions.orderId.options.call(this.plentyone, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/plentyone/actions/list-status-id-options/list-status-id-options.mjs
+++ b/components/plentyone/actions/list-status-id-options/list-status-id-options.mjs
@@ -1,0 +1,33 @@
+import plentyone from "../../plentyone.app.mjs";
+
+export default {
+  key: "plentyone-list-status-id-options",
+  name: "List Status ID Options",
+  description: "Retrieves available options for the Status ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    plentyone,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await plentyone.propDefinitions.statusId.options.call(this.plentyone, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/plentyone/package.json
+++ b/components/plentyone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/plentyone",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream PlentyONE Components",
   "main": "plentyone.app.mjs",
   "keywords": [

--- a/components/postgrid/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/postgrid/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -1,0 +1,33 @@
+import postgrid from "../../postgrid.app.mjs";
+
+export default {
+  key: "postgrid-list-contact-id-options",
+  name: "List Contact Options",
+  description: "Retrieves available options for the Contact field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    postgrid,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await postgrid.propDefinitions.contactId.options.call(this.postgrid, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/postgrid/actions/list-return-envelope-id-options/list-return-envelope-id-options.mjs
+++ b/components/postgrid/actions/list-return-envelope-id-options/list-return-envelope-id-options.mjs
@@ -1,0 +1,33 @@
+import postgrid from "../../postgrid.app.mjs";
+
+export default {
+  key: "postgrid-list-return-envelope-id-options",
+  name: "List Return Envelope Options",
+  description: "Retrieves available options for the Return Envelope field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    postgrid,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await postgrid.propDefinitions.returnEnvelopeId.options.call(this.postgrid, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/postgrid/package.json
+++ b/components/postgrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/postgrid",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream PostGrid Print & Mail Components",
   "main": "postgrid.app.mjs",
   "keywords": [

--- a/components/postmark/actions/list-domain-id-options/list-domain-id-options.mjs
+++ b/components/postmark/actions/list-domain-id-options/list-domain-id-options.mjs
@@ -1,0 +1,33 @@
+import postmark from "../../postmark.app.mjs";
+
+export default {
+  key: "postmark-list-domain-id-options",
+  name: "List Domain Id Options",
+  description: "Retrieves available options for the Domain Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    postmark,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await postmark.propDefinitions.domainId.options.call(this.postmark, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/postmark/actions/list-server-id-options/list-server-id-options.mjs
+++ b/components/postmark/actions/list-server-id-options/list-server-id-options.mjs
@@ -1,0 +1,33 @@
+import postmark from "../../postmark.app.mjs";
+
+export default {
+  key: "postmark-list-server-id-options",
+  name: "List Server Id Options",
+  description: "Retrieves available options for the Server Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    postmark,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await postmark.propDefinitions.serverId.options.call(this.postmark, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/postmark/actions/list-signature-id-options/list-signature-id-options.mjs
+++ b/components/postmark/actions/list-signature-id-options/list-signature-id-options.mjs
@@ -1,0 +1,33 @@
+import postmark from "../../postmark.app.mjs";
+
+export default {
+  key: "postmark-list-signature-id-options",
+  name: "List Signature Id Options",
+  description: "Retrieves available options for the Signature Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    postmark,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await postmark.propDefinitions.signatureId.options.call(this.postmark, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/postmark/package.json
+++ b/components/postmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/postmark",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Pipedream Postmark Components",
   "main": "postmark.app.mjs",
   "keywords": [
@@ -16,4 +16,3 @@
     "@pipedream/platform": "^1.6.8"
   }
 }
-

--- a/components/predictleads/actions/list-technology-id-options/list-technology-id-options.mjs
+++ b/components/predictleads/actions/list-technology-id-options/list-technology-id-options.mjs
@@ -1,0 +1,34 @@
+import predictleads from "../../predictleads.app.mjs";
+
+export default {
+  key: "predictleads-list-technology-id-options",
+  name: "List Technology Options",
+  description: "Retrieves available options for the Technology field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    predictleads,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await predictleads.propDefinitions.technologyId.options
+      .call(this.predictleads, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/predictleads/package.json
+++ b/components/predictleads/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/predictleads",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream PredictLeads Components",
   "main": "predictleads.app.mjs",
   "keywords": [

--- a/components/pretix/actions/list-organizer-slug-options/list-organizer-slug-options.mjs
+++ b/components/pretix/actions/list-organizer-slug-options/list-organizer-slug-options.mjs
@@ -1,0 +1,33 @@
+import pretix from "../../pretix.app.mjs";
+
+export default {
+  key: "pretix-list-organizer-slug-options",
+  name: "List Organizer Slug Options",
+  description: "Retrieves available options for the Organizer Slug field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    pretix,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await pretix.propDefinitions.organizerSlug.options.call(this.pretix, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/pretix/package.json
+++ b/components/pretix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/pretix",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream pretix Components",
   "main": "pretix.app.mjs",
   "keywords": [
@@ -16,4 +16,3 @@
     "@pipedream/platform": "^1.6.8"
   }
 }
-

--- a/components/printavo/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/printavo/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -1,0 +1,33 @@
+import printavo from "../../printavo.app.mjs";
+
+export default {
+  key: "printavo-list-customer-id-options",
+  name: "List Customer Id Options",
+  description: "Retrieves available options for the Customer Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    printavo,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await printavo.propDefinitions.customerId.options.call(this.printavo, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/printavo/package.json
+++ b/components/printavo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/printavo",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "Pipedream Printavo Components",
   "main": "printavo.app.mjs",
   "keywords": [

--- a/components/printful/actions/list-store-id-options/list-store-id-options.mjs
+++ b/components/printful/actions/list-store-id-options/list-store-id-options.mjs
@@ -1,0 +1,33 @@
+import printful from "../../printful.app.mjs";
+
+export default {
+  key: "printful-list-store-id-options",
+  name: "List Store ID Options",
+  description: "Retrieves available options for the Store ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    printful,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await printful.propDefinitions.storeId.options.call(this.printful, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/printful/package.json
+++ b/components/printful/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/printful",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream Printful Components",
   "main": "printful.app.mjs",
   "keywords": [

--- a/components/proabono/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/proabono/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -1,0 +1,33 @@
+import proabono from "../../proabono.app.mjs";
+
+export default {
+  key: "proabono-list-customer-id-options",
+  name: "List Customer ID Options",
+  description: "Retrieves available options for the Customer ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    proabono,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await proabono.propDefinitions.customerId.options.call(this.proabono, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/proabono/actions/list-offer-id-options/list-offer-id-options.mjs
+++ b/components/proabono/actions/list-offer-id-options/list-offer-id-options.mjs
@@ -1,0 +1,33 @@
+import proabono from "../../proabono.app.mjs";
+
+export default {
+  key: "proabono-list-offer-id-options",
+  name: "List Offer ID Options",
+  description: "Retrieves available options for the Offer ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    proabono,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await proabono.propDefinitions.offerId.options.call(this.proabono, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/proabono/package.json
+++ b/components/proabono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/proabono",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream ProAbono Components",
   "main": "proabono.app.mjs",
   "keywords": [

--- a/components/procore/actions/list-company-id-options/list-company-id-options.mjs
+++ b/components/procore/actions/list-company-id-options/list-company-id-options.mjs
@@ -1,0 +1,33 @@
+import procore from "../../procore.app.mjs";
+
+export default {
+  key: "procore-list-company-id-options",
+  name: "List Company ID Options",
+  description: "Retrieves available options for the Company ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    procore,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await procore.propDefinitions.companyId.options.call(this.procore, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/procore/package.json
+++ b/components/procore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/procore",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Procore (OAuth) Components",
   "main": "procore.app.mjs",
   "keywords": [


### PR DESCRIPTION
Adds a batch of 73 new actions for retrieving prop options that accept the page parameter.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added list options actions for multiple integrations including PagerDuty, PandaDoc, Paperform, PaperSign, Paystack, PDFFiller, Picqer, Pipeline, and many others. These actions retrieve available selections for various entity fields such as Customer IDs, Document IDs, and other resource identifiers.

* **Chores**
  * Version bumps across multiple components to reflect new functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PipedreamHQ/pipedream/pull/20916?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->