### PR TITLE
Add Xquik media and follower actions

### DIFF
--- a/components/xquik/actions/check-follower/check-follower.mjs
+++ b/components/xquik/actions/check-follower/check-follower.mjs
@@ -13,28 +13,28 @@ export default {
   },
   props: {
     xquik,
-    sourceUserId: {
+    sourceUsername: {
       propDefinition: [
         xquik,
-        "sourceUserId",
+        "sourceUsername",
       ],
     },
-    targetUserId: {
+    targetUsername: {
       propDefinition: [
         xquik,
-        "targetUserId",
+        "targetUsername",
       ],
     },
   },
   async run({ $ }) {
     const response = await this.xquik.checkFollower({
       $,
-      sourceUserId: this.sourceUserId,
-      targetUserId: this.targetUserId,
+      sourceUsername: this.sourceUsername,
+      targetUsername: this.targetUsername,
     });
 
-    const source = response?.sourceUsername ?? this.sourceUserId;
-    const target = response?.targetUsername ?? this.targetUserId;
+    const source = response?.sourceUsername ?? this.sourceUsername;
+    const target = response?.targetUsername ?? this.targetUsername;
     const result = response?.isFollowing
       ? "follows"
       : "does not follow";

--- a/components/xquik/actions/check-follower/check-follower.mjs
+++ b/components/xquik/actions/check-follower/check-follower.mjs
@@ -1,0 +1,45 @@
+import xquik from "../../xquik.app.mjs";
+
+export default {
+  key: "xquik-check-follower",
+  name: "Check Follower",
+  description: "Check if one public X/Twitter user follows another with Xquik. [See the documentation](https://docs.xquik.com/api-reference/x/check-follower)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    xquik,
+    sourceUserId: {
+      propDefinition: [
+        xquik,
+        "sourceUserId",
+      ],
+    },
+    targetUserId: {
+      propDefinition: [
+        xquik,
+        "targetUserId",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.xquik.checkFollower({
+      $,
+      sourceUserId: this.sourceUserId,
+      targetUserId: this.targetUserId,
+    });
+
+    const source = response?.sourceUsername ?? this.sourceUserId;
+    const target = response?.targetUsername ?? this.targetUserId;
+    const result = response?.isFollowing
+      ? "follows"
+      : "does not follow";
+
+    $.export("$summary", `${source} ${result} ${target}`);
+    return response;
+  },
+};

--- a/components/xquik/actions/download-tweet-media/download-tweet-media.mjs
+++ b/components/xquik/actions/download-tweet-media/download-tweet-media.mjs
@@ -1,0 +1,39 @@
+import xquik from "../../xquik.app.mjs";
+
+export default {
+  key: "xquik-download-tweet-media",
+  name: "Download Tweet Media",
+  description: "Download images and videos from a public X/Twitter post with Xquik. [See the documentation](https://docs.xquik.com/api-reference/x/download-media)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    xquik,
+    tweetInput: {
+      propDefinition: [
+        xquik,
+        "tweetInput",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.xquik.downloadTweetMedia({
+      $,
+      tweetInput: this.tweetInput,
+    });
+
+    const summary = response?.totalMedia !== undefined
+      ? `Downloaded ${response.totalMedia} media items`
+      : `Created media gallery for ${response?.tweetId ?? this.tweetInput}`;
+    const galleryUrl = response?.galleryUrl
+      ? ` Gallery: ${response.galleryUrl}`
+      : "";
+
+    $.export("$summary", `${summary}.${galleryUrl}`);
+    return response;
+  },
+};

--- a/components/xquik/actions/get-trends/get-trends.mjs
+++ b/components/xquik/actions/get-trends/get-trends.mjs
@@ -4,7 +4,7 @@ export default {
   key: "xquik-get-trends",
   name: "Get Trends",
   description: "Get trending public X/Twitter topics by region with Xquik. [See the documentation](https://docs.xquik.com/api-reference/x/trends)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/xquik/actions/get-tweet/get-tweet.mjs
+++ b/components/xquik/actions/get-tweet/get-tweet.mjs
@@ -4,7 +4,7 @@ export default {
   key: "xquik-get-tweet",
   name: "Get Tweet",
   description: "Get a public X/Twitter post by ID with Xquik. [See the documentation](https://docs.xquik.com/api-reference/x/get-tweet)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/xquik/actions/get-user-tweets/get-user-tweets.mjs
+++ b/components/xquik/actions/get-user-tweets/get-user-tweets.mjs
@@ -4,7 +4,7 @@ export default {
   key: "xquik-get-user-tweets",
   name: "Get User Tweets",
   description: "List recent public X/Twitter posts from a user with Xquik. [See the documentation](https://docs.xquik.com/api-reference/x/user-tweets)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/xquik/actions/get-user/get-user.mjs
+++ b/components/xquik/actions/get-user/get-user.mjs
@@ -4,7 +4,7 @@ export default {
   key: "xquik-get-user",
   name: "Get User",
   description: "Get a public X/Twitter user profile by username or ID with Xquik. [See the documentation](https://docs.xquik.com/api-reference/x/get-user)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/xquik/actions/search-tweets/search-tweets.mjs
+++ b/components/xquik/actions/search-tweets/search-tweets.mjs
@@ -4,7 +4,7 @@ export default {
   key: "xquik-search-tweets",
   name: "Search Tweets",
   description: "Search public X/Twitter posts with Xquik. [See the documentation](https://docs.xquik.com/api-reference/x/search-tweets)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/xquik/actions/search-users/search-users.mjs
+++ b/components/xquik/actions/search-users/search-users.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Search Users",
   description:
     "Search public X/Twitter users with Xquik. [See the documentation](https://docs.xquik.com/api-reference/x/search-users)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/xquik/package.json
+++ b/components/xquik/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/xquik",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pipedream Xquik Components",
   "main": "xquik.app.mjs",
   "keywords": [

--- a/components/xquik/xquik.app.mjs
+++ b/components/xquik/xquik.app.mjs
@@ -35,15 +35,15 @@ export default {
     },
     sourceUserId: {
       type: "string",
-      label: "Source User ID or Username",
+      label: "Source Username",
       description:
-        "The X user ID or username to check from. Examples: `44196397`, `@elonmusk`, `elonmusk`.",
+        "The X username to check from. Usernames may include or omit the leading `@`. Examples: `@participant_handle`, `participant_handle`.",
     },
     targetUserId: {
       type: "string",
-      label: "Target User ID or Username",
+      label: "Target Username",
       description:
-        "The X user ID or username to check against. Examples: `12`, `@jack`, `jack`.",
+        "The X username to check against. Usernames may include or omit the leading `@`. Examples: `@brand_handle`, `brand_handle`.",
     },
     tweetInput: {
       type: "string",
@@ -167,6 +167,30 @@ export default {
       }
 
       return identifier;
+    },
+    /**
+     * Validate and normalize a username-only API input.
+     *
+     * @param {unknown} value Username value.
+     * @param {string} name Human-readable field name for errors.
+     * @returns {string} Normalized username.
+     */
+    _normalizeUsername(value, name) {
+      const username = this._normalizeIdentifier(value, name, {
+        stripAt: true,
+      });
+
+      if (
+        /^\d+$/.test(username) ||
+        /^https?:\/\//i.test(username) ||
+        username.includes("/")
+      ) {
+        throw new Error(
+          `${name} must be a username, not a numeric ID or profile URL. Use Get User first to resolve numeric IDs or profile URLs to usernames.`,
+        );
+      }
+
+      return username;
     },
     /**
      * Validate and encode a URL path identifier.
@@ -331,12 +355,8 @@ export default {
     checkFollower({
       $, sourceUserId, targetUserId,
     }) {
-      const source = this._normalizeIdentifier(sourceUserId, "Source user", {
-        stripAt: true,
-      });
-      const target = this._normalizeIdentifier(targetUserId, "Target user", {
-        stripAt: true,
-      });
+      const source = this._normalizeUsername(sourceUserId, "Source user");
+      const target = this._normalizeUsername(targetUserId, "Target user");
 
       return this._makeRequest({
         $,

--- a/components/xquik/xquik.app.mjs
+++ b/components/xquik/xquik.app.mjs
@@ -33,6 +33,24 @@ export default {
       description:
         "The X user ID or username. Usernames may include or omit the leading `@`. Examples: `@jack`, `123456`.",
     },
+    sourceUserId: {
+      type: "string",
+      label: "Source User ID or Username",
+      description:
+        "The X user ID or username to check from. Examples: `44196397`, `@elonmusk`, `elonmusk`.",
+    },
+    targetUserId: {
+      type: "string",
+      label: "Target User ID or Username",
+      description:
+        "The X user ID or username to check against. Examples: `12`, `@jack`, `jack`.",
+    },
+    tweetInput: {
+      type: "string",
+      label: "Tweet URL or ID",
+      description:
+        "The X/Twitter post URL or numeric tweet ID to download media from. Examples: `https://x.com/username/status/1234567890123456789`, `1234567890123456789`.",
+    },
     cursor: {
       type: "string",
       label: "Cursor",
@@ -130,15 +148,15 @@ export default {
       );
     },
     /**
-     * Validate and encode a URL path identifier.
+     * Validate and normalize an API identifier.
      *
      * @param {unknown} value Identifier value.
      * @param {string} name Human-readable field name for errors.
-     * @param {object} options Encoding options.
+     * @param {object} options Normalization options.
      * @param {boolean} [options.stripAt=false] Strip leading @ characters.
-     * @returns {string} Encoded identifier.
+     * @returns {string} Normalized identifier.
      */
-    _encodeIdentifier(value, name, { stripAt = false } = {}) {
+    _normalizeIdentifier(value, name, { stripAt = false } = {}) {
       const raw = String(value ?? "").trim();
       const identifier = stripAt
         ? raw.replace(/^@+/, "")
@@ -148,6 +166,21 @@ export default {
         throw new Error(`${name} is required`);
       }
 
+      return identifier;
+    },
+    /**
+     * Validate and encode a URL path identifier.
+     *
+     * @param {unknown} value Identifier value.
+     * @param {string} name Human-readable field name for errors.
+     * @param {object} options Encoding options.
+     * @param {boolean} [options.stripAt=false] Strip leading @ characters.
+     * @returns {string} Encoded identifier.
+     */
+    _encodeIdentifier(value, name, { stripAt = false } = {}) {
+      const identifier = this._normalizeIdentifier(value, name, {
+        stripAt,
+      });
       return encodeURIComponent(identifier);
     },
     /**
@@ -286,6 +319,49 @@ export default {
         params: {
           woeid,
           count,
+        },
+      });
+    },
+    /**
+     * Check if one public X/Twitter user follows another.
+     *
+     * @param {object} args Follow check arguments.
+     * @returns {Promise<unknown>} Follow check response.
+     */
+    checkFollower({
+      $, sourceUserId, targetUserId,
+    }) {
+      const source = this._normalizeIdentifier(sourceUserId, "Source user", {
+        stripAt: true,
+      });
+      const target = this._normalizeIdentifier(targetUserId, "Target user", {
+        stripAt: true,
+      });
+
+      return this._makeRequest({
+        $,
+        path: "/x/followers/check",
+        params: {
+          source,
+          target,
+        },
+      });
+    },
+    /**
+     * Download media from a public X/Twitter post.
+     *
+     * @param {object} args Media download arguments.
+     * @returns {Promise<unknown>} Media download response.
+     */
+    downloadTweetMedia({
+      $, tweetInput,
+    }) {
+      return this._makeRequest({
+        $,
+        method: "POST",
+        path: "/x/media/download",
+        data: {
+          tweetInput,
         },
       });
     },

--- a/components/xquik/xquik.app.mjs
+++ b/components/xquik/xquik.app.mjs
@@ -33,13 +33,13 @@ export default {
       description:
         "The X user ID or username. Usernames may include or omit the leading `@`. Examples: `@jack`, `123456`.",
     },
-    sourceUserId: {
+    sourceUsername: {
       type: "string",
       label: "Source Username",
       description:
         "The X username to check from. Usernames may include or omit the leading `@`. Examples: `@participant_handle`, `participant_handle`.",
     },
-    targetUserId: {
+    targetUsername: {
       type: "string",
       label: "Target Username",
       description:
@@ -353,10 +353,10 @@ export default {
      * @returns {Promise<unknown>} Follow check response.
      */
     checkFollower({
-      $, sourceUserId, targetUserId,
+      $, sourceUsername, targetUsername,
     }) {
-      const source = this._normalizeUsername(sourceUserId, "Source user");
-      const target = this._normalizeUsername(targetUserId, "Target user");
+      const source = this._normalizeUsername(sourceUsername, "Source user");
+      const target = this._normalizeUsername(targetUsername, "Target user");
 
       return this._makeRequest({
         $,

--- a/components/xquik/xquik.app.mjs
+++ b/components/xquik/xquik.app.mjs
@@ -356,12 +356,17 @@ export default {
     downloadTweetMedia({
       $, tweetInput,
     }) {
+      const normalizedTweetInput = this._normalizeIdentifier(
+        tweetInput,
+        "Tweet URL or ID",
+      );
+
       return this._makeRequest({
         $,
         method: "POST",
         path: "/x/media/download",
         data: {
-          tweetInput,
+          tweetInput: normalizedTweetInput,
         },
       });
     },


### PR DESCRIPTION
## Summary

Adds two read-only Xquik actions:

- Check Follower - calls `GET /x/followers/check`
- Download Tweet Media - calls `POST /x/media/download`

The existing Xquik app integration is already present in `components/xquik`, so this is a narrow action refresh rather than a new app submission.

Source checks:

- Public docs checked for both actions:
  - https://docs.xquik.com/api-reference/x/check-follower
  - https://docs.xquik.com/api-reference/x/download-media
- Public OpenAPI checked at https://xquik.com/openapi.json
- Duplicate search checked open and closed Pipedream PRs/issues for `Xquik`, `x-twitter-scraper`, `x-developer`, and `xquik.com`

Validation:

- `node --check components/xquik/xquik.app.mjs`
- `node --check components/xquik/actions/check-follower/check-follower.mjs`
- `node --check components/xquik/actions/download-tweet-media/download-tweet-media.mjs`
- `python3 -m json.tool components/xquik/package.json`
- `pnpm exec eslint components/xquik/xquik.app.mjs components/xquik/actions/check-follower/check-follower.mjs components/xquik/actions/download-tweet-media/download-tweet-media.mjs`
- `node scripts/build-components.mjs components/xquik`

Local note: `pnpm exec jest --passWithNoTests components/xquik --runInBand` is blocked in this checkout by the repository Jest config: `extensionsToTreatAsEsm` includes `.js`, which this local Jest version rejects before collecting component tests.

## Checklist
Please check the following items before your PR can be reviewed:

### Versioning
- [x] All components updated in this PR had their version updated (`0.0.1` for new ones)
- [x] The app updated in this PR had its `package.json`'s version updated

### New app
If this is a new app, please submit [an app integration request](https://github.com/PipedreamHQ/pipedream/issues/new?template=app---service-integration.md) - the PR will only be reviewed after the app is integrated.
- [x] The app updated in this PR is already integrated

### CodeRabbit review
After the PR is opened, and if new changes are pushed, CodeRabbit will automatically review it. Do not 'mark as resolved' CodeRabbit's comments, but reply to them instead, whether you agree (and update the PR accordingly) or disagree.
- [x] I have addressed or acknowledged all of CodeRabbit's review comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an action to check whether one user follows another (source and target inputs).
  * Added an action to download media from tweets, returning media count and gallery URL when available.
  * App inputs added to support follower checks and tweet media downloads.
  * Improved input normalization/validation for usernames and tweet identifiers; actions expose human-readable summaries.

* **Chores**
  * Bumped package version to 0.2.0 and updated several action versions to 0.0.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->