### PR TITLE
Upgrade to the v3 SDK

### DIFF
--- a/packages/connect-react/CHANGELOG.md
+++ b/packages/connect-react/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 # Changelog
 
+## [3.0.0] - 2026-05-20
+
+### Changed
+
+- **BREAKING**: Updated `@pipedream/sdk` dependency to `^3.0.0`. The
+  v3 SDK is a type-only release — runtime behavior, network calls, env
+  vars, and the `PipedreamClient` constructor are all unchanged. The
+  breaking change is the flattening of the SDK's `ConfigurableProp`
+  and `Emitter` namespaces. See the SDK's [v2 → v3 migration
+  guide](https://github.com/PipedreamHQ/pipedream-sdk-typescript/blob/main/MIGRATE.md)
+  for details.
+- Internal type narrowing in `type-guards.ts` and
+  `form-field-context.tsx` updated to use the flat
+  `ConfigurableProp{Variant}` interfaces (e.g. `ConfigurablePropApp`
+  instead of `ConfigurableProp.App`). Consumers that import namespaced
+  types (e.g. `ConfigurableProp.App`) from `@pipedream/sdk` directly
+  need to migrate to the flat names.
+
 ## [2.8.0] - 2026-03-19
 
 ### Changed
@@ -11,24 +29,34 @@
 ## [2.7.3] - 2026-03-18
 
 ### Added
-- Globe icon for SharePoint sites and folder icon for drives in file picker navigation
+
+- Globe icon for SharePoint sites and folder icon for drives in file
+  picker navigation
 - Per-prop icon support via `propIcons` in `FilePickerAppConfig`
 
 ### Changed
-- File list is now more compact: metadata (size, item count) shown as columns instead of second row
-- Removed folder chevron from file list to keep Last Modified column aligned
-- Removed emoji prefix stripping from option labels (emojis no longer returned by API)
+
+- File list is now more compact: metadata (size, item count) shown as
+  columns instead of second row
+- Removed folder chevron from file list to keep Last Modified column
+  aligned
+- Removed emoji prefix stripping from option labels (emojis no longer
+  returned by API)
 - Updated `sharepoint_admin` config to use `fileIds` prop
 
 ## [2.7.2] - 2026-02-20
 
 ### Added
-- Added `webUrl` and `description` fields to `FilePickerItem` interface
-- Parse `webUrl` and `description` from JSON option values in file picker
+
+- Added `webUrl` and `description` fields to `FilePickerItem`
+  interface
+- Parse `webUrl` and `description` from JSON option values in file
+  picker
 
 ## [2.7.1] - 2026-02-19
 
 ### Added
+
 - Added a Refresh button to the file picker UI component
 
 ## [2.7.0] - 2026-02-11
@@ -38,30 +66,39 @@
 - **ConfigureFilePicker**: Enhanced file picker capabilities
   - Search functionality to filter files and folders by name
   - Select/deselect all buttons for batch operations
-  - Additional metadata display: file size, last modified date, child count
+  - Additional metadata display: file size, last modified date, child
+    count
   - Improved default icons for folders and files with SVGs
   - Better date and file size formatting utilities
 
 ### Changed
 
-- ConfigureFilePicker now initializes selected items from `initialConfiguredProps` when available
+- ConfigureFilePicker now initializes selected items from
+  `initialConfiguredProps` when available
 
 ## [2.6.0] - 2026-01-20
 
 ### Added
 
-- **Experimental**: `ConfigureFilePicker` and `ConfigureFilePickerModal` components for building custom file picker UIs
-  - Uses Pipedream's `configureProp` API to fetch hierarchical options (sites, drives, folders, files)
+- **Experimental**: `ConfigureFilePicker` and
+  `ConfigureFilePickerModal` components for building custom file
+  picker UIs
+  - Uses Pipedream's `configureProp` API to fetch hierarchical options
+    (sites, drives, folders, files)
   - Built-in support for SharePoint with extensible app configuration
-  - Features: folder navigation, multi-select, theming support, customizable icons
-  - Note: This is an experimental API and may change in future releases
+  - Features: folder navigation, multi-select, theming support,
+    customizable icons
+  - Note: This is an experimental API and may change in future
+    releases
 
 ## [2.5.0] - 2025-12-19
 
 ### Added
 
-- Support for new app filtering options in `SelectApp` and `useApps`: `hasActions`, `hasTriggers`, `hasComponents`
-- Added `componentsOptions` prop to `SelectComponent` for passing additional options (e.g., `registry`) to the components list API
+- Support for new app filtering options in `SelectApp` and `useApps`:
+  `hasActions`, `hasTriggers`, `hasComponents`
+- Added `componentsOptions` prop to `SelectComponent` for passing
+  additional options (e.g., `registry`) to the components list API
 
 ### Changed
 
@@ -71,23 +108,31 @@
 
 ### Fixed
 
-- Fixed HTTP request component input backgrounds using incorrect theme color (`neutral20` instead of `neutral0`)
-- Fixed CSS border shorthand/non-shorthand conflict causing React 19 warnings
-- Fixed `QueryClient` being recreated on every render in `FrontendClientProvider`
+- Fixed HTTP request component input backgrounds using incorrect theme
+  color (`neutral20` instead of `neutral0`)
+- Fixed CSS border shorthand/non-shorthand conflict causing React 19
+  warnings
+- Fixed `QueryClient` being recreated on every render in
+  `FrontendClientProvider`
 
 ## [2.4.0] - 2025-12-10
 
 ### Added
 
-- Added support for `http_request` prop type with `ControlHttpRequest` component
-- HTTP request builder UI with URL, method, headers, and body configuration
+- Added support for `http_request` prop type with `ControlHttpRequest`
+  component
+- HTTP request builder UI with URL, method, headers, and body
+  configuration
 
 ## [2.3.0] - 2025-12-07
 
 ### Added
 
-- Dark mode support for select components with new theme color tokens (`optionHover`, `optionSelected`, `optionSelectedHover`, `appIconBackground`)
-- App icon backgrounds in `SelectApp` for better visibility in dark mode
+- Dark mode support for select components with new theme color tokens
+  (`optionHover`, `optionSelected`, `optionSelectedHover`,
+  `appIconBackground`)
+- App icon backgrounds in `SelectApp` for better visibility in dark
+  mode
 
 ## [2.2.0] - 2025-11-29
 
@@ -97,18 +142,23 @@
 
 ### Fixed
 
-- Fixed dropdown menus being clipped or hidden behind other elements when rendered inside containers with overflow constraints (e.g., workflow builders, modals)
-- All select components now portal their menus to the document body with proper z-index handling
+- Fixed dropdown menus being clipped or hidden behind other elements
+  when rendered inside containers with overflow constraints (e.g.,
+  workflow builders, modals)
+- All select components now portal their menus to the document body
+  with proper z-index handling
 
 ### Changed
 
-- Upgraded `react-select` from 5.8.2 to 5.9.0 for React 19 compatibility
+- Upgraded `react-select` from 5.8.2 to 5.9.0 for React 19
+  compatibility
 
 ## [2.1.2] - 2025-11-14
 
 ### Fixed
 
-- Fixed issue where user input in dynamically loaded props was lost due to circular effect dependency
+- Fixed issue where user input in dynamically loaded props was lost
+  due to circular effect dependency
 
 ## [2.1.1] - 2025-10-27
 
@@ -116,32 +166,36 @@
 
 - Fixed optional props being removed when loading saved configurations
 - Optional props with values now automatically display as enabled
-- Improved handling of label-value format for remote options in multi-select fields
+- Improved handling of label-value format for remote options in
+  multi-select fields
 
 ## [2.1.0] - 2025-10-10
 
 ### Added
 
-- Added infinite scroll (with pagination) for `SelectApp` and `SelectComponent` dropdowns
+- Added infinite scroll (with pagination) for `SelectApp` and
+  `SelectComponent` dropdowns
 - Increased default page size to 50 items per request for better UX
 
 ### Fixed
 
-- Remote options now properly reset when parent props change (e.g., switching accounts)
+- Remote options now properly reset when parent props change (e.g.,
+  switching accounts)
 
 ## [2.0.0] - 2025-10-02
 
 ### Breaking Changes
 
-Use the new v2 version of the Pipedream SDK (i.e. `@pipedreamhq/pipedream-sdk`).
-This change involves migrating to the new types mostly, but also runtime changes
-involving the API calls.
+Use the new v2 version of the Pipedream SDK
+(i.e. `@pipedreamhq/pipedream-sdk`).  This change involves migrating
+to the new types mostly, but also runtime changes involving the API
+calls.
 
-The runtime behavior should not be affected from a user's perspective, except
-for consumers of the `connect-react` package itself, since some components (e.g.
-`FrontendClientProvider`) expect their consumers to inject a client instance of
-the same SDK version. For this reason, this change bumps the **major** version
-of this package.
+The runtime behavior should not be affected from a user's perspective,
+except for consumers of the `connect-react` package itself, since some
+components (e.g.  `FrontendClientProvider`) expect their consumers to
+inject a client instance of the same SDK version. For this reason,
+this change bumps the **major** version of this package.
 
 ## [1.5.0] - 2025-08-18
 
@@ -151,10 +205,13 @@ of this package.
 
 ### Added
 
-- Support for app sorting and filtering in `SelectApp` component and `useApps` hook
-- Added `appsOptions` prop to `SelectApp` for controlling sort order and filtering
+- Support for app sorting and filtering in `SelectApp` component and
+  `useApps` hook
+- Added `appsOptions` prop to `SelectApp` for controlling sort order
+  and filtering
 - Apps can now be sorted by `name`, `featured_weight`, or `name_slug`
-- Support for filtering apps by whether they have actions, triggers, or components
+- Support for filtering apps by whether they have actions, triggers,
+  or components
 
 ## [1.4.0] - 2025-08-01
 
@@ -164,39 +221,44 @@ of this package.
 
 ## [1.3.3] - 2025-07-22
 
-- Improved handling and sanitization of option objects in selection components.
+- Improved handling and sanitization of option objects in selection
+  components.
 
 ## [1.3.2] - 2025-07-15
 
 ### Changed
 
-- Do not perform prop validation for `app` props with nil auth type. This will
-  allow components to be deployed/executed without users having to authenticate
-  to the app (which would fail given that the app doesn't have a way to
-  authenticate anyways).
-- Use the `getComponents` method from the SDK instead of the deprecated
-  `components` method.
+- Do not perform prop validation for `app` props with nil auth
+  type. This will allow components to be deployed/executed without
+  users having to authenticate to the app (which would fail given that
+  the app doesn't have a way to authenticate anyways).
+- Use the `getComponents` method from the SDK instead of the
+  deprecated `components` method.
 
 ## [1.3.1] - 2025-06-30
 
 ### Changed
 
-- Fixed handling of the 'dir' prop type to exclude it from configurable props
+- Fixed handling of the 'dir' prop type to exclude it from
+  configurable props
 
 ## [1.3.0] - 2025-06-10
 
 ### Added
 
-- Support for `externalUserId` param across all components as the preferred way to identify users
+- Support for `externalUserId` param across all components as the
+  preferred way to identify users
 - Backward compatibility with existing `userId` parameter
 
 ### Changed
 
-- All internal SDK calls now use `externalUserId` parameter for consistency with backend SDK
+- All internal SDK calls now use `externalUserId` parameter for
+  consistency with backend SDK
 
 ### Deprecated
 
-- `userId` parameter in favor of `externalUserId` (existing code continues to work with console warnings)
+- `userId` parameter in favor of `externalUserId` (existing code
+  continues to work with console warnings)
 
 ### Migration
 
@@ -212,8 +274,10 @@ Replace `userId` with `externalUserId` in component props:
 
 ## [1.2.1] - 2025-06-07
 
-- Fixing the SelectApp component to properly handle controlled values when not found in search results
-- Fixing infinite re-render issue in ComponentFormContainer by memoizing configurableProps
+- Fixing the SelectApp component to properly handle controlled values
+  when not found in search results
+- Fixing infinite re-render issue in ComponentFormContainer by
+  memoizing configurableProps
 
 ## [1.2.0] - 2025-06-05
 
@@ -222,17 +286,20 @@ Replace `userId` with `externalUserId` in component props:
 ## [1.1.0] - 2025-06-04
 
 - Adding support for 'object' prop types
-- Modifying string and string[] inputs to hide the dropdown in the case of no options
+- Modifying string and string[] inputs to hide the dropdown in the
+  case of no options
 - Added basic styling to hyperlinks in prop descriptions
 
 ## [1.0.2] - 2025-04-24
 
-- Updating README to remove note about this package being in early preview
+- Updating README to remove note about this package being in early
+  preview
 
 ## [1.0.1] - 2025-04-16
 
 - remove bad polyfill (would break checking `document`)
-- handle bad `decode-named-character-reference` browser import via vite resolve.alias
+- handle bad `decode-named-character-reference` browser import via
+  vite resolve.alias
 - stop accidentally bundling `lodash` (-80KB for es build)
 
 ## [1.0.0-preview.30] - 2025-02-19
@@ -258,17 +325,21 @@ Replace `userId` with `externalUserId` in component props:
 ## [1.0.0-preview.25] - 2025-01-28
 
 - Show prop labels instead of values after selecting dynamic props
-- Fix the bug where a remote option would not be reloaded when the form component is re-rendered
+- Fix the bug where a remote option would not be reloaded when the
+  form component is re-rendered
 
 ## [1.0.0-preview.24] - 2025-01-24
 
-- Fix the bug where inputting multiple strings into an array prop would merge the strings into one
+- Fix the bug where inputting multiple strings into an array prop
+  would merge the strings into one
 - Fix custom string input for remote options
-- Fix the reloading of a previously selected remote option when re-rendering the form component
+- Fix the reloading of a previously selected remote option when
+  re-rendering the form component
 
 ## [1.0.0-preview.23] - 2025-01-22
 
-- Show the prop label instead of the value after selecting from a dropdown for string array props
+- Show the prop label instead of the value after selecting from a
+  dropdown for string array props
 
 ## [1.0.0-preview.22] - 2025-01-21
 
@@ -280,7 +351,8 @@ Replace `userId` with `externalUserId` in component props:
 
 ## [1.0.0-preview.20] - 2025-01-16
 
-- Check if a string prop is set instead of inspecting the contents of the string
+- Check if a string prop is set instead of inspecting the contents of
+  the string
 
 ## [1.0.0-preview.15] - 2024-12-18
 
@@ -288,7 +360,8 @@ Replace `userId` with `externalUserId` in component props:
 
 ## [1.0.0-preview.14] - 2024-12-17
 
-- Fixed one case of "maximum update depth exceeded" (useEffect component dependency)
+- Fixed one case of "maximum update depth exceeded" (useEffect
+  component dependency)
 
 ## [1.0.0-preview.13] - 2024-12-17
 
@@ -317,11 +390,13 @@ Replace `userId` with `externalUserId` in component props:
 
 ## [1.0.0-preview.7] - 2024-12-05
 
-- Use proper casing for `stringOptions` now that configure prop is properly async
+- Use proper casing for `stringOptions` now that configure prop is
+  properly async
 
 ## [1.0.0-preview.6] - 2024-12-05
 
-- Handle configurable prop `withLabel` (eg. fixes config of Airtable `tableId`)
+- Handle configurable prop `withLabel` (eg. fixes config of Airtable
+  `tableId`)
 
 ## [1.0.0-preview.5] - 2024-12-02
 
@@ -334,7 +409,8 @@ Replace `userId` with `externalUserId` in component props:
 
 ## [1.0.0-preview.3] - 2024-11-27
 
-- Previous version broken, lack of build before publish (not sure how preview.1 shipped)
+- Previous version broken, lack of build before publish (not sure how
+  preview.1 shipped)
 
 ## [1.0.0-preview.2] - 2024-11-27
 

--- a/packages/connect-react/package.json
+++ b/packages/connect-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/connect-react",
-  "version": "2.8.0",
+  "version": "3.0.0",
   "description": "Pipedream Connect library for React",
   "files": [
     "dist"
@@ -31,7 +31,7 @@
   "author": "Pipedream Engineering",
   "license": "MIT",
   "dependencies": {
-    "@pipedream/sdk": "^2.4.0",
+    "@pipedream/sdk": "^3.0.0",
     "@tanstack/react-query": "^5.59.16",
     "lodash.isequal": "^4.5.0",
     "react-markdown": "^9.0.1",

--- a/packages/connect-react/src/components/ControlApp.tsx
+++ b/packages/connect-react/src/components/ControlApp.tsx
@@ -17,7 +17,7 @@ import type { OptionProps } from "react-select";
 import type {
   Account,
   App,
-  ConfigurableProp,
+  ConfigurablePropApp,
 } from "@pipedream/sdk";
 
 const BaseOption = (props: OptionProps<SelectValue>) => {
@@ -46,7 +46,7 @@ export function ControlApp({ app }: ControlAppProps) {
   const {
     externalUserId, oauthAppConfig,
   } = useFormContext();
-  const formFieldCtx = useFormFieldContext<ConfigurableProp.App>();
+  const formFieldCtx = useFormFieldContext<ConfigurablePropApp>();
   const {
     id, prop, value, onChange,
   } = formFieldCtx;

--- a/packages/connect-react/src/components/ControlBoolean.tsx
+++ b/packages/connect-react/src/components/ControlBoolean.tsx
@@ -1,10 +1,10 @@
-import type { ConfigurableProp } from "@pipedream/sdk";
+import type { ConfigurablePropBoolean } from "@pipedream/sdk";
 import { useFormFieldContext } from "../hooks/form-field-context";
 import { useCustomize } from "../hooks/customization-context";
 import type { CSSProperties } from "react";
 
 export function ControlBoolean() {
-  const formFieldContextProps = useFormFieldContext<ConfigurableProp.Boolean>();
+  const formFieldContextProps = useFormFieldContext<ConfigurablePropBoolean>();
   const {
     id, value, onChange,
   } = formFieldContextProps;

--- a/packages/connect-react/src/hooks/customization-context.tsx
+++ b/packages/connect-react/src/hooks/customization-context.tsx
@@ -1,4 +1,8 @@
-import type { ConfigurableProp } from "@pipedream/sdk";
+import type {
+  ConfigurableProp,
+  ConfigurablePropApp,
+  ConfigurablePropBoolean,
+} from "@pipedream/sdk";
 import type {
   ComponentProps, CSSProperties, JSXElementConstructor,
 } from "react";
@@ -71,11 +75,11 @@ export type CustomizationOpts<P extends ComponentProps<JSXElementConstructor<any
 
 export type CustomizableProps = {
   componentForm: ComponentProps<typeof ComponentForm>;
-  connectButton: ComponentProps<typeof ControlApp> & FormFieldContext<ConfigurableProp.App>;
+  connectButton: ComponentProps<typeof ControlApp> & FormFieldContext<ConfigurablePropApp>;
   controlAny: ComponentProps<typeof ControlAny> & FormFieldContext<ConfigurableProp>;
-  controlApp: ComponentProps<typeof ControlApp> & FormFieldContext<ConfigurableProp.App>;
+  controlApp: ComponentProps<typeof ControlApp> & FormFieldContext<ConfigurablePropApp>;
   controlArray: ComponentProps<typeof ControlArray> & FormFieldContext<ConfigurableProp>;
-  controlBoolean: ComponentProps<typeof ControlBoolean> & FormFieldContext<ConfigurableProp.Boolean>;
+  controlBoolean: ComponentProps<typeof ControlBoolean> & FormFieldContext<ConfigurablePropBoolean>;
   controlHttpRequest: ComponentProps<typeof ControlHttpRequest> & FormFieldContext<ConfigurableProp>;
   controlInput: ComponentProps<typeof ControlInput> & FormFieldContext<ConfigurableProp>;
   controlObject: ComponentProps<typeof ControlObject> & FormFieldContext<ConfigurableProp>;

--- a/packages/connect-react/src/hooks/form-field-context.tsx
+++ b/packages/connect-react/src/hooks/form-field-context.tsx
@@ -2,12 +2,13 @@ import {
   createContext, useContext,
 } from "react";
 import type {
+  App,
   ConfigurableProp,
+  ConfigurablePropApp,
   PropValue,
 } from "@pipedream/sdk";
-import type { App } from "@pipedream/sdk";
 
-export type FormFieldContextExtra<T extends ConfigurableProp> = T extends ConfigurableProp.App ? {
+export type FormFieldContextExtra<T extends ConfigurableProp> = T extends ConfigurablePropApp ? {
   app?: App;
 } : object;
 

--- a/packages/connect-react/src/utils/type-guards.ts
+++ b/packages/connect-react/src/utils/type-guards.ts
@@ -4,6 +4,26 @@ import {
 } from "../types";
 import type {
   ConfigurableProp,
+  ConfigurablePropAirtableBaseId,
+  ConfigurablePropAirtableFieldId,
+  ConfigurablePropAirtableTableId,
+  ConfigurablePropAirtableViewId,
+  ConfigurablePropAlert,
+  ConfigurablePropAny,
+  ConfigurablePropApp,
+  ConfigurablePropApphook,
+  ConfigurablePropBoolean,
+  ConfigurablePropDb,
+  ConfigurablePropDiscordChannel,
+  ConfigurablePropDiscordChannelArray,
+  ConfigurablePropHttp,
+  ConfigurablePropInteger,
+  ConfigurablePropIntegerArray,
+  ConfigurablePropObject,
+  ConfigurablePropSql,
+  ConfigurablePropString,
+  ConfigurablePropStringArray,
+  ConfigurablePropTimer,
   PropOptionNested, PropOptionValue,
 } from "@pipedream/sdk";
 
@@ -21,30 +41,31 @@ export function isString(value: unknown): value is string {
  * This map is used to determine the specific type of a ConfigurableProp based
  * on its 'type' discriminator.
  *
- * Note: Uses ConfigurableProp namespace types (not base types) because these
- * include the 'type' discriminator needed for narrowing.
+ * Note: Uses the flat per-variant `ConfigurableProp{Variant}` interfaces from
+ * `@pipedream/sdk` v3.x; each one carries its own literal `type` field for
+ * narrowing.
  */
 type DiscriminatorPropTypeMap = {
-  "$.airtable.baseId": ConfigurableProp.AirtableBaseId;
-  "$.airtable.fieldId": ConfigurableProp.AirtableFieldId;
-  "$.airtable.tableId": ConfigurableProp.AirtableTableId;
-  "$.airtable.viewId": ConfigurableProp.AirtableViewId;
-  "$.discord.channel": ConfigurableProp.DiscordChannel;
-  "$.discord.channel[]": ConfigurableProp.DiscordChannelArray;
-  "$.interface.apphook": ConfigurableProp.InterfaceApphook;
-  "$.interface.http": ConfigurableProp.InterfaceHttp;
-  "$.interface.timer": ConfigurableProp.InterfaceTimer;
-  "$.service.db": ConfigurableProp.ServiceDb;
-  "integer[]": ConfigurableProp.IntegerArray;
-  "string[]": ConfigurableProp.StringArray;
-  alert: ConfigurableProp.Alert;
-  any: ConfigurableProp.Any;
-  app: ConfigurableProp.App;
-  boolean: ConfigurableProp.Boolean;
-  integer: ConfigurableProp.Integer;
-  object: ConfigurableProp.Object_;
-  sql: ConfigurableProp.Sql;
-  string: ConfigurableProp.String;
+  "$.airtable.baseId": ConfigurablePropAirtableBaseId;
+  "$.airtable.fieldId": ConfigurablePropAirtableFieldId;
+  "$.airtable.tableId": ConfigurablePropAirtableTableId;
+  "$.airtable.viewId": ConfigurablePropAirtableViewId;
+  "$.discord.channel": ConfigurablePropDiscordChannel;
+  "$.discord.channel[]": ConfigurablePropDiscordChannelArray;
+  "$.interface.apphook": ConfigurablePropApphook;
+  "$.interface.http": ConfigurablePropHttp;
+  "$.interface.timer": ConfigurablePropTimer;
+  "$.service.db": ConfigurablePropDb;
+  "integer[]": ConfigurablePropIntegerArray;
+  "string[]": ConfigurablePropStringArray;
+  alert: ConfigurablePropAlert;
+  any: ConfigurablePropAny;
+  app: ConfigurablePropApp;
+  boolean: ConfigurablePropBoolean;
+  integer: ConfigurablePropInteger;
+  object: ConfigurablePropObject;
+  sql: ConfigurablePropSql;
+  string: ConfigurablePropString;
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8946,7 +8946,7 @@ importers:
     dependencies:
       linkup-sdk:
         specifier: ^1.0.3
-        version: 1.2.0(@types/node@20.19.25)(typescript@5.6.3)
+        version: 1.2.0(@types/node@25.9.0)(typescript@5.9.3)
 
   components/linkupapi:
     dependencies:
@@ -18489,8 +18489,8 @@ importers:
   packages/connect-react:
     dependencies:
       '@pipedream/sdk':
-        specifier: ^2.4.0
-        version: 2.4.0
+        specifier: ^3.0.0
+        version: 3.0.4
       '@tanstack/react-query':
         specifier: ^5.59.16
         version: 5.90.9(react@18.3.1)
@@ -18570,7 +18570,7 @@ importers:
         version: 3.1.11
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.5(@babel/core@7.28.5)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.25)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.6.3)))(typescript@5.6.3)
+        version: 29.4.5(@babel/core@8.0.0-beta.3)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@8.0.0-beta.3))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.25)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.6.3)))(typescript@5.6.3)
       tsup:
         specifier: ^8.3.6
         version: 8.5.1(@microsoft/api-extractor@7.55.0(@types/node@20.19.25))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.6.3)(yaml@2.8.1)
