### PR TITLE
feat: add Returnista tracking update delivered instant source (#21035)

### DIFF
--- a/components/returnista/package.json
+++ b/components/returnista/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/returnista",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Returnista Components",
   "main": "returnista.app.mjs",
   "keywords": [

--- a/components/returnista/package.json
+++ b/components/returnista/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/returnista",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Pipedream Returnista Components",
   "main": "returnista.app.mjs",
   "keywords": [

--- a/components/returnista/sources/tracking-update-delivered-instant/test-event.mjs
+++ b/components/returnista/sources/tracking-update-delivered-instant/test-event.mjs
@@ -1,0 +1,64 @@
+export default {
+  "event": "shipment.received_tracking_updates.delivered",
+  "data": {
+    "id": "123e4567-e89b-12d3-a456-426614174000",
+    "storeId": "123e4567-e89b-12d3-a456-426614174000",
+    "accountId": "123e4567-e89b-12d3-a456-426614174000",
+    "returnOrderId": "123e4567-e89b-12d3-a456-426614174000",
+    "shippingProductId": "123e4567-e89b-12d3-a456-426614174000",
+    "shippingOptionId": "123e4567-e89b-12d3-a456-426614174000",
+    "status": "New",
+    "reason": "CreatedByConsumer",
+    "receiver": {
+      "id": "123e4567-e89b-12d3-a456-426614174000",
+      "name": "string",
+      "companyName": "string",
+      "attention": "string",
+      "contactName": "string",
+      "phoneNumber": "string",
+      "address": {
+        "street": "string",
+        "houseNumber": "string",
+        "suffix": "string",
+        "city": "string",
+        "postalCode": "string",
+        "countryCode": "AF",
+        "stateProvinceCode": "string"
+      }
+    },
+    "sender": {
+      "firstName": "string",
+      "lastName": "string",
+      "street": "string",
+      "houseNumber": "string",
+      "city": "string",
+      "postalCode": "string",
+      "countryCode": "string"
+    },
+    "labelUrl": "string",
+    "labelBarcode": "string",
+    "trackingUrl": "string",
+    "trackingNumber": "string",
+    "trackingUpdates": [
+      {
+        "status": "Delivered",
+        "explanation": "string",
+        "happenedAt": "0020-02-29T00:00Z",
+        "createdAt": "0020-02-29T00:00Z"
+      }
+    ],
+    "errorCode": "string",
+    "errorMessage": "string",
+    "createdAt": "0020-02-29T00:00Z",
+    "updatedAt": "0020-02-29T00:00Z",
+    "shippingProduct": {
+      "id": "123e4567-e89b-12d3-a456-426614174000",
+      "name": "string",
+      "productCode": "string",
+      "logoUrl": "string",
+      "shippingMethod": "CARRIER_INTEGRATION",
+      "labelType": "REQUIRED",
+      "key": "string"
+    }
+  }
+}

--- a/components/returnista/sources/tracking-update-delivered-instant/test-event.mjs
+++ b/components/returnista/sources/tracking-update-delivered-instant/test-event.mjs
@@ -1,64 +1,88 @@
 export default {
   "event": "shipment.received_tracking_updates.delivered",
   "data": {
-    "id": "123e4567-e89b-12d3-a456-426614174000",
-    "storeId": "123e4567-e89b-12d3-a456-426614174000",
-    "accountId": "123e4567-e89b-12d3-a456-426614174000",
-    "returnOrderId": "123e4567-e89b-12d3-a456-426614174000",
-    "shippingProductId": "123e4567-e89b-12d3-a456-426614174000",
-    "shippingOptionId": "123e4567-e89b-12d3-a456-426614174000",
-    "status": "New",
+    "id": "123e4567-12d3-a456-426614174000",
+    "returnOrderId": "123e4567-12d3-a456-426614174001",
+    "shippingOptionId": "123e4567-12d3-a456-426614174002",
+    "shippingProductId": "123e4567-12d3-a456-426614174003",
+    "status": "Delivered",
     "reason": "CreatedByConsumer",
     "receiver": {
-      "id": "123e4567-e89b-12d3-a456-426614174000",
-      "name": "string",
-      "companyName": "string",
-      "attention": "string",
-      "contactName": "string",
-      "phoneNumber": "string",
+      "id": "123e4567-12d3-a456-426614174004",
+      "name": "Example Warehouse",
+      "companyName": "Example Logistics",
+      "attention": "Returns Department",
+      "contactName": "",
       "address": {
-        "street": "string",
-        "houseNumber": "string",
-        "suffix": "string",
-        "city": "string",
-        "postalCode": "string",
-        "countryCode": "AF",
-        "stateProvinceCode": "string"
+        "city": "Amsterdam",
+        "countryCode": "NL",
+        "houseNumber": "1",
+        "postalCode": "1012 AB",
+        "stateProvinceCode": "",
+        "street": "Voorbeeldstraat",
+        "suffix": ""
       }
     },
     "sender": {
-      "firstName": "string",
-      "lastName": "string",
-      "street": "string",
-      "houseNumber": "string",
-      "city": "string",
-      "postalCode": "string",
-      "countryCode": "string"
+      "city": "Utrecht",
+      "countryCode": "NL",
+      "houseNumber": "2",
+      "postalCode": "3511 AB",
+      "street": "Voorbeeldlaan"
     },
-    "labelUrl": "string",
-    "labelBarcode": "string",
-    "trackingUrl": "string",
-    "trackingNumber": "string",
+    "labelBarcode": "01012AB00000000000000000000",
+    "labelUrl": "https://assets.returnista-integrations.com/labels/123e4567-12d3-a456-426614174005.pdf",
+    "trackingUrl": "https://www.dpdgroup.com/nl/mydpd/my-parcels/sending?parcelNumber=00000000000000",
+    "trackingNumber": "00000000000000",
+    "createdAt": "2026-06-04T07:48:14.686Z",
+    "updatedAt": "2026-06-05T09:03:36.907Z",
     "trackingUpdates": [
       {
-        "status": "Delivered",
-        "explanation": "string",
-        "happenedAt": "0020-02-29T00:00Z",
-        "createdAt": "0020-02-29T00:00Z"
+        "createdAt": "2026-06-04T07:48:14.686Z",
+        "explanation": "Shipment created",
+        "happenedAt": "2026-06-04T07:48:14.686Z",
+        "status": "New"
+      },
+      {
+        "createdAt": "2026-06-04T20:13:24.139Z",
+        "explanation": "dpd_has_received_your_parcel",
+        "happenedAt": "2026-06-04T12:46:30.000Z",
+        "status": "Collected"
+      },
+      {
+        "createdAt": "2026-06-04T20:13:24.139Z",
+        "explanation": "the_parcel_is_at_the_parcel_dispatch_centre",
+        "happenedAt": "2026-06-04T14:38:26.000Z",
+        "status": "Transit"
+      },
+      {
+        "createdAt": "2026-06-05T02:38:31.142Z",
+        "explanation": "at_parcel_delivery_centre",
+        "happenedAt": "2026-06-05T02:32:32.000Z",
+        "status": "In_depot"
+      },
+      {
+        "createdAt": "2026-06-05T09:03:36.906Z",
+        "explanation": "the_parcel_has_left_the_parcel_delivery_centre_and_is_on_its_way_to_the_consignee",
+        "happenedAt": "2026-06-05T07:42:48.000Z",
+        "status": "Out_delivery"
+      },
+      {
+        "createdAt": "2026-06-05T09:03:36.906Z",
+        "explanation": "your_parcel_has_been_delivered_successfully",
+        "happenedAt": "2026-06-05T08:45:30.000Z",
+        "status": "Delivered"
       }
     ],
-    "errorCode": "string",
-    "errorMessage": "string",
-    "createdAt": "0020-02-29T00:00Z",
-    "updatedAt": "0020-02-29T00:00Z",
     "shippingProduct": {
-      "id": "123e4567-e89b-12d3-a456-426614174000",
-      "name": "string",
-      "productCode": "string",
-      "logoUrl": "string",
+      "id": "123e4567-12d3-a456-426614174003",
+      "name": "DPD",
+      "logoUrl": "https://storage-repay.fra1.digitaloceanspaces.com/courier_service_logos/dpd.svg",
       "shippingMethod": "CARRIER_INTEGRATION",
       "labelType": "REQUIRED",
-      "key": "string"
-    }
+      "key": "dpd"
+    },
+    "storeId": "123e4567-12d3-a456-426614174006",
+    "accountId": "123e4567-12d3-a456-426614174007"
   }
-}
+};

--- a/components/returnista/sources/tracking-update-delivered-instant/tracking-update-delivered-instant.mjs
+++ b/components/returnista/sources/tracking-update-delivered-instant/tracking-update-delivered-instant.mjs
@@ -5,7 +5,7 @@ import { createHash } from "crypto";
 export default {
   ...common,
   key: "returnista-tracking-update-delivered-instant",
-  name: "Tracking Update Delivered (Instant)",
+  name: "New Tracking Update Delivered (Instant)",
   description: "Emit new event when a tracking update is received and the shipment status changes to delivered. [See the documentation](https://platform.returnista.com/reference/webhooks/)",
   version: "0.0.1",
   type: "source",
@@ -17,11 +17,19 @@ export default {
     },
     generateMeta({ data }) {
       const deliveredUpdate = data.trackingUpdates?.find((update) => update.status === "Delivered");
-      const ts = Date.parse(deliveredUpdate?.happenedAt || deliveredUpdate?.createdAt || data.happenedAt || data.createdAt || data.updatedAt);
+      const ts = Date.parse(
+        deliveredUpdate?.happenedAt ||
+        deliveredUpdate?.createdAt ||
+        data.happenedAt ||
+        data.createdAt ||
+        data.updatedAt,
+      );
       const rawId = `${data.id}-${ts}`;
       const id = rawId.length <= 64
         ? rawId
-        : createHash("sha256").update(rawId).digest("hex").slice(0, 64);
+        : createHash("sha256").update(rawId)
+          .digest("hex")
+          .slice(0, 64);
       return {
         id,
         summary: `Tracking Update Delivered: ${data.id}`,

--- a/components/returnista/sources/tracking-update-delivered-instant/tracking-update-delivered-instant.mjs
+++ b/components/returnista/sources/tracking-update-delivered-instant/tracking-update-delivered-instant.mjs
@@ -1,0 +1,27 @@
+import common from "../common/base.mjs";
+import sampleEmit from "./test-event.mjs";
+
+export default {
+  ...common,
+  key: "returnista-tracking-update-delivered-instant",
+  name: "Tracking Update Delivered (Instant)",
+  description: "Emit new event when a tracking update is received and the shipment status changes to delivered. [See the documentation](https://platform.returnista.com/reference/webhooks/)",
+  version: "0.0.1",
+  type: "source",
+  dedupe: "unique",
+  methods: {
+    ...common.methods,
+    getEvent() {
+      return "shipment.received_tracking_updates.delivered";
+    },
+    generateMeta({ data }) {
+      const ts = Date.parse(data.updatedAt);
+      return {
+        id: `${data.id}-${ts}`,
+        summary: `Tracking Update Delivered: ${data.id}`,
+        ts,
+      };
+    },
+  },
+  sampleEmit,
+};

--- a/components/returnista/sources/tracking-update-delivered-instant/tracking-update-delivered-instant.mjs
+++ b/components/returnista/sources/tracking-update-delivered-instant/tracking-update-delivered-instant.mjs
@@ -1,5 +1,6 @@
 import common from "../common/base.mjs";
 import sampleEmit from "./test-event.mjs";
+import { createHash } from "crypto";
 
 export default {
   ...common,
@@ -15,9 +16,14 @@ export default {
       return "shipment.received_tracking_updates.delivered";
     },
     generateMeta({ data }) {
-      const ts = Date.parse(data.updatedAt);
+      const deliveredUpdate = data.trackingUpdates?.find((update) => update.status === "Delivered");
+      const ts = Date.parse(deliveredUpdate?.happenedAt || deliveredUpdate?.createdAt || data.happenedAt || data.createdAt || data.updatedAt);
+      const rawId = `${data.id}-${ts}`;
+      const id = rawId.length <= 64
+        ? rawId
+        : createHash("sha256").update(rawId).digest("hex").slice(0, 64);
       return {
-        id: `${data.id}-${ts}`,
+        id,
         summary: `Tracking Update Delivered: ${data.id}`,
         ts,
       };

--- a/components/returnista/sources/tracking-update-delivered-instant/tracking-update-delivered-instant.mjs
+++ b/components/returnista/sources/tracking-update-delivered-instant/tracking-update-delivered-instant.mjs
@@ -1,6 +1,5 @@
 import common from "../common/base.mjs";
 import sampleEmit from "./test-event.mjs";
-import { createHash } from "crypto";
 
 export default {
   ...common,
@@ -16,22 +15,12 @@ export default {
       return "shipment.received_tracking_updates.delivered";
     },
     generateMeta({ data }) {
-      const deliveredUpdate = data.trackingUpdates?.find((update) => update.status === "Delivered");
-      const ts = Date.parse(
-        deliveredUpdate?.happenedAt ||
-        deliveredUpdate?.createdAt ||
-        data.happenedAt ||
-        data.createdAt ||
-        data.updatedAt,
-      );
-      const rawId = `${data.id}-${ts}`;
-      const id = rawId.length <= 64
-        ? rawId
-        : createHash("sha256").update(rawId)
-          .digest("hex")
-          .slice(0, 64);
+      const deliveredUpdate = data.trackingUpdates?.findLast(({ status }) => status === "Delivered");
+      const ts = Date.parse(deliveredUpdate?.happenedAt
+        || deliveredUpdate?.createdAt
+        || data.createdAt);
       return {
-        id,
+        id: `${data.id}-${ts}`,
         summary: `Tracking Update Delivered: ${data.id}`,
         ts,
       };


### PR DESCRIPTION
## Summary

This PR implements the missing event source for the Returnista integration to resolve the final requested trigger in issue #21035:

* **New Trigger**: **Tracking Update Delivered (Instant)**
  * **Event**: `shipment.received_tracking_updates.delivered`
  * **Behavior**: Fires when any tracking update is received for a shipment associated with a return order and its status transitions to `delivered`.
  * **Implementation**: Extends the shared Returnista webhook base component (`components/returnista/sources/common/base.mjs`) to leverage standard webhook activation/deactivation hooks and event handling logic.
  * **Docs**: Refers to the [Returnista Webhook API Docs](https://platform.returnista.com/reference/webhooks/).

### File Changes
* **New**: `components/returnista/sources/tracking-update-delivered-instant/tracking-update-delivered-instant.mjs`
* **New**: `components/returnista/sources/tracking-update-delivered-instant/test-event.mjs`

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Emit a deterministic "shipment delivered" tracking event with stable metadata (ID includes event timestamp, concise summary).
* **Tests**
  * Added a sample delivered-tracking event payload for validation and QA.
* **Chores**
  * Bumped component package version (0.1.0 → 0.2.0).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->