### PR TITLE
Google Sheets - add-single-row - update myColumnData prop to always be available

### DIFF
--- a/components/google_sheets/actions/add-single-row/add-single-row.mjs
+++ b/components/google_sheets/actions/add-single-row/add-single-row.mjs
@@ -10,7 +10,7 @@ export default {
   key: "google_sheets-add-single-row",
   name: "Add Single Row",
   description: "Add a single row of data to Google Sheets. Optionally insert the row at a specific index (e.g., row 2 to insert after headers, shifting existing data down). [See the documentation](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/append)",
-  version: "2.2.2",
+  version: "2.2.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -63,7 +63,10 @@ export default {
       },
       reloadProps: true,
     },
-    hasHeaders: common.props.hasHeaders,
+    hasHeaders: {
+      ...common.props.hasHeaders,
+      default: false,
+    },
     rowIndex: {
       type: "integer",
       label: "Row Index",
@@ -71,8 +74,13 @@ export default {
       optional: true,
       min: 1,
     },
+    myColumnData: {
+      type: "string[]",
+      label: "Values",
+      description: "Provide a value for each cell of the row. Google Sheets accepts strings, numbers and boolean values for each cell. To set a cell to an empty value, pass an empty string.",
+    },
   },
-  async additionalProps() {
+  async additionalProps(existingProps) {
     const {
       sheetId,
       worksheetId,
@@ -81,13 +89,7 @@ export default {
 
     // If using dynamic expressions for either sheetId or worksheetId, return only array input
     if (isDynamicExpression(sheetId) || isDynamicExpression(worksheetId)) {
-      return {
-        myColumnData: {
-          type: "string[]",
-          label: "Values",
-          description: "Provide a value for each cell of the row. Google Sheets accepts strings, numbers and boolean values for each cell. To set a cell to an empty value, pass an empty string.",
-        },
-      };
+      return {};
     }
 
     const props = {};
@@ -107,12 +109,7 @@ export default {
             optional: true,
           };
         }
-        props.myColumnData = {
-          type: "string[]",
-          label: "Enter Values as Array",
-          description: "Provide a value for each cell of the row. Google Sheets accepts strings, numbers and boolean values for each cell. To set a cell to an empty value, pass an empty string. This field will overwrite the column input fields.",
-          optional: true,
-        };
+        existingProps.myColumnData.optional = true;
       } catch (err) {
         console.error("Error fetching headers:", err);
         // Fallback to basic column input if headers can't be fetched
@@ -120,23 +117,12 @@ export default {
           headerError: {
             type: "string",
             label: "Header Fetch Error",
-            description: `Unable to fetch headers: ${err.message}. Using simple column input instead.`,
+            description: `Unable to fetch headers: ${err.message}. Use simple column input instead.`,
             optional: true,
             hidden: true,
           },
-          myColumnData: {
-            type: "string[]",
-            label: "Values",
-            description: "Provide a value for each cell of the row. Google Sheets accepts strings, numbers and boolean values for each cell. To set a cell to an empty value, pass an empty string.",
-          },
         };
       }
-    } else {
-      props.myColumnData = {
-        type: "string[]",
-        label: "Values",
-        description: "Provide a value for each cell of the row. Google Sheets accepts strings, numbers and boolean values for each cell. To set a cell to an empty value, pass an empty string.",
-      };
     }
     return props;
   },

--- a/components/google_sheets/actions/add-single-row/add-single-row.mjs
+++ b/components/google_sheets/actions/add-single-row/add-single-row.mjs
@@ -66,6 +66,7 @@ export default {
     hasHeaders: {
       ...common.props.hasHeaders,
       default: false,
+      optional: true,
     },
     rowIndex: {
       type: "integer",

--- a/components/google_sheets/actions/add-single-row/add-single-row.mjs
+++ b/components/google_sheets/actions/add-single-row/add-single-row.mjs
@@ -10,7 +10,7 @@ export default {
   key: "google_sheets-add-single-row",
   name: "Add Single Row",
   description: "Add a single row of data to Google Sheets. Optionally insert the row at a specific index (e.g., row 2 to insert after headers, shifting existing data down). [See the documentation](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/append)",
-  version: "2.2.3",
+  version: "2.3.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_sheets/package.json
+++ b/components/google_sheets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_sheets",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Pipedream Google_sheets Components",
   "main": "google_sheets.app.mjs",
   "keywords": [


### PR DESCRIPTION
Updates Google Sheets "Add Single Row" action so that `myColumnData` prop is available without reloading props.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add optional row index and support for providing column values as a list; header detection now defaults to off.
* **Bug Fixes**
  * Improved handling when header fetching fails (now surfaces a single hidden header error) and when sheet/worksheet selection is dynamic (no dynamic column props generated).
  * When headers are found, column-value input is preserved as optional.
* **Chores**
  * Package version updated to 0.14.3.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PipedreamHQ/pipedream/pull/20928?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->