### PR TITLE
add explicit API version to base URL

### DIFF
--- a/components/facebook_pages/actions/create-comment/create-comment.mjs
+++ b/components/facebook_pages/actions/create-comment/create-comment.mjs
@@ -5,7 +5,7 @@ export default {
   key: "facebook_pages-create-comment",
   name: "Create Comment",
   description: "Create a new comment on a post on a Facebook Page. [See the documentation](https://developers.facebook.com/docs/graph-api/reference/object/comments/#publish)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/facebook_pages/actions/create-post/create-post.mjs
+++ b/components/facebook_pages/actions/create-post/create-post.mjs
@@ -6,7 +6,7 @@ export default {
   key: "facebook_pages-create-post",
   name: "Create Post",
   description: "Create a new post on a Facebook Page. [See the documentation](https://developers.facebook.com/docs/graph-api/reference/page/feed#publish)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/facebook_pages/actions/get-comment/get-comment.mjs
+++ b/components/facebook_pages/actions/get-comment/get-comment.mjs
@@ -5,7 +5,7 @@ export default {
   key: "facebook_pages-get-comment",
   name: "Get Comment",
   description: "Retrieves a comment on a post on a Facebook Page. [See the documentation](https://developers.facebook.com/docs/graph-api/reference/comment/#read)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/facebook_pages/actions/get-page/get-page.mjs
+++ b/components/facebook_pages/actions/get-page/get-page.mjs
@@ -5,7 +5,7 @@ export default {
   key: "facebook_pages-get-page",
   name: "Get Page",
   description: "Retrieves a Facebook Page. [See the documentation](https://developers.facebook.com/docs/graph-api/reference/page)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/facebook_pages/actions/get-post/get-post.mjs
+++ b/components/facebook_pages/actions/get-post/get-post.mjs
@@ -5,7 +5,7 @@ export default {
   key: "facebook_pages-get-post",
   name: "Get Post",
   description: "Retrieves a post on a Facebook Page. [See the documentation](https://developers.facebook.com/docs/graph-api/reference/pagepost)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/facebook_pages/actions/list-comments/list-comments.mjs
+++ b/components/facebook_pages/actions/list-comments/list-comments.mjs
@@ -5,7 +5,7 @@ export default {
   key: "facebook_pages-list-comments",
   name: "List Comments",
   description: "Retrieves a list of comments on a post on a Facebook Page. [See the documentation](https://developers.facebook.com/docs/graph-api/reference/comment/#read)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/facebook_pages/actions/list-posts/list-posts.mjs
+++ b/components/facebook_pages/actions/list-posts/list-posts.mjs
@@ -4,8 +4,8 @@ export default {
   ...common,
   key: "facebook_pages-list-posts",
   name: "List Posts",
-  description: "Retrieves a list of posts on a Facebook Page. [See the documentation](https://developers.facebook.com/docs/graph-api/reference/v17.0/page/feed)",
-  version: "0.0.3",
+  description: "Retrieves a list of posts on a Facebook Page. [See the documentation](https://developers.facebook.com/docs/graph-api/reference/v25.0/page/feed)",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/facebook_pages/actions/update-comment/update-comment.mjs
+++ b/components/facebook_pages/actions/update-comment/update-comment.mjs
@@ -5,7 +5,7 @@ export default {
   key: "facebook_pages-update-comment",
   name: "Update Comment",
   description: "Updates an existing comment on a post on a Facebook Page. [See the documentation](https://developers.facebook.com/docs/graph-api/reference/comment/#updating)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/facebook_pages/actions/update-post/update-post.mjs
+++ b/components/facebook_pages/actions/update-post/update-post.mjs
@@ -5,7 +5,7 @@ export default {
   key: "facebook_pages-update-post",
   name: "Update Post",
   description: "Update an existing post on a Facebook Page. [See the documentation](https://developers.facebook.com/docs/graph-api/reference/post#updating)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/facebook_pages/facebook_pages.app.mjs
+++ b/components/facebook_pages/facebook_pages.app.mjs
@@ -104,7 +104,7 @@ export default {
   },
   methods: {
     _baseUrl() {
-      return "https://graph.facebook.com";
+      return "https://graph.facebook.com/v25.0";
     },
     _headers() {
       return {

--- a/components/facebook_pages/package.json
+++ b/components/facebook_pages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/facebook_pages",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream Facebook Pages Components",
   "main": "facebook_pages.app.mjs",
   "keywords": [


### PR DESCRIPTION
Resolves #21106 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Facebook Pages integration to use Facebook Graph API v25.0, ensuring compatibility with the latest API features and improvements
  * Upgraded all related actions and component to version 0.1.2 for enhanced stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->