### PR TITLE
Actions for page only prop options batch 13

### DIFF
--- a/components/teamleader_focus/actions/list-business-type-options/list-business-type-options.mjs
+++ b/components/teamleader_focus/actions/list-business-type-options/list-business-type-options.mjs
@@ -1,0 +1,34 @@
+import teamleader_focus from "../../teamleader_focus.app.mjs";
+
+export default {
+  key: "teamleader_focus-list-business-type-options",
+  name: "List Business Type Options",
+  description: "Retrieves available options for the Business Type field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    teamleader_focus,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await teamleader_focus.propDefinitions.businessType.options
+      .call(this.teamleader_focus, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/teamleader_focus/actions/list-company-options/list-company-options.mjs
+++ b/components/teamleader_focus/actions/list-company-options/list-company-options.mjs
@@ -1,0 +1,34 @@
+import teamleader_focus from "../../teamleader_focus.app.mjs";
+
+export default {
+  key: "teamleader_focus-list-company-options",
+  name: "List Company Options",
+  description: "Retrieves available options for the Company field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    teamleader_focus,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await teamleader_focus.propDefinitions.company.options
+      .call(this.teamleader_focus, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/teamleader_focus/actions/list-contact-options/list-contact-options.mjs
+++ b/components/teamleader_focus/actions/list-contact-options/list-contact-options.mjs
@@ -1,0 +1,34 @@
+import teamleader_focus from "../../teamleader_focus.app.mjs";
+
+export default {
+  key: "teamleader_focus-list-contact-options",
+  name: "List Contact Options",
+  description: "Retrieves available options for the Contact field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    teamleader_focus,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await teamleader_focus.propDefinitions.contact.options
+      .call(this.teamleader_focus, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/teamleader_focus/actions/list-deal-phase-options/list-deal-phase-options.mjs
+++ b/components/teamleader_focus/actions/list-deal-phase-options/list-deal-phase-options.mjs
@@ -1,0 +1,34 @@
+import teamleader_focus from "../../teamleader_focus.app.mjs";
+
+export default {
+  key: "teamleader_focus-list-deal-phase-options",
+  name: "List Phase Options",
+  description: "Retrieves available options for the Phase field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    teamleader_focus,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await teamleader_focus.propDefinitions.dealPhase.options
+      .call(this.teamleader_focus, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/teamleader_focus/actions/list-deal-source-options/list-deal-source-options.mjs
+++ b/components/teamleader_focus/actions/list-deal-source-options/list-deal-source-options.mjs
@@ -1,0 +1,34 @@
+import teamleader_focus from "../../teamleader_focus.app.mjs";
+
+export default {
+  key: "teamleader_focus-list-deal-source-options",
+  name: "List Source Options",
+  description: "Retrieves available options for the Source field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    teamleader_focus,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await teamleader_focus.propDefinitions.dealSource.options
+      .call(this.teamleader_focus, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/teamleader_focus/actions/list-invoice-options/list-invoice-options.mjs
+++ b/components/teamleader_focus/actions/list-invoice-options/list-invoice-options.mjs
@@ -1,0 +1,34 @@
+import teamleader_focus from "../../teamleader_focus.app.mjs";
+
+export default {
+  key: "teamleader_focus-list-invoice-options",
+  name: "List Invoice Options",
+  description: "Retrieves available options for the Invoice field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    teamleader_focus,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await teamleader_focus.propDefinitions.invoice.options
+      .call(this.teamleader_focus, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/teamleader_focus/actions/list-ticket-id-options/list-ticket-id-options.mjs
+++ b/components/teamleader_focus/actions/list-ticket-id-options/list-ticket-id-options.mjs
@@ -1,0 +1,34 @@
+import teamleader_focus from "../../teamleader_focus.app.mjs";
+
+export default {
+  key: "teamleader_focus-list-ticket-id-options",
+  name: "List Ticket ID Options",
+  description: "Retrieves available options for the Ticket ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    teamleader_focus,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await teamleader_focus.propDefinitions.ticketId.options
+      .call(this.teamleader_focus, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/teamleader_focus/actions/list-user-options/list-user-options.mjs
+++ b/components/teamleader_focus/actions/list-user-options/list-user-options.mjs
@@ -1,0 +1,34 @@
+import teamleader_focus from "../../teamleader_focus.app.mjs";
+
+export default {
+  key: "teamleader_focus-list-user-options",
+  name: "List User Options",
+  description: "Retrieves available options for the User field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    teamleader_focus,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await teamleader_focus.propDefinitions.user.options
+      .call(this.teamleader_focus, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/teamleader_focus/package.json
+++ b/components/teamleader_focus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/teamleader_focus",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Pipedream Teamleader Focus Components",
   "main": "teamleader_focus.app.mjs",
   "keywords": [

--- a/components/teamwork/actions/create-task/create-task.mjs
+++ b/components/teamwork/actions/create-task/create-task.mjs
@@ -3,7 +3,7 @@ import app from "../../teamwork.app.mjs";
 export default {
   type: "action",
   key: "teamwork-create-task",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/teamwork/actions/create-user/create-user.mjs
+++ b/components/teamwork/actions/create-user/create-user.mjs
@@ -4,7 +4,7 @@ import { parseObject } from "../../common/utils.mjs";
 export default {
   type: "action",
   key: "teamwork-create-user",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/teamwork/actions/delete-task/delete-task.mjs
+++ b/components/teamwork/actions/delete-task/delete-task.mjs
@@ -5,7 +5,7 @@ export default {
   key: "teamwork-delete-task",
   name: "Delete Task",
   description: "Delete a task. [See the docs here](https://apidocs.teamwork.com/docs/teamwork/67114797aa90c-delete-a-task)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/teamwork/actions/get-user/get-user.mjs
+++ b/components/teamwork/actions/get-user/get-user.mjs
@@ -4,7 +4,7 @@ export default {
   key: "teamwork-get-user",
   name: "Get User",
   description: "Get a user by ID. [See the documentation](https://apidocs.teamwork.com/docs/teamwork/v1/people/get-people-id-json)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/teamwork/actions/list-company-id-options/list-company-id-options.mjs
+++ b/components/teamwork/actions/list-company-id-options/list-company-id-options.mjs
@@ -1,0 +1,33 @@
+import teamwork from "../../teamwork.app.mjs";
+
+export default {
+  key: "teamwork-list-company-id-options",
+  name: "List Company ID Options",
+  description: "Retrieves available options for the Company ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    teamwork,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await teamwork.propDefinitions.companyId.options.call(this.teamwork, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/teamwork/actions/list-company-id-options/list-company-id-options.mjs
+++ b/components/teamwork/actions/list-company-id-options/list-company-id-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     teamwork,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        teamwork,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/teamwork/actions/list-people-id-options/list-people-id-options.mjs
+++ b/components/teamwork/actions/list-people-id-options/list-people-id-options.mjs
@@ -1,0 +1,33 @@
+import teamwork from "../../teamwork.app.mjs";
+
+export default {
+  key: "teamwork-list-people-id-options",
+  name: "List People Id Options",
+  description: "Retrieves available options for the People Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    teamwork,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await teamwork.propDefinitions.peopleId.options.call(this.teamwork, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/teamwork/actions/list-people-id-options/list-people-id-options.mjs
+++ b/components/teamwork/actions/list-people-id-options/list-people-id-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     teamwork,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        teamwork,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/teamwork/actions/list-project-tasks/list-project-tasks.mjs
+++ b/components/teamwork/actions/list-project-tasks/list-project-tasks.mjs
@@ -5,7 +5,7 @@ export default {
   key: "teamwork-list-project-tasks",
   name: "List Project Tasks",
   description: "List tasks from a project. [See the docs here](https://apidocs.teamwork.com/docs/teamwork/6e3da2c04d779-get-all-tasks-on-a-given-project)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/teamwork/actions/list-users/list-users.mjs
+++ b/components/teamwork/actions/list-users/list-users.mjs
@@ -4,7 +4,7 @@ export default {
   key: "teamwork-list-users",
   name: "List Users",
   description: "List all users. [See the documentation](https://apidocs.teamwork.com/docs/teamwork/v1/people/get-people-json)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/teamwork/actions/update-task/update-task.mjs
+++ b/components/teamwork/actions/update-task/update-task.mjs
@@ -5,7 +5,7 @@ export default {
   key: "teamwork-update-task",
   name: "Update Task",
   description: "Update a task. [See the docs here](https://apidocs.teamwork.com/docs/teamwork/6e3da2c04d779-update-a-task)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/teamwork/actions/update-user/update-user.mjs
+++ b/components/teamwork/actions/update-user/update-user.mjs
@@ -5,7 +5,7 @@ export default {
   key: "teamwork-update-user",
   name: "Update User",
   description: "Update a user in Teamwork. [See the documentation](https://apidocs.teamwork.com/docs/teamwork/v1/people/put-people-id-json)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/teamwork/package.json
+++ b/components/teamwork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/teamwork",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream TeamWork Components",
   "main": "teamwork.app.mjs",
   "keywords": [

--- a/components/teamwork/sources/new-task/new-task.mjs
+++ b/components/teamwork/sources/new-task/new-task.mjs
@@ -7,7 +7,7 @@ export default {
   key: "teamwork-new-task",
   name: "New Task (Instant)",
   description: "Emit new event when a new task is created",
-  version: "0.0.2",
+  version: "0.0.3",
   methods: {
     ...common.methods,
     _getEventName() {

--- a/components/teamwork/sources/new-user-created/new-user-created.mjs
+++ b/components/teamwork/sources/new-user-created/new-user-created.mjs
@@ -5,7 +5,7 @@ export default {
   key: "teamwork-new-user-created",
   name: "New User Created (Instant)",
   description: "Emit new event when a new user is created",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/teamwork/sources/task-deleted/task-deleted.mjs
+++ b/components/teamwork/sources/task-deleted/task-deleted.mjs
@@ -7,7 +7,7 @@ export default {
   key: "teamwork-task-deleted",
   name: "New Task Deleted (Instant)",
   description: "Emit new event when a new task is deleted",
-  version: "0.0.2",
+  version: "0.0.3",
   methods: {
     ...common.methods,
     _getEventName() {

--- a/components/teamwork/sources/task-updated/task-updated.mjs
+++ b/components/teamwork/sources/task-updated/task-updated.mjs
@@ -6,7 +6,7 @@ export default {
   key: "teamwork-task-updated",
   name: "New Task Updated (Instant)",
   description: "Emit new event when a new task is updated",
-  version: "0.0.2",
+  version: "0.0.3",
   methods: {
     ...common.methods,
     _getEventName() {

--- a/components/teamwork/sources/user-updated/user-updated.mjs
+++ b/components/teamwork/sources/user-updated/user-updated.mjs
@@ -5,7 +5,7 @@ export default {
   key: "teamwork-user-updated",
   name: "User Updated (Instant)",
   description: "Emit new event when a user is updated",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/teamwork/teamwork.app.mjs
+++ b/components/teamwork/teamwork.app.mjs
@@ -4,6 +4,13 @@ export default {
   type: "app",
   app: "teamwork",
   propDefinitions: {
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve, zero-based.",
+      min: 0,
+      default: 0,
+    },
     tasklistId: {
       type: "string",
       label: "Tasklist Id",

--- a/components/teamwork_desk/actions/create-customer/create-customer.mjs
+++ b/components/teamwork_desk/actions/create-customer/create-customer.mjs
@@ -3,7 +3,7 @@ import teamworkDesk from "../../teamwork_desk.app.mjs";
 export default {
   key: "teamwork_desk-create-customer",
   name: "Create Customer",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/teamwork_desk/actions/create-ticket/create-ticket.mjs
+++ b/components/teamwork_desk/actions/create-ticket/create-ticket.mjs
@@ -3,7 +3,7 @@ import teamworkDesk from "../../teamwork_desk.app.mjs";
 export default {
   key: "teamwork_desk-create-ticket",
   name: "Create Ticket",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/teamwork_desk/actions/list-company-id-options/list-company-id-options.mjs
+++ b/components/teamwork_desk/actions/list-company-id-options/list-company-id-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     teamwork_desk,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        teamwork_desk,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/teamwork_desk/actions/list-company-id-options/list-company-id-options.mjs
+++ b/components/teamwork_desk/actions/list-company-id-options/list-company-id-options.mjs
@@ -1,0 +1,33 @@
+import teamwork_desk from "../../teamwork_desk.app.mjs";
+
+export default {
+  key: "teamwork_desk-list-company-id-options",
+  name: "List Company Options",
+  description: "Retrieves available options for the Company field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    teamwork_desk,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await teamwork_desk.propDefinitions.companyId.options.call(this.teamwork_desk, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/teamwork_desk/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/teamwork_desk/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     teamwork_desk,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        teamwork_desk,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/teamwork_desk/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/teamwork_desk/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -1,0 +1,34 @@
+import teamwork_desk from "../../teamwork_desk.app.mjs";
+
+export default {
+  key: "teamwork_desk-list-customer-id-options",
+  name: "List Customer Options",
+  description: "Retrieves available options for the Customer field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    teamwork_desk,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await teamwork_desk.propDefinitions.customerId.options
+      .call(this.teamwork_desk, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/teamwork_desk/actions/list-inbox-id-options/list-inbox-id-options.mjs
+++ b/components/teamwork_desk/actions/list-inbox-id-options/list-inbox-id-options.mjs
@@ -1,0 +1,33 @@
+import teamwork_desk from "../../teamwork_desk.app.mjs";
+
+export default {
+  key: "teamwork_desk-list-inbox-id-options",
+  name: "List Inbox ID Options",
+  description: "Retrieves available options for the Inbox ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    teamwork_desk,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await teamwork_desk.propDefinitions.inboxId.options.call(this.teamwork_desk, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/teamwork_desk/actions/list-inbox-id-options/list-inbox-id-options.mjs
+++ b/components/teamwork_desk/actions/list-inbox-id-options/list-inbox-id-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     teamwork_desk,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        teamwork_desk,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/teamwork_desk/actions/list-inboxes-options/list-inboxes-options.mjs
+++ b/components/teamwork_desk/actions/list-inboxes-options/list-inboxes-options.mjs
@@ -1,0 +1,33 @@
+import teamwork_desk from "../../teamwork_desk.app.mjs";
+
+export default {
+  key: "teamwork_desk-list-inboxes-options",
+  name: "List Inboxes Options",
+  description: "Retrieves available options for the Inboxes field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    teamwork_desk,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await teamwork_desk.propDefinitions.inboxes.options.call(this.teamwork_desk, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/teamwork_desk/actions/list-inboxes-options/list-inboxes-options.mjs
+++ b/components/teamwork_desk/actions/list-inboxes-options/list-inboxes-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     teamwork_desk,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        teamwork_desk,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/teamwork_desk/actions/list-priority-id-options/list-priority-id-options.mjs
+++ b/components/teamwork_desk/actions/list-priority-id-options/list-priority-id-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     teamwork_desk,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        teamwork_desk,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/teamwork_desk/actions/list-priority-id-options/list-priority-id-options.mjs
+++ b/components/teamwork_desk/actions/list-priority-id-options/list-priority-id-options.mjs
@@ -1,0 +1,34 @@
+import teamwork_desk from "../../teamwork_desk.app.mjs";
+
+export default {
+  key: "teamwork_desk-list-priority-id-options",
+  name: "List Priority Id Options",
+  description: "Retrieves available options for the Priority Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    teamwork_desk,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await teamwork_desk.propDefinitions.priorityId.options
+      .call(this.teamwork_desk, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/teamwork_desk/actions/list-source-id-options/list-source-id-options.mjs
+++ b/components/teamwork_desk/actions/list-source-id-options/list-source-id-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     teamwork_desk,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        teamwork_desk,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/teamwork_desk/actions/list-source-id-options/list-source-id-options.mjs
+++ b/components/teamwork_desk/actions/list-source-id-options/list-source-id-options.mjs
@@ -1,0 +1,33 @@
+import teamwork_desk from "../../teamwork_desk.app.mjs";
+
+export default {
+  key: "teamwork_desk-list-source-id-options",
+  name: "List Source Id Options",
+  description: "Retrieves available options for the Source Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    teamwork_desk,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await teamwork_desk.propDefinitions.sourceId.options.call(this.teamwork_desk, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/teamwork_desk/actions/list-status-id-options/list-status-id-options.mjs
+++ b/components/teamwork_desk/actions/list-status-id-options/list-status-id-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     teamwork_desk,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        teamwork_desk,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/teamwork_desk/actions/list-status-id-options/list-status-id-options.mjs
+++ b/components/teamwork_desk/actions/list-status-id-options/list-status-id-options.mjs
@@ -1,0 +1,33 @@
+import teamwork_desk from "../../teamwork_desk.app.mjs";
+
+export default {
+  key: "teamwork_desk-list-status-id-options",
+  name: "List Status Id Options",
+  description: "Retrieves available options for the Status Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    teamwork_desk,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await teamwork_desk.propDefinitions.statusId.options.call(this.teamwork_desk, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/teamwork_desk/actions/list-tag-ids-options/list-tag-ids-options.mjs
+++ b/components/teamwork_desk/actions/list-tag-ids-options/list-tag-ids-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     teamwork_desk,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        teamwork_desk,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/teamwork_desk/actions/list-tag-ids-options/list-tag-ids-options.mjs
+++ b/components/teamwork_desk/actions/list-tag-ids-options/list-tag-ids-options.mjs
@@ -1,0 +1,33 @@
+import teamwork_desk from "../../teamwork_desk.app.mjs";
+
+export default {
+  key: "teamwork_desk-list-tag-ids-options",
+  name: "List Tags Options",
+  description: "Retrieves available options for the Tags field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    teamwork_desk,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await teamwork_desk.propDefinitions.tagIds.options.call(this.teamwork_desk, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/teamwork_desk/actions/list-ticket-id-options/list-ticket-id-options.mjs
+++ b/components/teamwork_desk/actions/list-ticket-id-options/list-ticket-id-options.mjs
@@ -1,0 +1,33 @@
+import teamwork_desk from "../../teamwork_desk.app.mjs";
+
+export default {
+  key: "teamwork_desk-list-ticket-id-options",
+  name: "List Ticket Id Options",
+  description: "Retrieves available options for the Ticket Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    teamwork_desk,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await teamwork_desk.propDefinitions.ticketId.options.call(this.teamwork_desk, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/teamwork_desk/actions/list-ticket-id-options/list-ticket-id-options.mjs
+++ b/components/teamwork_desk/actions/list-ticket-id-options/list-ticket-id-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     teamwork_desk,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        teamwork_desk,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/teamwork_desk/actions/list-type-id-options/list-type-id-options.mjs
+++ b/components/teamwork_desk/actions/list-type-id-options/list-type-id-options.mjs
@@ -14,11 +14,10 @@ export default {
   props: {
     teamwork_desk,
     page: {
-      type: "integer",
-      label: "Page",
-      description: "The page of results to retrieve.",
-      min: 0,
-      default: 0,
+      propDefinition: [
+        teamwork_desk,
+        "page",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/teamwork_desk/actions/list-type-id-options/list-type-id-options.mjs
+++ b/components/teamwork_desk/actions/list-type-id-options/list-type-id-options.mjs
@@ -1,0 +1,33 @@
+import teamwork_desk from "../../teamwork_desk.app.mjs";
+
+export default {
+  key: "teamwork_desk-list-type-id-options",
+  name: "List Type Id Options",
+  description: "Retrieves available options for the Type Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    teamwork_desk,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await teamwork_desk.propDefinitions.typeId.options.call(this.teamwork_desk, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/teamwork_desk/actions/reply-to-ticket/reply-to-ticket.mjs
+++ b/components/teamwork_desk/actions/reply-to-ticket/reply-to-ticket.mjs
@@ -3,7 +3,7 @@ import teamworkDesk from "../../teamwork_desk.app.mjs";
 export default {
   key: "teamwork_desk-reply-to-ticket",
   name: "Reply To Ticket",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/teamwork_desk/actions/update-customer/update-customer.mjs
+++ b/components/teamwork_desk/actions/update-customer/update-customer.mjs
@@ -3,7 +3,7 @@ import teamworkDesk from "../../teamwork_desk.app.mjs";
 export default {
   key: "teamwork_desk-update-customer",
   name: "Update Customer",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/teamwork_desk/actions/update-ticket/update-ticket.mjs
+++ b/components/teamwork_desk/actions/update-ticket/update-ticket.mjs
@@ -3,7 +3,7 @@ import teamworkDesk from "../../teamwork_desk.app.mjs";
 export default {
   key: "teamwork_desk-update-ticket",
   name: "Update Ticket",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/teamwork_desk/package.json
+++ b/components/teamwork_desk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/teamwork_desk",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream Teamwork Desk Components",
   "main": "teamwork_desk.app.mjs",
   "keywords": [

--- a/components/teamwork_desk/sources/customer-created/customer-created.mjs
+++ b/components/teamwork_desk/sources/customer-created/customer-created.mjs
@@ -6,7 +6,7 @@ export default {
   key: "teamwork_desk-customer-created",
   type: "source",
   description: "Emit new event when a new customer is created.",
-  version: "0.0.1",
+  version: "0.0.2",
   methods: {
     ...common.methods,
     getWebhookEvents() {

--- a/components/teamwork_desk/sources/customer-reply/customer-reply.mjs
+++ b/components/teamwork_desk/sources/customer-reply/customer-reply.mjs
@@ -6,7 +6,7 @@ export default {
   key: "teamwork_desk-customer-reply",
   type: "source",
   description: "Emit new event when a customer reply.",
-  version: "0.0.1",
+  version: "0.0.2",
   methods: {
     ...common.methods,
     getWebhookEvents() {

--- a/components/teamwork_desk/sources/ticket-created/ticket-created.mjs
+++ b/components/teamwork_desk/sources/ticket-created/ticket-created.mjs
@@ -6,7 +6,7 @@ export default {
   key: "teamwork_desk-ticket-created",
   type: "source",
   description: "Emit new event when a new ticket is created.",
-  version: "0.0.1",
+  version: "0.0.2",
   methods: {
     ...common.methods,
     getWebhookEvents() {

--- a/components/teamwork_desk/teamwork_desk.app.mjs
+++ b/components/teamwork_desk/teamwork_desk.app.mjs
@@ -4,6 +4,13 @@ export default {
   type: "app",
   app: "teamwork_desk",
   propDefinitions: {
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve, zero-based.",
+      min: 0,
+      default: 0,
+    },
     address: {
       type: "string",
       label: "Address",

--- a/components/telnyx/actions/list-call-control-app-id-options/list-call-control-app-id-options.mjs
+++ b/components/telnyx/actions/list-call-control-app-id-options/list-call-control-app-id-options.mjs
@@ -1,0 +1,33 @@
+import telnyx from "../../telnyx.app.mjs";
+
+export default {
+  key: "telnyx-list-call-control-app-id-options",
+  name: "List Call Control Application ID Options",
+  description: "Retrieves available options for the Call Control Application ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    telnyx,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await telnyx.propDefinitions.callControlAppId.options.call(this.telnyx, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/telnyx/actions/list-fax-app-id-options/list-fax-app-id-options.mjs
+++ b/components/telnyx/actions/list-fax-app-id-options/list-fax-app-id-options.mjs
@@ -1,0 +1,33 @@
+import telnyx from "../../telnyx.app.mjs";
+
+export default {
+  key: "telnyx-list-fax-app-id-options",
+  name: "List Fax Application ID Options",
+  description: "Retrieves available options for the Fax Application ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    telnyx,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await telnyx.propDefinitions.faxAppId.options.call(this.telnyx, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/telnyx/actions/list-messaging-profile-id-options/list-messaging-profile-id-options.mjs
+++ b/components/telnyx/actions/list-messaging-profile-id-options/list-messaging-profile-id-options.mjs
@@ -1,0 +1,33 @@
+import telnyx from "../../telnyx.app.mjs";
+
+export default {
+  key: "telnyx-list-messaging-profile-id-options",
+  name: "List Messaging Profile Id Options",
+  description: "Retrieves available options for the Messaging Profile Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    telnyx,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await telnyx.propDefinitions.messagingProfileId.options.call(this.telnyx, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/telnyx/actions/list-phone-number-options/list-phone-number-options.mjs
+++ b/components/telnyx/actions/list-phone-number-options/list-phone-number-options.mjs
@@ -1,0 +1,33 @@
+import telnyx from "../../telnyx.app.mjs";
+
+export default {
+  key: "telnyx-list-phone-number-options",
+  name: "List Phone Number Options",
+  description: "Retrieves available options for the Phone Number field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    telnyx,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await telnyx.propDefinitions.phoneNumber.options.call(this.telnyx, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/telnyx/package.json
+++ b/components/telnyx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/telnyx",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "Pipedream Telnyx Components",
   "main": "telnyx.app.mjs",
   "keywords": [

--- a/components/templatedocs/actions/list-template-id-options/list-template-id-options.mjs
+++ b/components/templatedocs/actions/list-template-id-options/list-template-id-options.mjs
@@ -1,0 +1,33 @@
+import templatedocs from "../../templatedocs.app.mjs";
+
+export default {
+  key: "templatedocs-list-template-id-options",
+  name: "List Template Options",
+  description: "Retrieves available options for the Template field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    templatedocs,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await templatedocs.propDefinitions.templateId.options.call(this.templatedocs, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/templatedocs/package.json
+++ b/components/templatedocs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/templatedocs",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream TemplateDocs Components",
   "main": "templatedocs.app.mjs",
   "keywords": [

--- a/components/terraform/actions/list-org-id-options/list-org-id-options.mjs
+++ b/components/terraform/actions/list-org-id-options/list-org-id-options.mjs
@@ -1,0 +1,33 @@
+import terraform from "../../terraform.app.mjs";
+
+export default {
+  key: "terraform-list-org-id-options",
+  name: "List Organization Options",
+  description: "Retrieves available options for the Organization field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    terraform,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await terraform.propDefinitions.orgId.options.call(this.terraform, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/terraform/package.json
+++ b/components/terraform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/terraform",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Terraform Components",
   "main": "terraform.app.mjs",
   "keywords": [

--- a/components/testlocally/actions/list-test-id-options/list-test-id-options.mjs
+++ b/components/testlocally/actions/list-test-id-options/list-test-id-options.mjs
@@ -1,0 +1,33 @@
+import testlocally from "../../testlocally.app.mjs";
+
+export default {
+  key: "testlocally-list-test-id-options",
+  name: "List Test ID Options",
+  description: "Retrieves available options for the Test ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    testlocally,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await testlocally.propDefinitions.testId.options.call(this.testlocally, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/testlocally/package.json
+++ b/components/testlocally/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/testlocally",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream TestLocally Components",
   "main": "testlocally.app.mjs",
   "keywords": [

--- a/components/testmo/actions/list-project-id-options/list-project-id-options.mjs
+++ b/components/testmo/actions/list-project-id-options/list-project-id-options.mjs
@@ -1,0 +1,33 @@
+import testmo from "../../testmo.app.mjs";
+
+export default {
+  key: "testmo-list-project-id-options",
+  name: "List Project Id Options",
+  description: "Retrieves available options for the Project Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    testmo,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await testmo.propDefinitions.projectId.options.call(this.testmo, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/testmo/actions/list-project-id-options/list-project-id-options.mjs
+++ b/components/testmo/actions/list-project-id-options/list-project-id-options.mjs
@@ -2,8 +2,8 @@ import testmo from "../../testmo.app.mjs";
 
 export default {
   key: "testmo-list-project-id-options",
-  name: "List Project Id Options",
-  description: "Retrieves available options for the Project Id field.",
+  name: "List Project ID Options",
+  description: "Retrieves available options for the Project ID field.",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/testmo/package.json
+++ b/components/testmo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/testmo",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Testmo Components",
   "main": "testmo.app.mjs",
   "keywords": [

--- a/components/testmonitor/actions/list-project-id-options/list-project-id-options.mjs
+++ b/components/testmonitor/actions/list-project-id-options/list-project-id-options.mjs
@@ -1,0 +1,33 @@
+import testmonitor from "../../testmonitor.app.mjs";
+
+export default {
+  key: "testmonitor-list-project-id-options",
+  name: "List Project ID Options",
+  description: "Retrieves available options for the Project ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    testmonitor,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await testmonitor.propDefinitions.projectId.options.call(this.testmonitor, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/testmonitor/package.json
+++ b/components/testmonitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/testmonitor",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Pipedream Testmonitor Components",
   "main": "testmonitor.app.mjs",
   "keywords": [

--- a/components/the_bookie/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/the_bookie/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -1,0 +1,33 @@
+import the_bookie from "../../the_bookie.app.mjs";
+
+export default {
+  key: "the_bookie-list-contact-id-options",
+  name: "List Contact ID Options",
+  description: "Retrieves available options for the Contact ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    the_bookie,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await the_bookie.propDefinitions.contactId.options.call(this.the_bookie, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/the_bookie/package.json
+++ b/components/the_bookie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/the_bookie",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Pipedream The Bookie Components",
   "main": "the_bookie.app.mjs",
   "keywords": [

--- a/components/thinkific/actions/list-course-id-options/list-course-id-options.mjs
+++ b/components/thinkific/actions/list-course-id-options/list-course-id-options.mjs
@@ -1,0 +1,33 @@
+import thinkific from "../../thinkific.app.mjs";
+
+export default {
+  key: "thinkific-list-course-id-options",
+  name: "List Course ID Options",
+  description: "Retrieves available options for the Course ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    thinkific,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await thinkific.propDefinitions.courseId.options.call(this.thinkific, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/thinkific/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/thinkific/actions/list-user-id-options/list-user-id-options.mjs
@@ -1,0 +1,33 @@
+import thinkific from "../../thinkific.app.mjs";
+
+export default {
+  key: "thinkific-list-user-id-options",
+  name: "List User ID Options",
+  description: "Retrieves available options for the User ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    thinkific,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await thinkific.propDefinitions.userId.options.call(this.thinkific, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/thinkific/package.json
+++ b/components/thinkific/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/thinkific",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Thinkific Components",
   "main": "thinkific.app.mjs",
   "keywords": [

--- a/components/thoughtly/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/thoughtly/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -1,0 +1,33 @@
+import thoughtly from "../../thoughtly.app.mjs";
+
+export default {
+  key: "thoughtly-list-contact-id-options",
+  name: "List Contact ID Options",
+  description: "Retrieves available options for the Contact ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    thoughtly,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await thoughtly.propDefinitions.contactId.options.call(this.thoughtly, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/thoughtly/actions/list-interview-id-options/list-interview-id-options.mjs
+++ b/components/thoughtly/actions/list-interview-id-options/list-interview-id-options.mjs
@@ -1,0 +1,33 @@
+import thoughtly from "../../thoughtly.app.mjs";
+
+export default {
+  key: "thoughtly-list-interview-id-options",
+  name: "List Interview ID Options",
+  description: "Retrieves available options for the Interview ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    thoughtly,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await thoughtly.propDefinitions.interviewId.options.call(this.thoughtly, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/thoughtly/package.json
+++ b/components/thoughtly/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/thoughtly",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Thoughtly Components",
   "main": "thoughtly.app.mjs",
   "keywords": [
@@ -16,4 +16,3 @@
     "@pipedream/platform": "^1.6.8"
   }
 }
-

--- a/components/tick/actions/list-client-id-options/list-client-id-options.mjs
+++ b/components/tick/actions/list-client-id-options/list-client-id-options.mjs
@@ -1,0 +1,33 @@
+import tick from "../../tick.app.mjs";
+
+export default {
+  key: "tick-list-client-id-options",
+  name: "List Client ID Options",
+  description: "Retrieves available options for the Client ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    tick,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await tick.propDefinitions.clientId.options.call(this.tick, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/tick/actions/list-project-id-options/list-project-id-options.mjs
+++ b/components/tick/actions/list-project-id-options/list-project-id-options.mjs
@@ -1,0 +1,33 @@
+import tick from "../../tick.app.mjs";
+
+export default {
+  key: "tick-list-project-id-options",
+  name: "List Project ID Options",
+  description: "Retrieves available options for the Project ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    tick,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await tick.propDefinitions.projectId.options.call(this.tick, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/tick/actions/list-task-id-options/list-task-id-options.mjs
+++ b/components/tick/actions/list-task-id-options/list-task-id-options.mjs
@@ -1,0 +1,33 @@
+import tick from "../../tick.app.mjs";
+
+export default {
+  key: "tick-list-task-id-options",
+  name: "List Task ID Options",
+  description: "Retrieves available options for the Task ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    tick,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await tick.propDefinitions.taskId.options.call(this.tick, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/tick/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/tick/actions/list-user-id-options/list-user-id-options.mjs
@@ -1,0 +1,33 @@
+import tick from "../../tick.app.mjs";
+
+export default {
+  key: "tick-list-user-id-options",
+  name: "List User ID Options",
+  description: "Retrieves available options for the User ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    tick,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await tick.propDefinitions.userId.options.call(this.tick, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/tick/package.json
+++ b/components/tick/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/tick",
-  "version": "0.0.6",
+  "version": "0.1.0",
   "description": "Pipedream Tick Components",
   "main": "tick.app.mjs",
   "keywords": [

--- a/components/ticket_source/actions/list-event-id-options/list-event-id-options.mjs
+++ b/components/ticket_source/actions/list-event-id-options/list-event-id-options.mjs
@@ -1,0 +1,33 @@
+import ticket_source from "../../ticket_source.app.mjs";
+
+export default {
+  key: "ticket_source-list-event-id-options",
+  name: "List Event ID Options",
+  description: "Retrieves available options for the Event ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    ticket_source,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await ticket_source.propDefinitions.eventId.options.call(this.ticket_source, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/ticket_source/package.json
+++ b/components/ticket_source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/ticket_source",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Ticket Source Components",
   "main": "ticket_source.app.mjs",
   "keywords": [

--- a/components/timebuzzer/actions/list-activity-id-options/list-activity-id-options.mjs
+++ b/components/timebuzzer/actions/list-activity-id-options/list-activity-id-options.mjs
@@ -1,0 +1,33 @@
+import timebuzzer from "../../timebuzzer.app.mjs";
+
+export default {
+  key: "timebuzzer-list-activity-id-options",
+  name: "List Activity ID Options",
+  description: "Retrieves available options for the Activity ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    timebuzzer,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await timebuzzer.propDefinitions.activityId.options.call(this.timebuzzer, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/timebuzzer/package.json
+++ b/components/timebuzzer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/timebuzzer",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream timeBuzzer Components",
   "main": "timebuzzer.app.mjs",
   "keywords": [

--- a/components/timeular/actions/list-activity-id-options/list-activity-id-options.mjs
+++ b/components/timeular/actions/list-activity-id-options/list-activity-id-options.mjs
@@ -1,0 +1,33 @@
+import timeular from "../../timeular.app.mjs";
+
+export default {
+  key: "timeular-list-activity-id-options",
+  name: "List Activity Id Options",
+  description: "Retrieves available options for the Activity Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    timeular,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await timeular.propDefinitions.activityId.options.call(this.timeular, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/timeular/actions/list-integration-options/list-integration-options.mjs
+++ b/components/timeular/actions/list-integration-options/list-integration-options.mjs
@@ -1,0 +1,33 @@
+import timeular from "../../timeular.app.mjs";
+
+export default {
+  key: "timeular-list-integration-options",
+  name: "List Integration Options",
+  description: "Retrieves available options for the Integration field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    timeular,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await timeular.propDefinitions.integration.options.call(this.timeular, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/timeular/package.json
+++ b/components/timeular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/timeular",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Timeular Components",
   "main": "timeular.app.mjs",
   "keywords": [

--- a/components/toggl/actions/list-time-entry-id-options/list-time-entry-id-options.mjs
+++ b/components/toggl/actions/list-time-entry-id-options/list-time-entry-id-options.mjs
@@ -1,0 +1,33 @@
+import toggl from "../../toggl.app.mjs";
+
+export default {
+  key: "toggl-list-time-entry-id-options",
+  name: "List Time Entry ID Options",
+  description: "Retrieves available options for the Time Entry ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    toggl,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await toggl.propDefinitions.timeEntryId.options.call(this.toggl, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/toggl/actions/list-workspace-id-options/list-workspace-id-options.mjs
+++ b/components/toggl/actions/list-workspace-id-options/list-workspace-id-options.mjs
@@ -2,8 +2,8 @@ import toggl from "../../toggl.app.mjs";
 
 export default {
   key: "toggl-list-workspace-id-options",
-  name: "List Workspace Id Options",
-  description: "Retrieves available options for the Workspace Id field.",
+  name: "List Workspace ID Options",
+  description: "Retrieves available options for the Workspace ID field.",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/toggl/actions/list-workspace-id-options/list-workspace-id-options.mjs
+++ b/components/toggl/actions/list-workspace-id-options/list-workspace-id-options.mjs
@@ -1,0 +1,33 @@
+import toggl from "../../toggl.app.mjs";
+
+export default {
+  key: "toggl-list-workspace-id-options",
+  name: "List Workspace Id Options",
+  description: "Retrieves available options for the Workspace Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    toggl,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await toggl.propDefinitions.workspaceId.options.call(this.toggl, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/toggl/package.json
+++ b/components/toggl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/toggl",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Pipedream Toggl Components",
   "main": "toggl.app.mjs",
   "keywords": [

--- a/components/transistor_fm/actions/list-show-id-options/list-show-id-options.mjs
+++ b/components/transistor_fm/actions/list-show-id-options/list-show-id-options.mjs
@@ -1,0 +1,33 @@
+import transistor_fm from "../../transistor_fm.app.mjs";
+
+export default {
+  key: "transistor_fm-list-show-id-options",
+  name: "List Show ID Options",
+  description: "Retrieves available options for the Show ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    transistor_fm,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await transistor_fm.propDefinitions.showId.options.call(this.transistor_fm, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/transistor_fm/package.json
+++ b/components/transistor_fm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/transistor_fm",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Pipedream Transistor.fm Components",
   "main": "transistor_fm.app.mjs",
   "keywords": [

--- a/components/transloadit/actions/list-assembly-id-options/list-assembly-id-options.mjs
+++ b/components/transloadit/actions/list-assembly-id-options/list-assembly-id-options.mjs
@@ -1,0 +1,33 @@
+import transloadit from "../../transloadit.app.mjs";
+
+export default {
+  key: "transloadit-list-assembly-id-options",
+  name: "List Assembly ID Options",
+  description: "Retrieves available options for the Assembly ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    transloadit,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await transloadit.propDefinitions.assemblyId.options.call(this.transloadit, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/transloadit/actions/list-template-id-options/list-template-id-options.mjs
+++ b/components/transloadit/actions/list-template-id-options/list-template-id-options.mjs
@@ -1,0 +1,33 @@
+import transloadit from "../../transloadit.app.mjs";
+
+export default {
+  key: "transloadit-list-template-id-options",
+  name: "List Template ID Options",
+  description: "Retrieves available options for the Template ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    transloadit,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await transloadit.propDefinitions.templateId.options.call(this.transloadit, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/transloadit/package.json
+++ b/components/transloadit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/transloadit",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Transloadit Components",
   "main": "transloadit.app.mjs",
   "keywords": [

--- a/components/trengo/actions/list-channel-id-options/list-channel-id-options.mjs
+++ b/components/trengo/actions/list-channel-id-options/list-channel-id-options.mjs
@@ -1,0 +1,33 @@
+import trengo from "../../trengo.app.mjs";
+
+export default {
+  key: "trengo-list-channel-id-options",
+  name: "List Channel ID Options",
+  description: "Retrieves available options for the Channel ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    trengo,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await trengo.propDefinitions.channelId.options.call(this.trengo, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/trengo/actions/list-help-center-id-options/list-help-center-id-options.mjs
+++ b/components/trengo/actions/list-help-center-id-options/list-help-center-id-options.mjs
@@ -1,0 +1,33 @@
+import trengo from "../../trengo.app.mjs";
+
+export default {
+  key: "trengo-list-help-center-id-options",
+  name: "List Help Center ID Options",
+  description: "Retrieves available options for the Help Center ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    trengo,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await trengo.propDefinitions.helpCenterId.options.call(this.trengo, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/trengo/actions/list-label-id-options/list-label-id-options.mjs
+++ b/components/trengo/actions/list-label-id-options/list-label-id-options.mjs
@@ -1,0 +1,33 @@
+import trengo from "../../trengo.app.mjs";
+
+export default {
+  key: "trengo-list-label-id-options",
+  name: "List Label ID Options",
+  description: "Retrieves available options for the Label ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    trengo,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await trengo.propDefinitions.labelId.options.call(this.trengo, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/trengo/actions/list-team-id-options/list-team-id-options.mjs
+++ b/components/trengo/actions/list-team-id-options/list-team-id-options.mjs
@@ -1,0 +1,33 @@
+import trengo from "../../trengo.app.mjs";
+
+export default {
+  key: "trengo-list-team-id-options",
+  name: "List Team ID Options",
+  description: "Retrieves available options for the Team ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    trengo,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await trengo.propDefinitions.teamId.options.call(this.trengo, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/trengo/actions/list-ticket-id-options/list-ticket-id-options.mjs
+++ b/components/trengo/actions/list-ticket-id-options/list-ticket-id-options.mjs
@@ -1,0 +1,33 @@
+import trengo from "../../trengo.app.mjs";
+
+export default {
+  key: "trengo-list-ticket-id-options",
+  name: "List Ticket ID Options",
+  description: "Retrieves available options for the Ticket ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    trengo,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await trengo.propDefinitions.ticketId.options.call(this.trengo, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/trengo/actions/list-ticket-result-id-options/list-ticket-result-id-options.mjs
+++ b/components/trengo/actions/list-ticket-result-id-options/list-ticket-result-id-options.mjs
@@ -1,0 +1,33 @@
+import trengo from "../../trengo.app.mjs";
+
+export default {
+  key: "trengo-list-ticket-result-id-options",
+  name: "List Ticket Result ID Options",
+  description: "Retrieves available options for the Ticket Result ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    trengo,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await trengo.propDefinitions.ticketResultId.options.call(this.trengo, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/trengo/actions/list-to-user-id-options/list-to-user-id-options.mjs
+++ b/components/trengo/actions/list-to-user-id-options/list-to-user-id-options.mjs
@@ -1,0 +1,33 @@
+import trengo from "../../trengo.app.mjs";
+
+export default {
+  key: "trengo-list-to-user-id-options",
+  name: "List To User ID Options",
+  description: "Retrieves available options for the To User ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    trengo,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await trengo.propDefinitions.toUserId.options.call(this.trengo, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/trengo/package.json
+++ b/components/trengo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/trengo",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Pipedream Trengo Components",
   "main": "trengo.app.mjs",
   "keywords": [

--- a/components/trint/actions/list-transcript-id-options/list-transcript-id-options.mjs
+++ b/components/trint/actions/list-transcript-id-options/list-transcript-id-options.mjs
@@ -1,0 +1,33 @@
+import trint from "../../trint.app.mjs";
+
+export default {
+  key: "trint-list-transcript-id-options",
+  name: "List Transcript ID Options",
+  description: "Retrieves available options for the Transcript ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    trint,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await trint.propDefinitions.transcriptId.options.call(this.trint, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/trint/package.json
+++ b/components/trint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/trint",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream Trint Components",
   "main": "trint.app.mjs",
   "keywords": [

--- a/components/trunkrs/actions/list-trunkrs-nr-options/list-trunkrs-nr-options.mjs
+++ b/components/trunkrs/actions/list-trunkrs-nr-options/list-trunkrs-nr-options.mjs
@@ -1,0 +1,33 @@
+import trunkrs from "../../trunkrs.app.mjs";
+
+export default {
+  key: "trunkrs-list-trunkrs-nr-options",
+  name: "List Trunkrs Number Options",
+  description: "Retrieves available options for the Trunkrs Number field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    trunkrs,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await trunkrs.propDefinitions.trunkrsNr.options.call(this.trunkrs, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/trunkrs/package.json
+++ b/components/trunkrs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/trunkrs",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Trunkrs Components",
   "main": "trunkrs.app.mjs",
   "keywords": [

--- a/components/twilio/actions/list-transcript-sids-options/list-transcript-sids-options.mjs
+++ b/components/twilio/actions/list-transcript-sids-options/list-transcript-sids-options.mjs
@@ -1,0 +1,33 @@
+import twilio from "../../twilio.app.mjs";
+
+export default {
+  key: "twilio-list-transcript-sids-options",
+  name: "List Transcript SIDs Options",
+  description: "Retrieves available options for the Transcript SIDs field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    twilio,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await twilio.propDefinitions.transcriptSids.options.call(this.twilio, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/twilio/package.json
+++ b/components/twilio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/twilio",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Pipedream Twilio Components",
   "main": "twilio.app.mjs",
   "keywords": [

--- a/components/typeform/actions/list-form-id-options/list-form-id-options.mjs
+++ b/components/typeform/actions/list-form-id-options/list-form-id-options.mjs
@@ -1,0 +1,33 @@
+import typeform from "../../typeform.app.mjs";
+
+export default {
+  key: "typeform-list-form-id-options",
+  name: "List Form Options",
+  description: "Retrieves available options for the Form field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    typeform,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await typeform.propDefinitions.formId.options.call(this.typeform, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/typeform/actions/list-workspace-href-options/list-workspace-href-options.mjs
+++ b/components/typeform/actions/list-workspace-href-options/list-workspace-href-options.mjs
@@ -1,0 +1,33 @@
+import typeform from "../../typeform.app.mjs";
+
+export default {
+  key: "typeform-list-workspace-href-options",
+  name: "List Workspace Options",
+  description: "Retrieves available options for the Workspace field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    typeform,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await typeform.propDefinitions.workspaceHref.options.call(this.typeform, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/typeform/actions/list-workspace-id-options/list-workspace-id-options.mjs
+++ b/components/typeform/actions/list-workspace-id-options/list-workspace-id-options.mjs
@@ -1,0 +1,33 @@
+import typeform from "../../typeform.app.mjs";
+
+export default {
+  key: "typeform-list-workspace-id-options",
+  name: "List Workspace ID Options",
+  description: "Retrieves available options for the Workspace ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    typeform,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await typeform.propDefinitions.workspaceId.options.call(this.typeform, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/typeform/package.json
+++ b/components/typeform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/typeform",
-  "version": "0.3.10",
+  "version": "0.4.0",
   "description": "Pipedream Typeform Components",
   "main": "typeform.app.mjs",
   "keywords": [

--- a/components/uberduck/actions/list-voicemodel-uuid-options/list-voicemodel-uuid-options.mjs
+++ b/components/uberduck/actions/list-voicemodel-uuid-options/list-voicemodel-uuid-options.mjs
@@ -1,0 +1,33 @@
+import uberduck from "../../uberduck.app.mjs";
+
+export default {
+  key: "uberduck-list-voicemodel-uuid-options",
+  name: "List Voice Model UUID Options",
+  description: "Retrieves available options for the Voice Model UUID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    uberduck,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await uberduck.propDefinitions.voicemodelUuid.options.call(this.uberduck, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/uberduck/package.json
+++ b/components/uberduck/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/uberduck",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Uberduck Components",
   "main": "uberduck.app.mjs",
   "keywords": [

--- a/components/uipath_automation_hub/actions/list-automation-id-options/list-automation-id-options.mjs
+++ b/components/uipath_automation_hub/actions/list-automation-id-options/list-automation-id-options.mjs
@@ -2,8 +2,8 @@ import uipath_automation_hub from "../../uipath_automation_hub.app.mjs";
 
 export default {
   key: "uipath_automation_hub-list-automation-id-options",
-  name: "List Idea Id Options",
-  description: "Retrieves available options for the Idea Id field.",
+  name: "List Automation ID Options",
+  description: "Retrieves available options for the Automation ID field.",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/uipath_automation_hub/actions/list-automation-id-options/list-automation-id-options.mjs
+++ b/components/uipath_automation_hub/actions/list-automation-id-options/list-automation-id-options.mjs
@@ -1,0 +1,34 @@
+import uipath_automation_hub from "../../uipath_automation_hub.app.mjs";
+
+export default {
+  key: "uipath_automation_hub-list-automation-id-options",
+  name: "List Idea Id Options",
+  description: "Retrieves available options for the Idea Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    uipath_automation_hub,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await uipath_automation_hub.propDefinitions.automationId.options
+      .call(this.uipath_automation_hub, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/uipath_automation_hub/actions/list-category-id-options/list-category-id-options.mjs
+++ b/components/uipath_automation_hub/actions/list-category-id-options/list-category-id-options.mjs
@@ -1,0 +1,34 @@
+import uipath_automation_hub from "../../uipath_automation_hub.app.mjs";
+
+export default {
+  key: "uipath_automation_hub-list-category-id-options",
+  name: "List Category Id Options",
+  description: "Retrieves available options for the Category Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    uipath_automation_hub,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await uipath_automation_hub.propDefinitions.categoryId.options
+      .call(this.uipath_automation_hub, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/uipath_automation_hub/package.json
+++ b/components/uipath_automation_hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/uipath_automation_hub",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream UiPath Automation Hub Components",
   "main": "uipath_automation_hub.app.mjs",
   "keywords": [

--- a/components/unbounce/actions/list-page-id-options/list-page-id-options.mjs
+++ b/components/unbounce/actions/list-page-id-options/list-page-id-options.mjs
@@ -1,0 +1,33 @@
+import unbounce from "../../unbounce.app.mjs";
+
+export default {
+  key: "unbounce-list-page-id-options",
+  name: "List Page Id Options",
+  description: "Retrieves available options for the Page Id field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    unbounce,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await unbounce.propDefinitions.pageId.options.call(this.unbounce, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/unbounce/package.json
+++ b/components/unbounce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/unbounce",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Unbounce Components",
   "main": "unbounce.app.mjs",
   "keywords": [

--- a/components/unione/actions/list-tags-options/list-tags-options.mjs
+++ b/components/unione/actions/list-tags-options/list-tags-options.mjs
@@ -1,0 +1,33 @@
+import unione from "../../unione.app.mjs";
+
+export default {
+  key: "unione-list-tags-options",
+  name: "List Tags Options",
+  description: "Retrieves available options for the Tags field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    unione,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await unione.propDefinitions.tags.options.call(this.unione, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/unione/actions/list-template-id-options/list-template-id-options.mjs
+++ b/components/unione/actions/list-template-id-options/list-template-id-options.mjs
@@ -1,0 +1,33 @@
+import unione from "../../unione.app.mjs";
+
+export default {
+  key: "unione-list-template-id-options",
+  name: "List Template ID Options",
+  description: "Retrieves available options for the Template ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    unione,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await unione.propDefinitions.templateId.options.call(this.unione, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/unione/package.json
+++ b/components/unione/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/unione",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream UniOne Components",
   "main": "unione.app.mjs",
   "keywords": [

--- a/components/unleashed_software/actions/list-customer-id-options/list-customer-id-options.mjs
+++ b/components/unleashed_software/actions/list-customer-id-options/list-customer-id-options.mjs
@@ -1,0 +1,34 @@
+import unleashed_software from "../../unleashed_software.app.mjs";
+
+export default {
+  key: "unleashed_software-list-customer-id-options",
+  name: "List Customer ID Options",
+  description: "Retrieves available options for the Customer ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    unleashed_software,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await unleashed_software.propDefinitions.customerId.options
+      .call(this.unleashed_software, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/unleashed_software/actions/list-product-id-options/list-product-id-options.mjs
+++ b/components/unleashed_software/actions/list-product-id-options/list-product-id-options.mjs
@@ -1,0 +1,34 @@
+import unleashed_software from "../../unleashed_software.app.mjs";
+
+export default {
+  key: "unleashed_software-list-product-id-options",
+  name: "List Product ID Options",
+  description: "Retrieves available options for the Product ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    unleashed_software,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await unleashed_software.propDefinitions.productId.options
+      .call(this.unleashed_software, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/unleashed_software/actions/list-purchase-order-id-options/list-purchase-order-id-options.mjs
+++ b/components/unleashed_software/actions/list-purchase-order-id-options/list-purchase-order-id-options.mjs
@@ -1,0 +1,34 @@
+import unleashed_software from "../../unleashed_software.app.mjs";
+
+export default {
+  key: "unleashed_software-list-purchase-order-id-options",
+  name: "List Purchase Order ID Options",
+  description: "Retrieves available options for the Purchase Order ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    unleashed_software,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await unleashed_software.propDefinitions.purchaseOrderId.options
+      .call(this.unleashed_software, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/unleashed_software/actions/list-sales-order-id-options/list-sales-order-id-options.mjs
+++ b/components/unleashed_software/actions/list-sales-order-id-options/list-sales-order-id-options.mjs
@@ -1,0 +1,34 @@
+import unleashed_software from "../../unleashed_software.app.mjs";
+
+export default {
+  key: "unleashed_software-list-sales-order-id-options",
+  name: "List Sales Order ID Options",
+  description: "Retrieves available options for the Sales Order ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    unleashed_software,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await unleashed_software.propDefinitions.salesOrderId.options
+      .call(this.unleashed_software, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/unleashed_software/actions/list-supplier-id-options/list-supplier-id-options.mjs
+++ b/components/unleashed_software/actions/list-supplier-id-options/list-supplier-id-options.mjs
@@ -1,0 +1,34 @@
+import unleashed_software from "../../unleashed_software.app.mjs";
+
+export default {
+  key: "unleashed_software-list-supplier-id-options",
+  name: "List Supplier ID Options",
+  description: "Retrieves available options for the Supplier ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    unleashed_software,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await unleashed_software.propDefinitions.supplierId.options
+      .call(this.unleashed_software, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/unleashed_software/actions/list-tax-code-options/list-tax-code-options.mjs
+++ b/components/unleashed_software/actions/list-tax-code-options/list-tax-code-options.mjs
@@ -1,0 +1,34 @@
+import unleashed_software from "../../unleashed_software.app.mjs";
+
+export default {
+  key: "unleashed_software-list-tax-code-options",
+  name: "List Tax Code Options",
+  description: "Retrieves available options for the Tax Code field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    unleashed_software,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await unleashed_software.propDefinitions.taxCode.options
+      .call(this.unleashed_software, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/unleashed_software/actions/list-warehouse-id-options/list-warehouse-id-options.mjs
+++ b/components/unleashed_software/actions/list-warehouse-id-options/list-warehouse-id-options.mjs
@@ -1,0 +1,34 @@
+import unleashed_software from "../../unleashed_software.app.mjs";
+
+export default {
+  key: "unleashed_software-list-warehouse-id-options",
+  name: "List Warehouse ID Options",
+  description: "Retrieves available options for the Warehouse ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    unleashed_software,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await unleashed_software.propDefinitions.warehouseId.options
+      .call(this.unleashed_software, {
+        page: this.page,
+      });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/unleashed_software/package.json
+++ b/components/unleashed_software/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/unleashed_software",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Unleashed Software Components",
   "main": "unleashed_software.app.mjs",
   "keywords": [

--- a/components/unsplash/actions/list-photo-id-options/list-photo-id-options.mjs
+++ b/components/unsplash/actions/list-photo-id-options/list-photo-id-options.mjs
@@ -1,0 +1,33 @@
+import unsplash from "../../unsplash.app.mjs";
+
+export default {
+  key: "unsplash-list-photo-id-options",
+  name: "List Photo ID Options",
+  description: "Retrieves available options for the Photo ID field.",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    unsplash,
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "The page of results to retrieve.",
+      min: 0,
+      default: 0,
+    },
+  },
+  async run({ $ }) {
+    const options = await unsplash.propDefinitions.photoId.options.call(this.unsplash, {
+      page: this.page,
+    });
+    $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
+      ? ""
+      : "s"}`);
+    return options;
+  },
+};

--- a/components/unsplash/package.json
+++ b/components/unsplash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/unsplash",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Pipedream Unsplash Components",
   "main": "unsplash.app.mjs",
   "keywords": [


### PR DESCRIPTION
Adds a batch of 74 new actions for retrieving prop options that accept the page parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added paginated "list options" actions across 40+ integrations, enabling field-specific option loading with page support for dropdowns and selectors.
* **Chores**
  * Package/component versions bumped for multiple integrations to publish the new actions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PipedreamHQ/pipedream/pull/20920?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->