### PR TITLE
chore(notion, databricks): bump package versions for publish

### DIFF
--- a/components/databricks_oauth/actions/list-endpoints/list-endpoints.mjs
+++ b/components/databricks_oauth/actions/list-endpoints/list-endpoints.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "databricks_oauth-list-endpoints",
-  version: "0.0.1",
+  version: "0.0.2",
   name,
   description,
   type,

--- a/components/databricks_oauth/package.json
+++ b/components/databricks_oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/databricks_oauth",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream Databricks (OAuth - Service Principal) Components",
   "main": "databricks_oauth.app.mjs",
   "keywords": [

--- a/components/notion/actions/append-block/append-block.mjs
+++ b/components/notion/actions/append-block/append-block.mjs
@@ -7,7 +7,7 @@ export default {
   key: "notion-append-block",
   name: "Append Block to Parent",
   description: "Append new and/or existing blocks to the specified parent. [See the documentation](https://developers.notion.com/reference/patch-block-children)",
-  version: "0.4.2",
+  version: "0.4.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/notion/actions/complete-file-upload/complete-file-upload.mjs
+++ b/components/notion/actions/complete-file-upload/complete-file-upload.mjs
@@ -6,7 +6,7 @@ export default {
   key: "notion-complete-file-upload",
   name: "Complete File Upload",
   description: "Use this action to finalize a `mode=multi_part` file upload after all of the parts have been sent successfully. [See the documentation](https://developers.notion.com/reference/complete-a-file-upload)",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/notion/actions/create-database/create-database.mjs
+++ b/components/notion/actions/create-database/create-database.mjs
@@ -7,7 +7,7 @@ export default {
   key: "notion-create-database",
   name: "Create Database",
   description: "Create a database and its initial data source. [See the documentation](https://developers.notion.com/reference/database-create)",
-  version: "0.1.6",
+  version: "0.1.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/notion/actions/create-file-upload/create-file-upload.mjs
+++ b/components/notion/actions/create-file-upload/create-file-upload.mjs
@@ -6,7 +6,7 @@ export default {
   key: "notion-create-file-upload",
   name: "Create File Upload",
   description: "Create a file upload. [See the documentation](https://developers.notion.com/reference/create-a-file-upload)",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/notion/actions/create-page-from-database/create-page-from-database.mjs
+++ b/components/notion/actions/create-page-from-database/create-page-from-database.mjs
@@ -10,7 +10,7 @@ export default {
   key: "notion-create-page-from-database",
   name: "Create Page from Data Source",
   description: "Create a page from a data source. [See the documentation](https://developers.notion.com/reference/post-page)",
-  version: "2.0.1",
+  version: "2.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/notion/actions/create-page/create-page.mjs
+++ b/components/notion/actions/create-page/create-page.mjs
@@ -6,7 +6,7 @@ export default {
   key: "notion-create-page",
   name: "Create Page",
   description: "Create a page from a parent page. [See the documentation](https://developers.notion.com/reference/post-page)",
-  version: "0.3.2",
+  version: "0.3.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/notion/actions/delete-block/delete-block.mjs
+++ b/components/notion/actions/delete-block/delete-block.mjs
@@ -6,7 +6,7 @@ export default {
   key: "notion-delete-block",
   name: "Delete Block",
   description: "Sets a Block object, including page blocks, to archived: true using the ID specified. [See the documentation](https://developers.notion.com/reference/delete-a-block)",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/notion/actions/duplicate-page/duplicate-page.mjs
+++ b/components/notion/actions/duplicate-page/duplicate-page.mjs
@@ -7,7 +7,7 @@ export default {
   key: "notion-duplicate-page",
   name: "Duplicate Page",
   description: "Create a new page copied from an existing page block. [See the documentation](https://developers.notion.com/reference/post-page)",
-  version: "0.0.24",
+  version: "0.0.25",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/notion/actions/list-file-uploads/list-file-uploads.mjs
+++ b/components/notion/actions/list-file-uploads/list-file-uploads.mjs
@@ -6,7 +6,7 @@ export default {
   key: "notion-list-file-uploads",
   name: "List File Uploads",
   description: "Use this action to list file uploads. [See the documentation](https://developers.notion.com/reference/list-file-uploads)",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/notion/actions/retrieve-file-upload/retrieve-file-upload.mjs
+++ b/components/notion/actions/retrieve-file-upload/retrieve-file-upload.mjs
@@ -6,7 +6,7 @@ export default {
   key: "notion-retrieve-file-upload",
   name: "Retrieve File Upload",
   description: "Use this action to retrieve a file upload. [See the documentation](https://developers.notion.com/reference/retrieve-a-file-upload)",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/notion/actions/send-file-upload/send-file-upload.mjs
+++ b/components/notion/actions/send-file-upload/send-file-upload.mjs
@@ -8,7 +8,7 @@ export default {
   key: "notion-send-file-upload",
   name: "Send File Upload",
   description: "Send a file upload. [See the documentation](https://developers.notion.com/reference/send-a-file-upload)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/notion/actions/update-block/update-block.mjs
+++ b/components/notion/actions/update-block/update-block.mjs
@@ -7,7 +7,7 @@ export default {
   key: "notion-update-block",
   name: "Update Child Block",
   description: "Updates a child block object. [See the documentation](https://developers.notion.com/reference/update-a-block)",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/notion/actions/update-database/update-database.mjs
+++ b/components/notion/actions/update-database/update-database.mjs
@@ -7,7 +7,7 @@ export default {
   key: "notion-update-database",
   name: "Update Data Source",
   description: "Update a data source. [See the documentation](https://developers.notion.com/reference/update-a-data-source)",
-  version: "1.0.6",
+  version: "1.0.7",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/notion/actions/update-page/update-page.mjs
+++ b/components/notion/actions/update-page/update-page.mjs
@@ -7,7 +7,7 @@ export default {
   key: "notion-update-page",
   name: "Update Page",
   description: "Update a page's property values. To append page content, use the *Append Block* action instead. [See the documentation](https://developers.notion.com/reference/patch-page)",
-  version: "2.0.6",
+  version: "2.0.7",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/notion/package.json
+++ b/components/notion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/notion",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Pipedream Notion Components",
   "main": "notion.app.mjs",
   "keywords": [


### PR DESCRIPTION
## Summary

<!-- Add your PR description here -->



## Checklist
Please check the following items before your PR can be reviewed:

### Versioning
- [ ] All components updated in this PR had their version updated (`0.0.1` for new ones)
- [ ] The app updated in this PR had its `package.json`'s version updated

### New app
If this is a new app, please submit [an app integration request](https://github.com/PipedreamHQ/pipedream/issues/new?template=app---service-integration.md) - the PR will only be reviewed after the app is integrated.
- [ ] The app updated in this PR is already integrated

### CodeRabbit review
After the PR is opened, and if new changes are pushed, CodeRabbit will automatically review it. Do not 'mark as resolved' CodeRabbit's comments, but reply to them instead, whether you agree (and update the PR accordingly) or disagree.
- [ ] I have addressed or acknowledged all of CodeRabbit's review comments



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Databricks OAuth integration (list-endpoints action and package) with version maintenance
  * Updated Notion integration (multiple actions and package) with version maintenance releases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->