@@ -22136,8 +22136,8 @@ packages:
     resolution: {integrity: sha512-nJG6+CsM4QhTD4lgU1tq3ejDieVJmp29DS6COLixdsDHbF8BfSNOxpkHqXKxii91DTm2aZ+WCjbtT5BHTSGcvQ==}
     engines: {node: '>=18.0.0'}
 
-  '@pipedream/sdk@2.4.0':
-    resolution: {integrity: sha512-3Pr21tVmRHDmyep7KFzMCehNFtpznZIOaCLsm5Ty3FnCsAX6YcqX0n38cpybB8Heex6X2v4s+O+9k/Vljxz/Qw==}
+  '@pipedream/sdk@3.0.4':
+    resolution: {integrity: sha512-kUi7UGZoklaRHJo2MAs47Rcd7L50gOFVGLcYpA7jytHzW/IT0JiGo4Ztn3CJh66RCWL+R0VzYMOX47qWmAqbgQ==}
     engines: {node: '>=18.0.0'}
 
   '@pipedream/sftp@0.5.1':
@@ -37435,7 +37435,7 @@ snapshots:
       '@babel/types': 7.28.5
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -37455,7 +37455,7 @@ snapshots:
       '@jridgewell/remapping': 2.3.5
       '@types/gensync': 1.0.4
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 7.8.0
@@ -37532,7 +37532,7 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -38301,7 +38301,7 @@ snapshots:
       '@babel/parser': 7.28.5
       '@babel/template': 7.27.2
       '@babel/types': 7.28.5
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -38313,7 +38313,7 @@ snapshots:
       '@babel/parser': 8.0.0-beta.3
       '@babel/template': 8.0.0-beta.3
       '@babel/types': 8.0.0-beta.3
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -38446,6 +38446,19 @@ snapshots:
       - '@types/node'
       - typescript
 
