### PR TITLE
Add Bilig WorkPaper formula readback action

### DIFF
--- a/components/bilig_workpaper/README.md
+++ b/components/bilig_workpaper/README.md
@@ -1,0 +1,39 @@
+# Overview
+
+Bilig WorkPaper runs spreadsheet-style formulas in backend services and agent
+tools. Use this app to edit a WorkPaper input cell, recalculate dependent
+formulas, and verify readback without driving Excel, LibreOffice, Google Sheets,
+or a browser UI.
+
+# Example Use Cases
+
+- Gate a quote, forecast, payout, or approval workflow on a formula workbook
+- Recalculate formula-backed business logic from webhook or CRM data
+- Verify computed output before sending a downstream update
+
+# Getting Started
+
+Use the **Verify Formula Readback** action with a Bilig connected account. The
+connected account supplies the Bilig Base URL.
+
+Editable cells in the demo forecast:
+
+- `B2`: qualified opportunities
+- `B3`: win rate
+- `B4`: average ARR
+- `B5`: expansion multiplier
+
+The action returns the edited cell, before/after computed values, and checks for
+formula persistence, restored-document equality, and changed computed output.
+
+# Troubleshooting
+
+If `verified` is false, inspect the returned `checks` object. A usable run
+should report:
+
+- `formulasPersisted: true`
+- `restoredMatchesAfter: true`
+- `computedOutputChanged: true`
+
+Make sure the connected account's **Bilig Base URL** points at the app origin and
+does not include the `/api/workpaper/n8n/forecast` path.

