### PR TITLE
Bug fix to Notion create-database action

### DIFF
--- a/components/notion/actions/create-database/create-database.mjs
+++ b/components/notion/actions/create-database/create-database.mjs
@@ -7,7 +7,7 @@ export default {
   key: "notion-create-database",
   name: "Create Database",
   description: "Create a database and its initial data source. [See the documentation](https://developers.notion.com/reference/database-create)",
-  version: "0.1.7",
+  version: "0.1.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -37,6 +37,23 @@ export default {
     },
   },
   async run({ $ }) {
+    const parsedProperties = utils.parseObject(this.properties);
+    const properties = parsedProperties && typeof parsedProperties === "object"
+      ? Object.fromEntries(
+        Object.entries(parsedProperties).map(([
+          key,
+          value,
+        ]) => [
+          key,
+          typeof value === "string"
+            ? {
+              [value]: {},
+            }
+            : value,
+        ]),
+      )
+      : parsedProperties;
+
     const response = await this.notion.createDatabase({
       parent: {
         type: "page_id",
@@ -51,7 +68,7 @@ export default {
         },
       ],
       initial_data_source: {
-        properties: utils.parseObject(this.properties),
+        properties,
       },
     });
 

--- a/components/notion/actions/create-database/create-database.mjs
+++ b/components/notion/actions/create-database/create-database.mjs
@@ -43,14 +43,33 @@ export default {
         Object.entries(parsedProperties).map(([
           key,
           value,
-        ]) => [
-          key,
-          typeof value === "string"
-            ? {
-              [value]: {},
+        ]) => {
+          if (typeof value === "string") {
+            return [
+              key,
+              {
+                [value]: {},
+              },
+            ];
+          }
+          // Normalize { type: "X" } objects missing their type-key: { type: "checkbox" } → { type: "checkbox", checkbox: {} }
+          if (value && typeof value === "object" && "type" in value) {
+            const typeKey = value.type;
+            if (typeKey && typeof typeKey === "string" && !(typeKey in value)) {
+              return [
+                key,
+                {
+                  ...value,
+                  [typeKey]: {},
+                },
+              ];
             }
-            : value,
-        ]),
+          }
+          return [
+            key,
+            value,
+          ];
+        }),
       )
       : parsedProperties;
 

--- a/components/notion/actions/create-database/create-database.mjs
+++ b/components/notion/actions/create-database/create-database.mjs
@@ -52,7 +52,7 @@ export default {
               },
             ];
           }
-          // Normalize { type: "X" } objects missing their type-key: { type: "checkbox" } → { type: "checkbox", checkbox: {} }
+          // Normalize {type:"X"} objects missing their type-key: {type:"checkbox"} → {checkbox:{}}
           if (value && typeof value === "object" && "type" in value) {
             const typeKey = value.type;
             if (typeKey && typeof typeKey === "string" && !(typeKey in value)) {

--- a/components/notion/package.json
+++ b/components/notion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/notion",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Pipedream Notion Components",
   "main": "notion.app.mjs",
   "keywords": [


### PR DESCRIPTION
Resolves #21102 

**Summary**
- parseObject() in common/utils.mjs silently returns bare strings when JSON.parse fails, so user-supplied property values like "title" or "select" passed through unchanged to Notion's API
- Notion's databases.create endpoint requires property values to be schema objects (e.g. {"title": {}}) — bare strings cause an opaque 400 validation_error with no helpful message
- After parsing this.properties, the action now normalizes any remaining bare-string values into proper property schema objects ("title" → {"title": {}}) before sending to Notion


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved property handling for Notion database creation to ensure correct formatting of string and object-type properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->