### PR TITLE
Microsoft Outlook Calendar - add RSVP actions (#21022)

### DIFF
--- a/components/microsoft_outlook_calendar/actions/accept-event/accept-event.mjs
+++ b/components/microsoft_outlook_calendar/actions/accept-event/accept-event.mjs
@@ -1,0 +1,60 @@
+import microsoftOutlook from "../../microsoft_outlook_calendar.app.mjs";
+
+export default {
+  key: "microsoft_outlook_calendar-accept-event",
+  name: "Accept Event",
+  description:
+    "Accept a calendar event invitation and optionally send a response to the organizer."
+    + " Use **List Events** or **Get Event** to find the event ID."
+    + " [See the documentation](https://learn.microsoft.com/en-us/graph/api/event-accept?view=graph-rest-1.0&tabs=http)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    microsoftOutlook,
+    eventId: {
+      type: "string",
+      label: "Event ID",
+      description: "The Microsoft Graph event ID. Use **List Events** or **Get Event** to retrieve this value — it is the `id` field on an event object.",
+    },
+    comment: {
+      propDefinition: [
+        microsoftOutlook,
+        "comment",
+      ],
+    },
+    sendResponse: {
+      propDefinition: [
+        microsoftOutlook,
+        "sendResponse",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const event = await this.microsoftOutlook.getCalendarEvent({
+      eventId: this.eventId,
+    });
+
+    const data = {
+      comment: this.comment,
+      sendResponse: this.sendResponse ?? true,
+    };
+
+    await this.microsoftOutlook.acceptCalendarEvent({
+      eventId: this.eventId,
+      data,
+    });
+
+    const subject = event?.subject ?? this.eventId;
+    $.export("$summary", `Accepted event "${subject}"`);
+    return {
+      success: true,
+      eventId: this.eventId,
+      subject,
+    };
+  },
+};

--- a/components/microsoft_outlook_calendar/actions/accept-event/accept-event.mjs
+++ b/components/microsoft_outlook_calendar/actions/accept-event/accept-event.mjs
@@ -17,9 +17,10 @@ export default {
   props: {
     microsoftOutlook,
     eventId: {
-      type: "string",
-      label: "Event ID",
-      description: "The Microsoft Graph event ID. Use **List Events** or **Get Event** to retrieve this value — it is the `id` field on an event object.",
+      propDefinition: [
+        microsoftOutlook,
+        "eventId",
+      ],
     },
     comment: {
       propDefinition: [

--- a/components/microsoft_outlook_calendar/actions/create-calendar-event/create-calendar-event.mjs
+++ b/components/microsoft_outlook_calendar/actions/create-calendar-event/create-calendar-event.mjs
@@ -9,7 +9,7 @@ import {
 export default {
   type: "action",
   key: "microsoft_outlook_calendar-create-calendar-event",
-  version: "0.0.15",
+  version: "0.0.16",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/microsoft_outlook_calendar/actions/decline-event/decline-event.mjs
+++ b/components/microsoft_outlook_calendar/actions/decline-event/decline-event.mjs
@@ -1,0 +1,71 @@
+import microsoftOutlook from "../../microsoft_outlook_calendar.app.mjs";
+
+export default {
+  key: "microsoft_outlook_calendar-decline-event",
+  name: "Decline Event",
+  description:
+    "Decline a calendar event invitation and optionally propose an alternate time."
+    + " Use **List Events** or **Get Event** to find the event ID."
+    + " To propose a new time, pass `proposedNewTime` as a JSON string with `start` and `end` objects (each with `dateTime` in ISO 8601 format and `timeZone` as a Windows timezone name, e.g. `\"Pacific Standard Time\"`). Alternate-time proposals are only valid when the event has `allowNewTimeProposals: true` and `sendResponse` is `true`."
+    + " [See the documentation](https://learn.microsoft.com/en-us/graph/api/event-decline?view=graph-rest-1.0&tabs=http)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    microsoftOutlook,
+    eventId: {
+      type: "string",
+      label: "Event ID",
+      description: "The Microsoft Graph event ID. Use **List Events** or **Get Event** to retrieve this value — it is the `id` field on an event object.",
+    },
+    comment: {
+      propDefinition: [
+        microsoftOutlook,
+        "comment",
+      ],
+    },
+    sendResponse: {
+      propDefinition: [
+        microsoftOutlook,
+        "sendResponse",
+      ],
+    },
+    proposedNewTime: {
+      type: "string",
+      label: "Proposed New Time",
+      description: "Optional alternate time to propose. JSON string with `start` and `end` objects, each having `dateTime` (ISO 8601) and `timeZone` (Windows timezone name). Example: `{\"start\":{\"dateTime\":\"2024-03-15T14:00:00\",\"timeZone\":\"Pacific Standard Time\"},\"end\":{\"dateTime\":\"2024-03-15T15:00:00\",\"timeZone\":\"Pacific Standard Time\"}}`. Only valid when the event allows new time proposals and `sendResponse` is `true`.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const event = await this.microsoftOutlook.getCalendarEvent({
+      eventId: this.eventId,
+    });
+
+    const data = {
+      comment: this.comment,
+      sendResponse: this.sendResponse ?? true,
+    };
+
+    if (this.proposedNewTime) {
+      data.proposedNewTime = JSON.parse(this.proposedNewTime);
+    }
+
+    await this.microsoftOutlook.declineCalendarEvent({
+      eventId: this.eventId,
+      data,
+    });
+
+    const subject = event?.subject ?? this.eventId;
+    $.export("$summary", `Declined event "${subject}"`);
+    return {
+      success: true,
+      eventId: this.eventId,
+      subject,
+    };
+  },
+};

--- a/components/microsoft_outlook_calendar/actions/decline-event/decline-event.mjs
+++ b/components/microsoft_outlook_calendar/actions/decline-event/decline-event.mjs
@@ -1,3 +1,4 @@
+import { ConfigurationError } from "@pipedream/platform";
 import microsoftOutlook from "../../microsoft_outlook_calendar.app.mjs";
 
 export default {
@@ -18,9 +19,10 @@ export default {
   props: {
     microsoftOutlook,
     eventId: {
-      type: "string",
-      label: "Event ID",
-      description: "The Microsoft Graph event ID. Use **List Events** or **Get Event** to retrieve this value — it is the `id` field on an event object.",
+      propDefinition: [
+        microsoftOutlook,
+        "eventId",
+      ],
     },
     comment: {
       propDefinition: [
@@ -52,7 +54,11 @@ export default {
     };
 
     if (this.proposedNewTime) {
-      data.proposedNewTime = JSON.parse(this.proposedNewTime);
+      try {
+        data.proposedNewTime = JSON.parse(this.proposedNewTime);
+      } catch (err) {
+        throw new ConfigurationError(`Invalid JSON for proposedNewTime: ${err.message}`);
+      }
     }
 
     await this.microsoftOutlook.declineCalendarEvent({

--- a/components/microsoft_outlook_calendar/actions/delete-calendar-event/delete-calendar-event.mjs
+++ b/components/microsoft_outlook_calendar/actions/delete-calendar-event/delete-calendar-event.mjs
@@ -3,7 +3,7 @@ import microsoftOutlook from "../../microsoft_outlook_calendar.app.mjs";
 export default {
   type: "action",
   key: "microsoft_outlook_calendar-delete-calendar-event",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/microsoft_outlook_calendar/actions/delete-recurring-event-instance/delete-recurring-event-instance.mjs
+++ b/components/microsoft_outlook_calendar/actions/delete-recurring-event-instance/delete-recurring-event-instance.mjs
@@ -4,7 +4,7 @@ import { ConfigurationError } from "@pipedream/platform";
 export default {
   type: "action",
   key: "microsoft_outlook_calendar-delete-recurring-event-instance",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/microsoft_outlook_calendar/actions/find-meeting-times/find-meeting-times.mjs
+++ b/components/microsoft_outlook_calendar/actions/find-meeting-times/find-meeting-times.mjs
@@ -6,7 +6,7 @@ export default {
   key: "microsoft_outlook_calendar-find-meeting-times",
   name: "Find Meeting Times",
   description: "Suggest meeting times and locations based on organizer and attendee availability. [See the documentation](https://learn.microsoft.com/en-us/graph/api/user-findmeetingtimes?view=graph-rest-1.0)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/microsoft_outlook_calendar/actions/get-current-user/get-current-user.mjs
+++ b/components/microsoft_outlook_calendar/actions/get-current-user/get-current-user.mjs
@@ -4,7 +4,7 @@ export default {
   key: "microsoft_outlook_calendar-get-current-user",
   name: "Get Current User",
   description: "Returns the authenticated Microsoft user's ID, display name, email, and principal name via Microsoft Graph. Call this first when the user says 'my calendar', 'my events', or needs to identify themselves as organizer/attendee. Use `id` or `mail` to filter results from **List Events** or set the organizer in **Create Calendar Event**. [See the documentation](https://learn.microsoft.com/en-us/graph/api/user-get).",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/microsoft_outlook_calendar/actions/get-event/get-event.mjs
+++ b/components/microsoft_outlook_calendar/actions/get-event/get-event.mjs
@@ -5,7 +5,7 @@ export default {
   key: "microsoft_outlook_calendar-get-event",
   name: "Get Event",
   description: "Retrieve a calendar event by its Microsoft Graph event ID. Pass the `id` from **List Events** when you need full details (for example `body`, `attendees`, or `recurrence`) that list responses may omit or truncate. [See the documentation](https://learn.microsoft.com/en-us/graph/api/event-get?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/microsoft_outlook_calendar/actions/get-schedule/get-schedule.mjs
+++ b/components/microsoft_outlook_calendar/actions/get-schedule/get-schedule.mjs
@@ -8,7 +8,7 @@ export default {
   key: "microsoft_outlook_calendar-get-schedule",
   name: "Get Free/Busy Schedule",
   description: "Get the free/busy availability information for a collection of users, distributions lists, or resources (rooms or equipment) for a specified time period. [See the documentation](https://learn.microsoft.com/en-us/graph/api/calendar-getschedule)",
-  version: "0.0.12",
+  version: "0.0.13",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/microsoft_outlook_calendar/actions/list-events/list-events.mjs
+++ b/components/microsoft_outlook_calendar/actions/list-events/list-events.mjs
@@ -7,7 +7,7 @@ export default {
   key: "microsoft_outlook_calendar-list-events",
   name: "List Events",
   description: "Get a list of event objects in the user's mailbox. [See the documentation](https://learn.microsoft.com/en-us/graph/api/user-list-events)",
-  version: "0.1.0",
+  version: "0.1.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/microsoft_outlook_calendar/actions/list-time-zone-options/list-time-zone-options.mjs
+++ b/components/microsoft_outlook_calendar/actions/list-time-zone-options/list-time-zone-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "microsoft_outlook_calendar-list-time-zone-options",
   name: "List Time Zone Options",
   description: "Retrieves available options for the Time Zone field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/microsoft_outlook_calendar/actions/search-contacts/search-contacts.mjs
+++ b/components/microsoft_outlook_calendar/actions/search-contacts/search-contacts.mjs
@@ -4,7 +4,7 @@ export default {
   key: "microsoft_outlook_calendar-search-contacts",
   name: "Search Contacts",
   description: "Search for contacts by name from your saved contacts list and retrieve their email addresses. [See the documentation](https://learn.microsoft.com/en-us/graph/api/user-list-contacts)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/microsoft_outlook_calendar/actions/search-people/search-people.mjs
+++ b/components/microsoft_outlook_calendar/actions/search-people/search-people.mjs
@@ -4,7 +4,7 @@ export default {
   key: "microsoft_outlook_calendar-search-people",
   name: "Search People",
   description: "Retrieve a collection of person objects ordered by their relevance to the user, based on communication and collaboration patterns and business relationships. [See the documentation](https://learn.microsoft.com/en-us/graph/api/user-list-people)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/microsoft_outlook_calendar/actions/tentatively-accept-event/tentatively-accept-event.mjs
+++ b/components/microsoft_outlook_calendar/actions/tentatively-accept-event/tentatively-accept-event.mjs
@@ -1,3 +1,4 @@
+import { ConfigurationError } from "@pipedream/platform";
 import microsoftOutlook from "../../microsoft_outlook_calendar.app.mjs";
 
 export default {
@@ -18,9 +19,10 @@ export default {
   props: {
     microsoftOutlook,
     eventId: {
-      type: "string",
-      label: "Event ID",
-      description: "The Microsoft Graph event ID. Use **List Events** or **Get Event** to retrieve this value — it is the `id` field on an event object.",
+      propDefinition: [
+        microsoftOutlook,
+        "eventId",
+      ],
     },
     comment: {
       propDefinition: [
@@ -52,7 +54,11 @@ export default {
     };
 
     if (this.proposedNewTime) {
-      data.proposedNewTime = JSON.parse(this.proposedNewTime);
+      try {
+        data.proposedNewTime = JSON.parse(this.proposedNewTime);
+      } catch (err) {
+        throw new ConfigurationError(`Invalid JSON for proposedNewTime: ${err.message}`);
+      }
     }
 
     await this.microsoftOutlook.tentativelyAcceptCalendarEvent({

--- a/components/microsoft_outlook_calendar/actions/tentatively-accept-event/tentatively-accept-event.mjs
+++ b/components/microsoft_outlook_calendar/actions/tentatively-accept-event/tentatively-accept-event.mjs
@@ -1,0 +1,71 @@
+import microsoftOutlook from "../../microsoft_outlook_calendar.app.mjs";
+
+export default {
+  key: "microsoft_outlook_calendar-tentatively-accept-event",
+  name: "Tentatively Accept Event",
+  description:
+    "Tentatively accept a calendar event invitation and optionally propose an alternate time."
+    + " Use **List Events** or **Get Event** to find the event ID."
+    + " To propose a new time, pass `proposedNewTime` as a JSON string with `start` and `end` objects (each with `dateTime` in ISO 8601 format and `timeZone` as a Windows timezone name, e.g. `\"Pacific Standard Time\"`). Alternate-time proposals are only valid when the event has `allowNewTimeProposals: true` and `sendResponse` is `true`."
+    + " [See the documentation](https://learn.microsoft.com/en-us/graph/api/event-tentativelyaccept?view=graph-rest-1.0&tabs=http)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    microsoftOutlook,
+    eventId: {
+      type: "string",
+      label: "Event ID",
+      description: "The Microsoft Graph event ID. Use **List Events** or **Get Event** to retrieve this value — it is the `id` field on an event object.",
+    },
+    comment: {
+      propDefinition: [
+        microsoftOutlook,
+        "comment",
+      ],
+    },
+    sendResponse: {
+      propDefinition: [
+        microsoftOutlook,
+        "sendResponse",
+      ],
+    },
+    proposedNewTime: {
+      type: "string",
+      label: "Proposed New Time",
+      description: "Optional alternate time to propose. JSON string with `start` and `end` objects, each having `dateTime` (ISO 8601) and `timeZone` (Windows timezone name). Example: `{\"start\":{\"dateTime\":\"2024-03-15T14:00:00\",\"timeZone\":\"Pacific Standard Time\"},\"end\":{\"dateTime\":\"2024-03-15T15:00:00\",\"timeZone\":\"Pacific Standard Time\"}}`. Only valid when the event allows new time proposals and `sendResponse` is `true`.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const event = await this.microsoftOutlook.getCalendarEvent({
+      eventId: this.eventId,
+    });
+
+    const data = {
+      comment: this.comment,
+      sendResponse: this.sendResponse ?? true,
+    };
+
+    if (this.proposedNewTime) {
+      data.proposedNewTime = JSON.parse(this.proposedNewTime);
+    }
+
+    await this.microsoftOutlook.tentativelyAcceptCalendarEvent({
+      eventId: this.eventId,
+      data,
+    });
+
+    const subject = event?.subject ?? this.eventId;
+    $.export("$summary", `Tentatively accepted event "${subject}"`);
+    return {
+      success: true,
+      eventId: this.eventId,
+      subject,
+    };
+  },
+};

--- a/components/microsoft_outlook_calendar/actions/update-calendar-event/update-calendar-event.mjs
+++ b/components/microsoft_outlook_calendar/actions/update-calendar-event/update-calendar-event.mjs
@@ -3,7 +3,7 @@ import microsoftOutlook from "../../microsoft_outlook_calendar.app.mjs";
 export default {
   type: "action",
   key: "microsoft_outlook_calendar-update-calendar-event",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/microsoft_outlook_calendar/actions/update-recurring-event-instance/update-recurring-event-instance.mjs
+++ b/components/microsoft_outlook_calendar/actions/update-recurring-event-instance/update-recurring-event-instance.mjs
@@ -4,7 +4,7 @@ import { ConfigurationError } from "@pipedream/platform";
 export default {
   type: "action",
   key: "microsoft_outlook_calendar-update-recurring-event-instance",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/microsoft_outlook_calendar/microsoft_outlook_calendar.app.mjs
+++ b/components/microsoft_outlook_calendar/microsoft_outlook_calendar.app.mjs
@@ -199,6 +199,19 @@ export default {
       optional: true,
       min: 1,
     },
+    comment: {
+      label: "Comment",
+      description: "An optional message to include with the RSVP response sent to the organizer.",
+      type: "string",
+      optional: true,
+    },
+    sendResponse: {
+      label: "Send Response to Organizer",
+      description: "Whether to send an email response to the organizer (default `true`).",
+      type: "boolean",
+      optional: true,
+      default: true,
+    },
   },
   methods: {
     client() {
@@ -298,6 +311,24 @@ export default {
         request = request.header("Prefer", `outlook.timezone="${timeZone}"`);
       }
       return await request.post(data);
+    },
+    async acceptCalendarEvent({
+      eventId, data = {},
+    } = {}) {
+      return await this.client().api(`/me/events/${eventId}/accept`)
+        .post(data);
+    },
+    async declineCalendarEvent({
+      eventId, data = {},
+    } = {}) {
+      return await this.client().api(`/me/events/${eventId}/decline`)
+        .post(data);
+    },
+    async tentativelyAcceptCalendarEvent({
+      eventId, data = {},
+    } = {}) {
+      return await this.client().api(`/me/events/${eventId}/tentativelyAccept`)
+        .post(data);
     },
   },
 };

--- a/components/microsoft_outlook_calendar/package.json
+++ b/components/microsoft_outlook_calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/microsoft_outlook_calendar",
-  "version": "8.3.1",
+  "version": "8.4.0",
   "description": "Pipedream Microsoft Outlook Calendar Components",
   "main": "microsoft_outlook_calendar.app.mjs",
   "keywords": [

--- a/components/microsoft_outlook_calendar/package.json
+++ b/components/microsoft_outlook_calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/microsoft_outlook_calendar",
-  "version": "8.3.0",
+  "version": "8.3.1",
   "description": "Pipedream Microsoft Outlook Calendar Components",
   "main": "microsoft_outlook_calendar.app.mjs",
   "keywords": [

--- a/components/microsoft_outlook_calendar/sources/new-calendar-event/new-calendar-event.mjs
+++ b/components/microsoft_outlook_calendar/sources/new-calendar-event/new-calendar-event.mjs
@@ -5,7 +5,7 @@ export default {
   key: "microsoft_outlook_calendar-new-calendar-event",
   name: "New Calendar Event (Instant)",
   description: "Emit new event when a new Calendar event is created",
-  version: "0.0.15",
+  version: "0.0.16",
   type: "source",
   hooks: {
     ...common.hooks,

--- a/components/microsoft_outlook_calendar/sources/new-upcoming-event-polling/new-upcoming-event-polling.mjs
+++ b/components/microsoft_outlook_calendar/sources/new-upcoming-event-polling/new-upcoming-event-polling.mjs
@@ -5,7 +5,7 @@ export default {
   key: "microsoft_outlook_calendar-new-upcoming-event-polling",
   name: "New Upcoming Calendar Event (Polling)",
   description: "Emit new event based on a time interval before an upcoming calendar event. [See the documentation](https://docs.microsoft.com/en-us/graph/api/user-list-events)",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/microsoft_outlook_calendar/sources/new-upcoming-event/new-upcoming-event.mjs
+++ b/components/microsoft_outlook_calendar/sources/new-upcoming-event/new-upcoming-event.mjs
@@ -6,7 +6,7 @@ export default {
   key: "microsoft_outlook_calendar-new-upcoming-event",
   name: "New Upcoming Calendar Event",
   description: "Emit new event when a Calendar event is upcoming, this source is using `reminderMinutesBeforeStart` property of the event to determine the time it should emit.",
-  version: "0.0.11",
+  version: "0.0.12",
   type: "source",
   props: {
     ...common.props,

--- a/components/microsoft_outlook_calendar/sources/updated-calendar-event/updated-calendar-event.mjs
+++ b/components/microsoft_outlook_calendar/sources/updated-calendar-event/updated-calendar-event.mjs
@@ -5,7 +5,7 @@ export default {
   key: "microsoft_outlook_calendar-updated-calendar-event",
   name: "New Calendar Event Update (Instant)",
   description: "Emit new event when a Calendar event is updated",
-  version: "0.0.15",
+  version: "0.0.16",
   type: "source",
   hooks: {
     ...common.hooks,


### PR DESCRIPTION
Resolves #21022 

Add accept-event, decline-event, and tentatively-accept-event actions for responding to calendar event invitations via Microsoft Graph API.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Accept, decline, or tentatively accept calendar event invitations
  * Add comments when responding to event invitations
  * Option to control whether a response is sent to meeting organizers

* **Chores**
  * Minor version updates across calendar actions and sources; overall package version bumped
<!-- end of auto-generated comment: release notes by coderabbit.ai -->