### PR TITLE
[Components] [Linear] Add missing webhook source IPs to CLIENT_IPS allowlist

### DIFF
--- a/components/linear_app/common/constants.mjs
+++ b/components/linear_app/common/constants.mjs
@@ -27,6 +27,10 @@ const RESOURCE_TYPES = Object.values(RESOURCE_TYPE);
 const CLIENT_IPS = [
   "35.231.147.226",
   "35.243.134.228",
+  "34.140.253.14",
+  "34.38.87.206",
+  "34.134.222.122",
+  "35.222.25.142",
 ];
 
 const FIELD = {

--- a/components/linear_app/package.json
+++ b/components/linear_app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/linear_app",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Pipedream Linear_app Components",
   "main": "linear_app.app.mjs",
   "keywords": [

--- a/components/linear_app/sources/comment-created-instant/comment-created-instant.mjs
+++ b/components/linear_app/sources/comment-created-instant/comment-created-instant.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Comment Created (Instant)",
   description: "Triggers instantly when a new comment is added to an issue in Linear. Returns comment details including content, author, issue reference, and timestamps. Supports filtering by team. See Linear docs for additional info [here](https://linear.app/developers/webhooks).",
   type: "source",
-  version: "0.1.21",
+  version: "0.1.22",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/linear_app/sources/issue-created-instant/issue-created-instant.mjs
+++ b/components/linear_app/sources/issue-created-instant/issue-created-instant.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Issue Created (Instant)",
   description: "Triggers instantly when a new issue is created in Linear. Provides complete issue details including title, description, team, assignee, state, and timestamps. Supports filtering by team and project. See Linear docs for additional info [here](https://linear.app/developers/webhooks).",
   type: "source",
-  version: "0.3.21",
+  version: "0.3.22",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/linear_app/sources/issue-updated-instant/issue-updated-instant.mjs
+++ b/components/linear_app/sources/issue-updated-instant/issue-updated-instant.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Issue Updated (Instant)",
   description: "Triggers instantly when any issue is updated in Linear. Provides complete issue details with changes. Supports filtering by team and project. Includes all updates except status changes. See Linear docs for additional info [here](https://linear.app/developers/webhooks).",
   type: "source",
-  version: "0.3.21",
+  version: "0.3.22",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/linear_app/sources/new-issue-status-updated/new-issue-status-updated.mjs
+++ b/components/linear_app/sources/new-issue-status-updated/new-issue-status-updated.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Issue Status Updated (Instant)",
   description: "Triggers instantly when an issue's workflow state changes (e.g., Todo to In Progress). Returns issue with previous and current state info. Can filter by specific target state. See Linear docs for additional info [here](https://linear.app/developers/webhooks).",
   type: "source",
-  version: "0.1.21",
+  version: "0.1.22",
   dedupe: "unique",
   props: {
     linearApp: common.props.linearApp,

--- a/components/linear_app/sources/new-projectupdate-created/new-projectupdate-created.mjs
+++ b/components/linear_app/sources/new-projectupdate-created/new-projectupdate-created.mjs
@@ -8,7 +8,7 @@ export default {
   name: "New Project Update Written (Instant)",
   description: "Triggers instantly when a project update (status report) is created in Linear. Returns update content, author, project details, and health status. Filters by team and optionally by project. See Linear docs for additional info [here](https://linear.app/developers/webhooks).",
   type: "source",
-  version: "0.0.13",
+  version: "0.0.14",
   dedupe: "unique",
   props: {
     linearApp,

--- a/components/linear_app/sources/project-updated-instant/project-updated-instant.mjs
+++ b/components/linear_app/sources/project-updated-instant/project-updated-instant.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Project Updated (Instant)",
   description: "Triggers instantly when a project is updated in Linear. Returns project details including name, description, status, dates, and team info. Supports filtering by specific teams. See Linear docs for additional info [here](https://linear.app/developers/webhooks).",
   type: "source",
-  version: "0.0.14",
+  version: "0.0.15",
   dedupe: "unique",
   props: {
     linearApp,


### PR DESCRIPTION
## Why

Linear instant webhook sources validate inbound deliveries against a hardcoded source-IP allowlist (`CLIENT_IPS` in `components/linear_app/common/constants.mjs`). Linear currently delivers webhooks from **6** source IPs ([docs](https://linear.app/developers/webhooks)), but the allowlist contained only **2**.

In `components/linear_app/sources/common/webhook.mjs`, `run()` drops any delivery whose IP isn't allowlisted:

```js
if (!this.isWebhookValid(clientIp)) {
  console.log("Webhook is not valid");
  return;
}
```

Because the source still returns HTTP `200`, Linear marks the delivery successful and does not retry, so events delivered from the 4 missing IPs are **silently lost** — no emitted event and no error. Admin-connected accounts (which provision the real webhook) are affected; non-admin accounts use the polling path and are not. The deploy-time backfill also uses the polling/API path and bypasses this check, which masks the problem: the source looks correctly configured (and the webhook shows healthy in Linear) but never fires on new activity.

## What

- Add the 4 missing IPs to `CLIENT_IPS` — `34.140.253.14`, `34.38.87.206`, `34.134.222.122`, `35.222.25.142` — matching Linear's current documented list.
- Patch-bump the `linear_app` webhook source components that consume `CLIENT_IPS`.

## Scope

Scoped to `linear_app` only per review. The `linear` (OAuth) re-exports and the `package.json` version/dependency bumps are intentionally left out, to be handled in a follow-up. Refs #21229.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Linear webhook source IP address allowlist with additional trusted addresses.
  * Bumped the webhook configuration version for multiple Linear webhook sources to keep them in sync.
  * Updated the Linear app package version to the next patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->