### PR TITLE
[20701] fix(databricks): handle empty response in list-endpoints action

### DIFF
--- a/components/databricks/actions/list-endpoints/list-endpoints.mjs
+++ b/components/databricks/actions/list-endpoints/list-endpoints.mjs
@@ -4,7 +4,7 @@ export default {
   key: "databricks-list-endpoints",
   name: "List Endpoints",
   description: "List all vector search endpoints. [See the documentation](https://docs.databricks.com/api/workspace/vectorsearchendpoints/listendpoints)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -26,14 +26,14 @@ export default {
 
     do {
       const {
-        endpoints, next_page_token,
+        endpoints = [], next_page_token,
       } = await this.databricks.listEndpoints({
         params,
         $,
       });
 
       allEndpoints.push(...endpoints);
-      if (!next_page_token) break;
+      if (!next_page_token || !endpoints.length) break;
       params.page_token = next_page_token;
     } while (allEndpoints.length < this.maxResults);
 

--- a/components/databricks/package.json
+++ b/components/databricks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/databricks",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Pipedream Databricks Components",
   "main": "databricks.app.mjs",
   "keywords": [


### PR DESCRIPTION
## Summary

<!-- Add your PR description here -->
Closes https://github.com/PipedreamHQ/pipedream/issues/20701
Fixes the `TypeError: endpoints is not iterable` caused when databricks does not return the `endpoints` key in the response where an account has no vector-search endpoints.

## Checklist
Please check the following items before your PR can be reviewed:

### Versioning
- [x] All components updated in this PR had their version updated (`0.0.1` for new ones)
- [x] The app updated in this PR had its `package.json`'s version updated

### New app
If this is a new app, please submit [an app integration request](https://github.com/PipedreamHQ/pipedream/issues/new?template=app---service-integration.md) - the PR will only be reviewed after the app is integrated.
- [ ] The app updated in this PR is already integrated

### CodeRabbit review
After the PR is opened, and if new changes are pushed, CodeRabbit will automatically review it. Do not 'mark as resolved' CodeRabbit's comments, but reply to them instead, whether you agree (and update the PR accordingly) or disagree.
- [ ] I have addressed or acknowledged all of CodeRabbit's review comments



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the Databricks List Endpoints action to more reliably handle pagination when retrieving endpoints, ensuring proper termination of result fetching in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->