### PR TITLE
Hubspot - set propertyGroups prop as optional

### DIFF
--- a/components/hubspot/actions/common/common-create.mjs
+++ b/components/hubspot/actions/common/common-create.mjs
@@ -141,7 +141,6 @@ export default {
       }
 
       if (existingProps.objectProperties) {
-        existingProps.objectProperties.hidden = true;
         existingProps.objectProperties.optional = true;
       }
       if (existingProps.propertyGroups) {

--- a/components/hubspot/actions/common/common-update-object.mjs
+++ b/components/hubspot/actions/common/common-update-object.mjs
@@ -23,7 +23,7 @@ export default {
     objectProperties: {
       type: "object",
       label: "Object Properties",
-      description: "Enter the object properties to update as a JSON object. This will overwrite any properties entered individually.",
+      description: "Enter the object properties to update as a JSON object. Example: {\"firstname\": \"Alice\", \"lastname\": \"Smith\"}. This will overwrite any properties entered individually.",
     },
   },
   methods: {

--- a/components/hubspot/actions/common/common-update-object.mjs
+++ b/components/hubspot/actions/common/common-update-object.mjs
@@ -9,6 +9,7 @@ export default {
       type: "string[]",
       label: "Property Groups",
       reloadProps: true,
+      optional: true,
       async options() {
         const { results: groups } = await this.hubspot.getPropertyGroups({
           objectType: this.getObjectType(),
@@ -22,7 +23,7 @@ export default {
     objectProperties: {
       type: "object",
       label: "Object Properties",
-      description: "Enter the object properties to update as a JSON object",
+      description: "Enter the object properties to update as a JSON object. This will overwrite any properties entered individually.",
     },
   },
   methods: {

--- a/components/hubspot/actions/create-communication/create-communication.mjs
+++ b/components/hubspot/actions/create-communication/create-communication.mjs
@@ -9,7 +9,7 @@ export default {
   name: "Create Communication",
   description:
     "Create a WhatsApp, LinkedIn, or SMS message. [See the documentation](https://developers.hubspot.com/beta-docs/reference/api/crm/engagements/communications/v3#post-%2Fcrm%2Fv3%2Fobjects%2Fcommunications)",
-  version: "0.0.25",
+  version: "0.0.26",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-company/create-company.mjs
+++ b/components/hubspot/actions/create-company/create-company.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Create Company",
   description:
     "Create a company in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/companies#endpoint?spec=POST-/crm/v3/objects/companies)",
-  version: "0.0.37",
+  version: "0.0.38",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-custom-object/create-custom-object.mjs
+++ b/components/hubspot/actions/create-custom-object/create-custom-object.mjs
@@ -10,7 +10,7 @@ export default {
   name: "Create Custom Object",
   description:
     "Create a new custom object in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/custom-objects#create-a-custom-object)",
-  version: "1.0.19",
+  version: "1.0.20",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-deal/create-deal.mjs
+++ b/components/hubspot/actions/create-deal/create-deal.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Create Deal",
   description:
     "Create a deal in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/deals#endpoint?spec=POST-/crm/v3/objects/deals)",
-  version: "0.0.37",
+  version: "0.0.38",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-engagement/create-engagement.mjs
+++ b/components/hubspot/actions/create-engagement/create-engagement.mjs
@@ -90,7 +90,7 @@ export default {
     + "No `reloadProps` step and no **CONFIGURE_COMPONENT** requirement: association fields accept raw HubSpot IDs (use **Search CRM** or the Associations API to resolve `associationType` when needed). "
     + "For **only** a note on a contact by ID, **Add Note to Contact** (`hubspot-add-note-to-contact`) is still simpler. "
     + "[See the documentation](https://developers.hubspot.com/docs/api/crm/engagements)",
-  version: "0.1.2",
+  version: "0.1.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-lead/create-lead.mjs
+++ b/components/hubspot/actions/create-lead/create-lead.mjs
@@ -13,7 +13,7 @@ export default {
   name: "Create Lead",
   description:
     "Create a lead in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/leads#create-leads)",
-  version: "0.0.25",
+  version: "0.0.26",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-meeting/create-meeting.mjs
+++ b/components/hubspot/actions/create-meeting/create-meeting.mjs
@@ -11,7 +11,7 @@ export default {
   name: "Create Meeting",
   description:
     "Creates a new meeting with optional associations to other objects. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/engagements/meetings#post-%2Fcrm%2Fv3%2Fobjects%2Fmeetings)",
-  version: "0.0.17",
+  version: "0.0.18",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-note/create-note.mjs
+++ b/components/hubspot/actions/create-note/create-note.mjs
@@ -11,7 +11,7 @@ export default {
     + "MCP/AI: For **only** contact ID + note body, use **Add Note to Contact** — fewer props and no association-type configuration. "
     + "If associating to another record, supply `toObjectType`, `toObjectId`, and `associationType` together; use **CONFIGURE_COMPONENT** with `componentKey` `hubspot-create-note` to load dropdown options for those props when needed. "
     + "[See the documentation](https://developers.hubspot.com/docs/api/crm/objects/notes)",
-  version: "0.0.17",
+  version: "0.0.18",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-or-update-contact/create-or-update-contact.mjs
+++ b/components/hubspot/actions/create-or-update-contact/create-or-update-contact.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Create or Update Contact",
   description:
     "Create or update a contact in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts#endpoint?spec=POST-/crm/v3/objects/contacts)",
-  version: "0.0.35",
+  version: "0.0.36",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/hubspot/actions/create-task/create-task.mjs
+++ b/components/hubspot/actions/create-task/create-task.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Create Task",
   description:
     "Create a new task. [See the documentation](https://developers.hubspot.com/docs/api/crm/engagements)",
-  version: "0.0.17",
+  version: "0.0.18",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-ticket/create-ticket.mjs
+++ b/components/hubspot/actions/create-ticket/create-ticket.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Create Ticket",
   description:
     "Create a ticket in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/tickets)",
-  version: "0.0.28",
+  version: "0.0.29",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/search-crm/search-crm.mjs
+++ b/components/hubspot/actions/search-crm/search-crm.mjs
@@ -19,7 +19,7 @@ export default {
   name: "Search CRM",
   description:
     "Search companies, contacts, deals, feedback submissions, products, tickets, line-items, quotes, leads, or custom objects. [See the documentation](https://developers.hubspot.com/docs/api/crm/search)",
-  version: "1.1.8",
+  version: "1.1.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/update-company/update-company.mjs
+++ b/components/hubspot/actions/update-company/update-company.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Update Company",
   description:
     "Update a company in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/companies)",
-  version: "0.0.33",
+  version: "0.0.34",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/hubspot/actions/update-contact/update-contact.mjs
+++ b/components/hubspot/actions/update-contact/update-contact.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Update Contact",
   description:
     "Update a contact in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts#endpoint?spec=POST-/crm/v3/objects/contacts)",
-  version: "0.0.34",
+  version: "0.0.35",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/hubspot/actions/update-custom-object/update-custom-object.mjs
+++ b/components/hubspot/actions/update-custom-object/update-custom-object.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Update Custom Object",
   description:
     "Update a custom object in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/custom-objects#update-existing-custom-objects)",
-  version: "1.0.19",
+  version: "1.0.20",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/hubspot/actions/update-deal/update-deal.mjs
+++ b/components/hubspot/actions/update-deal/update-deal.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Update Deal",
   description:
     "Update a deal in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/deals#update-deals)",
-  version: "0.0.24",
+  version: "0.0.25",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/hubspot/actions/update-lead/update-lead.mjs
+++ b/components/hubspot/actions/update-lead/update-lead.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Update Lead",
   description:
     "Update a lead in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/leads#update-leads)",
-  version: "0.0.25",
+  version: "0.0.26",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/hubspot/package.json
+++ b/components/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/hubspot",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "description": "Pipedream Hubspot Components",
   "main": "hubspot.app.mjs",
   "keywords": [


### PR DESCRIPTION
Updates the `propertyGroups` prop to be optional. Allows users to enter `objectProperties` with or without selecting a `propertyGroup` or relying on dynamic props.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified guidance for creating notes, including recommended association patterns and usage guidance.

* **Chores**
  * Improved handling of optional object properties and clarified that supplying a JSON object will overwrite individually entered properties.
  * Incremented multiple HubSpot action package versions and bumped the HubSpot package to 1.15.1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PipedreamHQ/pipedream/pull/20935?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->