### PR TITLE
[21005] fix(hubspot): migrate "New Engagement" source to v3 2026-03 search API

### DIFF
--- a/components/hubspot/actions/add-comment/add-comment.mjs
+++ b/components/hubspot/actions/add-comment/add-comment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-add-comment",
   name: "Add Comment",
   description: "Adds a comment to a thread. [See the documentation](https://developers.hubspot.com/docs/api-reference/conversations-conversations-inbox-&-messages-v3/public-message/post-conversations-v3-conversations-threads-threadId-messages)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/add-contact-to-list/add-contact-to-list.mjs
+++ b/components/hubspot/actions/add-contact-to-list/add-contact-to-list.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Add Contact to List",
   description:
     "Adds a contact to a specific static list. [See the documentation](https://developers.hubspot.com/docs/api-reference/crm-lists-v3/memberships/put-crm-v3-lists-listId-memberships-add)",
-  version: "0.1.1",
+  version: "0.1.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/add-note-to-contact/add-note-to-contact.mjs
+++ b/components/hubspot/actions/add-note-to-contact/add-note-to-contact.mjs
@@ -31,7 +31,7 @@ export default {
     + "Do **not** use **Create Engagement** for this workflow. "
     + "For every writable note property or non-contact associations, use **Create Note** instead. "
     + "[See the documentation](https://developers.hubspot.com/docs/api/crm/objects/notes)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/archive-thread/archive-thread.mjs
+++ b/components/hubspot/actions/archive-thread/archive-thread.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-archive-thread",
   name: "Archive Thread",
   description: "Archives a thread (soft delete). The thread is hidden from active views but can be restored via the HubSpot UI or by listing archived threads. [See the documentation](https://developers.hubspot.com/docs/reference/api/conversations/inbox-and-messages#archive-threads)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/batch-create-companies/batch-create-companies.mjs
+++ b/components/hubspot/actions/batch-create-companies/batch-create-companies.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Batch Create Companies",
   description:
     "Create a batch of companies in Hubspot. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/objects/companies#post-%2Fcrm%2Fv3%2Fobjects%2Fcompanies%2Fbatch%2Fcreate)",
-  version: "0.0.15",
+  version: "0.0.16",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/batch-create-or-update-contact/batch-create-or-update-contact.mjs
+++ b/components/hubspot/actions/batch-create-or-update-contact/batch-create-or-update-contact.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Batch Create or Update Contact",
   description:
     "Create or update a batch of contacts by its ID or email. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts)",
-  version: "0.0.29",
+  version: "0.0.30",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/hubspot/actions/batch-update-companies/batch-update-companies.mjs
+++ b/components/hubspot/actions/batch-update-companies/batch-update-companies.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Batch Update Companies",
   description:
     "Update a batch of companies in Hubspot. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/objects/companies#post-%2Fcrm%2Fv3%2Fobjects%2Fcompanies%2Fbatch%2Fupdate)",
-  version: "0.0.15",
+  version: "0.0.16",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/hubspot/actions/batch-upsert-companies/batch-upsert-companies.mjs
+++ b/components/hubspot/actions/batch-upsert-companies/batch-upsert-companies.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-batch-upsert-companies",
   name: "Batch Upsert Companies",
   description: "Upsert a batch of companies in Hubspot. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/objects/companies#post-%2Fcrm%2Fv3%2Fobjects%2Fcompanies%2Fbatch%2Fupsert)",
-  version: "0.0.14",
+  version: "0.0.15",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/hubspot/actions/clone-email/clone-email.mjs
+++ b/components/hubspot/actions/clone-email/clone-email.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Clone Marketing Email",
   description:
     "Clone a marketing email in HubSpot. [See the documentation](https://developers.hubspot.com/docs/reference/api/marketing/emails/marketing-emails#post-%2Fmarketing%2Fv3%2Femails%2Fclone)",
-  version: "0.0.13",
+  version: "0.0.14",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/clone-site-page/clone-site-page.mjs
+++ b/components/hubspot/actions/clone-site-page/clone-site-page.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Clone Site Page",
   description:
     "Clone a site page in Hubspot. [See the documentation](https://developers.hubspot.com/docs/reference/api/cms/pages#post-%2Fcms%2Fv3%2Fpages%2Fsite-pages%2Fclone)",
-  version: "0.0.13",
+  version: "0.0.14",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-association/create-association.mjs
+++ b/components/hubspot/actions/create-association/create-association.mjs
@@ -12,7 +12,7 @@ export default {
     + " deal→contact (3), contact→deal (4), deal→company (5), company→deal (6),"
     + " ticket→contact (15), contact→ticket (16), ticket→company (26), company→ticket (25)."
     + " [See the documentation](https://developers.hubspot.com/docs/api/crm/associations)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-associations/create-associations.mjs
+++ b/components/hubspot/actions/create-associations/create-associations.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Create Associations",
   description:
     "Create associations between objects. [See the documentation](https://developers.hubspot.com/docs/api/crm/associations#endpoint?spec=POST-/crm/v3/associations/{fromObjectType}/{toObjectType}/batch/create)",
-  version: "1.0.18",
+  version: "1.0.19",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-blog-post/create-blog-post.mjs
+++ b/components/hubspot/actions/create-blog-post/create-blog-post.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-create-blog-post",
   name: "Create Blog Post",
   description: "Creates a new blog post in HubSpot. [See the documentation](https://developers.hubspot.com/docs/api-reference/cms-posts-v3/basic/post-cms-v3-blogs-posts)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/create-communication/create-communication.mjs
+++ b/components/hubspot/actions/create-communication/create-communication.mjs
@@ -9,7 +9,7 @@ export default {
   name: "Create Communication",
   description:
     "Create a WhatsApp, LinkedIn, or SMS message. [See the documentation](https://developers.hubspot.com/beta-docs/reference/api/crm/engagements/communications/v3#post-%2Fcrm%2Fv3%2Fobjects%2Fcommunications)",
-  version: "0.0.26",
+  version: "0.0.27",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-company/create-company.mjs
+++ b/components/hubspot/actions/create-company/create-company.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Create Company",
   description:
     "Create a company in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/companies#endpoint?spec=POST-/crm/v3/objects/companies)",
-  version: "0.0.38",
+  version: "0.0.39",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-contact-workflow/create-contact-workflow.mjs
+++ b/components/hubspot/actions/create-contact-workflow/create-contact-workflow.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Create Contact Workflow",
   description:
     "Create a contact workflow in Hubspot. [See the documentation](https://developers.hubspot.com/docs/reference/api/automation/create-manage-workflows#post-%2Fautomation%2Fv4%2Fflows)",
-  version: "0.0.14",
+  version: "0.0.15",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-crm-object/create-crm-object.mjs
+++ b/components/hubspot/actions/create-crm-object/create-crm-object.mjs
@@ -14,7 +14,7 @@ export default {
     + " and **List Pipelines and Stages** to find valid pipeline/stage IDs for deals and tickets."
     + " Use **List Owners** to find valid `hubspot_owner_id` values."
     + " [See the documentation](https://developers.hubspot.com/docs/api/crm/objects)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-custom-object/create-custom-object.mjs
+++ b/components/hubspot/actions/create-custom-object/create-custom-object.mjs
@@ -10,7 +10,7 @@ export default {
   name: "Create Custom Object",
   description:
     "Create a new custom object in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/custom-objects#create-a-custom-object)",
-  version: "1.0.20",
+  version: "1.0.21",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-deal/create-deal.mjs
+++ b/components/hubspot/actions/create-deal/create-deal.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Create Deal",
   description:
     "Create a deal in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/deals#endpoint?spec=POST-/crm/v3/objects/deals)",
-  version: "0.0.38",
+  version: "0.0.39",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-email/create-email.mjs
+++ b/components/hubspot/actions/create-email/create-email.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Create Marketing Email",
   description:
     "Create a marketing email in Hubspot. [See the documentation](https://developers.hubspot.com/docs/reference/api/marketing/emails/marketing-emails#post-%2Fmarketing%2Fv3%2Femails%2F)",
-  version: "0.0.13",
+  version: "0.0.14",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-engagement/create-engagement.mjs
+++ b/components/hubspot/actions/create-engagement/create-engagement.mjs
@@ -90,7 +90,7 @@ export default {
     + "No `reloadProps` step and no **CONFIGURE_COMPONENT** requirement: association fields accept raw HubSpot IDs (use **Search CRM** or the Associations API to resolve `associationType` when needed). "
     + "For **only** a note on a contact by ID, **Add Note to Contact** (`hubspot-add-note-to-contact`) is still simpler. "
     + "[See the documentation](https://developers.hubspot.com/docs/api/crm/engagements)",
-  version: "0.1.3",
+  version: "0.1.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-form/create-form.mjs
+++ b/components/hubspot/actions/create-form/create-form.mjs
@@ -10,7 +10,7 @@ export default {
   name: "Create Form",
   description:
     "Create a form in HubSpot. [See the documentation](https://developers.hubspot.com/docs/reference/api/marketing/forms#post-%2Fmarketing%2Fv3%2Fforms%2F)",
-  version: "0.0.13",
+  version: "0.0.14",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-landing-page/create-landing-page.mjs
+++ b/components/hubspot/actions/create-landing-page/create-landing-page.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Create Landing Page",
   description:
     "Create a landing page in Hubspot. [See the documentation](https://developers.hubspot.com/docs/reference/api/cms/pages#post-%2Fcms%2Fv3%2Fpages%2Flanding-pages)",
-  version: "0.0.14",
+  version: "0.0.15",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-lead/create-lead.mjs
+++ b/components/hubspot/actions/create-lead/create-lead.mjs
@@ -13,7 +13,7 @@ export default {
   name: "Create Lead",
   description:
     "Create a lead in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/leads#create-leads)",
-  version: "0.0.26",
+  version: "0.0.27",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-meeting/create-meeting.mjs
+++ b/components/hubspot/actions/create-meeting/create-meeting.mjs
@@ -11,7 +11,7 @@ export default {
   name: "Create Meeting",
   description:
     "Creates a new meeting with optional associations to other objects. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/engagements/meetings#post-%2Fcrm%2Fv3%2Fobjects%2Fmeetings)",
-  version: "0.0.18",
+  version: "0.0.19",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-note/create-note.mjs
+++ b/components/hubspot/actions/create-note/create-note.mjs
@@ -11,7 +11,7 @@ export default {
     + "MCP/AI: For **only** contact ID + note body, use **Add Note to Contact** — fewer props and no association-type configuration. "
     + "If associating to another record, supply `toObjectType`, `toObjectId`, and `associationType` together; use **CONFIGURE_COMPONENT** with `componentKey` `hubspot-create-note` to load dropdown options for those props when needed. "
     + "[See the documentation](https://developers.hubspot.com/docs/api/crm/objects/notes)",
-  version: "0.0.18",
+  version: "0.0.19",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-or-update-contact/create-or-update-contact.mjs
+++ b/components/hubspot/actions/create-or-update-contact/create-or-update-contact.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Create or Update Contact",
   description:
     "Create or update a contact in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts#endpoint?spec=POST-/crm/v3/objects/contacts)",
-  version: "0.0.36",
+  version: "0.0.37",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/hubspot/actions/create-page/create-page.mjs
+++ b/components/hubspot/actions/create-page/create-page.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Create Page",
   description:
     "Create a page in HubSpot. [See the documentation](https://developers.hubspot.com/docs/reference/api/cms/pages#post-%2Fcms%2Fv3%2Fpages%2Fsite-pages)",
-  version: "0.0.14",
+  version: "0.0.15",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-task/create-task.mjs
+++ b/components/hubspot/actions/create-task/create-task.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Create Task",
   description:
     "Create a new task. [See the documentation](https://developers.hubspot.com/docs/api/crm/engagements)",
-  version: "0.0.18",
+  version: "0.0.19",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-ticket/create-ticket.mjs
+++ b/components/hubspot/actions/create-ticket/create-ticket.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Create Ticket",
   description:
     "Create a ticket in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/tickets)",
-  version: "0.0.29",
+  version: "0.0.30",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-workflow/create-workflow.mjs
+++ b/components/hubspot/actions/create-workflow/create-workflow.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-create-workflow",
   name: "Create a New Workflow",
   description: "Create a new workflow. [See the documentation](https://developers.hubspot.com/docs/api-reference/legacy/create-manage-workflows-v3/post-automation-v3-workflows)",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/delete-workflow/delete-workflow.mjs
+++ b/components/hubspot/actions/delete-workflow/delete-workflow.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-delete-workflow",
   name: "Delete a Workflow",
   description: "Delete a workflow by ID. [See the documentation](https://developers.hubspot.com/docs/api-reference/legacy/create-manage-workflows-v3/delete-automation-v3-workflows-workflowId)",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/hubspot/actions/enroll-contact-in-sequence/enroll-contact-in-sequence.mjs
+++ b/components/hubspot/actions/enroll-contact-in-sequence/enroll-contact-in-sequence.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-enroll-contact-in-sequence",
   name: "Enroll Contact in Sequence",
   description: "Enroll a contact into a HubSpot sequence. [See the documentation](https://developers.hubspot.com/docs/api-reference/latest/automation/sequences/enroll-contact)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/enroll-contact-into-workflow/enroll-contact-into-workflow.mjs
+++ b/components/hubspot/actions/enroll-contact-into-workflow/enroll-contact-into-workflow.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Enroll Contact Into Workflow",
   description:
     "Add a contact to a workflow. Note: The Workflows API currently only supports contact-based workflows and is only available for Marketing Hub Enterprise accounts. [See the documentation](https://legacydocs.hubspot.com/docs/methods/workflows/add_contact)",
-  version: "0.0.32",
+  version: "0.0.33",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/get-actor/get-actor.mjs
+++ b/components/hubspot/actions/get-actor/get-actor.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-get-actor",
   name: "Get Actor",
   description: "Resolves an actor ID (e.g. the value returned by a message's `senders[].actorId` field) to its name, email, and type. [See the documentation](https://developers.hubspot.com/docs/reference/api/conversations/inbox-and-messages#get-actors)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/get-associated-emails/get-associated-emails.mjs
+++ b/components/hubspot/actions/get-associated-emails/get-associated-emails.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Get Associated Emails",
   description:
     "Retrieves emails associated with a specific object (contact, company, or deal). [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/search)",
-  version: "0.0.14",
+  version: "0.0.15",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/get-associated-meetings/get-associated-meetings.mjs
+++ b/components/hubspot/actions/get-associated-meetings/get-associated-meetings.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Get Associated Meetings",
   description:
     "Retrieves meetings associated with a specific object (contact, company, or deal) with optional time filtering. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/associations/association-details#get-%2Fcrm%2Fv4%2Fobjects%2F%7Bobjecttype%7D%2F%7Bobjectid%7D%2Fassociations%2F%7Btoobjecttype%7D)",
-  version: "0.0.17",
+  version: "0.0.18",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/get-blog-post-draft/get-blog-post-draft.mjs
+++ b/components/hubspot/actions/get-blog-post-draft/get-blog-post-draft.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-get-blog-post-draft",
   name: "Get Blog Post Draft",
   description: "Retrieves the draft version of a blog post. [See the documentation](https://developers.hubspot.com/docs/api-reference/cms-posts-v3/basic/get-cms-v3-blogs-posts-objectId-draft)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/get-channel/get-channel.mjs
+++ b/components/hubspot/actions/get-channel/get-channel.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-get-channel",
   name: "Get Channel",
   description: "Retrieves a single channel by its ID. [See the documentation](https://developers.hubspot.com/docs/api-reference/conversations-conversations-inbox-&-messages-v3/public-channel/get-conversations-v3-conversations-channels-channelId)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/get-company/get-company.mjs
+++ b/components/hubspot/actions/get-company/get-company.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Get Company",
   description:
     "Gets a company. [See the documentation](https://developers.hubspot.com/docs/api/crm/companies#endpoint?spec=GET-/crm/v3/objects/companies/{companyId})",
-  version: "0.0.32",
+  version: "0.0.33",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/get-contact/get-contact.mjs
+++ b/components/hubspot/actions/get-contact/get-contact.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Get Contact",
   description:
     "Gets a contact. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts#endpoint?spec=GET-/crm/v3/objects/contacts/{contactId})",
-  version: "0.0.32",
+  version: "0.0.33",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/get-crm-objects/get-crm-objects.mjs
+++ b/components/hubspot/actions/get-crm-objects/get-crm-objects.mjs
@@ -11,7 +11,7 @@ export default {
     + " Use **Search CRM Objects** first to find record IDs, then use this tool to fetch full details."
     + " Max 100 IDs per request."
     + " [See the documentation](https://developers.hubspot.com/docs/api/crm/objects)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/get-deal/get-deal.mjs
+++ b/components/hubspot/actions/get-deal/get-deal.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Get Deal",
   description:
     "Gets a deal. [See the documentation](https://developers.hubspot.com/docs/api/crm/deals#endpoint?spec=GET-/crm/v3/objects/deals/{dealId})",
-  version: "0.0.32",
+  version: "0.0.33",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/get-engagements/get-engagements.mjs
+++ b/components/hubspot/actions/get-engagements/get-engagements.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-get-engagements",
   name: "Get Engagements",
   description: "Retrieves one or more engagements by their IDs. Use this action to fetch details about multiple engagements, such as their types, timestamps, and associated CRM objects. Requires engagement IDs, which you can obtain from the **List CRM Objects** action. [See the documentation](https://developers.hubspot.com/docs/api-reference/legacy/crm/objects/objects/batch/get-objects)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/get-file-public-url/get-file-public-url.mjs
+++ b/components/hubspot/actions/get-file-public-url/get-file-public-url.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Get File Public URL",
   description:
     "Get a publicly available URL for a file that was uploaded using a Hubspot form. [See the documentation](https://developers.hubspot.com/docs/api/files/files#endpoint?spec=GET-/files/v3/files/{fileId}/signed-url)",
-  version: "0.0.32",
+  version: "0.0.33",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/get-inbox/get-inbox.mjs
+++ b/components/hubspot/actions/get-inbox/get-inbox.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-get-inbox",
   name: "Get Inbox",
   description: "Retrieves a single inbox by its ID. [See the documentation](https://developers.hubspot.com/docs/api-reference/conversations-conversations-inbox-&-messages-v3/public-inbox/get-conversations-v3-conversations-inboxes-inboxId)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/get-meeting/get-meeting.mjs
+++ b/components/hubspot/actions/get-meeting/get-meeting.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Get Meeting",
   description:
     "Retrieves a specific meeting by its ID. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/engagements/meetings#get-%2Fcrm%2Fv3%2Fobjects%2Fmeetings%2F%7Bmeetingid%7D)",
-  version: "0.0.17",
+  version: "0.0.18",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/get-owner/get-owner.mjs
+++ b/components/hubspot/actions/get-owner/get-owner.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-get-owner",
   name: "Get Owner",
   description:
-    "Get a single HubSpot owner (user) by ID. Select an owner from the dropdown (search by email), enter an ID manually, or use **List Owners** for a full list."
+    "Get a single HubSpot owner (user) by ID. Provide an owner ID or use **List Owners** to fetch IDs."
     + " [See the documentation](https://developers.hubspot.com/docs/api-reference/crm-owners-v3/owners/get-crm-v3-owners-ownerId)",
   version: "0.0.4",
   annotations: {

--- a/components/hubspot/actions/get-owner/get-owner.mjs
+++ b/components/hubspot/actions/get-owner/get-owner.mjs
@@ -6,7 +6,7 @@ export default {
   description:
     "Get a single HubSpot owner (user) by ID. Select an owner from the dropdown (search by email), enter an ID manually, or use **List Owners** for a full list."
     + " [See the documentation](https://developers.hubspot.com/docs/api-reference/crm-owners-v3/owners/get-crm-v3-owners-ownerId)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/get-properties/get-properties.mjs
+++ b/components/hubspot/actions/get-properties/get-properties.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Get Properties",
   description:
     "Get detailed property definitions for specific properties on a CRM object type. Returns full metadata including data types, enum options with valid values, referenced object types, and read-only status. Use this after **Search Properties** to get valid values for specific fields (e.g. enum options for `dealstage` or `hs_pipeline`). Property details can be large — fetch only the properties you need rather than all of them. [See the documentation](https://developers.hubspot.com/docs/api/crm/properties)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/get-sequence-enrollment/get-sequence-enrollment.mjs
+++ b/components/hubspot/actions/get-sequence-enrollment/get-sequence-enrollment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-get-sequence-enrollment",
   name: "Get Sequence Enrollment",
   description: "Retrieve a contact's sequence enrollment status. [See the documentation](https://developers.hubspot.com/docs/api-reference/latest/automation/sequences/get-enrollment)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/get-subscription-preferences/get-subscription-preferences.mjs
+++ b/components/hubspot/actions/get-subscription-preferences/get-subscription-preferences.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Get Subscription Preferences",
   description:
     "Retrieves the subscription preferences for a contact. [See the documentation](https://developers.hubspot.com/docs/reference/api/marketing/subscriptions#get-%2Fcommunication-preferences%2Fv4%2Fstatuses%2F%7Bsubscriberidstring%7D)",
-  version: "0.0.14",
+  version: "0.0.15",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/get-thread/get-thread.mjs
+++ b/components/hubspot/actions/get-thread/get-thread.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-get-thread",
   name: "Get Thread",
   description: "Retrieves a single thread's metadata, including status, assignee, associations, and latest-message info. [See the documentation](https://developers.hubspot.com/docs/reference/api/conversations/inbox-and-messages#retrieve-threads)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/get-user-details/get-user-details.mjs
+++ b/components/hubspot/actions/get-user-details/get-user-details.mjs
@@ -10,7 +10,7 @@ export default {
     + " (e.g. 'my deals' requires filtering by `hubspot_owner_id`)."
     + " Also returns available CRM object types for the account."
     + " [See the documentation](https://developers.hubspot.com/docs/api/oauth/tokens)",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/list-associated-engagements/list-associated-engagements.mjs
+++ b/components/hubspot/actions/list-associated-engagements/list-associated-engagements.mjs
@@ -9,7 +9,7 @@ export default {
     + " Use **Offset** for pagination when `hasMore` is true."
     + " For newer CRM v3 engagement objects, prefer v4 **List CRM Associations** from the record to `notes`, `tasks`, `calls`, etc."
     + " [See the documentation](https://developers.hubspot.com/docs/api-reference/legacy/engagements-v1/engagements/get-engagements-v1-engagements-associated-crm-object-id-paged)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/list-association-labels/list-association-labels.mjs
+++ b/components/hubspot/actions/list-association-labels/list-association-labels.mjs
@@ -8,7 +8,7 @@ export default {
     + " Use the returned `typeId` values when creating associations with **Create Association** or **Create CRM Object** (associations JSON)."
     + " Order matters: from/to defines the direction of the relationship."
     + " [See the documentation](https://developers.hubspot.com/docs/api-reference/crm/associations-v4/definitions/get-crm-v4-associations-fromToObjectType-toToObjectType-labels)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/list-blog-posts/list-blog-posts.mjs
+++ b/components/hubspot/actions/list-blog-posts/list-blog-posts.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-list-blog-posts",
   name: "List Blog Posts",
   description: "Retrieves a list of blog posts. [See the documentation](https://developers.hubspot.com/docs/reference/api/cms/blogs/blog-posts)",
-  version: "0.0.15",
+  version: "0.0.16",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/list-campaigns/list-campaigns.mjs
+++ b/components/hubspot/actions/list-campaigns/list-campaigns.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-list-campaigns",
   name: "List Campaigns",
   description: "Retrieves a list of campaigns. [See the documentation](https://developers.hubspot.com/docs/reference/api/marketing/campaigns#get-%2Fmarketing%2Fv3%2Fcampaigns%2F)",
-  version: "0.0.15",
+  version: "0.0.16",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/list-channels/list-channels.mjs
+++ b/components/hubspot/actions/list-channels/list-channels.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-list-channels",
   name: "List Channels",
   description: "Retrieves a list of channels. [See the documentation](https://developers.hubspot.com/docs/api-reference/conversations-conversations-inbox-&-messages-v3/public-channel/get-conversations-v3-conversations-channels)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/list-crm-associations/list-crm-associations.mjs
+++ b/components/hubspot/actions/list-crm-associations/list-crm-associations.mjs
@@ -8,7 +8,7 @@ export default {
     + " Returns associated record IDs and association types for each link."
     + " Direction matters: `from` is the record you are querying from; swap from/to to traverse the relationship the other way."
     + " [See the documentation](https://developers.hubspot.com/docs/api-reference/crm/associations-v4/basic/get-crm-v4-objects-objectType-objectId-associations-toObjectType)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/list-custom-object-type-options/list-custom-object-type-options.mjs
+++ b/components/hubspot/actions/list-custom-object-type-options/list-custom-object-type-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-list-custom-object-type-options",
   name: "List Custom Object Type Options",
   description: "Retrieves available options for the Custom Object Type field.",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/list-deal-pipeline-options/list-deal-pipeline-options.mjs
+++ b/components/hubspot/actions/list-deal-pipeline-options/list-deal-pipeline-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-list-deal-pipeline-options",
   name: "List Pipeline Options",
   description: "Retrieves available options for the Pipeline field.",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/list-file-url-options/list-file-url-options.mjs
+++ b/components/hubspot/actions/list-file-url-options/list-file-url-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-list-file-url-options",
   name: "List File URL Options",
   description: "Retrieves available options for the File URL field.",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/list-forms-options/list-forms-options.mjs
+++ b/components/hubspot/actions/list-forms-options/list-forms-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-list-forms-options",
   name: "List Form Options",
   description: "Retrieves available options for the Form field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/list-forms/list-forms.mjs
+++ b/components/hubspot/actions/list-forms/list-forms.mjs
@@ -5,7 +5,7 @@ export default {
   name: "List Forms",
   description:
     "Retrieves a list of forms. [See the documentation](https://developers.hubspot.com/docs/reference/api/marketing/forms#get-%2Fmarketing%2Fv3%2Fforms%2F)",
-  version: "0.0.15",
+  version: "0.0.16",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/list-inboxes/list-inboxes.mjs
+++ b/components/hubspot/actions/list-inboxes/list-inboxes.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-list-inboxes",
   name: "List Inboxes",
   description: "Retrieves a list of inboxes. [See the documentation](https://developers.hubspot.com/docs/api-reference/conversations-conversations-inbox-&-messages-v3/public-inbox/get-conversations-v3-conversations-inboxes)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/list-marketing-emails/list-marketing-emails.mjs
+++ b/components/hubspot/actions/list-marketing-emails/list-marketing-emails.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-list-marketing-emails",
   name: "List Marketing Emails",
   description: "Retrieves a list of marketing emails. [See the documentation](https://developers.hubspot.com/docs/reference/api/marketing/emails/marketing-emails#get-%2Fmarketing%2Fv3%2Femails%2F)",
-  version: "0.0.15",
+  version: "0.0.16",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/list-marketing-events/list-marketing-events.mjs
+++ b/components/hubspot/actions/list-marketing-events/list-marketing-events.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-list-marketing-events",
   name: "List Marketing Events",
   description: "Retrieves a list of marketing events. [See the documentation](https://developers.hubspot.com/docs/reference/api/marketing/marketing-events#get-%2Fmarketing%2Fv3%2Fmarketing-events%2F)",
-  version: "0.0.15",
+  version: "0.0.16",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/list-messages/list-messages.mjs
+++ b/components/hubspot/actions/list-messages/list-messages.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-list-messages",
   name: "List Messages",
   description: "Retrieves a list of messages in a thread. [See the documentation](https://developers.hubspot.com/docs/api-reference/conversations-conversations-inbox-&-messages-v3/public-message/get-conversations-v3-conversations-threads-threadId-messages)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/list-object-schema-options/list-object-schema-options.mjs
+++ b/components/hubspot/actions/list-object-schema-options/list-object-schema-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-list-object-schema-options",
   name: "List Object Schema Options",
   description: "Retrieves available options for the Object Schema field.",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/list-owners/list-owners.mjs
+++ b/components/hubspot/actions/list-owners/list-owners.mjs
@@ -6,7 +6,7 @@ export default {
   name: "List Owners",
   description:
     "List owners (users) in the HubSpot account. Returns owner IDs, names, and emails. Use this to discover valid values for the `hubspot_owner_id` property when creating or updating any CRM object (contacts, companies, deals, tickets, etc.). [See the documentation](https://developers.hubspot.com/docs/api/crm/owners)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/list-pages/list-pages.mjs
+++ b/components/hubspot/actions/list-pages/list-pages.mjs
@@ -5,7 +5,7 @@ export default {
   name: "List Pages",
   description:
     "Retrieves a list of site pages. [See the documentation](https://developers.hubspot.com/docs/reference/api/cms/pages)",
-  version: "0.0.15",
+  version: "0.0.16",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/list-pipelines-and-stages/list-pipelines-and-stages.mjs
+++ b/components/hubspot/actions/list-pipelines-and-stages/list-pipelines-and-stages.mjs
@@ -6,7 +6,7 @@ export default {
   name: "List Pipelines and Stages",
   description:
     "List all pipelines and their stages for deals or tickets. Returns pipeline IDs, labels, and each pipeline's ordered stages with stage IDs and labels. Use this to discover valid `pipeline` and `dealstage` / `hs_pipeline_stage` values before creating or updating deals and tickets. [See the documentation](https://developers.hubspot.com/docs/api/crm/pipelines)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/list-template-path-options/list-template-path-options.mjs
+++ b/components/hubspot/actions/list-template-path-options/list-template-path-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-list-template-path-options",
   name: "List Template Path Options",
   description: "Retrieves available options for the Template Path field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/list-templates/list-templates.mjs
+++ b/components/hubspot/actions/list-templates/list-templates.mjs
@@ -5,7 +5,7 @@ export default {
   name: "List Templates",
   description:
     "Retrieves a list of templates. [See the documentation](https://developers.hubspot.com/docs/reference/api/cms/templates)",
-  version: "0.0.14",
+  version: "0.0.15",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/list-threads/list-threads.mjs
+++ b/components/hubspot/actions/list-threads/list-threads.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-list-threads",
   name: "List Threads",
   description: "Retrieves a list of threads. [See the documentation](https://developers.hubspot.com/docs/api-reference/conversations-conversations-inbox-&-messages-v3/public-thread/get-conversations-v3-conversations-threads)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/list-ticket-pipeline-options/list-ticket-pipeline-options.mjs
+++ b/components/hubspot/actions/list-ticket-pipeline-options/list-ticket-pipeline-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-list-ticket-pipeline-options",
   name: "List Pipeline Options",
   description: "Retrieves available options for the Pipeline field.",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/push-blog-post-draft-live/push-blog-post-draft-live.mjs
+++ b/components/hubspot/actions/push-blog-post-draft-live/push-blog-post-draft-live.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-push-blog-post-draft-live",
   name: "Push Blog Post Draft Live",
   description: "Pushes a blog post draft live, making it the published version. [See the documentation](https://developers.hubspot.com/docs/api-reference/cms-posts-v3/basic/post-cms-v3-blogs-posts-objectId-draft-push-live)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/retrieve-migrated-workflow-mappings/retrieve-migrated-workflow-mappings.mjs
+++ b/components/hubspot/actions/retrieve-migrated-workflow-mappings/retrieve-migrated-workflow-mappings.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-retrieve-migrated-workflow-mappings",
   name: "Retrieve Migrated Workflow Mappings",
   description: "Retrieve the IDs of v3 workflows that have been migrated to the v4 API. [See the documentation](https://developers.hubspot.com/docs/api-reference/automation-automation-v4-v4/workflow-id-mappings/post-automation-v4-workflow-id-mappings-batch-read)",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/retrieve-quotes/retrieve-quotes.mjs
+++ b/components/hubspot/actions/retrieve-quotes/retrieve-quotes.mjs
@@ -10,7 +10,7 @@ export default {
     "Fetch one quote by ID or list quotes with CRM v3 pagination (`after`, `limit`)."
     + " Complements **Create CRM Object** for quotes when you need read access outside **Search CRM**."
     + " [See the documentation](https://developers.hubspot.com/docs/api-reference/crm-quotes-v3/basic/get-crm-v3-objects-quotes)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/retrieve-workflow-details/retrieve-workflow-details.mjs
+++ b/components/hubspot/actions/retrieve-workflow-details/retrieve-workflow-details.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-retrieve-workflow-details",
   name: "Retrieve Workflow Details",
   description: "Retrieve detailed information about a specific workflow. [See the documentation](https://developers.hubspot.com/docs/api-reference/legacy/create-manage-workflows-v3/get-automation-v3-workflows-workflowId)",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/retrieve-workflow-emails/retrieve-workflow-emails.mjs
+++ b/components/hubspot/actions/retrieve-workflow-emails/retrieve-workflow-emails.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-retrieve-workflow-emails",
   name: "Retrieve Workflow Emails",
   description: "Retrieve emails sent by a workflow by ID. [See the documentation](https://developers.hubspot.com/docs/api-reference/automation-automation-v4-v4/email-campaigns/get-automation-v4-flows-email-campaigns)",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/retrieve-workflows/retrieve-workflows.mjs
+++ b/components/hubspot/actions/retrieve-workflows/retrieve-workflows.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-retrieve-workflows",
   name: "Retrieve Workflows",
   description: "Retrieve a list of all workflows. [See the documentation](https://developers.hubspot.com/docs/api-reference/legacy/create-manage-workflows-v3/get-automation-v3-workflows)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/schedule-blog-post/schedule-blog-post.mjs
+++ b/components/hubspot/actions/schedule-blog-post/schedule-blog-post.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-schedule-blog-post",
   name: "Schedule Blog Post",
   description: "Schedules a blog post to be published at a specified time. [See the documentation](https://developers.hubspot.com/docs/api-reference/cms-posts-v3/basic/post-cms-v3-blogs-posts-schedule)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/search-crm-objects/search-crm-objects.mjs
+++ b/components/hubspot/actions/search-crm-objects/search-crm-objects.mjs
@@ -35,7 +35,7 @@ export default {
     + " Use `filterGroups` for advanced filtering with operators like EQ, NEQ, LT, GT, CONTAINS_TOKEN, IN, HAS_PROPERTY, etc."
     + " You can combine up to 5 filter groups (OR logic) with up to 6 filters each (AND logic within a group)."
     + " [See the documentation](https://developers.hubspot.com/docs/api/crm/search)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/search-crm/search-crm.mjs
+++ b/components/hubspot/actions/search-crm/search-crm.mjs
@@ -19,7 +19,7 @@ export default {
   name: "Search CRM",
   description:
     "Search companies, contacts, deals, feedback submissions, products, tickets, line-items, quotes, leads, or custom objects. [See the documentation](https://developers.hubspot.com/docs/api/crm/search)",
-  version: "1.1.9",
+  version: "1.1.10",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/search-properties/search-properties.mjs
+++ b/components/hubspot/actions/search-properties/search-properties.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Search Properties",
   description:
     "Search for property definitions (field names) on a CRM object type. Returns lightweight results: property names, labels, descriptions, and types — without enum options. Use this to discover what fields exist before creating or updating records. To get full details including valid enum values for a specific property, use **Get Properties**. To search for actual CRM data/records, use **Search CRM**. [See the documentation](https://developers.hubspot.com/docs/api/crm/properties)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/send-message/send-message.mjs
+++ b/components/hubspot/actions/send-message/send-message.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-send-message",
   name: "Send Message",
   description: "Sends a message to a thread. [See the documentation](https://developers.hubspot.com/docs/api-reference/conversations-conversations-inbox-&-messages-v3/public-message/post-conversations-v3-conversations-threads-threadId-messages)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/unarchive-thread/unarchive-thread.mjs
+++ b/components/hubspot/actions/unarchive-thread/unarchive-thread.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-unarchive-thread",
   name: "Unarchive Thread",
   description: "Restores a previously-archived thread, returning it to the active inbox. Sends `PATCH` with body `{ archived: false }`, the only restore path HubSpot's API supports. The Thread ID dropdown lists archived threads. [See the documentation](https://developers.hubspot.com/docs/reference/api/conversations/inbox-and-messages#update-or-restore-threads)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/update-blog-post-draft/update-blog-post-draft.mjs
+++ b/components/hubspot/actions/update-blog-post-draft/update-blog-post-draft.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-update-blog-post-draft",
   name: "Update Blog Post Draft",
   description: "Updates the draft version of an existing blog post in HubSpot. [See the documentation](https://developers.hubspot.com/docs/api-reference/cms-posts-v3/basic/patch-cms-v3-blogs-posts-objectId-draft)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   annotations: {
     destructiveHint: true,

--- a/components/hubspot/actions/update-blog-post/update-blog-post.mjs
+++ b/components/hubspot/actions/update-blog-post/update-blog-post.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-update-blog-post",
   name: "Update Blog Post",
   description: "Updates an existing blog post in HubSpot. [See the documentation](https://developers.hubspot.com/docs/api-reference/cms-posts-v3/basic/patch-cms-v3-blogs-posts-objectId)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   annotations: {
     destructiveHint: true,

--- a/components/hubspot/actions/update-company/update-company.mjs
+++ b/components/hubspot/actions/update-company/update-company.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Update Company",
   description:
     "Update a company in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/companies)",
-  version: "0.0.34",
+  version: "0.0.35",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/hubspot/actions/update-contact/update-contact.mjs
+++ b/components/hubspot/actions/update-contact/update-contact.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Update Contact",
   description:
     "Update a contact in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts#endpoint?spec=POST-/crm/v3/objects/contacts)",
-  version: "0.0.35",
+  version: "0.0.36",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/hubspot/actions/update-crm-object/update-crm-object.mjs
+++ b/components/hubspot/actions/update-crm-object/update-crm-object.mjs
@@ -13,7 +13,7 @@ export default {
     + " **Search Properties** to discover available fields,"
     + " and **Get Properties** to find valid enum values."
     + " [See the documentation](https://developers.hubspot.com/docs/api/crm/objects)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/update-custom-object/update-custom-object.mjs
+++ b/components/hubspot/actions/update-custom-object/update-custom-object.mjs
@@ -9,7 +9,7 @@ export default {
     "Update a custom object in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/custom-objects#update-existing-custom-objects)",
   version: "1.0.21",
   annotations: {
-    destructiveHint: true,
+    destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },

--- a/components/hubspot/actions/update-custom-object/update-custom-object.mjs
+++ b/components/hubspot/actions/update-custom-object/update-custom-object.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Update Custom Object",
   description:
     "Update a custom object in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/custom-objects#update-existing-custom-objects)",
-  version: "1.0.20",
+  version: "1.0.21",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/hubspot/actions/update-deal/update-deal.mjs
+++ b/components/hubspot/actions/update-deal/update-deal.mjs
@@ -10,7 +10,7 @@ export default {
     "Update a deal in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/deals#update-deals)",
   version: "0.0.26",
   annotations: {
-    destructiveHint: true,
+    destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },

--- a/components/hubspot/actions/update-deal/update-deal.mjs
+++ b/components/hubspot/actions/update-deal/update-deal.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Update Deal",
   description:
     "Update a deal in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/deals#update-deals)",
-  version: "0.0.25",
+  version: "0.0.26",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/hubspot/actions/update-fields-on-the-form/update-fields-on-the-form.mjs
+++ b/components/hubspot/actions/update-fields-on-the-form/update-fields-on-the-form.mjs
@@ -10,7 +10,7 @@ export default {
   name: "Update Fields on the Form",
   description:
     "Update some of the form definition components. [See the documentation](https://developers.hubspot.com/docs/reference/api/marketing/forms#patch-%2Fmarketing%2Fv3%2Fforms%2F%7Bformid%7D)",
-  version: "0.0.13",
+  version: "0.0.14",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/hubspot/actions/update-landing-page/update-landing-page.mjs
+++ b/components/hubspot/actions/update-landing-page/update-landing-page.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Update Landing Page",
   description:
     "Update a landing page in HubSpot. [See the documentation](https://developers.hubspot.com/docs/reference/api/cms/pages#patch-%2Fcms%2Fv3%2Fpages%2Flanding-pages%2F%7Bobjectid%7D)",
-  version: "0.0.14",
+  version: "0.0.15",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/hubspot/actions/update-lead/update-lead.mjs
+++ b/components/hubspot/actions/update-lead/update-lead.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Update Lead",
   description:
     "Update a lead in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/leads#update-leads)",
-  version: "0.0.26",
+  version: "0.0.27",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/hubspot/actions/update-page/update-page.mjs
+++ b/components/hubspot/actions/update-page/update-page.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Update Page",
   description:
     "Update a page in Hubspot. [See the documentation](https://developers.hubspot.com/docs/reference/api/cms/pages#patch-%2Fcms%2Fv3%2Fpages%2Fsite-pages%2F%7Bobjectid%7D)",
-  version: "0.0.14",
+  version: "0.0.15",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/hubspot/actions/update-thread/update-thread.mjs
+++ b/components/hubspot/actions/update-thread/update-thread.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-update-thread",
   name: "Update Thread",
   description: "Updates an existing thread's status. To archive a thread, use the **Archive Thread** action; to restore an archived thread, use the **Unarchive Thread** action. HubSpot's PATCH endpoint does not support either operation via a status change. [See the documentation](https://developers.hubspot.com/docs/reference/api/conversations/inbox-and-messages#update-or-restore-threads)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/common/constants.mjs
+++ b/components/hubspot/common/constants.mjs
@@ -39,6 +39,15 @@ const ASSOCIATION_CATEGORY = {
 };
 
 const DEFAULT_LIMIT = 100;
+const MAX_INITIAL_EVENTS = 25;
+
+// HubSpot date-based API version for the dated CRM objects endpoints
+// (e.g. /crm/2026-03/objects/{type}/search).
+const CRM_OBJECTS_VERSION = "2026-03";
+
+// Read-only record-creation property used to sort/filter engagement objects.
+// Not hs_timestamp, which is the user-settable activity time.
+const ENGAGEMENT_CREATED_DATE_PROPERTY = "hs_createdate";
 
 const DEFAULT_CONTACT_PROPERTIES = [
   "firstname",
@@ -221,6 +230,42 @@ const ENGAGEMENT_TYPE_OPTIONS = [
   },
 ];
 
+// CRM v3 object types backing the "New Engagement" source, with the property used
+// to build each emitted event's summary. Kept separate from ENGAGEMENT_TYPE_OPTIONS
+// (used by the engagement actions) so postal_mail does not leak into those actions.
+const ENGAGEMENT_OBJECT_TYPES = [
+  {
+    label: "Call",
+    value: "calls",
+    summaryProperty: "hs_call_title",
+  },
+  {
+    label: "Email",
+    value: "emails",
+    summaryProperty: "hs_email_subject",
+  },
+  {
+    label: "Meeting",
+    value: "meetings",
+    summaryProperty: "hs_meeting_title",
+  },
+  {
+    label: "Note",
+    value: "notes",
+    summaryProperty: "hs_body_preview",
+  },
+  {
+    label: "Postal Mail",
+    value: "postal_mail",
+    summaryProperty: "hs_postal_mail_body",
+  },
+  {
+    label: "Task",
+    value: "tasks",
+    summaryProperty: "hs_task_subject",
+  },
+];
+
 const LANGUAGE_OPTIONS = [
   {
     label: "Afrikaans",
@@ -384,16 +429,20 @@ export {
   API_PATH,
   ASSOCIATION_CATEGORY,
   BASE_URL,
+  CRM_OBJECTS_VERSION,
   DEFAULT_COMPANY_PROPERTIES,
   DEFAULT_CONTACT_PROPERTIES,
   DEFAULT_DEAL_PROPERTIES,
   DEFAULT_EMAIL_PROPERTIES,
   DEFAULT_LEAD_PROPERTIES,
   DEFAULT_LIMIT,
+  MAX_INITIAL_EVENTS,
   DEFAULT_LINE_ITEM_PROPERTIES,
   DEFAULT_MEETING_PROPERTIES,
   DEFAULT_PRODUCT_PROPERTIES,
   DEFAULT_TICKET_PROPERTIES,
+  ENGAGEMENT_CREATED_DATE_PROPERTY,
+  ENGAGEMENT_OBJECT_TYPES,
   ENGAGEMENT_TYPE_OPTIONS,
   HUBSPOT_OWNER,
   LANGUAGE_OPTIONS,

--- a/components/hubspot/hubspot.app.mjs
+++ b/components/hubspot/hubspot.app.mjs
@@ -1210,8 +1210,14 @@ export default {
       })) || [];
     },
     async searchCRM({
-      object, ...opts
+      object, version, ...opts
     }) {
+      // When `version` is set, target the date-versioned CRM objects API
+      // (e.g. /crm/2026-03/objects/{type}/search); otherwise keep the default
+      // /crm/v3 path so existing callers are unaffected.
+      const api = version
+        ? `/crm/${version}`
+        : API_PATH.CRMV3;
       // Adding retry logic here since the search endpoint specifically has a per-second rate limit
       const MAX_RETRIES = 5;
       const BASE_RETRY_DELAY = 500;
@@ -1220,7 +1226,7 @@ export default {
       while (!success) {
         try {
           const response = await this.makeRequest({
-            api: API_PATH.CRMV3,
+            api,
             method: "POST",
             endpoint: `/objects/${object}/search`,
             ...opts,

--- a/components/hubspot/package.json
+++ b/components/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/hubspot",
-  "version": "1.16.3",
+  "version": "1.16.4",
   "description": "Pipedream Hubspot Components",
   "main": "hubspot.app.mjs",
   "keywords": [

--- a/components/hubspot/sources/delete-blog-article/delete-blog-article.mjs
+++ b/components/hubspot/sources/delete-blog-article/delete-blog-article.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-delete-blog-article",
   name: "Deleted Blog Posts",
   description: "Emit new event for each deleted blog post.",
-  version: "0.0.41",
+  version: "0.0.42",
   dedupe: "unique",
   type: "source",
   methods: {

--- a/components/hubspot/sources/new-company-property-change/new-company-property-change.mjs
+++ b/components/hubspot/sources/new-company-property-change/new-company-property-change.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-new-company-property-change",
   name: "New Company Property Change",
   description: "Emit new event when a specified property is provided or updated on a company. [See the documentation](https://developers.hubspot.com/docs/api/crm/companies)",
-  version: "0.0.34",
+  version: "0.0.35",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-contact-added-to-list/new-contact-added-to-list.mjs
+++ b/components/hubspot/sources/new-contact-added-to-list/new-contact-added-to-list.mjs
@@ -12,7 +12,7 @@ export default {
   name: "New Contact Added to List",
   description:
     "Emit new event when a contact is added to a HubSpot list. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/lists#get-%2Fcrm%2Fv3%2Flists%2F%7Blistid%7D%2Fmemberships%2Fjoin-order)",
-  version: "0.0.13",
+  version: "0.0.14",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/hubspot/sources/new-contact-property-change/new-contact-property-change.mjs
+++ b/components/hubspot/sources/new-contact-property-change/new-contact-property-change.mjs
@@ -8,7 +8,7 @@ export default {
   name: "New Contact Property Change",
   description:
     "Emit new event when a specified property is provided or updated on a contact. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts)",
-  version: "0.0.37",
+  version: "0.0.38",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-custom-object-property-change/new-custom-object-property-change.mjs
+++ b/components/hubspot/sources/new-custom-object-property-change/new-custom-object-property-change.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Custom Object Property Change",
   description:
     "Emit new event when a specified property is provided or updated on a custom object.",
-  version: "0.0.26",
+  version: "0.0.27",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-deal-in-stage/new-deal-in-stage.mjs
+++ b/components/hubspot/sources/new-deal-in-stage/new-deal-in-stage.mjs
@@ -13,7 +13,7 @@ export default {
   key: "hubspot-new-deal-in-stage",
   name: "New Deal In Stage",
   description: "Emit new event for each new deal in a stage.",
-  version: "0.1.8",
+  version: "0.1.9",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-deal-property-change/new-deal-property-change.mjs
+++ b/components/hubspot/sources/new-deal-property-change/new-deal-property-change.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-new-deal-property-change",
   name: "New Deal Property Change",
   description: "Emit new event when a specified property is provided or updated on a deal. [See the documentation](https://developers.hubspot.com/docs/api/crm/deals)",
-  version: "0.0.36",
+  version: "0.0.37",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-email-event/new-email-event.mjs
+++ b/components/hubspot/sources/new-email-event/new-email-event.mjs
@@ -8,7 +8,7 @@ export default {
   key: "hubspot-new-email-event",
   name: "New Email Event",
   description: "Emit new event for each new Hubspot email event.",
-  version: "0.0.44",
+  version: "0.0.45",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-email-subscriptions-timeline/new-email-subscriptions-timeline.mjs
+++ b/components/hubspot/sources/new-email-subscriptions-timeline/new-email-subscriptions-timeline.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-new-email-subscriptions-timeline",
   name: "New Email Subscriptions Timeline",
   description: "Emit new event when a new email timeline subscription is added for the portal.",
-  version: "0.0.41",
+  version: "0.0.42",
   dedupe: "unique",
   type: "source",
   methods: {

--- a/components/hubspot/sources/new-engagement/new-engagement.mjs
+++ b/components/hubspot/sources/new-engagement/new-engagement.mjs
@@ -1,14 +1,43 @@
-import { DEFAULT_LIMIT } from "../../common/constants.mjs";
-import { ENGAGEMENT_TYPES } from "../../common/object-types.mjs";
+import {
+  CRM_OBJECTS_VERSION,
+  DEFAULT_LIMIT,
+  ENGAGEMENT_CREATED_DATE_PROPERTY,
+  ENGAGEMENT_OBJECT_TYPES,
+  MAX_INITIAL_EVENTS,
+} from "../../common/constants.mjs";
 import common from "../common/common.mjs";
 import sampleEmit from "./test-event.mjs";
+
+const LABEL_BY_TYPE = Object.fromEntries(
+  ENGAGEMENT_OBJECT_TYPES.map(({
+    value, label,
+  }) => [
+    value,
+    label,
+  ]),
+);
+
+const SUMMARY_PROPERTY_BY_TYPE = Object.fromEntries(
+  ENGAGEMENT_OBJECT_TYPES.map(({
+    value, summaryProperty,
+  }) => [
+    value,
+    summaryProperty,
+  ]),
+);
 
 export default {
   ...common,
   key: "hubspot-new-engagement",
   name: "New Engagement",
-  description: "Emit new event for each new engagement created. This action returns a maximum of 5000 records at a time, make sure you set a correct time range so you don't miss any events",
-  version: "0.0.47",
+  description: "Emit new event for each new engagement (call, email, meeting, note, postal mail, or task) created."
+  + " See the documentation: [Calls](https://developers.hubspot.com/docs/api-reference/latest/crm/activities/calls/search/search-calls)"
+  + " [Emails](https://developers.hubspot.com/docs/api-reference/latest/crm/activities/emails/search/search-emails)"
+  + " [Meetings](https://developers.hubspot.com/docs/api-reference/latest/crm/activities/meetings/search/search-meetings)"
+  + " [Notes](https://developers.hubspot.com/docs/api-reference/latest/crm/activities/notes/search/search-notes)"
+  + " [Postal Mail](https://developers.hubspot.com/docs/api-reference/latest/crm/activities/postal-mail/search/search-postal-mail)"
+  + " [Tasks](https://developers.hubspot.com/docs/api-reference/latest/crm/activities/tasks/search/search-tasks)",
+  version: "0.0.48",
   dedupe: "unique",
   type: "source",
   props: {
@@ -16,52 +45,147 @@ export default {
     types: {
       type: "string[]",
       label: "Engagement Types",
-      description: "Filter results by the type of engagement",
-      options: ENGAGEMENT_TYPES,
+      description: "Filter results by the type of engagement. Defaults to all types.",
+      options: ENGAGEMENT_OBJECT_TYPES.map(({
+        label, value,
+      }) => ({
+        label,
+        value,
+      })),
       optional: true,
     },
   },
   methods: {
     ...common.methods,
     getTs(engagement) {
-      return engagement.engagement.createdAt;
+      return Date.parse(engagement.createdAt);
     },
     generateMeta(engagement) {
-      const {
-        id, type,
-      } = engagement.engagement;
-      const ts = this.getTs(engagement);
+      const { objectType } = engagement;
+      const summaryValue =
+        engagement.properties?.[SUMMARY_PROPERTY_BY_TYPE[objectType]] || engagement.id;
       return {
-        id,
-        summary: type,
-        ts,
+        id: engagement.id,
+        summary: `New ${LABEL_BY_TYPE[objectType]}: ${summaryValue}`,
+        ts: this.getTs(engagement),
       };
     },
-    isRelevant(engagement, createdAfter) {
-      if (this.getTs(engagement) < createdAfter) {
-        return false;
+    getSelectedTypes() {
+      return this.types?.length
+        ? this.types
+        : ENGAGEMENT_OBJECT_TYPES.map(({ value }) => value);
+    },
+    async getObjectProperties(objectType) {
+      const { results } = await this.hubspot.getProperties({
+        objectType,
+      });
+      return results.map(({ name }) => name);
+    },
+    buildSearchParams(objectType, after, properties) {
+      const filters = [];
+      if (after) {
+        filters.push({
+          propertyName: ENGAGEMENT_CREATED_DATE_PROPERTY,
+          operator: "GT",
+          value: `${after}`,
+        });
       }
-      if (this.types?.length) {
-        return this.types.includes(engagement.engagement.type);
+      return {
+        object: objectType,
+        version: CRM_OBJECTS_VERSION,
+        data: {
+          limit: DEFAULT_LIMIT,
+          properties,
+          sorts: [
+            {
+              propertyName: ENGAGEMENT_CREATED_DATE_PROPERTY,
+              direction: "DESCENDING",
+            },
+          ],
+          filterGroups: filters.length
+            ? [
+              {
+                filters,
+              },
+            ]
+            : [],
+        },
+      };
+    },
+    async fetchEngagementsByType(objectType, after) {
+      const engagements = [];
+      try {
+        const properties = await this.getObjectProperties(objectType);
+        const params = this.buildSearchParams(objectType, after, properties);
+        let paginate = true;
+        while (paginate) {
+          const {
+            results = [], paging,
+          } = await this.hubspot.searchCRM(params);
+          for (const result of results) {
+            engagements.push({
+              ...result,
+              objectType,
+            });
+          }
+          // First run: a single newest-first page is enough to find the global
+          // newest MAX_INITIAL_EVENTS. Subsequent runs: keep paging until every
+          // engagement created after the cursor has been collected.
+          if (!after || !paging?.next?.after) {
+            paginate = false;
+          } else {
+            params.data.after = paging.next.after;
+          }
+        }
+      } catch (error) {
+        // A single object type failing (e.g. missing scope) should not break the
+        // whole source; skip it and continue with the other types.
+        console.warn(`Failed to fetch ${objectType} engagements: ${error.message}`);
       }
-      return true;
+      return engagements;
+    },
+    emitEngagements(engagements) {
+      for (const engagement of engagements) {
+        this.emitEvent(engagement);
+      }
     },
   },
   async run() {
-    const createdAfter = this._getAfter();
-    const params = {
-      params: {
-        limit: DEFAULT_LIMIT,
-      },
-    };
+    const after = this._getAfter();
+    const types = this.getSelectedTypes();
 
-    await this.paginateUsingHasMore(
-      params,
-      this.hubspot.getEngagements.bind(this),
-      "results",
-      createdAfter,
-      20,
+    const perType = await Promise.all(
+      types.map((objectType) => this.fetchEngagementsByType(objectType, after)),
     );
+    const engagements = perType
+      .flat()
+      .sort((a, b) => this.getTs(b) - this.getTs(a));
+
+    if (!engagements.length) {
+      return;
+    }
+
+    if (!after) {
+      // First deployment: emit only the most recent engagements as a sample,
+      // newest-first.
+      const initial = engagements.slice(0, MAX_INITIAL_EVENTS);
+      this.emitEngagements(initial);
+      const oldestEmittedTs = this.getTs(initial[initial.length - 1]);
+      this._setAfter(oldestEmittedTs - 1);
+      return;
+    }
+
+    // Subsequent runs: every engagement was already filtered to created > cursor,
+    // so emit them all and advance the cursor to the newest created timestamp.
+    let maxTs = after;
+    for (const engagement of engagements) {
+      const ts = this.getTs(engagement);
+      if (ts > maxTs) {
+        maxTs = ts;
+      }
+    }
+    this.emitEngagements(engagements);
+    this._setAfter(maxTs);
   },
   sampleEmit,
 };

--- a/components/hubspot/sources/new-engagement/new-engagement.mjs
+++ b/components/hubspot/sources/new-engagement/new-engagement.mjs
@@ -31,12 +31,13 @@ export default {
   key: "hubspot-new-engagement",
   name: "New Engagement",
   description: "Emit new event for each new engagement (call, email, meeting, note, postal mail, or task) created."
-  + " See the documentation: [Calls](https://developers.hubspot.com/docs/api-reference/latest/crm/activities/calls/search/search-calls)"
+  + " Per-activity docs: [Calls](https://developers.hubspot.com/docs/api-reference/latest/crm/activities/calls/search/search-calls)"
   + " [Emails](https://developers.hubspot.com/docs/api-reference/latest/crm/activities/emails/search/search-emails)"
   + " [Meetings](https://developers.hubspot.com/docs/api-reference/latest/crm/activities/meetings/search/search-meetings)"
   + " [Notes](https://developers.hubspot.com/docs/api-reference/latest/crm/activities/notes/search/search-notes)"
   + " [Postal Mail](https://developers.hubspot.com/docs/api-reference/latest/crm/activities/postal-mail/search/search-postal-mail)"
-  + " [Tasks](https://developers.hubspot.com/docs/api-reference/latest/crm/activities/tasks/search/search-tasks)",
+  + " [Tasks](https://developers.hubspot.com/docs/api-reference/latest/crm/activities/tasks/search/search-tasks)"
+  + " [See the documentation](https://developers.hubspot.com/docs/api-reference/latest/crm/using-object-apis)",
   version: "0.0.48",
   dedupe: "unique",
   type: "source",

--- a/components/hubspot/sources/new-engagement/test-event.mjs
+++ b/components/hubspot/sources/new-engagement/test-event.mjs
@@ -1,42 +1,18 @@
 export default {
-  "engagement": {
-    "id": 54890657094,
-    "portalId": 6890009,
-    "active": true,
-    "createdAt": 1719006221998,
-    "lastUpdated": 1719006222686,
-    "createdBy": 9555737,
-    "modifiedBy": 9555737,
-    "ownerId": 41488296,
-    "type": "TASK",
-    "timestamp": 1719403200000,
-    "allAccessibleTeamIds": [],
-    "queueMembershipIds": [],
-    "bodyPreviewIsTruncated": false
+  "id": "372824111803",
+  "properties": {
+    "hs_createdate": "2026-06-01T06:36:42.831Z",
+    "hs_lastmodifieddate": "2026-06-01T06:36:42.831Z",
+    "hs_object_id": "372824111803",
+    "hs_task_subject": "Follow up with Brian",
+    "hs_task_body": "Discuss the cupcake supplier proposal.",
+    "hs_task_status": "NOT_STARTED",
+    "hs_task_priority": "NONE",
+    "hs_timestamp": "2026-06-01T06:36:42.831Z",
+    "hubspot_owner_id": "41488296"
   },
-  "associations": {
-    "contactIds": [],
-    "companyIds": [],
-    "dealIds": [],
-    "ownerIds": [],
-    "workflowIds": [],
-    "ticketIds": [],
-    "contentIds": [],
-    "quoteIds": [],
-    "marketingEventIds": [],
-    "partnerClientIds": []
-  },
-  "attachments": [],
-  "scheduledTasks": [],
-  "metadata": {
-    "body": "<div style=\"\" dir=\"auto\" data-top-level=\"true\"><br></div>",
-    "status": "NOT_STARTED",
-    "forObjectType": "OWNER",
-    "subject": "task",
-    "taskType": "TODO",
-    "reminders": [],
-    "sendDefaultReminder": false,
-    "priority": "NONE",
-    "isAllDay": false
-  }
+  "createdAt": "2026-06-01T06:36:42.831Z",
+  "updatedAt": "2026-06-01T06:36:42.831Z",
+  "archived": false,
+  "objectType": "tasks"
 }

--- a/components/hubspot/sources/new-event/new-event.mjs
+++ b/components/hubspot/sources/new-event/new-event.mjs
@@ -8,7 +8,7 @@ export default {
   key: "hubspot-new-event",
   name: "New Events",
   description: "Emit new event for each new Hubspot event. Note: Only available for Marketing Hub Enterprise, Sales Hub Enterprise, Service Hub Enterprise, or CMS Hub Enterprise accounts",
-  version: "0.0.45",
+  version: "0.0.46",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-form-submission/new-form-submission.mjs
+++ b/components/hubspot/sources/new-form-submission/new-form-submission.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-new-form-submission",
   name: "New Form Submission",
   description: "Emit new event for each new submission of a form.",
-  version: "0.0.47",
+  version: "0.0.48",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-message-in-thread/new-message-in-thread.mjs
+++ b/components/hubspot/sources/new-message-in-thread/new-message-in-thread.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-new-message-in-thread",
   name: "New Message in Thread",
   description: "Emit new event when a new message is added to a thread. [See the documentation](https://developers.hubspot.com/docs/api-reference/conversations-conversations-inbox-&-messages-v3/public-message/get-conversations-v3-conversations-threads-threadId-messages)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/hubspot/sources/new-note/new-note.mjs
+++ b/components/hubspot/sources/new-note/new-note.mjs
@@ -8,7 +8,7 @@ export default {
   key: "hubspot-new-note",
   name: "New Note Created",
   description: "Emit new event for each new note created. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/engagements/notes#get-%2Fcrm%2Fv3%2Fobjects%2Fnotes)",
-  version: "1.0.22",
+  version: "1.0.23",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/hubspot/sources/new-or-updated-blog-article/new-or-updated-blog-article.mjs
+++ b/components/hubspot/sources/new-or-updated-blog-article/new-or-updated-blog-article.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-new-or-updated-blog-article",
   name: "New or Updated Blog Post",
   description: "Emit new event for each new or updated blog post in Hubspot.",
-  version: "0.0.28",
+  version: "0.0.29",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-company/new-or-updated-company.mjs
+++ b/components/hubspot/sources/new-or-updated-company/new-or-updated-company.mjs
@@ -10,7 +10,7 @@ export default {
   key: "hubspot-new-or-updated-company",
   name: "New or Updated Company",
   description: "Emit new event for each new or updated company in Hubspot.",
-  version: "0.0.28",
+  version: "0.0.29",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-contact/new-or-updated-contact.mjs
+++ b/components/hubspot/sources/new-or-updated-contact/new-or-updated-contact.mjs
@@ -10,7 +10,7 @@ export default {
   key: "hubspot-new-or-updated-contact",
   name: "New or Updated Contact",
   description: "Emit new event for each new or updated contact in Hubspot.",
-  version: "0.0.30",
+  version: "0.0.31",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-crm-object/new-or-updated-crm-object.mjs
+++ b/components/hubspot/sources/new-or-updated-crm-object/new-or-updated-crm-object.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-new-or-updated-crm-object",
   name: "New or Updated CRM Object",
   description: "Emit new event each time a CRM Object of the specified object type is updated.",
-  version: "0.0.41",
+  version: "0.0.42",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-custom-object/new-or-updated-custom-object.mjs
+++ b/components/hubspot/sources/new-or-updated-custom-object/new-or-updated-custom-object.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-new-or-updated-custom-object",
   name: "New or Updated Custom Object",
   description: "Emit new event each time a Custom Object of the specified schema is updated.",
-  version: "0.0.30",
+  version: "0.0.31",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-deal/new-or-updated-deal.mjs
+++ b/components/hubspot/sources/new-or-updated-deal/new-or-updated-deal.mjs
@@ -10,7 +10,7 @@ export default {
   key: "hubspot-new-or-updated-deal",
   name: "New or Updated Deal",
   description: "Emit new event for each new or updated deal in Hubspot",
-  version: "0.0.28",
+  version: "0.0.29",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-line-item/new-or-updated-line-item.mjs
+++ b/components/hubspot/sources/new-or-updated-line-item/new-or-updated-line-item.mjs
@@ -10,7 +10,7 @@ export default {
   key: "hubspot-new-or-updated-line-item",
   name: "New or Updated Line Item",
   description: "Emit new event for each new line item added or updated in Hubspot.",
-  version: "0.0.28",
+  version: "0.0.29",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-product/new-or-updated-product.mjs
+++ b/components/hubspot/sources/new-or-updated-product/new-or-updated-product.mjs
@@ -10,7 +10,7 @@ export default {
   key: "hubspot-new-or-updated-product",
   name: "New or Updated Product",
   description: "Emit new event for each new or updated product in Hubspot.",
-  version: "0.0.28",
+  version: "0.0.29",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-social-media-message/new-social-media-message.mjs
+++ b/components/hubspot/sources/new-social-media-message/new-social-media-message.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Social Media Message",
   description:
     "Emit new event when a message is posted from HubSpot to the specified social media channel. Note: Only available for Marketing Hub Enterprise accounts",
-  version: "0.0.41",
+  version: "0.0.42",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/hubspot/sources/new-task/new-task.mjs
+++ b/components/hubspot/sources/new-task/new-task.mjs
@@ -9,7 +9,7 @@ export default {
   name: "New Task Created",
   description:
     "Emit new event for each new task created. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/engagements/tasks#get-%2Fcrm%2Fv3%2Fobjects%2Ftasks)",
-  version: "1.0.22",
+  version: "1.0.23",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/hubspot/sources/new-thread-created/new-thread-created.mjs
+++ b/components/hubspot/sources/new-thread-created/new-thread-created.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-new-thread-created",
   name: "New Thread Created",
   description: "Emit new event when a new thread is created. [See the documentation](https://developers.hubspot.com/docs/api-reference/conversations-conversations-inbox-&-messages-v3/public-thread/get-conversations-v3-conversations-threads)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/hubspot/sources/new-ticket-property-change/new-ticket-property-change.mjs
+++ b/components/hubspot/sources/new-ticket-property-change/new-ticket-property-change.mjs
@@ -8,7 +8,7 @@ export default {
   name: "New Ticket Property Change",
   description:
     "Emit new event when a specified property is provided or updated on a ticket. [See the documentation](https://developers.hubspot.com/docs/api/crm/tickets)",
-  version: "0.0.35",
+  version: "0.0.36",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-ticket/new-ticket.mjs
+++ b/components/hubspot/sources/new-ticket/new-ticket.mjs
@@ -10,7 +10,7 @@ export default {
   key: "hubspot-new-ticket",
   name: "New Ticket",
   description: "Emit new event for each new ticket created.",
-  version: "0.0.41",
+  version: "0.0.42",
   dedupe: "unique",
   type: "source",
   props: {


### PR DESCRIPTION
## Summary

<!-- Add your PR description here -->
Closes https://github.com/PipedreamHQ/pipedream/issues/21005
Modify `hubspot-new-engagement` source to use hubspot `/v3` `2026-03` endpoints to fetch data from 6 different endpoints and merge the results


## Checklist
Please check the following items before your PR can be reviewed:

### Versioning
- [x] All components updated in this PR had their version updated (`0.0.1` for new ones)
- [x] The app updated in this PR had its `package.json`'s version updated

### New app
If this is a new app, please submit [an app integration request](https://github.com/PipedreamHQ/pipedream/issues/new?template=app---service-integration.md) - the PR will only be reviewed after the app is integrated.
- [ ] The app updated in this PR is already integrated

### CodeRabbit review
After the PR is opened, and if new changes are pushed, CodeRabbit will automatically review it. Do not 'mark as resolved' CodeRabbit's comments, but reply to them instead, whether you agree (and update the PR accordingly) or disagree.
- [ ] I have addressed or acknowledged all of CodeRabbit's review comments



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Support for date-versioned HubSpot CRM endpoints
  - Expanded engagement types (adds postal mail and additional CRM-backed types)

* **Improvements**
  - Refactored New Engagement source to fetch per-type in parallel for faster, more reliable syncs
  - Improved pagination: limited initial emits, emit-only-new behavior on subsequent runs, and robust cursor handling
  - searchCRM can target a specified CRM version

* **Chores / Documentation**
  - Many component version bumps and description updates
<!-- end of auto-generated comment: release notes by coderabbit.ai -->