### PR TITLE
google_docs: bump find-document so it ships the all-drives fix

### DIFF
--- a/components/google_docs/actions/find-document/find-document.mjs
+++ b/components/google_docs/actions/find-document/find-document.mjs
@@ -14,7 +14,7 @@ export default {
   ...others,
   key: "google_docs-find-document",
   name: "Find Document",
-  version: "0.0.5",
+  version: "0.0.6",
   description,
   type,
   props: {

--- a/components/google_docs/package.json
+++ b/components/google_docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_docs",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Pipedream Google_docs Components",
   "main": "google_docs.app.mjs",
   "keywords": [


### PR DESCRIPTION
Resolves #21142 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Google Docs package and find-document action versions for maintenance purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->