### PR TITLE
Microsoft Outlook Calendar - add deleted calendar event trigger

### DIFF
--- a/components/microsoft_outlook/package.json
+++ b/components/microsoft_outlook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/microsoft_outlook",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Pipedream Microsoft Outlook Components",
   "main": "microsoft_outlook.app.mjs",
   "keywords": [

--- a/components/microsoft_outlook/sources/common/common.mjs
+++ b/components/microsoft_outlook/sources/common/common.mjs
@@ -67,6 +67,7 @@ export default {
     },
     async deactivate() {
       const hookId = this.db.get("hookId");
+      if (!hookId) return;
       await this.microsoftOutlook.deleteHook({
         hookId,
       });

--- a/components/microsoft_outlook/sources/new-attachment-received/new-attachment-received.mjs
+++ b/components/microsoft_outlook/sources/new-attachment-received/new-attachment-received.mjs
@@ -6,7 +6,7 @@ export default {
   key: "microsoft_outlook-new-attachment-received",
   name: "New Attachment Received (Instant)",
   description: "Emit new event when a new email containing one or more attachments arrives in a specified Microsoft Outlook folder.",
-  version: "0.1.13",
+  version: "0.1.14",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/microsoft_outlook/sources/new-contact/new-contact.mjs
+++ b/components/microsoft_outlook/sources/new-contact/new-contact.mjs
@@ -5,7 +5,7 @@ export default {
   key: "microsoft_outlook-new-contact",
   name: "New Contact Event (Instant)",
   description: "Emit new event when a new Contact is created",
-  version: "0.0.29",
+  version: "0.0.30",
   type: "source",
   hooks: {
     ...common.hooks,

--- a/components/microsoft_outlook/sources/new-email/new-email.mjs
+++ b/components/microsoft_outlook/sources/new-email/new-email.mjs
@@ -7,7 +7,7 @@ export default {
   key: "microsoft_outlook-new-email",
   name: "New Email Event (Instant)",
   description: "Emit new event when an email is received in specified folders.",
-  version: "0.1.15",
+  version: "0.1.16",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/microsoft_outlook_calendar/package.json
+++ b/components/microsoft_outlook_calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/microsoft_outlook_calendar",
-  "version": "8.4.0",
+  "version": "8.5.0",
   "description": "Pipedream Microsoft Outlook Calendar Components",
   "main": "microsoft_outlook_calendar.app.mjs",
   "keywords": [

--- a/components/microsoft_outlook_calendar/sources/deleted-calendar-event/deleted-calendar-event.mjs
+++ b/components/microsoft_outlook_calendar/sources/deleted-calendar-event/deleted-calendar-event.mjs
@@ -1,0 +1,75 @@
+import common from "../common/common.mjs";
+
+export default {
+  ...common,
+  key: "microsoft_outlook_calendar-deleted-calendar-event",
+  name: "Calendar Event Deleted (Instant)",
+  description: "Emit new event when a Calendar event is deleted",
+  version: "0.0.1",
+  type: "source",
+  hooks: {
+    ...common.hooks,
+    async activate() {
+      await this.activate({
+        changeType: "deleted",
+        resource: "/me/events",
+      });
+    },
+    async deactivate() {
+      await this.deactivate();
+    },
+  },
+  methods: {
+    ...common.methods,
+    async getSampleEvents() {
+      return {
+        value: [],
+      };
+    },
+    emitEvent(notification) {
+      const eventId = notification.resourceData?.id;
+      const ts = Date.now();
+      this.$emit({
+        eventId,
+        changeType: notification.changeType,
+        subscriptionId: notification.subscriptionId,
+        tenantId: notification.tenantId,
+        notificationTimestamp: new Date(ts).toISOString(),
+      }, {
+        id: eventId || `deleted-${ts}`,
+        summary: `Calendar event deleted (ID:${eventId})`,
+        ts,
+      });
+    },
+  },
+  async run(event) {
+    if (event.interval_seconds || event.cron) {
+      await this.microsoftOutlook.renewHook({
+        hookId: this.db.get("hookId"),
+        data: {
+          expirationDateTime: this.getIntervalEnd(),
+        },
+      });
+      return;
+    }
+    if (event.query && event.query.validationToken) {
+      this.http.respond({
+        status: 200,
+        headers: {
+          "Content-Type": "text/plain",
+        },
+        body: event.query.validationToken,
+      });
+    } else {
+      this.http.respond({
+        status: 202,
+      });
+      const eventBody = JSON.parse(event.bodyRaw);
+      for (const notification of eventBody.value) {
+        if (!notification.clientState || notification.clientState === this.db.get("clientState")) {
+          this.emitEvent(notification);
+        }
+      }
+    }
+  },
+};

--- a/components/microsoft_outlook_calendar/sources/deleted-calendar-event/deleted-calendar-event.mjs
+++ b/components/microsoft_outlook_calendar/sources/deleted-calendar-event/deleted-calendar-event.mjs
@@ -1,10 +1,36 @@
+import { createHash } from "crypto";
 import common from "../common/common.mjs";
+
+function makeStableId(notification) {
+  const rawId = notification.resourceData?.id;
+  if (rawId) {
+    return rawId.length <= 64
+      ? rawId
+      : `del-${createHash("sha256").update(rawId)
+        .digest("hex")
+        .slice(0, 16)}`;
+  }
+  const key = `${notification.subscriptionId ?? ""}:${notification.resource ?? ""}`;
+  return `deleted-${createHash("sha256").update(key)
+    .digest("hex")
+    .slice(0, 16)}`;
+}
+
+function notificationTs(notification) {
+  const raw =
+    notification.resourceData?.lastModifiedDateTime ||
+    notification.resourceData?.createdDateTime ||
+    notification.subscriptionExpirationDateTime;
+  return raw
+    ? Date.parse(raw)
+    : Date.now();
+}
 
 export default {
   ...common,
   key: "microsoft_outlook_calendar-deleted-calendar-event",
   name: "Calendar Event Deleted (Instant)",
-  description: "Emit new event when a Calendar event is deleted",
+  description: "Emit new event when a Microsoft Outlook Calendar event is deleted. Use this trigger to react in real time to calendar event deletions. Emits a payload with the deleted event identifier, change type, subscription ID, tenant ID, and notification timestamp. [See the documentation](https://learn.microsoft.com/en-us/graph/api/resources/changenotification?view=graph-rest-1.0)",
   version: "0.0.1",
   type: "source",
   hooks: {
@@ -28,7 +54,8 @@ export default {
     },
     emitEvent(notification) {
       const eventId = notification.resourceData?.id;
-      const ts = Date.now();
+      const id = makeStableId(notification);
+      const ts = notificationTs(notification);
       this.$emit({
         eventId,
         changeType: notification.changeType,
@@ -36,8 +63,8 @@ export default {
         tenantId: notification.tenantId,
         notificationTimestamp: new Date(ts).toISOString(),
       }, {
-        id: eventId || `deleted-${ts}`,
-        summary: `Calendar event deleted (ID:${eventId})`,
+        id,
+        summary: `Calendar event deleted (ID:${eventId ?? id})`,
         ts,
       });
     },

--- a/components/microsoft_outlook_calendar/sources/deleted-calendar-event/deleted-calendar-event.mjs
+++ b/components/microsoft_outlook_calendar/sources/deleted-calendar-event/deleted-calendar-event.mjs
@@ -19,8 +19,7 @@ function makeStableId(notification) {
 function notificationTs(notification) {
   const raw =
     notification.resourceData?.lastModifiedDateTime ||
-    notification.resourceData?.createdDateTime ||
-    notification.subscriptionExpirationDateTime;
+    notification.resourceData?.createdDateTime;
   return raw
     ? Date.parse(raw)
     : Date.now();
@@ -30,15 +29,27 @@ export default {
   ...common,
   key: "microsoft_outlook_calendar-deleted-calendar-event",
   name: "Calendar Event Deleted (Instant)",
-  description: "Emit new event when a Microsoft Outlook Calendar event is deleted. Use this trigger to react in real time to calendar event deletions. Emits a payload with the deleted event identifier, change type, subscription ID, tenant ID, and notification timestamp. [See the documentation](https://learn.microsoft.com/en-us/graph/api/resources/changenotification?view=graph-rest-1.0)",
+  props: {
+    ...common.props,
+    userId: {
+      type: "string",
+      label: "User ID",
+      description: "Optional user ID or principal name for delegated/admin scenarios. When provided, subscribes to `/users/{userId}/events` instead of `/me/events`.",
+      optional: true,
+    },
+  },
+  description: "Emit new event when a Microsoft Outlook Calendar event is deleted. Because deleted events cannot be re-fetched from the Outlook API after deletion, this trigger emits notification metadata only (not the full event object). The emitted payload includes the deleted event identifier (`eventId`), `changeType`, `subscriptionId`, `tenantId`, and `notificationTimestamp`. Downstream processors must rely solely on this metadata. [See the documentation](https://learn.microsoft.com/en-us/graph/api/resources/changenotification?view=graph-rest-1.0)",
   version: "0.0.1",
   type: "source",
   hooks: {
     ...common.hooks,
     async activate() {
+      const resource = this.userId
+        ? `/users/${this.userId}/events`
+        : "/me/events";
       await this.activate({
         changeType: "deleted",
-        resource: "/me/events",
+        resource,
       });
     },
     async deactivate() {


### PR DESCRIPTION
Resolves #21054 

Adds a new instant source that emits when a Calendar event is deleted. Emits notification metadata (eventId, changeType, subscriptionId, tenantId, notificationTimestamp) since deleted events cannot be fetched after deletion.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects deleted events in Microsoft Outlook calendar integration, enabling workflows to trigger on event deletions.
* **Bug Fixes**
  * Prevents errors during calendar hook deactivation when a stored hook identifier is missing.
* **Chores**
  * Bumped Microsoft Outlook Calendar component version (v8.4.0 → v8.5.0) and Microsoft Outlook package (v1.13.0 → v1.13.1); minor version bumps for several Outlook sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->