### PR TITLE
Add Freshdesk ticket search tools

### DIFF
--- a/components/freshdesk/actions/list-all-tickets/list-all-tickets.mjs
+++ b/components/freshdesk/actions/list-all-tickets/list-all-tickets.mjs
@@ -4,8 +4,8 @@ export default {
   key: "freshdesk-list-all-tickets",
   name: "List Tickets",
   description:
-    "Fetch up to 100 tickets according to the selected filters. [See the documentation](https://developers.freshdesk.com/api/#list_all_tickets)",
-  version: "0.2.12",
+    "List tickets according to the selected filters. [See the documentation](https://developers.freshdesk.com/api/#list_all_tickets)",
+  version: "0.2.13",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -55,14 +55,32 @@ export default {
         },
       ],
     },
+    status: {
+      propDefinition: [
+        freshdesk,
+        "ticketStatus",
+      ],
+      optional: true,
+    },
+    maxResults: {
+      propDefinition: [
+        freshdesk,
+        "maxResults",
+      ],
+    },
   },
   async run({ $ }) {
-    const response = await this.freshdesk.listTickets({
-      $,
-      params: {
-        order_by: this.orderBy,
-        order_type: this.orderType,
+    const response = await this.freshdesk.getPaginatedResources({
+      fn: this.freshdesk.listTickets,
+      args: {
+        $,
+        params: {
+          order_by: this.orderBy,
+          order_type: this.orderType,
+          status: this.status,
+        },
       },
+      max: this.maxResults,
     });
 
     const { length } = response;

--- a/components/freshdesk/actions/search-tickets/search-tickets.mjs
+++ b/components/freshdesk/actions/search-tickets/search-tickets.mjs
@@ -1,0 +1,55 @@
+import freshdesk from "../../freshdesk.app.mjs";
+
+export default {
+  key: "freshdesk-search-tickets",
+  name: "Search Tickets",
+  description: "Search tickets using Freshdesk's filter query syntax. [See the documentation](https://developers.freshdesk.com/api/#filter_tickets)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  type: "action",
+  props: {
+    freshdesk,
+    query: {
+      type: "string",
+      label: "Query",
+      description: "Freshdesk ticket filter query. For example, `status:2` or `priority:4 OR priority:3`.",
+    },
+    maxResults: {
+      propDefinition: [
+        freshdesk,
+        "maxResults",
+      ],
+    },
+  },
+  methods: {
+    formatQuery(query) {
+      const trimmed = query.trim();
+      return trimmed.startsWith("\"") && trimmed.endsWith("\"")
+        ? trimmed
+        : `"${trimmed}"`;
+    },
+  },
+  async run({ $ }) {
+    const results = [];
+    const params = {
+      query: this.formatQuery(this.query),
+      page: 1,
+    };
+
+    for await (const ticket of this.freshdesk.filterTickets(params)) {
+      results.push(ticket);
+      if (this.maxResults && results.length >= this.maxResults) {
+        break;
+      }
+    }
+
+    $.export("$summary", `Successfully found ${results.length} ticket${results.length === 1
+      ? ""
+      : "s"}`);
+    return results;
+  },
+};


### PR DESCRIPTION
## Summary
- Add a Freshdesk `Search Tickets` action for the documented `/api/v2/search/tickets` endpoint.
- Add optional `status` filtering and `maxResults` pagination to `List Tickets`.
- Keep both ticket-list/search actions annotated as read-only for MCP/agent usage.

Partially addresses #20630

## Notes
- `Get Ticket Details` already exists in the Freshdesk component.
- This PR does not add ticket activities because `GET /tickets/{id}/activities` was not clearly documented in the official Freshdesk API docs.

## Testing
- `node -e "const mods=['./components/freshdesk/actions/search-tickets/search-tickets.mjs','./components/freshdesk/actions/list-all-tickets/list-all-tickets.mjs']; for (const path of mods) { const mod = await import(path); console.log(path, mod.default.key, mod.default.annotations); }"`
- `corepack pnpm exec eslint components/freshdesk/actions/list-all-tickets/list-all-tickets.mjs components/freshdesk/actions/search-tickets/search-tickets.mjs`
- `node scripts/generate-package-report.js --package=freshdesk`
- `git diff --check`

## Test note
- `corepack pnpm test -- components/freshdesk --passWithNoTests` currently fails before test discovery with a repo-level Jest config validation error: `extensionsToTreatAsEsm` includes `.js`, which this Jest version rejects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new "Search Tickets" action that empowers users to easily search across Freshdesk tickets using keyword queries, with full support for customizable result limits
  * Enhanced the "List Tickets" action with improved ticket status filtering capabilities and granular controls to set a maximum number of results for better query management

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PipedreamHQ/pipedream/pull/20964?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->