### PR TITLE
Actions for page only prop options batch 10

### DIFF
--- a/components/prodpad/actions/list-company-id-options/list-company-id-options.mjs
+++ b/components/prodpad/actions/list-company-id-options/list-company-id-options.mjs
@@ -1,0 +1,33 @@
+import prodpad from "../../prodpad.app.mjs";
+
+export default {
+  key: "prodpad-list-company-id-options",
+  name: "List Company ID Options",
+  description: "Retrieves available options for the Company ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    prodpad,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await prodpad.propDefinitions.companyId.options.call(this.prodpad, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/prodpad/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/prodpad/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -1,0 +1,33 @@
+import prodpad from "../../prodpad.app.mjs";
+
+export default {
+  key: "prodpad-list-contact-id-options",
+  name: "List Contact ID Options",
+  description: "Retrieves available options for the Contact ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    prodpad,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await prodpad.propDefinitions.contactId.options.call(this.prodpad, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/prodpad/actions/list-feedback-id-options/list-feedback-id-options.mjs
+++ b/components/prodpad/actions/list-feedback-id-options/list-feedback-id-options.mjs
@@ -1,0 +1,33 @@
+import prodpad from "../../prodpad.app.mjs";
+
+export default {
+  key: "prodpad-list-feedback-id-options",
+  name: "List Feedback ID Options",
+  description: "Retrieves available options for the Feedback ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    prodpad,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await prodpad.propDefinitions.feedbackId.options.call(this.prodpad, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/prodpad/actions/list-idea-id-options/list-idea-id-options.mjs
+++ b/components/prodpad/actions/list-idea-id-options/list-idea-id-options.mjs
@@ -1,0 +1,33 @@
+import prodpad from "../../prodpad.app.mjs";
+
+export default {
+  key: "prodpad-list-idea-id-options",
+  name: "List Idea ID Options",
+  description: "Retrieves available options for the Idea ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    prodpad,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await prodpad.propDefinitions.ideaId.options.call(this.prodpad, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/prodpad/package.json
+++ b/components/prodpad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/prodpad",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream ProdPad Components",
   "main": "prodpad.app.mjs",
   "keywords": [

--- a/components/productive_io/actions/list-company-id-options/list-company-id-options.mjs
+++ b/components/productive_io/actions/list-company-id-options/list-company-id-options.mjs
@@ -1,0 +1,33 @@
+import productive_io from "../../productive_io.app.mjs";
+
+export default {
+  key: "productive_io-list-company-id-options",
+  name: "List Company ID Options",
+  description: "Retrieves available options for the Company ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    productive_io,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await productive_io.propDefinitions.companyId.options.call(this.productive_io, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/productive_io/actions/list-event-id-options/list-event-id-options.mjs
+++ b/components/productive_io/actions/list-event-id-options/list-event-id-options.mjs
@@ -1,0 +1,33 @@
+import productive_io from "../../productive_io.app.mjs";
+
+export default {
+  key: "productive_io-list-event-id-options",
+  name: "List Event ID Options",
+  description: "Retrieves available options for the Event ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    productive_io,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await productive_io.propDefinitions.eventId.options.call(this.productive_io, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/productive_io/actions/list-person-id-options/list-person-id-options.mjs
+++ b/components/productive_io/actions/list-person-id-options/list-person-id-options.mjs
@@ -1,0 +1,33 @@
+import productive_io from "../../productive_io.app.mjs";
+
+export default {
+  key: "productive_io-list-person-id-options",
+  name: "List Person ID Options",
+  description: "Retrieves available options for the Person ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    productive_io,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await productive_io.propDefinitions.personId.options.call(this.productive_io, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/productive_io/actions/list-project-id-options/list-project-id-options.mjs
+++ b/components/productive_io/actions/list-project-id-options/list-project-id-options.mjs
@@ -1,0 +1,33 @@
+import productive_io from "../../productive_io.app.mjs";
+
+export default {
+  key: "productive_io-list-project-id-options",
+  name: "List Project Options",
+  description: "Retrieves available options for the Project field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    productive_io,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await productive_io.propDefinitions.projectId.options.call(this.productive_io, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/productive_io/actions/list-project-id-options/list-project-id-options.mjs
+++ b/components/productive_io/actions/list-project-id-options/list-project-id-options.mjs
@@ -2,8 +2,8 @@ import productive_io from "../../productive_io.app.mjs";
 
 export default {
   key: "productive_io-list-project-id-options",
-  name: "List Project Options",
-  description: "Retrieves available options for the Project field.",
+  name: "List Project ID Options",
+  description: "Retrieves available options for the Project ID field.",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/productive_io/actions/list-service-id-options/list-service-id-options.mjs
+++ b/components/productive_io/actions/list-service-id-options/list-service-id-options.mjs
@@ -1,0 +1,33 @@
+import productive_io from "../../productive_io.app.mjs";
+
+export default {
+  key: "productive_io-list-service-id-options",
+  name: "List Service ID Options",
+  description: "Retrieves available options for the Service ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    productive_io,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await productive_io.propDefinitions.serviceId.options.call(this.productive_io, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/productive_io/package.json
+++ b/components/productive_io/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/productive_io",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Productive.io Components",
   "main": "productive_io.app.mjs",
   "keywords": [

--- a/components/project_broadcast/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/project_broadcast/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -1,0 +1,34 @@
+import project_broadcast from "../../project_broadcast.app.mjs";
+
+export default {
+  key: "project_broadcast-list-contact-id-options",
+  name: "List Contact ID Options",
+  description: "Retrieves available options for the Contact ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    project_broadcast,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await project_broadcast.propDefinitions.contactId.options
+      .call(this.project_broadcast, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/project_broadcast/actions/list-keyword-id-options/list-keyword-id-options.mjs
+++ b/components/project_broadcast/actions/list-keyword-id-options/list-keyword-id-options.mjs
@@ -1,0 +1,34 @@
+import project_broadcast from "../../project_broadcast.app.mjs";
+
+export default {
+  key: "project_broadcast-list-keyword-id-options",
+  name: "List Keyword ID Options",
+  description: "Retrieves available options for the Keyword ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    project_broadcast,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await project_broadcast.propDefinitions.keywordId.options
+      .call(this.project_broadcast, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/project_broadcast/package.json
+++ b/components/project_broadcast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/project_broadcast",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream Project Broadcast Components",
   "main": "project_broadcast.app.mjs",
   "keywords": [

--- a/components/proworkflow/actions/list-client-id-options/list-client-id-options.mjs
+++ b/components/proworkflow/actions/list-client-id-options/list-client-id-options.mjs
@@ -1,0 +1,33 @@
+import proworkflow from "../../proworkflow.app.mjs";
+
+export default {
+  key: "proworkflow-list-client-id-options",
+  name: "List Client ID Options",
+  description: "Retrieves available options for the Client ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    proworkflow,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await proworkflow.propDefinitions.clientId.options.call(this.proworkflow, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/proworkflow/actions/list-company-id-options/list-company-id-options.mjs
+++ b/components/proworkflow/actions/list-company-id-options/list-company-id-options.mjs
@@ -1,0 +1,33 @@
+import proworkflow from "../../proworkflow.app.mjs";
+
+export default {
+  key: "proworkflow-list-company-id-options",
+  name: "List Company ID Options",
+  description: "Retrieves available options for the Company ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    proworkflow,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await proworkflow.propDefinitions.companyId.options.call(this.proworkflow, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/proworkflow/actions/list-project-id-options/list-project-id-options.mjs
+++ b/components/proworkflow/actions/list-project-id-options/list-project-id-options.mjs
@@ -1,0 +1,33 @@
+import proworkflow from "../../proworkflow.app.mjs";
+
+export default {
+  key: "proworkflow-list-project-id-options",
+  name: "List Project ID Options",
+  description: "Retrieves available options for the Project ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    proworkflow,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await proworkflow.propDefinitions.projectId.options.call(this.proworkflow, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/proworkflow/actions/list-task-id-options/list-task-id-options.mjs
+++ b/components/proworkflow/actions/list-task-id-options/list-task-id-options.mjs
@@ -1,0 +1,33 @@
+import proworkflow from "../../proworkflow.app.mjs";
+
+export default {
+  key: "proworkflow-list-task-id-options",
+  name: "List Task ID Options",
+  description: "Retrieves available options for the Task ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    proworkflow,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await proworkflow.propDefinitions.taskId.options.call(this.proworkflow, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/proworkflow/package.json
+++ b/components/proworkflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/proworkflow",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Proworkflow Components",
   "main": "proworkflow.app.mjs",
   "keywords": [

--- a/components/qualiobee/actions/list-customer-uuid-options/list-customer-uuid-options.mjs
+++ b/components/qualiobee/actions/list-customer-uuid-options/list-customer-uuid-options.mjs
@@ -1,0 +1,33 @@
+import qualiobee from "../../qualiobee.app.mjs";
+
+export default {
+  key: "qualiobee-list-customer-uuid-options",
+  name: "List Customer UUID Options",
+  description: "Retrieves available options for the Customer UUID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    qualiobee,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await qualiobee.propDefinitions.customerUuid.options.call(this.qualiobee, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/qualiobee/actions/list-learner-uuid-options/list-learner-uuid-options.mjs
+++ b/components/qualiobee/actions/list-learner-uuid-options/list-learner-uuid-options.mjs
@@ -1,0 +1,33 @@
+import qualiobee from "../../qualiobee.app.mjs";
+
+export default {
+  key: "qualiobee-list-learner-uuid-options",
+  name: "List Learner UUID Options",
+  description: "Retrieves available options for the Learner UUID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    qualiobee,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await qualiobee.propDefinitions.learnerUuid.options.call(this.qualiobee, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/qualiobee/actions/list-module-uuid-options/list-module-uuid-options.mjs
+++ b/components/qualiobee/actions/list-module-uuid-options/list-module-uuid-options.mjs
@@ -1,0 +1,33 @@
+import qualiobee from "../../qualiobee.app.mjs";
+
+export default {
+  key: "qualiobee-list-module-uuid-options",
+  name: "List Module UUID Options",
+  description: "Retrieves available options for the Module UUID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    qualiobee,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await qualiobee.propDefinitions.moduleUuid.options.call(this.qualiobee, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/qualiobee/package.json
+++ b/components/qualiobee/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/qualiobee",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Qualiobee Components",
   "main": "qualiobee.app.mjs",
   "keywords": [

--- a/components/quickbooks/actions/list-account-ids-options/list-account-ids-options.mjs
+++ b/components/quickbooks/actions/list-account-ids-options/list-account-ids-options.mjs
@@ -1,0 +1,33 @@
+import quickbooks from "../../quickbooks.app.mjs";
+
+export default {
+  key: "quickbooks-list-account-ids-options",
+  name: "List Account IDs Options",
+  description: "Retrieves available options for the Account IDs field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    quickbooks,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await quickbooks.propDefinitions.accountIds.options.call(this.quickbooks, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/quickbooks/actions/list-bill-id-options/list-bill-id-options.mjs
+++ b/components/quickbooks/actions/list-bill-id-options/list-bill-id-options.mjs
@@ -1,0 +1,33 @@
+import quickbooks from "../../quickbooks.app.mjs";
+
+export default {
+  key: "quickbooks-list-bill-id-options",
+  name: "List Bill ID Options",
+  description: "Retrieves available options for the Bill ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    quickbooks,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await quickbooks.propDefinitions.billId.options.call(this.quickbooks, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/quickbooks/actions/list-class-ids-options/list-class-ids-options.mjs
+++ b/components/quickbooks/actions/list-class-ids-options/list-class-ids-options.mjs
@@ -1,0 +1,33 @@
+import quickbooks from "../../quickbooks.app.mjs";
+
+export default {
+  key: "quickbooks-list-class-ids-options",
+  name: "List Class IDs Options",
+  description: "Retrieves available options for the Class IDs field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    quickbooks,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await quickbooks.propDefinitions.classIds.options.call(this.quickbooks, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/quickbooks/actions/list-currency-options/list-currency-options.mjs
+++ b/components/quickbooks/actions/list-currency-options/list-currency-options.mjs
@@ -1,0 +1,33 @@
+import quickbooks from "../../quickbooks.app.mjs";
+
+export default {
+  key: "quickbooks-list-currency-options",
+  name: "List Currency Code Options",
+  description: "Retrieves available options for the Currency Code field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    quickbooks,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await quickbooks.propDefinitions.currency.options.call(this.quickbooks, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/quickbooks/actions/list-customer-options/list-customer-options.mjs
+++ b/components/quickbooks/actions/list-customer-options/list-customer-options.mjs
@@ -1,0 +1,33 @@
+import quickbooks from "../../quickbooks.app.mjs";
+
+export default {
+  key: "quickbooks-list-customer-options",
+  name: "List Customer Reference Options",
+  description: "Retrieves available options for the Customer Reference field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    quickbooks,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await quickbooks.propDefinitions.customer.options.call(this.quickbooks, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/quickbooks/actions/list-customer-type-options/list-customer-type-options.mjs
+++ b/components/quickbooks/actions/list-customer-type-options/list-customer-type-options.mjs
@@ -1,0 +1,33 @@
+import quickbooks from "../../quickbooks.app.mjs";
+
+export default {
+  key: "quickbooks-list-customer-type-options",
+  name: "List Customer Type Options",
+  description: "Retrieves available options for the Customer Type field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    quickbooks,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await quickbooks.propDefinitions.customerType.options.call(this.quickbooks, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/quickbooks/actions/list-department-ids-options/list-department-ids-options.mjs
+++ b/components/quickbooks/actions/list-department-ids-options/list-department-ids-options.mjs
@@ -1,0 +1,33 @@
+import quickbooks from "../../quickbooks.app.mjs";
+
+export default {
+  key: "quickbooks-list-department-ids-options",
+  name: "List Department IDs Options",
+  description: "Retrieves available options for the Department IDs field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    quickbooks,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await quickbooks.propDefinitions.departmentIds.options.call(this.quickbooks, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/quickbooks/actions/list-employee-ids-options/list-employee-ids-options.mjs
+++ b/components/quickbooks/actions/list-employee-ids-options/list-employee-ids-options.mjs
@@ -1,0 +1,33 @@
+import quickbooks from "../../quickbooks.app.mjs";
+
+export default {
+  key: "quickbooks-list-employee-ids-options",
+  name: "List Employee IDs Options",
+  description: "Retrieves available options for the Employee IDs field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    quickbooks,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await quickbooks.propDefinitions.employeeIds.options.call(this.quickbooks, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/quickbooks/actions/list-estimate-id-options/list-estimate-id-options.mjs
+++ b/components/quickbooks/actions/list-estimate-id-options/list-estimate-id-options.mjs
@@ -1,0 +1,33 @@
+import quickbooks from "../../quickbooks.app.mjs";
+
+export default {
+  key: "quickbooks-list-estimate-id-options",
+  name: "List Estimate ID Options",
+  description: "Retrieves available options for the Estimate ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    quickbooks,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await quickbooks.propDefinitions.estimateId.options.call(this.quickbooks, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/quickbooks/actions/list-invoice-id-options/list-invoice-id-options.mjs
+++ b/components/quickbooks/actions/list-invoice-id-options/list-invoice-id-options.mjs
@@ -1,0 +1,33 @@
+import quickbooks from "../../quickbooks.app.mjs";
+
+export default {
+  key: "quickbooks-list-invoice-id-options",
+  name: "List Invoice ID Options",
+  description: "Retrieves available options for the Invoice ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    quickbooks,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await quickbooks.propDefinitions.invoiceId.options.call(this.quickbooks, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/quickbooks/actions/list-item-id-options/list-item-id-options.mjs
+++ b/components/quickbooks/actions/list-item-id-options/list-item-id-options.mjs
@@ -1,0 +1,33 @@
+import quickbooks from "../../quickbooks.app.mjs";
+
+export default {
+  key: "quickbooks-list-item-id-options",
+  name: "List Item ID Options",
+  description: "Retrieves available options for the Item ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    quickbooks,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await quickbooks.propDefinitions.itemId.options.call(this.quickbooks, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/quickbooks/actions/list-payment-id-options/list-payment-id-options.mjs
+++ b/components/quickbooks/actions/list-payment-id-options/list-payment-id-options.mjs
@@ -1,0 +1,33 @@
+import quickbooks from "../../quickbooks.app.mjs";
+
+export default {
+  key: "quickbooks-list-payment-id-options",
+  name: "List Payment ID Options",
+  description: "Retrieves available options for the Payment ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    quickbooks,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await quickbooks.propDefinitions.paymentId.options.call(this.quickbooks, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/quickbooks/actions/list-payment-method-options/list-payment-method-options.mjs
+++ b/components/quickbooks/actions/list-payment-method-options/list-payment-method-options.mjs
@@ -1,0 +1,33 @@
+import quickbooks from "../../quickbooks.app.mjs";
+
+export default {
+  key: "quickbooks-list-payment-method-options",
+  name: "List Payment Method Options",
+  description: "Retrieves available options for the Payment Method field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    quickbooks,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await quickbooks.propDefinitions.paymentMethod.options.call(this.quickbooks, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/quickbooks/actions/list-purchase-id-options/list-purchase-id-options.mjs
+++ b/components/quickbooks/actions/list-purchase-id-options/list-purchase-id-options.mjs
@@ -1,0 +1,33 @@
+import quickbooks from "../../quickbooks.app.mjs";
+
+export default {
+  key: "quickbooks-list-purchase-id-options",
+  name: "List Purchase ID Options",
+  description: "Retrieves available options for the Purchase ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    quickbooks,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await quickbooks.propDefinitions.purchaseId.options.call(this.quickbooks, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/quickbooks/actions/list-purchase-order-id-options/list-purchase-order-id-options.mjs
+++ b/components/quickbooks/actions/list-purchase-order-id-options/list-purchase-order-id-options.mjs
@@ -1,0 +1,33 @@
+import quickbooks from "../../quickbooks.app.mjs";
+
+export default {
+  key: "quickbooks-list-purchase-order-id-options",
+  name: "List Purchase Order ID Options",
+  description: "Retrieves available options for the Purchase Order ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    quickbooks,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await quickbooks.propDefinitions.purchaseOrderId.options.call(this.quickbooks, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/quickbooks/actions/list-sales-receipt-id-options/list-sales-receipt-id-options.mjs
+++ b/components/quickbooks/actions/list-sales-receipt-id-options/list-sales-receipt-id-options.mjs
@@ -1,0 +1,33 @@
+import quickbooks from "../../quickbooks.app.mjs";
+
+export default {
+  key: "quickbooks-list-sales-receipt-id-options",
+  name: "List Sales Receipt ID Options",
+  description: "Retrieves available options for the Sales Receipt ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    quickbooks,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await quickbooks.propDefinitions.salesReceiptId.options.call(this.quickbooks, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/quickbooks/actions/list-tax-classification-id-options/list-tax-classification-id-options.mjs
+++ b/components/quickbooks/actions/list-tax-classification-id-options/list-tax-classification-id-options.mjs
@@ -1,0 +1,34 @@
+import quickbooks from "../../quickbooks.app.mjs";
+
+export default {
+  key: "quickbooks-list-tax-classification-id-options",
+  name: "List Tax Classification ID Options",
+  description: "Retrieves available options for the Tax Classification ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    quickbooks,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await quickbooks.propDefinitions.taxClassificationId.options
+      .call(this.quickbooks, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/quickbooks/actions/list-tax-code-id-options/list-tax-code-id-options.mjs
+++ b/components/quickbooks/actions/list-tax-code-id-options/list-tax-code-id-options.mjs
@@ -1,0 +1,33 @@
+import quickbooks from "../../quickbooks.app.mjs";
+
+export default {
+  key: "quickbooks-list-tax-code-id-options",
+  name: "List Tax Code ID Options",
+  description: "Retrieves available options for the Tax Code ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    quickbooks,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await quickbooks.propDefinitions.taxCodeId.options.call(this.quickbooks, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/quickbooks/actions/list-term-ids-options/list-term-ids-options.mjs
+++ b/components/quickbooks/actions/list-term-ids-options/list-term-ids-options.mjs
@@ -1,0 +1,33 @@
+import quickbooks from "../../quickbooks.app.mjs";
+
+export default {
+  key: "quickbooks-list-term-ids-options",
+  name: "List Term IDs Options",
+  description: "Retrieves available options for the Term IDs field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    quickbooks,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await quickbooks.propDefinitions.termIds.options.call(this.quickbooks, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/quickbooks/actions/list-time-activity-id-options/list-time-activity-id-options.mjs
+++ b/components/quickbooks/actions/list-time-activity-id-options/list-time-activity-id-options.mjs
@@ -1,0 +1,33 @@
+import quickbooks from "../../quickbooks.app.mjs";
+
+export default {
+  key: "quickbooks-list-time-activity-id-options",
+  name: "List Time Activity ID Options",
+  description: "Retrieves available options for the Time Activity ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    quickbooks,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await quickbooks.propDefinitions.timeActivityId.options.call(this.quickbooks, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/quickbooks/actions/list-vendor-ids-options/list-vendor-ids-options.mjs
+++ b/components/quickbooks/actions/list-vendor-ids-options/list-vendor-ids-options.mjs
@@ -1,0 +1,33 @@
+import quickbooks from "../../quickbooks.app.mjs";
+
+export default {
+  key: "quickbooks-list-vendor-ids-options",
+  name: "List Vendor IDs Options",
+  description: "Retrieves available options for the Vendor IDs field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    quickbooks,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await quickbooks.propDefinitions.vendorIds.options.call(this.quickbooks, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/quickbooks/actions/list-vendor-options/list-vendor-options.mjs
+++ b/components/quickbooks/actions/list-vendor-options/list-vendor-options.mjs
@@ -1,0 +1,33 @@
+import quickbooks from "../../quickbooks.app.mjs";
+
+export default {
+  key: "quickbooks-list-vendor-options",
+  name: "List Vendor Reference Options",
+  description: "Retrieves available options for the Vendor Reference field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    quickbooks,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await quickbooks.propDefinitions.vendor.options.call(this.quickbooks, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/quickbooks/package.json
+++ b/components/quickbooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/quickbooks",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Pipedream Quickbooks Components",
   "main": "quickbooks.app.mjs",
   "keywords": [

--- a/components/raisely/actions/list-campaign-id-options/list-campaign-id-options.mjs
+++ b/components/raisely/actions/list-campaign-id-options/list-campaign-id-options.mjs
@@ -1,0 +1,33 @@
+import raisely from "../../raisely.app.mjs";
+
+export default {
+  key: "raisely-list-campaign-id-options",
+  name: "List Campaign Options",
+  description: "Retrieves available options for the Campaign field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    raisely,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await raisely.propDefinitions.campaignId.options.call(this.raisely, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/raisely/package.json
+++ b/components/raisely/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/raisely",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Raisely Components",
   "main": "raisely.app.mjs",
   "keywords": [

--- a/components/readwise/actions/list-book-id-options/list-book-id-options.mjs
+++ b/components/readwise/actions/list-book-id-options/list-book-id-options.mjs
@@ -1,0 +1,33 @@
+import readwise from "../../readwise.app.mjs";
+
+export default {
+  key: "readwise-list-book-id-options",
+  name: "List Book Id Options",
+  description: "Retrieves available options for the Book Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    readwise,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await readwise.propDefinitions.bookId.options.call(this.readwise, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/readwise/package.json
+++ b/components/readwise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/readwise",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Readwise Components",
   "main": "readwise.app.mjs",
   "keywords": [

--- a/components/recharge/actions/list-address-id-options/list-address-id-options.mjs
+++ b/components/recharge/actions/list-address-id-options/list-address-id-options.mjs
@@ -1,0 +1,33 @@
+import recharge from "../../recharge.app.mjs";
+
+export default {
+  key: "recharge-list-address-id-options",
+  name: "List Address ID Options",
+  description: "Retrieves available options for the Address ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    recharge,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await recharge.propDefinitions.addressId.options.call(this.recharge, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/recharge/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/recharge/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -1,0 +1,33 @@
+import recharge from "../../recharge.app.mjs";
+
+export default {
+  key: "recharge-list-customer-id-options",
+  name: "List Customer ID Options",
+  description: "Retrieves available options for the Customer ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    recharge,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await recharge.propDefinitions.customerId.options.call(this.recharge, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/recharge/actions/list-external-variant-id-options/list-external-variant-id-options.mjs
+++ b/components/recharge/actions/list-external-variant-id-options/list-external-variant-id-options.mjs
@@ -1,0 +1,33 @@
+import recharge from "../../recharge.app.mjs";
+
+export default {
+  key: "recharge-list-external-variant-id-options",
+  name: "List External Variant ID Options",
+  description: "Retrieves available options for the External Variant ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    recharge,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await recharge.propDefinitions.externalVariantId.options.call(this.recharge, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/recharge/actions/list-subscription-id-options/list-subscription-id-options.mjs
+++ b/components/recharge/actions/list-subscription-id-options/list-subscription-id-options.mjs
@@ -1,0 +1,33 @@
+import recharge from "../../recharge.app.mjs";
+
+export default {
+  key: "recharge-list-subscription-id-options",
+  name: "List Subscription ID Options",
+  description: "Retrieves available options for the Subscription ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    recharge,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await recharge.propDefinitions.subscriptionId.options.call(this.recharge, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/recharge/package.json
+++ b/components/recharge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/recharge",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Recharge Components",
   "main": "recharge.app.mjs",
   "keywords": [

--- a/components/recreation_gov/actions/list-activities-options/list-activities-options.mjs
+++ b/components/recreation_gov/actions/list-activities-options/list-activities-options.mjs
@@ -1,0 +1,34 @@
+import recreation_gov from "../../recreation_gov.app.mjs";
+
+export default {
+  key: "recreation_gov-list-activities-options",
+  name: "List Activities Options",
+  description: "Retrieves available options for the Activities field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    recreation_gov,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await recreation_gov.propDefinitions.activities.options
+      .call(this.recreation_gov, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/recreation_gov/actions/list-campsite-id-options/list-campsite-id-options.mjs
+++ b/components/recreation_gov/actions/list-campsite-id-options/list-campsite-id-options.mjs
@@ -1,0 +1,34 @@
+import recreation_gov from "../../recreation_gov.app.mjs";
+
+export default {
+  key: "recreation_gov-list-campsite-id-options",
+  name: "List Campsite Id Options",
+  description: "Retrieves available options for the Campsite Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    recreation_gov,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await recreation_gov.propDefinitions.campsiteId.options
+      .call(this.recreation_gov, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/recreation_gov/actions/list-rec-area-id-options/list-rec-area-id-options.mjs
+++ b/components/recreation_gov/actions/list-rec-area-id-options/list-rec-area-id-options.mjs
@@ -1,0 +1,34 @@
+import recreation_gov from "../../recreation_gov.app.mjs";
+
+export default {
+  key: "recreation_gov-list-rec-area-id-options",
+  name: "List Recreation Area Id Options",
+  description: "Retrieves available options for the Recreation Area Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    recreation_gov,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await recreation_gov.propDefinitions.recAreaId.options
+      .call(this.recreation_gov, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/recreation_gov/package.json
+++ b/components/recreation_gov/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/recreation_gov",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "Pipedream Recreation.gov Components",
   "main": "recreation_gov.app.mjs",
   "keywords": [

--- a/components/recruiterflow/actions/list-candidate-id-options/list-candidate-id-options.mjs
+++ b/components/recruiterflow/actions/list-candidate-id-options/list-candidate-id-options.mjs
@@ -1,0 +1,34 @@
+import recruiterflow from "../../recruiterflow.app.mjs";
+
+export default {
+  key: "recruiterflow-list-candidate-id-options",
+  name: "List Candidate ID Options",
+  description: "Retrieves available options for the Candidate ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    recruiterflow,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await recruiterflow.propDefinitions.candidateId.options
+      .call(this.recruiterflow, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/recruiterflow/actions/list-company-id-options/list-company-id-options.mjs
+++ b/components/recruiterflow/actions/list-company-id-options/list-company-id-options.mjs
@@ -1,0 +1,33 @@
+import recruiterflow from "../../recruiterflow.app.mjs";
+
+export default {
+  key: "recruiterflow-list-company-id-options",
+  name: "List Company ID Options",
+  description: "Retrieves available options for the Company ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    recruiterflow,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await recruiterflow.propDefinitions.companyId.options.call(this.recruiterflow, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/recruiterflow/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/recruiterflow/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -1,0 +1,33 @@
+import recruiterflow from "../../recruiterflow.app.mjs";
+
+export default {
+  key: "recruiterflow-list-contact-id-options",
+  name: "List Contact ID Options",
+  description: "Retrieves available options for the Contact ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    recruiterflow,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await recruiterflow.propDefinitions.contactId.options.call(this.recruiterflow, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/recruiterflow/actions/list-job-id-options/list-job-id-options.mjs
+++ b/components/recruiterflow/actions/list-job-id-options/list-job-id-options.mjs
@@ -1,0 +1,33 @@
+import recruiterflow from "../../recruiterflow.app.mjs";
+
+export default {
+  key: "recruiterflow-list-job-id-options",
+  name: "List Job ID Options",
+  description: "Retrieves available options for the Job ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    recruiterflow,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await recruiterflow.propDefinitions.jobId.options.call(this.recruiterflow, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/recruiterflow/package.json
+++ b/components/recruiterflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/recruiterflow",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Recruiterflow Components",
   "main": "recruiterflow.app.mjs",
   "keywords": [

--- a/components/referralhero/actions/list-list-id-options/list-list-id-options.mjs
+++ b/components/referralhero/actions/list-list-id-options/list-list-id-options.mjs
@@ -1,0 +1,33 @@
+import referralhero from "../../referralhero.app.mjs";
+
+export default {
+  key: "referralhero-list-list-id-options",
+  name: "List List Options",
+  description: "Retrieves available options for the List field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    referralhero,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await referralhero.propDefinitions.listId.options.call(this.referralhero, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/referralhero/package.json
+++ b/components/referralhero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/referralhero",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream ReferralHero Components",
   "main": "referralhero.app.mjs",
   "keywords": [

--- a/components/referrizer/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/referrizer/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -1,0 +1,33 @@
+import referrizer from "../../referrizer.app.mjs";
+
+export default {
+  key: "referrizer-list-contact-id-options",
+  name: "List Contact ID Options",
+  description: "Retrieves available options for the Contact ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    referrizer,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await referrizer.propDefinitions.contactId.options.call(this.referrizer, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/referrizer/actions/list-loyalty-reward-id-options/list-loyalty-reward-id-options.mjs
+++ b/components/referrizer/actions/list-loyalty-reward-id-options/list-loyalty-reward-id-options.mjs
@@ -1,0 +1,33 @@
+import referrizer from "../../referrizer.app.mjs";
+
+export default {
+  key: "referrizer-list-loyalty-reward-id-options",
+  name: "List Loyalty Reward ID Options",
+  description: "Retrieves available options for the Loyalty Reward ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    referrizer,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await referrizer.propDefinitions.loyaltyRewardId.options.call(this.referrizer, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/referrizer/package.json
+++ b/components/referrizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/referrizer",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Referrizer Components",
   "main": "referrizer.app.mjs",
   "keywords": [
@@ -16,4 +16,3 @@
     "@pipedream/platform": "^1.6.8"
   }
 }
-

--- a/components/refersion/actions/list-affiliate-id-options/list-affiliate-id-options.mjs
+++ b/components/refersion/actions/list-affiliate-id-options/list-affiliate-id-options.mjs
@@ -1,0 +1,33 @@
+import refersion from "../../refersion.app.mjs";
+
+export default {
+  key: "refersion-list-affiliate-id-options",
+  name: "List Affiliate ID Options",
+  description: "Retrieves available options for the Affiliate ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    refersion,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await refersion.propDefinitions.affiliateId.options.call(this.refersion, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/refersion/package.json
+++ b/components/refersion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/refersion",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "description": "Pipedream Refersion Components",
   "main": "refersion.app.mjs",
   "keywords": [

--- a/components/refiner/actions/list-segment-id-options/list-segment-id-options.mjs
+++ b/components/refiner/actions/list-segment-id-options/list-segment-id-options.mjs
@@ -1,0 +1,33 @@
+import refiner from "../../refiner.app.mjs";
+
+export default {
+  key: "refiner-list-segment-id-options",
+  name: "List Segment ID Options",
+  description: "Retrieves available options for the Segment ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    refiner,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await refiner.propDefinitions.segmentId.options.call(this.refiner, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/refiner/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/refiner/actions/list-user-id-options/list-user-id-options.mjs
@@ -1,0 +1,33 @@
+import refiner from "../../refiner.app.mjs";
+
+export default {
+  key: "refiner-list-user-id-options",
+  name: "List User ID Options",
+  description: "Retrieves available options for the User ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    refiner,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await refiner.propDefinitions.userId.options.call(this.refiner, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/refiner/package.json
+++ b/components/refiner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/refiner",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Refiner Components",
   "main": "refiner.app.mjs",
   "keywords": [

--- a/components/relevance_ai/actions/list-tool-id-options/list-tool-id-options.mjs
+++ b/components/relevance_ai/actions/list-tool-id-options/list-tool-id-options.mjs
@@ -1,0 +1,33 @@
+import relevance_ai from "../../relevance_ai.app.mjs";
+
+export default {
+  key: "relevance_ai-list-tool-id-options",
+  name: "List Tool ID Options",
+  description: "Retrieves available options for the Tool ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    relevance_ai,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await relevance_ai.propDefinitions.toolId.options.call(this.relevance_ai, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/relevance_ai/package.json
+++ b/components/relevance_ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/relevance_ai",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Relevance AI Components",
   "main": "relevance_ai.app.mjs",
   "keywords": [
@@ -16,4 +16,3 @@
     "@pipedream/platform": "^1.6.8"
   }
 }
-

--- a/components/remote/actions/list-employment-id-options/list-employment-id-options.mjs
+++ b/components/remote/actions/list-employment-id-options/list-employment-id-options.mjs
@@ -1,0 +1,33 @@
+import remote from "../../remote.app.mjs";
+
+export default {
+  key: "remote-list-employment-id-options",
+  name: "List Employment ID Options",
+  description: "Retrieves available options for the Employment ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    remote,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await remote.propDefinitions.employmentId.options.call(this.remote, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/remote/package.json
+++ b/components/remote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/remote",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream Remote Components",
   "main": "remote.app.mjs",
   "keywords": [

--- a/components/renderform/actions/list-template-options/list-template-options.mjs
+++ b/components/renderform/actions/list-template-options/list-template-options.mjs
@@ -1,0 +1,33 @@
+import renderform from "../../renderform.app.mjs";
+
+export default {
+  key: "renderform-list-template-options",
+  name: "List Template Options",
+  description: "Retrieves available options for the Template field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    renderform,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await renderform.propDefinitions.template.options.call(this.renderform, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/renderform/package.json
+++ b/components/renderform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/renderform",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream RenderForm Components",
   "main": "renderform.app.mjs",
   "keywords": [

--- a/components/repairshopr/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/repairshopr/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -1,0 +1,33 @@
+import repairshopr from "../../repairshopr.app.mjs";
+
+export default {
+  key: "repairshopr-list-customer-id-options",
+  name: "List Customer ID Options",
+  description: "Retrieves available options for the Customer ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    repairshopr,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await repairshopr.propDefinitions.customerId.options.call(this.repairshopr, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/repairshopr/package.json
+++ b/components/repairshopr/package.json
@@ -1,18 +1,18 @@
 {
-    "name": "@pipedream/repairshopr",
-    "version": "0.0.3",
-    "description": "Pipedream Repairshopr Components",
-    "main": "repairshopr.app.mjs",
-    "keywords": [
-        "pipedream",
-        "repairshopr"
-    ],
-    "homepage": "https://pipedream.com/apps/repairshopr",
-    "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
-    "publishConfig": {
-        "access": "public"
-    },
-    "dependencies": {
-        "@pipedream/platform": "^1.6.8"
-    }
+  "name": "@pipedream/repairshopr",
+  "version": "0.1.0",
+  "description": "Pipedream Repairshopr Components",
+  "main": "repairshopr.app.mjs",
+  "keywords": [
+    "pipedream",
+    "repairshopr"
+  ],
+  "homepage": "https://pipedream.com/apps/repairshopr",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^1.6.8"
+  }
 }

--- a/components/resource_guru/actions/list-booker-id-options/list-booker-id-options.mjs
+++ b/components/resource_guru/actions/list-booker-id-options/list-booker-id-options.mjs
@@ -1,0 +1,33 @@
+import resource_guru from "../../resource_guru.app.mjs";
+
+export default {
+  key: "resource_guru-list-booker-id-options",
+  name: "List Booker Id Options",
+  description: "Retrieves available options for the Booker Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    resource_guru,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await resource_guru.propDefinitions.bookerId.options.call(this.resource_guru, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/resource_guru/actions/list-booking-id-options/list-booking-id-options.mjs
+++ b/components/resource_guru/actions/list-booking-id-options/list-booking-id-options.mjs
@@ -1,0 +1,33 @@
+import resource_guru from "../../resource_guru.app.mjs";
+
+export default {
+  key: "resource_guru-list-booking-id-options",
+  name: "List Booking Id Options",
+  description: "Retrieves available options for the Booking Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    resource_guru,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await resource_guru.propDefinitions.bookingId.options.call(this.resource_guru, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/resource_guru/actions/list-client-id-options/list-client-id-options.mjs
+++ b/components/resource_guru/actions/list-client-id-options/list-client-id-options.mjs
@@ -1,0 +1,33 @@
+import resource_guru from "../../resource_guru.app.mjs";
+
+export default {
+  key: "resource_guru-list-client-id-options",
+  name: "List Client Id Options",
+  description: "Retrieves available options for the Client Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    resource_guru,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await resource_guru.propDefinitions.clientId.options.call(this.resource_guru, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/resource_guru/actions/list-project-id-options/list-project-id-options.mjs
+++ b/components/resource_guru/actions/list-project-id-options/list-project-id-options.mjs
@@ -1,0 +1,33 @@
+import resource_guru from "../../resource_guru.app.mjs";
+
+export default {
+  key: "resource_guru-list-project-id-options",
+  name: "List Project Id Options",
+  description: "Retrieves available options for the Project Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    resource_guru,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await resource_guru.propDefinitions.projectId.options.call(this.resource_guru, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/resource_guru/actions/list-resource-ids-options/list-resource-ids-options.mjs
+++ b/components/resource_guru/actions/list-resource-ids-options/list-resource-ids-options.mjs
@@ -1,0 +1,34 @@
+import resource_guru from "../../resource_guru.app.mjs";
+
+export default {
+  key: "resource_guru-list-resource-ids-options",
+  name: "List Resource Ids Options",
+  description: "Retrieves available options for the Resource Ids field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    resource_guru,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await resource_guru.propDefinitions.resourceIds.options
+      .call(this.resource_guru, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/resource_guru/package.json
+++ b/components/resource_guru/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/resource_guru",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Resource Guru Components",
   "main": "resource_guru.app.mjs",
   "keywords": [

--- a/components/retently/actions/list-response-id-options/list-response-id-options.mjs
+++ b/components/retently/actions/list-response-id-options/list-response-id-options.mjs
@@ -1,0 +1,33 @@
+import retently from "../../retently.app.mjs";
+
+export default {
+  key: "retently-list-response-id-options",
+  name: "List Response Options",
+  description: "Retrieves available options for the Response field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    retently,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await retently.propDefinitions.responseId.options.call(this.retently, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/retently/package.json
+++ b/components/retently/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/retently",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Retently Components",
   "main": "retently.app.mjs",
   "keywords": [

--- a/components/rex/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/rex/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -1,0 +1,33 @@
+import rex from "../../rex.app.mjs";
+
+export default {
+  key: "rex-list-contact-id-options",
+  name: "List Contact Options",
+  description: "Retrieves available options for the Contact field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    rex,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await rex.propDefinitions.contactId.options.call(this.rex, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/rex/actions/list-listing-id-options/list-listing-id-options.mjs
+++ b/components/rex/actions/list-listing-id-options/list-listing-id-options.mjs
@@ -1,0 +1,33 @@
+import rex from "../../rex.app.mjs";
+
+export default {
+  key: "rex-list-listing-id-options",
+  name: "List Listing Options",
+  description: "Retrieves available options for the Listing field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    rex,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await rex.propDefinitions.listingId.options.call(this.rex, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/rex/actions/list-project-id-options/list-project-id-options.mjs
+++ b/components/rex/actions/list-project-id-options/list-project-id-options.mjs
@@ -1,0 +1,33 @@
+import rex from "../../rex.app.mjs";
+
+export default {
+  key: "rex-list-project-id-options",
+  name: "List Project Options",
+  description: "Retrieves available options for the Project field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    rex,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await rex.propDefinitions.projectId.options.call(this.rex, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/rex/actions/list-project-stage-id-options/list-project-stage-id-options.mjs
+++ b/components/rex/actions/list-project-stage-id-options/list-project-stage-id-options.mjs
@@ -1,0 +1,33 @@
+import rex from "../../rex.app.mjs";
+
+export default {
+  key: "rex-list-project-stage-id-options",
+  name: "List Project Stage Options",
+  description: "Retrieves available options for the Project Stage field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    rex,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await rex.propDefinitions.projectStageId.options.call(this.rex, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/rex/actions/list-property-id-options/list-property-id-options.mjs
+++ b/components/rex/actions/list-property-id-options/list-property-id-options.mjs
@@ -1,0 +1,33 @@
+import rex from "../../rex.app.mjs";
+
+export default {
+  key: "rex-list-property-id-options",
+  name: "List Property Options",
+  description: "Retrieves available options for the Property field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    rex,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await rex.propDefinitions.propertyId.options.call(this.rex, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/rex/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/rex/actions/list-user-id-options/list-user-id-options.mjs
@@ -2,8 +2,8 @@ import rex from "../../rex.app.mjs";
 
 export default {
   key: "rex-list-user-id-options",
-  name: "List Remindee Options",
-  description: "Retrieves available options for the Remindee field.",
+  name: "List User ID Options",
+  description: "Retrieves available options for the User ID field.",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/rex/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/rex/actions/list-user-id-options/list-user-id-options.mjs
@@ -1,0 +1,33 @@
+import rex from "../../rex.app.mjs";
+
+export default {
+  key: "rex-list-user-id-options",
+  name: "List Remindee Options",
+  description: "Retrieves available options for the Remindee field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    rex,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await rex.propDefinitions.userId.options.call(this.rex, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/rex/package.json
+++ b/components/rex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/rex",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Rex Components",
   "main": "rex.app.mjs",
   "keywords": [


### PR DESCRIPTION
Adds a batch of 75 new actions for retrieving prop options that accept the page parameter.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* **List Options Actions**: Added pagination-enabled list actions across 30+ integrations for retrieving available options for various entity types (contacts, companies, projects, customers, etc.). Users can now fetch and reference these option sets when configuring workflows.

## Chores

* **Package Version Updates**: Bumped minor versions for ProdPad, Productive.io, Project Broadcast, ProWorkflow, Qualiobee, QuickBooks, Raisely, Readwise, Recharge, Recreation.gov, Recruiterflow, Referral Hero, Referrizer, Refersion, Refiner, Relevance AI, Remote, Renderform, RepairShopr, Resource Guru, Retently, and Rex.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PipedreamHQ/pipedream/pull/20917?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->