### PR TITLE
New Components - ai_readiness

### DIFF
--- a/components/ai_readiness/actions/check-ai-readiness/check-ai-readiness.mjs
+++ b/components/ai_readiness/actions/check-ai-readiness/check-ai-readiness.mjs
@@ -4,9 +4,14 @@ import app from "../../ai_readiness.app.mjs";
 export default {
   key: "ai_readiness-check-ai-readiness",
   name: "Check AI Search Readiness",
-  description: "Check whether a website is visible to AI search engines (ChatGPT, Perplexity, Claude, Google AI Overviews). Returns a 0-100 score, a grade, and a specific fix for each gap. [See the docs](https://samedaydesk.com/tools/ai-readiness).",
+  description: "Check whether a website is visible to AI search engines (ChatGPT, Perplexity, Claude, Google AI Overviews). Returns a 0-100 score, a grade, and a specific fix for each gap. [See the documentation](https://samedaydesk.com/tools/ai-readiness).",
   version: "0.0.1",
   type: "action",
+  annotations: {
+    openWorldHint: true,
+    readOnlyHint: true,
+    destructiveHint: false,
+  },
   props: {
     app,
     url: {

--- a/components/ai_readiness/actions/check-ai-readiness/check-ai-readiness.mjs
+++ b/components/ai_readiness/actions/check-ai-readiness/check-ai-readiness.mjs
@@ -1,0 +1,28 @@
+import { axios } from "@pipedream/platform";
+import app from "../../ai_readiness.app.mjs";
+
+export default {
+  key: "ai_readiness-check-ai-readiness",
+  name: "Check AI Search Readiness",
+  description: "Check whether a website is visible to AI search engines (ChatGPT, Perplexity, Claude, Google AI Overviews). Returns a 0-100 score, a grade, and a specific fix for each gap. [See the docs](https://samedaydesk.com/tools/ai-readiness).",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    app,
+    url: {
+      type: "string",
+      label: "URL",
+      description: "The website to check, e.g. `example.com` or `https://example.com`.",
+    },
+  },
+  async run({ $ }) {
+    const data = await axios($, {
+      url: "https://samedaydesk.com/api/tools/ai-readiness",
+      params: {
+        url: this.url,
+      },
+    });
+    $.export("$summary", `Checked ${this.url} — score ${data.score}/100 (grade ${data.grade})`);
+    return data;
+  },
+};

--- a/components/ai_readiness/ai_readiness.app.mjs
+++ b/components/ai_readiness/ai_readiness.app.mjs
@@ -1,0 +1,6 @@
+export default {
+  type: "app",
+  app: "ai_readiness",
+  propDefinitions: {},
+  methods: {},
+};

--- a/components/ai_readiness/package.json
+++ b/components/ai_readiness/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@pipedream/ai_readiness",
+  "version": "0.0.1",
+  "description": "Pipedream AI Readiness Components",
+  "main": "ai_readiness.app.mjs",
+  "keywords": [
+    "pipedream",
+    "ai_readiness"
+  ],
+  "homepage": "https://pipedream.com/apps/ai_readiness",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^3.0.3"
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new `ai_readiness` app and one action, **Check AI Search Readiness** (`check_ai_readiness`). It calls the public, key-less endpoint at samedaydesk.com and returns a 0-100 score, a letter grade, and a specific fix for each gap (AI-crawler access, JSON-LD structured data, title/meta, Open Graph, sitemap, llms.txt).

- No authentication required (public API).
- Single string prop: `url`.
- Useful in workflows that monitor or gate on a site's AI-search / SEO readiness after a deploy or content change.

App request: #21347

## Checklist

- [x] New app + action follow the [component guidelines](https://pipedream.com/docs/components/guidelines/)
- [x] Versioning: initial `0.0.1`
- [x] App integration requested (#21347)
- [x] CodeRabbit review addressed (no actionable comments)

Let me know if you'd like any changes to naming or structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "Check AI Search Readiness" action that accepts a URL and evaluates it, returning a readiness score, grade, and the full API response for workflow use.
  * Introduced an AI Readiness integration within Pipedream, packaged as a new module for easy reuse in automations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
