### PR TITLE
[20936] refactor(figma): remove generic reloadProps

### DIFF
--- a/components/figma/actions/delete-comment/delete-comment.mjs
+++ b/components/figma/actions/delete-comment/delete-comment.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Delete a Comment",
   description: "Delete a comment to a file. [See the docs here](https://www.figma.com/developers/api#delete-comments-endpoint)",
   key: "figma-delete-comment",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/figma/actions/delete-comment/delete-comment.mjs
+++ b/components/figma/actions/delete-comment/delete-comment.mjs
@@ -1,8 +1,6 @@
-import common from "../../common/common.mjs";
-const { figmaApp } = common.props;
+import figmaApp from "../../figma.app.mjs";
 
 export default {
-  ...common,
   name: "Delete a Comment",
   description: "Delete a comment to a file. [See the docs here](https://www.figma.com/developers/api#delete-comments-endpoint)",
   key: "figma-delete-comment",
@@ -14,7 +12,7 @@ export default {
   },
   type: "action",
   props: {
-    ...common.props,
+    figmaApp,
     projectId: {
       propDefinition: [
         figmaApp,

--- a/components/figma/actions/list-comments/list-comments.mjs
+++ b/components/figma/actions/list-comments/list-comments.mjs
@@ -6,7 +6,7 @@ export default {
   name: "List Comments",
   description: "Lists all comments left on a file. [See the docs here](https://www.figma.com/developers/api#get-comments-endpoint)",
   key: "figma-list-comments",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/figma/actions/list-comments/list-comments.mjs
+++ b/components/figma/actions/list-comments/list-comments.mjs
@@ -1,8 +1,6 @@
-import common from "../../common/common.mjs";
-const { figmaApp } = common.props;
+import figmaApp from "../../figma.app.mjs";
 
 export default {
-  ...common,
   name: "List Comments",
   description: "Lists all comments left on a file. [See the docs here](https://www.figma.com/developers/api#get-comments-endpoint)",
   key: "figma-list-comments",
@@ -14,7 +12,7 @@ export default {
   },
   type: "action",
   props: {
-    ...common.props,
+    figmaApp,
     projectId: {
       propDefinition: [
         figmaApp,

--- a/components/figma/actions/post-a-comment/post-a-comment.mjs
+++ b/components/figma/actions/post-a-comment/post-a-comment.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Post a Comment",
   description: "Posts a comment to a file. [See the docs here](https://www.figma.com/developers/api#post-comments-endpoint)",
   key: "figma-post-a-comment",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/figma/actions/post-a-comment/post-a-comment.mjs
+++ b/components/figma/actions/post-a-comment/post-a-comment.mjs
@@ -1,8 +1,6 @@
-import common from "../../common/common.mjs";
-const { figmaApp } = common.props;
+import figmaApp from "../../figma.app.mjs";
 
 export default {
-  ...common,
   name: "Post a Comment",
   description: "Posts a comment to a file. [See the docs here](https://www.figma.com/developers/api#post-comments-endpoint)",
   key: "figma-post-a-comment",
@@ -14,7 +12,7 @@ export default {
   },
   type: "action",
   props: {
-    ...common.props,
+    figmaApp,
     projectId: {
       propDefinition: [
         figmaApp,

--- a/components/figma/common/common.mjs
+++ b/components/figma/common/common.mjs
@@ -4,6 +4,7 @@ export default {
   props: {
     figmaApp: {
       ...figma,
+      reloadProps: true,
     },
   },
   methods: {

--- a/components/figma/common/common.mjs
+++ b/components/figma/common/common.mjs
@@ -4,7 +4,6 @@ export default {
   props: {
     figmaApp: {
       ...figma,
-      reloadProps: true,
     },
   },
   methods: {

--- a/components/figma/package.json
+++ b/components/figma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/figma",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream Figma Components",
   "main": "figma.app.mjs",
   "keywords": [

--- a/components/figma/sources/new-comment/new-comment.mjs
+++ b/components/figma/sources/new-comment/new-comment.mjs
@@ -10,7 +10,6 @@ export default {
   version: "0.0.5",
   type: "source",
   dedupe: "unique",
-  reloadProps: true,
   props: {
     alert: {
       type: "alert",

--- a/components/figma/sources/new-comment/new-comment.mjs
+++ b/components/figma/sources/new-comment/new-comment.mjs
@@ -7,9 +7,10 @@ export default {
   key: "figma-new-comment",
   name: "New Comment (Instant)",
   description: "Emit new event when someone comments on a file",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "source",
   dedupe: "unique",
+  reloadProps: true,
   props: {
     alert: {
       type: "alert",


### PR DESCRIPTION
## Summary
Closes https://github.com/PipedreamHQ/pipedream/issues/20936
Remove generic `reloadProps` across all actions to avoid call to fetch teamId
Retain `reloadProps` only for the `new-comment` source
<!-- Add your PR description here -->



## Checklist
Please check the following items before your PR can be reviewed:

### Versioning
- [x] All components updated in this PR had their version updated (`0.0.1` for new ones)
- [x] The app updated in this PR had its `package.json`'s version updated

### New app
If this is a new app, please submit [an app integration request](https://github.com/PipedreamHQ/pipedream/issues/new?template=app---service-integration.md) - the PR will only be reviewed after the app is integrated.
- [ ] The app updated in this PR is already integrated

### CodeRabbit review
After the PR is opened, and if new changes are pushed, CodeRabbit will automatically review it. Do not 'mark as resolved' CodeRabbit's comments, but reply to them instead, whether you agree (and update the PR accordingly) or disagree.
- [ ] I have addressed or acknowledged all of CodeRabbit's review comments



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Figma component versions: Bumped Delete a Comment, List Comments, and Post a Comment action versions to 0.0.6; updated New Comment source version to 0.0.5; incremented package version to 0.1.2.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PipedreamHQ/pipedream/pull/20939?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->