### PR TITLE
Add Voxell Forge embeddings component

### DIFF
--- a/components/voxell_forge/actions/create-embeddings/create-embeddings.mjs
+++ b/components/voxell_forge/actions/create-embeddings/create-embeddings.mjs
@@ -1,0 +1,62 @@
+import { ConfigurationError } from "@pipedream/platform";
+import voxellForge from "../../voxell_forge.app.mjs";
+
+export default {
+  key: "voxell_forge-create-embeddings",
+  name: "Create Embeddings",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  description: "Create vector embeddings for one or more text inputs using Voxell Forge. [See the documentation](https://dash.voxell.ai/docs)",
+  type: "action",
+  props: {
+    voxellForge,
+    texts: {
+      type: "string[]",
+      label: "Texts",
+      description: "One or more text inputs to embed.",
+    },
+    model: {
+      propDefinition: [
+        voxellForge,
+        "model",
+      ],
+    },
+    dim: {
+      propDefinition: [
+        voxellForge,
+        "dim",
+      ],
+    },
+    inputType: {
+      propDefinition: [
+        voxellForge,
+        "inputType",
+      ],
+    },
+  },
+  async run({ $ }) {
+    if (!this.texts?.length) {
+      throw new ConfigurationError("Provide at least one text input.");
+    }
+
+    const emptyIndex = this.texts.findIndex((text) => !text?.trim());
+    if (emptyIndex >= 0) {
+      throw new ConfigurationError(`Text #${emptyIndex + 1} is empty.`);
+    }
+
+    const response = await this.voxellForge.createEmbeddings({
+      $,
+      texts: this.texts,
+      model: this.model,
+      dim: this.dim,
+      inputType: this.inputType,
+    });
+
+    $.export("$summary", `Created ${response.embeddings?.length ?? this.texts.length} embedding(s)`);
+    return response;
+  },
+};

--- a/components/voxell_forge/package.json
+++ b/components/voxell_forge/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@pipedream/voxell_forge",
+  "version": "0.0.1",
+  "description": "Pipedream Voxell Forge Components",
+  "main": "voxell_forge.app.mjs",
+  "keywords": [
+    "pipedream",
+    "voxell_forge"
+  ],
+  "homepage": "https://pipedream.com/apps/voxell_forge",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^3.3.0"
+  }
+}

--- a/components/voxell_forge/voxell_forge.app.mjs
+++ b/components/voxell_forge/voxell_forge.app.mjs
@@ -1,0 +1,88 @@
+import { axios } from "@pipedream/platform";
+
+export default {
+  type: "app",
+  app: "voxell_forge",
+  propDefinitions: {
+    model: {
+      type: "string",
+      label: "Model",
+      description: "Forge embedding model tier.",
+      options: [
+        {
+          label: "Turbo - 1024 dimensions",
+          value: "turbo",
+        },
+        {
+          label: "Pro - 2560 dimensions",
+          value: "pro",
+        },
+        {
+          label: "Ultra 4K - 4096 dimensions",
+          value: "ultra-4k",
+        },
+      ],
+      default: "turbo",
+    },
+    inputType: {
+      type: "string",
+      label: "Input Type",
+      description: "Use query for search queries and document for content being indexed.",
+      options: [
+        "document",
+        "query",
+      ],
+      default: "document",
+      optional: true,
+    },
+    dim: {
+      type: "integer",
+      label: "Dimensions",
+      description: "Optional Matryoshka truncation dimension. Leave blank to use the model's native dimension.",
+      optional: true,
+      min: 1,
+    },
+  },
+  methods: {
+    _baseUrl() {
+      return "https://api.voxell.ai/v1";
+    },
+    _headers(headers = {}) {
+      return {
+        ...headers,
+        Authorization: `Bearer ${this.$auth.api_key}`,
+        "Content-Type": "application/json",
+      };
+    },
+    _makeRequest({
+      $ = this, path, headers, ...args
+    } = {}) {
+      return axios($, {
+        ...args,
+        url: `${this._baseUrl()}${path}`,
+        headers: this._headers(headers),
+      });
+    },
+    createEmbeddings({
+      $,
+      texts,
+      model,
+      dim,
+      inputType,
+    }) {
+      const data = {
+        texts,
+        model,
+      };
+      if (dim) data.dim = dim;
+      if (inputType) data.input_type = inputType;
+
+      return this._makeRequest({
+        $,
+        method: "POST",
+        path: "/embed",
+        data,
+      });
+    },
+  },
+};


### PR DESCRIPTION
## Summary\n- Add a Voxell Forge app component\n- Add a Create Embeddings action using Forge's native /v1/embed endpoint\n- Support model tier, optional dimensions, and query/document input type\n\n## Validation\n- node --check components/voxell_forge/voxell_forge.app.mjs\n- node --check components/voxell_forge/actions/create-embeddings/create-embeddings.mjs\n- node scripts/generate-package-report.js --package=voxell_forge\n\n## Notes\nVoxell Forge also supports OpenAI-compatible embeddings at https://api.voxell.ai/v1/embeddings. This Pipedream component uses the native endpoint because Pipedream actions can call the provider API directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Voxell Forge integration, enabling users to generate text embeddings with configurable model tiers (turbo, pro, ultra-4k), input types, and optional truncation dimensions via the "Create Embeddings" action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->