### PR TITLE
Google Business Profile - bug fix & new actions

### DIFF
--- a/components/google_my_business/actions/create-post/create-post.ts
+++ b/components/google_my_business/actions/create-post/create-post.ts
@@ -12,7 +12,7 @@ export default defineAction({
   key: "google_my_business-create-post",
   name: "Create Post",
   description: `Create a new local post associated with a location. [See the documentation](${DOCS_LINK})`,
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_my_business/actions/create-update-reply-to-review/create-update-reply-to-review.ts
+++ b/components/google_my_business/actions/create-update-reply-to-review/create-update-reply-to-review.ts
@@ -8,7 +8,7 @@ export default defineAction({
   key: "google_my_business-create-update-reply-to-review",
   name: "Create or Update Reply to Review",
   description: `Create or update a reply to the specified review. [See the documentation](${DOCS_LINK})`,
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_my_business/actions/get-reviews-multiple-locations/get-reviews-multiple-locations.ts
+++ b/components/google_my_business/actions/get-reviews-multiple-locations/get-reviews-multiple-locations.ts
@@ -8,7 +8,7 @@ export default defineAction({
   key: "google_my_business-get-reviews-multiple-locations",
   name: "Get Reviews from Multiple Locations",
   description: `Get reviews from multiple locations at once. [See the documentation](${DOCS_LINK})`,
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_my_business/actions/get-specific-review/get-specific-review.ts
+++ b/components/google_my_business/actions/get-specific-review/get-specific-review.ts
@@ -8,7 +8,7 @@ export default defineAction({
   key: "google_my_business-get-specific-review",
   name: "Get a Specific Review",
   description: `Return a specific review by name. [See the documentation](${DOCS_LINK})`,
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_my_business/actions/list-accounts/list-accounts.ts
+++ b/components/google_my_business/actions/list-accounts/list-accounts.ts
@@ -1,0 +1,70 @@
+import { defineAction } from "@pipedream/types";
+import app from "../../app/google_my_business.app";
+import { ListAccountsParams } from "../../common/requestParams";
+import { Account } from "../../common/responseSchemas";
+
+const DOCS_LINK = "https://developers.google.com/my-business/reference/accountmanagement/rest/v1/accounts/list";
+
+export default defineAction({
+  key: "google_my_business-list-accounts",
+  name: "List Accounts",
+  description: `Lists all accounts accessible to the authenticated user. [See the documentation](${DOCS_LINK})`,
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  type: "action",
+  props: {
+    app,
+    parentAccount: {
+      type: "string",
+      label: "Parent Account",
+      description: "The resource name of the account for which the list of directly accessible accounts is to be retrieved. Format: `accounts/{account_id}`. If omitted, returns all accounts accessible to the authenticated user.",
+      optional: true,
+    },
+    filter: {
+      type: "string",
+      label: "Filter",
+      description: "A filter constraining the accounts to return. Currently only supports filtering by `type` (e.g. `type=USER_GROUP`).",
+      optional: true,
+    },
+    pageSize: {
+      type: "integer",
+      label: "Page Size",
+      description: "Number of accounts to return per page. Default and maximum is 20.",
+      optional: true,
+    },
+    pageToken: {
+      type: "string",
+      label: "Page Token",
+      description: "Token from a previous response to retrieve the next page of results.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const {
+      parentAccount, filter, pageSize, pageToken,
+    } = this;
+
+    const params: ListAccountsParams = {
+      $,
+      params: {
+        parentAccount,
+        filter,
+        pageSize,
+        pageToken,
+      },
+    };
+
+    const response: { accounts?: Account[]; nextPageToken?: string; } = await this.app.listAccounts(params);
+    const accounts = response?.accounts ?? [];
+
+    $.export("$summary", `Successfully listed ${accounts.length} account${accounts.length !== 1
+      ? "s"
+      : ""}`);
+
+    return response;
+  },
+});

--- a/components/google_my_business/actions/list-accounts/list-accounts.ts
+++ b/components/google_my_business/actions/list-accounts/list-accounts.ts
@@ -33,7 +33,10 @@ export default defineAction({
     pageSize: {
       type: "integer",
       label: "Page Size",
-      description: "Number of accounts to return per page. Default and maximum is 20.",
+      description: "Number of accounts to return per page.",
+      min: 1,
+      max: 20,
+      default: 20,
       optional: true,
     },
     pageToken: {

--- a/components/google_my_business/actions/list-all-reviews/list-all-reviews.ts
+++ b/components/google_my_business/actions/list-all-reviews/list-all-reviews.ts
@@ -8,7 +8,7 @@ export default defineAction({
   key: "google_my_business-list-all-reviews",
   name: "List All Reviews",
   description: `List all reviews of a location to audit reviews in bulk. [See the documentation](${DOCS_LINK})`,
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -46,7 +46,9 @@ export default defineAction({
 
     const response = await this.app.listReviews(params);
 
-    $.export("$summary", `Successfully listed ${response.length} reviews`);
+    $.export("$summary", `Successfully listed ${response?.length ?? 0} review${response?.length ?? 0 > 1
+      ? "s"
+      : ""}`);
 
     return response;
   },

--- a/components/google_my_business/actions/list-all-reviews/list-all-reviews.ts
+++ b/components/google_my_business/actions/list-all-reviews/list-all-reviews.ts
@@ -46,7 +46,7 @@ export default defineAction({
 
     const response = await this.app.listReviews(params);
 
-    $.export("$summary", `Successfully listed ${response?.length ?? 0} review${response?.length ?? 0 > 1
+    $.export("$summary", `Successfully listed ${response?.length ?? 0} review${(response?.length ?? 0) !== 1
       ? "s"
       : ""}`);
 

--- a/components/google_my_business/actions/list-locations/list-locations.ts
+++ b/components/google_my_business/actions/list-locations/list-locations.ts
@@ -45,7 +45,10 @@ export default defineAction({
     pageSize: {
       type: "integer",
       label: "Page Size",
-      description: "Number of locations to return per page. Minimum 1, maximum 100. Defaults to 10.",
+      description: "Number of locations to return per page.",
+      min: 1,
+      max: 100,
+      default: 100,
       optional: true,
     },
     pageToken: {

--- a/components/google_my_business/actions/list-locations/list-locations.ts
+++ b/components/google_my_business/actions/list-locations/list-locations.ts
@@ -1,0 +1,84 @@
+import { defineAction } from "@pipedream/types";
+import app from "../../app/google_my_business.app";
+import { ListLocationsParams } from "../../common/requestParams";
+import { Location } from "../../common/responseSchemas";
+
+const DOCS_LINK = "https://developers.google.com/my-business/reference/businessinformation/rest/v1/accounts.locations/list";
+
+export default defineAction({
+  key: "google_my_business-list-locations",
+  name: "List Locations",
+  description: `Lists the locations for the specified account. [See the documentation](${DOCS_LINK})`,
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  type: "action",
+  props: {
+    app,
+    account: {
+      propDefinition: [
+        app,
+        "account",
+      ],
+    },
+    readMask: {
+      type: "string",
+      label: "Read Mask",
+      description: "A comma-separated list of fields to return for each location (e.g. `name,title,categories,storefrontAddress`). Defaults to `name,title` if omitted.",
+      optional: true,
+    },
+    filter: {
+      type: "string",
+      label: "Filter",
+      description: "A filter constraining the locations to return. [See the documentation](https://developers.google.com/my-business/content/location-data#filter_results_when_you_list_locations) for supported filter syntax.",
+      optional: true,
+    },
+    orderBy: {
+      type: "string",
+      label: "Order By",
+      description: "Sorting order for the request. Multiple fields should be comma-separated, following SQL syntax. The default sorting order is ascending. To specify descending order, a suffix \" desc\" should be added. Valid fields to orderBy are title and storeCode. For example: \"title, storeCode desc\" or \"title\" or \"storeCode desc\"",
+      optional: true,
+    },
+    pageSize: {
+      type: "integer",
+      label: "Page Size",
+      description: "Number of locations to return per page. Minimum 1, maximum 100. Defaults to 10.",
+      optional: true,
+    },
+    pageToken: {
+      type: "string",
+      label: "Page Token",
+      description: "Token from a previous response to retrieve the next page of results.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const {
+      account, readMask, filter, orderBy, pageSize, pageToken,
+    } = this;
+
+    const params: ListLocationsParams = {
+      $,
+      account,
+      params: {
+        readMask: readMask ?? "name,title",
+        filter,
+        orderBy,
+        pageSize,
+        pageToken,
+      },
+    };
+
+    const response: { locations?: Location[]; nextPageToken?: string; totalSize?: number; } = await this.app.listLocations(params);
+    const locations = response?.locations ?? [];
+
+    $.export("$summary", `Successfully listed ${locations.length} location${locations.length !== 1
+      ? "s"
+      : ""}`);
+
+    return response;
+  },
+});

--- a/components/google_my_business/actions/list-posts/list-posts.ts
+++ b/components/google_my_business/actions/list-posts/list-posts.ts
@@ -9,7 +9,7 @@ export default defineAction({
   key: "google_my_business-list-posts",
   name: "List Posts",
   description: `List local posts associated with a location. [See the documentation](${DOCS_LINK})`,
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_my_business/app/google_my_business.app.ts
+++ b/components/google_my_business/app/google_my_business.app.ts
@@ -133,9 +133,12 @@ export default defineApp({
     },
     async _httpRequest({
       $ = this,
+      url,
       ...args
     }: HttpRequestParams): Promise<object> {
+      const cleanUrl = url?.replace(/\/(accounts|locations)\/\1\//g, "/$1/");
       return axios($, {
+        url: cleanUrl,
         ...args,
         headers: this._getHeaders(),
       });

--- a/components/google_my_business/app/google_my_business.app.ts
+++ b/components/google_my_business/app/google_my_business.app.ts
@@ -24,7 +24,7 @@ export default defineApp({
         }
         const response = await this.listAccounts({
           params: {
-            pageSize: 50,
+            pageSize: 20,
             pageToken,
           },
         });

--- a/components/google_my_business/common/requestParams.ts
+++ b/components/google_my_business/common/requestParams.ts
@@ -28,6 +28,26 @@ interface AccountLocation {
   location: string;
 }
 
+export interface ListAccountsParams extends PdAxiosRequest {
+  params?: {
+    parentAccount?: string;
+    pageSize?: number;
+    pageToken?: string;
+    filter?: string;
+  };
+}
+
+export interface ListLocationsParams extends PdAxiosRequest {
+  account: string;
+  params?: {
+    pageSize?: number;
+    pageToken?: string;
+    filter?: string;
+    orderBy?: string;
+    readMask?: string;
+  };
+}
+
 export interface ListPostsParams extends PaginatedRequest, AccountLocation { }
 export interface ListReviewsParams extends PaginatedRequest, AccountLocation { }
 

--- a/components/google_my_business/package.json
+++ b/components/google_my_business/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_my_business",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Pipedream Google My Business Components",
   "main": "dist/app/google_my_business.app.mjs",
   "keywords": [

--- a/components/google_my_business/sources/new-post-created/new-post-created.ts
+++ b/components/google_my_business/sources/new-post-created/new-post-created.ts
@@ -10,7 +10,7 @@ export default defineSource({
   key: "google_my_business-new-post-created",
   name: "New Post Created",
   description: `Emit new event for each new local post on a location [See the documentation](${DOCS_LINK})`,
-  version: "0.0.6",
+  version: "0.0.7",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/google_my_business/sources/new-review-created-multiple-locations/new-review-created-multiple-locations.ts
+++ b/components/google_my_business/sources/new-review-created-multiple-locations/new-review-created-multiple-locations.ts
@@ -13,7 +13,7 @@ export default defineSource({
   key: "google_my_business-new-review-created-multiple-locations",
   name: "New Review Created (Multiple Locations)",
   description: `Emit new event for each new review on any of the selected locations [See the documentation](${DOCS_LINK})`,
-  version: "0.0.3",
+  version: "0.0.4",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_my_business/sources/new-review-created/new-review-created.ts
+++ b/components/google_my_business/sources/new-review-created/new-review-created.ts
@@ -10,7 +10,7 @@ export default defineSource({
   key: "google_my_business-new-review-created",
   name: "New Review Created",
   description: `Emit new event for each new review on a location [See the documentation](${DOCS_LINK})`,
-  version: "0.0.6",
+  version: "0.0.7",
   type: "source",
   dedupe: "unique",
   methods: {


### PR DESCRIPTION
Resolves #21012 

The Google Business Profile API returns account and location names in the format, `accounts/117665792695448708367`, `locations/16566134112349858382`. However, our components expect only the integer part and not the leading "/accounts" or "/locations". 

This PR removes any duplications of "/accounts" or "/locations" in the url before making the axios call so that account and location names may be entered with or without the preceeding "/accounts" or "/locations".

Also adds 2 new actions, "List Accounts" and "List Locations".



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added actions to list accounts and to list locations for a specified business account

* **Bug Fixes**
  * Fixed review-list summary to handle missing responses and pluralize correctly
  * Normalized HTTP request URLs to remove duplicated path segments
  * Adjusted account listing request page size to improve account fetch consistency

* **Chores**
  * Bumped action, source, and package versions across the Google My Business component
<!-- end of auto-generated comment: release notes by coderabbit.ai -->