### PR TITLE
Airtable - adding fallback to withLabel props

### DIFF
--- a/components/airtable_oauth/actions/common/common-list.mjs
+++ b/components/airtable_oauth/actions/common/common-list.mjs
@@ -9,8 +9,8 @@ export default {
         ({
           baseId, tableId,
         }) => ({
-          baseId: baseId.value,
-          tableId: tableId.value,
+          baseId: baseId?.value ?? baseId,
+          tableId: tableId?.value ?? tableId,
         }),
       ],
       optional: true,

--- a/components/airtable_oauth/actions/common/common.mjs
+++ b/components/airtable_oauth/actions/common/common.mjs
@@ -20,7 +20,7 @@ export default {
         airtable,
         "tableId",
         ({ baseId }) => ({
-          baseId: baseId.value,
+          baseId: baseId?.value ?? baseId,
         }),
       ],
       withLabel: true,

--- a/components/airtable_oauth/actions/create-comment/create-comment.mjs
+++ b/components/airtable_oauth/actions/create-comment/create-comment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "airtable_oauth-create-comment",
   name: "Create Comment",
   description: "Create a comment on a selected record. [See the documentation](https://airtable.com/developers/web/api/create-comment)",
-  version: "0.0.13",
+  version: "0.0.14",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -20,8 +20,8 @@ export default {
         ({
           baseId, tableId,
         }) => ({
-          baseId: baseId.value,
-          tableId: tableId.value,
+          baseId: baseId?.value ?? baseId,
+          tableId: tableId?.value ?? tableId,
         }),
       ],
     },
