### PR TITLE
[21021] fix(jira): modify desc to type transition ID as a string for agents

### DIFF
--- a/components/jira/actions/add-attachment-to-issue/add-attachment-to-issue.mjs
+++ b/components/jira/actions/add-attachment-to-issue/add-attachment-to-issue.mjs
@@ -6,7 +6,7 @@ export default {
   key: "jira-add-attachment-to-issue",
   name: "Add Attachment To Issue",
   description: "Adds an attachment to an issue. [See the documentation](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-attachments/#api-rest-api-3-issue-issueidorkey-attachments-post)",
-  version: "1.0.13",
+  version: "1.0.14",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/jira/actions/add-comment-to-issue/add-comment-to-issue.mjs
+++ b/components/jira/actions/add-comment-to-issue/add-comment-to-issue.mjs
@@ -7,7 +7,7 @@ export default {
   key: "jira-add-comment-to-issue",
   name: "Add Comment To Issue",
   description: "Adds a new comment to an issue. [See the documentation](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-comments/#api-rest-api-3-issue-issueidorkey-comment-post)",
-  version: "0.1.20",
+  version: "0.1.21",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/jira/actions/add-multiple-attachments-to-issue/add-multiple-attachments-to-issue.mjs
+++ b/components/jira/actions/add-multiple-attachments-to-issue/add-multiple-attachments-to-issue.mjs
@@ -6,7 +6,7 @@ export default {
   key: "jira-add-multiple-attachments-to-issue",
   name: "Add Multiple Attachments To Issue",
   description: "Adds multiple attachments to an issue. [See the documentation](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-attachments/#api-rest-api-3-issue-issueidorkey-attachments-post)",
-  version: "1.0.13",
+  version: "1.0.14",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/jira/actions/add-watcher-to-issue/add-watcher-to-issue.mjs
+++ b/components/jira/actions/add-watcher-to-issue/add-watcher-to-issue.mjs
@@ -3,7 +3,7 @@ import jira from "../../jira.app.mjs";
 export default {
   key: "jira-add-watcher-to-issue",
   name: "Add Watcher To Issue",
-  version: "0.0.19",
+  version: "0.0.20",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/jira/actions/assign-issue/assign-issue.mjs
+++ b/components/jira/actions/assign-issue/assign-issue.mjs
@@ -3,7 +3,7 @@ import jira from "../../jira.app.mjs";
 export default {
   key: "jira-assign-issue",
   name: "Assign Issue",
-  version: "0.0.19",
+  version: "0.0.20",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/jira/actions/assign-issue/assign-issue.mjs
+++ b/components/jira/actions/assign-issue/assign-issue.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Assign Issue",
   version: "0.0.20",
   annotations: {
-    destructiveHint: true,
+    destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },

--- a/components/jira/actions/check-issues-against-jql/check-issues-against-jql.mjs
+++ b/components/jira/actions/check-issues-against-jql/check-issues-against-jql.mjs
@@ -4,7 +4,7 @@ export default {
   key: "jira-check-issues-against-jql",
   name: "Check Issues Against JQL",
   description: "Checks whether one or more issues would be returned by one or more JQL queries. [See the documentation](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/#api-rest-api-3-jql-match-post)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   annotations: {
     readOnlyHint: true,

--- a/components/jira/actions/count-issues-using-jql/count-issues-using-jql.mjs
+++ b/components/jira/actions/count-issues-using-jql/count-issues-using-jql.mjs
@@ -4,7 +4,7 @@ export default {
   key: "jira-count-issues-using-jql",
   name: "Count Issues Using JQL",
   description: "Provide an estimated count of the issues that match the JQL. [See the documentation](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/#api-rest-api-3-search-approximate-count-post)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   annotations: {
     readOnlyHint: true,

--- a/components/jira/actions/create-custom-field-options-context/create-custom-field-options-context.mjs
+++ b/components/jira/actions/create-custom-field-options-context/create-custom-field-options-context.mjs
@@ -5,7 +5,7 @@ export default {
   key: "jira-create-custom-field-options-context",
   name: "Create Custom Field Options (Context)",
   description: "Create a context for custom field options. [See the documentation](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-custom-field-options/#api-rest-api-3-field-fieldid-context-contextid-option-post).",
-  version: "0.0.12",
+  version: "0.0.13",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/jira/actions/create-future-sprint/create-future-sprint.mjs
+++ b/components/jira/actions/create-future-sprint/create-future-sprint.mjs
@@ -4,7 +4,7 @@ export default {
   key: "jira-create-future-sprint",
   name: "Create Future Sprint",
   description: "Creates a future sprint. [See the documentation](https://developer.atlassian.com/cloud/jira/software/rest/api-group-sprint/#api-rest-agile-1-0-sprint-post)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/jira/actions/create-issue/create-issue.mjs
+++ b/components/jira/actions/create-issue/create-issue.mjs
@@ -8,7 +8,7 @@ export default {
   key: "jira-create-issue",
   name: "Create Issue",
   description: "Creates an issue or, where the option to create subtasks is enabled in Jira, a subtask. [See the documentation](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-post)",
-  version: "0.1.31",
+  version: "0.1.32",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/jira/actions/create-version/create-version.mjs
+++ b/components/jira/actions/create-version/create-version.mjs
@@ -4,7 +4,7 @@ export default {
   key: "jira-create-version",
   name: "Create Jira Version in Project",
   description: "Creates a project version. [See the documentation](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-project-versions/#api-rest-api-3-version-post)",
-  version: "0.1.20",
+  version: "0.1.21",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/jira/actions/delete-project/delete-project.mjs
+++ b/components/jira/actions/delete-project/delete-project.mjs
@@ -4,7 +4,7 @@ export default {
   key: "jira-delete-project",
   name: "Delete Project",
   description: "Deletes a project. [See the documentation](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-projects/#api-rest-api-3-project-projectidorkey-delete)",
-  version: "0.1.20",
+  version: "0.1.21",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/jira/actions/get-all-projects/get-all-projects.mjs
+++ b/components/jira/actions/get-all-projects/get-all-projects.mjs
@@ -4,7 +4,7 @@ export default {
   key: "jira-get-all-projects",
   name: "Get All Projects",
   description: "Gets metadata on all projects. [See the documentation](https://developer.atlassian.com/cloud/jira/platform/rest/v3/#api-rest-api-3-project-get)",
-  version: "0.1.21",
+  version: "0.1.22",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/jira/actions/get-board/get-board.mjs
+++ b/components/jira/actions/get-board/get-board.mjs
@@ -4,7 +4,7 @@ export default {
   key: "jira-get-board",
   name: "Get Board",
   description: "Returns the board for the given board ID. [See the documentation](https://developer.atlassian.com/cloud/jira/software/rest/api-group-board/#api-rest-agile-1-0-board-boardid-get)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/jira/actions/get-cloud-id/get-cloud-id.mjs
+++ b/components/jira/actions/get-cloud-id/get-cloud-id.mjs
@@ -4,7 +4,7 @@ export default {
   key: "jira-get-cloud-id",
   name: "Get Cloud ID",
   description: "Gets the cloud ID and details of all accessible Jira Cloud sites. [See the documentation](https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps/)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/jira/actions/get-current-user/get-current-user.mjs
+++ b/components/jira/actions/get-current-user/get-current-user.mjs
@@ -4,7 +4,7 @@ export default {
   key: "jira-get-current-user",
   name: "Get Current User",
   description: "Returns the authenticated Jira user's account ID, display name, email, and active status. Call this first when the user says 'my issues', 'assigned to me', or needs their Jira identity. Use the returned `accountId` with **Search Issues with JQL** (e.g. `assignee = '{accountId}'`) or **Assign Issue**. Requires a Cloud ID to identify the Jira site. [See the documentation](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-myself/#api-rest-api-3-myself-get).",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/jira/actions/get-issue-picker-suggestions/get-issue-picker-suggestions.mjs
+++ b/components/jira/actions/get-issue-picker-suggestions/get-issue-picker-suggestions.mjs
@@ -4,7 +4,7 @@ export default {
   key: "jira-get-issue-picker-suggestions",
   name: "Get Issue Picker Suggestions",
   description: "Returns lists of issues matching a query string. [See the documentation](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/#api-rest-api-3-issue-picker-get)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   annotations: {
     readOnlyHint: true,

--- a/components/jira/actions/get-issue-types/get-issue-types.mjs
+++ b/components/jira/actions/get-issue-types/get-issue-types.mjs
@@ -4,7 +4,7 @@ export default {
   key: "jira-get-issue-types",
   name: "Get Issue Types",
   description: "Gets the available issue types. If a project ID is provided, returns issue types for that project. Otherwise, returns all issue types accessible to the user. [See the documentation](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-types/#api-rest-api-3-issuetype-get)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/jira/actions/get-issue/get-issue.mjs
+++ b/components/jira/actions/get-issue/get-issue.mjs
@@ -4,7 +4,7 @@ export default {
   key: "jira-get-issue",
   name: "Get Issue",
   description: "Gets the details for an issue. [See the documentation](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-get)",
-  version: "0.1.22",
+  version: "0.1.23",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/jira/actions/get-sprint/get-sprint.mjs
+++ b/components/jira/actions/get-sprint/get-sprint.mjs
@@ -4,7 +4,7 @@ export default {
   key: "jira-get-sprint",
   name: "Get Sprint",
   description: "Returns the sprint for a given sprint ID. [See the documentation](https://developer.atlassian.com/cloud/jira/software/rest/api-group-sprint/#api-rest-agile-1-0-sprint-sprintid-get)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/jira/actions/get-task/get-task.mjs
+++ b/components/jira/actions/get-task/get-task.mjs
@@ -4,7 +4,7 @@ export default {
   key: "jira-get-task",
   name: "Get Task",
   description: "Gets the status of a long-running asynchronous task. [See the documentation](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-tasks/#api-rest-api-3-task-taskid-get)",
-  version: "0.1.20",
+  version: "0.1.21",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/jira/actions/get-transitions/get-transitions.mjs
+++ b/components/jira/actions/get-transitions/get-transitions.mjs
@@ -4,7 +4,7 @@ export default {
   key: "jira-get-transitions",
   name: "Get Transitions",
   description: "Gets either all transitions or a transition that can be performed by the user on an issue, based on the issue's status. [See the documentation](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-transitions-get)",
-  version: "0.1.20",
+  version: "0.1.21",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/jira/actions/get-user/get-user.mjs
+++ b/components/jira/actions/get-user/get-user.mjs
@@ -4,7 +4,7 @@ export default {
   key: "jira-get-user",
   name: "Get User",
   description: "Gets details of user. [See the documentation](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-users/#api-rest-api-3-user-get)",
-  version: "0.1.20",
+  version: "0.1.21",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/jira/actions/get-users/get-users.mjs
+++ b/components/jira/actions/get-users/get-users.mjs
@@ -4,7 +4,7 @@ export default {
   key: "jira-get-users",
   name: "Get Users",
   description: "Gets the details for a list of users. [See the documentation](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-user-search/#api-rest-api-3-user-search-get)",
-  version: "0.0.15",
+  version: "0.0.16",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/jira/actions/list-board-issues/list-board-issues.mjs
+++ b/components/jira/actions/list-board-issues/list-board-issues.mjs
@@ -4,7 +4,7 @@ export default {
   key: "jira-list-board-issues",
   name: "List Board Issues",
   description: "Returns all issues from a board, for the given board ID. [See the documentation](https://developer.atlassian.com/cloud/jira/software/rest/api-group-board/#api-rest-agile-1-0-board-boardid-issue-get)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/jira/actions/list-boards/list-boards.mjs
+++ b/components/jira/actions/list-boards/list-boards.mjs
@@ -4,7 +4,7 @@ export default {
   key: "jira-list-boards",
   name: "List Boards",
   description: "Returns all boards. [See the documentation](https://developer.atlassian.com/cloud/jira/software/rest/api-group-board/#api-rest-agile-1-0-board-get)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/jira/actions/list-epic-issues/list-epic-issues.mjs
+++ b/components/jira/actions/list-epic-issues/list-epic-issues.mjs
@@ -5,7 +5,7 @@ export default {
   key: "jira-list-epic-issues",
   name: "List Epic Issues",
   description: "Returns all issues that belong to an epic on the given board. [See the documentation](https://developer.atlassian.com/cloud/jira/software/rest/api-group-board/#api-rest-agile-1-0-board-boardid-epic-epicid-issue-get)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/jira/actions/list-epics/list-epics.mjs
+++ b/components/jira/actions/list-epics/list-epics.mjs
@@ -4,7 +4,7 @@ export default {
   key: "jira-list-epics",
   name: "List Epics",
   description: "Returns all epics from a board, for the given board ID. [See the documentation](https://developer.atlassian.com/cloud/jira/software/rest/api-group-board/#api-rest-agile-1-0-board-boardid-epic-get)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/jira/actions/list-issue-comments/list-issue-comments.mjs
+++ b/components/jira/actions/list-issue-comments/list-issue-comments.mjs
@@ -4,7 +4,7 @@ export default {
   key: "jira-list-issue-comments",
   name: "List Issue Comments",
   description: "Lists all comments for an issue. [See the documentation](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-comments/#api-rest-api-3-issue-issueidorkey-comment-get)",
-  version: "0.1.20",
+  version: "0.1.21",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/jira/actions/list-labels-options/list-labels-options.mjs
+++ b/components/jira/actions/list-labels-options/list-labels-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "jira-list-labels-options",
   name: "List Labels Options",
   description: "Retrieves available options for the Labels field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/jira/actions/list-sprint-issues/list-sprint-issues.mjs
+++ b/components/jira/actions/list-sprint-issues/list-sprint-issues.mjs
@@ -4,7 +4,7 @@ export default {
   key: "jira-list-sprint-issues",
   name: "List Sprint Issues",
   description: "Returns all issues in a sprint. [See the documentation](https://developer.atlassian.com/cloud/jira/software/rest/api-group-sprint/#api-rest-agile-1-0-sprint-sprintid-issue-get)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/jira/actions/list-sprints/list-sprints.mjs
+++ b/components/jira/actions/list-sprints/list-sprints.mjs
@@ -4,7 +4,7 @@ export default {
   key: "jira-list-sprints",
   name: "List Sprints",
   description: "Returns all sprints from a board, for the given board ID. [See the documentation](https://developer.atlassian.com/cloud/jira/software/rest/api-group-board/#api-rest-agile-1-0-board-boardid-sprint-get)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/jira/actions/move-issues-to-sprint/move-issues-to-sprint.mjs
+++ b/components/jira/actions/move-issues-to-sprint/move-issues-to-sprint.mjs
@@ -5,7 +5,7 @@ export default {
   key: "jira-move-issues-to-sprint",
   name: "Move Issues to Sprint",
   description: "Moves issues to a sprint, for a given sprint ID. [See the documentation](https://developer.atlassian.com/cloud/jira/software/rest/api-group-sprint/#api-rest-agile-1-0-sprint-sprintid-issue-post)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: true,

--- a/components/jira/actions/search-issues-with-jql-post/search-issues-with-jql-post.mjs
+++ b/components/jira/actions/search-issues-with-jql-post/search-issues-with-jql-post.mjs
@@ -4,7 +4,7 @@ export default {
   key: "jira-search-issues-with-jql-post",
   name: "Search Issues with JQL (POST)",
   description: "Searches for issues using JQL with enhanced search capabilities. [See the documentation](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/#api-rest-api-3-search-jql-post)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   annotations: {
     readOnlyHint: true,

--- a/components/jira/actions/search-issues-with-jql/search-issues-with-jql.mjs
+++ b/components/jira/actions/search-issues-with-jql/search-issues-with-jql.mjs
@@ -4,7 +4,7 @@ export default {
   name: "Search Issues with JQL",
   description: "Search for issues using JQL (Jira Query Language). [See the documentation](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/#api-rest-api-3-search-jql-get)",
   key: "jira-search-issues-with-jql",
-  version: "0.1.8",
+  version: "0.1.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/jira/actions/transition-issue/transition-issue.mjs
+++ b/components/jira/actions/transition-issue/transition-issue.mjs
@@ -5,7 +5,7 @@ export default {
   key: "jira-transition-issue",
   name: "Transition Issue",
   description: "Performs an issue transition and, if the transition has a screen, updates the fields from the transition screen. [See the documentation](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-transitions-post)",
-  version: "0.1.22",
+  version: "0.1.23",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
@@ -38,6 +38,8 @@ export default {
           cloudId: configuredProps.cloudId,
         }),
       ],
+      label: "Transition ID",
+      description: "The string ID of the transition to perform (e.g. `\"11\"`). Use the `id` value returned by the **Get Transitions** action.",
       optional: false,
     },
     fields: {

--- a/components/jira/actions/update-comment/update-comment.mjs
+++ b/components/jira/actions/update-comment/update-comment.mjs
@@ -7,7 +7,7 @@ export default {
   key: "jira-update-comment",
   name: "Update Comment",
   description: "Updates a comment. [See the documentation](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-comments/#api-rest-api-3-issue-issueidorkey-comment-id-put)",
-  version: "0.1.20",
+  version: "0.1.21",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/jira/actions/update-issue/update-issue.mjs
+++ b/components/jira/actions/update-issue/update-issue.mjs
@@ -8,7 +8,7 @@ export default {
   key: "jira-update-issue",
   name: "Update Issue",
   description: "Updates an issue. A transition may be applied and issue properties updated as part of the edit. [See the documentation](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-put)",
-  version: "0.2.24",
+  version: "0.2.25",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/jira/jira.app.mjs
+++ b/components/jira/jira.app.mjs
@@ -199,7 +199,7 @@ export default {
     transition: {
       type: "string",
       label: "Transition ID",
-      description: "The string ID of a transition (e.g. `\"11\"`). Required when performing a transition; optional when creating or editing an issue. Use the `id` value returned by the **Get Transitions** action. You can also edit the workflow and choose the Text option instead of the Diagram option to see the transition ID in parenthesis. [See the transitions doc](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-transitions-post).",
+      description: "The string ID of a transition (e.g. `\"11\"`). Required when performing a transition; optional when creating or editing an issue. Use the `id` value returned by the **Get Transitions** action. [See the documentation](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-transitions-post).",
       optional: true,
       async options({
         prevContext, issueIdOrKey, cloudId,

--- a/components/jira/jira.app.mjs
+++ b/components/jira/jira.app.mjs
@@ -198,8 +198,8 @@ export default {
     },
     transition: {
       type: "string",
-      label: "Transition",
-      description: "Details of a transition. Required when performing a transition, optional when creating or editing an issue, See `Transition` section of [doc](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-put). Also you can go edit the workflow and choose the Text option instead of the Diagram option. You can see the transition ID in parenthesis.",
+      label: "Transition ID",
+      description: "The string ID of a transition (e.g. `\"11\"`). Required when performing a transition; optional when creating or editing an issue. Use the `id` value returned by the **Get Transitions** action. You can also edit the workflow and choose the Text option instead of the Diagram option to see the transition ID in parenthesis. [See the transitions doc](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-transitions-post).",
       optional: true,
       async options({
         prevContext, issueIdOrKey, cloudId,

--- a/components/jira/package.json
+++ b/components/jira/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/jira",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Pipedream Jira Components",
   "main": "jira.app.mjs",
   "keywords": [

--- a/components/jira/sources/events/events.mjs
+++ b/components/jira/sources/events/events.mjs
@@ -5,7 +5,7 @@ export default {
   key: "jira-events",
   name: "New Event",
   description: "Emit new event when an event with subscribed event source triggered, [See the documentation](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-webhooks/#api-rest-api-3-webhook-post)",
-  version: "0.0.20",
+  version: "0.0.21",
   type: "source",
   dedupe: "unique",
   ...common,

--- a/components/jira/sources/issue-created/issue-created.mjs
+++ b/components/jira/sources/issue-created/issue-created.mjs
@@ -4,7 +4,7 @@ export default {
   key: "jira-issue-created",
   name: "New Issue Created Event (Instant)",
   description: "Emit new event when an issue is created. Note that Jira supports only one webhook, if more sources are needed please use `New Event` source and select multiple events.",
-  version: "0.0.20",
+  version: "0.0.21",
   type: "source",
   dedupe: "unique",
   ...common,

--- a/components/jira/sources/issue-deleted/issue-deleted.mjs
+++ b/components/jira/sources/issue-deleted/issue-deleted.mjs
@@ -4,7 +4,7 @@ export default {
   key: "jira-issue-deleted",
   name: "New Issue Deleted Event (Instant)",
   description: "Emit new event when an issue is deleted. Note that Jira supports only one webhook, if more sources are needed please use `New Event` source and select multiple events.",
-  version: "0.0.20",
+  version: "0.0.21",
   type: "source",
   dedupe: "unique",
   ...common,

--- a/components/jira/sources/issue-updated/issue-updated.mjs
+++ b/components/jira/sources/issue-updated/issue-updated.mjs
@@ -4,7 +4,7 @@ export default {
   key: "jira-issue-updated",
   name: "New Issue Updated Event (Instant)",
   description: "Emit new event when an issue is updated. Note that Jira supports only one webhook, if more sources are needed please use `New Event` source and select multiple events.",
-  version: "0.0.20",
+  version: "0.0.21",
   type: "source",
   dedupe: "unique",
   ...common,


### PR DESCRIPTION
## Summary
Closes https://github.com/PipedreamHQ/pipedream/issues/21021

When an AI agent chains `jira-get-transitions` -> `jira-transition-issue`, the transition `id` returned by `get-transitions` (a string like `"11"`, matching the Jira API) gets coerced to an integer, so the transition POST fails. Agents currently work around this by coercing string IDs in a prompt.
The problem is the **agent-facing schema text**: `transition-issue` used the bare `transition` propDefinition and inherited a generic, misleading description ("Details of a transition...") that links the wrong (PUT-issue) doc and never says the value is a string. Its sibling actions (`get-transitions`, `update-issue`) already override this with a clear "Transition ID" label.
<!-- Add your PR description here -->



## Checklist
Please check the following items before your PR can be reviewed:

### Versioning
- [x] All components updated in this PR had their version updated (`0.0.1` for new ones)
- [x] The app updated in this PR had its `package.json`'s version updated

### New app
If this is a new app, please submit [an app integration request](https://github.com/PipedreamHQ/pipedream/issues/new?template=app---service-integration.md) - the PR will only be reviewed after the app is integrated.
- [ ] The app updated in this PR is already integrated

### CodeRabbit review
After the PR is opened, and if new changes are pushed, CodeRabbit will automatically review it. Do not 'mark as resolved' CodeRabbit's comments, but reply to them instead, whether you agree (and update the PR accordingly) or disagree.
- [ ] I have addressed or acknowledged all of CodeRabbit's review comments



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Renamed the Jira "Transition" field to "Transition ID" and clarified guidance to enter the transition's string ID (references Get Transitions and docs).
* **Chores**
  * Updated package and action/source versions across the Jira component to publish a patch release; no runtime behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->