### PR TITLE
google_calendar: drop "ID" suffix from Calendar and Event prop labels

### DIFF
--- a/components/google_calendar/actions/add-attendees-to-event/add-attendees-to-event.mjs
+++ b/components/google_calendar/actions/add-attendees-to-event/add-attendees-to-event.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_calendar-add-attendees-to-event",
   name: "Add Attendees To Event",
   description: "Add attendees to an existing event. [See the documentation](https://googleapis.dev/nodejs/googleapis/latest/calendar/classes/Resource$Events.html#update)",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_calendar/actions/create-event/create-event.mjs
+++ b/components/google_calendar/actions/create-event/create-event.mjs
@@ -7,7 +7,7 @@ export default {
   key: "google_calendar-create-event",
   name: "Create Event",
   description: "Create an event in a Google Calendar. [See the documentation](https://developers.google.com/calendar/api/v3/reference/events/insert)",
-  version: "1.0.2",
+  version: "1.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_calendar/actions/delete-event/delete-event.mjs
+++ b/components/google_calendar/actions/delete-event/delete-event.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_calendar-delete-event",
   name: "Delete an Event",
   description: "Delete an event from a Google Calendar. [See the documentation](https://googleapis.dev/nodejs/googleapis/latest/calendar/classes/Resource$Events.html#delete)",
-  version: "0.1.10",
+  version: "0.1.11",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_calendar/actions/get-calendar/get-calendar.mjs
+++ b/components/google_calendar/actions/get-calendar/get-calendar.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_calendar-get-calendar",
   name: "Retrieve Calendar Details",
   description: "Retrieve calendar details of a Google Calendar. [See the documentation](https://googleapis.dev/nodejs/googleapis/latest/calendar/classes/Resource$Calendars.html#get)",
-  version: "0.1.11",
+  version: "0.1.12",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_calendar/actions/get-current-user/get-current-user.mjs
+++ b/components/google_calendar/actions/get-current-user/get-current-user.mjs
@@ -7,7 +7,7 @@ export default {
   key: "google_calendar-get-current-user",
   name: "Get Current User",
   description: "Retrieve information about the authenticated Google Calendar account, including the primary calendar (summary, timezone, ACL flags), a list of accessible calendars, user-level settings (timezone, locale, week start), and the color palette that controls events and calendars. Ideal for confirming which calendar account is in use, customizing downstream scheduling, or equipping LLMs with the user’s context (timezones, available calendars) prior to creating or updating events. [See the documentation](https://developers.google.com/calendar/api/v3/reference/calendars/get).",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/google_calendar/actions/get-date-time/get-date-time.mjs
+++ b/components/google_calendar/actions/get-date-time/get-date-time.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_calendar-get-date-time",
   name: "Get Date Time",
   description: "Get current date and time for use in Google Calendar actions. Useful for agents that need datetime awareness and timezone context before calling other Google Calendar tools.",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/google_calendar/actions/get-event/get-event.mjs
+++ b/components/google_calendar/actions/get-event/get-event.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_calendar-get-event",
   name: "Retrieve Event Details",
   description: "Retrieve event details from Google Calendar. [See the documentation](https://googleapis.dev/nodejs/googleapis/latest/calendar/classes/Resource$Events.html#get)",
-  version: "0.1.11",
+  version: "0.1.12",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_calendar/actions/list-calendars/list-calendars.mjs
+++ b/components/google_calendar/actions/list-calendars/list-calendars.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_calendar-list-calendars",
   name: "List Calendars",
   description: "Retrieve a list of calendars from Google Calendar. [See the documentation](https://googleapis.dev/nodejs/googleapis/latest/calendar/classes/Resource$Calendarlist.html#list)",
-  version: "0.1.11",
+  version: "0.1.12",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_calendar/actions/list-color-id-options/list-color-id-options.mjs
+++ b/components/google_calendar/actions/list-color-id-options/list-color-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_calendar-list-color-id-options",
   name: "List Color ID Options",
   description: "Retrieves available options for the Color ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/google_calendar/actions/list-event-instances/list-event-instances.mjs
+++ b/components/google_calendar/actions/list-event-instances/list-event-instances.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_calendar-list-event-instances",
   name: "List Event Instances",
   description: "Retrieve instances of a recurring event. [See the documentation](https://developers.google.com/calendar/api/v3/reference/events/instances)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/google_calendar/actions/list-events/list-events.mjs
+++ b/components/google_calendar/actions/list-events/list-events.mjs
@@ -6,7 +6,7 @@ export default {
   key: "google_calendar-list-events",
   name: "List Events",
   description: "Retrieve a list of event from the Google Calendar. [See the documentation](https://developers.google.com/calendar/api/v3/reference/events/list)",
-  version: "0.0.14",
+  version: "0.0.15",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_calendar/actions/query-free-busy-calendars/query-free-busy-calendars.mjs
+++ b/components/google_calendar/actions/query-free-busy-calendars/query-free-busy-calendars.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_calendar-query-free-busy-calendars",
   name: "Retrieve Free/Busy Calendar Details",
   description: "Retrieve free/busy calendar details from Google Calendar. [See the documentation](https://googleapis.dev/nodejs/googleapis/latest/calendar/classes/Resource$Freebusy.html#query)",
-  version: "0.2.1",
+  version: "0.2.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_calendar/actions/quick-add-event/quick-add-event.mjs
+++ b/components/google_calendar/actions/quick-add-event/quick-add-event.mjs
@@ -6,7 +6,7 @@ export default {
   key: "google_calendar-quick-add-event",
   name: "Add Quick Event",
   description: "Create a quick event to the Google Calendar. [See the documentation](https://googleapis.dev/nodejs/googleapis/latest/calendar/classes/Resource$Events.html#quickAdd)",
-  version: "0.1.12",
+  version: "0.1.13",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_calendar/actions/update-event-instance/update-event-instance.mjs
+++ b/components/google_calendar/actions/update-event-instance/update-event-instance.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_calendar-update-event-instance",
   name: "Update Event Instance",
   description: "Update a specific instance of a recurring event. Changes apply only to the selected instance. [See the documentation](https://developers.google.com/calendar/api/v3/reference/events/update)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   annotations: {
     destructiveHint: true,

--- a/components/google_calendar/actions/update-event/update-event.mjs
+++ b/components/google_calendar/actions/update-event/update-event.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_calendar-update-event",
   name: "Update Event",
   description: "Update an event from Google Calendar. [See the documentation](https://googleapis.dev/nodejs/googleapis/latest/calendar/classes/Resource$Events.html#update)",
-  version: "0.0.15",
+  version: "0.0.16",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_calendar/actions/update-following-instances/update-following-instances.mjs
+++ b/components/google_calendar/actions/update-following-instances/update-following-instances.mjs
@@ -6,7 +6,7 @@ export default {
   key: "google_calendar-update-following-instances",
   name: "Update Following Event Instances",
   description: "Update all instances of a recurring event following a specific instance. This creates a new recurring event starting from the selected instance. [See the documentation](https://developers.google.com/calendar/api/guides/recurringevents#modifying_all_following_instances)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   annotations: {
     destructiveHint: true,

--- a/components/google_calendar/google_calendar.app.mjs
+++ b/components/google_calendar/google_calendar.app.mjs
@@ -8,7 +8,7 @@ export default {
   app: "google_calendar",
   propDefinitions: {
     calendarId: {
-      label: "Calendar ID",
+      label: "Calendar",
       type: "string",
       description: "Optionally select the calendar, defaults to the primary calendar for the logged-in user",
       default: "primary",
@@ -34,7 +34,7 @@ export default {
       },
     },
     eventId: {
-      label: "Event ID",
+      label: "Event",
       type: "string",
       description: "Select an event from Google Calendar.",
       async options({ calendarId }) {

--- a/components/google_calendar/package.json
+++ b/components/google_calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_calendar",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Pipedream Google_calendar Components",
   "main": "google_calendar.app.mjs",
   "keywords": [

--- a/components/google_calendar/sources/event-cancelled/event-cancelled.mjs
+++ b/components/google_calendar/sources/event-cancelled/event-cancelled.mjs
@@ -6,7 +6,7 @@ export default {
   key: "google_calendar-event-cancelled",
   name: "New Cancelled Event",
   description: "Emit new event when a Google Calendar event is cancelled or deleted",
-  version: "0.1.14",
+  version: "0.1.15",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_calendar/sources/event-ended/event-ended.mjs
+++ b/components/google_calendar/sources/event-ended/event-ended.mjs
@@ -6,7 +6,7 @@ export default {
   key: "google_calendar-event-ended",
   name: "New Ended Event",
   description: "Emit new event when a Google Calendar event ends",
-  version: "0.1.14",
+  version: "0.1.15",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_calendar/sources/new-calendar/new-calendar.mjs
+++ b/components/google_calendar/sources/new-calendar/new-calendar.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_calendar-new-calendar",
   name: "New Calendar Created",
   description: "Emit new event when a calendar is created.",
-  version: "0.1.14",
+  version: "0.1.15",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_calendar/sources/new-event-search/new-event-search.mjs
+++ b/components/google_calendar/sources/new-event-search/new-event-search.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_calendar-new-event-search",
   name: "New Event Matching a Search",
   description: "Emit new event when a Google Calendar event is created that matches a search",
-  version: "0.1.14",
+  version: "0.1.15",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_calendar/sources/new-or-updated-event-instant/new-or-updated-event-instant.mjs
+++ b/components/google_calendar/sources/new-or-updated-event-instant/new-or-updated-event-instant.mjs
@@ -8,7 +8,7 @@ export default {
   type: "source",
   name: "New Created or Updated Event (Instant)",
   description: "Emit new event when a Google Calendar events is created or updated (does not emit cancelled events)",
-  version: "0.1.18",
+  version: "0.1.19",
   dedupe: "unique",
   props: {
     googleCalendar,

--- a/components/google_calendar/sources/upcoming-event-alert-polling/upcoming-event-alert-polling.mjs
+++ b/components/google_calendar/sources/upcoming-event-alert-polling/upcoming-event-alert-polling.mjs
@@ -6,7 +6,7 @@ export default {
   key: "google_calendar-upcoming-event-alert-polling",
   name: "New Upcoming Event Alert (Polling)",
   description: "Emit new event based on a time interval before an upcoming event in the calendar. [See the documentation](https://developers.google.com/calendar/api/v3/reference/events/list)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_calendar/sources/upcoming-event-alert/upcoming-event-alert.mjs
+++ b/components/google_calendar/sources/upcoming-event-alert/upcoming-event-alert.mjs
@@ -6,7 +6,7 @@ export default {
   key: "google_calendar-upcoming-event-alert",
   name: "New Upcoming Event Alert",
   description: "Emit new event based on a time interval before an upcoming event in the calendar.",
-  version: "0.1.3",
+  version: "0.1.4",
   type: "source",
   props: {
     googleCalendar,


### PR DESCRIPTION
## Summary

Fixes #20945.

The `calendarId` and `eventId` propDefinitions in `google_calendar.app.mjs` used the labels `"Calendar ID"` and `"Event ID"`. The dropdowns show calendar names and event summaries, so the "ID" suffix didn't match what the user actually picks.

This is the corrected version of #20946 (closed — accidentally based on the wrong branch).

## Changes

- `google_calendar.app.mjs`: `"Calendar ID"` → `"Calendar"`, `"Event ID"` → `"Event"`
- Patch-bumped 18 consuming actions and sources
- Patch-bumped `package.json` (0.9.0 → 0.9.1)

Prop identity is keyed by `calendarId` / `eventId`, not the label, so existing workflows keep their stored values. No behavior change beyond the visible label.

## Checklist

### Versioning
- [x] All components updated in this PR had their version updated
- [x] The app updated in this PR had its `package.json`'s version updated

### New app
- [x] The app updated in this PR is already integrated

## Test plan

- [x] ESLint passes (0 errors; 4 pre-existing `pollingInfo` warnings unrelated)
- [x] Runtime import of `google_calendar.app.mjs` confirms `calendarId.label === "Calendar"` and `eventId.label === "Event"`; `type`, `default`, `optional` preserved
- [x] Sampled consumer imports load with bumped versions (`get-event` v0.1.12, `list-events` v0.0.15, `create-event` v1.0.3, `new-or-updated-event-instant` v0.1.19)
- [ ] Manual UI check: render an updated action and confirm the prop labels show as `Calendar` and `Event`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Google Calendar component package to version 0.9.1
  * Incremented metadata versions for 16 Google Calendar actions (various event, calendar, and utility operations)
  * Bumped versions for 7 event source triggers (new/updated events, cancellations, alerts)
  * Simplified UI field labels: "Calendar ID" → "Calendar", "Event ID" → "Event"

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PipedreamHQ/pipedream/pull/20948?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->