+  '@commitlint/cli@19.8.1(@types/node@25.9.0)(typescript@5.9.3)':
+    dependencies:
+      '@commitlint/format': 19.8.1
+      '@commitlint/lint': 19.8.1
+      '@commitlint/load': 19.8.1(@types/node@25.9.0)(typescript@5.9.3)
+      '@commitlint/read': 19.8.1
+      '@commitlint/types': 19.8.1
+      tinyexec: 1.0.2
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - typescript
+
   '@commitlint/config-conventional@19.8.1':
     dependencies:
       '@commitlint/types': 19.8.1
@@ -38493,6 +38506,22 @@ snapshots:
       chalk: 5.6.2
       cosmiconfig: 9.0.0(typescript@5.6.3)
       cosmiconfig-typescript-loader: 6.2.0(@types/node@20.19.25)(cosmiconfig@9.0.0(typescript@5.6.3))(typescript@5.6.3)
+      lodash.isplainobject: 4.0.6
+      lodash.merge: 4.6.2
+      lodash.uniq: 4.5.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - typescript
+
+  '@commitlint/load@19.8.1(@types/node@25.9.0)(typescript@5.9.3)':
+    dependencies:
+      '@commitlint/config-validator': 19.8.1
+      '@commitlint/execute-rule': 19.8.1
+      '@commitlint/resolve-extends': 19.8.1
+      '@commitlint/types': 19.8.1
+      chalk: 5.6.2
+      cosmiconfig: 9.0.0(typescript@5.9.3)
+      cosmiconfig-typescript-loader: 6.2.0(@types/node@25.9.0)(cosmiconfig@9.0.0(typescript@5.9.3))(typescript@5.9.3)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -39041,7 +39070,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -39055,7 +39084,7 @@ snapshots:
   '@eslint/eslintrc@3.3.1':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -39550,7 +39579,7 @@ snapshots:
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
@@ -41363,7 +41392,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@pipedream/sdk@2.4.0': {}
+  '@pipedream/sdk@3.0.4': {}
 
   '@pipedream/sftp@0.5.1':
     dependencies:
