### PR TITLE
Exa - update find-similar-links after failed publish

### DIFF
--- a/components/exa/actions/find-similar-links/find-similar-links.mjs
+++ b/components/exa/actions/find-similar-links/find-similar-links.mjs
@@ -12,7 +12,7 @@ export default {
   key: "exa-find-similar-links",
   name: "Find Similar Links",
   description: "Find pages similar to a seed URL with optional nested Exa content extraction. **This action is deprecated for new workflows. Prefer Search, optionally after Get Contents on the seed URL, for related-page discovery.** [See the documentation](https://docs.exa.ai/reference/find-similar-links)",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -23,7 +23,6 @@ export default {
     app,
     alert: {
       type: "alert",
-      description: "Guidance for new workflows.",
       alertType: "warning",
       content: "This action is deprecated for new workflows. Prefer **Search** with a query derived from the seed page, optionally after **Get Contents** if you need to inspect the seed URL first.",
     },

--- a/components/exa/package.json
+++ b/components/exa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/exa",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Exa Components",
   "main": "exa.app.mjs",
   "keywords": [


### PR DESCRIPTION
Exa action "Find Similar Links" failed to publish from PR #20804. This bumps the component version and removes the description from the alert prop (alert props don't accept labels or descriptions).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecation Notice**
  * The Find Similar Links action deprecation alert has been updated with a warning-level notification. The message now provides more explicit guidance, recommending alternative search-based approaches for discovering related pages and content.

* **Chores**
  * Version updates to core packages for improved stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PipedreamHQ/pipedream/pull/20993?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->