--- a/components/bilig_workpaper/actions/verify-formula-readback/verify-formula-readback.mjs
+++ b/components/bilig_workpaper/actions/verify-formula-readback/verify-formula-readback.mjs
@@ -1,0 +1,61 @@
+import { ConfigurationError } from "@pipedream/platform";
+
+import biligWorkpaper from "../../bilig_workpaper.app.mjs";
+
+export default {
+  key: "bilig_workpaper-verify-formula-readback",
+  name: "Verify Formula Readback",
+  description: "Write a Bilig WorkPaper forecast input cell and return verified recalculated formula output. [See the documentation](https://github.com/proompteng/bilig/tree/main/integrations/pipedream-bilig-workpaper)",
+  type: "action",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    biligWorkpaper,
+    sheetName: {
+      propDefinition: [
+        biligWorkpaper,
+        "forecastSheetName",
+      ],
+    },
+    address: {
+      propDefinition: [
+        biligWorkpaper,
+        "forecastCell",
+      ],
+    },
+    value: {
+      propDefinition: [
+        biligWorkpaper,
+        "forecastValue",
+      ],
+    },
+    valueDivisor: {
+      propDefinition: [
+        biligWorkpaper,
+        "forecastValueDivisor",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const numericValue = Number(this.value) / Number(this.valueDivisor);
+
+    if (!Number.isFinite(numericValue)) {
+      throw new ConfigurationError("Value divided by Value Divisor must produce a finite number.");
+    }
+
+    const result = await this.biligWorkpaper.verifyForecastReadback({
+      $,
+      sheetName: this.sheetName,
+      address: this.address,
+      value: numericValue,
+    });
+
+    $.export("$summary", `Verified ${result.editedCell}: expected ARR ${result.before?.expectedArr} -> ${result.after?.expectedArr}`);
+
+    return result;
+  },
+};

--- a/components/bilig_workpaper/bilig_workpaper.app.mjs
+++ b/components/bilig_workpaper/bilig_workpaper.app.mjs
@@ -1,11 +1,140 @@
+import {
+  axios,
+  ConfigurationError,
+} from "@pipedream/platform";
+
 export default {
   type: "app",
   app: "bilig_workpaper",
-  propDefinitions: {},
+  propDefinitions: {
+    forecastSheetName: {
+      type: "string",
+      label: "Sheet Name",
+      description: "Forecast input sheet to edit. Example: `Inputs`.",
+      default: "Inputs",
+    },
+    forecastCell: {
+      type: "string",
+      label: "Cell",
+      description: "Editable forecast input cell.",
+      options: [
+        {
+          label: "B2 Qualified Opportunities",
+          value: "B2",
+        },
+        {
+          label: "B3 Win Rate",
+          value: "B3",
+        },
+        {
+          label: "B4 Average ARR",
+          value: "B4",
+        },
+        {
+          label: "B5 Expansion Multiplier",
+          value: "B5",
+        },
+      ],
+      default: "B3",
+    },
+    forecastValue: {
+      type: "integer",
+      label: "Value",
+      description: "Numeric value to write before formula readback.",
+      default: 40,
+    },
+    forecastValueDivisor: {
+      type: "integer",
+      label: "Value Divisor",
+      description: "Divide Value by this number before sending. Use 100 for percentages like 40 -> 0.4.",
+      default: 100,
+      min: 1,
+    },
+  },
   methods: {
-    // this.$auth contains connected account data
-    authKeys() {
-      console.log(Object.keys(this.$auth));
+    /**
+     * Returns the connected account's Bilig base URL.
+     *
+     * @returns {string} Base URL without trailing slashes.
+     */
+    _baseUrl() {
+      const baseUrl = this.$auth?.base_url;
+
+      if (typeof baseUrl !== "string" || baseUrl.trim() === "") {
+        throw new ConfigurationError("Bilig Base URL is required in the connected account.");
+      }
+
+      return baseUrl.trim().replace(/\/+$/, "");
+    },
+
+    /**
+     * Makes an HTTP request to a Bilig WorkPaper endpoint.
+     *
+     * @param {object} args - Request arguments.
+     * @param {object} args.$ - Pipedream step context.
+     * @param {string} args.path - API path to request.
+     * @returns {Promise<object>} Bilig API response.
+     */
+    _makeRequest({
+      $,
+      path,
+      ...args
+    }) {
+      return axios($, {
+        baseURL: this._baseUrl(),
+        url: path,
+        ...args,
+      });
+    },
+
+    /**
+     * Writes one forecast input and verifies formula readback proof.
+     *
+     * @param {object} args - Verification arguments.
+     * @param {object} args.$ - Pipedream step context.
+     * @param {string} args.sheetName - Sheet containing the input cell.
+     * @param {string} args.address - A1-style input cell address.
+     * @param {number} args.value - Numeric value to write.
+     * @returns {Promise<object>} Verified Bilig WorkPaper proof response.
+     */
+    async verifyForecastReadback({
+      $,
+      sheetName,
+      address,
+      value,
+    }) {
+      const response = await this._makeRequest({
+        $,
+        path: "/api/workpaper/n8n/forecast",
+        method: "POST",
+        headers: {
+          "accept": "application/json",
+          "content-type": "application/json",
+        },
+        data: {
+          sheetName,
+          address,
+          value,
+        },
+      });
+
+      if (response?.verified !== true) {
+        throw new Error("Bilig did not return verified formula readback proof.");
+      }
+
+      const checks = response.checks ?? {};
+      const requiredChecks = [
+        "formulasPersisted",
+        "restoredMatchesAfter",
+        "computedOutputChanged",
+      ];
+      const missingChecks = requiredChecks.filter((key) => checks[key] !== true);
+
+      if (missingChecks.length > 0) {
+        throw new Error(`Bilig formula proof failed checks: ${missingChecks.join(", ")}.`);
+      }
+
+      return response;
     },
   },
 };

--- a/components/bilig_workpaper/package.json
+++ b/components/bilig_workpaper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/bilig_workpaper",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Bilig WorkPaper Components",
   "main": "bilig_workpaper.app.mjs",
   "keywords": [
@@ -11,5 +11,8 @@
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^3.1.1"
   }
 }

--- a/components/bilig_workpaper/package.json
+++ b/components/bilig_workpaper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/bilig_workpaper",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "Pipedream Bilig WorkPaper Components",
   "main": "bilig_workpaper.app.mjs",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1816,7 +1816,11 @@ importers:
         specifier: ^1.6.8
         version: 1.6.8
 
-  components/bilig_workpaper: {}
+  components/bilig_workpaper:
+    dependencies:
+      '@pipedream/platform':
+        specifier: ^3.1.1
+        version: 3.4.0
 
   components/bilionis:
     dependencies:


### PR DESCRIPTION
## Summary

Closes #20957.

Adds a focused **Verify Formula Readback** action to the existing `bilig_workpaper` app scaffold. The action writes one forecast input cell, asks Bilig WorkPaper to recalculate the workbook, and fails unless the API returns strict formula readback proof.

## Changes

- Add reusable Bilig WorkPaper prop definitions and request helpers
- Add `bilig_workpaper-verify-formula-readback`
- Use the connected account's `base_url` from `$auth` instead of a Base URL action prop
- Require `response.verified === true`
- Require proof checks for formula persistence, restored-document equality, and changed computed output
- Add the app README; no per-action README is included
- Bump `@pipedream/bilig_workpaper` to `0.1.0`

## Validation

```bash
pnpm exec eslint 'components/bilig_workpaper/**/*.mjs'
node scripts/generate-package-report.js --package=bilig_workpaper --verbose
node -e 'Promise.all([import("./components/bilig_workpaper/bilig_workpaper.app.mjs"), import("./components/bilig_workpaper/actions/verify-formula-readback/verify-formula-readback.mjs")]).then(([app, action])=>{ const methods = app.default.methods; const context = { ...methods, $auth: { base_url: "https://bilig.proompteng.ai/" } }; if ("baseUrl" in app.default.propDefinitions) process.exit(1); if ("baseUrl" in action.default.props) process.exit(2); if (context._baseUrl() !== "https://bilig.proompteng.ai") process.exit(3); if (app.default.app !== "bilig_workpaper" || action.default.key !== "bilig_workpaper-verify-formula-readback") process.exit(4); console.log(`${app.default.app} ${action.default.key}`); })'
curl -fsS -X POST https://bilig.proompteng.ai/api/workpaper/n8n/forecast -H 'content-type: application/json' -d '{"sheetName":"Inputs","address":"B3","value":0.4}'
git diff --check
```

The live Bilig endpoint returned `verified: true`, edited `Inputs!B3`, ARR `60000 -> 96000`, and all required proof checks true.

## Checklist

### Versioning
- [x] All components updated in this PR had their version updated (`0.0.1` for new ones)
- [x] The app updated in this PR had its `package.json` version updated

### New app
If this is a new app, please submit [an app integration request](https://github.com/PipedreamHQ/pipedream/issues/new?template=app---service-integration.md) - the PR will only be reviewed after the app is integrated.
- [x] The app updated in this PR is already integrated

### CodeRabbit review
After the PR is opened, and if new changes are pushed, CodeRabbit will automatically review it. Do not 'mark as resolved' CodeRabbit's comments, but reply to them instead, whether you agree (and update the PR accordingly) or disagree.
- [x] I have addressed or acknowledged all CodeRabbit review comments