@@ -41435,7 +41464,7 @@ snapshots:
 
   '@pnpm/tabtab@0.5.4':
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       enquirer: 2.4.1
       minimist: 1.2.8
       untildify: 4.0.0
@@ -41521,7 +41550,7 @@ snapshots:
 
   '@puppeteer/browsers@2.11.2':
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.5.0
@@ -41614,7 +41643,7 @@ snapshots:
       '@putout/babel': 3.2.0
       '@putout/engine-parser': 12.6.0
       '@putout/operate': 13.5.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       jessy: 4.1.0
       nessy: 5.3.0
     transitivePeerDependencies:
@@ -41625,7 +41654,7 @@ snapshots:
       '@putout/babel': 3.2.0
       '@putout/engine-parser': 13.1.0(rolldown@1.0.0-beta.60(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1))(rollup@4.53.2)
       '@putout/operate': 13.5.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       jessy: 4.1.0
       nessy: 5.3.0
     transitivePeerDependencies:
@@ -41638,7 +41667,7 @@ snapshots:
       '@putout/babel': 4.5.4(rolldown@1.0.0-beta.60(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1))(rollup@4.53.2)
       '@putout/engine-parser': 14.2.0(rolldown@1.0.0-beta.60(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1))(rollup@4.53.2)
       '@putout/operate': 14.2.0(rolldown@1.0.0-beta.60(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1))(rollup@4.53.2)
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       jessy: 4.1.0
       nessy: 5.3.0
     transitivePeerDependencies:
@@ -41735,7 +41764,7 @@ snapshots:
       '@putout/operator-filesystem': 9.0.1(putout@40.14.0(eslint@8.57.1)(rolldown@1.0.0-beta.60(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1))(rollup@4.53.2)(typescript@5.6.3))(rolldown@1.0.0-beta.60(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1))(rollup@4.53.2)
       '@putout/operator-json': 2.2.0
       '@putout/plugin-filesystem': 11.0.1(putout@40.14.0(eslint@8.57.1)(rolldown@1.0.0-beta.60(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1))(rollup@4.53.2)(typescript@5.6.3))(rolldown@1.0.0-beta.60(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1))(rollup@4.53.2)
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       fullstore: 3.0.0
       jessy: 4.1.0
       nessy: 5.3.0
@@ -42930,11 +42959,25 @@ snapshots:
       conventional-changelog-writer: 8.2.0
       conventional-commits-filter: 5.0.0
       conventional-commits-parser: 6.2.1
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       import-from-esm: 2.0.0
       lodash-es: 4.18.1
       micromatch: 4.0.8
       semantic-release: 24.2.9(typescript@5.6.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@semantic-release/commit-analyzer@13.0.1(semantic-release@24.2.9(typescript@5.9.3))':
+    dependencies:
+      conventional-changelog-angular: 8.1.0
+      conventional-changelog-writer: 8.2.0
+      conventional-commits-filter: 5.0.0
+      conventional-commits-parser: 6.2.1
+      debug: 4.4.3(supports-color@9.4.0)
+      import-from-esm: 2.0.0
+      lodash-es: 4.18.1
+      micromatch: 4.0.8
+      semantic-release: 24.2.9(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -42948,7 +42991,7 @@ snapshots:
       '@octokit/plugin-throttling': 11.0.3(@octokit/core@7.0.6)
       '@semantic-release/error': 4.0.0
       aggregate-error: 5.0.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       dir-glob: 3.0.1
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -42957,6 +43000,28 @@ snapshots:
       mime: 4.1.0
       p-filter: 4.1.0
       semantic-release: 24.2.9(typescript@5.6.3)
+      tinyglobby: 0.2.15
+      url-join: 5.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@semantic-release/github@11.0.6(semantic-release@24.2.9(typescript@5.9.3))':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/plugin-paginate-rest': 13.2.1(@octokit/core@7.0.6)
+      '@octokit/plugin-retry': 8.0.3(@octokit/core@7.0.6)
+      '@octokit/plugin-throttling': 11.0.3(@octokit/core@7.0.6)
+      '@semantic-release/error': 4.0.0
+      aggregate-error: 5.0.0
+      debug: 4.4.3(supports-color@9.4.0)
+      dir-glob: 3.0.1
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      issue-parser: 7.0.1
+      lodash-es: 4.18.1
+      mime: 4.1.0
+      p-filter: 4.1.0
+      semantic-release: 24.2.9(typescript@5.9.3)
       tinyglobby: 0.2.15
       url-join: 5.0.0
     transitivePeerDependencies:
@@ -42979,19 +43044,52 @@ snapshots:
       semver: 7.8.0
       tempy: 3.1.0
 
+  '@semantic-release/npm@12.0.2(semantic-release@24.2.9(typescript@5.9.3))':
+    dependencies:
+      '@semantic-release/error': 4.0.0
+      aggregate-error: 5.0.0
+      execa: 9.6.0
+      fs-extra: 11.3.2
+      lodash-es: 4.18.1
+      nerf-dart: 1.0.0
+      normalize-url: 8.1.0
+      npm: 10.9.4
+      rc: 1.2.8
+      read-pkg: 9.0.1
+      registry-auth-token: 5.1.0
+      semantic-release: 24.2.9(typescript@5.9.3)
+      semver: 7.8.0
+      tempy: 3.1.0
+
   '@semantic-release/release-notes-generator@14.1.0(semantic-release@24.2.9(typescript@5.6.3))':
     dependencies:
       conventional-changelog-angular: 8.1.0
       conventional-changelog-writer: 8.2.0
       conventional-commits-filter: 5.0.0
       conventional-commits-parser: 6.2.1
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       get-stream: 7.0.1
       import-from-esm: 2.0.0
       into-stream: 7.0.0
       lodash-es: 4.18.1
       read-package-up: 11.0.0
       semantic-release: 24.2.9(typescript@5.6.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@semantic-release/release-notes-generator@14.1.0(semantic-release@24.2.9(typescript@5.9.3))':
+    dependencies:
+      conventional-changelog-angular: 8.1.0
+      conventional-changelog-writer: 8.2.0
+      conventional-commits-filter: 5.0.0
+      conventional-commits-parser: 6.2.1
+      debug: 4.4.3(supports-color@9.4.0)
+      get-stream: 7.0.1
+      import-from-esm: 2.0.0
+      into-stream: 7.0.0
+      lodash-es: 4.18.1
+      read-package-up: 11.0.0
+      semantic-release: 24.2.9(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -44004,7 +44102,7 @@ snapshots:
 
   '@tokenizer/inflate@0.3.1':
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       fflate: 0.8.2
       token-types: 6.1.2
     transitivePeerDependencies:
@@ -44012,7 +44110,7 @@ snapshots:
 
   '@tokenizer/inflate@0.4.1':
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       token-types: 6.1.2
     transitivePeerDependencies:
       - supports-color
@@ -44455,7 +44553,7 @@ snapshots:
       '@typescript-eslint/types': 8.46.4
       '@typescript-eslint/typescript-estree': 8.46.4(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 8.46.4
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       eslint: 8.57.1
       typescript: 5.6.3
     transitivePeerDependencies:
@@ -44467,7 +44565,7 @@ snapshots:
       '@typescript-eslint/types': 8.46.4
       '@typescript-eslint/typescript-estree': 8.46.4(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.46.4
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       eslint: 8.57.1
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -44486,7 +44584,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.46.4(typescript@5.6.3)
       '@typescript-eslint/types': 8.46.4
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
@@ -44495,7 +44593,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.46.4(typescript@5.9.3)
       '@typescript-eslint/types': 8.46.4
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -44518,7 +44616,7 @@ snapshots:
       '@typescript-eslint/types': 8.46.4
       '@typescript-eslint/typescript-estree': 8.46.4(typescript@5.6.3)
       '@typescript-eslint/utils': 8.46.4(eslint@8.57.1)(typescript@5.6.3)
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       eslint: 8.57.1
       ts-api-utils: 2.1.0(typescript@5.6.3)
       typescript: 5.6.3
@@ -44530,7 +44628,7 @@ snapshots:
       '@typescript-eslint/types': 8.46.4
       '@typescript-eslint/typescript-estree': 8.46.4(typescript@5.9.3)
       '@typescript-eslint/utils': 8.46.4(eslint@8.57.1)(typescript@5.9.3)
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       eslint: 8.57.1
       ts-api-utils: 2.1.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -44561,7 +44659,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.46.4(typescript@5.6.3)
       '@typescript-eslint/types': 8.46.4
       '@typescript-eslint/visitor-keys': 8.46.4
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.9
@@ -44577,7 +44675,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.46.4(typescript@5.9.3)
       '@typescript-eslint/types': 8.46.4
       '@typescript-eslint/visitor-keys': 8.46.4
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.9
@@ -44616,7 +44714,7 @@ snapshots:
 
   '@typescript/vfs@1.6.2(typescript@5.4.5)':
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
@@ -44996,7 +45094,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -45779,7 +45877,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       http-errors: 2.0.0
       iconv-lite: 0.6.3
       on-finished: 2.4.1
@@ -46585,6 +46683,13 @@ snapshots:
       jiti: 2.6.1
       typescript: 5.6.3
 
+  cosmiconfig-typescript-loader@6.2.0(@types/node@25.9.0)(cosmiconfig@9.0.0(typescript@5.9.3))(typescript@5.9.3):
+    dependencies:
+      '@types/node': 25.9.0
+      cosmiconfig: 9.0.0(typescript@5.9.3)
+      jiti: 2.6.1
+      typescript: 5.9.3
+
   cosmiconfig@5.2.1:
     dependencies:
       import-fresh: 2.0.0
@@ -46608,6 +46713,15 @@ snapshots:
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.6.3
+
+  cosmiconfig@9.0.0(typescript@5.9.3):
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 5.9.3
 
   cp-file@6.2.0:
     dependencies:
@@ -47743,7 +47857,7 @@ snapshots:
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       eslint: 8.57.1
       get-tsconfig: 4.13.0
       is-bun-module: 2.0.0
@@ -48016,7 +48130,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -48275,7 +48389,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -48620,7 +48734,7 @@ snapshots:
 
   finalhandler@2.1.0:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -48733,7 +48847,7 @@ snapshots:
     dependencies:
       '@putout/engine-loader': 16.2.1(putout@40.14.0(eslint@8.57.1)(rolldown@1.0.0-beta.60(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1))(rollup@4.53.2)(typescript@5.6.3))
       '@putout/operator-keyword': 2.2.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       js-tokens: 9.0.1
     transitivePeerDependencies:
       - putout
@@ -48757,7 +48871,7 @@ snapshots:
 
   follow-redirects@1.16.0(debug@4.4.3):
     optionalDependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
 
   fontkit@2.0.4:
     dependencies:
@@ -49072,7 +49186,7 @@ snapshots:
     dependencies:
       basic-ftp: 5.0.5
       data-uri-to-buffer: 6.0.2
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -49825,14 +49939,14 @@ snapshots:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -49885,14 +49999,14 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -49988,7 +50102,7 @@ snapshots:
 
   import-from-esm@2.0.0:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       import-meta-resolve: 4.2.0
     transitivePeerDependencies:
       - supports-color
@@ -50514,7 +50628,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -51270,7 +51384,7 @@ snapshots:
     dependencies:
       '@types/express': 4.17.25
       '@types/jsonwebtoken': 9.0.10
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       jose: 4.15.9
       limiter: 1.1.5
       lru-memoizer: 2.3.0
@@ -51468,6 +51582,20 @@ snapshots:
       '@commitlint/config-conventional': 19.8.1
       axios: 1.15.2(debug@3.2.7)
       semantic-release: 24.2.9(typescript@5.6.3)
+      zod: 3.25.76
+      zod-to-json-schema: 3.24.6(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@types/node'
+      - debug
+      - supports-color
+      - typescript
+
+  linkup-sdk@1.2.0(@types/node@25.9.0)(typescript@5.9.3):
+    dependencies:
+      '@commitlint/cli': 19.8.1(@types/node@25.9.0)(typescript@5.9.3)
+      '@commitlint/config-conventional': 19.8.1
+      axios: 1.15.2(debug@3.2.7)
+      semantic-release: 24.2.9(typescript@5.9.3)
       zod: 3.25.76
       zod-to-json-schema: 3.24.6(zod@3.25.76)
     transitivePeerDependencies:
@@ -51722,7 +51850,7 @@ snapshots:
   log4js@6.4.4:
     dependencies:
       date-format: 4.0.14
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       flatted: 3.3.3
       rfdc: 1.4.1
       streamroller: 3.1.5
@@ -52365,7 +52493,7 @@ snapshots:
 
   micromark@2.11.4:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       parse-entities: 2.0.0
     transitivePeerDependencies:
       - supports-color
@@ -52373,7 +52501,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       decode-named-character-reference: 1.2.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -52596,7 +52724,7 @@ snapshots:
   mqtt-packet@6.10.0:
     dependencies:
       bl: 4.1.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       process-nextick-args: 2.0.1
     transitivePeerDependencies:
       - supports-color
@@ -52605,7 +52733,7 @@ snapshots:
     dependencies:
       commist: 1.1.0
       concat-stream: 2.0.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       duplexify: 4.1.3
       help-me: 3.0.0
       inherits: 2.0.4
@@ -52644,7 +52772,7 @@ snapshots:
     dependencies:
       '@tediousjs/connection-string': 0.5.0
       commander: 11.1.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       rfdc: 1.4.1
       tarn: 3.0.2
       tedious: 16.7.1
@@ -52791,7 +52919,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 1.0.2
       cron-parser: 4.9.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       decache: 4.6.2
       dot-prop: 9.0.0
       dotenv: 17.2.3
@@ -53130,7 +53258,7 @@ snapshots:
 
   number-allocator@1.0.14:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       js-sdsl: 4.3.0
     transitivePeerDependencies:
       - supports-color
@@ -53584,7 +53712,7 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       get-uri: 6.0.5
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -54193,7 +54321,7 @@ snapshots:
   proxy-agent@6.3.1:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
@@ -54206,7 +54334,7 @@ snapshots:
   proxy-agent@6.5.0:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
@@ -54301,7 +54429,7 @@ snapshots:
     dependencies:
       '@puppeteer/browsers': 2.11.2
       chromium-bidi: 13.0.1(devtools-protocol@0.0.1551306)
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       devtools-protocol: 0.0.1551306
       typed-query-selector: 2.12.0
       webdriver-bidi-protocol: 0.4.0
@@ -54465,7 +54593,7 @@ snapshots:
       '@putout/traverse': 14.0.0(rolldown@1.0.0-beta.60(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1))(rollup@4.53.2)
       ajv: 8.17.1
       ci-info: 4.3.1
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       deepmerge: 4.3.1
       escalade: 3.2.0
       fast-glob: 3.3.3
@@ -55153,7 +55281,7 @@ snapshots:
 
   retry-request@5.0.2:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       extend: 3.0.2
     transitivePeerDependencies:
       - supports-color
@@ -55214,7 +55342,7 @@ snapshots:
       '@babel/types': 7.28.5
       ast-kit: 2.2.0
       birpc: 2.8.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       dts-resolver: 2.1.3
       get-tsconfig: 4.13.0
       rolldown: 1.0.0-beta.9
@@ -55306,7 +55434,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -55440,7 +55568,42 @@ snapshots:
       '@semantic-release/release-notes-generator': 14.1.0(semantic-release@24.2.9(typescript@5.6.3))
       aggregate-error: 5.0.0
       cosmiconfig: 9.0.0(typescript@5.6.3)
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
+      env-ci: 11.2.0
+      execa: 9.6.0
+      figures: 6.1.0
+      find-versions: 6.0.0
+      get-stream: 6.0.1
+      git-log-parser: 1.2.1
+      hook-std: 4.0.0
+      hosted-git-info: 8.1.0
+      import-from-esm: 2.0.0
+      lodash-es: 4.18.1
+      marked: 15.0.12
+      marked-terminal: 7.3.0(marked@15.0.12)
+      micromatch: 4.0.8
+      p-each-series: 3.0.0
+      p-reduce: 3.0.0
+      read-package-up: 11.0.0
+      resolve-from: 5.0.0
+      semver: 7.7.4
+      semver-diff: 5.0.0
+      signale: 1.4.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  semantic-release@24.2.9(typescript@5.9.3):
+    dependencies:
+      '@semantic-release/commit-analyzer': 13.0.1(semantic-release@24.2.9(typescript@5.9.3))
+      '@semantic-release/error': 4.0.0
+      '@semantic-release/github': 11.0.6(semantic-release@24.2.9(typescript@5.9.3))
+      '@semantic-release/npm': 12.0.2(semantic-release@24.2.9(typescript@5.9.3))
+      '@semantic-release/release-notes-generator': 14.1.0(semantic-release@24.2.9(typescript@5.9.3))
+      aggregate-error: 5.0.0
+      cosmiconfig: 9.0.0(typescript@5.9.3)
+      debug: 4.4.3(supports-color@9.4.0)
       env-ci: 11.2.0
       execa: 9.6.0
       figures: 6.1.0
@@ -55510,7 +55673,7 @@ snapshots:
 
   send@1.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -55845,7 +56008,7 @@ snapshots:
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       socks: 2.8.7
     transitivePeerDependencies:
       - supports-color
@@ -56059,7 +56222,7 @@ snapshots:
   streamroller@3.1.5:
     dependencies:
       date-format: 4.0.14
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       fs-extra: 8.1.0
     transitivePeerDependencies:
       - supports-color
@@ -56271,7 +56434,7 @@ snapshots:
       cosmiconfig: 9.0.0(typescript@5.6.3)
       css-functions-list: 3.2.3
       css-tree: 3.1.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       fast-glob: 3.3.3
       fastest-levenshtein: 1.0.16
       file-entry-cache: 10.1.4
@@ -56346,7 +56509,7 @@ snapshots:
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       form-data: 2.5.4
       formidable: 1.2.6
       methods: 1.1.2
@@ -56360,7 +56523,7 @@ snapshots:
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       fast-safe-stringify: 2.1.1
       form-data: 3.0.4
       formidable: 1.2.6
@@ -56722,7 +56885,7 @@ snapshots:
     dependencies:
       '@aws-sdk/client-s3': 3.931.0(aws-crt@1.27.5)
       '@aws-sdk/s3-request-presigner': 3.931.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       form-data: 4.0.4
       got: 14.4.9
       into-stream: 9.0.0
@@ -56774,27 +56937,6 @@ snapshots:
       typescript: 5.9.3
 
   ts-interface-checker@0.1.13: {}
-
-  ts-jest@29.4.5(@babel/core@7.28.5)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.25)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.6.3)))(typescript@5.6.3):
-    dependencies:
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      handlebars: 4.7.9
-      jest: 29.7.0(@types/node@20.19.25)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.6.3))
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.7.4
-      type-fest: 4.41.0
-      typescript: 5.6.3
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.28.5
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.28.5)
-      esbuild: 0.27.0
-      jest-util: 29.7.0
 
   ts-jest@29.4.5(@babel/core@8.0.0-beta.3)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@8.0.0-beta.3))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.25)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.6.3)))(typescript@5.6.3):
     dependencies:
@@ -56865,7 +57007,7 @@ snapshots:
       ansis: 4.2.0
       cac: 6.7.14
       chokidar: 4.0.3
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       diff: 8.0.2
       empathic: 1.1.0
       hookable: 5.5.3
@@ -56930,7 +57072,7 @@ snapshots:
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       esbuild: 0.27.0
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
@@ -56959,7 +57101,7 @@ snapshots:
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       esbuild: 0.27.0
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
@@ -57002,7 +57144,7 @@ snapshots:
   tuf-js@4.1.0:
     dependencies:
       '@tufjs/models': 4.1.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       make-fetch-happen: 15.0.5
     transitivePeerDependencies:
       - supports-color
@@ -57658,7 +57800,7 @@ snapshots:
       '@volar/typescript': 2.4.23
       '@vue/language-core': 2.2.0(typescript@5.9.3)
       compare-versions: 6.1.1
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
       kolorist: 1.8.0
       local-pkg: 1.1.2
       magic-string: 0.30.21
@@ -57696,7 +57838,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       commander: 9.5.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## Summary

Use the new v3 version of the Pipedream SDK in the `connect-react` package. This change only affects type information, no runtime changes are involved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 3.0.0
  * Updated `@pipedream/sdk` dependency to v3.0.0

* **Documentation**
  * Updated changelog with v3.0.0 release information

* **Refactor**
  * Updated internal type system to align with latest SDK version

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PipedreamHQ/pipedream/pull/20950?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->