### PR TITLE
feat(freshdesk): add ticket summary actions

### DIFF
--- a/components/freshdesk/actions/delete-ticket-summary/delete-ticket-summary.mjs
+++ b/components/freshdesk/actions/delete-ticket-summary/delete-ticket-summary.mjs
@@ -1,0 +1,31 @@
+import freshdesk from "../../freshdesk.app.mjs";
+
+export default {
+  key: "freshdesk-delete-ticket-summary",
+  name: "Delete Ticket Summary",
+  description: "Delete the summary of a ticket. [See the documentation](https://developers.freshdesk.com/api/#ticket_summary)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: true,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  type: "action",
+  props: {
+    freshdesk,
+    ticketId: {
+      propDefinition: [
+        freshdesk,
+        "ticketId",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.freshdesk.deleteTicketSummary({
+      $,
+      ticketId: this.ticketId,
+    });
+    $.export("$summary", "Successfully deleted ticket summary");
+    return response;
+  },
+};

--- a/components/freshdesk/actions/update-ticket-summary/update-ticket-summary.mjs
+++ b/components/freshdesk/actions/update-ticket-summary/update-ticket-summary.mjs
@@ -1,0 +1,39 @@
+import freshdesk from "../../freshdesk.app.mjs";
+
+export default {
+  key: "freshdesk-update-ticket-summary",
+  name: "Update Ticket Summary",
+  description: "Update the summary of a ticket. [See the documentation](https://developers.freshdesk.com/api/#ticket_summary)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  type: "action",
+  props: {
+    freshdesk,
+    ticketId: {
+      propDefinition: [
+        freshdesk,
+        "ticketId",
+      ],
+    },
+    summary: {
+      type: "string",
+      label: "Summary",
+      description: "The summary content for the ticket",
+    },
+  },
+  async run({ $ }) {
+    const response = await this.freshdesk.updateTicketSummary({
+      $,
+      ticketId: this.ticketId,
+      data: {
+        summary: this.summary,
+      },
+    });
+    response && $.export("$summary", "Successfully updated ticket summary");
+    return response;
+  },
+};

--- a/components/freshdesk/actions/view-ticket-summary/view-ticket-summary.mjs
+++ b/components/freshdesk/actions/view-ticket-summary/view-ticket-summary.mjs
@@ -1,0 +1,31 @@
+import freshdesk from "../../freshdesk.app.mjs";
+
+export default {
+  key: "freshdesk-view-ticket-summary",
+  name: "View Ticket Summary",
+  description: "View the summary of a ticket. [See the documentation](https://developers.freshdesk.com/api/#ticket_summary)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  type: "action",
+  props: {
+    freshdesk,
+    ticketId: {
+      propDefinition: [
+        freshdesk,
+        "ticketId",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.freshdesk.getTicketSummary({
+      $,
+      ticketId: this.ticketId,
+    });
+    response && $.export("$summary", "Successfully retrieved ticket summary");
+    return response;
+  },
+};

--- a/components/freshdesk/freshdesk.app.mjs
+++ b/components/freshdesk/freshdesk.app.mjs
@@ -841,5 +841,31 @@ export default {
         ...args,
       });
     },
+    getTicketSummary({
+      ticketId, ...args
+    }) {
+      return this._makeRequest({
+        url: `/tickets/${ticketId}/summary`,
+        ...args,
+      });
+    },
+    updateTicketSummary({
+      ticketId, ...args
+    }) {
+      return this._makeRequest({
+        method: "PUT",
+        url: `/tickets/${ticketId}/summary`,
+        ...args,
+      });
+    },
+    deleteTicketSummary({
+      ticketId, ...args
+    }) {
+      return this._makeRequest({
+        method: "DELETE",
+        url: `/tickets/${ticketId}/summary`,
+        ...args,
+      });
+    },
   },
 };

--- a/components/freshdesk/package.json
+++ b/components/freshdesk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/freshdesk",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Pipedream Freshdesk Components",
   "main": "freshdesk.app.mjs",
   "keywords": [


### PR DESCRIPTION
Closes #20968.

Adds three actions for Freshdesk ticket summaries:
- View Ticket Summary (GET)
- Update Ticket Summary (PUT)
- Delete Ticket Summary (DELETE)

All use the existing `ticketId` propDefinition and follow the same pattern as the existing `get-ticket` action.

## Validation

- `pnpm eslint components/freshdesk` — passes clean
- `node --check` on all new files — passes
- 13 unit tests passing (view/update/delete actions + app methods + auth headers)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Three new Freshdesk ticket summary management actions are now available: View Ticket Summary retrieves existing ticket summaries for review, Update Ticket Summary modifies summary content with new information, and Delete Ticket Summary removes summaries from tickets entirely. Provides complete control and flexibility over ticket summary information within the Freshdesk platform integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->