### PR TITLE
Fixing Outlook trigger datetime sort

### DIFF
--- a/components/microsoft_outlook/package.json
+++ b/components/microsoft_outlook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/microsoft_outlook",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "Pipedream Microsoft Outlook Components",
   "main": "microsoft_outlook.app.mjs",
   "keywords": [

--- a/components/microsoft_outlook/sources/new-email-in-shared-folder/new-email-in-shared-folder.mjs
+++ b/components/microsoft_outlook/sources/new-email-in-shared-folder/new-email-in-shared-folder.mjs
@@ -62,20 +62,26 @@ export default {
       for await (const item of items) {
         responseArray.push(item);
       }
-      if (responseArray.length) {
-        this._setLastDate(responseArray[0].receivedDateTime);
-      }
-
-      for (const item of responseArray.reverse()) {
-        const ts = Date.parse(item.receivedDateTime);
-        this.$emit(
-          item,
-          {
-            id: md5(item.id),
-            summary: `A new email with subject ${item.subject} was received!`,
-            ts,
-          },
-        );
+      let newLastDate;
+      try {
+        for (const item of responseArray.reverse()) {
+          const ts = Date.parse(item.receivedDateTime);
+          this.$emit(
+            item,
+            {
+              id: md5(item.id),
+              summary: `A new email with subject ${item.subject} was received!`,
+              ts,
+            },
+          );
+          // advance the checkpoint only after a successful emit, so a failed
+          // emit doesn't silently skip un-emitted events on the next poll
+          newLastDate = item.receivedDateTime;
+        }
+      } finally {
+        if (newLastDate) {
+          this._setLastDate(newLastDate);
+        }
       }
     },
   },

--- a/components/microsoft_outlook/sources/new-email-in-shared-folder/new-email-in-shared-folder.mjs
+++ b/components/microsoft_outlook/sources/new-email-in-shared-folder/new-email-in-shared-folder.mjs
@@ -7,7 +7,7 @@ export default {
   key: "microsoft_outlook-new-email-in-shared-folder",
   name: "New Email in Shared Folder Event",
   description: "Emit new event when an email is received in specified shared folders.",
-  version: "0.0.16",
+  version: "0.0.17",
   type: "source",
   dedupe: "unique",
   props: {
@@ -48,8 +48,8 @@ export default {
         fn: this.microsoftOutlook.listSharedFolderMessages,
         args: {
           params: {
-            $orderBy: "sentDateTime desc",
-            $filter: `sentDateTime gt ${lastDate}`,
+            $orderBy: "receivedDateTime desc",
+            $filter: `receivedDateTime gt ${lastDate}`,
           },
           sharedFolderId: this.sharedFolderId,
           userId: this.userId,
@@ -63,11 +63,11 @@ export default {
         responseArray.push(item);
       }
       if (responseArray.length) {
-        this._setLastDate(responseArray[0].sentDateTime);
+        this._setLastDate(responseArray[0].receivedDateTime);
       }
 
       for (const item of responseArray.reverse()) {
-        const ts = Date.parse(item.sentDateTime);
+        const ts = Date.parse(item.receivedDateTime);
         this.$emit(
           item,
           {


### PR DESCRIPTION
Closes #21159 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved new email detection for shared folders by using the message received date for filtering and ordering, improving polling accuracy and checkpointing behavior.
* **Chores**
  * Bumped the Microsoft Outlook package version for the shared-folder email source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->