@@ -33,8 +33,8 @@ export default {
   },
   async run({ $ }) {
     const response = await this.airtable.createComment({
-      baseId: this.baseId.value,
-      tableId: this.tableId.value,
+      baseId: this.baseId?.value ?? this.baseId,
+      tableId: this.tableId?.value ?? this.tableId,
       recordId: this.recordId,
       data: {
         text: this.comment,

--- a/components/airtable_oauth/actions/create-field/create-field.mjs
+++ b/components/airtable_oauth/actions/create-field/create-field.mjs
@@ -5,7 +5,7 @@ export default {
   key: "airtable_oauth-create-field",
   name: "Create Field",
   description: "Create a new field in a table. [See the documentation](https://airtable.com/developers/web/api/create-field)",
-  version: "0.1.5",
+  version: "0.1.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -43,8 +43,8 @@ export default {
       description, name, options, type,
     } = this;
     const response = await this.airtable.createField({
-      baseId: this.baseId.value,
-      tableId: this.tableId.value,
+      baseId: this.baseId?.value ?? this.baseId,
+      tableId: this.tableId?.value ?? this.tableId,
       data: {
         name,
         type,

--- a/components/airtable_oauth/actions/create-multiple-records/create-multiple-records.mjs
+++ b/components/airtable_oauth/actions/create-multiple-records/create-multiple-records.mjs
@@ -9,7 +9,7 @@ export default {
   key: "airtable_oauth-create-multiple-records",
   name: "Create Multiple Records",
   description: "Create one or more records in a table in a single operation with an array. [See the documentation](https://airtable.com/developers/web/api/create-records)",
-  version: "0.0.13",
+  version: "0.0.14",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/airtable_oauth/actions/create-or-update-record/create-or-update-record.mjs
+++ b/components/airtable_oauth/actions/create-or-update-record/create-or-update-record.mjs
@@ -6,7 +6,7 @@ export default {
   key: "airtable_oauth-create-or-update-record",
   name: "Create or Update Record",
   description: "Create a new record or update an existing one. [See the documentation](https://airtable.com/developers/web/api/create-records)",
-  version: "0.1.5",
+  version: "0.1.6",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
@@ -26,8 +26,8 @@ export default {
         ({
           baseId, tableId,
         }) => ({
-          baseId: baseId.value,
-          tableId: tableId.value,
+          baseId: baseId?.value ?? baseId,
+          tableId: tableId?.value ?? tableId,
         }),
       ],
       optional: true,

--- a/components/airtable_oauth/actions/create-single-record/create-single-record.mjs
+++ b/components/airtable_oauth/actions/create-single-record/create-single-record.mjs
@@ -6,7 +6,7 @@ export default {
   key: "airtable_oauth-create-single-record",
   name: "Create Single Record",
   description: "Adds a record to a table.",
-  version: "0.0.14",
+  version: "0.0.15",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/airtable_oauth/actions/create-table/create-table.mjs
+++ b/components/airtable_oauth/actions/create-table/create-table.mjs
@@ -4,7 +4,7 @@ export default {
   key: "airtable_oauth-create-table",
   name: "Create Table",
   description: "Create a new table. [See the documentation](https://airtable.com/developers/web/api/create-table)",
-  version: "0.0.13",
+  version: "0.0.14",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -45,7 +45,7 @@ export default {
       fields.push(fieldObj);
     }
     const response = await this.airtable.createTable({
-      baseId: this.baseId,
+      baseId: this.baseId?.value ?? this.baseId,
       data: {
         name: this.name,
         description: this.description,

--- a/components/airtable_oauth/actions/delete-record/delete-record.mjs
+++ b/components/airtable_oauth/actions/delete-record/delete-record.mjs
@@ -5,7 +5,7 @@ export default {
   key: "airtable_oauth-delete-record",
   name: "Delete Record",
   description: "Delete a selected record from a table. [See the documentation](https://airtable.com/developers/web/api/delete-record)",
-  version: "0.0.13",
+  version: "0.0.14",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
@@ -21,8 +21,8 @@ export default {
         ({
           baseId, tableId,
         }) => ({
-          baseId: baseId.value,
-          tableId: tableId.value,
+          baseId: baseId?.value ?? baseId,
+          tableId: tableId?.value ?? tableId,
         }),
       ],
     },

--- a/components/airtable_oauth/actions/get-record-or-create/get-record-or-create.mjs
+++ b/components/airtable_oauth/actions/get-record-or-create/get-record-or-create.mjs
@@ -6,7 +6,7 @@ export default {
   key: "airtable_oauth-get-record-or-create",
   name: "Get Record Or Create",
   description: "Get a specific record, or create one if it doesn't exist. [See the documentation](https://airtable.com/developers/web/api/create-records)",
-  version: "0.0.15",
+  version: "0.0.16",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -26,8 +26,8 @@ export default {
         ({
           baseId, tableId,
         }) => ({
-          baseId: baseId.value,
-          tableId: tableId.value,
+          baseId: baseId?.value ?? baseId,
+          tableId: tableId?.value ?? tableId,
         }),
       ],
       optional: true,

--- a/components/airtable_oauth/actions/get-record/get-record.mjs
+++ b/components/airtable_oauth/actions/get-record/get-record.mjs
@@ -6,7 +6,7 @@ export default {
   key: "airtable_oauth-get-record",
   name: "Get Record",
   description: "Get data of a selected record from a table. [See the documentation](https://airtable.com/developers/web/api/get-record)",
-  version: "0.0.14",
+  version: "0.0.15",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -28,8 +28,8 @@ export default {
         ({
           baseId, tableId,
         }) => ({
-          baseId: baseId.value,
-          tableId: tableId.value,
+          baseId: baseId?.value ?? baseId,
+          tableId: tableId?.value ?? tableId,
         }),
       ],
     },

--- a/components/airtable_oauth/actions/list-records-in-view/list-records-in-view.mjs
+++ b/components/airtable_oauth/actions/list-records-in-view/list-records-in-view.mjs
@@ -6,7 +6,7 @@ export default {
   name: "List Records in View",
   description: "Retrieve records from a view, optionally sorting and filtering results. [See the documentation](https://airtable.com/developers/web/api/list-views)",
   type: "action",
-  version: "0.0.13",
+  version: "0.0.14",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -27,8 +27,8 @@ export default {
         ({
           baseId, tableId,
         }) => ({
-          baseId: baseId.value,
-          tableId: tableId.value,
+          baseId: baseId?.value ?? baseId,
+          tableId: tableId?.value ?? tableId,
         }),
       ],
       withLabel: true,

--- a/components/airtable_oauth/actions/list-records/list-records.mjs
+++ b/components/airtable_oauth/actions/list-records/list-records.mjs
@@ -6,7 +6,7 @@ export default {
   name: "List Records",
   description: "Retrieve records from a table, optionally sorting and filtering results. [See the documentation](https://airtable.com/developers/web/api/list-records)",
   type: "action",
-  version: "0.0.13",
+  version: "0.0.14",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/airtable_oauth/actions/list-tables/list-tables.mjs
+++ b/components/airtable_oauth/actions/list-tables/list-tables.mjs
@@ -6,7 +6,7 @@ export default {
   description:
     "Get a list of tables in the selected base. [See the documentation](https://airtable.com/developers/web/api/get-base-schema)",
   type: "action",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -24,7 +24,7 @@ export default {
   async run({ $ }) {
     const { tables } = await this.airtable.listTables({
       $,
-      baseId: this.baseId,
+      baseId: this.baseId?.value ?? this.baseId,
     });
     $.export(
       "$summary",

--- a/components/airtable_oauth/actions/search-records/search-records.mjs
+++ b/components/airtable_oauth/actions/search-records/search-records.mjs
@@ -5,7 +5,7 @@ export default {
   key: "airtable_oauth-search-records",
   name: "Search Records",
   description: "Search for a record by formula or by field value. [See the documentation](https://airtable.com/developers/web/api/list-records)",
-  version: "0.0.15",
+  version: "0.0.16",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -69,9 +69,9 @@ export default {
     fieldTypeToPropType,
     async listFields() {
       const { tables } = await this.airtable.listTables({
-        baseId: this.baseId.value,
+        baseId: this.baseId?.value ?? this.baseId,
       });
-      const table = tables.find(({ id }) => id === this.tableId.value);
+      const table = tables.find(({ id }) => id === (this.tableId?.value ?? this.tableId));
       return table.fields ?? [];
     },
   },

--- a/components/airtable_oauth/actions/update-comment/update-comment.mjs
+++ b/components/airtable_oauth/actions/update-comment/update-comment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "airtable_oauth-update-comment",
   name: "Update Comment",
   description: "Update an existing comment on a selected record. [See the documentation](https://airtable.com/developers/web/api/update-comment)",
-  version: "0.0.13",
+  version: "0.0.14",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
@@ -20,8 +20,8 @@ export default {
         ({
           baseId, tableId,
         }) => ({
-          baseId: baseId.value,
-          tableId: tableId.value,
+          baseId: baseId?.value ?? baseId,
+          tableId: tableId?.value ?? tableId,
         }),
       ],
     },
@@ -32,8 +32,8 @@ export default {
         ({
           baseId, tableId, recordId,
         }) => ({
-          baseId: baseId.value,
-          tableId: tableId.value,
+          baseId: baseId?.value ?? baseId,
+          tableId: tableId?.value ?? tableId,
           recordId,
         }),
       ],
@@ -46,8 +46,8 @@ export default {
   },
   async run({ $ }) {
     const response = await this.airtable.updateComment({
-      baseId: this.baseId.value,
-      tableId: this.tableId.value,
+      baseId: this.baseId?.value ?? this.baseId,
+      tableId: this.tableId?.value ?? this.tableId,
       recordId: this.recordId,
       commentId: this.commentId,
       data: {

--- a/components/airtable_oauth/actions/update-field/update-field.mjs
+++ b/components/airtable_oauth/actions/update-field/update-field.mjs
@@ -5,7 +5,7 @@ export default {
   key: "airtable_oauth-update-field",
   name: "Update Field",
   description: "Update an existing field in a table. [See the documentation](https://airtable.com/developers/web/api/update-field)",
-  version: "0.0.13",
+  version: "0.0.14",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
@@ -21,8 +21,8 @@ export default {
         ({
           baseId, tableId,
         }) => ({
-          baseId: baseId.value,
-          tableId: tableId.value,
+          baseId: baseId?.value ?? baseId,
+          tableId: tableId?.value ?? tableId,
         }),
       ],
       label: "Field ID",
@@ -55,8 +55,8 @@ export default {
       data.description = this.description;
     }
     const response = await this.airtable.updateField({
-      baseId: this.baseId.value,
-      tableId: this.tableId.value,
+      baseId: this.baseId?.value ?? this.baseId,
+      tableId: this.tableId?.value ?? this.tableId,
       fieldId: this.fieldId,
       data,
       $,

--- a/components/airtable_oauth/actions/update-record/update-record.mjs
+++ b/components/airtable_oauth/actions/update-record/update-record.mjs
@@ -6,7 +6,7 @@ export default {
   key: "airtable_oauth-update-record",
   name: "Update Record",
   description: "Update a single record in a table by Record ID. [See the documentation](https://airtable.com/developers/web/api/update-record)",
-  version: "0.0.14",
+  version: "0.0.15",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
@@ -27,8 +27,8 @@ export default {
         ({
           baseId, tableId,
         }) => ({
-          baseId: baseId.value,
-          tableId: tableId.value,
+          baseId: baseId?.value ?? baseId,
+          tableId: tableId?.value ?? tableId,
         }),
       ],
     },

--- a/components/airtable_oauth/actions/update-table/update-table.mjs
+++ b/components/airtable_oauth/actions/update-table/update-table.mjs
@@ -4,7 +4,7 @@ export default {
   key: "airtable_oauth-update-table",
   name: "Update Table",
   description: "Update an existing table. [See the documentation](https://airtable.com/developers/web/api/update-table)",
-  version: "0.0.13",
+  version: "0.0.14",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
@@ -35,8 +35,8 @@ export default {
       data.description = this.description;
     }
     const response = await this.airtable.updateTable({
-      baseId: this.baseId.value,
-      tableId: this.tableId.value,
+      baseId: this.baseId?.value ?? this.baseId,
+      tableId: this.tableId?.value ?? this.tableId,
       data,
       $,
     });

--- a/components/airtable_oauth/package.json
+++ b/components/airtable_oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/airtable_oauth",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Pipedream Airtable (OAuth) Components",
   "main": "airtable_oauth.app.mjs",
   "keywords": [

--- a/components/airtable_oauth/sources/common/common-webhook-field.mjs
+++ b/components/airtable_oauth/sources/common/common-webhook-field.mjs
@@ -11,7 +11,7 @@ export default {
     },
     async saveAdditionalData() {
       const tableData = await this.airtable.listTables({
-        baseId: this.baseId,
+        baseId: this.baseId?.value ?? this.baseId,
       });
       const filteredData = tableData?.tables?.map(({
         id, name, fields,

--- a/components/airtable_oauth/sources/common/common-webhook-record.mjs
+++ b/components/airtable_oauth/sources/common/common-webhook-record.mjs
@@ -66,7 +66,7 @@ export default {
       try {
         const res = await withRetry(
           () => this.airtable.getRecord({
-            baseId: this.baseId,
+            baseId: this.baseId?.value ?? this.baseId,
             tableId,
             recordId,
           }),

--- a/components/airtable_oauth/sources/common/common-webhook.mjs
+++ b/components/airtable_oauth/sources/common/common-webhook.mjs
@@ -20,7 +20,7 @@ export default {
         airtable,
         "tableId",
         (c) => ({
-          baseId: c.baseId,
+          baseId: c.baseId?.value ?? c.baseId,
         }),
       ],
       description: "If specified, events will only be emitted for the selected Table",
@@ -31,8 +31,8 @@ export default {
         airtable,
         "viewId",
         (c) => ({
-          baseId: c.baseId,
-          tableId: c.tableId,
+          baseId: c.baseId?.value ?? c.baseId,
+          tableId: c.tableId?.value ?? c.tableId,
         }),
       ],
       description: "If specified, events will only be emitted for the selected View",
@@ -48,8 +48,10 @@ export default {
   },
   hooks: {
     async activate() {
+      const baseId = this.baseId?.value ?? this.baseId;
+      const tableId = this.tableId?.value ?? this.tableId;
       const { id } = await this.airtable.createWebhook({
-        baseId: this.baseId,
+        baseId,
         data: {
           notificationUrl: `${this.http.endpoint}/`,
           specification: {
@@ -57,8 +59,8 @@ export default {
               filters: {
                 recordChangeScope: this.viewId
                   ? this.viewId
-                  : this.tableId
-                    ? this.tableId
+                  : tableId
+                    ? tableId
                     : undefined,
                 dataTypes: this.getDataTypes(),
                 changeTypes: this.getChangeTypes(),
@@ -81,7 +83,7 @@ export default {
       const webhookId = this._getHookId();
       if (webhookId) {
         await this.airtable.deleteWebhook({
-          baseId: this.baseId,
+          baseId: this.baseId?.value ?? this.baseId,
           webhookId,
         });
       }
@@ -170,7 +172,7 @@ export default {
       const {
         cursor, mightHaveMore, payloads,
       } = await this.airtable.listWebhookPayloads({
-        baseId: this.baseId,
+        baseId: this.baseId?.value ?? this.baseId,
         webhookId,
         params,
       });

--- a/components/airtable_oauth/sources/new-field/new-field.mjs
+++ b/components/airtable_oauth/sources/new-field/new-field.mjs
@@ -5,7 +5,7 @@ export default {
   name: "New Field Created (Instant)",
   description: "Emit new event when a field is created in the selected table. [See the documentation](https://airtable.com/developers/web/api/get-base-schema)",
   key: "airtable_oauth-new-field",
-  version: "1.0.4",
+  version: "1.0.5",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/airtable_oauth/sources/new-modified-or-deleted-records-instant/new-modified-or-deleted-records-instant.mjs
+++ b/components/airtable_oauth/sources/new-modified-or-deleted-records-instant/new-modified-or-deleted-records-instant.mjs
@@ -8,7 +8,7 @@ export default {
   name: "New Record Created, Updated or Deleted (Instant)",
   description: "Emit new event when a record is added, updated, or deleted in a table or selected view.",
   key: "airtable_oauth-new-modified-or-deleted-records-instant",
-  version: "0.1.4",
+  version: "0.1.5",
   type: "source",
   dedupe: "unique",
   props: {
@@ -30,8 +30,8 @@ export default {
         airtable,
         "sortFieldId",
         (c) => ({
-          baseId: c.baseId,
-          tableId: c.tableId,
+          baseId: c.baseId?.value ?? c.baseId,
+          tableId: c.tableId?.value ?? c.tableId,
         }),
       ],
       type: "string[]",

--- a/components/airtable_oauth/sources/new-modified-or-deleted-records/new-modified-or-deleted-records.mjs
+++ b/components/airtable_oauth/sources/new-modified-or-deleted-records/new-modified-or-deleted-records.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New, Modified or Deleted Records",
   description: "Emit new event each time a record is added, updated, or deleted in an Airtable table. Supports tables up to 10,000 records",
   key: "airtable_oauth-new-modified-or-deleted-records",
-  version: "0.0.13",
+  version: "0.0.14",
   type: "source",
   dedupe: "unique",
   props: {
@@ -16,7 +16,7 @@ export default {
         base.props.airtable,
         "tableId",
         ({ baseId }) => ({
-          baseId,
+          baseId: baseId?.value ?? baseId,
         }),
       ],
       description: "The table ID to watch for changes.",
@@ -38,11 +38,9 @@ export default {
     },
   },
   async run(event) {
-    const {
-      baseId,
-      tableId,
-      viewId,
-    } = this;
+    const baseId = this.baseId?.value ?? this.baseId;
+    const tableId = this.tableId?.value ?? this.tableId;
+    const { viewId } = this;
 
     const metadata = {
       baseId,

--- a/components/airtable_oauth/sources/new-or-modified-field/new-or-modified-field.mjs
+++ b/components/airtable_oauth/sources/new-or-modified-field/new-or-modified-field.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New or Modified Field (Instant)",
   description: "Emit new event when a field is created or updated in the selected table",
   key: "airtable_oauth-new-or-modified-field",
-  version: "1.0.4",
+  version: "1.0.5",
   type: "source",
   dedupe: "unique",
   methods: {
@@ -25,8 +25,8 @@ export default {
         airtable,
         "sortFieldId",
         (c) => ({
-          baseId: c.baseId,
-          tableId: c.tableId,
+          baseId: c.baseId?.value ?? c.baseId,
+          tableId: c.tableId?.value ?? c.tableId,
         }),
       ],
       type: "string[]",

--- a/components/airtable_oauth/sources/new-or-modified-records-in-view/new-or-modified-records-in-view.mjs
+++ b/components/airtable_oauth/sources/new-or-modified-records-in-view/new-or-modified-records-in-view.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New or Modified Records in View",
   description: "Emit new event for each new or modified record in a view",
   key: "airtable_oauth-new-or-modified-records-in-view",
-  version: "0.0.14",
+  version: "0.0.15",
   type: "source",
   props: {
     ...base.props,
@@ -15,7 +15,7 @@ export default {
         base.props.airtable,
         "tableId",
         ({ baseId }) => ({
-          baseId,
+          baseId: baseId?.value ?? baseId,
         }),
       ],
       description: "The table ID to watch for changes.",
@@ -27,8 +27,8 @@ export default {
         ({
           baseId, tableId,
         }) => ({
-          baseId,
-          tableId,
+          baseId: baseId?.value ?? baseId,
+          tableId: tableId?.value ?? tableId,
         }),
       ],
       description: "The view ID to watch for changes.",
@@ -41,11 +41,9 @@ export default {
     },
   },
   async run(event) {
-    const {
-      baseId,
-      tableId,
-      viewId,
-    } = this;
+    const baseId = this.baseId?.value ?? this.baseId;
+    const tableId = this.tableId?.value ?? this.tableId;
+    const { viewId } = this;
 
     const lastTimestamp = this._getLastTimestamp();
     const params = this.getListRecordsParams({

--- a/components/airtable_oauth/sources/new-or-modified-records/new-or-modified-records.mjs
+++ b/components/airtable_oauth/sources/new-or-modified-records/new-or-modified-records.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New or Modified Records (Instant)",
   key: "airtable_oauth-new-or-modified-records",
   description: "Emit new event for each new or modified record in a table or view",
-  version: "1.0.4",
+  version: "1.0.5",
   type: "source",
   dedupe: "unique",
   methods: {
@@ -25,8 +25,8 @@ export default {
         airtable,
         "sortFieldId",
         (c) => ({
-          baseId: c.baseId,
-          tableId: c.tableId,
+          baseId: c.baseId?.value ?? c.baseId,
+          tableId: c.tableId?.value ?? c.tableId,
         }),
       ],
       type: "string[]",

--- a/components/airtable_oauth/sources/new-records-in-view/new-records-in-view.mjs
+++ b/components/airtable_oauth/sources/new-records-in-view/new-records-in-view.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Records in View",
   description: "Emit new event for each new record in a view",
   key: "airtable_oauth-new-records-in-view",
-  version: "0.0.13",
+  version: "0.0.14",
   type: "source",
   dedupe: "unique",
   props: {
@@ -16,7 +16,7 @@ export default {
         base.props.airtable,
         "tableId",
         ({ baseId }) => ({
-          baseId,
+          baseId: baseId?.value ?? baseId,
         }),
       ],
       description: "The table ID to watch for changes.",
@@ -28,8 +28,8 @@ export default {
         ({
           baseId, tableId,
         }) => ({
-          baseId,
-          tableId,
+          baseId: baseId?.value ?? baseId,
+          tableId: tableId?.value ?? tableId,
         }),
       ],
       description: "The view ID to watch for changes.",
@@ -42,11 +42,9 @@ export default {
     },
   },
   async run() {
-    const {
-      baseId,
-      tableId,
-      viewId,
-    } = this;
+    const baseId = this.baseId?.value ?? this.baseId;
+    const tableId = this.tableId?.value ?? this.tableId;
+    const { viewId } = this;
 
     const lastTimestamp = this._getLastTimestamp();
     const params = this.getListRecordsParams({

--- a/components/airtable_oauth/sources/new-records/new-records.mjs
+++ b/components/airtable_oauth/sources/new-records/new-records.mjs
@@ -5,7 +5,7 @@ export default {
   name: "New Record(s) Created (Instant)",
   description: "Emit new event for each new record in a table",
   key: "airtable_oauth-new-records",
-  version: "1.0.4",
+  version: "1.0.5",
   type: "source",
   dedupe: "unique",
   methods: {


### PR DESCRIPTION
Adding a fallback pattern of `this.prop?.value ?? this.prop` to all read sites of baseId and tableId across Airtable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Airtable base and table ID parameters across actions and event sources to support different input formats, preventing compatibility issues when IDs are provided in various formats.

* **Chores**
  * Version bumps across multiple Airtable OAuth components and package to reflect robustness improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->