### PR TITLE
peakon_employee_voice: add 7 AI-optimized MCP actions

### DIFF
--- a/components/peakon_employee_voice/actions/create-employee/create-employee.mjs
+++ b/components/peakon_employee_voice/actions/create-employee/create-employee.mjs
@@ -78,25 +78,18 @@ export default {
     const custom = this.customAttributes
       ? JSON.parse(this.customAttributes)
       : {};
-    const response = await this.app._makeRequest({
+    const response = await this.app.createEmployee({
       $,
-      method: "POST",
-      path: "/api/v1/employees",
-      data: {
-        data: {
-          type: "employees",
-          attributes: {
-            firstName: this.firstName,
-            lastName: this.lastName,
-            identifier: this.identifier,
-            ...(this.email && {
-              email: this.email,
-            }),
-            type: this.employeeType,
-            employmentStatus: this.employmentStatus,
-            ...custom,
-          },
-        },
+      attributes: {
+        firstName: this.firstName,
+        lastName: this.lastName,
+        identifier: this.identifier,
+        ...(this.email && {
+          email: this.email,
+        }),
+        type: this.employeeType,
+        employmentStatus: this.employmentStatus,
+        ...custom,
       },
     });
     const employee = response.data;

--- a/components/peakon_employee_voice/actions/create-employee/create-employee.mjs
+++ b/components/peakon_employee_voice/actions/create-employee/create-employee.mjs
@@ -23,19 +23,22 @@ export default {
   props: {
     app,
     firstName: {
-      type: "string",
-      label: "First Name",
-      description: "Employee's first name.",
+      propDefinition: [
+        app,
+        "firstName",
+      ],
     },
     lastName: {
-      type: "string",
-      label: "Last Name",
-      description: "Employee's last name.",
+      propDefinition: [
+        app,
+        "lastName",
+      ],
     },
     identifier: {
-      type: "string",
-      label: "Identifier",
-      description: "HR employee number or unique identifier (e.g. `E001`). Must be unique across employees.",
+      propDefinition: [
+        app,
+        "identifier",
+      ],
     },
     email: {
       type: "string",
@@ -58,20 +61,17 @@ export default {
       default: "permanent",
     },
     employmentStatus: {
-      type: "string",
-      label: "Employment Status",
-      description: "Current employment status (e.g. `employed`, `on_leave`).",
-      optional: true,
+      propDefinition: [
+        app,
+        "employmentStatus",
+      ],
       default: "employed",
     },
     customAttributes: {
-      type: "string",
-      label: "Custom Attributes",
-      description:
-        "JSON object of custom HR attributes to set on the employee. "
-        + "Example: `{\"Department\": \"Sales\", \"Region\": \"North America\", \"Job Level\": \"Manager\"}`. "
-        + "Enum values are accepted as plain strings.",
-      optional: true,
+      propDefinition: [
+        app,
+        "customAttributes",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/peakon_employee_voice/actions/create-employee/create-employee.mjs
+++ b/components/peakon_employee_voice/actions/create-employee/create-employee.mjs
@@ -84,9 +84,7 @@ export default {
         firstName: this.firstName,
         lastName: this.lastName,
         identifier: this.identifier,
-        ...(this.email && {
-          email: this.email,
-        }),
+        email: this.email,
         type: this.employeeType,
         employmentStatus: this.employmentStatus,
         ...custom,

--- a/components/peakon_employee_voice/actions/create-employee/create-employee.mjs
+++ b/components/peakon_employee_voice/actions/create-employee/create-employee.mjs
@@ -1,0 +1,106 @@
+import app from "../../peakon_employee_voice.app.mjs";
+
+export default {
+  key: "peakon_employee_voice-create-employee",
+  name: "Create Employee",
+  description:
+    "Creates a new employee record in Peakon. Requires `firstName`, `lastName`, and `identifier` "
+    + "(the HR employee number, e.g. `E001` — must be unique). "
+    + "Optional standard fields: `email`, `employeeType` (permanent/contractor/temporary/volunteer/other), "
+    + "`employmentStatus`. "
+    + "Custom HR attributes such as Department, Region, and Job Level can be set via `customAttributes` "
+    + "as a JSON object — e.g. `{\"Department\": \"Sales\", \"Region\": \"North America\"}`. "
+    + "Returns the new employee record including the internal `id`, which can be used with "
+    + "**Update Employee** or **Delete Employee**. "
+    + "[See the Peakon API documentation](https://developer.peakon.com/reference/post_employees)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    app,
+    firstName: {
+      type: "string",
+      label: "First Name",
+      description: "Employee's first name.",
+    },
+    lastName: {
+      type: "string",
+      label: "Last Name",
+      description: "Employee's last name.",
+    },
+    identifier: {
+      type: "string",
+      label: "Identifier",
+      description: "HR employee number or unique identifier (e.g. `E001`). Must be unique across employees.",
+    },
+    email: {
+      type: "string",
+      label: "Email",
+      description: "Employee's work email address.",
+      optional: true,
+    },
+    employeeType: {
+      type: "string",
+      label: "Employee Type",
+      description: "Employment type.",
+      options: [
+        "permanent",
+        "contractor",
+        "temporary",
+        "volunteer",
+        "other",
+      ],
+      optional: true,
+      default: "permanent",
+    },
+    employmentStatus: {
+      type: "string",
+      label: "Employment Status",
+      description: "Current employment status (e.g. `employed`, `on_leave`).",
+      optional: true,
+      default: "employed",
+    },
+    customAttributes: {
+      type: "string",
+      label: "Custom Attributes",
+      description:
+        "JSON object of custom HR attributes to set on the employee. "
+        + "Example: `{\"Department\": \"Sales\", \"Region\": \"North America\", \"Job Level\": \"Manager\"}`. "
+        + "Enum values are accepted as plain strings.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const custom = this.customAttributes
+      ? JSON.parse(this.customAttributes)
+      : {};
+    const response = await this.app._makeRequest({
+      $,
+      method: "POST",
+      path: "/api/v1/employees",
+      data: {
+        data: {
+          type: "employees",
+          attributes: {
+            firstName: this.firstName,
+            lastName: this.lastName,
+            identifier: this.identifier,
+            ...(this.email && {
+              email: this.email,
+            }),
+            type: this.employeeType,
+            employmentStatus: this.employmentStatus,
+            ...custom,
+          },
+        },
+      },
+    });
+    const employee = response.data;
+    $.export("$summary", `Created employee ${employee.attributes.name} (ID: ${employee.id})`);
+    return response;
+  },
+};

--- a/components/peakon_employee_voice/actions/delete-employee/delete-employee.mjs
+++ b/components/peakon_employee_voice/actions/delete-employee/delete-employee.mjs
@@ -26,10 +26,9 @@ export default {
     },
   },
   async run({ $ }) {
-    await this.app._makeRequest({
+    await this.app.deleteEmployee({
       $,
-      method: "DELETE",
-      path: `/api/v1/employees/${this.employeeId}`,
+      employeeId: this.employeeId,
     });
     $.export("$summary", `Deleted employee ${this.employeeId}`);
     return {

--- a/components/peakon_employee_voice/actions/delete-employee/delete-employee.mjs
+++ b/components/peakon_employee_voice/actions/delete-employee/delete-employee.mjs
@@ -1,0 +1,40 @@
+import app from "../../peakon_employee_voice.app.mjs";
+
+export default {
+  key: "peakon_employee_voice-delete-employee",
+  name: "Delete Employee",
+  description:
+    "Permanently deletes an employee record from Peakon. This action is irreversible — "
+    + "the employee and all associated survey data will be removed. "
+    + "Use **List Employees** to find the employee's `id` first. "
+    + "Returns a confirmation when deletion succeeds. "
+    + "[See the Peakon API documentation](https://developer.peakon.com/reference/delete_employees-employeeid)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: true,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    app,
+    employeeId: {
+      propDefinition: [
+        app,
+        "employeeId",
+      ],
+    },
+  },
+  async run({ $ }) {
+    await this.app._makeRequest({
+      $,
+      method: "DELETE",
+      path: `/api/v1/employees/${this.employeeId}`,
+    });
+    $.export("$summary", `Deleted employee ${this.employeeId}`);
+    return {
+      id: this.employeeId,
+      deleted: true,
+    };
+  },
+};

--- a/components/peakon_employee_voice/actions/get-driver-scores/get-driver-scores.mjs
+++ b/components/peakon_employee_voice/actions/get-driver-scores/get-driver-scores.mjs
@@ -62,9 +62,9 @@ export default {
   },
   async run({ $ }) {
     const params = {
-      interval: this.interval,
-      observations: this.observations,
-      participation: this.participation,
+      "interval": this.interval,
+      "observations": this.observations,
+      "participation": this.participation,
       "filter[employee.segmentIds][$contains]": this.filterSegmentIds,
     };
     const response = await this.app.getDriverScores({

--- a/components/peakon_employee_voice/actions/get-driver-scores/get-driver-scores.mjs
+++ b/components/peakon_employee_voice/actions/get-driver-scores/get-driver-scores.mjs
@@ -1,0 +1,81 @@
+import app from "../../peakon_employee_voice.app.mjs";
+
+export default {
+  key: "peakon_employee_voice-get-driver-scores",
+  name: "Get Driver Scores",
+  description:
+    "Returns engagement scores broken down by Peakon's 14 core drivers: Accomplishment, Autonomy, "
+    + "Environment, Freedom of Opinions, Goal-Setting, Growth, Manager Support, Meaningful Work, "
+    + "Organizational Fit, Peer Relationships, Recognition, Reward, Strategy, and Workload. "
+    + "Each driver includes a score (0–10), grade (positive/neutral/negative), impact rating, "
+    + "and classification (e.g. strength, priority). "
+    + "Pass a `contextId` formatted as `company_[companyId]` for company-wide scores or "
+    + "`segment_[segmentId]` to scope to a specific segment — use **List Segments** to discover IDs. "
+    + "Use when the user asks 'which drivers are lowest?', 'how is recognition scoring?', or "
+    + "'what are the priority areas to focus on?'. "
+    + "[See the Peakon API documentation](https://developer.peakon.com/reference/get_engagement-contexts-contextid-drivers)",
+  version: "0.0.2",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    app,
+    contextId: {
+      type: "string",
+      label: "Context ID",
+      description:
+        "A company or segment context ID. Format: `company_[companyId]` for company-wide scores, "
+        + "or `segment_[segmentId]` for a specific segment. "
+        + "Use **List Segments** to discover segment context IDs.",
+    },
+    interval: {
+      propDefinition: [
+        app,
+        "interval",
+      ],
+    },
+    observations: {
+      type: "boolean",
+      label: "Include Observations",
+      description: "Whether to include the observations array in the response. Defaults to false.",
+      optional: true,
+      default: false,
+    },
+    participation: {
+      type: "boolean",
+      label: "Include Participation",
+      description: "Whether to include participation data in the response. Defaults to false.",
+      optional: true,
+      default: false,
+    },
+    filterSegmentIds: {
+      type: "string",
+      label: "Filter by Segment IDs",
+      description:
+        "Comma-separated list of segment IDs to filter driver scores by employee segments. "
+        + "Example: `1001,1002`. Sent as `filter[employee.segmentIds][$contains]`.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const params = {
+      interval: this.interval || undefined,
+      observations: this.observations,
+      participation: this.participation,
+    };
+    if (this.filterSegmentIds) {
+      params["filter[employee.segmentIds][$contains]"] = this.filterSegmentIds;
+    }
+    const response = await this.app._makeRequest({
+      $,
+      path: `/api/v1/engagement/contexts/${this.contextId}/drivers`,
+      params,
+    });
+    const drivers = response.data ?? [];
+    $.export("$summary", `Retrieved scores for ${drivers.length} engagement driver(s)`);
+    return response;
+  },
+};

--- a/components/peakon_employee_voice/actions/get-driver-scores/get-driver-scores.mjs
+++ b/components/peakon_employee_voice/actions/get-driver-scores/get-driver-scores.mjs
@@ -14,7 +14,7 @@ export default {
     + "Use when the user asks 'which drivers are lowest?', 'how is recognition scoring?', or "
     + "'what are the priority areas to focus on?'. "
     + "[See the Peakon API documentation](https://developer.peakon.com/reference/get_engagement-contexts-contextid-drivers)",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/peakon_employee_voice/actions/get-driver-scores/get-driver-scores.mjs
+++ b/components/peakon_employee_voice/actions/get-driver-scores/get-driver-scores.mjs
@@ -24,12 +24,10 @@ export default {
   props: {
     app,
     contextId: {
-      type: "string",
-      label: "Context ID",
-      description:
-        "A company or segment context ID. Format: `company_[companyId]` for company-wide scores, "
-        + "or `segment_[segmentId]` for a specific segment. "
-        + "Use **List Segments** to discover segment context IDs.",
+      propDefinition: [
+        app,
+        "contextId",
+      ],
     },
     interval: {
       propDefinition: [
@@ -38,26 +36,22 @@ export default {
       ],
     },
     observations: {
-      type: "boolean",
-      label: "Include Observations",
-      description: "Whether to include the observations array in the response. Defaults to false.",
-      optional: true,
-      default: false,
+      propDefinition: [
+        app,
+        "observations",
+      ],
     },
     participation: {
-      type: "boolean",
-      label: "Include Participation",
-      description: "Whether to include participation data in the response. Defaults to false.",
-      optional: true,
-      default: false,
+      propDefinition: [
+        app,
+        "participation",
+      ],
     },
     filterSegmentIds: {
-      type: "string",
-      label: "Filter by Segment IDs",
-      description:
-        "Comma-separated list of segment IDs to filter driver scores by employee segments. "
-        + "Example: `1001,1002`. Sent as `filter[employee.segmentIds][$contains]`.",
-      optional: true,
+      propDefinition: [
+        app,
+        "filterSegmentIds",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/peakon_employee_voice/actions/get-driver-scores/get-driver-scores.mjs
+++ b/components/peakon_employee_voice/actions/get-driver-scores/get-driver-scores.mjs
@@ -62,13 +62,11 @@ export default {
   },
   async run({ $ }) {
     const params = {
-      interval: this.interval || undefined,
+      interval: this.interval,
       observations: this.observations,
       participation: this.participation,
+      "filter[employee.segmentIds][$contains]": this.filterSegmentIds,
     };
-    if (this.filterSegmentIds) {
-      params["filter[employee.segmentIds][$contains]"] = this.filterSegmentIds;
-    }
     const response = await this.app.getDriverScores({
       $,
       contextId: this.contextId,

--- a/components/peakon_employee_voice/actions/get-driver-scores/get-driver-scores.mjs
+++ b/components/peakon_employee_voice/actions/get-driver-scores/get-driver-scores.mjs
@@ -69,9 +69,9 @@ export default {
     if (this.filterSegmentIds) {
       params["filter[employee.segmentIds][$contains]"] = this.filterSegmentIds;
     }
-    const response = await this.app._makeRequest({
+    const response = await this.app.getDriverScores({
       $,
-      path: `/api/v1/engagement/contexts/${this.contextId}/drivers`,
+      contextId: this.contextId,
       params,
     });
     const drivers = response.data ?? [];

--- a/components/peakon_employee_voice/actions/get-engagement-overview/get-engagement-overview.mjs
+++ b/components/peakon_employee_voice/actions/get-engagement-overview/get-engagement-overview.mjs
@@ -1,0 +1,70 @@
+import app from "../../peakon_employee_voice.app.mjs";
+
+export default {
+  key: "peakon_employee_voice-get-engagement-overview",
+  name: "Get Engagement Overview",
+  description:
+    "Returns the engagement score, response rate, NPS breakdown, and favorability data "
+    + "for a company or specific segment context. "
+    + "Pass a `contextId` formatted as `company_[companyId]` for company-wide metrics or "
+    + "`segment_[segmentId]` for a specific segment — use **List Segments** to discover segment IDs. "
+    + "Use when the user asks 'what is our overall engagement score?', 'how engaged is [segment]?', "
+    + "or 'what is the response rate?'. "
+    + "Returns: engagement score (0–10 scale), NPS score, favorable/neutral/unfavorable split, "
+    + "response count, and last survey date. "
+    + "[See the Peakon API documentation](https://developer.peakon.com/reference/get_engagement-contexts-contextid-overview)",
+  version: "0.0.2",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    app,
+    contextId: {
+      type: "string",
+      label: "Context ID",
+      description:
+        "A company or segment context ID. Format: `company_[companyId]` for company-wide metrics, "
+        + "or `segment_[segmentId]` for a specific segment. "
+        + "Use **List Segments** to discover segment context IDs.",
+    },
+    interval: {
+      propDefinition: [
+        app,
+        "interval",
+      ],
+    },
+    observations: {
+      type: "boolean",
+      label: "Include Observations",
+      description: "Whether to include the observations array in the response. Defaults to false.",
+      optional: true,
+      default: false,
+    },
+    participation: {
+      type: "boolean",
+      label: "Include Participation",
+      description: "Whether to include participation data in the response. Defaults to false.",
+      optional: true,
+      default: false,
+    },
+  },
+  async run({ $ }) {
+    const response = await this.app._makeRequest({
+      $,
+      path: `/api/v1/engagement/contexts/${this.contextId}/overview`,
+      params: {
+        interval: this.interval || undefined,
+        observations: this.observations,
+        participation: this.participation,
+      },
+    });
+    const score = response.data?.attributes?.scores?.mean;
+    $.export("$summary", `Engagement overview retrieved — score: ${score !== undefined
+      ? score.toFixed(2)
+      : "N/A"}`);
+    return response;
+  },
+};

--- a/components/peakon_employee_voice/actions/get-engagement-overview/get-engagement-overview.mjs
+++ b/components/peakon_employee_voice/actions/get-engagement-overview/get-engagement-overview.mjs
@@ -52,9 +52,9 @@ export default {
     },
   },
   async run({ $ }) {
-    const response = await this.app._makeRequest({
+    const response = await this.app.getEngagementOverview({
       $,
-      path: `/api/v1/engagement/contexts/${this.contextId}/overview`,
+      contextId: this.contextId,
       params: {
         interval: this.interval || undefined,
         observations: this.observations,

--- a/components/peakon_employee_voice/actions/get-engagement-overview/get-engagement-overview.mjs
+++ b/components/peakon_employee_voice/actions/get-engagement-overview/get-engagement-overview.mjs
@@ -23,12 +23,10 @@ export default {
   props: {
     app,
     contextId: {
-      type: "string",
-      label: "Context ID",
-      description:
-        "A company or segment context ID. Format: `company_[companyId]` for company-wide metrics, "
-        + "or `segment_[segmentId]` for a specific segment. "
-        + "Use **List Segments** to discover segment context IDs.",
+      propDefinition: [
+        app,
+        "contextId",
+      ],
     },
     interval: {
       propDefinition: [
@@ -37,18 +35,16 @@ export default {
       ],
     },
     observations: {
-      type: "boolean",
-      label: "Include Observations",
-      description: "Whether to include the observations array in the response. Defaults to false.",
-      optional: true,
-      default: false,
+      propDefinition: [
+        app,
+        "observations",
+      ],
     },
     participation: {
-      type: "boolean",
-      label: "Include Participation",
-      description: "Whether to include participation data in the response. Defaults to false.",
-      optional: true,
-      default: false,
+      propDefinition: [
+        app,
+        "participation",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/peakon_employee_voice/actions/get-engagement-overview/get-engagement-overview.mjs
+++ b/components/peakon_employee_voice/actions/get-engagement-overview/get-engagement-overview.mjs
@@ -56,7 +56,7 @@ export default {
       $,
       contextId: this.contextId,
       params: {
-        interval: this.interval || undefined,
+        interval: this.interval,
         observations: this.observations,
         participation: this.participation,
       },

--- a/components/peakon_employee_voice/actions/get-engagement-overview/get-engagement-overview.mjs
+++ b/components/peakon_employee_voice/actions/get-engagement-overview/get-engagement-overview.mjs
@@ -62,7 +62,7 @@ export default {
       },
     });
     const score = response.data?.attributes?.scores?.mean;
-    $.export("$summary", `Engagement overview retrieved — score: ${score !== undefined
+    $.export("$summary", `Engagement overview retrieved — score: ${score != null && Number.isFinite(score)
       ? score.toFixed(2)
       : "N/A"}`);
     return response;

--- a/components/peakon_employee_voice/actions/get-engagement-overview/get-engagement-overview.mjs
+++ b/components/peakon_employee_voice/actions/get-engagement-overview/get-engagement-overview.mjs
@@ -13,7 +13,7 @@ export default {
     + "Returns: engagement score (0–10 scale), NPS score, favorable/neutral/unfavorable split, "
     + "response count, and last survey date. "
     + "[See the Peakon API documentation](https://developer.peakon.com/reference/get_engagement-contexts-contextid-overview)",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/peakon_employee_voice/actions/list-employees/list-employees.mjs
+++ b/components/peakon_employee_voice/actions/list-employees/list-employees.mjs
@@ -12,7 +12,7 @@ export default {
     + "Call this first whenever the user refers to an employee by name or attribute and you need "
     + "their ID to perform an update or deletion. "
     + "[See the Peakon API documentation](https://developer.peakon.com/reference/get_employees)",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/peakon_employee_voice/actions/list-employees/list-employees.mjs
+++ b/components/peakon_employee_voice/actions/list-employees/list-employees.mjs
@@ -61,12 +61,10 @@ export default {
       optional: true,
     },
     filterSegmentIds: {
-      type: "string",
-      label: "Filter by Segment IDs",
-      description:
-        "Comma-separated list of segment IDs to filter employees by segment membership. "
-        + "Example: `1001,1002`.",
-      optional: true,
+      propDefinition: [
+        app,
+        "filterSegmentIds",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/peakon_employee_voice/actions/list-employees/list-employees.mjs
+++ b/components/peakon_employee_voice/actions/list-employees/list-employees.mjs
@@ -68,9 +68,8 @@ export default {
     if (this.filterEmployeeId !== undefined) params["filter[employeeId]"] = this.filterEmployeeId;
     if (this.filterManager !== undefined) params["filter[manager]"] = this.filterManager;
     if (this.filterSegmentIds) params["filter[segmentIds]"] = this.filterSegmentIds;
-    const response = await this.app._makeRequest({
+    const response = await this.app.listEmployees({
       $,
-      path: "/api/v1/employees",
       params,
     });
     const employees = response.data ?? [];

--- a/components/peakon_employee_voice/actions/list-employees/list-employees.mjs
+++ b/components/peakon_employee_voice/actions/list-employees/list-employees.mjs
@@ -61,13 +61,14 @@ export default {
     },
   },
   async run({ $ }) {
-    const params = {};
-    if (this.filterEmail) params["filter[account.email]"] = this.filterEmail;
-    if (this.filterAccountId !== undefined) params["filter[accountId]"] = this.filterAccountId;
-    if (this.filterAdmin !== undefined) params["filter[admin]"] = this.filterAdmin;
-    if (this.filterEmployeeId !== undefined) params["filter[employeeId]"] = this.filterEmployeeId;
-    if (this.filterManager !== undefined) params["filter[manager]"] = this.filterManager;
-    if (this.filterSegmentIds) params["filter[segmentIds]"] = this.filterSegmentIds;
+    const params = {
+      "filter[account.email]": this.filterEmail,
+      "filter[accountId]": this.filterAccountId,
+      "filter[admin]": this.filterAdmin,
+      "filter[employeeId]": this.filterEmployeeId,
+      "filter[manager]": this.filterManager,
+      "filter[segmentIds]": this.filterSegmentIds,
+    };
     const response = await this.app.listEmployees({
       $,
       params,

--- a/components/peakon_employee_voice/actions/list-employees/list-employees.mjs
+++ b/components/peakon_employee_voice/actions/list-employees/list-employees.mjs
@@ -1,0 +1,80 @@
+import app from "../../peakon_employee_voice.app.mjs";
+
+export default {
+  key: "peakon_employee_voice-list-employees",
+  name: "List Employees",
+  description:
+    "Lists employee records in Peakon. Use the filter parameters to narrow results by email, "
+    + "account ID, admin status, employee ID, manager status, or segment membership. "
+    + "Returns each employee's internal `id`, name, identifier (HR employee number), "
+    + "employment status, and custom HR attributes (Department, Region, Job Level, etc.). "
+    + "The `id` field returned here is required by **Update Employee** and **Delete Employee**. "
+    + "Call this first whenever the user refers to an employee by name or attribute and you need "
+    + "their ID to perform an update or deletion. "
+    + "[See the Peakon API documentation](https://developer.peakon.com/reference/get_employees)",
+  version: "0.0.2",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    app,
+    filterEmail: {
+      type: "string",
+      label: "Filter by Email",
+      description: "Filter employees by account email address.",
+      optional: true,
+    },
+    filterAccountId: {
+      type: "integer",
+      label: "Filter by Account ID",
+      description: "Filter employees by their account ID.",
+      optional: true,
+    },
+    filterAdmin: {
+      type: "boolean",
+      label: "Filter Admins Only",
+      description: "When true, returns only employees with admin access.",
+      optional: true,
+    },
+    filterEmployeeId: {
+      type: "integer",
+      label: "Filter by Employee ID",
+      description: "Filter by the employee's internal numeric ID.",
+      optional: true,
+    },
+    filterManager: {
+      type: "boolean",
+      label: "Filter Managers Only",
+      description: "When true, returns only employees who are managers.",
+      optional: true,
+    },
+    filterSegmentIds: {
+      type: "string",
+      label: "Filter by Segment IDs",
+      description:
+        "Comma-separated list of segment IDs to filter employees by segment membership. "
+        + "Example: `1001,1002`.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const params = {};
+    if (this.filterEmail) params["filter[account.email]"] = this.filterEmail;
+    if (this.filterAccountId !== undefined) params["filter[accountId]"] = this.filterAccountId;
+    if (this.filterAdmin !== undefined) params["filter[admin]"] = this.filterAdmin;
+    if (this.filterEmployeeId !== undefined) params["filter[employeeId]"] = this.filterEmployeeId;
+    if (this.filterManager !== undefined) params["filter[manager]"] = this.filterManager;
+    if (this.filterSegmentIds) params["filter[segmentIds]"] = this.filterSegmentIds;
+    const response = await this.app._makeRequest({
+      $,
+      path: "/api/v1/employees",
+      params,
+    });
+    const employees = response.data ?? [];
+    $.export("$summary", `Found ${employees.length} employee(s)`);
+    return response;
+  },
+};

--- a/components/peakon_employee_voice/actions/list-employees/list-employees.mjs
+++ b/components/peakon_employee_voice/actions/list-employees/list-employees.mjs
@@ -44,6 +44,15 @@ export default {
       label: "Filter by Employee ID",
       description: "Filter by the employee's internal numeric ID.",
       optional: true,
+      async options() {
+        const response = await this.app.listEmployees({
+          params: {},
+        });
+        return (response.data ?? []).map((emp) => ({
+          label: `${emp.attributes.name} (${emp.attributes.identifier})`,
+          value: parseInt(emp.id),
+        }));
+      },
     },
     filterManager: {
       type: "boolean",

--- a/components/peakon_employee_voice/actions/list-segments/list-segments.mjs
+++ b/components/peakon_employee_voice/actions/list-segments/list-segments.mjs
@@ -56,9 +56,8 @@ export default {
     if (this.filterDirect !== undefined) params["filter[direct]"] = this.filterDirect;
     if (this.filterManagerId !== undefined) params["filter[managerId]"] = this.filterManagerId;
     if (this.filterType) params["filter[type]"] = this.filterType;
-    const response = await this.app._makeRequest({
+    const response = await this.app.listSegments({
       $,
-      path: "/api/v1/segments",
       params,
     });
     const segments = response.data ?? [];

--- a/components/peakon_employee_voice/actions/list-segments/list-segments.mjs
+++ b/components/peakon_employee_voice/actions/list-segments/list-segments.mjs
@@ -34,7 +34,7 @@ export default {
     filterManagerId: {
       type: "integer",
       label: "Filter by Manager ID",
-      description: "The employee ID of a manager to filter segments by.",
+      description: "The employee ID of a manager to filter segments by. Use **List Employees** to find the ID.",
       optional: true,
     },
     filterType: {

--- a/components/peakon_employee_voice/actions/list-segments/list-segments.mjs
+++ b/components/peakon_employee_voice/actions/list-segments/list-segments.mjs
@@ -1,0 +1,68 @@
+import app from "../../peakon_employee_voice.app.mjs";
+
+export default {
+  key: "peakon_employee_voice-list-segments",
+  name: "List Segments",
+  description:
+    "Lists all demographic and organizational segments configured in Peakon. "
+    + "Each segment includes a `contextId` that can be passed to **Get Engagement Overview** "
+    + "and **Get Driver Scores** to scope analytics to a specific population (e.g. a department, "
+    + "region, or tenure band). Call this first whenever the user asks about a specific team, "
+    + "department, or demographic group and needs analytics scoped to it. "
+    + "[See the Peakon API documentation](https://developer.peakon.com/reference/get_segments)",
+  version: "0.0.2",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    app,
+    filterAttributeId: {
+      type: "integer",
+      label: "Filter by Attribute ID",
+      description: "The ID of the attribute that is the source of a segment.",
+      optional: true,
+    },
+    filterDirect: {
+      type: "boolean",
+      label: "Filter Direct Reports Only",
+      description: "When true, returns segments including only direct reports. When false, includes all reports.",
+      optional: true,
+    },
+    filterManagerId: {
+      type: "integer",
+      label: "Filter by Manager ID",
+      description: "The employee ID of a manager to filter segments by.",
+      optional: true,
+    },
+    filterType: {
+      type: "string",
+      label: "Filter by Type",
+      description: "The type of attribute that is the source of a segment.",
+      options: [
+        "employee",
+        "option",
+        "date",
+        "number",
+      ],
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const params = {};
+    if (this.filterAttributeId !== undefined) params["filter[attributeId]"] = this.filterAttributeId;
+    if (this.filterDirect !== undefined) params["filter[direct]"] = this.filterDirect;
+    if (this.filterManagerId !== undefined) params["filter[managerId]"] = this.filterManagerId;
+    if (this.filterType) params["filter[type]"] = this.filterType;
+    const response = await this.app._makeRequest({
+      $,
+      path: "/api/v1/segments",
+      params,
+    });
+    const segments = response.data ?? [];
+    $.export("$summary", `Retrieved ${segments.length} segment(s)`);
+    return response;
+  },
+};

--- a/components/peakon_employee_voice/actions/list-segments/list-segments.mjs
+++ b/components/peakon_employee_voice/actions/list-segments/list-segments.mjs
@@ -51,11 +51,12 @@ export default {
     },
   },
   async run({ $ }) {
-    const params = {};
-    if (this.filterAttributeId !== undefined) params["filter[attributeId]"] = this.filterAttributeId;
-    if (this.filterDirect !== undefined) params["filter[direct]"] = this.filterDirect;
-    if (this.filterManagerId !== undefined) params["filter[managerId]"] = this.filterManagerId;
-    if (this.filterType) params["filter[type]"] = this.filterType;
+    const params = {
+      "filter[attributeId]": this.filterAttributeId,
+      "filter[direct]": this.filterDirect,
+      "filter[managerId]": this.filterManagerId,
+      "filter[type]": this.filterType,
+    };
     const response = await this.app.listSegments({
       $,
       params,

--- a/components/peakon_employee_voice/actions/list-segments/list-segments.mjs
+++ b/components/peakon_employee_voice/actions/list-segments/list-segments.mjs
@@ -10,7 +10,7 @@ export default {
     + "region, or tenure band). Call this first whenever the user asks about a specific team, "
     + "department, or demographic group and needs analytics scoped to it. "
     + "[See the Peakon API documentation](https://developer.peakon.com/reference/get_segments)",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/peakon_employee_voice/actions/update-employee/update-employee.mjs
+++ b/components/peakon_employee_voice/actions/update-employee/update-employee.mjs
@@ -65,11 +65,24 @@ export default {
     const custom = this.customAttributes
       ? JSON.parse(this.customAttributes)
       : {};
-    const standardAttrs = {};
-    if (this.firstName) standardAttrs.firstName = this.firstName;
-    if (this.lastName) standardAttrs.lastName = this.lastName;
-    if (this.identifier) standardAttrs.identifier = this.identifier;
-    if (this.employmentStatus) standardAttrs.employmentStatus = this.employmentStatus;
+    const response = await this.app._makeRequest({
+      $,
+      method: "PATCH",
+      path: `/api/v1/employees/${this.employeeId}`,
+      data: {
+        data: {
+          type: "employees",
+          id: this.employeeId,
+          attributes: {
+            firstName: this.firstName,
+            lastName: this.lastName,
+            identifier: this.identifier,
+            employmentStatus: this.employmentStatus,
+            ...custom,
+          },
+        },
+      },
+    });
     const response = await this.app._makeRequest({
       $,
       method: "PATCH",

--- a/components/peakon_employee_voice/actions/update-employee/update-employee.mjs
+++ b/components/peakon_employee_voice/actions/update-employee/update-employee.mjs
@@ -70,19 +70,12 @@ export default {
     if (this.lastName !== undefined) standardAttrs.lastName = this.lastName;
     if (this.identifier !== undefined) standardAttrs.identifier = this.identifier;
     if (this.employmentStatus !== undefined) standardAttrs.employmentStatus = this.employmentStatus;
-    const response = await this.app._makeRequest({
+    const response = await this.app.updateEmployee({
       $,
-      method: "PATCH",
-      path: `/api/v1/employees/${this.employeeId}`,
-      data: {
-        data: {
-          type: "employees",
-          id: this.employeeId,
-          attributes: {
-            ...standardAttrs,
-            ...custom,
-          },
-        },
+      employeeId: this.employeeId,
+      attributes: {
+        ...standardAttrs,
+        ...custom,
       },
     });
     $.export("$summary", `Updated employee ${this.employeeId}`);

--- a/components/peakon_employee_voice/actions/update-employee/update-employee.mjs
+++ b/components/peakon_employee_voice/actions/update-employee/update-employee.mjs
@@ -65,16 +65,14 @@ export default {
     const custom = this.customAttributes
       ? JSON.parse(this.customAttributes)
       : {};
-    const standardAttrs = {};
-    if (this.firstName !== undefined) standardAttrs.firstName = this.firstName;
-    if (this.lastName !== undefined) standardAttrs.lastName = this.lastName;
-    if (this.identifier !== undefined) standardAttrs.identifier = this.identifier;
-    if (this.employmentStatus !== undefined) standardAttrs.employmentStatus = this.employmentStatus;
     const response = await this.app.updateEmployee({
       $,
       employeeId: this.employeeId,
       attributes: {
-        ...standardAttrs,
+        firstName: this.firstName,
+        lastName: this.lastName,
+        identifier: this.identifier,
+        employmentStatus: this.employmentStatus,
         ...custom,
       },
     });

--- a/components/peakon_employee_voice/actions/update-employee/update-employee.mjs
+++ b/components/peakon_employee_voice/actions/update-employee/update-employee.mjs
@@ -1,0 +1,91 @@
+import app from "../../peakon_employee_voice.app.mjs";
+
+export default {
+  key: "peakon_employee_voice-update-employee",
+  name: "Update Employee",
+  description:
+    "Partially updates an existing employee's attributes using their internal ID. "
+    + "Only the fields you provide will be updated — omitted fields are left unchanged. "
+    + "Use **List Employees** to find the employee's `id` first. "
+    + "Standard fields: `firstName`, `lastName`, `identifier`, `employmentStatus`. "
+    + "Custom HR attributes (Department, Region, Job Level, etc.) can be updated via `customAttributes` "
+    + "as a JSON object — e.g. `{\"Department\": \"Engineering\"}`. "
+    + "Enum attribute values are accepted as plain strings; Peakon resolves option IDs internally. "
+    + "[See the Peakon API documentation](https://developer.peakon.com/reference/patch_employees-employeeid)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    app,
+    employeeId: {
+      propDefinition: [
+        app,
+        "employeeId",
+      ],
+    },
+    firstName: {
+      type: "string",
+      label: "First Name",
+      description: "Updated first name.",
+      optional: true,
+    },
+    lastName: {
+      type: "string",
+      label: "Last Name",
+      description: "Updated last name.",
+      optional: true,
+    },
+    identifier: {
+      type: "string",
+      label: "Identifier",
+      description: "Updated HR employee number.",
+      optional: true,
+    },
+    employmentStatus: {
+      type: "string",
+      label: "Employment Status",
+      description: "Updated employment status (e.g. `employed`, `on_leave`).",
+      optional: true,
+    },
+    customAttributes: {
+      type: "string",
+      label: "Custom Attributes",
+      description:
+        "JSON object of custom HR attributes to update. "
+        + "Example: `{\"Department\": \"Engineering\", \"Job Level\": \"Senior Manager\"}`. "
+        + "Only provided attributes are changed.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const custom = this.customAttributes
+      ? JSON.parse(this.customAttributes)
+      : {};
+    const standardAttrs = {};
+    if (this.firstName) standardAttrs.firstName = this.firstName;
+    if (this.lastName) standardAttrs.lastName = this.lastName;
+    if (this.identifier) standardAttrs.identifier = this.identifier;
+    if (this.employmentStatus) standardAttrs.employmentStatus = this.employmentStatus;
+    const response = await this.app._makeRequest({
+      $,
+      method: "PATCH",
+      path: `/api/v1/employees/${this.employeeId}`,
+      data: {
+        data: {
+          type: "employees",
+          id: this.employeeId,
+          attributes: {
+            ...standardAttrs,
+            ...custom,
+          },
+        },
+      },
+    });
+    $.export("$summary", `Updated employee ${this.employeeId}`);
+    return response;
+  },
+};

--- a/components/peakon_employee_voice/actions/update-employee/update-employee.mjs
+++ b/components/peakon_employee_voice/actions/update-employee/update-employee.mjs
@@ -28,37 +28,37 @@ export default {
       ],
     },
     firstName: {
-      type: "string",
-      label: "First Name",
-      description: "Updated first name.",
+      propDefinition: [
+        app,
+        "firstName",
+      ],
       optional: true,
     },
     lastName: {
-      type: "string",
-      label: "Last Name",
-      description: "Updated last name.",
+      propDefinition: [
+        app,
+        "lastName",
+      ],
       optional: true,
     },
     identifier: {
-      type: "string",
-      label: "Identifier",
-      description: "Updated HR employee number.",
+      propDefinition: [
+        app,
+        "identifier",
+      ],
       optional: true,
     },
     employmentStatus: {
-      type: "string",
-      label: "Employment Status",
-      description: "Updated employment status (e.g. `employed`, `on_leave`).",
-      optional: true,
+      propDefinition: [
+        app,
+        "employmentStatus",
+      ],
     },
     customAttributes: {
-      type: "string",
-      label: "Custom Attributes",
-      description:
-        "JSON object of custom HR attributes to update. "
-        + "Example: `{\"Department\": \"Engineering\", \"Job Level\": \"Senior Manager\"}`. "
-        + "Only provided attributes are changed.",
-      optional: true,
+      propDefinition: [
+        app,
+        "customAttributes",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/peakon_employee_voice/actions/update-employee/update-employee.mjs
+++ b/components/peakon_employee_voice/actions/update-employee/update-employee.mjs
@@ -65,24 +65,11 @@ export default {
     const custom = this.customAttributes
       ? JSON.parse(this.customAttributes)
       : {};
-    const response = await this.app._makeRequest({
-      $,
-      method: "PATCH",
-      path: `/api/v1/employees/${this.employeeId}`,
-      data: {
-        data: {
-          type: "employees",
-          id: this.employeeId,
-          attributes: {
-            firstName: this.firstName,
-            lastName: this.lastName,
-            identifier: this.identifier,
-            employmentStatus: this.employmentStatus,
-            ...custom,
-          },
-        },
-      },
-    });
+    const standardAttrs = {};
+    if (this.firstName !== undefined) standardAttrs.firstName = this.firstName;
+    if (this.lastName !== undefined) standardAttrs.lastName = this.lastName;
+    if (this.identifier !== undefined) standardAttrs.identifier = this.identifier;
+    if (this.employmentStatus !== undefined) standardAttrs.employmentStatus = this.employmentStatus;
     const response = await this.app._makeRequest({
       $,
       method: "PATCH",

--- a/components/peakon_employee_voice/package.json
+++ b/components/peakon_employee_voice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/peakon_employee_voice",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Peakon Employee Voice Components",
   "main": "peakon_employee_voice.app.mjs",
   "keywords": [

--- a/components/peakon_employee_voice/package.json
+++ b/components/peakon_employee_voice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/peakon_employee_voice",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "Pipedream Peakon Employee Voice Components",
   "main": "peakon_employee_voice.app.mjs",
   "keywords": [

--- a/components/peakon_employee_voice/package.json
+++ b/components/peakon_employee_voice/package.json
@@ -9,6 +9,9 @@
   ],
   "homepage": "https://pipedream.com/apps/peakon_employee_voice",
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "dependencies": {
+    "@pipedream/platform": "^3.1.1"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/components/peakon_employee_voice/peakon_employee_voice.app.mjs
+++ b/components/peakon_employee_voice/peakon_employee_voice.app.mjs
@@ -1,11 +1,55 @@
+import { axios } from "@pipedream/platform";
+
 export default {
   type: "app",
   app: "peakon_employee_voice",
-  propDefinitions: {},
+  propDefinitions: {
+    contextId: {
+      type: "string",
+      label: "Context ID",
+      description:
+        "Optional segment or context ID to scope analytics to a specific population "
+        + "(e.g. `segment_62704631`). Use **List Segments** to discover available contextIds.",
+      optional: true,
+    },
+    interval: {
+      type: "string",
+      label: "Interval",
+      description: "Time interval for analytics data. Defaults to `quarter`.",
+      options: [
+        "month",
+        "quarter",
+        "year",
+        "all",
+        "recent",
+      ],
+      optional: true,
+      default: "quarter",
+    },
+    employeeId: {
+      type: "string",
+      label: "Employee ID",
+      description:
+        "Internal Peakon employee ID (e.g. `80166956`). "
+        + "Use **List Employees** to find the ID by searching by name.",
+    },
+  },
   methods: {
-    // this.$auth contains connected account data
-    authKeys() {
-      console.log(Object.keys(this.$auth));
+    _baseUrl() {
+      return `https://${this.$auth.subdomain}.${this.$auth.environment}.com`;
+    },
+    async _makeRequest({
+      $, path, method = "GET", params, data,
+    }) {
+      return axios($, {
+        method,
+        url: `${this._baseUrl()}${path}`,
+        headers: {
+          Authorization: `Bearer ${this.$auth.oauth_access_token}`,
+        },
+        params,
+        data,
+      });
     },
   },
 };

--- a/components/peakon_employee_voice/peakon_employee_voice.app.mjs
+++ b/components/peakon_employee_voice/peakon_employee_voice.app.mjs
@@ -51,21 +51,30 @@ export default {
         data,
       });
     },
-    listSegments({ $, params }) {
+    listSegments({
+      $,
+      params,
+    }) {
       return this._makeRequest({
         $,
         path: "/api/v1/segments",
         params,
       });
     },
-    listEmployees({ $, params }) {
+    listEmployees({
+      $,
+      params,
+    }) {
       return this._makeRequest({
         $,
         path: "/api/v1/employees",
         params,
       });
     },
-    createEmployee({ $, attributes }) {
+    createEmployee({
+      $,
+      attributes,
+    }) {
       return this._makeRequest({
         $,
         method: "POST",
@@ -78,7 +87,11 @@ export default {
         },
       });
     },
-    updateEmployee({ $, employeeId, attributes }) {
+    updateEmployee({
+      $,
+      employeeId,
+      attributes,
+    }) {
       return this._makeRequest({
         $,
         method: "PATCH",
@@ -92,21 +105,32 @@ export default {
         },
       });
     },
-    deleteEmployee({ $, employeeId }) {
+    deleteEmployee({
+      $,
+      employeeId,
+    }) {
       return this._makeRequest({
         $,
         method: "DELETE",
         path: `/api/v1/employees/${employeeId}`,
       });
     },
-    getEngagementOverview({ $, contextId, params }) {
+    getEngagementOverview({
+      $,
+      contextId,
+      params,
+    }) {
       return this._makeRequest({
         $,
         path: `/api/v1/engagement/contexts/${contextId}/overview`,
         params,
       });
     },
-    getDriverScores({ $, contextId, params }) {
+    getDriverScores({
+      $,
+      contextId,
+      params,
+    }) {
       return this._makeRequest({
         $,
         path: `/api/v1/engagement/contexts/${contextId}/drivers`,

--- a/components/peakon_employee_voice/peakon_employee_voice.app.mjs
+++ b/components/peakon_employee_voice/peakon_employee_voice.app.mjs
@@ -51,5 +51,67 @@ export default {
         data,
       });
     },
+    listSegments({ $, params }) {
+      return this._makeRequest({
+        $,
+        path: "/api/v1/segments",
+        params,
+      });
+    },
+    listEmployees({ $, params }) {
+      return this._makeRequest({
+        $,
+        path: "/api/v1/employees",
+        params,
+      });
+    },
+    createEmployee({ $, attributes }) {
+      return this._makeRequest({
+        $,
+        method: "POST",
+        path: "/api/v1/employees",
+        data: {
+          data: {
+            type: "employees",
+            attributes,
+          },
+        },
+      });
+    },
+    updateEmployee({ $, employeeId, attributes }) {
+      return this._makeRequest({
+        $,
+        method: "PATCH",
+        path: `/api/v1/employees/${employeeId}`,
+        data: {
+          data: {
+            type: "employees",
+            id: employeeId,
+            attributes,
+          },
+        },
+      });
+    },
+    deleteEmployee({ $, employeeId }) {
+      return this._makeRequest({
+        $,
+        method: "DELETE",
+        path: `/api/v1/employees/${employeeId}`,
+      });
+    },
+    getEngagementOverview({ $, contextId, params }) {
+      return this._makeRequest({
+        $,
+        path: `/api/v1/engagement/contexts/${contextId}/overview`,
+        params,
+      });
+    },
+    getDriverScores({ $, contextId, params }) {
+      return this._makeRequest({
+        $,
+        path: `/api/v1/engagement/contexts/${contextId}/drivers`,
+        params,
+      });
+    },
   },
 };

--- a/components/peakon_employee_voice/peakon_employee_voice.app.mjs
+++ b/components/peakon_employee_voice/peakon_employee_voice.app.mjs
@@ -8,9 +8,9 @@ export default {
       type: "string",
       label: "Context ID",
       description:
-        "Optional segment or context ID to scope analytics to a specific population "
-        + "(e.g. `segment_62704631`). Use **List Segments** to discover available contextIds.",
-      optional: true,
+        "Company or segment context ID. Format: `company_[companyId]` for company-wide metrics "
+        + "or `segment_[segmentId]` for a specific segment. "
+        + "Use **List Segments** to discover available segment IDs.",
     },
     interval: {
       type: "string",
@@ -32,6 +32,58 @@ export default {
       description:
         "Internal Peakon employee ID (e.g. `80166956`). "
         + "Use **List Employees** to find the ID by searching by name.",
+    },
+    observations: {
+      type: "boolean",
+      label: "Include Observations",
+      description: "Whether to include the observations array in the response. Defaults to false.",
+      optional: true,
+      default: false,
+    },
+    participation: {
+      type: "boolean",
+      label: "Include Participation",
+      description: "Whether to include participation data in the response. Defaults to false.",
+      optional: true,
+      default: false,
+    },
+    filterSegmentIds: {
+      type: "string",
+      label: "Filter by Segment IDs",
+      description:
+        "Comma-separated list of segment IDs to filter by segment membership. "
+        + "Example: `1001,1002`. Use **List Segments** to discover available segment IDs.",
+      optional: true,
+    },
+    firstName: {
+      type: "string",
+      label: "First Name",
+      description: "Employee's first name.",
+    },
+    lastName: {
+      type: "string",
+      label: "Last Name",
+      description: "Employee's last name.",
+    },
+    identifier: {
+      type: "string",
+      label: "Identifier",
+      description: "HR employee number or unique identifier (e.g. `E001`). Must be unique across employees.",
+    },
+    employmentStatus: {
+      type: "string",
+      label: "Employment Status",
+      description: "Current employment status (e.g. `employed`, `on_leave`).",
+      optional: true,
+    },
+    customAttributes: {
+      type: "string",
+      label: "Custom Attributes",
+      description:
+        "JSON object of custom HR attributes for the employee. "
+        + "Example: `{\"Department\": \"Sales\", \"Region\": \"North America\", \"Job Level\": \"Manager\"}`. "
+        + "Enum values are accepted as plain strings.",
+      optional: true,
     },
   },
   methods: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3418,8 +3418,7 @@ importers:
 
   components/commcare: {}
 
-  components/commerce_tools:
-    specifiers: {}
+  components/commerce_tools: {}
 
   components/commercehq: {}
 
@@ -5544,8 +5543,7 @@ importers:
         specifier: ^3.2.5
         version: 3.3.0
 
-  components/filetopdf_dev:
-    specifiers: {}
+  components/filetopdf_dev: {}
 
   components/fillout:
     dependencies:
@@ -6112,8 +6110,7 @@ importers:
         specifier: ^3.1.1
         version: 3.1.1
 
-  components/gamma:
-    specifiers: {}
+  components/gamma: {}
 
   components/gan_ai:
     dependencies:
@@ -8985,7 +8982,7 @@ importers:
     dependencies:
       linkup-sdk:
         specifier: ^1.0.3
-        version: 1.2.0(@types/node@20.19.41)(typescript@5.9.3)
+        version: 1.2.0(@types/node@25.9.1)(typescript@5.9.3)
 
   components/linkupapi:
     dependencies:
@@ -10447,7 +10444,7 @@ importers:
         version: 0.5.6
       netlify:
         specifier: ^23.0.0
-        version: 23.11.0(@azure/identity@4.13.1)(@azure/storage-blob@12.29.1)(@types/express@4.17.25)(@types/node@20.19.41)(encoding@0.1.13)(picomatch@4.0.3)(rollup@4.53.2)
+        version: 23.11.0(@azure/identity@4.13.1)(@azure/storage-blob@12.29.1)(@types/express@4.17.25)(@types/node@25.9.1)(encoding@0.1.13)(picomatch@4.0.3)(rollup@4.53.2)
       parse-link-header:
         specifier: ^2.0.0
         version: 2.0.0
@@ -11696,7 +11693,11 @@ importers:
         specifier: ^2.0.2
         version: 2.0.2
 
-  components/peakon_employee_voice: {}
+  components/peakon_employee_voice:
+    dependencies:
+      '@pipedream/platform':
+        specifier: ^3.1.1
+        version: 3.4.0
 
   components/peekalink: {}
 
@@ -13191,8 +13192,7 @@ importers:
 
   components/renderio: {}
 
-  components/rendex:
-    specifiers: {}
+  components/rendex: {}
 
   components/rendi:
     dependencies:
@@ -15015,15 +15015,13 @@ importers:
         specifier: ^13.0.0
         version: 13.0.0
 
-  components/snowflake_oauth:
-    specifiers: {}
+  components/snowflake_oauth: {}
 
   components/snowflake_test: {}
 
   components/snyk: {}
 
-  components/social_fetch:
-    specifiers: {}
+  components/social_fetch: {}
 
   components/social_intents:
     dependencies:
@@ -18707,7 +18705,7 @@ importers:
         version: 3.1.0
       jest:
         specifier: ^29.1.2
-        version: 29.7.0(@types/node@20.19.41)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.6.3))
+        version: 29.7.0(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.6.3))
       type-fest:
         specifier: ^4.15.0
         version: 4.41.0
@@ -32312,7 +32310,6 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
-
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qified@0.5.2:
@@ -33008,11 +33005,6 @@ packages:
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
-  semver@7.8.1:
-    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -37555,7 +37547,7 @@ snapshots:
       debug: 4.4.3(supports-color@9.4.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
-      semver: 7.8.1
+      semver: 7.8.2
     transitivePeerDependencies:
       - supports-color
 
@@ -37565,7 +37557,7 @@ snapshots:
       eslint: 8.57.1
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
-      semver: 7.8.1
+      semver: 7.8.2
 
   '@babel/generator@7.28.5':
     dependencies:
@@ -37602,7 +37594,7 @@ snapshots:
       '@babel/helper-validator-option': 8.0.0-beta.3
       browserslist: 4.28.0
       lru-cache: 7.18.3
-      semver: 7.8.1
+      semver: 7.8.2
 
   '@babel/helper-create-class-features-plugin@7.28.5(@babel/core@7.28.5)':
     dependencies:
@@ -38545,11 +38537,11 @@ snapshots:
       - '@types/node'
       - typescript
 
-  '@commitlint/cli@19.8.1(@types/node@20.19.41)(typescript@5.9.3)':
+  '@commitlint/cli@19.8.1(@types/node@25.9.1)(typescript@5.9.3)':
     dependencies:
       '@commitlint/format': 19.8.1
       '@commitlint/lint': 19.8.1
-      '@commitlint/load': 19.8.1(@types/node@20.19.41)(typescript@5.9.3)
+      '@commitlint/load': 19.8.1(@types/node@25.9.1)(typescript@5.9.3)
       '@commitlint/read': 19.8.1
       '@commitlint/types': 19.8.1
       tinyexec: 1.0.2
@@ -38612,7 +38604,7 @@ snapshots:
       - '@types/node'
       - typescript
 
-  '@commitlint/load@19.8.1(@types/node@20.19.41)(typescript@5.9.3)':
+  '@commitlint/load@19.8.1(@types/node@25.9.1)(typescript@5.9.3)':
     dependencies:
       '@commitlint/config-validator': 19.8.1
       '@commitlint/execute-rule': 19.8.1
@@ -38620,7 +38612,7 @@ snapshots:
       '@commitlint/types': 19.8.1
       chalk: 5.6.2
       cosmiconfig: 9.0.0(typescript@5.9.3)
-      cosmiconfig-typescript-loader: 6.2.0(@types/node@20.19.41)(cosmiconfig@9.0.0(typescript@5.9.3))(typescript@5.9.3)
+      cosmiconfig-typescript-loader: 6.2.0(@types/node@25.9.1)(cosmiconfig@9.0.0(typescript@5.9.3))(typescript@5.9.3)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -39705,12 +39697,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 17.0.45
 
-  '@inquirer/external-editor@1.0.3(@types/node@20.19.41)':
+  '@inquirer/external-editor@1.0.3(@types/node@25.9.1)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 20.19.41
+      '@types/node': 25.9.1
 
   '@isaacs/balanced-match@4.0.1': {}
 
@@ -39744,7 +39736,7 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.19.25
+      '@types/node': 20.19.41
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -39785,7 +39777,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.6.3))':
+  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.6.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -39799,7 +39791,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.19.41)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.6.3))
+      jest-config: 29.7.0(@types/node@20.19.41)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.6.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -39824,7 +39816,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.25
+      '@types/node': 20.19.41
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -39842,7 +39834,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 20.19.25
+      '@types/node': 20.19.41
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -39864,7 +39856,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 20.19.25
+      '@types/node': 20.19.41
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit: 0.1.2
@@ -40061,7 +40053,7 @@ snapshots:
       https-proxy-agent: 7.0.6
       node-fetch: 2.7.0(encoding@0.1.13)
       nopt: 8.1.0
-      semver: 7.7.4
+      semver: 7.8.2
       tar: 7.5.16
     transitivePeerDependencies:
       - encoding
@@ -40074,7 +40066,7 @@ snapshots:
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
       node-fetch: 2.7.0(encoding@0.1.13)
       nopt: 8.1.0
-      semver: 7.7.4
+      semver: 7.8.2
       tar: 7.5.16
     transitivePeerDependencies:
       - encoding
@@ -40278,7 +40270,7 @@ snapshots:
       yaml: 2.8.1
       yargs: 17.7.2
 
-  '@netlify/build@35.3.1(@opentelemetry/api@1.8.0)(@types/node@20.19.41)(encoding@0.1.13)(picomatch@4.0.3)(rollup@4.53.2)':
+  '@netlify/build@35.3.1(@opentelemetry/api@1.8.0)(@types/node@25.9.1)(encoding@0.1.13)(picomatch@4.0.3)(rollup@4.53.2)':
     dependencies:
       '@bugsnag/js': 8.6.0
       '@netlify/blobs': 10.3.3(supports-color@10.2.2)
@@ -40326,7 +40318,7 @@ snapshots:
       string-width: 7.2.0
       supports-color: 10.2.2
       terminal-link: 4.0.0
-      ts-node: 10.9.2(@types/node@20.19.41)(typescript@5.6.3)
+      ts-node: 10.9.2(@types/node@25.9.1)(typescript@5.6.3)
       typescript: 5.6.3
       uuid: 11.1.0
       yaml: 2.8.1
@@ -40412,7 +40404,7 @@ snapshots:
       image-size: 2.0.2
       js-image-generator: 1.0.4
       parse-gitignore: 2.0.0
-      semver: 7.7.4
+      semver: 7.8.2
       tmp-promise: 3.0.3
       uuid: 11.1.0
       write-file-atomic: 5.0.1
@@ -41028,7 +41020,7 @@ snapshots:
       '@opentelemetry/propagator-b3': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/propagator-jaeger': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
-      semver: 7.7.4
+      semver: 7.8.2
 
   '@opentelemetry/semantic-conventions@1.28.0': {}
 
@@ -42119,6 +42111,7 @@ snapshots:
     transitivePeerDependencies:
       - rolldown
       - rollup
+      - supports-color
 
   '@putout/operator-parens@2.0.0(rolldown@1.0.0-beta.60(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1))(rollup@4.53.2)':
     dependencies:
@@ -43188,7 +43181,7 @@ snapshots:
       read-pkg: 9.0.1
       registry-auth-token: 5.1.0
       semantic-release: 24.2.9(typescript@5.6.3)
-      semver: 7.8.1
+      semver: 7.8.2
       tempy: 3.1.0
 
   '@semantic-release/npm@12.0.2(semantic-release@24.2.9(typescript@5.9.3))':
@@ -43205,7 +43198,7 @@ snapshots:
       read-pkg: 9.0.1
       registry-auth-token: 5.1.0
       semantic-release: 24.2.9(typescript@5.9.3)
-      semver: 7.8.1
+      semver: 7.8.2
       tempy: 3.1.0
 
   '@semantic-release/release-notes-generator@14.1.0(semantic-release@24.2.9(typescript@5.6.3))':
@@ -44356,7 +44349,7 @@ snapshots:
 
   '@types/conventional-commits-parser@5.0.2':
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 20.19.41
 
   '@types/debug@4.1.12':
     dependencies:
@@ -44374,7 +44367,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.7':
     dependencies:
-      '@types/node': 22.19.1
+      '@types/node': 20.19.41
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -44413,7 +44406,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 20.19.25
+      '@types/node': 20.19.41
 
   '@types/hast@3.0.4':
     dependencies:
@@ -44573,12 +44566,12 @@ snapshots:
 
   '@types/readable-stream@4.0.22':
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 20.19.41
 
   '@types/request@2.48.13':
     dependencies:
       '@types/caseless': 0.12.5
-      '@types/node': 22.19.1
+      '@types/node': 20.19.41
       '@types/tough-cookie': 4.0.5
       form-data: 2.5.4
 
@@ -44602,11 +44595,11 @@ snapshots:
   '@types/send@0.17.6':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 22.19.1
+      '@types/node': 20.19.41
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 22.19.1
+      '@types/node': 20.19.41
 
   '@types/serve-static@1.15.10':
     dependencies:
@@ -44792,7 +44785,7 @@ snapshots:
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.9
-      semver: 7.8.1
+      semver: 7.8.2
       ts-api-utils: 2.1.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -44808,7 +44801,7 @@ snapshots:
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.9
-      semver: 7.8.1
+      semver: 7.8.2
       ts-api-utils: 2.1.0(typescript@5.6.3)
       typescript: 5.6.3
     transitivePeerDependencies:
@@ -44824,7 +44817,7 @@ snapshots:
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.9
-      semver: 7.8.1
+      semver: 7.8.2
       ts-api-utils: 2.1.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -45869,7 +45862,8 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  bare-events@2.8.3: {}
+  bare-events@2.8.3:
+    optional: true
 
   bare-events@2.9.1: {}
 
@@ -46790,7 +46784,7 @@ snapshots:
       conventional-commits-filter: 5.0.0
       handlebars: 4.7.9
       meow: 13.2.0
-      semver: 7.7.4
+      semver: 7.8.2
 
   conventional-commits-filter@5.0.0: {}
 
@@ -46855,9 +46849,9 @@ snapshots:
       jiti: 2.6.1
       typescript: 5.6.3
 
-  cosmiconfig-typescript-loader@6.2.0(@types/node@20.19.41)(cosmiconfig@9.0.0(typescript@5.9.3))(typescript@5.9.3):
+  cosmiconfig-typescript-loader@6.2.0(@types/node@25.9.1)(cosmiconfig@9.0.0(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
-      '@types/node': 20.19.41
+      '@types/node': 25.9.1
       cosmiconfig: 9.0.0(typescript@5.9.3)
       jiti: 2.6.1
       typescript: 5.9.3
@@ -46957,13 +46951,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@20.19.41)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.6.3)):
+  create-jest@29.7.0(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.6.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.19.41)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.6.3))
+      jest-config: 29.7.0(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.6.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -47996,7 +47990,7 @@ snapshots:
   eslint-compat-utils@0.5.1(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
-      semver: 7.8.1
+      semver: 7.8.2
 
   eslint-config-next@15.5.6(eslint@8.57.1)(typescript@5.6.3):
     dependencies:
@@ -48135,7 +48129,7 @@ snapshots:
       globals: 15.15.0
       globrex: 0.1.2
       ignore: 5.3.2
-      semver: 7.8.1
+      semver: 7.8.2
       ts-declaration-location: 1.0.7(typescript@5.6.3)
     transitivePeerDependencies:
       - typescript
@@ -48150,7 +48144,7 @@ snapshots:
       globals: 15.15.0
       globrex: 0.1.2
       ignore: 5.3.2
-      semver: 7.8.1
+      semver: 7.8.2
       ts-declaration-location: 1.0.7(typescript@5.9.3)
     transitivePeerDependencies:
       - typescript
@@ -48430,7 +48424,7 @@ snapshots:
 
   events-universal@1.0.1:
     dependencies:
-      bare-events: 2.8.3
+      bare-events: 2.9.1
     transitivePeerDependencies:
       - bare-abort-controller
 
@@ -50325,12 +50319,12 @@ snapshots:
 
   inline-style-parser@0.2.6: {}
 
-  inquirer-autocomplete-prompt@1.4.0(inquirer@8.2.7(@types/node@20.19.41)):
+  inquirer-autocomplete-prompt@1.4.0(inquirer@8.2.7(@types/node@25.9.1)):
     dependencies:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       figures: 3.2.0
-      inquirer: 8.2.7(@types/node@20.19.41)
+      inquirer: 8.2.7(@types/node@25.9.1)
       run-async: 2.4.1
       rxjs: 6.6.7
 
@@ -50354,9 +50348,9 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  inquirer@8.2.7(@types/node@20.19.41):
+  inquirer@8.2.7(@types/node@25.9.1):
     dependencies:
-      '@inquirer/external-editor': 1.0.3(@types/node@20.19.41)
+      '@inquirer/external-editor': 1.0.3(@types/node@25.9.1)
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       cli-cursor: 3.1.0
@@ -50860,7 +50854,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.25
+      '@types/node': 20.19.41
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.0(babel-plugin-macros@3.1.0)
@@ -50899,16 +50893,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@20.19.41)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.6.3)):
+  jest-cli@29.7.0(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.6.3)):
     dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.6.3))
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.6.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.19.41)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.6.3))
+      create-jest: 29.7.0(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.6.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@20.19.41)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.6.3))
+      jest-config: 29.7.0(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.6.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -50980,7 +50974,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@20.19.41)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.6.3)):
+  jest-config@29.7.0(@types/node@20.19.41)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.6.3)):
     dependencies:
       '@babel/core': 7.28.5
       '@jest/test-sequencer': 29.7.0
@@ -51006,7 +51000,38 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.19.41
-      ts-node: 10.9.2(@types/node@20.19.41)(typescript@5.6.3)
+      ts-node: 10.9.2(@types/node@25.9.1)(typescript@5.6.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@29.7.0(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.6.3)):
+    dependencies:
+      '@babel/core': 7.28.5
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.28.5)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 25.9.1
+      ts-node: 10.9.2(@types/node@25.9.1)(typescript@5.6.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -51042,7 +51067,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.25
+      '@types/node': 20.19.41
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -51054,7 +51079,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 20.19.25
+      '@types/node': 20.19.41
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -51100,7 +51125,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.19.25
+      '@types/node': 20.19.41
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -51135,7 +51160,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.25
+      '@types/node': 20.19.41
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -51163,7 +51188,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.25
+      '@types/node': 20.19.41
       chalk: 4.1.2
       cjs-module-lexer: 1.4.3
       collect-v8-coverage: 1.0.3
@@ -51209,7 +51234,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.19.25
+      '@types/node': 20.19.41
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -51228,7 +51253,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.19.25
+      '@types/node': 20.19.41
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -51237,7 +51262,7 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 20.19.25
+      '@types/node': 20.19.41
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -51254,12 +51279,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@20.19.41)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.6.3)):
+  jest@29.7.0(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.6.3)):
     dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.6.3))
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.6.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@20.19.41)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.6.3))
+      jest-cli: 29.7.0(@types/node@25.9.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.6.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -51733,9 +51758,9 @@ snapshots:
       - supports-color
       - typescript
 
-  linkup-sdk@1.2.0(@types/node@20.19.41)(typescript@5.9.3):
+  linkup-sdk@1.2.0(@types/node@25.9.1)(typescript@5.9.3):
     dependencies:
-      '@commitlint/cli': 19.8.1(@types/node@20.19.41)(typescript@5.9.3)
+      '@commitlint/cli': 19.8.1(@types/node@25.9.1)(typescript@5.9.3)
       '@commitlint/config-conventional': 19.8.1
       axios: 1.17.0(debug@3.2.7)
       semantic-release: 24.2.9(typescript@5.9.3)
@@ -52140,7 +52165,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.2
 
   make-error@1.3.6: {}
 
@@ -53030,13 +53055,13 @@ snapshots:
 
   netlify-redirector@0.5.0: {}
 
-  netlify@23.11.0(@azure/identity@4.13.1)(@azure/storage-blob@12.29.1)(@types/express@4.17.25)(@types/node@20.19.41)(encoding@0.1.13)(picomatch@4.0.3)(rollup@4.53.2):
+  netlify@23.11.0(@azure/identity@4.13.1)(@azure/storage-blob@12.29.1)(@types/express@4.17.25)(@types/node@25.9.1)(encoding@0.1.13)(picomatch@4.0.3)(rollup@4.53.2):
     dependencies:
       '@fastify/static': 7.0.4
       '@netlify/ai': 0.3.0(@netlify/api@14.0.9)
       '@netlify/api': 14.0.9
       '@netlify/blobs': 10.1.0
-      '@netlify/build': 35.3.1(@opentelemetry/api@1.8.0)(@types/node@20.19.41)(encoding@0.1.13)(picomatch@4.0.3)(rollup@4.53.2)
+      '@netlify/build': 35.3.1(@opentelemetry/api@1.8.0)(@types/node@25.9.1)(encoding@0.1.13)(picomatch@4.0.3)(rollup@4.53.2)
       '@netlify/build-info': 10.0.9
       '@netlify/config': 24.0.8
       '@netlify/dev-utils': 4.3.0
@@ -53087,8 +53112,8 @@ snapshots:
       http-proxy: 1.18.1(debug@4.4.3)
       http-proxy-middleware: 2.0.9(@types/express@4.17.25)(debug@4.4.3)
       https-proxy-agent: 7.0.6
-      inquirer: 8.2.7(@types/node@20.19.41)
-      inquirer-autocomplete-prompt: 1.4.0(inquirer@8.2.7(@types/node@20.19.41))
+      inquirer: 8.2.7(@types/node@25.9.1)
+      inquirer-autocomplete-prompt: 1.4.0(inquirer@8.2.7(@types/node@25.9.1))
       ipx: 3.1.1(@azure/identity@4.13.1)(@azure/storage-blob@12.29.1)(@netlify/blobs@10.1.0)
       is-docker: 3.0.0
       is-stream: 4.0.1
@@ -53318,7 +53343,7 @@ snapshots:
   normalize-package-data@6.0.2:
     dependencies:
       hosted-git-info: 7.0.2
-      semver: 7.7.2
+      semver: 7.8.2
       validate-npm-package-license: 3.0.4
 
   normalize-package-data@7.0.1:
@@ -53883,7 +53908,7 @@ snapshots:
       ky: 1.14.0
       registry-auth-token: 5.1.0
       registry-url: 6.0.1
-      semver: 7.7.4
+      semver: 7.8.2
 
   package-lock-only@0.0.4:
     dependencies:
@@ -54427,7 +54452,7 @@ snapshots:
       jsdoc: 4.0.5
       minimist: 1.2.8
       protobufjs: 7.2.6
-      semver: 7.8.1
+      semver: 7.8.2
       tmp: 0.2.7
       uglify-js: 3.19.3
 
@@ -55781,7 +55806,7 @@ snapshots:
 
   semver-diff@5.0.0:
     dependencies:
-      semver: 7.8.1
+      semver: 7.8.2
 
   semver-regex@4.0.5: {}
 
@@ -55798,8 +55823,6 @@ snapshots:
   semver@7.7.3: {}
 
   semver@7.7.4: {}
-
-  semver@7.8.1: {}
 
   semver@7.8.2: {}
 
@@ -55915,7 +55938,7 @@ snapshots:
     dependencies:
       '@img/colour': 1.0.0
       detect-libc: 2.1.2
-      semver: 7.8.1
+      semver: 7.8.2
 
   shebang-command@1.2.0:
     dependencies:
@@ -56025,7 +56048,7 @@ snapshots:
 
   simple-update-notifier@2.0.0:
     dependencies:
-      semver: 7.8.1
+      semver: 7.8.2
 
   simple-xml2json@1.2.3: {}
 
@@ -57129,14 +57152,14 @@ snapshots:
       yn: 3.1.1
     optional: true
 
-  ts-node@10.9.2(@types/node@20.19.41)(typescript@5.6.3):
+  ts-node@10.9.2(@types/node@25.9.1)(typescript@5.6.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 20.19.41
+      '@types/node': 25.9.1
       acorn: 8.15.0
       acorn-walk: 8.3.4
       arg: 4.1.3


### PR DESCRIPTION
## Summary

- Adds 7 new AI-optimized actions for Peakon Employee Voice: `get-engagement-overview`, `get-driver-scores`, `list-segments`, `list-employees`, `create-employee`, `update-employee`, `delete-employee`
- Updates the app file to use `oauth_access_token` as Bearer JWT directly (Pipedream's OAuth flow handles the Peakon token exchange) and adds a shared `_makeRequest` helper
- All actions use static schemas (no `additionalProps`/`reloadProps`), correct MCP annotations (`readOnlyHint`, `destructiveHint`, `openWorldHint`), and cross-references between tools in descriptions

## Test plan

- [ ] All 7 evals pass at 100% (confirmed on staging account: `pipedream.staging-peakon.com`)
- [ ] Lint passes (exit 0)
- [ ] `list-segments` → returns 423 segments with `contextId` values
- [ ] `get-engagement-overview` → scoped to segment via contextId
- [ ] `get-driver-scores` → returns 14 driver scores with grade/impact
- [ ] `list-employees` → filters by manager/admin/email/segmentIds
- [ ] `create-employee` → POST with JSON API body, returns internal ID
- [ ] `update-employee` → PATCH partial update including custom HR attributes
- [ ] `delete-employee` → permanent DELETE, destructiveHint: true

Closes #20291

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Employee management: create, update, delete, and list employees with configurable filters and custom attributes
  * Engagement analytics: retrieve driver scores and an engagement overview (with interval, observations, participation options)
  * Segmentation: list demographic/organizational segments with filter options

* **Chores**
  * Improved API integration with authenticated requests, richer prop-driven inputs, and package version bump
<!-- end of auto-generated comment: release notes by coderabbit.ai -->