### PR TITLE
Google Calendar - add respond-to-event action (#21023)

### DIFF
--- a/components/google_calendar/actions/add-attendees-to-event/add-attendees-to-event.mjs
+++ b/components/google_calendar/actions/add-attendees-to-event/add-attendees-to-event.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_calendar-add-attendees-to-event",
   name: "Add Attendees To Event",
   description: "Add attendees to an existing event. [See the documentation](https://googleapis.dev/nodejs/googleapis/latest/calendar/classes/Resource$Events.html#update)",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_calendar/actions/create-event/create-event.mjs
+++ b/components/google_calendar/actions/create-event/create-event.mjs
@@ -7,7 +7,7 @@ export default {
   key: "google_calendar-create-event",
   name: "Create Event",
   description: "Create an event in a Google Calendar. [See the documentation](https://developers.google.com/calendar/api/v3/reference/events/insert)",
-  version: "1.0.3",
+  version: "1.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_calendar/actions/delete-event/delete-event.mjs
+++ b/components/google_calendar/actions/delete-event/delete-event.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_calendar-delete-event",
   name: "Delete an Event",
   description: "Delete an event from a Google Calendar. [See the documentation](https://googleapis.dev/nodejs/googleapis/latest/calendar/classes/Resource$Events.html#delete)",
-  version: "0.1.11",
+  version: "0.1.12",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_calendar/actions/get-calendar/get-calendar.mjs
+++ b/components/google_calendar/actions/get-calendar/get-calendar.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_calendar-get-calendar",
   name: "Retrieve Calendar Details",
   description: "Retrieve calendar details of a Google Calendar. [See the documentation](https://googleapis.dev/nodejs/googleapis/latest/calendar/classes/Resource$Calendars.html#get)",
-  version: "0.1.12",
+  version: "0.1.13",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_calendar/actions/get-current-user/get-current-user.mjs
+++ b/components/google_calendar/actions/get-current-user/get-current-user.mjs
@@ -7,7 +7,7 @@ export default {
   key: "google_calendar-get-current-user",
   name: "Get Current User",
   description: "Retrieve information about the authenticated Google Calendar account, including the primary calendar (summary, timezone, ACL flags), a list of accessible calendars, user-level settings (timezone, locale, week start), and the color palette that controls events and calendars. Ideal for confirming which calendar account is in use, customizing downstream scheduling, or equipping LLMs with the user’s context (timezones, available calendars) prior to creating or updating events. [See the documentation](https://developers.google.com/calendar/api/v3/reference/calendars/get).",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/google_calendar/actions/get-date-time/get-date-time.mjs
+++ b/components/google_calendar/actions/get-date-time/get-date-time.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_calendar-get-date-time",
   name: "Get Date Time",
   description: "Get current date and time for use in Google Calendar actions. Useful for agents that need datetime awareness and timezone context before calling other Google Calendar tools.",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/google_calendar/actions/get-event/get-event.mjs
+++ b/components/google_calendar/actions/get-event/get-event.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_calendar-get-event",
   name: "Retrieve Event Details",
   description: "Retrieve event details from Google Calendar. [See the documentation](https://googleapis.dev/nodejs/googleapis/latest/calendar/classes/Resource$Events.html#get)",
-  version: "0.1.12",
+  version: "0.1.13",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_calendar/actions/list-calendars/list-calendars.mjs
+++ b/components/google_calendar/actions/list-calendars/list-calendars.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_calendar-list-calendars",
   name: "List Calendars",
   description: "Retrieve a list of calendars from Google Calendar. [See the documentation](https://googleapis.dev/nodejs/googleapis/latest/calendar/classes/Resource$Calendarlist.html#list)",
-  version: "0.1.12",
+  version: "0.1.13",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_calendar/actions/list-color-id-options/list-color-id-options.mjs
+++ b/components/google_calendar/actions/list-color-id-options/list-color-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_calendar-list-color-id-options",
   name: "List Color ID Options",
   description: "Retrieves available options for the Color ID field.",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/google_calendar/actions/list-event-instances/list-event-instances.mjs
+++ b/components/google_calendar/actions/list-event-instances/list-event-instances.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_calendar-list-event-instances",
   name: "List Event Instances",
   description: "Retrieve instances of a recurring event. [See the documentation](https://developers.google.com/calendar/api/v3/reference/events/instances)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/google_calendar/actions/list-events/list-events.mjs
+++ b/components/google_calendar/actions/list-events/list-events.mjs
@@ -6,7 +6,7 @@ export default {
   key: "google_calendar-list-events",
   name: "List Events",
   description: "Retrieve a list of event from the Google Calendar. [See the documentation](https://developers.google.com/calendar/api/v3/reference/events/list)",
-  version: "0.0.15",
+  version: "0.0.16",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_calendar/actions/query-free-busy-calendars/query-free-busy-calendars.mjs
+++ b/components/google_calendar/actions/query-free-busy-calendars/query-free-busy-calendars.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_calendar-query-free-busy-calendars",
   name: "Retrieve Free/Busy Calendar Details",
   description: "Retrieve free/busy calendar details from Google Calendar. [See the documentation](https://googleapis.dev/nodejs/googleapis/latest/calendar/classes/Resource$Freebusy.html#query)",
-  version: "0.2.2",
+  version: "0.2.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_calendar/actions/quick-add-event/quick-add-event.mjs
+++ b/components/google_calendar/actions/quick-add-event/quick-add-event.mjs
@@ -6,7 +6,7 @@ export default {
   key: "google_calendar-quick-add-event",
   name: "Add Quick Event",
   description: "Create a quick event to the Google Calendar. [See the documentation](https://googleapis.dev/nodejs/googleapis/latest/calendar/classes/Resource$Events.html#quickAdd)",
-  version: "0.1.13",
+  version: "0.1.14",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_calendar/actions/respond-to-event/respond-to-event.mjs
+++ b/components/google_calendar/actions/respond-to-event/respond-to-event.mjs
@@ -1,0 +1,141 @@
+import { ConfigurationError } from "@pipedream/platform";
+import app from "../../google_calendar.app.mjs";
+
+export default {
+  key: "google_calendar-respond-to-event",
+  name: "Respond to Event Invitation",
+  description: "Accept, decline, or tentatively accept a Google Calendar event invitation on behalf of the authenticated user. Use this when you need to RSVP to an event. You can identify the event by its exact `eventId` or by `eventName` (searches upcoming events by title). If both are provided, `eventId` takes precedence. The `calendarId` defaults to `primary` (the user's main calendar). [See the documentation](https://developers.google.com/calendar/api/v3/reference/events/patch)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    app,
+    calendarId: {
+      propDefinition: [
+        app,
+        "calendarId",
+      ],
+    },
+    eventId: {
+      type: "string",
+      label: "Event ID",
+      description: "The ID of the event to respond to. Use this when you have the exact event ID. If you only have the event title, use `eventName` instead.",
+      optional: true,
+    },
+    eventName: {
+      type: "string",
+      label: "Event Name",
+      description: "The title (summary) of the event to respond to. Used to search for the event when you don't have the event ID. A case-insensitive search is performed and the first matching upcoming event is used.",
+      optional: true,
+    },
+    responseStatus: {
+      type: "string",
+      label: "Response Status",
+      description: "Your RSVP response to the event invitation.",
+      options: [
+        {
+          label: "Accept",
+          value: "accepted",
+        },
+        {
+          label: "Decline",
+          value: "declined",
+        },
+        {
+          label: "Tentatively Accept",
+          value: "tentative",
+        },
+      ],
+    },
+    sendUpdates: {
+      propDefinition: [
+        app,
+        "sendUpdates",
+      ],
+      default: "all",
+      description: "Whether to send notification emails to the organizer and other attendees. Defaults to `all` (notify everyone).",
+    },
+  },
+  async run({ $ }) {
+    const calendarId = this.calendarId || "primary";
+
+    // Get the current user's email from the primary calendar
+    const primaryCalendar = await this.app.getCalendar({
+      calendarId: "primary",
+    });
+    const userEmail = primaryCalendar.id;
+
+    // Resolve event: use provided ID (GET the full event) or search by name
+    let event;
+    let resolvedEventId = this.eventId;
+    if (resolvedEventId) {
+      event = await this.app.getEvent({
+        calendarId,
+        eventId: resolvedEventId,
+      });
+    } else {
+      if (!this.eventName) {
+        throw new ConfigurationError("Either `eventId` or `eventName` must be provided.");
+      }
+      const searchResults = await this.app.listEvents({
+        calendarId,
+        q: this.eventName,
+        singleEvents: true,
+        orderBy: "startTime",
+        timeMin: new Date().toISOString(),
+        maxResults: 10,
+      });
+      event = (searchResults.items || []).find(
+        (item) => item.summary?.toLowerCase().includes(this.eventName.toLowerCase()),
+      );
+      if (!event) {
+        throw new Error(`No upcoming event found matching "${this.eventName}".`);
+      }
+      resolvedEventId = event.id;
+    }
+
+    // Build updated attendees list — update existing entry or add user if not present
+    const existingAttendees = event.attendees || [];
+    const userEmailLower = userEmail.toLowerCase();
+    const userIsAttendee = existingAttendees.some((a) => a.email?.toLowerCase() === userEmailLower);
+    const attendees = userIsAttendee
+      ? existingAttendees.map((attendee) =>
+        attendee.email?.toLowerCase() === userEmailLower
+          ? {
+            ...attendee,
+            responseStatus: this.responseStatus,
+          }
+          : attendee)
+      : [
+        ...existingAttendees,
+        {
+          email: userEmail,
+          responseStatus: this.responseStatus,
+        },
+      ];
+
+    // PATCH the event with the updated attendees
+    const response = await this.app.patchEvent({
+      calendarId,
+      eventId: resolvedEventId,
+      sendUpdates: this.sendUpdates,
+      requestBody: {
+        attendees,
+      },
+    });
+
+    const statusLabel = {
+      accepted: "accepted",
+      declined: "declined",
+      tentative: "tentatively accepted",
+    }[this.responseStatus] || this.responseStatus;
+
+    $.export("$summary", `${statusLabel} "${response.summary || resolvedEventId}"`);
+
+    return response;
+  },
+};

--- a/components/google_calendar/actions/update-event-instance/update-event-instance.mjs
+++ b/components/google_calendar/actions/update-event-instance/update-event-instance.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_calendar-update-event-instance",
   name: "Update Event Instance",
   description: "Update a specific instance of a recurring event. Changes apply only to the selected instance. [See the documentation](https://developers.google.com/calendar/api/v3/reference/events/update)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   annotations: {
     destructiveHint: true,

--- a/components/google_calendar/actions/update-event/update-event.mjs
+++ b/components/google_calendar/actions/update-event/update-event.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_calendar-update-event",
   name: "Update Event",
   description: "Update an event from Google Calendar. [See the documentation](https://googleapis.dev/nodejs/googleapis/latest/calendar/classes/Resource$Events.html#update)",
-  version: "0.0.16",
+  version: "0.0.17",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_calendar/actions/update-following-instances/update-following-instances.mjs
+++ b/components/google_calendar/actions/update-following-instances/update-following-instances.mjs
@@ -6,7 +6,7 @@ export default {
   key: "google_calendar-update-following-instances",
   name: "Update Following Event Instances",
   description: "Update all instances of a recurring event following a specific instance. This creates a new recurring event starting from the selected instance. [See the documentation](https://developers.google.com/calendar/api/guides/recurringevents#modifying_all_following_instances)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   annotations: {
     destructiveHint: true,

--- a/components/google_calendar/google_calendar.app.mjs
+++ b/components/google_calendar/google_calendar.app.mjs
@@ -486,6 +486,13 @@ export default {
         args,
       });
     },
+    async patchEvent(args = {}) {
+      return this.requestHandler({
+        api: constants.API.EVENTS.NAME,
+        method: constants.API.EVENTS.METHOD.PATCH,
+        args,
+      });
+    },
     async deleteEvent(args = {}) {
       return this.requestHandler({
         api: constants.API.EVENTS.NAME,

--- a/components/google_calendar/package.json
+++ b/components/google_calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_calendar",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Pipedream Google_calendar Components",
   "main": "google_calendar.app.mjs",
   "keywords": [

--- a/components/google_calendar/sources/event-cancelled/event-cancelled.mjs
+++ b/components/google_calendar/sources/event-cancelled/event-cancelled.mjs
@@ -6,7 +6,7 @@ export default {
   key: "google_calendar-event-cancelled",
   name: "New Cancelled Event",
   description: "Emit new event when a Google Calendar event is cancelled or deleted",
-  version: "0.1.15",
+  version: "0.1.16",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_calendar/sources/event-ended/event-ended.mjs
+++ b/components/google_calendar/sources/event-ended/event-ended.mjs
@@ -6,7 +6,7 @@ export default {
   key: "google_calendar-event-ended",
   name: "New Ended Event",
   description: "Emit new event when a Google Calendar event ends",
-  version: "0.1.15",
+  version: "0.1.16",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_calendar/sources/new-calendar/new-calendar.mjs
+++ b/components/google_calendar/sources/new-calendar/new-calendar.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_calendar-new-calendar",
   name: "New Calendar Created",
   description: "Emit new event when a calendar is created.",
-  version: "0.1.15",
+  version: "0.1.16",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_calendar/sources/new-event-search/new-event-search.mjs
+++ b/components/google_calendar/sources/new-event-search/new-event-search.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_calendar-new-event-search",
   name: "New Event Matching a Search",
   description: "Emit new event when a Google Calendar event is created that matches a search",
-  version: "0.1.15",
+  version: "0.1.16",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_calendar/sources/new-or-updated-event-instant/new-or-updated-event-instant.mjs
+++ b/components/google_calendar/sources/new-or-updated-event-instant/new-or-updated-event-instant.mjs
@@ -8,7 +8,7 @@ export default {
   type: "source",
   name: "New Created or Updated Event (Instant)",
   description: "Emit new event when a Google Calendar events is created or updated (does not emit cancelled events)",
-  version: "0.1.19",
+  version: "0.1.20",
   dedupe: "unique",
   props: {
     googleCalendar,

--- a/components/google_calendar/sources/upcoming-event-alert-polling/upcoming-event-alert-polling.mjs
+++ b/components/google_calendar/sources/upcoming-event-alert-polling/upcoming-event-alert-polling.mjs
@@ -6,7 +6,7 @@ export default {
   key: "google_calendar-upcoming-event-alert-polling",
   name: "New Upcoming Event Alert (Polling)",
   description: "Emit new event based on a time interval before an upcoming event in the calendar. [See the documentation](https://developers.google.com/calendar/api/v3/reference/events/list)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_calendar/sources/upcoming-event-alert/upcoming-event-alert.mjs
+++ b/components/google_calendar/sources/upcoming-event-alert/upcoming-event-alert.mjs
@@ -6,7 +6,7 @@ export default {
   key: "google_calendar-upcoming-event-alert",
   name: "New Upcoming Event Alert",
   description: "Emit new event based on a time interval before an upcoming event in the calendar.",
-  version: "0.1.4",
+  version: "0.1.5",
   type: "source",
   props: {
     googleCalendar,


### PR DESCRIPTION
Resolves #21023 

Adds `google_calendar-respond-to-event` — an AI-optimized action for accepting, declining, or tentatively accepting calendar event invitations.

Uses a read-modify-write pattern (GET event → update attendee responseStatus → PATCH event). Accepts either an event ID or event title (searches internally via listEvents?q=). Also adds `patchEvent()` method to the app file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Respond to Google Calendar invitations (accept/decline/tentative) with lookup by event ID or name; updates attendee response and can send update notifications.
* **Chores**
  * Bumped versions across Google Calendar actions and sources, published a minor package release, and added an app method to support event patching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->