### PR TITLE
Bugfix on Outlook new-attachment-received

### DIFF
--- a/components/microsoft_outlook/package.json
+++ b/components/microsoft_outlook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/microsoft_outlook",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "Pipedream Microsoft Outlook Components",
   "main": "microsoft_outlook.app.mjs",
   "keywords": [

--- a/components/microsoft_outlook/sources/new-attachment-received/new-attachment-received.mjs
+++ b/components/microsoft_outlook/sources/new-attachment-received/new-attachment-received.mjs
@@ -1,3 +1,4 @@
+import md5 from "md5";
 import common from "../common/common-new-email.mjs";
 import { Readable } from "stream";
 
@@ -6,7 +7,7 @@ export default {
   key: "microsoft_outlook-new-attachment-received",
   name: "New Attachment Received (Instant)",
   description: "Emit new event when a new email containing one or more attachments arrives in a specified Microsoft Outlook folder.",
-  version: "0.1.14",
+  version: "0.1.15",
   type: "source",
   dedupe: "unique",
   props: {
@@ -80,7 +81,11 @@ export default {
     },
     generateMeta(item) {
       return {
-        id: item.contentId,
+        // Attachment `id` is unique per message+attachment but exceeds 64
+        // characters, so hash it. Do NOT use `contentId` here: Graph only
+        // populates it for inline attachments, leaving it null for ordinary
+        // file attachments, which collapses dedupe and drops events.
+        id: md5(`${item.messageId}-${item.id}`),
         summary: `New attachment ${item.name}`,
         ts: Date.parse(item.messageReceivedDateTime),
       };


### PR DESCRIPTION
A lot of events weren't coming through due to the `contentId` field being used for the deduped id, and it isn't present in most attachments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated attachment ID generation in the new-attachment-received source to improve accuracy and reliability of duplicate detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->