### PR TITLE
[Components] attio: fire New Note Updated source on note body edits (note-content.updated)

### DIFF
--- a/components/attio/package.json
+++ b/components/attio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/attio",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Pipedream Attio Components",
   "main": "attio.app.mjs",
   "keywords": [

--- a/components/attio/sources/note-updated-instant/note-updated-instant.mjs
+++ b/components/attio/sources/note-updated-instant/note-updated-instant.mjs
@@ -5,8 +5,8 @@ export default {
   ...common,
   key: "attio-note-updated-instant",
   name: "New Note Updated (Instant)",
-  description: "Emit new event when the title of a note is modified. Body updates do not currently trigger webhooks.",
-  version: "0.0.4",
+  description: "Emit new event when a note is updated. Fires when the title is modified (`note.updated`) and when the body content is edited (`note-content.updated`).",
+  version: "0.0.5",
   type: "source",
   dedupe: "unique",
   methods: {
@@ -15,6 +15,10 @@ export default {
       return [
         {
           event_type: "note.updated",
+          filter: null,
+        },
+        {
+          event_type: "note-content.updated",
           filter: null,
         },
       ];


### PR DESCRIPTION
## WHY

The **New Note Updated (Instant)** source (`attio-note-updated-instant`) only subscribes to Attio's `note.updated` webhook event, which fires on **title** changes only — note **body** edits never trigger it. The source description even noted: "Body updates do not currently trigger webhooks."

That is no longer true upstream: Attio now provides a dedicated [`note-content.updated`](https://docs.attio.com/rest-api/webhook-reference/note-content-events/note-contentupdated) event that fires when a note's body content is edited.

In practice the gap means: a user creates a note (title saved first → `note.updated` fires → downstream automation fetches the note while the body is still empty), then writes the body — and the automation never fires again. Note bodies are effectively invisible to event-driven workflows.

## WHAT

Per maintainer suggestion (Slack), subscribe the **existing** source to both events instead of adding a new sibling source:

- `getSubscriptions()` now returns `note.updated` + `note-content.updated`
- Updated the source description accordingly
- Version bumps: component `0.0.4 → 0.0.5`, `@pipedream/attio` `0.5.0 → 0.5.1`

The `note-content.updated` payload carries the same identifying shape as `note.updated` (`id.workspace_id` / `id.note_id`, `parent_object_id`, `parent_record_id`, `actor`), so the shared `run()` handler and `generateMeta()` work unchanged.

## Notes for reviewers

- Attio autosaves note content while the user types, so `note-content.updated` may fire multiple times during a single editing session (we observe the same multi-fire behavior today with `note.updated` while a title is being typed). Each event has a distinct payload, so `dedupe: "unique"` with the `${note_id}-${ts}` meta id passes them all through — consumers that need "once per note" semantics should debounce downstream. Happy to adjust if you'd prefer different dedupe semantics in the source itself.
- We have a paying customer blocked on this — this PR follows up on a Slack conversation with your team earlier today.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended note-updated-instant source to support additional note-content.updated event emissions.

* **Chores**
  * Updated Attio package version to 0.5.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->