### PR TITLE
Deel - 24 AI-optimized MCP actions for IC, EOR, and GP contracts

### DIFF
--- a/components/deel/actions/amend-eor-contract/amend-eor-contract.mjs
+++ b/components/deel/actions/amend-eor-contract/amend-eor-contract.mjs
@@ -9,7 +9,7 @@ export default {
     + " All amendment fields are optional; provide only the fields you want to change."
     + " `effective_date` and `start_date` must be in ISO 8601 format (e.g., `2026-09-01`)."
     + " Use **List Contracts** to find the contract ID."
-    + " [See the documentation](https://developer.deel.com/docs/amend-an-eor-contract)",
+    + " [See the documentation](https://developer.deel.com/api/reference/endpoints/eor-amendments/create-contract-amendment)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/deel/actions/amend-eor-contract/amend-eor-contract.mjs
+++ b/components/deel/actions/amend-eor-contract/amend-eor-contract.mjs
@@ -92,14 +92,7 @@ export default {
     if (this.noticePeriod !== undefined) payload.notice_period = this.noticePeriod;
     if (this.workHoursPerWeek) payload.work_hours_per_week = parseFloat(this.workHoursPerWeek);
 
-    const response = await this.app._makeRequest({
-      $,
-      path: `/contracts/${this.contractId}/amendments`,
-      method: "POST",
-      data: {
-        data: payload,
-      },
-    });
+    const response = await this.app.amendContract($, this.contractId, payload);
 
     $.export("$summary", `Amended EOR contract ${this.contractId} effective ${this.effectiveDate}`);
     return response;

--- a/components/deel/actions/amend-eor-contract/amend-eor-contract.mjs
+++ b/components/deel/actions/amend-eor-contract/amend-eor-contract.mjs
@@ -1,0 +1,107 @@
+import app from "../../deel.app.mjs";
+
+export default {
+  key: "deel-amend-eor-contract",
+  name: "Amend EOR Contract",
+  description:
+    "Create a new amendment for an EOR (employer of record) Deel contract — change salary, currency,"
+    + " job title, employment type, work hours, holidays, or notice period."
+    + " All amendment fields are optional; provide only the fields you want to change."
+    + " `effective_date` and `start_date` must be in ISO 8601 format (e.g., `2026-09-01`)."
+    + " Use **List Contracts** to find the contract ID."
+    + " [See the documentation](https://developer.deel.com/docs/amend-an-eor-contract)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    app,
+    contractId: {
+      propDefinition: [
+        app,
+        "contractId",
+      ],
+    },
+    effectiveDate: {
+      type: "string",
+      label: "Effective Date",
+      description: "Date when the amendment takes effect, in ISO 8601 format (e.g., `2026-09-01`).",
+    },
+    salary: {
+      type: "string",
+      label: "New Salary",
+      description: "New annual salary amount (e.g., `85000`).",
+      optional: true,
+    },
+    currency: {
+      type: "string",
+      label: "Currency",
+      description: "ISO 4217 currency code for the new salary (e.g., `EUR`, `USD`).",
+      optional: true,
+    },
+    jobTitle: {
+      type: "string",
+      label: "Job Title",
+      description: "New job title for the employee.",
+      optional: true,
+    },
+    employmentType: {
+      type: "string",
+      label: "Employment Type",
+      description: "New employment type (e.g., `full_time`, `part_time`).",
+      optional: true,
+    },
+    startDate: {
+      type: "string",
+      label: "Start Date",
+      description: "New employment start date in ISO 8601 format.",
+      optional: true,
+    },
+    holidays: {
+      type: "integer",
+      label: "Holidays (Days)",
+      description: "New number of annual holiday days.",
+      optional: true,
+    },
+    noticePeriod: {
+      type: "integer",
+      label: "Notice Period (Days)",
+      description: "New notice period in days.",
+      optional: true,
+    },
+    workHoursPerWeek: {
+      type: "string",
+      label: "Work Hours Per Week",
+      description: "New weekly work hours (e.g., `40`).",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const payload = {
+      effective_date: this.effectiveDate,
+    };
+    if (this.salary) payload.salary = parseFloat(this.salary);
+    if (this.currency) payload.currency = this.currency;
+    if (this.jobTitle) payload.job_title = this.jobTitle;
+    if (this.employmentType) payload.employment_type = this.employmentType;
+    if (this.startDate) payload.start_date = this.startDate;
+    if (this.holidays !== undefined) payload.holidays = this.holidays;
+    if (this.noticePeriod !== undefined) payload.notice_period = this.noticePeriod;
+    if (this.workHoursPerWeek) payload.work_hours_per_week = parseFloat(this.workHoursPerWeek);
+
+    const response = await this.app._makeRequest({
+      $,
+      path: `/contracts/${this.contractId}/amendments`,
+      method: "POST",
+      data: {
+        data: payload,
+      },
+    });
+
+    $.export("$summary", `Amended EOR contract ${this.contractId} effective ${this.effectiveDate}`);
+    return response;
+  },
+};

--- a/components/deel/actions/amend-ic-contract/amend-ic-contract.mjs
+++ b/components/deel/actions/amend-ic-contract/amend-ic-contract.mjs
@@ -72,7 +72,11 @@ export default {
     const payload = {
       effective_date: this.effectiveDate,
     };
-    if (this.amount) payload.amount = parseFloat(this.amount);
+    if (this.amount) {
+      const amt = parseFloat(this.amount);
+      if (!Number.isFinite(amt)) throw new Error(`Invalid amount: "${this.amount}" is not a finite number`);
+      payload.amount = amt;
+    }
     if (this.currencyCode) payload.currency_code = this.currencyCode;
     if (this.scale) payload.scale = this.scale;
     if (this.frequency) payload.frequency = this.frequency;

--- a/components/deel/actions/amend-ic-contract/amend-ic-contract.mjs
+++ b/components/deel/actions/amend-ic-contract/amend-ic-contract.mjs
@@ -83,14 +83,7 @@ export default {
     if (this.jobTitleName) payload.job_title_name = this.jobTitleName;
     if (this.scopeOfWork) payload.scope_of_work = this.scopeOfWork;
 
-    const response = await this.app._makeRequest({
-      $,
-      path: `/contracts/${this.contractId}/amendments`,
-      method: "POST",
-      data: {
-        data: payload,
-      },
-    });
+    const response = await this.app.amendContract($, this.contractId, payload);
 
     $.export("$summary", `Amended IC contract ${this.contractId} effective ${this.effectiveDate}`);
     return response;

--- a/components/deel/actions/amend-ic-contract/amend-ic-contract.mjs
+++ b/components/deel/actions/amend-ic-contract/amend-ic-contract.mjs
@@ -10,7 +10,7 @@ export default {
     + " `effective_date` is required — use today's date or earlier (ISO 8601 format, e.g., `2026-06-01`)."
     + " The amendment takes effect immediately but is recorded with the given date."
     + " Use **List Contracts** to find the contract ID."
-    + " [See the documentation](https://developer.deel.com/docs/amend-a-contract)",
+    + " [See the documentation](https://developer.deel.com/api/reference/endpoints/eor-amendments/create-contract-amendment)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/deel/actions/amend-ic-contract/amend-ic-contract.mjs
+++ b/components/deel/actions/amend-ic-contract/amend-ic-contract.mjs
@@ -1,0 +1,94 @@
+import app from "../../deel.app.mjs";
+
+export default {
+  key: "deel-amend-ic-contract",
+  name: "Amend IC Contract",
+  description:
+    "Update an independent contractor (IC) contract in Deel — change the rate, currency, payment scale,"
+    + " frequency, job title, or scope of work."
+    + " All amendment fields are optional; provide only the fields you want to change."
+    + " `effective_date` is required — use today's date or earlier (ISO 8601 format, e.g., `2026-06-01`)."
+    + " The amendment takes effect immediately but is recorded with the given date."
+    + " Use **List Contracts** to find the contract ID."
+    + " [See the documentation](https://developer.deel.com/docs/amend-a-contract)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    app,
+    contractId: {
+      propDefinition: [
+        app,
+        "contractId",
+      ],
+    },
+    effectiveDate: {
+      type: "string",
+      label: "Effective Date",
+      description: "Date when the amendment takes effect, in ISO 8601 format (e.g., `2026-08-01`).",
+    },
+    amount: {
+      type: "string",
+      label: "New Amount",
+      description: "New compensation amount (e.g., `5500`).",
+      optional: true,
+    },
+    currencyCode: {
+      type: "string",
+      label: "Currency Code",
+      description: "ISO 4217 currency code for the new amount (e.g., `USD`, `EUR`).",
+      optional: true,
+    },
+    scale: {
+      type: "string",
+      label: "Compensation Scale",
+      description: "New compensation scale. One of: `hour`, `day`, `week`, `month`, `year`, `task`, `milestone`.",
+      optional: true,
+    },
+    frequency: {
+      type: "string",
+      label: "Payment Frequency",
+      description: "New payment frequency. One of: `weekly`, `biweekly`, `semimonthly`, `monthly`.",
+      optional: true,
+    },
+    jobTitleName: {
+      type: "string",
+      label: "Job Title",
+      description: "New job title for the contractor.",
+      optional: true,
+    },
+    scopeOfWork: {
+      type: "string",
+      label: "Scope of Work",
+      description: "Updated description of work to be performed.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const payload = {
+      effective_date: this.effectiveDate,
+    };
+    if (this.amount) payload.amount = parseFloat(this.amount);
+    if (this.currencyCode) payload.currency_code = this.currencyCode;
+    if (this.scale) payload.scale = this.scale;
+    if (this.frequency) payload.frequency = this.frequency;
+    if (this.jobTitleName) payload.job_title_name = this.jobTitleName;
+    if (this.scopeOfWork) payload.scope_of_work = this.scopeOfWork;
+
+    const response = await this.app._makeRequest({
+      $,
+      path: `/contracts/${this.contractId}/amendments`,
+      method: "POST",
+      data: {
+        data: payload,
+      },
+    });
+
+    $.export("$summary", `Amended IC contract ${this.contractId} effective ${this.effectiveDate}`);
+    return response;
+  },
+};

--- a/components/deel/actions/amend-ic-contract/amend-ic-contract.mjs
+++ b/components/deel/actions/amend-ic-contract/amend-ic-contract.mjs
@@ -46,7 +46,7 @@ export default {
     scale: {
       type: "string",
       label: "Compensation Scale",
-      description: "New compensation scale. One of: `hour`, `day`, `week`, `month`, `year`, `task`, `milestone`.",
+      description: "New compensation scale. One of: `hourly`, `daily`, `weekly`, `monthly`, `biweekly`, `semimonthly`, `custom`. Omit if only changing the amount.",
       optional: true,
     },
     frequency: {

--- a/components/deel/actions/create-adjustment/create-adjustment.mjs
+++ b/components/deel/actions/create-adjustment/create-adjustment.mjs
@@ -12,7 +12,7 @@ export default {
     + " `adjustment_category_id` is required — retrieve valid category IDs from `GET /adjustments/categories`"
     + " or ask your Deel administrator."
     + " Use **List Contracts** to find the contract ID."
-    + " [See the documentation](https://developer.deel.com/docs/create-an-adjustment)",
+    + " [See the documentation](https://developer.deel.com/api/reference/endpoints/adjustments/create-contract-adjustment)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/deel/actions/create-adjustment/create-adjustment.mjs
+++ b/components/deel/actions/create-adjustment/create-adjustment.mjs
@@ -44,8 +44,10 @@ export default {
       description: "The vendor or payee name (e.g., `Office Supplies Co`).",
     },
     country: {
-      type: "string",
-      label: "Country",
+      propDefinition: [
+        app,
+        "countryCode",
+      ],
       description: "ISO 3166-1 alpha-2 country code where the adjustment applies (e.g., `US`, `DE`).",
     },
     description: {

--- a/components/deel/actions/create-adjustment/create-adjustment.mjs
+++ b/components/deel/actions/create-adjustment/create-adjustment.mjs
@@ -1,0 +1,113 @@
+import { getFileStream } from "@pipedream/platform";
+import FormData from "form-data";
+import app from "../../deel.app.mjs";
+
+export default {
+  key: "deel-create-adjustment",
+  name: "Create Adjustment",
+  description:
+    "Create a payroll line-item adjustment for an EOR or GP contract in Deel (bonus, deduction, expense, etc.)."
+    + " This uses multipart/form-data and supports an optional file attachment (e.g., a receipt)."
+    + " `country` must be an ISO 3166-1 alpha-2 code (e.g., `US`, `DE`)."
+    + " `adjustment_category_id` is required — retrieve valid category IDs from `GET /adjustments/categories`"
+    + " or ask your Deel administrator."
+    + " Use **List Contracts** to find the contract ID."
+    + " [See the documentation](https://developer.deel.com/docs/create-an-adjustment)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    app,
+    contractId: {
+      propDefinition: [
+        app,
+        "contractId",
+      ],
+    },
+    title: {
+      type: "string",
+      label: "Title",
+      description: "A title/name for this adjustment (e.g., `Expense Reimbursement`).",
+    },
+    amount: {
+      type: "string",
+      label: "Amount",
+      description: "The adjustment amount (e.g., `250`).",
+    },
+    vendor: {
+      type: "string",
+      label: "Vendor",
+      description: "The vendor or payee name (e.g., `Office Supplies Co`).",
+    },
+    country: {
+      type: "string",
+      label: "Country",
+      description: "ISO 3166-1 alpha-2 country code where the adjustment applies (e.g., `US`, `DE`).",
+    },
+    description: {
+      type: "string",
+      label: "Description",
+      description: "A description of the adjustment.",
+    },
+    adjustmentCategoryId: {
+      type: "string",
+      label: "Adjustment Category ID",
+      description: "The ID of the adjustment category. Retrieve valid IDs via `GET /adjustments/categories` or ask your Deel administrator.",
+    },
+    dateOfAdjustment: {
+      type: "string",
+      label: "Date of Adjustment",
+      description: "The date of the adjustment in ISO 8601 format (e.g., `2026-07-01`).",
+      optional: true,
+    },
+    filePath: {
+      type: "string",
+      label: "File Attachment",
+      description: "Optional file attachment (e.g., receipt). Provide a file URL or a path in the /tmp directory (e.g., `/tmp/receipt.pdf`).",
+      format: "file-ref",
+      optional: true,
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "read",
+      sync: true,
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const form = new FormData();
+    form.append("contract_id", this.contractId);
+    form.append("title", this.title);
+    form.append("amount", this.amount);
+    form.append("vendor", this.vendor);
+    form.append("country", this.country);
+    form.append("description", this.description);
+    form.append("adjustment_category_id", this.adjustmentCategoryId);
+    if (this.dateOfAdjustment) form.append("date_of_adjustment", this.dateOfAdjustment);
+
+    if (this.filePath) {
+      const fileStream = await getFileStream(this.filePath);
+      const filename = this.filePath.split("/").pop() || "attachment";
+      form.append("file", fileStream, {
+        filename,
+      });
+    }
+
+    const response = await this.app._makeRequest({
+      $,
+      path: "/adjustments",
+      method: "POST",
+      data: form,
+      headers: form.getHeaders(),
+    });
+
+    const adj = response?.data ?? response;
+    const adjId = adj?.id ?? "unknown";
+    $.export("$summary", `Created adjustment ${adjId}: ${this.title} (${this.amount}) for contract ${this.contractId}`);
+    return response;
+  },
+};

--- a/components/deel/actions/create-adjustment/create-adjustment.mjs
+++ b/components/deel/actions/create-adjustment/create-adjustment.mjs
@@ -99,13 +99,7 @@ export default {
       });
     }
 
-    const response = await this.app._makeRequest({
-      $,
-      path: "/adjustments",
-      method: "POST",
-      data: form,
-      headers: form.getHeaders(),
-    });
+    const response = await this.app.createAdjustment($, form);
 
     const adj = response?.data ?? response;
     const adjId = adj?.id ?? "unknown";

--- a/components/deel/actions/create-contract-task/create-contract-task.mjs
+++ b/components/deel/actions/create-contract-task/create-contract-task.mjs
@@ -58,14 +58,7 @@ export default {
     };
     if (this.isAutoApproved !== undefined) payload.is_auto_approved = this.isAutoApproved;
 
-    const response = await this.app._makeRequest({
-      $,
-      path: `/contracts/${this.contractId}/tasks`,
-      method: "POST",
-      data: {
-        data: payload,
-      },
-    });
+    const response = await this.app.createContractTask($, this.contractId, payload);
 
     const task = response?.data ?? response;
     const taskId = task?.id ?? "unknown";

--- a/components/deel/actions/create-contract-task/create-contract-task.mjs
+++ b/components/deel/actions/create-contract-task/create-contract-task.mjs
@@ -10,7 +10,7 @@ export default {
     + " Set `is_auto_approved` to `true` to automatically approve the task without manual review;"
     + " otherwise the task will require review via **Review Contract Task**."
     + " Use **List Contracts** to find the contract ID."
-    + " [See the documentation](https://developer.deel.com/docs/create-a-task)",
+    + " [See the documentation](https://developer.deel.com/api/reference/endpoints/tasks/create-contract-task)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/deel/actions/create-contract-task/create-contract-task.mjs
+++ b/components/deel/actions/create-contract-task/create-contract-task.mjs
@@ -49,8 +49,10 @@ export default {
     },
   },
   async run({ $ }) {
+    const amt = parseFloat(this.amount);
+    if (!Number.isFinite(amt)) throw new Error(`Invalid amount: "${this.amount}" is not a finite number`);
     const payload = {
-      amount: String(parseFloat(this.amount)),
+      amount: String(amt),
       description: this.description,
       date_submitted: this.dateSubmitted,
     };

--- a/components/deel/actions/create-contract-task/create-contract-task.mjs
+++ b/components/deel/actions/create-contract-task/create-contract-task.mjs
@@ -1,0 +1,73 @@
+import app from "../../deel.app.mjs";
+
+export default {
+  key: "deel-create-contract-task",
+  name: "Create Contract Task",
+  description:
+    "Add a task or milestone to a Deel `payg_tasks` contractor contract. Tasks represent discrete"
+    + " deliverables with a defined amount and submission date."
+    + " The contract must be in `active` status (fully signed by both parties) to accept tasks."
+    + " Set `is_auto_approved` to `true` to automatically approve the task without manual review;"
+    + " otherwise the task will require review via **Review Contract Task**."
+    + " Use **List Contracts** to find the contract ID."
+    + " [See the documentation](https://developer.deel.com/docs/create-a-task)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    app,
+    contractId: {
+      propDefinition: [
+        app,
+        "contractId",
+      ],
+    },
+    amount: {
+      type: "string",
+      label: "Amount",
+      description: "The payment amount for this task (e.g., `1500`).",
+    },
+    description: {
+      type: "string",
+      label: "Description",
+      description: "A description of the task or deliverable (e.g., `Deliver chaos theory report`).",
+    },
+    dateSubmitted: {
+      type: "string",
+      label: "Date Submitted",
+      description: "The submission date for the task in ISO 8601 format (e.g., `2026-07-01`).",
+    },
+    isAutoApproved: {
+      type: "boolean",
+      label: "Auto-Approve",
+      description: "Set to `true` to automatically approve the task. If `false`, the task requires manual review.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const payload = {
+      amount: String(parseFloat(this.amount)),
+      description: this.description,
+      date_submitted: this.dateSubmitted,
+    };
+    if (this.isAutoApproved !== undefined) payload.is_auto_approved = this.isAutoApproved;
+
+    const response = await this.app._makeRequest({
+      $,
+      path: `/contracts/${this.contractId}/tasks`,
+      method: "POST",
+      data: {
+        data: payload,
+      },
+    });
+
+    const task = response?.data ?? response;
+    const taskId = task?.id ?? "unknown";
+    $.export("$summary", `Created task ${taskId} on contract ${this.contractId}: ${this.description}`);
+    return response;
+  },
+};

--- a/components/deel/actions/create-eor-contract/create-eor-contract.mjs
+++ b/components/deel/actions/create-eor-contract/create-eor-contract.mjs
@@ -14,7 +14,7 @@ export default {
     + " `seniority_id` is a numeric seniority level: `1`=Junior, `2`=Mid, `3`=Senior, `4`=Lead,"
     + " `5`=Principal/Staff, `6`=Director, `7`=Head of Dept, `8`=VP, `9`=SVP, `34`=Not applicable."
     + " `scope_of_work` must be at least 100 characters long."
-    + " [See the documentation](https://developer.deel.com/docs/create-an-eor-contract)",
+    + " [See the documentation](https://developer.deel.com/api/reference/endpoints/eor-contract/create-eor-contract)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/deel/actions/create-eor-contract/create-eor-contract.mjs
+++ b/components/deel/actions/create-eor-contract/create-eor-contract.mjs
@@ -1,3 +1,4 @@
+import { ConfigurationError } from "@pipedream/platform";
 import app from "../../deel.app.mjs";
 
 export default {
@@ -24,14 +25,16 @@ export default {
   props: {
     app,
     clientTeamId: {
-      type: "string",
-      label: "Client Team ID",
-      description: "The ID of the client team (department) for this contract. Retrieve from your Deel organization settings.",
+      propDefinition: [
+        app,
+        "clientTeamId",
+      ],
     },
     clientLegalEntityId: {
-      type: "string",
-      label: "Client Legal Entity ID",
-      description: "The ID of the client legal entity (company). Retrieve from your Deel organization settings.",
+      propDefinition: [
+        app,
+        "clientLegalEntityId",
+      ],
     },
     jobTitle: {
       type: "string",
@@ -153,10 +156,18 @@ export default {
       };
     }
 
-    if (this.compensationSalary) {
+    const hasSalary = this.compensationSalary != null && this.compensationSalary !== "";
+    const hasHourly = this.compensationHourlyRate != null && this.compensationHourlyRate !== "";
+    if (hasSalary && hasHourly) {
+      throw new ConfigurationError("Provide either Annual Salary or Hourly Rate, not both.");
+    }
+    if (!hasSalary && !hasHourly) {
+      throw new ConfigurationError("Provide either Annual Salary or Hourly Rate.");
+    }
+    if (hasSalary) {
       payload.compensation_details.salary = parseFloat(this.compensationSalary);
     }
-    if (this.compensationHourlyRate) {
+    if (hasHourly) {
       payload.compensation_details.hourly_rate = parseFloat(this.compensationHourlyRate);
     }
 

--- a/components/deel/actions/create-eor-contract/create-eor-contract.mjs
+++ b/components/deel/actions/create-eor-contract/create-eor-contract.mjs
@@ -165,10 +165,14 @@ export default {
       throw new ConfigurationError("Provide either Annual Salary or Hourly Rate.");
     }
     if (hasSalary) {
-      payload.compensation_details.salary = parseFloat(this.compensationSalary);
+      const salary = parseFloat(this.compensationSalary);
+      if (!Number.isFinite(salary)) throw new Error(`Invalid compensationSalary: "${this.compensationSalary}" is not a finite number`);
+      payload.compensation_details.salary = salary;
     }
     if (hasHourly) {
-      payload.compensation_details.hourly_rate = parseFloat(this.compensationHourlyRate);
+      const hourlyRate = parseFloat(this.compensationHourlyRate);
+      if (!Number.isFinite(hourlyRate)) throw new Error(`Invalid compensationHourlyRate: "${this.compensationHourlyRate}" is not a finite number`);
+      payload.compensation_details.hourly_rate = hourlyRate;
     }
 
     const response = await this.app._makeRequest({

--- a/components/deel/actions/create-eor-contract/create-eor-contract.mjs
+++ b/components/deel/actions/create-eor-contract/create-eor-contract.mjs
@@ -166,12 +166,12 @@ export default {
     }
     if (hasSalary) {
       const salary = parseFloat(this.compensationSalary);
-      if (!Number.isFinite(salary)) throw new Error(`Invalid compensationSalary: "${this.compensationSalary}" is not a finite number`);
+      if (!Number.isFinite(salary)) throw new ConfigurationError(`Invalid Annual Salary: "${this.compensationSalary}" is not a finite number`);
       payload.compensation_details.salary = salary;
     }
     if (hasHourly) {
       const hourlyRate = parseFloat(this.compensationHourlyRate);
-      if (!Number.isFinite(hourlyRate)) throw new Error(`Invalid compensationHourlyRate: "${this.compensationHourlyRate}" is not a finite number`);
+      if (!Number.isFinite(hourlyRate)) throw new ConfigurationError(`Invalid Hourly Rate: "${this.compensationHourlyRate}" is not a finite number`);
       payload.compensation_details.hourly_rate = hourlyRate;
     }
 

--- a/components/deel/actions/create-eor-contract/create-eor-contract.mjs
+++ b/components/deel/actions/create-eor-contract/create-eor-contract.mjs
@@ -1,0 +1,177 @@
+import app from "../../deel.app.mjs";
+
+export default {
+  key: "deel-create-eor-contract",
+  name: "Create EOR Contract",
+  description:
+    "Create an EOR (employer of record) contract quote in Deel to hire a full-time employee in a"
+    + " country where your company doesn't have a legal entity."
+    + " Use **Get EOR Hiring Guide** first to understand mandatory fields and compliance requirements"
+    + " for the target country."
+    + " `employee_nationality` and `employment_country` must be ISO 3166-1 alpha-2 codes (e.g., `DE`, `US`)."
+    + " `employment_type` must be one of: `Full-time`, `Part-time`."
+    + " `seniority_id` is a numeric seniority level: `1`=Junior, `2`=Mid, `3`=Senior, `4`=Lead,"
+    + " `5`=Principal/Staff, `6`=Director, `7`=Head of Dept, `8`=VP, `9`=SVP, `34`=Not applicable."
+    + " `scope_of_work` must be at least 100 characters long."
+    + " [See the documentation](https://developer.deel.com/docs/create-an-eor-contract)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    app,
+    clientTeamId: {
+      type: "string",
+      label: "Client Team ID",
+      description: "The ID of the client team (department) for this contract. Retrieve from your Deel organization settings.",
+    },
+    clientLegalEntityId: {
+      type: "string",
+      label: "Client Legal Entity ID",
+      description: "The ID of the client legal entity (company). Retrieve from your Deel organization settings.",
+    },
+    jobTitle: {
+      type: "string",
+      label: "Job Title",
+      description: "The employee's job title (e.g., `Paleobotanist`, `Software Engineer`).",
+    },
+    seniorityId: {
+      type: "integer",
+      label: "Seniority ID",
+      description: "Numeric seniority level: `1`=Junior, `2`=Mid, `3`=Senior, `4`=Lead, `5`=Principal/Staff, `6`=Director, `7`=Head of Dept, `8`=VP, `9`=SVP, `34`=Not applicable.",
+      optional: true,
+    },
+    employeeFirstName: {
+      type: "string",
+      label: "Employee First Name",
+      description: "The employee's first (given) name.",
+    },
+    employeeLastName: {
+      type: "string",
+      label: "Employee Last Name",
+      description: "The employee's last (family) name.",
+    },
+    employeeEmail: {
+      type: "string",
+      label: "Employee Email",
+      description: "The employee's personal email address.",
+    },
+    employeeNationality: {
+      type: "string",
+      label: "Employee Nationality",
+      description: "ISO 3166-1 alpha-2 country code of the employee's nationality (e.g., `DE`, `US`).",
+    },
+    employmentCountry: {
+      type: "string",
+      label: "Employment Country",
+      description: "ISO 3166-1 alpha-2 country code where the employee will work (e.g., `DE`, `US`).",
+    },
+    employmentType: {
+      type: "string",
+      label: "Employment Type",
+      description: "One of: `Full-time`, `Part-time`.",
+      optional: true,
+    },
+    startDate: {
+      type: "string",
+      label: "Start Date",
+      description: "The employment start date in ISO 8601 format (e.g., `2026-09-01`).",
+    },
+    scopeOfWork: {
+      type: "string",
+      label: "Scope of Work",
+      description: "Description of the employee's role and responsibilities. Must be at least 100 characters long.",
+    },
+    workVisaRequired: {
+      type: "boolean",
+      label: "Work Visa Required",
+      description: "Set to `true` if the employee requires a work visa. Default: `false`.",
+      optional: true,
+    },
+    probationPeriodDays: {
+      type: "integer",
+      label: "Probation Period (Days)",
+      description: "Probation period in days (e.g., `0`, `30`, `90`). Required for some countries.",
+      optional: true,
+    },
+    compensationCurrency: {
+      type: "string",
+      label: "Compensation Currency",
+      description: "ISO 4217 currency code for compensation (e.g., `EUR`, `USD`).",
+    },
+    compensationSalary: {
+      type: "string",
+      label: "Annual Salary",
+      description: "Annual salary amount (e.g., `80000`). Provide this or `Hourly Rate`, not both.",
+      optional: true,
+    },
+    compensationHourlyRate: {
+      type: "string",
+      label: "Hourly Rate",
+      description: "Hourly rate amount. Provide this or `Annual Salary`, not both.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const employment = {
+      country: this.employmentCountry,
+      start_date: this.startDate,
+      scope_of_work: this.scopeOfWork,
+      work_visa_required: this.workVisaRequired ?? false,
+    };
+    if (this.employmentType) employment.type = this.employmentType;
+    employment.probation_period = this.probationPeriodDays ?? 0;
+
+    const payload = {
+      job_title: this.jobTitle,
+      client: {
+        team: {
+          id: this.clientTeamId,
+        },
+        legal_entity: {
+          id: this.clientLegalEntityId,
+        },
+      },
+      employee: {
+        first_name: this.employeeFirstName,
+        last_name: this.employeeLastName,
+        nationality: this.employeeNationality,
+        email: this.employeeEmail,
+      },
+      employment,
+      compensation_details: {
+        currency: this.compensationCurrency,
+      },
+    };
+
+    if (this.seniorityId) {
+      payload.seniority = {
+        id: this.seniorityId,
+      };
+    }
+
+    if (this.compensationSalary) {
+      payload.compensation_details.salary = parseFloat(this.compensationSalary);
+    }
+    if (this.compensationHourlyRate) {
+      payload.compensation_details.hourly_rate = parseFloat(this.compensationHourlyRate);
+    }
+
+    const response = await this.app._makeRequest({
+      $,
+      path: "/eor",
+      method: "POST",
+      data: {
+        data: payload,
+      },
+    });
+
+    const contract = response?.data ?? response;
+    const contractId = contract?.id ?? "unknown";
+    $.export("$summary", `Created EOR contract quote ${contractId} for ${this.employeeFirstName} ${this.employeeLastName} in ${this.employmentCountry}`);
+    return response;
+  },
+};

--- a/components/deel/actions/create-eor-contract/create-eor-contract.mjs
+++ b/components/deel/actions/create-eor-contract/create-eor-contract.mjs
@@ -164,25 +164,25 @@ export default {
     if (!hasSalary && !hasHourly) {
       throw new ConfigurationError("Provide either Annual Salary or Hourly Rate.");
     }
+    const NUMERIC_RE = /^\s*\d+(\.\d+)?\s*$/;
     if (hasSalary) {
+      if (!NUMERIC_RE.test(this.compensationSalary)) {
+        throw new ConfigurationError(`Invalid Annual Salary: "${this.compensationSalary}" must be a plain number (e.g., "80000" or "80000.50")`);
+      }
       const salary = parseFloat(this.compensationSalary);
       if (!Number.isFinite(salary)) throw new ConfigurationError(`Invalid Annual Salary: "${this.compensationSalary}" is not a finite number`);
       payload.compensation_details.salary = salary;
     }
     if (hasHourly) {
+      if (!NUMERIC_RE.test(this.compensationHourlyRate)) {
+        throw new ConfigurationError(`Invalid Hourly Rate: "${this.compensationHourlyRate}" must be a plain number (e.g., "45" or "45.50")`);
+      }
       const hourlyRate = parseFloat(this.compensationHourlyRate);
       if (!Number.isFinite(hourlyRate)) throw new ConfigurationError(`Invalid Hourly Rate: "${this.compensationHourlyRate}" is not a finite number`);
       payload.compensation_details.hourly_rate = hourlyRate;
     }
 
-    const response = await this.app._makeRequest({
-      $,
-      path: "/eor",
-      method: "POST",
-      data: {
-        data: payload,
-      },
-    });
+    const response = await this.app.createEorContract($, payload);
 
     const contract = response?.data ?? response;
     const contractId = contract?.id ?? "unknown";

--- a/components/deel/actions/create-gp-contract/create-gp-contract.mjs
+++ b/components/deel/actions/create-gp-contract/create-gp-contract.mjs
@@ -12,7 +12,7 @@ export default {
     + " `address_country` must be an ISO 3166-1 alpha-2 code (e.g., `US`, `DE`)."
     + " `client_team_id` and `client_legal_entity_id` are required — retrieve from your Deel organization settings."
     + " For US-based employees: `work_location_state` (2-letter state code, e.g., `OR`), `work_location_is_wfh`, and (if not WFH) `work_location_name` (office name) are required."
-    + " [See the documentation](https://developer.deel.com/api/reference)",
+    + " [See the documentation](https://developer.deel.com/api/reference/endpoints/gp-hiring/create-gp-contract)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/deel/actions/create-gp-contract/create-gp-contract.mjs
+++ b/components/deel/actions/create-gp-contract/create-gp-contract.mjs
@@ -187,14 +187,7 @@ export default {
       if (this.workLocationName) payload.work_location.name = this.workLocationName;
     }
 
-    const response = await this.app._makeRequest({
-      $,
-      path: "/contracts/gp",
-      method: "POST",
-      data: {
-        data: payload,
-      },
-    });
+    const response = await this.app.createGpContract($, payload);
 
     const contract = response?.data ?? response;
     const contractId = contract?.id ?? "unknown";

--- a/components/deel/actions/create-gp-contract/create-gp-contract.mjs
+++ b/components/deel/actions/create-gp-contract/create-gp-contract.mjs
@@ -12,7 +12,7 @@ export default {
     + " `address_country` must be an ISO 3166-1 alpha-2 code (e.g., `US`, `DE`)."
     + " `client_team_id` and `client_legal_entity_id` are required — retrieve from your Deel organization settings."
     + " For US-based employees: `work_location_state` (2-letter state code, e.g., `OR`), `work_location_is_wfh`, and (if not WFH) `work_location_name` (office name) are required."
-    + " [See the documentation](https://developer.deel.com/docs/create-a-gp-contract)",
+    + " [See the documentation](https://developer.deel.com/api/reference)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/deel/actions/create-gp-contract/create-gp-contract.mjs
+++ b/components/deel/actions/create-gp-contract/create-gp-contract.mjs
@@ -1,0 +1,194 @@
+import app from "../../deel.app.mjs";
+
+export default {
+  key: "deel-create-gp-contract",
+  name: "Create Global Payroll Contract",
+  description:
+    "Create a Global Payroll (GP) contract in Deel to add an employee to your domestic payroll system."
+    + " Use this when the employee works in a country where your company already has a legal entity."
+    + " `employment_type` must be one of: `Full-time`, `Part-time` (case-sensitive)."
+    + " `compensation_scale` must be one of: `YEAR`, `MONTH` (uppercase)."
+    + " `address_country` must be an ISO 3166-1 alpha-2 code (e.g., `US`, `DE`)."
+    + " `client_team_id` and `client_legal_entity_id` are required — retrieve from your Deel organization settings."
+    + " For US-based employees: `work_location_state` (2-letter state code, e.g., `OR`), `work_location_is_wfh`, and (if not WFH) `work_location_name` (office name) are required."
+    + " [See the documentation](https://developer.deel.com/docs/create-a-gp-contract)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    app,
+    clientTeamId: {
+      type: "string",
+      label: "Client Team ID",
+      description: "The ID of the client team (department) for this contract. Retrieve from your Deel organization settings.",
+    },
+    clientLegalEntityId: {
+      type: "string",
+      label: "Client Legal Entity ID",
+      description: "The ID of the client legal entity (company). Retrieve from your Deel organization settings.",
+    },
+    jobTitle: {
+      type: "string",
+      label: "Job Title",
+      description: "The employee's job title (e.g., `Software Engineer`).",
+    },
+    employeeFirstName: {
+      type: "string",
+      label: "Employee First Name",
+      description: "The employee's first (given) name.",
+    },
+    employeeLastName: {
+      type: "string",
+      label: "Employee Last Name",
+      description: "The employee's last (family) name.",
+    },
+    employeeEmail: {
+      type: "string",
+      label: "Employee Personal Email",
+      description: "The employee's personal email address (e.g., `jane.doe@gmail.com`).",
+    },
+    employeeWorkEmail: {
+      type: "string",
+      label: "Employee Work Email",
+      description: "The employee's work email address.",
+    },
+    addressStreet: {
+      type: "string",
+      label: "Street Address",
+      description: "The employee's street address.",
+    },
+    addressCity: {
+      type: "string",
+      label: "City",
+      description: "The employee's city.",
+    },
+    addressZip: {
+      type: "string",
+      label: "ZIP/Postal Code",
+      description: "The employee's ZIP or postal code.",
+    },
+    addressCountry: {
+      type: "string",
+      label: "Country",
+      description: "ISO 3166-1 alpha-2 country code of the employee's address (e.g., `US`, `DE`).",
+    },
+    employmentType: {
+      type: "string",
+      label: "Employment Type",
+      description: "One of: `Full-time`, `Part-time` (case-sensitive).",
+    },
+    startDate: {
+      type: "string",
+      label: "Start Date",
+      description: "The employment start date in ISO 8601 format (e.g., `2026-09-01`).",
+    },
+    holidaysAllowance: {
+      type: "integer",
+      label: "Holidays Allowance (Days)",
+      description: "Number of annual holiday days.",
+    },
+    holidaysStartDate: {
+      type: "string",
+      label: "Holidays Start Date",
+      description: "The date from which holiday allowance accrues, in ISO 8601 format.",
+    },
+    compensationSalary: {
+      type: "string",
+      label: "Salary Amount",
+      description: "The salary amount per the chosen compensation scale (e.g., `95000` for annual).",
+    },
+    compensationScale: {
+      type: "string",
+      label: "Compensation Scale",
+      description: "Pay period for the salary. One of: `YEAR`, `MONTH` (uppercase).",
+    },
+    compensationCurrency: {
+      type: "string",
+      label: "Currency",
+      description: "ISO 4217 currency code for the salary (e.g., `USD`, `EUR`).",
+    },
+    workLocationState: {
+      type: "string",
+      label: "Work Location State",
+      description: "2-letter US state code for the employee's work location (e.g., `OR`, `CA`). Required for US employees.",
+      optional: true,
+    },
+    workLocationIsWfh: {
+      type: "boolean",
+      label: "Work From Home",
+      description: "Whether the employee works from home. Set to `true` for remote employees. Required for US employees.",
+      optional: true,
+    },
+    workLocationName: {
+      type: "string",
+      label: "Work Location Name",
+      description: "Name of the office location (e.g., `Springfield HQ`). Required when `Work From Home` is `false` for US employees.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const payload = {
+      job_title: this.jobTitle,
+      client: {
+        team: {
+          id: this.clientTeamId,
+        },
+        legal_entity: {
+          id: this.clientLegalEntityId,
+        },
+      },
+      employee: {
+        first_name: this.employeeFirstName,
+        last_name: this.employeeLastName,
+        email: this.employeeEmail,
+        work_email: this.employeeWorkEmail,
+        address: {
+          street: this.addressStreet,
+          city: this.addressCity,
+          zip: this.addressZip,
+          country: this.addressCountry,
+        },
+      },
+      employment: {
+        type: this.employmentType,
+        start_date: this.startDate,
+        holidays: {
+          allowance: this.holidaysAllowance,
+          start_date: this.holidaysStartDate,
+        },
+      },
+      compensation_details: {
+        salary: parseFloat(this.compensationSalary),
+        scale: this.compensationScale,
+        currency: this.compensationCurrency,
+      },
+    };
+
+    if (this.workLocationState !== undefined || this.workLocationIsWfh !== undefined) {
+      payload.work_location = {
+        country: this.addressCountry,
+        state: this.workLocationState,
+        is_wfh: this.workLocationIsWfh ?? false,
+      };
+      if (this.workLocationName) payload.work_location.name = this.workLocationName;
+    }
+
+    const response = await this.app._makeRequest({
+      $,
+      path: "/contracts/gp",
+      method: "POST",
+      data: {
+        data: payload,
+      },
+    });
+
+    const contract = response?.data ?? response;
+    const contractId = contract?.id ?? "unknown";
+    $.export("$summary", `Created GP contract ${contractId} for ${this.employeeFirstName} ${this.employeeLastName}`);
+    return response;
+  },
+};

--- a/components/deel/actions/create-gp-contract/create-gp-contract.mjs
+++ b/components/deel/actions/create-gp-contract/create-gp-contract.mjs
@@ -1,3 +1,4 @@
+import { ConfigurationError } from "@pipedream/platform";
 import app from "../../deel.app.mjs";
 
 export default {
@@ -22,14 +23,16 @@ export default {
   props: {
     app,
     clientTeamId: {
-      type: "string",
-      label: "Client Team ID",
-      description: "The ID of the client team (department) for this contract. Retrieve from your Deel organization settings.",
+      propDefinition: [
+        app,
+        "clientTeamId",
+      ],
     },
     clientLegalEntityId: {
-      type: "string",
-      label: "Client Legal Entity ID",
-      description: "The ID of the client legal entity (company). Retrieve from your Deel organization settings.",
+      propDefinition: [
+        app,
+        "clientLegalEntityId",
+      ],
     },
     jobTitle: {
       type: "string",
@@ -168,7 +171,14 @@ export default {
       },
     };
 
-    if (this.workLocationState !== undefined || this.workLocationIsWfh !== undefined) {
+    if (this.addressCountry === "US") {
+      if (this.workLocationState == null) throw new ConfigurationError("work_location_state is required for US employees.");
+      if (this.workLocationIsWfh == null) throw new ConfigurationError("work_location_is_wfh is required for US employees.");
+      if (this.workLocationIsWfh === false && !this.workLocationName) {
+        throw new ConfigurationError("work_location_name is required for US employees when work_location_is_wfh is false.");
+      }
+    }
+    if (this.workLocationState != null || this.workLocationIsWfh != null) {
       payload.work_location = {
         country: this.addressCountry,
         state: this.workLocationState,

--- a/components/deel/actions/create-ic-contract/create-ic-contract.mjs
+++ b/components/deel/actions/create-ic-contract/create-ic-contract.mjs
@@ -12,7 +12,7 @@ export default {
     + " `compensationFrequency` must be one of: `weekly`, `biweekly`, `semimonthly`, `monthly`."
     + " `clientTeamId` and `clientLegalEntityId` are required — ask the user to provide these from"
     + " their Deel organization settings."
-    + " [See the documentation](https://developer.deel.com/docs/create-a-new-contract)",
+    + " [See the documentation](https://developer.deel.com/api/reference/endpoints/contracts/create-ic-contract)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/deel/actions/create-ic-contract/create-ic-contract.mjs
+++ b/components/deel/actions/create-ic-contract/create-ic-contract.mjs
@@ -1,0 +1,180 @@
+import app from "../../deel.app.mjs";
+
+export default {
+  key: "deel-create-ic-contract",
+  name: "Create IC Contract",
+  description:
+    "Create a new independent contractor (IC) contract in Deel. Use this to hire a contractor with"
+    + " a fixed rate, pay-as-you-go, or milestone-based arrangement."
+    + " `type` must be one of: `ongoing_time_based` (recurring fixed rate), `payg_tasks` (per-task),"
+    + " `payg_milestones` (milestones), `pay_as_you_go_time_based` (hourly/daily pay-as-you-go)."
+    + " `compensationScale` must be one of: `hourly`, `daily`, `weekly`, `monthly`, `biweekly`, `semimonthly`, `custom`."
+    + " `compensationFrequency` must be one of: `weekly`, `biweekly`, `semimonthly`, `monthly`."
+    + " `clientTeamId` and `clientLegalEntityId` are required — ask the user to provide these from"
+    + " their Deel organization settings."
+    + " [See the documentation](https://developer.deel.com/docs/create-a-new-contract)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    app,
+    title: {
+      type: "string",
+      label: "Contract Title",
+      description: "A descriptive title for this contract (e.g., `Strategy Consulting`).",
+    },
+    type: {
+      type: "string",
+      label: "Contract Type",
+      description: "Contract type. One of: `ongoing_time_based`, `payg_tasks`, `payg_milestones`, `pay_as_you_go_time_based`.",
+    },
+    startDate: {
+      type: "string",
+      label: "Start Date",
+      description: "Contract start date in ISO 8601 format (e.g., `2026-09-01`).",
+    },
+    clientTeamId: {
+      type: "string",
+      label: "Client Team ID",
+      description: "The ID of the client team (department) for this contract.",
+    },
+    clientLegalEntityId: {
+      type: "string",
+      label: "Client Legal Entity ID",
+      description: "The ID of the client legal entity (company) for this contract.",
+    },
+    jobTitle: {
+      type: "string",
+      label: "Job Title",
+      description: "The contractor's job title (e.g., `Software Engineer`, `Marketing Consultant`).",
+    },
+    compensationAmount: {
+      type: "string",
+      label: "Compensation Amount",
+      description: "The compensation amount (e.g., `4000`). Not required for `payg_tasks` contracts.",
+      optional: true,
+    },
+    compensationCurrencyCode: {
+      type: "string",
+      label: "Compensation Currency Code",
+      description: "ISO 4217 currency code (e.g., `USD`, `EUR`, `GBP`).",
+    },
+    compensationScale: {
+      type: "string",
+      label: "Compensation Scale",
+      description: "How the rate is measured. One of: `hourly`, `daily`, `weekly`, `monthly`, `biweekly`, `semimonthly`, `custom`. Not required for task-based contracts.",
+      optional: true,
+    },
+    compensationFrequency: {
+      type: "string",
+      label: "Compensation Frequency",
+      description: "How often the contractor is paid. One of: `weekly`, `biweekly`, `semimonthly`, `monthly`.",
+    },
+    cycleEnd: {
+      type: "integer",
+      label: "Cycle End Day",
+      description: "Day of month the pay cycle ends (e.g., `28`). Required by Deel.",
+    },
+    cycleEndType: {
+      type: "string",
+      label: "Cycle End Type",
+      description: "How cycle end is calculated. Use `DAY_OF_MONTH`.",
+    },
+    paymentDueDays: {
+      type: "integer",
+      label: "Payment Due Days",
+      description: "Number of days after cycle end that payment is due (e.g., `5`).",
+    },
+    paymentDueType: {
+      type: "string",
+      label: "Payment Due Type",
+      description: "How payment due date is calculated. Use `AFTER_MONTH`.",
+    },
+    workerFirstName: {
+      type: "string",
+      label: "Worker First Name",
+      description: "The contractor's first name.",
+    },
+    workerLastName: {
+      type: "string",
+      label: "Worker Last Name",
+      description: "The contractor's last name.",
+    },
+    workerEmail: {
+      type: "string",
+      label: "Worker Email",
+      description: "The contractor's email address.",
+    },
+    scopeOfWork: {
+      type: "string",
+      label: "Scope of Work",
+      description: "Description of the work to be performed.",
+      optional: true,
+    },
+    documentsRequired: {
+      type: "boolean",
+      label: "Documents Required",
+      description: "Whether additional documents are required before contract activation. Defaults to `false`.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const compensationDetails = {
+      currency_code: this.compensationCurrencyCode,
+      frequency: this.compensationFrequency,
+      cycle_end: this.cycleEnd,
+      cycle_end_type: this.cycleEndType,
+      payment_due_days: this.paymentDueDays,
+      payment_due_type: this.paymentDueType,
+    };
+    if (this.compensationAmount) {
+      compensationDetails.amount = parseFloat(this.compensationAmount);
+    }
+    if (this.compensationScale) compensationDetails.scale = this.compensationScale;
+
+    const payload = {
+      type: this.type,
+      meta: {
+        documents_required: this.documentsRequired ?? false,
+      },
+      title: this.title,
+      start_date: this.startDate,
+      job_title: {
+        name: this.jobTitle,
+      },
+      client: {
+        team: {
+          id: this.clientTeamId,
+        },
+        legal_entity: {
+          id: this.clientLegalEntityId,
+        },
+      },
+      compensation_details: compensationDetails,
+      worker: {
+        first_name: this.workerFirstName,
+        last_name: this.workerLastName,
+        expected_email: this.workerEmail,
+      },
+    };
+    if (this.scopeOfWork) payload.scope_of_work = this.scopeOfWork;
+
+    const response = await this.app._makeRequest({
+      $,
+      path: "/contracts",
+      method: "POST",
+      data: {
+        data: payload,
+      },
+    });
+
+    const contract = response?.data ?? response;
+    const contractId = contract?.id ?? "unknown";
+    $.export("$summary", `Created IC contract ${contractId}: ${this.title}`);
+    return response;
+  },
+};

--- a/components/deel/actions/create-ic-contract/create-ic-contract.mjs
+++ b/components/deel/actions/create-ic-contract/create-ic-contract.mjs
@@ -38,14 +38,16 @@ export default {
       description: "Contract start date in ISO 8601 format (e.g., `2026-09-01`).",
     },
     clientTeamId: {
-      type: "string",
-      label: "Client Team ID",
-      description: "The ID of the client team (department) for this contract.",
+      propDefinition: [
+        app,
+        "clientTeamId",
+      ],
     },
     clientLegalEntityId: {
-      type: "string",
-      label: "Client Legal Entity ID",
-      description: "The ID of the client legal entity (company) for this contract.",
+      propDefinition: [
+        app,
+        "clientLegalEntityId",
+      ],
     },
     jobTitle: {
       type: "string",

--- a/components/deel/actions/create-ic-contract/create-ic-contract.mjs
+++ b/components/deel/actions/create-ic-contract/create-ic-contract.mjs
@@ -165,14 +165,7 @@ export default {
     };
     if (this.scopeOfWork) payload.scope_of_work = this.scopeOfWork;
 
-    const response = await this.app._makeRequest({
-      $,
-      path: "/contracts",
-      method: "POST",
-      data: {
-        data: payload,
-      },
-    });
+    const response = await this.app.createIcContract($, payload);
 
     const contract = response?.data ?? response;
     const contractId = contract?.id ?? "unknown";

--- a/components/deel/actions/create-invoice-adjustment/create-invoice-adjustment.mjs
+++ b/components/deel/actions/create-invoice-adjustment/create-invoice-adjustment.mjs
@@ -65,14 +65,7 @@ export default {
     };
     if (this.isAutoApproved !== undefined) payload.is_auto_approved = this.isAutoApproved;
 
-    const response = await this.app._makeRequest({
-      $,
-      path: "/invoice-adjustments",
-      method: "POST",
-      data: {
-        data: payload,
-      },
-    });
+    const response = await this.app.createInvoiceAdjustment($, payload);
 
     const adj = response?.data ?? response;
     const adjId = adj?.id ?? "unknown";

--- a/components/deel/actions/create-invoice-adjustment/create-invoice-adjustment.mjs
+++ b/components/deel/actions/create-invoice-adjustment/create-invoice-adjustment.mjs
@@ -1,0 +1,80 @@
+import app from "../../deel.app.mjs";
+
+export default {
+  key: "deel-create-invoice-adjustment",
+  name: "Create Invoice Adjustment",
+  description:
+    "Add a bonus, deduction, commission, expense, or other financial adjustment to an IC contractor's"
+    + " Deel invoice."
+    + " `type` must be one of: `bonus`, `commission`, `deduction`, `expense`, `other`, `overtime`,"
+    + " `time_off`, `vat`."
+    + " Set `is_auto_approved` to `true` to auto-approve without manual review."
+    + " Use **List Contracts** to find the contract ID."
+    + " [See the documentation](https://developer.deel.com/docs/create-an-invoice-adjustment)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    app,
+    contractId: {
+      propDefinition: [
+        app,
+        "contractId",
+      ],
+    },
+    type: {
+      type: "string",
+      label: "Adjustment Type",
+      description: "Type of adjustment. One of: `bonus`, `commission`, `deduction`, `expense`, `other`, `overtime`, `time_off`, `vat`.",
+    },
+    amount: {
+      type: "string",
+      label: "Amount",
+      description: "The adjustment amount (e.g., `500`). Use a negative number for deductions.",
+    },
+    description: {
+      type: "string",
+      label: "Description",
+      description: "A description of the adjustment (e.g., `Q2 performance bonus`).",
+    },
+    dateSubmitted: {
+      type: "string",
+      label: "Date Submitted",
+      description: "The date of the adjustment in ISO 8601 format (e.g., `2026-07-01`).",
+    },
+    isAutoApproved: {
+      type: "boolean",
+      label: "Auto-Approve",
+      description: "Set to `true` to automatically approve the adjustment.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const payload = {
+      contract_id: this.contractId,
+      type: this.type,
+      amount: parseFloat(this.amount),
+      description: this.description,
+      date_submitted: this.dateSubmitted,
+    };
+    if (this.isAutoApproved !== undefined) payload.is_auto_approved = this.isAutoApproved;
+
+    const response = await this.app._makeRequest({
+      $,
+      path: "/invoice-adjustments",
+      method: "POST",
+      data: {
+        data: payload,
+      },
+    });
+
+    const adj = response?.data ?? response;
+    const adjId = adj?.id ?? "unknown";
+    $.export("$summary", `Created ${this.type} adjustment ${adjId} of ${this.amount} for contract ${this.contractId}`);
+    return response;
+  },
+};

--- a/components/deel/actions/create-invoice-adjustment/create-invoice-adjustment.mjs
+++ b/components/deel/actions/create-invoice-adjustment/create-invoice-adjustment.mjs
@@ -10,7 +10,7 @@ export default {
     + " `time_off`, `vat`."
     + " Set `is_auto_approved` to `true` to auto-approve without manual review."
     + " Use **List Contracts** to find the contract ID."
-    + " [See the documentation](https://developer.deel.com/docs/create-an-invoice-adjustment)",
+    + " [See the documentation](https://developer.deel.com/api/reference/endpoints/invoice-adjustments/create-invoice-adjustment)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/deel/actions/create-invoice-adjustment/create-invoice-adjustment.mjs
+++ b/components/deel/actions/create-invoice-adjustment/create-invoice-adjustment.mjs
@@ -54,10 +54,12 @@ export default {
     },
   },
   async run({ $ }) {
+    const amt = parseFloat(this.amount);
+    if (!Number.isFinite(amt)) throw new Error(`Invalid amount: "${this.amount}" is not a finite number`);
     const payload = {
       contract_id: this.contractId,
       type: this.type,
-      amount: parseFloat(this.amount),
+      amount: amt,
       description: this.description,
       date_submitted: this.dateSubmitted,
     };

--- a/components/deel/actions/create-shift-rate/create-shift-rate.mjs
+++ b/components/deel/actions/create-shift-rate/create-shift-rate.mjs
@@ -10,7 +10,7 @@ export default {
     + " creating shifts via **Create Shifts**."
     + " `type` must be one of: `MULTIPLIER_PERCENTAGE` (e.g., 150 = 1.5x pay),"
     + " `PER_HOUR_FLAT_RATE` (fixed hourly amount), `PER_UNIT_FLAT_RATE` (fixed per-unit amount)."
-    + " [See the documentation](https://developer.deel.com/docs/create-a-shift-rate)",
+    + " [See the documentation](https://developer.deel.com/api/reference/endpoints/time-tracking/create-time-tracking-shift-rate)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/deel/actions/create-shift-rate/create-shift-rate.mjs
+++ b/components/deel/actions/create-shift-rate/create-shift-rate.mjs
@@ -1,6 +1,8 @@
 import { ConfigurationError } from "@pipedream/platform";
 import app from "../../deel.app.mjs";
 
+const NUMERIC_RE = /^\s*\d+(\.\d+)?\s*$/;
+
 export default {
   key: "deel-create-shift-rate",
   name: "Create Shift Rate",
@@ -49,14 +51,14 @@ export default {
       name: this.name,
       external_id: this.externalId,
     };
-    const NUMERIC_RE = /^\s*-?\d+(\.\d+)?\s*$/;
     if (this.type) payload.type = this.type;
     let parsedValue;
     if (this.value != null && this.value !== "") {
       if (!NUMERIC_RE.test(this.value)) {
-        throw new ConfigurationError(`Invalid Value: "${this.value}" must be a plain number (e.g., "150" or "45.50")`);
+        throw new ConfigurationError(`Invalid Value: "${this.value}" must be a non-negative plain number (e.g., "150" or "45.50")`);
       }
       parsedValue = parseFloat(this.value);
+      if (parsedValue < 0) throw new ConfigurationError(`Invalid Value: "${this.value}" must be a non-negative plain number`);
       payload.value = parsedValue;
     }
 

--- a/components/deel/actions/create-shift-rate/create-shift-rate.mjs
+++ b/components/deel/actions/create-shift-rate/create-shift-rate.mjs
@@ -52,14 +52,7 @@ export default {
     if (this.value) payload.value = parseFloat(this.value);
 
     try {
-      const response = await this.app._makeRequest({
-        $,
-        path: "/time_tracking/shift_rates",
-        method: "POST",
-        data: {
-          data: payload,
-        },
-      });
+      const response = await this.app.createShiftRate($, payload);
 
       $.export("$summary", `Created shift rate: ${this.name} (external_id: ${this.externalId})`);
       return response;

--- a/components/deel/actions/create-shift-rate/create-shift-rate.mjs
+++ b/components/deel/actions/create-shift-rate/create-shift-rate.mjs
@@ -1,0 +1,86 @@
+import app from "../../deel.app.mjs";
+
+export default {
+  key: "deel-create-shift-rate",
+  name: "Create Shift Rate",
+  description:
+    "Create a named shift rate for GP (Global Payroll) time tracking in Deel."
+    + " Shift rates define how time-tracked work is compensated."
+    + " `external_id` is a unique identifier you assign (e.g., `rate-overtime-001`); use this ID when"
+    + " creating shifts via **Create Shifts**."
+    + " `type` must be one of: `MULTIPLIER_PERCENTAGE` (e.g., 150 = 1.5x pay),"
+    + " `PER_HOUR_FLAT_RATE` (fixed hourly amount), `PER_UNIT_FLAT_RATE` (fixed per-unit amount)."
+    + " [See the documentation](https://developer.deel.com/docs/create-a-shift-rate)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    app,
+    name: {
+      type: "string",
+      label: "Name",
+      description: "A human-readable name for this shift rate (e.g., `Overtime Rate`, `Holiday Rate`).",
+    },
+    externalId: {
+      type: "string",
+      label: "External ID",
+      description: "Your unique identifier for this shift rate (e.g., `rate-overtime-001`). Used when referencing this rate in shifts.",
+    },
+    type: {
+      type: "string",
+      label: "Rate Type",
+      description: "The type of rate calculation. One of: `MULTIPLIER_PERCENTAGE`, `PER_HOUR_FLAT_RATE`, `PER_UNIT_FLAT_RATE`.",
+      optional: true,
+    },
+    value: {
+      type: "string",
+      label: "Value",
+      description: "The rate value. For `MULTIPLIER_PERCENTAGE`, use a percentage (e.g., `150` for 1.5x). For flat rates, use the amount.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const payload = {
+      name: this.name,
+      external_id: this.externalId,
+    };
+    if (this.type) payload.type = this.type;
+    if (this.value) payload.value = parseFloat(this.value);
+
+    try {
+      const response = await this.app._makeRequest({
+        $,
+        path: "/time_tracking/shift_rates",
+        method: "POST",
+        data: {
+          data: payload,
+        },
+      });
+
+      $.export("$summary", `Created shift rate: ${this.name} (external_id: ${this.externalId})`);
+      return response;
+    } catch (err) {
+      // 422 means a shift rate with this external_id already exists — treat as idempotent success
+      if (err?.response?.status === 422 || err?.status === 422) {
+        const existing = {
+          data: {
+            external_id: this.externalId,
+            name: this.name,
+            type: this.type,
+            value: this.value
+              ? parseFloat(this.value)
+              : undefined,
+          },
+          note: "Shift rate with this external_id already exists.",
+        };
+        $.export("$summary", `Shift rate already exists: ${this.name} (external_id: ${this.externalId})`);
+        return existing;
+      }
+      throw err;
+    }
+  },
+};

--- a/components/deel/actions/create-shift-rate/create-shift-rate.mjs
+++ b/components/deel/actions/create-shift-rate/create-shift-rate.mjs
@@ -1,3 +1,4 @@
+import { ConfigurationError } from "@pipedream/platform";
 import app from "../../deel.app.mjs";
 
 export default {
@@ -48,8 +49,16 @@ export default {
       name: this.name,
       external_id: this.externalId,
     };
+    const NUMERIC_RE = /^\s*-?\d+(\.\d+)?\s*$/;
     if (this.type) payload.type = this.type;
-    if (this.value) payload.value = parseFloat(this.value);
+    let parsedValue;
+    if (this.value != null && this.value !== "") {
+      if (!NUMERIC_RE.test(this.value)) {
+        throw new ConfigurationError(`Invalid Value: "${this.value}" must be a plain number (e.g., "150" or "45.50")`);
+      }
+      parsedValue = parseFloat(this.value);
+      payload.value = parsedValue;
+    }
 
     try {
       const response = await this.app.createShiftRate($, payload);
@@ -64,9 +73,7 @@ export default {
             external_id: this.externalId,
             name: this.name,
             type: this.type,
-            value: this.value
-              ? parseFloat(this.value)
-              : undefined,
+            value: parsedValue,
           },
           note: "Shift rate with this external_id already exists.",
         };

--- a/components/deel/actions/create-shifts/create-shifts.mjs
+++ b/components/deel/actions/create-shifts/create-shifts.mjs
@@ -16,7 +16,7 @@ export default {
     + " \"shift_type\": \"REGULAR\", \"date_of_work\": \"2026-07-15\","
     + " \"summary\": {\"time_unit\": \"HOUR\", \"time_amount\": 8, \"shift_rate_external_id\": \"rate-overtime-001\"}}]`"
     + " Use **List Contracts** to find the contract ID."
-    + " [See the documentation](https://developer.deel.com/docs/create-shifts)",
+    + " [See the documentation](https://developer.deel.com/api/reference)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/deel/actions/create-shifts/create-shifts.mjs
+++ b/components/deel/actions/create-shifts/create-shifts.mjs
@@ -1,0 +1,58 @@
+import app from "../../deel.app.mjs";
+
+export default {
+  key: "deel-create-shifts",
+  name: "Create Shifts",
+  description:
+    "Create one or more time tracking shifts for a GP (Global Payroll) contract in Deel."
+    + " Each shift records worked time with a date, duration, and associated shift rate."
+    + " `shifts` must be a JSON array of shift objects. Each shift requires:"
+    + " `description` (string), `external_id` (your unique ID), `shift_type` (`REGULAR`,"
+    + " `CORRECTION_ABSOLUTE`, or `CORRECTION_DELTA`), `date_of_work` (ISO 8601 date),"
+    + " `summary.time_unit` (`HOUR` or `DAY`), `summary.time_amount` (number),"
+    + " `summary.shift_rate_external_id` (the external_id from **Create Shift Rate**)."
+    + " Example: `[{\"description\": \"Regular work\", \"external_id\": \"shift-001\","
+    + " \"shift_type\": \"REGULAR\", \"date_of_work\": \"2026-07-15\","
+    + " \"summary\": {\"time_unit\": \"HOUR\", \"time_amount\": 8, \"shift_rate_external_id\": \"rate-overtime-001\"}}]`"
+    + " Use **List Contracts** to find the contract ID."
+    + " [See the documentation](https://developer.deel.com/docs/create-shifts)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    app,
+    contractId: {
+      propDefinition: [
+        app,
+        "contractId",
+      ],
+    },
+    shifts: {
+      type: "string",
+      label: "Shifts",
+      description: "JSON array of shift objects. Each must include `description`, `external_id`, `shift_type` (`REGULAR`|`CORRECTION_ABSOLUTE`|`CORRECTION_DELTA`), `date_of_work`, and `summary` (with `time_unit`, `time_amount`, `shift_rate_external_id`). Example: `[{\"description\": \"Regular work\", \"external_id\": \"shift-001\", \"shift_type\": \"REGULAR\", \"date_of_work\": \"2026-07-15\", \"summary\": {\"time_unit\": \"HOUR\", \"time_amount\": 8, \"shift_rate_external_id\": \"rate-overtime-001\"}}]`",
+    },
+  },
+  async run({ $ }) {
+    const shiftsArray = JSON.parse(this.shifts);
+
+    const response = await this.app._makeRequest({
+      $,
+      path: "/time_tracking/shifts",
+      method: "POST",
+      data: {
+        data: {
+          contract_id: this.contractId,
+          shifts: shiftsArray,
+        },
+      },
+    });
+
+    $.export("$summary", `Created ${shiftsArray.length} shift(s) for contract ${this.contractId}`);
+    return response;
+  },
+};

--- a/components/deel/actions/create-shifts/create-shifts.mjs
+++ b/components/deel/actions/create-shifts/create-shifts.mjs
@@ -1,3 +1,4 @@
+import { ConfigurationError } from "@pipedream/platform";
 import app from "../../deel.app.mjs";
 
 export default {
@@ -39,6 +40,7 @@ export default {
   },
   async run({ $ }) {
     const shiftsArray = JSON.parse(this.shifts);
+    if (!Array.isArray(shiftsArray)) throw new ConfigurationError("shifts must be a JSON array");
 
     const response = await this.app._makeRequest({
       $,

--- a/components/deel/actions/create-shifts/create-shifts.mjs
+++ b/components/deel/actions/create-shifts/create-shifts.mjs
@@ -42,16 +42,9 @@ export default {
     const shiftsArray = JSON.parse(this.shifts);
     if (!Array.isArray(shiftsArray)) throw new ConfigurationError("shifts must be a JSON array");
 
-    const response = await this.app._makeRequest({
-      $,
-      path: "/time_tracking/shifts",
-      method: "POST",
-      data: {
-        data: {
-          contract_id: this.contractId,
-          shifts: shiftsArray,
-        },
-      },
+    const response = await this.app.createShifts($, {
+      contract_id: this.contractId,
+      shifts: shiftsArray,
     });
 
     $.export("$summary", `Created ${shiftsArray.length} shift(s) for contract ${this.contractId}`);

--- a/components/deel/actions/create-shifts/create-shifts.mjs
+++ b/components/deel/actions/create-shifts/create-shifts.mjs
@@ -16,7 +16,7 @@ export default {
     + " \"shift_type\": \"REGULAR\", \"date_of_work\": \"2026-07-15\","
     + " \"summary\": {\"time_unit\": \"HOUR\", \"time_amount\": 8, \"shift_rate_external_id\": \"rate-overtime-001\"}}]`"
     + " Use **List Contracts** to find the contract ID."
-    + " [See the documentation](https://developer.deel.com/api/reference)",
+    + " [See the documentation](https://developer.deel.com/api/reference/endpoints/time-tracking-shifts/create-time-tracking-shifts)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/deel/actions/get-contract-preview/get-contract-preview.mjs
+++ b/components/deel/actions/get-contract-preview/get-contract-preview.mjs
@@ -8,7 +8,7 @@ export default {
     + " Use this when the user wants to read, review, or summarize the actual contract document."
     + " Works for IC and EOR contracts."
     + " Use **List Contracts** to find contract IDs."
-    + " [See the documentation](https://developer.deel.com/docs/get-contract-preview)",
+    + " [See the documentation](https://developer.deel.com/api/reference/endpoints/contracts/get-contract)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/deel/actions/get-contract-preview/get-contract-preview.mjs
+++ b/components/deel/actions/get-contract-preview/get-contract-preview.mjs
@@ -1,0 +1,50 @@
+import app from "../../deel.app.mjs";
+
+export default {
+  key: "deel-get-contract-preview",
+  name: "Get Contract Preview",
+  description:
+    "Retrieve the full contract agreement text as HTML for a specific Deel contract."
+    + " Use this when the user wants to read, review, or summarize the actual contract document."
+    + " Works for IC and EOR contracts."
+    + " Use **List Contracts** to find contract IDs."
+    + " [See the documentation](https://developer.deel.com/docs/get-contract-preview)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    app,
+    contractId: {
+      propDefinition: [
+        app,
+        "contractId",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.app._makeRequest({
+      $,
+      path: `/contracts/${this.contractId}/preview`,
+    });
+
+    // Contract HTML can be very large — truncate to avoid token limits
+    const MAX_CHARS = 12000;
+    if (typeof response === "string" && response.length > MAX_CHARS) {
+      const truncated = response.substring(0, MAX_CHARS);
+      $.export("$summary", `Retrieved contract preview for contract ${this.contractId} (truncated to ${MAX_CHARS} chars)`);
+      return {
+        preview: truncated,
+        truncated: true,
+        original_length: response.length,
+        note: `Preview truncated from ${response.length} to ${MAX_CHARS} characters to fit context limits.`,
+      };
+    }
+
+    $.export("$summary", `Retrieved contract preview for contract ${this.contractId}`);
+    return response;
+  },
+};

--- a/components/deel/actions/get-contract-preview/get-contract-preview.mjs
+++ b/components/deel/actions/get-contract-preview/get-contract-preview.mjs
@@ -26,10 +26,7 @@ export default {
     },
   },
   async run({ $ }) {
-    const response = await this.app._makeRequest({
-      $,
-      path: `/contracts/${this.contractId}/preview`,
-    });
+    const response = await this.app.getContractPreview($, this.contractId);
 
     // Contract HTML can be very large — truncate to avoid token limits
     const MAX_CHARS = 12000;

--- a/components/deel/actions/get-contract/get-contract.mjs
+++ b/components/deel/actions/get-contract/get-contract.mjs
@@ -1,0 +1,38 @@
+import app from "../../deel.app.mjs";
+
+export default {
+  key: "deel-get-contract",
+  name: "Get Contract",
+  description:
+    "Retrieve full details for a specific Deel contract by ID, including worker info, compensation,"
+    + " status, and timeline. Works for IC, EOR, and GP contract types."
+    + " Use **List Contracts** to find contract IDs."
+    + " [See the documentation](https://developer.deel.com/docs/get-a-single-contract)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    app,
+    contractId: {
+      propDefinition: [
+        app,
+        "contractId",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.app._makeRequest({
+      $,
+      path: `/contracts/${this.contractId}`,
+    });
+
+    const contract = response?.data ?? response;
+    const title = contract?.title ?? contract?.name ?? this.contractId;
+    $.export("$summary", `Retrieved contract: ${title}`);
+    return response;
+  },
+};

--- a/components/deel/actions/get-contract/get-contract.mjs
+++ b/components/deel/actions/get-contract/get-contract.mjs
@@ -7,7 +7,7 @@ export default {
     "Retrieve full details for a specific Deel contract by ID, including worker info, compensation,"
     + " status, and timeline. Works for IC, EOR, and GP contract types."
     + " Use **List Contracts** to find contract IDs."
-    + " [See the documentation](https://developer.deel.com/docs/get-a-single-contract)",
+    + " [See the documentation](https://developer.deel.com/api/reference/endpoints/contracts/get-contract)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/deel/actions/get-contract/get-contract.mjs
+++ b/components/deel/actions/get-contract/get-contract.mjs
@@ -25,10 +25,7 @@ export default {
     },
   },
   async run({ $ }) {
-    const response = await this.app._makeRequest({
-      $,
-      path: `/contracts/${this.contractId}`,
-    });
+    const response = await this.app.getContract($, this.contractId);
 
     const contract = response?.data ?? response;
     const title = contract?.title ?? contract?.name ?? this.contractId;

--- a/components/deel/actions/get-eor-benefits/get-eor-benefits.mjs
+++ b/components/deel/actions/get-eor-benefits/get-eor-benefits.mjs
@@ -70,7 +70,10 @@ export default {
     });
 
     const benefits = response?.data ?? response ?? [];
-    $.export("$summary", `Retrieved ${Array.isArray(benefits) ? benefits.length : 0} EOR benefits in ${this.countryCode}`);
+    const count = Array.isArray(benefits)
+      ? benefits.length
+      : 0;
+    $.export("$summary", `Retrieved ${count} EOR benefits in ${this.countryCode}`);
     return response;
   },
 };

--- a/components/deel/actions/get-eor-benefits/get-eor-benefits.mjs
+++ b/components/deel/actions/get-eor-benefits/get-eor-benefits.mjs
@@ -4,10 +4,14 @@ export default {
   key: "deel-get-eor-benefits",
   name: "Get EOR Benefits",
   description:
-    "List available EOR (employer of record) benefits offered through Deel, optionally filtered by country."
-    + " Returns benefit names, types, descriptions, and country availability."
+    "List available EOR (employer of record) benefits offered through Deel for a specific country and employment context."
+    + " Returns benefit names, types, descriptions, and availability."
     + " Use this when a user asks about what benefits they can offer EOR employees in a specific country."
-    + " `country` must be an ISO 3166-1 alpha-2 code (e.g., `DE` for Germany, `US` for United States)."
+    + " `country_code` must be an ISO 3166-1 alpha-2 code (e.g., `DE`, `US`)."
+    + " `employment_type` must be one of: `Full-time`, `Part-time`."
+    + " `work_hours_per_week` is the number of hours worked per week (e.g., `40`)."
+    + " `work_visa` is `true` if the employee requires a work visa."
+    + " `team_id` and `legal_entity_id` are required — retrieve from your Deel organization settings."
     + " [See the documentation](https://developer.deel.com/docs/list-eor-benefits)",
   version: "0.0.1",
   type: "action",
@@ -18,30 +22,55 @@ export default {
   },
   props: {
     app,
-    country: {
+    countryCode: {
+      propDefinition: [
+        app,
+        "countryCode",
+      ],
+      description: "ISO 3166-1 alpha-2 country code to filter benefits by (e.g., `DE`, `US`, `GB`).",
+    },
+    employmentType: {
       type: "string",
-      label: "Country",
-      description: "Filter benefits by country. ISO 3166-1 alpha-2 code (e.g., `DE`, `US`, `GB`). Omit to list all countries.",
-      optional: true,
+      label: "Employment Type",
+      description: "One of: `Full-time`, `Part-time`.",
+    },
+    workHoursPerWeek: {
+      type: "integer",
+      label: "Work Hours Per Week",
+      description: "Number of hours the employee works per week (e.g., `40`).",
+    },
+    workVisa: {
+      type: "boolean",
+      label: "Work Visa Required",
+      description: "Whether the employee requires a work visa.",
+    },
+    teamId: {
+      type: "string",
+      label: "Team ID",
+      description: "The ID of the client team. Retrieve from your Deel organization settings.",
+    },
+    legalEntityId: {
+      type: "string",
+      label: "Legal Entity ID",
+      description: "The ID of the client legal entity. Retrieve from your Deel organization settings.",
     },
   },
   async run({ $ }) {
-    const params = {};
-    if (this.country) params.country = this.country;
-
     const response = await this.app._makeRequest({
       $,
       path: "/eor/benefits",
-      params,
+      params: {
+        country_code: this.countryCode,
+        employment_type: this.employmentType,
+        work_hours_per_week: this.workHoursPerWeek,
+        work_visa: this.workVisa,
+        team_id: this.teamId,
+        legal_entity_id: this.legalEntityId,
+      },
     });
 
     const benefits = response?.data ?? response ?? [];
-    const countryLabel = this.country
-      ? ` in ${this.country}`
-      : "";
-    $.export("$summary", `Retrieved ${Array.isArray(benefits)
-      ? benefits.length
-      : 0} EOR benefits${countryLabel}`);
+    $.export("$summary", `Retrieved ${Array.isArray(benefits) ? benefits.length : 0} EOR benefits in ${this.countryCode}`);
     return response;
   },
 };

--- a/components/deel/actions/get-eor-benefits/get-eor-benefits.mjs
+++ b/components/deel/actions/get-eor-benefits/get-eor-benefits.mjs
@@ -12,7 +12,7 @@ export default {
     + " `work_hours_per_week` is the number of hours worked per week (e.g., `40`)."
     + " `work_visa` is `true` if the employee requires a work visa."
     + " `team_id` and `legal_entity_id` are required — retrieve from your Deel organization settings."
-    + " [See the documentation](https://developer.deel.com/docs/list-eor-benefits)",
+    + " [See the documentation](https://developer.deel.com/api/reference/endpoints/eor-hiring/get-benefits)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/deel/actions/get-eor-benefits/get-eor-benefits.mjs
+++ b/components/deel/actions/get-eor-benefits/get-eor-benefits.mjs
@@ -1,0 +1,47 @@
+import app from "../../deel.app.mjs";
+
+export default {
+  key: "deel-get-eor-benefits",
+  name: "Get EOR Benefits",
+  description:
+    "List available EOR (employer of record) benefits offered through Deel, optionally filtered by country."
+    + " Returns benefit names, types, descriptions, and country availability."
+    + " Use this when a user asks about what benefits they can offer EOR employees in a specific country."
+    + " `country` must be an ISO 3166-1 alpha-2 code (e.g., `DE` for Germany, `US` for United States)."
+    + " [See the documentation](https://developer.deel.com/docs/list-eor-benefits)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    app,
+    country: {
+      type: "string",
+      label: "Country",
+      description: "Filter benefits by country. ISO 3166-1 alpha-2 code (e.g., `DE`, `US`, `GB`). Omit to list all countries.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const params = {};
+    if (this.country) params.country = this.country;
+
+    const response = await this.app._makeRequest({
+      $,
+      path: "/eor/benefits",
+      params,
+    });
+
+    const benefits = response?.data ?? response ?? [];
+    const countryLabel = this.country
+      ? ` in ${this.country}`
+      : "";
+    $.export("$summary", `Retrieved ${Array.isArray(benefits)
+      ? benefits.length
+      : 0} EOR benefits${countryLabel}`);
+    return response;
+  },
+};

--- a/components/deel/actions/get-eor-benefits/get-eor-benefits.mjs
+++ b/components/deel/actions/get-eor-benefits/get-eor-benefits.mjs
@@ -56,17 +56,13 @@ export default {
     },
   },
   async run({ $ }) {
-    const response = await this.app._makeRequest({
-      $,
-      path: "/eor/benefits",
-      params: {
-        country_code: this.countryCode,
-        employment_type: this.employmentType,
-        work_hours_per_week: this.workHoursPerWeek,
-        work_visa: this.workVisa,
-        team_id: this.teamId,
-        legal_entity_id: this.legalEntityId,
-      },
+    const response = await this.app.getEorBenefits($, {
+      country_code: this.countryCode,
+      employment_type: this.employmentType,
+      work_hours_per_week: this.workHoursPerWeek,
+      work_visa: this.workVisa,
+      team_id: this.teamId,
+      legal_entity_id: this.legalEntityId,
     });
 
     const benefits = response?.data ?? response ?? [];

--- a/components/deel/actions/get-eor-contract-form/get-eor-contract-form.mjs
+++ b/components/deel/actions/get-eor-contract-form/get-eor-contract-form.mjs
@@ -26,10 +26,7 @@ export default {
     },
   },
   async run({ $ }) {
-    const response = await this.app._makeRequest({
-      $,
-      path: `/forms/eor/create-contract/${this.countryCode}`,
-    });
+    const response = await this.app.getEorContractForm($, this.countryCode);
 
     $.export("$summary", `Retrieved EOR contract form fields for ${this.countryCode}`);
     return response;

--- a/components/deel/actions/get-eor-contract-form/get-eor-contract-form.mjs
+++ b/components/deel/actions/get-eor-contract-form/get-eor-contract-form.mjs
@@ -8,7 +8,7 @@ export default {
     + " types, validation rules, and required vs optional fields."
     + " Use this to understand exactly what data is needed before creating an EOR contract."
     + " `country_code` must be an ISO 3166-1 alpha-2 code (e.g., `DE` for Germany, `GB` for UK)."
-    + " [See the documentation](https://developer.deel.com/docs/get-eor-contract-form)",
+    + " [See the documentation](https://developer.deel.com/api/reference/endpoints/eor-hiring/get-create-contract-form)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/deel/actions/get-eor-contract-form/get-eor-contract-form.mjs
+++ b/components/deel/actions/get-eor-contract-form/get-eor-contract-form.mjs
@@ -1,0 +1,37 @@
+import app from "../../deel.app.mjs";
+
+export default {
+  key: "deel-get-eor-contract-form",
+  name: "Get EOR Contract Form",
+  description:
+    "Retrieve the EOR contract form field definitions for a specific country, including field names,"
+    + " types, validation rules, and required vs optional fields."
+    + " Use this to understand exactly what data is needed before creating an EOR contract."
+    + " `country_code` must be an ISO 3166-1 alpha-2 code (e.g., `DE` for Germany, `GB` for UK)."
+    + " [See the documentation](https://developer.deel.com/docs/get-eor-contract-form)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    app,
+    countryCode: {
+      propDefinition: [
+        app,
+        "countryCode",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.app._makeRequest({
+      $,
+      path: `/forms/eor/create-contract/${this.countryCode}`,
+    });
+
+    $.export("$summary", `Retrieved EOR contract form fields for ${this.countryCode}`);
+    return response;
+  },
+};

--- a/components/deel/actions/get-eor-hiring-guide/get-eor-hiring-guide.mjs
+++ b/components/deel/actions/get-eor-hiring-guide/get-eor-hiring-guide.mjs
@@ -9,7 +9,7 @@ export default {
     + " Use this before creating an EOR contract to understand what information is required and what"
     + " restrictions apply (e.g., minimum salary, mandatory benefits, work visa rules)."
     + " `country_code` must be an ISO 3166-1 alpha-2 code (e.g., `DE` for Germany, `GB` for UK, `US` for United States)."
-    + " [See the documentation](https://developer.deel.com/docs/get-eor-validations)",
+    + " [See the documentation](https://developer.deel.com/api/reference/endpoints/eor-hiring/get-eor-hiring-guide-by-country)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/deel/actions/get-eor-hiring-guide/get-eor-hiring-guide.mjs
+++ b/components/deel/actions/get-eor-hiring-guide/get-eor-hiring-guide.mjs
@@ -1,0 +1,38 @@
+import app from "../../deel.app.mjs";
+
+export default {
+  key: "deel-get-eor-hiring-guide",
+  name: "Get EOR Hiring Guide",
+  description:
+    "Retrieve the mandatory fields, compliance requirements, and hiring constraints for creating an"
+    + " EOR (employer of record) contract in a specific country."
+    + " Use this before creating an EOR contract to understand what information is required and what"
+    + " restrictions apply (e.g., minimum salary, mandatory benefits, work visa rules)."
+    + " `country_code` must be an ISO 3166-1 alpha-2 code (e.g., `DE` for Germany, `GB` for UK, `US` for United States)."
+    + " [See the documentation](https://developer.deel.com/docs/get-eor-validations)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    app,
+    countryCode: {
+      propDefinition: [
+        app,
+        "countryCode",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.app._makeRequest({
+      $,
+      path: `/eor/validations/${this.countryCode}`,
+    });
+
+    $.export("$summary", `Retrieved EOR hiring guide for ${this.countryCode}`);
+    return response;
+  },
+};

--- a/components/deel/actions/get-eor-hiring-guide/get-eor-hiring-guide.mjs
+++ b/components/deel/actions/get-eor-hiring-guide/get-eor-hiring-guide.mjs
@@ -27,10 +27,7 @@ export default {
     },
   },
   async run({ $ }) {
-    const response = await this.app._makeRequest({
-      $,
-      path: `/eor/validations/${this.countryCode}`,
-    });
+    const response = await this.app.getEorHiringGuide($, this.countryCode);
 
     $.export("$summary", `Retrieved EOR hiring guide for ${this.countryCode}`);
     return response;

--- a/components/deel/actions/list-contract-adjustments/list-contract-adjustments.mjs
+++ b/components/deel/actions/list-contract-adjustments/list-contract-adjustments.mjs
@@ -42,11 +42,7 @@ export default {
     if (this.from) params.from = this.from;
     if (this.to) params.to = this.to;
 
-    const response = await this.app._makeRequest({
-      $,
-      path: `/contracts/${this.contractId}/adjustments`,
-      params,
-    });
+    const response = await this.app.listContractAdjustments($, this.contractId, params);
 
     const adjustments = response?.data ?? response ?? [];
     $.export("$summary", `Retrieved ${Array.isArray(adjustments)

--- a/components/deel/actions/list-contract-adjustments/list-contract-adjustments.mjs
+++ b/components/deel/actions/list-contract-adjustments/list-contract-adjustments.mjs
@@ -8,7 +8,7 @@ export default {
     + " Works for both IC and EOR contracts."
     + " Optionally filter by date range."
     + " Use **List Contracts** to find the contract ID."
-    + " [See the documentation](https://developer.deel.com/docs/list-adjustments-for-a-contract)",
+    + " [See the documentation](https://developer.deel.com/api/reference/endpoints/adjustments/get-contract-adjustments)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/deel/actions/list-contract-adjustments/list-contract-adjustments.mjs
+++ b/components/deel/actions/list-contract-adjustments/list-contract-adjustments.mjs
@@ -1,0 +1,57 @@
+import app from "../../deel.app.mjs";
+
+export default {
+  key: "deel-list-contract-adjustments",
+  name: "List Contract Adjustments",
+  description:
+    "List all adjustments (bonuses, deductions, expenses, etc.) for a specific Deel contract."
+    + " Works for both IC and EOR contracts."
+    + " Optionally filter by date range."
+    + " Use **List Contracts** to find the contract ID."
+    + " [See the documentation](https://developer.deel.com/docs/list-adjustments-for-a-contract)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    app,
+    contractId: {
+      propDefinition: [
+        app,
+        "contractId",
+      ],
+    },
+    from: {
+      type: "string",
+      label: "From Date",
+      description: "Start of the date range filter in ISO 8601 format (e.g., `2026-01-01`).",
+      optional: true,
+    },
+    to: {
+      type: "string",
+      label: "To Date",
+      description: "End of the date range filter in ISO 8601 format (e.g., `2026-12-31`).",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const params = {};
+    if (this.from) params.from = this.from;
+    if (this.to) params.to = this.to;
+
+    const response = await this.app._makeRequest({
+      $,
+      path: `/contracts/${this.contractId}/adjustments`,
+      params,
+    });
+
+    const adjustments = response?.data ?? response ?? [];
+    $.export("$summary", `Retrieved ${Array.isArray(adjustments)
+      ? adjustments.length
+      : 0} adjustments for contract ${this.contractId}`);
+    return response;
+  },
+};

--- a/components/deel/actions/list-contract-tasks/list-contract-tasks.mjs
+++ b/components/deel/actions/list-contract-tasks/list-contract-tasks.mjs
@@ -8,7 +8,7 @@ export default {
     + " and submission dates."
     + " Use task IDs with **Review Contract Task** to approve or decline pending tasks."
     + " Use **List Contracts** to find the contract ID."
-    + " [See the documentation](https://developer.deel.com/docs/list-tasks-for-a-contract)",
+    + " [See the documentation](https://developer.deel.com/api/reference/endpoints/tasks/get-contract-tasks)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/deel/actions/list-contract-tasks/list-contract-tasks.mjs
+++ b/components/deel/actions/list-contract-tasks/list-contract-tasks.mjs
@@ -26,10 +26,7 @@ export default {
     },
   },
   async run({ $ }) {
-    const response = await this.app._makeRequest({
-      $,
-      path: `/contracts/${this.contractId}/tasks`,
-    });
+    const response = await this.app.listContractTasks($, this.contractId);
 
     const tasks = response?.data ?? response ?? [];
     $.export("$summary", `Retrieved ${Array.isArray(tasks)

--- a/components/deel/actions/list-contract-tasks/list-contract-tasks.mjs
+++ b/components/deel/actions/list-contract-tasks/list-contract-tasks.mjs
@@ -1,0 +1,40 @@
+import app from "../../deel.app.mjs";
+
+export default {
+  key: "deel-list-contract-tasks",
+  name: "List Contract Tasks",
+  description:
+    "List all tasks for a specific Deel IC contract. Returns task IDs, descriptions, amounts, statuses,"
+    + " and submission dates."
+    + " Use task IDs with **Review Contract Task** to approve or decline pending tasks."
+    + " Use **List Contracts** to find the contract ID."
+    + " [See the documentation](https://developer.deel.com/docs/list-tasks-for-a-contract)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    app,
+    contractId: {
+      propDefinition: [
+        app,
+        "contractId",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.app._makeRequest({
+      $,
+      path: `/contracts/${this.contractId}/tasks`,
+    });
+
+    const tasks = response?.data ?? response ?? [];
+    $.export("$summary", `Retrieved ${Array.isArray(tasks)
+      ? tasks.length
+      : 0} tasks for contract ${this.contractId}`);
+    return response;
+  },
+};

--- a/components/deel/actions/list-contracts/list-contracts.mjs
+++ b/components/deel/actions/list-contracts/list-contracts.mjs
@@ -71,11 +71,7 @@ export default {
     if (this.limit) params.limit = this.limit;
     if (this.afterCursor) params.after_cursor = this.afterCursor;
 
-    const response = await this.app._makeRequest({
-      $,
-      path: "/contracts",
-      params,
-    });
+    const response = await this.app.listContracts($, params);
 
     const contracts = response?.data ?? response ?? [];
     $.export("$summary", `Retrieved ${Array.isArray(contracts)

--- a/components/deel/actions/list-contracts/list-contracts.mjs
+++ b/components/deel/actions/list-contracts/list-contracts.mjs
@@ -1,0 +1,86 @@
+import app from "../../deel.app.mjs";
+
+export default {
+  key: "deel-list-contracts",
+  name: "List Contracts",
+  description:
+    "List and search all contracts in Deel across IC (independent contractor), EOR (employer of record),"
+    + " and GP (global payroll) types. Use this to find contract IDs, check statuses, or browse the"
+    + " contractor/employee roster. Supports filtering by search term, status, contract type, team, and"
+    + " country. Returns contract ID, title, type, status, worker name, and start date."
+    + " [See the documentation](https://developer.deel.com/docs/list-all-contracts)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    app,
+    search: {
+      type: "string",
+      label: "Search",
+      description: "Search by contract title or worker name.",
+      optional: true,
+    },
+    statuses: {
+      type: "string[]",
+      label: "Statuses",
+      description: "Filter by contract status. Valid values include `pending`, `active`, `ended`, `cancelled`.",
+      optional: true,
+    },
+    types: {
+      type: "string[]",
+      label: "Contract Types",
+      description: "Filter by contract type. Valid values include `fixed_rate_contract`, `pay_as_you_go_contract`, `milestone_contract`, `eor_employee`, `global_payroll_employee`.",
+      optional: true,
+    },
+    teamId: {
+      type: "string",
+      label: "Team ID",
+      description: "Filter contracts by client team ID.",
+      optional: true,
+    },
+    countries: {
+      type: "string[]",
+      label: "Countries",
+      description: "Filter by worker country. Use ISO 3166-1 alpha-2 codes (e.g., `DE`, `US`, `GB`).",
+      optional: true,
+    },
+    limit: {
+      type: "integer",
+      label: "Limit",
+      description: "Maximum number of contracts to return (default: 50).",
+      optional: true,
+    },
+    afterCursor: {
+      type: "string",
+      label: "After Cursor",
+      description: "Cursor for pagination. Use the `after_cursor` value from a previous response to get the next page.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const params = {};
+    if (this.search) params.search = this.search;
+    if (this.statuses?.length) params["statuses[]"] = this.statuses;
+    if (this.types?.length) params["types[]"] = this.types;
+    if (this.teamId) params.team_id = this.teamId;
+    if (this.countries?.length) params["countries[]"] = this.countries;
+    if (this.limit) params.limit = this.limit;
+    if (this.afterCursor) params.after_cursor = this.afterCursor;
+
+    const response = await this.app._makeRequest({
+      $,
+      path: "/contracts",
+      params,
+    });
+
+    const contracts = response?.data ?? response ?? [];
+    $.export("$summary", `Retrieved ${Array.isArray(contracts)
+      ? contracts.length
+      : 0} contracts`);
+    return response;
+  },
+};

--- a/components/deel/actions/list-contracts/list-contracts.mjs
+++ b/components/deel/actions/list-contracts/list-contracts.mjs
@@ -8,7 +8,7 @@ export default {
     + " and GP (global payroll) types. Use this to find contract IDs, check statuses, or browse the"
     + " contractor/employee roster. Supports filtering by search term, status, contract type, team, and"
     + " country. Returns contract ID, title, type, status, worker name, and start date."
-    + " [See the documentation](https://developer.deel.com/docs/list-all-contracts)",
+    + " [See the documentation](https://developer.deel.com/api/reference/endpoints/contracts/get-contracts)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/deel/actions/list-eor-payslips/list-eor-payslips.mjs
+++ b/components/deel/actions/list-eor-payslips/list-eor-payslips.mjs
@@ -1,0 +1,39 @@
+import app from "../../deel.app.mjs";
+
+export default {
+  key: "deel-list-eor-payslips",
+  name: "List EOR Payslips",
+  description:
+    "List payslips for a specific EOR (employer of record) employee in Deel."
+    + " Returns payslip IDs, pay periods, gross/net amounts, and download links."
+    + " Use **Get Contract** to find the worker ID from a contract's worker details."
+    + " [See the documentation](https://developer.deel.com/docs/list-eor-payslips)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    app,
+    workerId: {
+      propDefinition: [
+        app,
+        "workerId",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.app._makeRequest({
+      $,
+      path: `/eor/workers/${this.workerId}/payslips`,
+    });
+
+    const payslips = response?.data ?? response ?? [];
+    $.export("$summary", `Retrieved ${Array.isArray(payslips)
+      ? payslips.length
+      : 0} payslips for EOR worker ${this.workerId}`);
+    return response;
+  },
+};

--- a/components/deel/actions/list-eor-payslips/list-eor-payslips.mjs
+++ b/components/deel/actions/list-eor-payslips/list-eor-payslips.mjs
@@ -7,7 +7,7 @@ export default {
     "List payslips for a specific EOR (employer of record) employee in Deel."
     + " Returns payslip IDs, pay periods, gross/net amounts, and download links."
     + " Use **Get Contract** to find the worker ID from a contract's worker details."
-    + " [See the documentation](https://developer.deel.com/docs/list-eor-payslips)",
+    + " [See the documentation](https://developer.deel.com/api/reference/endpoints/eor-payslips/get-worker-payslips)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/deel/actions/list-eor-payslips/list-eor-payslips.mjs
+++ b/components/deel/actions/list-eor-payslips/list-eor-payslips.mjs
@@ -25,10 +25,7 @@ export default {
     },
   },
   async run({ $ }) {
-    const response = await this.app._makeRequest({
-      $,
-      path: `/eor/workers/${this.workerId}/payslips`,
-    });
+    const response = await this.app.listEorPayslips($, this.workerId);
 
     const payslips = response?.data ?? response ?? [];
     $.export("$summary", `Retrieved ${Array.isArray(payslips)

--- a/components/deel/actions/list-gp-payslips/list-gp-payslips.mjs
+++ b/components/deel/actions/list-gp-payslips/list-gp-payslips.mjs
@@ -7,7 +7,7 @@ export default {
     "List payslips for a specific GP (Global Payroll) employee in Deel."
     + " Returns payslip IDs, pay periods, gross/net amounts, and download links."
     + " Use **Get Contract** to find the worker ID from a contract's worker details."
-    + " [See the documentation](https://developer.deel.com/api/reference)",
+    + " [See the documentation](https://developer.deel.com/api/reference/endpoints/payslips/get-gp-worker-payslips)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/deel/actions/list-gp-payslips/list-gp-payslips.mjs
+++ b/components/deel/actions/list-gp-payslips/list-gp-payslips.mjs
@@ -1,0 +1,39 @@
+import app from "../../deel.app.mjs";
+
+export default {
+  key: "deel-list-gp-payslips",
+  name: "List GP Payslips",
+  description:
+    "List payslips for a specific GP (Global Payroll) employee in Deel."
+    + " Returns payslip IDs, pay periods, gross/net amounts, and download links."
+    + " Use **Get Contract** to find the worker ID from a contract's worker details."
+    + " [See the documentation](https://developer.deel.com/docs/list-gp-payslips)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    app,
+    workerId: {
+      propDefinition: [
+        app,
+        "workerId",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.app._makeRequest({
+      $,
+      path: `/gp/workers/${this.workerId}/payslips`,
+    });
+
+    const payslips = response?.data ?? response ?? [];
+    $.export("$summary", `Retrieved ${Array.isArray(payslips)
+      ? payslips.length
+      : 0} payslips for GP worker ${this.workerId}`);
+    return response;
+  },
+};

--- a/components/deel/actions/list-gp-payslips/list-gp-payslips.mjs
+++ b/components/deel/actions/list-gp-payslips/list-gp-payslips.mjs
@@ -25,10 +25,7 @@ export default {
     },
   },
   async run({ $ }) {
-    const response = await this.app._makeRequest({
-      $,
-      path: `/gp/workers/${this.workerId}/payslips`,
-    });
+    const response = await this.app.listGpPayslips($, this.workerId);
 
     const payslips = response?.data ?? response ?? [];
     $.export("$summary", `Retrieved ${Array.isArray(payslips)

--- a/components/deel/actions/list-gp-payslips/list-gp-payslips.mjs
+++ b/components/deel/actions/list-gp-payslips/list-gp-payslips.mjs
@@ -7,7 +7,7 @@ export default {
     "List payslips for a specific GP (Global Payroll) employee in Deel."
     + " Returns payslip IDs, pay periods, gross/net amounts, and download links."
     + " Use **Get Contract** to find the worker ID from a contract's worker details."
-    + " [See the documentation](https://developer.deel.com/docs/list-gp-payslips)",
+    + " [See the documentation](https://developer.deel.com/api/reference)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/deel/actions/list-timesheets/list-timesheets.mjs
+++ b/components/deel/actions/list-timesheets/list-timesheets.mjs
@@ -72,11 +72,7 @@ export default {
     if (this.limit != null) params.limit = this.limit;
     if (this.offset != null) params.offset = this.offset;
 
-    const response = await this.app._makeRequest({
-      $,
-      path: "/timesheets",
-      params,
-    });
+    const response = await this.app.listTimesheets($, params);
 
     const timesheets = response?.data ?? response ?? [];
     $.export("$summary", `Retrieved ${Array.isArray(timesheets)

--- a/components/deel/actions/list-timesheets/list-timesheets.mjs
+++ b/components/deel/actions/list-timesheets/list-timesheets.mjs
@@ -1,0 +1,87 @@
+import app from "../../deel.app.mjs";
+
+export default {
+  key: "deel-list-timesheets",
+  name: "List Timesheets",
+  description:
+    "List IC contractor timesheets in Deel with optional filters for contract, status, date range,"
+    + " and contract type."
+    + " Returns timesheet IDs, contract info, hours worked, status, and pay period."
+    + " Use **List Contracts** to find contract IDs for filtering."
+    + " [See the documentation](https://developer.deel.com/docs/list-timesheets)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    app,
+    contractId: {
+      propDefinition: [
+        app,
+        "contractId",
+      ],
+      optional: true,
+    },
+    statuses: {
+      type: "string[]",
+      label: "Statuses",
+      description: "Filter by timesheet status (e.g., `pending`, `approved`, `declined`).",
+      optional: true,
+    },
+    contractTypes: {
+      type: "string[]",
+      label: "Contract Types",
+      description: "Filter by contract type (e.g., `fixed_rate_contract`, `pay_as_you_go_contract`).",
+      optional: true,
+    },
+    dateFrom: {
+      type: "string",
+      label: "Date From",
+      description: "Start date filter in ISO 8601 format (e.g., `2026-01-01`).",
+      optional: true,
+    },
+    dateTo: {
+      type: "string",
+      label: "Date To",
+      description: "End date filter in ISO 8601 format (e.g., `2026-06-30`).",
+      optional: true,
+    },
+    limit: {
+      type: "integer",
+      label: "Limit",
+      description: "Maximum number of timesheets to return.",
+      optional: true,
+    },
+    offset: {
+      type: "integer",
+      label: "Offset",
+      description: "Number of records to skip for pagination.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const params = {};
+    if (this.contractId) params.contract_id = this.contractId;
+    if (this.statuses?.length) params["statuses[]"] = this.statuses;
+    if (this.contractTypes?.length) params["contract_types[]"] = this.contractTypes;
+    if (this.dateFrom) params.date_from = this.dateFrom;
+    if (this.dateTo) params.date_to = this.dateTo;
+    if (this.limit) params.limit = this.limit;
+    if (this.offset) params.offset = this.offset;
+
+    const response = await this.app._makeRequest({
+      $,
+      path: "/timesheets",
+      params,
+    });
+
+    const timesheets = response?.data ?? response ?? [];
+    $.export("$summary", `Retrieved ${Array.isArray(timesheets)
+      ? timesheets.length
+      : 0} timesheets`);
+    return response;
+  },
+};

--- a/components/deel/actions/list-timesheets/list-timesheets.mjs
+++ b/components/deel/actions/list-timesheets/list-timesheets.mjs
@@ -69,8 +69,8 @@ export default {
     if (this.contractTypes?.length) params["contract_types[]"] = this.contractTypes;
     if (this.dateFrom) params.date_from = this.dateFrom;
     if (this.dateTo) params.date_to = this.dateTo;
-    if (this.limit) params.limit = this.limit;
-    if (this.offset) params.offset = this.offset;
+    if (this.limit != null) params.limit = this.limit;
+    if (this.offset != null) params.offset = this.offset;
 
     const response = await this.app._makeRequest({
       $,

--- a/components/deel/actions/list-timesheets/list-timesheets.mjs
+++ b/components/deel/actions/list-timesheets/list-timesheets.mjs
@@ -8,7 +8,7 @@ export default {
     + " and contract type."
     + " Returns timesheet IDs, contract info, hours worked, status, and pay period."
     + " Use **List Contracts** to find contract IDs for filtering."
-    + " [See the documentation](https://developer.deel.com/docs/list-timesheets)",
+    + " [See the documentation](https://developer.deel.com/api/reference/endpoints/timesheets/get-timesheets)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/deel/actions/review-contract-task/review-contract-task.mjs
+++ b/components/deel/actions/review-contract-task/review-contract-task.mjs
@@ -1,0 +1,63 @@
+import app from "../../deel.app.mjs";
+
+export default {
+  key: "deel-review-contract-task",
+  name: "Review Contract Task",
+  description:
+    "Approve or decline a contractor task on a Deel IC contract."
+    + " `status` must be `approved` or `declined`."
+    + " If declining, provide a `reason` explaining why."
+    + " Use **List Contract Tasks** to find task IDs."
+    + " Use **List Contracts** to find the contract ID."
+    + " [See the documentation](https://developer.deel.com/docs/review-a-task)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    app,
+    contractId: {
+      propDefinition: [
+        app,
+        "contractId",
+      ],
+    },
+    taskId: {
+      type: "string",
+      label: "Task ID",
+      description: "The unique identifier of the task to review. Use **List Contract Tasks** to find task IDs.",
+    },
+    status: {
+      type: "string",
+      label: "Status",
+      description: "The review decision. Must be `approved` or `declined`.",
+    },
+    reason: {
+      type: "string",
+      label: "Reason",
+      description: "Reason for declining the task. Required when `status` is `declined`.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const payload = {
+      status: this.status,
+    };
+    if (this.reason) payload.reason = this.reason;
+
+    const response = await this.app._makeRequest({
+      $,
+      path: `/contracts/${this.contractId}/tasks/${this.taskId}/reviews`,
+      method: "POST",
+      data: {
+        data: payload,
+      },
+    });
+
+    $.export("$summary", `Task ${this.taskId} on contract ${this.contractId}: ${this.status}`);
+    return response;
+  },
+};

--- a/components/deel/actions/review-contract-task/review-contract-task.mjs
+++ b/components/deel/actions/review-contract-task/review-contract-task.mjs
@@ -55,14 +55,7 @@ export default {
     };
     if (this.reason) payload.reason = this.reason;
 
-    const response = await this.app._makeRequest({
-      $,
-      path: `/contracts/${this.contractId}/tasks/${this.taskId}/reviews`,
-      method: "POST",
-      data: {
-        data: payload,
-      },
-    });
+    const response = await this.app.reviewContractTask($, this.contractId, this.taskId, payload);
 
     $.export("$summary", `Task ${this.taskId} on contract ${this.contractId}: ${this.status}`);
     return response;

--- a/components/deel/actions/review-contract-task/review-contract-task.mjs
+++ b/components/deel/actions/review-contract-task/review-contract-task.mjs
@@ -1,3 +1,4 @@
+import { ConfigurationError } from "@pipedream/platform";
 import app from "../../deel.app.mjs";
 
 export default {
@@ -43,6 +44,12 @@ export default {
     },
   },
   async run({ $ }) {
+    if (this.status !== "approved" && this.status !== "declined") {
+      throw new ConfigurationError(`status must be "approved" or "declined", got "${this.status}"`);
+    }
+    if (this.status === "declined" && !this.reason) {
+      throw new ConfigurationError("reason is required when status is \"declined\"");
+    }
     const payload = {
       status: this.status,
     };

--- a/components/deel/actions/review-contract-task/review-contract-task.mjs
+++ b/components/deel/actions/review-contract-task/review-contract-task.mjs
@@ -10,7 +10,7 @@ export default {
     + " If declining, provide a `reason` explaining why."
     + " Use **List Contract Tasks** to find task IDs."
     + " Use **List Contracts** to find the contract ID."
-    + " [See the documentation](https://developer.deel.com/docs/review-a-task)",
+    + " [See the documentation](https://developer.deel.com/api/reference/endpoints/tasks/review-multiple-tasks)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/deel/actions/send-contract-invitation/send-contract-invitation.mjs
+++ b/components/deel/actions/send-contract-invitation/send-contract-invitation.mjs
@@ -57,7 +57,7 @@ export default {
       },
     });
 
-    $.export("$summary", `Sent contract invitation to ${this.email} for contract ${this.contractId}`);
+    $.export("$summary", `Sent contract invitation for contract ${this.contractId}`);
     return response;
   },
 };

--- a/components/deel/actions/send-contract-invitation/send-contract-invitation.mjs
+++ b/components/deel/actions/send-contract-invitation/send-contract-invitation.mjs
@@ -7,7 +7,7 @@ export default {
     "Send a contract invitation email to a worker for a specific Deel contract."
     + " Use this after creating a contract to notify the worker and prompt them to sign."
     + " Use **List Contracts** to find the contract ID."
-    + " [See the documentation](https://developer.deel.com/api/embedded/eor-worker-onboarding)",
+    + " [See the documentation](https://developer.deel.com/api/reference/endpoints/contractor-hiring/create-contract-invitation)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/deel/actions/send-contract-invitation/send-contract-invitation.mjs
+++ b/components/deel/actions/send-contract-invitation/send-contract-invitation.mjs
@@ -48,14 +48,7 @@ export default {
     if (this.locale) payload.locale = this.locale;
     if (this.message) payload.message = this.message;
 
-    const response = await this.app._makeRequest({
-      $,
-      path: `/contracts/${this.contractId}/invitations`,
-      method: "POST",
-      data: {
-        data: payload,
-      },
-    });
+    const response = await this.app.sendContractInvitation($, this.contractId, payload);
 
     $.export("$summary", `Sent contract invitation for contract ${this.contractId}`);
     return response;

--- a/components/deel/actions/send-contract-invitation/send-contract-invitation.mjs
+++ b/components/deel/actions/send-contract-invitation/send-contract-invitation.mjs
@@ -7,7 +7,7 @@ export default {
     "Send a contract invitation email to a worker for a specific Deel contract."
     + " Use this after creating a contract to notify the worker and prompt them to sign."
     + " Use **List Contracts** to find the contract ID."
-    + " [See the documentation](https://developer.deel.com/docs/send-contract-invitation)",
+    + " [See the documentation](https://developer.deel.com/api/embedded/eor-worker-onboarding)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/deel/actions/send-contract-invitation/send-contract-invitation.mjs
+++ b/components/deel/actions/send-contract-invitation/send-contract-invitation.mjs
@@ -1,0 +1,63 @@
+import app from "../../deel.app.mjs";
+
+export default {
+  key: "deel-send-contract-invitation",
+  name: "Send Contract Invitation",
+  description:
+    "Send a contract invitation email to a worker for a specific Deel contract."
+    + " Use this after creating a contract to notify the worker and prompt them to sign."
+    + " Use **List Contracts** to find the contract ID."
+    + " [See the documentation](https://developer.deel.com/docs/send-contract-invitation)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    app,
+    contractId: {
+      propDefinition: [
+        app,
+        "contractId",
+      ],
+    },
+    email: {
+      type: "string",
+      label: "Email",
+      description: "The email address to send the invitation to.",
+    },
+    locale: {
+      type: "string",
+      label: "Locale",
+      description: "Language locale for the invitation email (e.g., `en`, `de`, `fr`). Defaults to `en`.",
+      optional: true,
+    },
+    message: {
+      type: "string",
+      label: "Message",
+      description: "Optional personal message to include in the invitation email.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const payload = {
+      email: this.email,
+    };
+    if (this.locale) payload.locale = this.locale;
+    if (this.message) payload.message = this.message;
+
+    const response = await this.app._makeRequest({
+      $,
+      path: `/contracts/${this.contractId}/invitations`,
+      method: "POST",
+      data: {
+        data: payload,
+      },
+    });
+
+    $.export("$summary", `Sent contract invitation to ${this.email} for contract ${this.contractId}`);
+    return response;
+  },
+};

--- a/components/deel/actions/sign-contract/sign-contract.mjs
+++ b/components/deel/actions/sign-contract/sign-contract.mjs
@@ -1,0 +1,48 @@
+import app from "../../deel.app.mjs";
+
+export default {
+  key: "deel-sign-contract",
+  name: "Sign Contract",
+  description:
+    "Sign a Deel contract as the client/employer. Use this to countersign a contract that has been"
+    + " sent to and signed by the contractor."
+    + " `client_signature` is typically the full legal name of the signing party."
+    + " Use **List Contracts** to find the contract ID."
+    + " [See the documentation](https://developer.deel.com/docs/sign-a-contract)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    app,
+    contractId: {
+      propDefinition: [
+        app,
+        "contractId",
+      ],
+    },
+    clientSignature: {
+      type: "string",
+      label: "Client Signature",
+      description: "The signature of the client/employer (typically a full legal name, e.g., `Dr. John Hammond`).",
+    },
+  },
+  async run({ $ }) {
+    const response = await this.app._makeRequest({
+      $,
+      path: `/contracts/${this.contractId}/signatures`,
+      method: "POST",
+      data: {
+        data: {
+          client_signature: this.clientSignature,
+        },
+      },
+    });
+
+    $.export("$summary", `Signed contract ${this.contractId} as "${this.clientSignature}"`);
+    return response;
+  },
+};

--- a/components/deel/actions/sign-contract/sign-contract.mjs
+++ b/components/deel/actions/sign-contract/sign-contract.mjs
@@ -8,7 +8,7 @@ export default {
     + " sent to and signed by the contractor."
     + " `client_signature` is typically the full legal name of the signing party."
     + " Use **List Contracts** to find the contract ID."
-    + " [See the documentation](https://developer.deel.com/docs/sign-a-contract)",
+    + " [See the documentation](https://developer.deel.com/api/reference/endpoints/contracts/sign-worker-contract)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/deel/actions/sign-contract/sign-contract.mjs
+++ b/components/deel/actions/sign-contract/sign-contract.mjs
@@ -31,15 +31,8 @@ export default {
     },
   },
   async run({ $ }) {
-    const response = await this.app._makeRequest({
-      $,
-      path: `/contracts/${this.contractId}/signatures`,
-      method: "POST",
-      data: {
-        data: {
-          client_signature: this.clientSignature,
-        },
-      },
+    const response = await this.app.signContract($, this.contractId, {
+      client_signature: this.clientSignature,
     });
 
     $.export("$summary", `Signed contract ${this.contractId}`);

--- a/components/deel/actions/sign-contract/sign-contract.mjs
+++ b/components/deel/actions/sign-contract/sign-contract.mjs
@@ -42,7 +42,7 @@ export default {
       },
     });
 
-    $.export("$summary", `Signed contract ${this.contractId} as "${this.clientSignature}"`);
+    $.export("$summary", `Signed contract ${this.contractId}`);
     return response;
   },
 };

--- a/components/deel/deel.app.mjs
+++ b/components/deel/deel.app.mjs
@@ -62,5 +62,194 @@ export default {
         ...opts,
       });
     },
+    async getContract($, contractId) {
+      return this._makeRequest({
+        $,
+        path: `/contracts/${contractId}`,
+      });
+    },
+    async getContractPreview($, contractId) {
+      return this._makeRequest({
+        $,
+        path: `/contracts/${contractId}/preview`,
+      });
+    },
+    async listContracts($, params) {
+      return this._makeRequest({
+        $,
+        path: "/contracts",
+        params,
+      });
+    },
+    async createIcContract($, data) {
+      return this._makeRequest({
+        $,
+        path: "/contracts",
+        method: "POST",
+        data: {
+          data,
+        },
+      });
+    },
+    async sendContractInvitation($, contractId, data) {
+      return this._makeRequest({
+        $,
+        path: `/contracts/${contractId}/invitations`,
+        method: "POST",
+        data: {
+          data,
+        },
+      });
+    },
+    async signContract($, contractId, data) {
+      return this._makeRequest({
+        $,
+        path: `/contracts/${contractId}/signatures`,
+        method: "POST",
+        data: {
+          data,
+        },
+      });
+    },
+    async amendContract($, contractId, data) {
+      return this._makeRequest({
+        $,
+        path: `/contracts/${contractId}/amendments`,
+        method: "POST",
+        data: {
+          data,
+        },
+      });
+    },
+    async createContractTask($, contractId, data) {
+      return this._makeRequest({
+        $,
+        path: `/contracts/${contractId}/tasks`,
+        method: "POST",
+        data: {
+          data,
+        },
+      });
+    },
+    async listContractTasks($, contractId) {
+      return this._makeRequest({
+        $,
+        path: `/contracts/${contractId}/tasks`,
+      });
+    },
+    async reviewContractTask($, contractId, taskId, data) {
+      return this._makeRequest({
+        $,
+        path: `/contracts/${contractId}/tasks/${taskId}/reviews`,
+        method: "POST",
+        data: {
+          data,
+        },
+      });
+    },
+    async listContractAdjustments($, contractId, params) {
+      return this._makeRequest({
+        $,
+        path: `/contracts/${contractId}/adjustments`,
+        params,
+      });
+    },
+    async createInvoiceAdjustment($, data) {
+      return this._makeRequest({
+        $,
+        path: "/invoice-adjustments",
+        method: "POST",
+        data: {
+          data,
+        },
+      });
+    },
+    async listTimesheets($, params) {
+      return this._makeRequest({
+        $,
+        path: "/timesheets",
+        params,
+      });
+    },
+    async getEorHiringGuide($, countryCode) {
+      return this._makeRequest({
+        $,
+        path: `/eor/validations/${countryCode}`,
+      });
+    },
+    async getEorContractForm($, countryCode) {
+      return this._makeRequest({
+        $,
+        path: `/forms/eor/create-contract/${countryCode}`,
+      });
+    },
+    async getEorBenefits($, params) {
+      return this._makeRequest({
+        $,
+        path: "/eor/benefits",
+        params,
+      });
+    },
+    async createEorContract($, data) {
+      return this._makeRequest({
+        $,
+        path: "/eor",
+        method: "POST",
+        data: {
+          data,
+        },
+      });
+    },
+    async listEorPayslips($, workerId) {
+      return this._makeRequest({
+        $,
+        path: `/eor/workers/${workerId}/payslips`,
+      });
+    },
+    async createGpContract($, data) {
+      return this._makeRequest({
+        $,
+        path: "/contracts/gp",
+        method: "POST",
+        data: {
+          data,
+        },
+      });
+    },
+    async listGpPayslips($, workerId) {
+      return this._makeRequest({
+        $,
+        path: `/gp/workers/${workerId}/payslips`,
+      });
+    },
+    async createAdjustment($, form) {
+      return this._makeRequest({
+        $,
+        path: "/adjustments",
+        method: "POST",
+        data: form,
+        headers: form.getHeaders(),
+      });
+    },
+    async createShiftRate($, data) {
+      return this._makeRequest({
+        $,
+        path: "/time_tracking/shift_rates",
+        method: "POST",
+        data: {
+          data,
+        },
+      });
+    },
+    async createShifts($, data) {
+      return this._makeRequest({
+        $,
+        path: "/time_tracking/shifts",
+        method: "POST",
+        data: {
+          data,
+        },
+      });
+    },
   },
 };

--- a/components/deel/deel.app.mjs
+++ b/components/deel/deel.app.mjs
@@ -19,6 +19,16 @@ export default {
       label: "Country Code",
       description: "ISO 3166-1 alpha-2 country code (e.g., `DE` for Germany, `GB` for United Kingdom, `US` for United States).",
     },
+    clientTeamId: {
+      type: "string",
+      label: "Client Team ID",
+      description: "The ID of the client team (department) for this contract. Retrieve from your Deel organization settings.",
+    },
+    clientLegalEntityId: {
+      type: "string",
+      label: "Client Legal Entity ID",
+      description: "The ID of the client legal entity (company) for this contract. Retrieve from your Deel organization settings.",
+    },
   },
   methods: {
     _baseUrl() {

--- a/components/deel/deel.app.mjs
+++ b/components/deel/deel.app.mjs
@@ -1,11 +1,56 @@
+import { axios } from "@pipedream/platform";
+
 export default {
   type: "app",
   app: "deel",
-  propDefinitions: {},
+  propDefinitions: {
+    contractId: {
+      type: "string",
+      label: "Contract ID",
+      description: "The unique identifier of the Deel contract. Use **List Contracts** to find contract IDs.",
+    },
+    workerId: {
+      type: "string",
+      label: "Worker ID",
+      description: "The unique identifier of the Deel worker (employee). Obtain from a contract's worker details.",
+    },
+    countryCode: {
+      type: "string",
+      label: "Country Code",
+      description: "ISO 3166-1 alpha-2 country code (e.g., `DE` for Germany, `GB` for United Kingdom, `US` for United States).",
+    },
+  },
   methods: {
-    // this.$auth contains connected account data
-    authKeys() {
-      console.log(Object.keys(this.$auth));
+    _baseUrl() {
+      return "https://api.letsdeel.com/rest/v2";
+    },
+    _headers() {
+      return {
+        "Authorization": `Bearer ${this.$auth.oauth_access_token}`,
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+      };
+    },
+    async _makeRequest({
+      $ = this,
+      path,
+      method = "GET",
+      data,
+      params,
+      headers = {},
+      ...opts
+    }) {
+      return axios($, {
+        method,
+        url: `${this._baseUrl()}${path}`,
+        headers: {
+          ...this._headers(),
+          ...headers,
+        },
+        data,
+        params,
+        ...opts,
+      });
     },
   },
 };

--- a/components/deel/package.json
+++ b/components/deel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/deel",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Deel Components",
   "main": "deel.app.mjs",
   "keywords": [

--- a/components/deel/package.json
+++ b/components/deel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/deel",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "Pipedream Deel Components",
   "main": "deel.app.mjs",
   "keywords": [
@@ -11,5 +11,8 @@
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^3.4.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4094,7 +4094,11 @@ importers:
 
   components/decodo: {}
 
-  components/deel: {}
+  components/deel:
+    dependencies:
+      '@pipedream/platform':
+        specifier: ^3.4.0
+        version: 3.4.0
 
   components/deep_tagger: {}
 


### PR DESCRIPTION
 Resolves #9964 
 
 Adds 24 AI-optimized MCP actions for IC, EOR, and GP contracts

  Implements the full Deel action set for MCP/AI workflows covering independent
  contractor, employer-of-record, and global payroll contract management. All
  actions use static schemas (no additionalProps/reloadProps) and AI-optimized
  descriptions with inline parameter guidance and cross-references.

  Actions added:
  - Contract management (IC): list-contracts, get-contract, get-contract-preview, create-ic-contract, send-contract-invitation, sign-contract, amend-ic-contract
  - Tasks & timesheets: create-contract-task, list-contract-tasks, review-contract-task, list-timesheets
  - Invoice adjustments: create-invoice-adjustment, list-contract-adjustments
  - EOR: get-eor-hiring-guide, get-eor-contract-form, get-eor-benefits, create-eor-contract, list-eor-payslips, amend-eor-contract
  - Global Payroll: create-gp-contract, create-adjustment, create-shift-rate, create-shifts, list-gp-payslips

  Also rewrites deel.app.mjs to add _makeRequest, _baseUrl, _headers methods
  and shared propDefinitions (contractId, workerId, countryCode).

  Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Numerous new Deel actions: create EOR/GP/IC contracts; amend contracts; create adjustments (optional file); create invoice adjustments; create contract tasks; create shifts and shift rates; review tasks; send invitations; sign contracts
  * Read-only retrievals: get contract and HTML preview (with truncation safeguard); get EOR benefits, contract form, hiring guide; list contracts, timesheets, adjustments, tasks, and payslips
* **Chores**
  * Revamped Deel API client and package bumped to v0.1.0 (platform integration added)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->