### PR TITLE
[Components] github - AI-optimized actions for MCP (Phase 2)

### DIFF
--- a/components/github/actions/create-branch/create-branch.mjs
+++ b/components/github/actions/create-branch/create-branch.mjs
@@ -1,11 +1,10 @@
-import { ConfigurationError } from "@pipedream/platform";
 import github from "../../github.app.mjs";
 
 export default {
   key: "github-create-branch",
   name: "Create Branch",
-  description: "Create a new branch in a GitHub repo. [See the documentation](https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28#create-a-reference)",
-  version: "0.0.22",
+  description: "Create a new branch in a repository, pointing at the tip of a source branch. Provide the repository as an `owner/repo` string, the new `branchName`, and optionally the `sourceBranch` to branch from (defaults to the repository's default branch). Use **Create or Update File Contents** to add commits to the new branch, then **Create Pull Request** to open a PR. [See the documentation](https://docs.github.com/en/rest/git/refs#create-a-reference)",
+  version: "1.0.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -17,53 +16,43 @@ export default {
     repoFullname: {
       propDefinition: [
         github,
-        "repoFullname",
+        "repoFullnameStatic",
       ],
     },
     branchName: {
       label: "Branch Name",
-      description: "The name of the new branch that will be created",
+      description: "The name of the new branch to create, e.g. `feature/new-paddock`.",
       type: "string",
     },
-    branchSha: {
+    sourceBranch: {
       label: "Source Branch",
-      description: "The source branch that will be used to create the new branch. Defaults to the repository's default branch (usually `main` or `master`)",
-      propDefinition: [
-        github,
-        "branch",
-        (c) => ({
-          repoFullname: c.repoFullname,
-        }),
-      ],
+      description: "The existing branch to create the new branch from. Defaults to the repository's default branch (usually `main` or `master`).",
+      type: "string",
       optional: true,
     },
   },
   async run({ $ }) {
-    if (this.branchSha) {
-      this.branchSha = this.branchSha.split("/")[0];
-    } else {
-      const branches = await this.github.getBranches({
-        repoFullname: this.repoFullname,
-      });
+    const repoFullname = await this.github._resolveRepoFullname(this.repoFullname);
 
-      const masterBranch = branches.filter((branch) => branch.name === "master" || branch.name === "main");
+    const sourceBranch = this.sourceBranch
+      ?? (await this.github.getRepo({
+        repoFullname,
+      })).default_branch;
 
-      if (masterBranch.length) this.branchSha = masterBranch[0].commit.sha;
-    }
-
-    if (!this.branchSha) {
-      throw new ConfigurationError("Is required to select one source branch");
-    }
+    const ref = await this.github.getRef({
+      repoFullname,
+      ref: `heads/${sourceBranch}`,
+    });
 
     const response = await this.github.createBranch({
-      repoFullname: this.repoFullname,
+      repoFullname,
       data: {
         ref: `refs/heads/${this.branchName}`,
-        sha: this.branchSha,
+        sha: ref.object.sha,
       },
     });
 
-    $.export("$summary", `Successfully created branch with ID ${response.object.sha}.`);
+    $.export("$summary", `Successfully created branch \`${this.branchName}\` from \`${sourceBranch}\``);
 
     return response;
   },

--- a/components/github/actions/create-gist/create-gist.mjs
+++ b/components/github/actions/create-gist/create-gist.mjs
@@ -5,7 +5,7 @@ export default {
   key: "github-create-gist",
   name: "Create Gist",
   description: "Allows you to add a new gist with one or more files. [See the documentation](https://docs.github.com/en/rest/gists/gists?apiVersion=2022-11-28#create-a-gist)",
-  version: "0.0.16",
+  version: "0.0.17",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/create-issue-comment/create-issue-comment.mjs
+++ b/components/github/actions/create-issue-comment/create-issue-comment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-create-issue-comment",
   name: "Create Issue Comment",
   description: "Add a comment to an existing issue **or pull request** (GitHub treats PRs as issues for comments, so the same `number` works for both). Provide the repository as an `owner/repo` string, the issue/PR number, and the comment body. If you only know the issue/PR by title, call **Search Issues and Pull Requests** first to resolve its number. [See the documentation](https://docs.github.com/en/rest/issues/comments#create-an-issue-comment)",
-  version: "0.1.0",
+  version: "0.1.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/create-issue/create-issue.mjs
+++ b/components/github/actions/create-issue/create-issue.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-create-issue",
   name: "Create Issue",
   description: "Create a new issue in a repository, optionally with labels, assignees, and a milestone. Provide the repository as an `owner/repo` string. Labels and assignees are passed by name/login (e.g. `bug`, `octocat`) — setting them requires push access to the repo. To comment on an existing issue instead, use **Create Issue Comment**; to change an existing issue, use **Update Issue**. [See the documentation](https://docs.github.com/en/rest/issues/issues#create-an-issue)",
-  version: "0.4.0",
+  version: "0.4.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/create-or-update-file-contents/create-or-update-file-contents.mjs
+++ b/components/github/actions/create-or-update-file-contents/create-or-update-file-contents.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-create-or-update-file-contents",
   name: "Create or Update File Contents",
   description: "Create a new file or overwrite an existing one in a repository with a single commit. Provide the repository as an `owner/repo` string, the file `path`, the raw text `content` (passed as-is — do not base64-encode it yourself), and a commit message. If the file already exists on the target branch it is overwritten; the required blob SHA is resolved for you automatically. Defaults to the repository's default branch unless `branch` is set. [See the documentation](https://docs.github.com/en/rest/repos/contents#create-or-update-file-contents)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/github/actions/create-pull-request-review/create-pull-request-review.mjs
+++ b/components/github/actions/create-pull-request-review/create-pull-request-review.mjs
@@ -1,3 +1,4 @@
+import { ConfigurationError } from "@pipedream/platform";
 import github from "../../github.app.mjs";
 
 export default {
@@ -50,9 +51,14 @@ export default {
   },
   async run({ $ }) {
     const repoFullname = await this.github._resolveRepoFullname(this.repoFullname);
-    const comments = typeof this.comments === "string"
-      ? JSON.parse(this.comments)
-      : this.comments;
+    let comments = this.comments;
+    if (typeof comments === "string") {
+      try {
+        comments = JSON.parse(comments);
+      } catch {
+        throw new ConfigurationError("`comments` must be a valid JSON array, e.g. `[{\"path\": \"file.js\", \"line\": 3, \"body\": \"...\"}]`");
+      }
+    }
 
     const data = {
       event: this.event,

--- a/components/github/actions/create-pull-request-review/create-pull-request-review.mjs
+++ b/components/github/actions/create-pull-request-review/create-pull-request-review.mjs
@@ -1,0 +1,75 @@
+import github from "../../github.app.mjs";
+
+export default {
+  key: "github-create-pull-request-review",
+  name: "Create Pull Request Review",
+  description: "Submit a review on a pull request: approve it, request changes, or leave a general comment. Set `event` to `APPROVE`, `REQUEST_CHANGES`, or `COMMENT` — a `body` is required for `REQUEST_CHANGES` and `COMMENT`. Optionally attach inline `comments` tied to specific lines of the diff. GitHub forbids approving your own pull request, so use `COMMENT` to leave feedback on PRs you authored. Provide the repository as an `owner/repo` string and the PR number. Use **Get Pull Request Files** to find the file paths and lines to comment on, and **Search Issues and Pull Requests** with `is:pr` to resolve the PR number from a title. [See the documentation](https://docs.github.com/en/rest/pulls/reviews#create-a-review-for-a-pull-request)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  type: "action",
+  props: {
+    github,
+    repoFullname: {
+      propDefinition: [
+        github,
+        "repoFullnameStatic",
+      ],
+    },
+    pullNumber: {
+      propDefinition: [
+        github,
+        "pullNumberStatic",
+      ],
+    },
+    event: {
+      type: "string",
+      label: "Event",
+      description: "The review action to perform. `APPROVE` and `REQUEST_CHANGES` formally affect the PR's review state; `COMMENT` leaves general feedback without approving or blocking.",
+      options: [
+        "APPROVE",
+        "REQUEST_CHANGES",
+        "COMMENT",
+      ],
+    },
+    body: {
+      type: "string",
+      label: "Body",
+      description: "The body text of the review. Required when `event` is `REQUEST_CHANGES` or `COMMENT`. Supports GitHub-flavored Markdown.",
+      optional: true,
+    },
+    comments: {
+      type: "string",
+      label: "Inline Comments",
+      description: "Optional JSON array of inline review comments tied to lines in the diff. Each entry is `{\"path\": \"...\", \"line\": N, \"body\": \"...\"}`, e.g. `[{\"path\": \"paddocks/trex.md\", \"line\": 3, \"body\": \"Check the voltage here\"}]`. Use **Get Pull Request Files** to find valid paths and line numbers.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const repoFullname = await this.github._resolveRepoFullname(this.repoFullname);
+    const comments = typeof this.comments === "string"
+      ? JSON.parse(this.comments)
+      : this.comments;
+
+    const data = {
+      event: this.event,
+      body: this.body,
+      ...(comments?.length && {
+        comments,
+      }),
+    };
+
+    const response = await this.github.createPullRequestReview({
+      repoFullname,
+      pullNumber: this.pullNumber,
+      data,
+    });
+
+    $.export("$summary", `Submitted ${this.event} review on pull request #${this.pullNumber}`);
+
+    return response;
+  },
+};

--- a/components/github/actions/create-pull-request-review/create-pull-request-review.mjs
+++ b/components/github/actions/create-pull-request-review/create-pull-request-review.mjs
@@ -51,12 +51,17 @@ export default {
   },
   async run({ $ }) {
     const repoFullname = await this.github._resolveRepoFullname(this.repoFullname);
-    let comments = this.comments;
-    if (typeof comments === "string") {
+    let comments;
+    if (this.comments) {
       try {
-        comments = JSON.parse(comments);
+        comments = typeof this.comments === "string"
+          ? JSON.parse(this.comments)
+          : this.comments;
       } catch {
         throw new ConfigurationError("`comments` must be a valid JSON array, e.g. `[{\"path\": \"file.js\", \"line\": 3, \"body\": \"...\"}]`");
+      }
+      if (!Array.isArray(comments)) {
+        throw new ConfigurationError("`comments` must be a JSON array, e.g. `[{\"path\": \"file.js\", \"line\": 3, \"body\": \"...\"}]`");
       }
     }
 

--- a/components/github/actions/create-pull-request/create-pull-request.mjs
+++ b/components/github/actions/create-pull-request/create-pull-request.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-create-pull-request",
   name: "Create Pull Request",
   description: "Open a pull request proposing to merge one branch into another within a repository. Provide the repository as an `owner/repo` string, the `head` branch (the source containing your changes) and the `base` branch (the target, e.g. `main`), plus a title. The head and base branches must already exist and differ. For a cross-fork PR, set `head` to `username:branch`. Use **Create or Update File Contents** to push changes to a branch before opening the PR. [See the documentation](https://docs.github.com/en/rest/pulls/pulls#create-a-pull-request)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/create-repository/create-repository.mjs
+++ b/components/github/actions/create-repository/create-repository.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-create-repository",
   name: "Create Repository",
   description: "Creates a new repository for the authenticated user. [See the documentation](https://docs.github.com/en/rest/repos/repos#create-a-repository-for-the-authenticated-user)",
-  version: "0.0.21",
+  version: "0.0.22",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/create-workflow-dispatch/create-workflow-dispatch.mjs
+++ b/components/github/actions/create-workflow-dispatch/create-workflow-dispatch.mjs
@@ -5,7 +5,7 @@ export default {
   key: "github-create-workflow-dispatch",
   name: "Create Workflow Dispatch",
   description: "Creates a new workflow dispatch event. [See the documentation](https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event)",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/disable-workflow/disable-workflow.mjs
+++ b/components/github/actions/disable-workflow/disable-workflow.mjs
@@ -5,7 +5,7 @@ export default {
   key: "github-disable-workflow",
   name: "Disable Workflow",
   description: "Disables a workflow and sets the **state** of the workflow to **disabled_manually**. [See the documentation](https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#disable-a-workflow)",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/github/actions/enable-workflow/enable-workflow.mjs
+++ b/components/github/actions/enable-workflow/enable-workflow.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-enable-workflow",
   name: "Enable Workflow",
   description: "Enables a workflow and sets the **state** of the workflow to **active**. [See the documentation](https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#enable-a-workflow)",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/github/actions/get-commit/get-commit.mjs
+++ b/components/github/actions/get-commit/get-commit.mjs
@@ -3,8 +3,8 @@ import github from "../../github.app.mjs";
 export default {
   key: "github-get-commit",
   name: "Get Commit",
-  description: "Get a commit in a GitHub repo. [See the documentation](https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#get-a-commit)",
-  version: "0.0.6",
+  description: "Get the details of a single commit, including the list of files it changed (with per-file additions/deletions and patches) and aggregate stats. Provide the repository as an `owner/repo` string and a `ref` — a commit SHA, branch name, or tag. Use **List Commits** to find a commit SHA, or pass a branch name like `main` to get its latest commit. [See the documentation](https://docs.github.com/en/rest/commits/commits#get-a-commit)",
+  version: "1.0.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -16,26 +16,23 @@ export default {
     repoFullname: {
       propDefinition: [
         github,
-        "repoFullname",
+        "repoFullnameStatic",
       ],
     },
-    commitSha: {
-      propDefinition: [
-        github,
-        "commitSha",
-        (c) => ({
-          repoFullname: c.repoFullname,
-        }),
-      ],
+    ref: {
+      type: "string",
+      label: "Ref",
+      description: "The commit to retrieve: a commit SHA, branch name (e.g. `main`), or tag.",
     },
   },
   async run({ $ }) {
+    const repoFullname = await this.github._resolveRepoFullname(this.repoFullname);
     const commit = await this.github.getCommit({
-      repoFullname: this.repoFullname,
-      commitRef: this.commitSha,
+      repoFullname,
+      commitRef: this.ref,
     });
 
-    $.export("$summary", `Successfully retrieved commit ${this.commitSha}`);
+    $.export("$summary", `Successfully retrieved commit ${commit.sha?.slice(0, 7) ?? this.ref}`);
 
     return commit;
   },

--- a/components/github/actions/get-current-user/get-current-user.mjs
+++ b/components/github/actions/get-current-user/get-current-user.mjs
@@ -7,7 +7,7 @@ export default {
   key: "github-get-current-user",
   name: "Get Current User",
   description: "Gather a full snapshot of the authenticated GitHub actor, combining `/user`, `/user/orgs`, and `/user/teams`. Returns profile metadata (login, name, email, company, plan, creation timestamps) and trimmed lists of organizations and teams for quick role awareness. Helpful when you need to validate which user is calling the API, adapt behavior based on their org/team memberships, or provide LLMs with grounding before repository operations. [See the documentation](https://docs.github.com/en/rest/users/users?apiVersion=2022-11-28#get-the-authenticated-user).",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/github/actions/get-issue-assignees/get-issue-assignees.mjs
+++ b/components/github/actions/get-issue-assignees/get-issue-assignees.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-get-issue-assignees",
   name: "Get Issue Assignees",
   description: "Get assignees for an issue in a GitHub repo. [See the documentation](https://docs.github.com/en/rest/issues/issues#get-an-issue)",
-  version: "0.0.27",
+  version: "0.0.28",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/get-issue/get-issue.mjs
+++ b/components/github/actions/get-issue/get-issue.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-get-issue",
   name: "Get Issue",
   description: "Get the full details of a single issue: title, body, state, labels, assignees, milestone, comment count, and timestamps. Provide the repository as an `owner/repo` string and the issue number. If you only know the issue by title or topic, call **Search Issues and Pull Requests** first to resolve its number. [See the documentation](https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#get-an-issue)",
-  version: "0.1.0",
+  version: "0.1.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/get-pull-request-files/get-pull-request-files.mjs
+++ b/components/github/actions/get-pull-request-files/get-pull-request-files.mjs
@@ -1,0 +1,40 @@
+import github from "../../github.app.mjs";
+
+export default {
+  key: "github-get-pull-request-files",
+  name: "Get Pull Request Files",
+  description: "List the files changed in a pull request (the PR diff at the file level). Returns each file's `filename`, `status` (added/modified/removed/renamed), additions/deletions/changes counts, and the unified `patch` when available — use this to review what a PR changes before approving or merging it. Provide the repository as an `owner/repo` string and the PR number. If you only know the PR by title, call **Get Pull Request** or **Search Issues and Pull Requests** with `is:pr` first to resolve its number. [See the documentation](https://docs.github.com/en/rest/pulls/pulls#list-pull-requests-files)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  type: "action",
+  props: {
+    github,
+    repoFullname: {
+      propDefinition: [
+        github,
+        "repoFullnameStatic",
+      ],
+    },
+    pullNumber: {
+      propDefinition: [
+        github,
+        "pullNumberStatic",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const repoFullname = await this.github._resolveRepoFullname(this.repoFullname);
+    const files = await this.github.getPullRequestFiles({
+      repoFullname,
+      pullNumber: this.pullNumber,
+    });
+
+    $.export("$summary", `Retrieved ${files.length} changed file(s) for pull request #${this.pullNumber}`);
+
+    return files;
+  },
+};

--- a/components/github/actions/get-pull-request/get-pull-request.mjs
+++ b/components/github/actions/get-pull-request/get-pull-request.mjs
@@ -83,21 +83,25 @@ export default {
   },
   async run({ $ }) {
     const repoFullname = await this.github._resolveRepoFullname(this.repoFullname);
-    const pullRequest = await this.github.getPullRequest({
-      repoFullname,
-      pullNumber: this.pullNumber,
-    });
-
-    const headSha = pullRequest.head?.sha;
     const [
+      pullRequest,
       reviews,
-      combinedStatus,
-      checkRuns,
     ] = await Promise.all([
+      this.github.getPullRequest({
+        repoFullname,
+        pullNumber: this.pullNumber,
+      }),
       this.github.getReviewsForPullRequest({
         repoFullname,
         pullNumber: this.pullNumber,
       }),
+    ]);
+
+    const headSha = pullRequest.head?.sha;
+    const [
+      combinedStatus,
+      checkRuns,
+    ] = await Promise.all([
       headSha
         ? this.github.getCommitStatus({
           repoFullname,

--- a/components/github/actions/get-pull-request/get-pull-request.mjs
+++ b/components/github/actions/get-pull-request/get-pull-request.mjs
@@ -30,8 +30,10 @@ export default {
     summarizeChecks(combinedStatus, checkRuns) {
       // Combined commit status (legacy statuses API)
       const statuses = combinedStatus?.statuses ?? [];
-      // Check runs (GitHub Actions / Checks API)
-      const runs = checkRuns?.check_runs ?? [];
+      // Check runs (GitHub Actions / Checks API) — paginated to a flat array
+      const runs = Array.isArray(checkRuns)
+        ? checkRuns
+        : checkRuns?.check_runs ?? [];
 
       const counts = {
         success: 0,

--- a/components/github/actions/get-pull-request/get-pull-request.mjs
+++ b/components/github/actions/get-pull-request/get-pull-request.mjs
@@ -3,8 +3,8 @@ import github from "../../github.app.mjs";
 export default {
   key: "github-get-pull-request",
   name: "Get Pull Request",
-  description: "Get the full details of a single pull request along with its reviews. Returns PR metadata (title, body, state, head/base branches, merge status, draft flag, timestamps) plus the list of reviews and a deduplicated list of reviewers with their review states (e.g. `APPROVED`, `CHANGES_REQUESTED`). Provide the repository as an `owner/repo` string and the PR number. If you only know the PR by title, call **Search Issues and Pull Requests** with `is:pr` first to resolve its number. [See the documentation](https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request)",
-  version: "0.0.1",
+  description: "Get the full details of a single pull request along with its reviews and a CI/merge readiness summary. Returns PR metadata (title, body, state, head/base branches, draft flag, timestamps), the `mergeable`/`mergeable_state` flags, a `checksSummary` rollup of CI status for the head commit (combined commit status + check runs, summarized to an overall state and pass/fail counts), the list of reviews, and a deduplicated list of reviewers with their review states (e.g. `APPROVED`, `CHANGES_REQUESTED`). Use this to answer \"can I merge this?\" and \"is CI green?\" before calling **Merge Pull Request**. Provide the repository as an `owner/repo` string and the PR number. If you only know the PR by title, call **Search Issues and Pull Requests** with `is:pr` first to resolve its number. [See the documentation](https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request)",
+  version: "0.1.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -20,25 +20,94 @@ export default {
       ],
     },
     pullNumber: {
-      type: "integer",
-      label: "Pull Request Number",
-      description: "The pull request number — the `#N` shown in the GitHub UI.",
+      propDefinition: [
+        github,
+        "pullNumberStatic",
+      ],
+    },
+  },
+  methods: {
+    summarizeChecks(combinedStatus, checkRuns) {
+      // Combined commit status (legacy statuses API)
+      const statuses = combinedStatus?.statuses ?? [];
+      // Check runs (GitHub Actions / Checks API)
+      const runs = checkRuns?.check_runs ?? [];
+
+      const counts = {
+        success: 0,
+        failure: 0,
+        pending: 0,
+      };
+
+      for (const status of statuses) {
+        if (status.state === "success") counts.success += 1;
+        else if (status.state === "failure" || status.state === "error") counts.failure += 1;
+        else counts.pending += 1;
+      }
+
+      for (const run of runs) {
+        if (run.status !== "completed") {
+          counts.pending += 1;
+        } else if ([
+          "success",
+          "neutral",
+          "skipped",
+        ].includes(run.conclusion)) {
+          counts.success += 1;
+        } else if ([
+          "failure",
+          "timed_out",
+          "cancelled",
+          "action_required",
+          "stale",
+        ].includes(run.conclusion)) {
+          counts.failure += 1;
+        } else {
+          counts.pending += 1;
+        }
+      }
+
+      let state = "no_checks";
+      if (counts.failure > 0) state = "failure";
+      else if (counts.pending > 0) state = "pending";
+      else if (counts.success > 0) state = "success";
+
+      return {
+        state,
+        total: counts.success + counts.failure + counts.pending,
+        ...counts,
+      };
     },
   },
   async run({ $ }) {
     const repoFullname = await this.github._resolveRepoFullname(this.repoFullname);
+    const pullRequest = await this.github.getPullRequest({
+      repoFullname,
+      pullNumber: this.pullNumber,
+    });
+
+    const headSha = pullRequest.head?.sha;
     const [
-      pullRequest,
       reviews,
+      combinedStatus,
+      checkRuns,
     ] = await Promise.all([
-      this.github.getPullRequest({
-        repoFullname,
-        pullNumber: this.pullNumber,
-      }),
       this.github.getReviewsForPullRequest({
         repoFullname,
         pullNumber: this.pullNumber,
       }),
+      headSha
+        ? this.github.getCommitStatus({
+          repoFullname,
+          ref: headSha,
+        })
+        : null,
+      headSha
+        ? this.github.getCheckRunsForRef({
+          repoFullname,
+          ref: headSha,
+        })
+        : null,
     ]);
 
     const reviewers = [
@@ -53,10 +122,15 @@ export default {
       ).values(),
     ];
 
-    $.export("$summary", `Retrieved pull request #${this.pullNumber}: ${pullRequest.title}`);
+    const checksSummary = this.summarizeChecks(combinedStatus, checkRuns);
+
+    $.export("$summary", `Retrieved pull request #${this.pullNumber}: ${pullRequest.title} (mergeable: ${pullRequest.mergeable ?? "unknown"}, checks: ${checksSummary.state})`);
 
     return {
       pullRequest,
+      mergeable: pullRequest.mergeable,
+      mergeable_state: pullRequest.mergeable_state,
+      checksSummary,
       reviews,
       reviewers,
     };

--- a/components/github/actions/get-repository-content/get-repository-content.mjs
+++ b/components/github/actions/get-repository-content/get-repository-content.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-get-repository-content",
   name: "Get Repository Content",
   description: "Read a file's contents or list a directory in a repository. For a file, the base64 payload is decoded for you and returned as plain text in the `content` field. For a directory, returns the list of entries (name, path, type). Provide the repository as an `owner/repo` string and the `path` to the file or directory (omit `path` for the repo root). Use **Get Repository** first if you need to know the default branch. [See the documentation](https://docs.github.com/en/rest/repos/contents#get-repository-content)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/get-repository/get-repository.mjs
+++ b/components/github/actions/get-repository/get-repository.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-get-repository",
   name: "Get Repository Info",
   description: "Get metadata for a single repository: description, default branch, visibility, topics, star/fork/open-issue counts, your permission level, and timestamps. Use this to discover a repo's default branch before reading files with **Get Repository Content** or listing history with **List Commits**. Provide the repository as an `owner/repo` string (e.g. `PipedreamHQ/pipedream`). [See the documentation](https://docs.github.com/en/rest/repos/repos#get-a-repository)",
-  version: "0.1.0",
+  version: "0.1.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/get-reviewers/get-reviewers.mjs
+++ b/components/github/actions/get-reviewers/get-reviewers.mjs
@@ -6,7 +6,7 @@ export default {
   key: "github-get-reviewers",
   name: "Get Reviewers",
   description: "Get reviewers for a PR ([see documentation](https://docs.github.com/en/rest/pulls/reviews#list-reviews-for-a-pull-request)) or Commit SHA ([see documentation](https://docs.github.com/en/rest/commits/commits#list-pull-requests-associated-with-a-commit)).",
-  version: "0.1.8",
+  version: "0.1.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/get-workflow-run/get-workflow-run.mjs
+++ b/components/github/actions/get-workflow-run/get-workflow-run.mjs
@@ -3,8 +3,8 @@ import github from "../../github.app.mjs";
 export default {
   key: "github-get-workflow-run",
   name: "Get Workflow Run",
-  description: "Gets a specific workflow run. [See the documentation](https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#get-a-workflow-run)",
-  version: "0.0.8",
+  description: "Get the details of a single GitHub Actions workflow run, including its per-job conclusions and a link to the run's logs. Returns the run's `status`/`conclusion` and timestamps plus a `jobs` array (each job's name, status, conclusion, and `logsUrl`) so you can see exactly which job failed. Provide the repository as an `owner/repo` string and the run ID. Use **List Workflow Runs** to find a run ID, then **Run Workflow** to re-run the failed jobs. [See the documentation](https://docs.github.com/en/rest/actions/workflow-runs#get-a-workflow-run)",
+  version: "1.0.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -16,27 +16,46 @@ export default {
     repoFullname: {
       propDefinition: [
         github,
-        "repoFullname",
+        "repoFullnameStatic",
       ],
     },
-    workflowRunId: {
-      propDefinition: [
-        github,
-        "workflowRunId",
-        ({ repoFullname }) => ({
-          repoFullname,
-        }),
-      ],
+    runId: {
+      type: "string",
+      label: "Run ID",
+      description: "The workflow run ID. Use **List Workflow Runs** to find it.",
     },
   },
   async run({ $ }) {
-    const response = await this.github.getWorkflowRun({
-      repoFullname: this.repoFullname,
-      workflowRunId: this.workflowRunId,
-    });
+    const repoFullname = await this.github._resolveRepoFullname(this.repoFullname);
+    const [
+      run,
+      jobs,
+    ] = await Promise.all([
+      this.github.getWorkflowRun({
+        repoFullname,
+        workflowRunId: this.runId,
+      }),
+      this.github.getWorkflowRunJobs({
+        repoFullname,
+        workflowRunId: this.runId,
+      }),
+    ]);
 
-    $.export("$summary", `Successfully retrieved the workflow run with Id: ${this.workflowRunId}!.`);
+    const jobSummaries = jobs.map((job) => ({
+      id: job.id,
+      name: job.name,
+      status: job.status,
+      conclusion: job.conclusion,
+      logsUrl: job.html_url,
+    }));
 
-    return response;
+    $.export("$summary", `Workflow run ${this.runId}: ${run.status}${run.conclusion
+      ? ` / ${run.conclusion}`
+      : ""}`);
+
+    return {
+      run,
+      jobs: jobSummaries,
+    };
   },
 };

--- a/components/github/actions/list-branches/list-branches.mjs
+++ b/components/github/actions/list-branches/list-branches.mjs
@@ -35,11 +35,32 @@ export default {
   },
   async run({ $ }) {
     const repoFullname = await this.github._resolveRepoFullname(this.repoFullname);
-    const branches = await this.github.getBranches({
-      repoFullname,
-      protected: this.protected,
-      per_page: this.maxResults,
-    });
+
+    let page = 1;
+    const perPage = 100;
+    let branches = [];
+
+    while (branches.length < this.maxResults) {
+      const batch = await this.github.getBranches({
+        repoFullname,
+        protected: this.protected,
+        per_page: perPage,
+        page,
+      });
+
+      if (!batch?.length) {
+        break;
+      }
+
+      branches = branches.concat(batch);
+
+      if (batch.length < perPage) {
+        break;
+      }
+      page += 1;
+    }
+
+    branches = branches.slice(0, this.maxResults);
 
     $.export("$summary", `Successfully fetched ${branches.length} branch(es)`);
 

--- a/components/github/actions/list-branches/list-branches.mjs
+++ b/components/github/actions/list-branches/list-branches.mjs
@@ -1,11 +1,10 @@
 import github from "../../github.app.mjs";
-import { ConfigurationError } from "@pipedream/platform";
 
 export default {
   key: "github-list-branches",
   name: "List Branches",
-  description: "List branches for a repository using its `owner/repo` full name (for example, `octocat/Hello-World`). If you need to discover repository names first, use **List Repositories**. [See the documentation](https://docs.github.com/en/rest/branches/branches?apiVersion=2026-03-10#list-branches)",
-  version: "0.0.2",
+  description: "List the branches in a repository. Provide the repository as an `owner/repo` string. Optionally filter to only protected (or only unprotected) branches. If you need to discover repository names first, use **List Repositories**. [See the documentation](https://docs.github.com/en/rest/branches/branches#list-branches)",
+  version: "1.0.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -17,49 +16,33 @@ export default {
     repoFullname: {
       propDefinition: [
         github,
-        "repoFullname",
+        "repoFullnameStatic",
       ],
     },
     protected: {
       type: "boolean",
       label: "Protected",
-      description: "Setting to `true` returns only branches protected by branch protections or rulesets. When set to `false`, only unprotected branches are returned. Omitting this parameter returns all branches.",
+      description: "Set to `true` to return only branches protected by branch protections or rulesets, or `false` for only unprotected branches. Omit to return all branches.",
       optional: true,
     },
-    page: {
+    maxResults: {
       type: "integer",
-      label: "Page",
-      description: "The page number of the results to return. Defaults to 1.",
-      default: 1,
-      min: 1,
-      optional: true,
-    },
-    perPage: {
-      type: "integer",
-      label: "Per Page",
-      description: "The number of results to return per page. Defaults to 30. Maximum is 100.",
-      default: 30,
-      max: 100,
-      min: 1,
+      label: "Max Results",
+      description: "The maximum number of branches to return. Defaults: `100`",
+      default: 100,
       optional: true,
     },
   },
   async run({ $ }) {
-    if (this.page < 1 || this.perPage < 1) {
-      throw new ConfigurationError("Page and Per Page must be greater than 0");
-    }
-
-    if (this.perPage > 100) {
-      throw new ConfigurationError("Per Page must be less than or equal to 100");
-    }
-
+    const repoFullname = await this.github._resolveRepoFullname(this.repoFullname);
     const branches = await this.github.getBranches({
-      repoFullname: this.repoFullname,
+      repoFullname,
       protected: this.protected,
-      page: this.page,
-      per_page: this.perPage,
+      per_page: this.maxResults,
     });
-    $.export("$summary", `Successfully fetched ${branches.length} branches`);
+
+    $.export("$summary", `Successfully fetched ${branches.length} branch(es)`);
+
     return branches;
   },
 };

--- a/components/github/actions/list-commits/list-commits.mjs
+++ b/components/github/actions/list-commits/list-commits.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-list-commits",
   name: "List Commits",
   description: "List commits in a repository, most recent first. Optionally scope to a branch or starting SHA, a file path, an author, or a date range. Provide the repository as an `owner/repo` string. Use **Get Repository** to find the default branch name if needed. [See the documentation](https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#list-commits)",
-  version: "0.1.0",
+  version: "0.1.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/list-gist-id-options/list-gist-id-options.mjs
+++ b/components/github/actions/list-gist-id-options/list-gist-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-list-gist-id-options",
   name: "List Gist Id Options",
   description: "Retrieves available options for the Gist Id field.",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/github/actions/list-gists-for-a-user/list-gists-for-a-user.mjs
+++ b/components/github/actions/list-gists-for-a-user/list-gists-for-a-user.mjs
@@ -5,7 +5,7 @@ export default {
   key: "github-list-gists-for-a-user",
   name: "List Gists for a User",
   description: "Lists public gists for the specified user. [See the documentation](https://docs.github.com/en/rest/gists/gists?apiVersion=2022-11-28#list-gists-for-a-user)",
-  version: "0.1.8",
+  version: "0.1.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/list-org-name-options/list-org-name-options.mjs
+++ b/components/github/actions/list-org-name-options/list-org-name-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-list-org-name-options",
   name: "List Organization Options",
   description: "Retrieves available options for the Organization field.",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/github/actions/list-organization-repositories/list-organization-repositories.mjs
+++ b/components/github/actions/list-organization-repositories/list-organization-repositories.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-list-organization-repositories",
   name: "List Organization Repositories",
   description: "List repositories for an organization. [See the documentation](https://docs.github.com/en/rest/repos/repos?apiVersion=2026-03-10#list-organization-repositories)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/github/actions/list-organizations/list-organizations.mjs
+++ b/components/github/actions/list-organizations/list-organizations.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-list-organizations",
   name: "List Organizations",
   description: "List all organizations in the authenticated user's account. [See the documentation](https://docs.github.com/en/rest/orgs/orgs?apiVersion=2026-03-10#list-organizations-for-the-authenticated-user)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/github/actions/list-releases/list-releases.mjs
+++ b/components/github/actions/list-releases/list-releases.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-list-releases",
   name: "List Releases",
   description: "List releases for a repository [See the documentation](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#list-releases)",
-  version: "0.0.14",
+  version: "0.0.15",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/list-repositories/list-repositories.mjs
+++ b/components/github/actions/list-repositories/list-repositories.mjs
@@ -5,7 +5,7 @@ export default {
   key: "github-list-repositories",
   name: "List Repositories",
   description: "List repositories the authenticated user can access, or — when `org` is provided — the repositories of a specific organization. Use this to discover a repo's `owner/repo` name before calling **Get Repository**, **Get Repository Content**, or **List Commits**. To find repos by name, set the `name` substring filter. [See the documentation](https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-repositories-for-the-authenticated-user)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/list-team-id-options/list-team-id-options.mjs
+++ b/components/github/actions/list-team-id-options/list-team-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-list-team-id-options",
   name: "List Team Id Options",
   description: "Retrieves available options for the Team Id field.",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/github/actions/list-workflow-runs/list-workflow-runs.mjs
+++ b/components/github/actions/list-workflow-runs/list-workflow-runs.mjs
@@ -71,6 +71,10 @@ export default {
       }
 
       runs = runs.concat(workflowRuns);
+
+      if (workflowRuns.length < perPage) {
+        break;
+      }
       page += 1;
     }
 

--- a/components/github/actions/list-workflow-runs/list-workflow-runs.mjs
+++ b/components/github/actions/list-workflow-runs/list-workflow-runs.mjs
@@ -3,8 +3,8 @@ import github from "../../github.app.mjs";
 export default {
   key: "github-list-workflow-runs",
   name: "List Workflow Runs",
-  description: "List workflowRuns for a repository [See the documentation](https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#list-workflow-runs-for-a-repository)",
-  version: "0.0.8",
+  description: "List GitHub Actions workflow runs for a repository, most recent first. Optionally filter by `branch` or `status` (e.g. `completed`, `in_progress`, `failure`, `success`). Returns each run's `id`, workflow name, `status`, `conclusion`, branch, and timestamps. Use this to triage CI — find a failing run, then pass its `id` to **Get Workflow Run** for job details or to **Run Workflow** to re-run its failed jobs. Provide the repository as an `owner/repo` string. [See the documentation](https://docs.github.com/en/rest/actions/workflow-runs#list-workflow-runs-for-a-repository)",
+  version: "1.0.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -16,40 +16,68 @@ export default {
     repoFullname: {
       propDefinition: [
         github,
-        "repoFullname",
+        "repoFullnameStatic",
       ],
     },
-    limit: {
+    branch: {
+      type: "string",
+      label: "Branch",
+      description: "Only return runs associated with this branch, e.g. `main`.",
+      optional: true,
+    },
+    status: {
+      type: "string",
+      label: "Status",
+      description: "Filter runs by status or conclusion.",
+      options: [
+        "queued",
+        "in_progress",
+        "completed",
+        "success",
+        "failure",
+        "cancelled",
+        "skipped",
+        "timed_out",
+        "action_required",
+      ],
+      optional: true,
+    },
+    maxResults: {
       type: "integer",
-      label: "Limit",
-      description: "The maximum quantity to be returned.",
+      label: "Max Results",
+      description: "The maximum number of workflow runs to return. Defaults: `100`",
       default: 100,
+      optional: true,
     },
   },
   async run({ $ }) {
+    const repoFullname = await this.github._resolveRepoFullname(this.repoFullname);
+
     let page = 1;
     const perPage = 100;
-    let allWorkflowRuns = [];
-    let count = 0;
+    let runs = [];
 
-    while (count < this.limit) {
+    while (runs.length < this.maxResults) {
       const { workflow_runs: workflowRuns } = await this.github.listWorkflowRuns({
-        repoFullname: this.repoFullname,
-        perPage: perPage,
-        page: page,
+        repoFullname,
+        perPage,
+        page,
+        branch: this.branch,
+        status: this.status,
       });
 
-      if (workflowRuns.length === 0) {
+      if (!workflowRuns?.length) {
         break;
       }
 
-      allWorkflowRuns = allWorkflowRuns.concat(workflowRuns);
-      count += workflowRuns.length;
+      runs = runs.concat(workflowRuns);
       page += 1;
     }
 
-    $.export("$summary", `Successfully retrieved ${allWorkflowRuns.length} workflow runs.`);
+    runs = runs.slice(0, this.maxResults);
 
-    return allWorkflowRuns;
+    $.export("$summary", `Successfully retrieved ${runs.length} workflow run(s)`);
+
+    return runs;
   },
 };

--- a/components/github/actions/list-workflows/list-workflows.mjs
+++ b/components/github/actions/list-workflows/list-workflows.mjs
@@ -29,11 +29,31 @@ export default {
   },
   async run({ $ }) {
     const repoFullname = await this.github._resolveRepoFullname(this.repoFullname);
-    const { workflows } = await this.github.listWorkflows({
-      repoFullname,
-      perPage: this.maxResults,
-      page: 1,
-    });
+
+    let page = 1;
+    const perPage = 100;
+    let workflows = [];
+
+    while (workflows.length < this.maxResults) {
+      const { workflows: batch } = await this.github.listWorkflows({
+        repoFullname,
+        perPage,
+        page,
+      });
+
+      if (!batch?.length) {
+        break;
+      }
+
+      workflows = workflows.concat(batch);
+
+      if (batch.length < perPage) {
+        break;
+      }
+      page += 1;
+    }
+
+    workflows = workflows.slice(0, this.maxResults);
 
     $.export("$summary", `Retrieved ${workflows.length} workflow(s)`);
 

--- a/components/github/actions/list-workflows/list-workflows.mjs
+++ b/components/github/actions/list-workflows/list-workflows.mjs
@@ -1,0 +1,42 @@
+import github from "../../github.app.mjs";
+
+export default {
+  key: "github-list-workflows",
+  name: "List Workflows",
+  description: "List the GitHub Actions workflows defined in a repository. Returns each workflow's `id`, `name`, `path` (e.g. `.github/workflows/ci.yml`), and `state`. Use this to discover the workflow file name or ID needed by **Run Workflow**. Provide the repository as an `owner/repo` string. [See the documentation](https://docs.github.com/en/rest/actions/workflows#list-repository-workflows)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  type: "action",
+  props: {
+    github,
+    repoFullname: {
+      propDefinition: [
+        github,
+        "repoFullnameStatic",
+      ],
+    },
+    maxResults: {
+      type: "integer",
+      label: "Max Results",
+      description: "The maximum number of workflows to return. Defaults: `100`",
+      default: 100,
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const repoFullname = await this.github._resolveRepoFullname(this.repoFullname);
+    const { workflows } = await this.github.listWorkflows({
+      repoFullname,
+      perPage: this.maxResults,
+      page: 1,
+    });
+
+    $.export("$summary", `Retrieved ${workflows.length} workflow(s)`);
+
+    return workflows;
+  },
+};

--- a/components/github/actions/merge-pull-request/merge-pull-request.mjs
+++ b/components/github/actions/merge-pull-request/merge-pull-request.mjs
@@ -1,0 +1,73 @@
+import github from "../../github.app.mjs";
+
+export default {
+  key: "github-merge-pull-request",
+  name: "Merge Pull Request",
+  description: "Merge an open pull request into its base branch. Choose the `mergeMethod`: `merge` (a merge commit, the default), `squash` (combine all commits into one), or `rebase`. The merge fails if the PR is not mergeable (conflicts, failing required checks, or required reviews missing) — check mergeable state and CI with **Get Pull Request** first. Provide the repository as an `owner/repo` string and the PR number. To create the PR first, use **Create Pull Request**. [See the documentation](https://docs.github.com/en/rest/pulls/pulls#merge-a-pull-request)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  type: "action",
+  props: {
+    github,
+    repoFullname: {
+      propDefinition: [
+        github,
+        "repoFullnameStatic",
+      ],
+    },
+    pullNumber: {
+      propDefinition: [
+        github,
+        "pullNumberStatic",
+      ],
+    },
+    mergeMethod: {
+      type: "string",
+      label: "Merge Method",
+      description: "How to merge the pull request. Defaults to `merge`.",
+      options: [
+        "merge",
+        "squash",
+        "rebase",
+      ],
+      default: "merge",
+      optional: true,
+    },
+    commitTitle: {
+      type: "string",
+      label: "Commit Title",
+      description: "Title for the merge commit. Defaults to GitHub's automatic title.",
+      optional: true,
+    },
+    commitMessage: {
+      type: "string",
+      label: "Commit Message",
+      description: "Extra detail appended to the merge commit message.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const repoFullname = await this.github._resolveRepoFullname(this.repoFullname);
+    const data = {
+      merge_method: this.mergeMethod,
+      commit_title: this.commitTitle,
+      commit_message: this.commitMessage,
+    };
+
+    const response = await this.github.mergePullRequest({
+      repoFullname,
+      pullNumber: this.pullNumber,
+      data,
+    });
+
+    $.export("$summary", `Merged pull request #${this.pullNumber}${response?.merged
+      ? ` (${response.sha})`
+      : ""}`);
+
+    return response;
+  },
+};

--- a/components/github/actions/run-workflow/run-workflow.mjs
+++ b/components/github/actions/run-workflow/run-workflow.mjs
@@ -1,0 +1,114 @@
+import { ConfigurationError } from "@pipedream/platform";
+import github from "../../github.app.mjs";
+
+export default {
+  key: "github-run-workflow",
+  name: "Run Workflow",
+  description: "Trigger a GitHub Actions workflow run, or re-run the failed jobs of a previous run. To start a new run, provide `workflow` (the workflow file name, e.g. `ci.yml`, its display name, or its numeric ID) and optionally `ref` (the branch or tag to run on — defaults to the repository's default branch) and `inputs` (for `workflow_dispatch` workflows). To re-run only the failed jobs of an existing run instead, provide `rerunFailedRunId`. The workflow must already have a `workflow_dispatch` trigger to be dispatchable. Use **List Workflows** to find the workflow file name and **List Workflow Runs** to find a run ID. Provide the repository as an `owner/repo` string. [See the documentation](https://docs.github.com/en/rest/actions/workflows#create-a-workflow-dispatch-event)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  type: "action",
+  props: {
+    github,
+    repoFullname: {
+      propDefinition: [
+        github,
+        "repoFullnameStatic",
+      ],
+    },
+    workflow: {
+      type: "string",
+      label: "Workflow",
+      description: "The workflow to dispatch — its file name (e.g. `ci.yml`), display name, or numeric ID. Required unless re-running failed jobs. Use **List Workflows** to discover available workflows.",
+      optional: true,
+    },
+    ref: {
+      type: "string",
+      label: "Ref",
+      description: "The branch or tag to run the workflow on, e.g. `main`. Defaults to the repository's default branch.",
+      optional: true,
+    },
+    inputs: {
+      type: "object",
+      label: "Inputs",
+      description: "Input keys and values configured in the workflow's `workflow_dispatch` definition (max 10). Defaults from the workflow file are used for omitted inputs.",
+      optional: true,
+    },
+    rerunFailedRunId: {
+      type: "string",
+      label: "Re-run Failed Run ID",
+      description: "Provide a workflow run ID here to re-run only its failed jobs instead of dispatching a new run. Use **List Workflow Runs** to find a run ID.",
+      optional: true,
+    },
+  },
+  methods: {
+    // Resolve a workflow file name / display name to the value the dispatch
+    // endpoint accepts (file name or numeric ID). Lets "eval" resolve to
+    // "eval.yml" in a single call rather than forcing a List Workflows step.
+    async resolveWorkflowId(repoFullname, workflow) {
+      // Numeric ID or already a workflow file name — use as-is.
+      if (/^\d+$/.test(workflow) || /\.ya?ml$/i.test(workflow)) {
+        return workflow;
+      }
+      const { workflows } = await this.github.listWorkflows({
+        repoFullname,
+        perPage: 100,
+        page: 1,
+      });
+      const target = workflow.toLowerCase();
+      const match = workflows.find((wf) => {
+        const fileName = wf.path.split("/").pop();
+        const stem = fileName.replace(/\.ya?ml$/i, "");
+        return [
+          wf.name?.toLowerCase(),
+          fileName.toLowerCase(),
+          stem.toLowerCase(),
+          String(wf.id),
+        ].includes(target);
+      });
+      if (!match) {
+        throw new ConfigurationError(`No workflow matching "${workflow}" found. Use **List Workflows** to see available workflows.`);
+      }
+      return match.path.split("/").pop();
+    },
+  },
+  async run({ $ }) {
+    const repoFullname = await this.github._resolveRepoFullname(this.repoFullname);
+
+    if (this.rerunFailedRunId) {
+      const response = await this.github.rerunFailedJobs({
+        repoFullname,
+        workflowRunId: this.rerunFailedRunId,
+      });
+      $.export("$summary", `Re-ran failed jobs for workflow run ${this.rerunFailedRunId}`);
+      return response;
+    }
+
+    if (!this.workflow) {
+      throw new ConfigurationError("Provide a `workflow` to dispatch, or a `rerunFailedRunId` to re-run failed jobs.");
+    }
+
+    const ref = this.ref ?? (await this.github.getRepo({
+      repoFullname,
+    })).default_branch;
+
+    const workflowId = await this.resolveWorkflowId(repoFullname, this.workflow);
+
+    const response = await this.github.createWorkflowDispatch({
+      repoFullname,
+      workflowId,
+      data: {
+        ref,
+        inputs: this.inputs,
+      },
+    });
+
+    $.export("$summary", `Dispatched workflow \`${workflowId}\` on \`${ref}\``);
+
+    return response;
+  },
+};

--- a/components/github/actions/search-issues-and-pull-requests/search-issues-and-pull-requests.mjs
+++ b/components/github/actions/search-issues-and-pull-requests/search-issues-and-pull-requests.mjs
@@ -7,7 +7,7 @@ export default {
     + "Build the `query` from space-separated qualifiers: `repo:owner/name` to scope to one repo (a bare `repo:name` with no owner is auto-resolved to your own account), `is:issue`/`is:pr`, `is:open`/`is:closed`, `label:bug`, `author:octocat`, `assignee:octocat`, `in:title`/`in:body`, and free-text keywords. "
     + "Example: `repo:PipedreamHQ/pipedream is:issue is:open label:bug raptor`. "
     + "Returns matching items (each with `number`, `title`, `state`, `labels`, `html_url`); feed a result's `number` into **Get Issue**, **Get Pull Request**, or **Create Issue Comment**. [See the query syntax](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests)",
-  version: "0.3.0",
+  version: "0.3.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/star-repo/star-repo.mjs
+++ b/components/github/actions/star-repo/star-repo.mjs
@@ -5,7 +5,7 @@ export default {
   key: "github-star-repo",
   name: "Star Repo",
   description: "Star a repository. [See the docs](https://docs.github.com/en/rest/activity/starring?apiVersion=2022-11-28#star-a-repository-for-the-authenticated-user) for more info.",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/sync-fork-branch-with-upstream/sync-fork-branch-with-upstream.mjs
+++ b/components/github/actions/sync-fork-branch-with-upstream/sync-fork-branch-with-upstream.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-sync-fork-branch-with-upstream",
   name: "Sync Fork Branch with Upstream",
   description: "Sync a forked branch with the upstream branch. [See the documentation](https://docs.github.com/en/rest/branches/branches?apiVersion=2022-11-28#sync-a-fork-branch-with-the-upstream-repository)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: true,

--- a/components/github/actions/update-gist/update-gist.mjs
+++ b/components/github/actions/update-gist/update-gist.mjs
@@ -6,7 +6,7 @@ export default {
   key: "github-update-gist",
   name: "Update Gist",
   description: "Allows you to update a gist's description and to update, delete, or rename gist files. [See the documentation](https://docs.github.com/en/rest/gists/gists?apiVersion=2022-11-28#update-a-gist)",
-  version: "0.0.16",
+  version: "0.0.17",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/github/actions/update-issue/update-issue.mjs
+++ b/components/github/actions/update-issue/update-issue.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-update-issue",
   name: "Update Issue",
   description: "Update an existing issue: change its title, body, state (open/closed), labels, assignees, or milestone. Provide the repository as an `owner/repo` string and the issue number. Setting `labels` **replaces** the full label set (it does not append), so include any existing labels you want to keep. Closing an issue is done here by setting `state` to `closed`. Use **Get Issue** first if you need the current values. [See the documentation](https://docs.github.com/en/rest/issues/issues#update-an-issue)",
-  version: "0.3.0",
+  version: "0.3.1",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/github/actions/update-project-v2-item-status/update-project-v2-item-status.mjs
+++ b/components/github/actions/update-project-v2-item-status/update-project-v2-item-status.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-update-project-v2-item-status",
   name: "Update Project (V2) Item Status",
   description: "Update the status of an item in the selected Project (V2). [See the documentation](https://docs.github.com/en/graphql/reference/mutations#updateprojectv2itemfieldvalue)",
-  version: "0.0.11",
+  version: "0.0.12",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/github/actions/update-pull-request/update-pull-request.mjs
+++ b/components/github/actions/update-pull-request/update-pull-request.mjs
@@ -3,8 +3,8 @@ import github from "../../github.app.mjs";
 export default {
   key: "github-update-pull-request",
   name: "Update Pull Request",
-  description: "Updates an existing pull request with new title, body, state, or base branch. [See the documentation](https://docs.github.com/en/rest/pulls/pulls#update-a-pull-request)",
-  version: "0.0.3",
+  description: "Update an existing pull request's title, body, state (`open`/`closed`), or base branch. Only the fields you provide are changed. Provide the repository as an `owner/repo` string and the PR number. If you only know the PR by title, call **Get Pull Request** or **Search Issues and Pull Requests** with `is:pr` first to resolve its number. To merge a PR, use **Merge Pull Request**; to comment on it, use **Create Issue Comment**. [See the documentation](https://docs.github.com/en/rest/pulls/pulls#update-a-pull-request)",
+  version: "1.0.0",
   type: "action",
   annotations: {
     destructiveHint: true,
@@ -16,37 +16,30 @@ export default {
     repoFullname: {
       propDefinition: [
         github,
-        "repoFullname",
+        "repoFullnameStatic",
       ],
-      label: "Repository",
-      description: "The repository where the pull request exists.",
     },
     pullNumber: {
       propDefinition: [
         github,
-        "pullNumber",
-        (c) => ({
-          repoFullname: c.repoFullname,
-        }),
+        "pullNumberStatic",
       ],
-      label: "Pull Request Number",
-      description: "The number of the pull request to update.",
     },
     title: {
       label: "Title",
-      description: "The title of the pull request.",
+      description: "The new title of the pull request.",
       type: "string",
       optional: true,
     },
     body: {
       label: "Body",
-      description: "The contents of the pull request body. Supports markdown.",
+      description: "The new contents of the pull request body. Supports GitHub-flavored Markdown.",
       type: "string",
       optional: true,
     },
     state: {
       label: "State",
-      description: "The desired state of the pull request.",
+      description: "The desired state of the pull request. Set to `closed` to close it without merging, or `open` to reopen.",
       type: "string",
       optional: true,
       options: [
@@ -55,68 +48,28 @@ export default {
       ],
     },
     base: {
-      propDefinition: [
-        github,
-        "branch",
-        (c) => ({
-          repoFullname: c.repoFullname,
-        }),
-      ],
       label: "Base Branch",
-      description: "The name of the branch you want your changes pulled into. This should be an existing branch on the current repository.",
-      optional: true,
-    },
-    maintainerCanModify: {
-      label: "Maintainers Can Modify",
-      description: "Indicates whether [maintainers can modify](https://docs.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) the pull request.",
-      type: "boolean",
+      description: "The name of the branch you want the changes pulled into, e.g. `main`. Must be an existing branch in the repository.",
+      type: "string",
       optional: true,
     },
   },
   async run({ $ }) {
-    const {
-      github,
+    const repoFullname = await this.github._resolveRepoFullname(this.repoFullname);
+    const data = {
+      title: this.title,
+      body: this.body,
+      state: this.state,
+      base: this.base,
+    };
+
+    const response = await this.github.updatePullRequest({
       repoFullname,
-      pullNumber,
-      title,
-      body,
-      state,
-      base,
-      maintainerCanModify,
-    } = this;
-
-    const data = {};
-
-    if (title) {
-      data.title = title;
-    }
-
-    if (body) {
-      data.body = body;
-    }
-
-    if (state) {
-      data.state = state;
-    }
-
-    if (base) {
-      // Extract branch name from the branch prop format (sha/branchname)
-      data.base = base.split("/")[1];
-    }
-
-    // Only include maintainer_can_modify if explicitly set to true
-    // This field only applies to cross-repo pull requests (from forks)
-    if (maintainerCanModify === true) {
-      data.maintainer_can_modify = maintainerCanModify;
-    }
-
-    const response = await github.updatePullRequest({
-      repoFullname,
-      pullNumber,
+      pullNumber: this.pullNumber,
       data,
     });
 
-    $.export("$summary", `Successfully updated pull request with ID \`${response.id}\``);
+    $.export("$summary", `Successfully updated pull request #${this.pullNumber}`);
 
     return response;
   },

--- a/components/github/github.app.mjs
+++ b/components/github/github.app.mjs
@@ -1033,10 +1033,9 @@ export default {
     async getCheckRunsForRef({
       repoFullname, ref,
     }) {
-      const response = await this._client().request(`GET /repos/${repoFullname}/commits/${ref}/check-runs`, {
+      return this._client().paginate(`GET /repos/${repoFullname}/commits/${ref}/check-runs`, {
         per_page: 100,
       });
-      return response.data;
     },
     async getRef({
       repoFullname, ref,

--- a/components/github/github.app.mjs
+++ b/components/github/github.app.mjs
@@ -49,6 +49,11 @@ export default {
       description: "The issue number — the `#N` shown in the GitHub UI, not the global issue ID. Use **Search Issues and Pull Requests** or **Get Issue** to find it when you only know the title.",
       type: "integer",
     },
+    pullNumberStatic: {
+      label: "Pull Request Number",
+      description: "The pull request number — the `#N` shown in the GitHub UI. Use **Search Issues and Pull Requests** with `is:pr` or **Get Pull Request** to find it when you only know the title.",
+      type: "integer",
+    },
     repoOrg: {
       label: "Organization Repository",
       description: "The repository in a organization",
@@ -831,10 +836,12 @@ export default {
       repoFullname,
       perPage,
       page,
+      ...args
     }) {
       const response = await this._client().request(`GET /repos/${repoFullname}/actions/runs`, {
         per_page: perPage,
         page: page,
+        ...args,
       });
 
       return response.data;
@@ -996,6 +1003,58 @@ export default {
       repoFullname, ...args
     }) {
       const response = await this._client().request(`GET /repos/${repoFullname}/commits`, args);
+      return response.data;
+    },
+    async mergePullRequest({
+      repoFullname, pullNumber, data,
+    }) {
+      const response = await this._client().request(`PUT /repos/${repoFullname}/pulls/${pullNumber}/merge`, data);
+      return response.data;
+    },
+    async createPullRequestReview({
+      repoFullname, pullNumber, data,
+    }) {
+      const response = await this._client().request(`POST /repos/${repoFullname}/pulls/${pullNumber}/reviews`, data);
+      return response.data;
+    },
+    async getPullRequestFiles({
+      repoFullname, pullNumber,
+    }) {
+      return this._client().paginate(`GET /repos/${repoFullname}/pulls/${pullNumber}/files`, {
+        per_page: 100,
+      });
+    },
+    async getCommitStatus({
+      repoFullname, ref,
+    }) {
+      const response = await this._client().request(`GET /repos/${repoFullname}/commits/${ref}/status`, {});
+      return response.data;
+    },
+    async getCheckRunsForRef({
+      repoFullname, ref,
+    }) {
+      const response = await this._client().request(`GET /repos/${repoFullname}/commits/${ref}/check-runs`, {
+        per_page: 100,
+      });
+      return response.data;
+    },
+    async getRef({
+      repoFullname, ref,
+    }) {
+      const response = await this._client().request(`GET /repos/${repoFullname}/git/ref/${ref}`, {});
+      return response.data;
+    },
+    async getWorkflowRunJobs({
+      repoFullname, workflowRunId,
+    }) {
+      return this._client().paginate(`GET /repos/${repoFullname}/actions/runs/${workflowRunId}/jobs`, {
+        per_page: 100,
+      });
+    },
+    async rerunFailedJobs({
+      repoFullname, workflowRunId,
+    }) {
+      const response = await this._client().request(`POST /repos/${repoFullname}/actions/runs/${workflowRunId}/rerun-failed-jobs`, {});
       return response.data;
     },
   },

--- a/components/github/package.json
+++ b/components/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/github",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Pipedream GitHub Components",
   "main": "github.app.mjs",
   "keywords": [

--- a/components/github/sources/new-branch/new-branch.mjs
+++ b/components/github/sources/new-branch/new-branch.mjs
@@ -8,7 +8,7 @@ export default {
   key: "github-new-branch",
   name: "New Branch Created",
   description: "Emit new event when a branch is created.",
-  version: "1.0.14",
+  version: "1.0.15",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-card-in-column/new-card-in-column.mjs
+++ b/components/github/sources/new-card-in-column/new-card-in-column.mjs
@@ -7,7 +7,7 @@ export default {
   key: "github-new-card-in-column",
   name: "New Card in Column (Classic Projects)",
   description: "Emit new event when a (classic) project card is created or moved to a specific column. For Projects V2 use `New Issue with Status` trigger. [More information here](https://docs.github.com/en/issues/organizing-your-work-with-project-boards/tracking-work-with-project-boards/adding-issues-and-pull-requests-to-a-project-board)",
-  version: "1.0.13",
+  version: "1.0.14",
   type: "source",
   props: {
     ...common.props,

--- a/components/github/sources/new-collaborator/new-collaborator.mjs
+++ b/components/github/sources/new-collaborator/new-collaborator.mjs
@@ -8,7 +8,7 @@ export default {
   key: "github-new-collaborator",
   name: "New Collaborator",
   description: "Emit new event when a collaborator is added",
-  version: "1.0.14",
+  version: "1.0.15",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-commit-comment/new-commit-comment.mjs
+++ b/components/github/sources/new-commit-comment/new-commit-comment.mjs
@@ -8,7 +8,7 @@ export default {
   key: "github-new-commit-comment",
   name: "New Commit Comment",
   description: "Emit new event when a commit comment is created",
-  version: "1.0.14",
+  version: "1.0.15",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/github/sources/new-commit/new-commit.mjs
+++ b/components/github/sources/new-commit/new-commit.mjs
@@ -8,7 +8,7 @@ export default {
   key: "github-new-commit",
   name: "New Commit",
   description: "Emit new event when commits are pushed to a branch",
-  version: "1.0.15",
+  version: "1.0.16",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/github/sources/new-discussion/new-discussion.mjs
+++ b/components/github/sources/new-discussion/new-discussion.mjs
@@ -8,7 +8,7 @@ export default {
   key: "github-new-discussion",
   name: "New Discussion",
   description: "Emit new event when a discussion is created",
-  version: "1.0.14",
+  version: "1.0.15",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-fork/new-fork.mjs
+++ b/components/github/sources/new-fork/new-fork.mjs
@@ -8,7 +8,7 @@ export default {
   key: "github-new-fork",
   name: "New Fork",
   description: "Emit new event when a repository is forked",
-  version: "1.0.14",
+  version: "1.0.15",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-gist/new-gist.mjs
+++ b/components/github/sources/new-gist/new-gist.mjs
@@ -5,7 +5,7 @@ export default {
   key: "github-new-gist",
   name: "New Gist",
   description: "Emit new events when new gists are created by the authenticated user. [See the documentation](https://docs.github.com/en/rest/gists/gists?apiVersion=20.2.61-28#list-gists-for-the-authenticated-user)",
-  version: "0.2.9",
+  version: "0.2.10",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-issue-comment/new-issue-comment.mjs
+++ b/components/github/sources/new-issue-comment/new-issue-comment.mjs
@@ -8,7 +8,7 @@ export default {
   key: "github-new-issue-comment",
   name: "New Issue Comment",
   description: "Emit new event when a new comment is added to an issue or pull request",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-issue-with-status/new-issue-with-status.mjs
+++ b/components/github/sources/new-issue-with-status/new-issue-with-status.mjs
@@ -8,7 +8,7 @@ export default {
   key: "github-new-issue-with-status",
   name: "Project Item Status Changed",
   description: "Emit new event when a project item is tagged with a specific status. Currently supports Organization Projects only. [More information here](https://docs.github.com/en/issues/planning-and-tracking-with-projects/managing-items-in-your-project/adding-items-to-your-project)",
-  version: "0.1.12",
+  version: "0.1.13",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/github/sources/new-label/new-label.mjs
+++ b/components/github/sources/new-label/new-label.mjs
@@ -8,7 +8,7 @@ export default {
   key: "github-new-label",
   name: "New Label",
   description: "Emit new event when a new label is created",
-  version: "1.0.14",
+  version: "1.0.15",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-mention/new-mention.mjs
+++ b/components/github/sources/new-mention/new-mention.mjs
@@ -5,7 +5,7 @@ export default {
   key: "github-new-mention",
   name: "New Mention",
   description: "Emit new event when you are @mentioned in a new commit, comment, issue or pull request. [See the documentation](https://docs.github.com/en/rest/activity/notifications?apiVersion=20.2.71-28#list-notifications-for-the-authenticated-user)",
-  version: "0.2.8",
+  version: "0.2.9",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-notification/new-notification.mjs
+++ b/components/github/sources/new-notification/new-notification.mjs
@@ -5,7 +5,7 @@ export default {
   key: "github-new-notification",
   name: "New Notification",
   description: "Emit new event when the authenticated user receives a new notification. [See the documentation](https://docs.github.com/en/rest/activity/notifications?apiVersion=20.2.71-28#list-notifications-for-the-authenticated-user)",
-  version: "0.2.8",
+  version: "0.2.9",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-or-updated-issue/new-or-updated-issue.mjs
+++ b/components/github/sources/new-or-updated-issue/new-or-updated-issue.mjs
@@ -9,7 +9,7 @@ export default {
   key: "github-new-or-updated-issue",
   name: "New or Updated Issue",
   description: "Emit new events when an issue is created or updated",
-  version: "1.1.11",
+  version: "1.1.12",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-or-updated-milestone/new-or-updated-milestone.mjs
+++ b/components/github/sources/new-or-updated-milestone/new-or-updated-milestone.mjs
@@ -9,7 +9,7 @@ export default {
   key: "github-new-or-updated-milestone",
   name: "New or Updated Milestone",
   description: "Emit new event when a milestone is created or updated",
-  version: "1.1.11",
+  version: "1.1.12",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-or-updated-pull-request/new-or-updated-pull-request.mjs
+++ b/components/github/sources/new-or-updated-pull-request/new-or-updated-pull-request.mjs
@@ -9,7 +9,7 @@ export default {
   key: "github-new-or-updated-pull-request",
   name: "New or Updated Pull Request",
   description: "Emit new event when a pull request is opened or updated",
-  version: "1.2.11",
+  version: "1.2.12",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-organization/new-organization.mjs
+++ b/components/github/sources/new-organization/new-organization.mjs
@@ -5,7 +5,7 @@ export default {
   key: "github-new-organization",
   name: "New Organization",
   description: "Emit new event when the authenticated user is added to a new organization. [See the documentation](https://docs.github.com/en/rest/orgs/orgs?apiVersion=20.2.71-28#list-organizations-for-the-authenticated-user)",
-  version: "0.2.8",
+  version: "0.2.9",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-release/new-release.mjs
+++ b/components/github/sources/new-release/new-release.mjs
@@ -8,7 +8,7 @@ export default {
   key: "github-new-release",
   name: "New release",
   description: "Emit new event when a new release is created",
-  version: "1.0.14",
+  version: "1.0.15",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-repository/new-repository.mjs
+++ b/components/github/sources/new-repository/new-repository.mjs
@@ -5,7 +5,7 @@ export default {
   key: "github-new-repository",
   name: "New Repository",
   description: "Emit new event when a new repository is created or when the authenticated user receives access. [See the documentation](https://docs.github.com/en/rest/repos/repos?apiVersion=20.2.71-28#list-repositories-for-the-authenticated-user)",
-  version: "0.2.8",
+  version: "0.2.9",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-review-request/new-review-request.mjs
+++ b/components/github/sources/new-review-request/new-review-request.mjs
@@ -5,7 +5,7 @@ export default {
   key: "github-new-review-request",
   name: "New Review Request",
   description: "Emit new event for new review request notifications. [See the documentation](https://docs.github.com/en/rest/activity/notifications?apiVersion=20.2.71-28#list-notifications-for-the-authenticated-user)",
-  version: "0.2.8",
+  version: "0.2.9",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-security-alert/new-security-alert.mjs
+++ b/components/github/sources/new-security-alert/new-security-alert.mjs
@@ -5,7 +5,7 @@ export default {
   key: "github-new-security-alert",
   name: "New Security Alert",
   description: "Emit new event for security alert notifications. [See the documentation](https://docs.github.com/en/rest/activity/notifications?apiVersion=20.2.71-28#list-notifications-for-the-authenticated-user)",
-  version: "0.2.8",
+  version: "0.2.9",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-star-by-user/new-star-by-user.mjs
+++ b/components/github/sources/new-star-by-user/new-star-by-user.mjs
@@ -5,7 +5,7 @@ export default {
   key: "github-new-star-by-user",
   name: "New Star By User",
   description: "Emit new events when the specified user stars a repository. [See the documentation](https://docs.github.com/en/rest/activity/starring?apiVersion=2022-11-28#list-repositories-starred-by-a-user)",
-  version: "0.0.13",
+  version: "0.0.14",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/github/sources/new-star/new-star.mjs
+++ b/components/github/sources/new-star/new-star.mjs
@@ -8,7 +8,7 @@ export default {
   key: "github-new-star",
   name: "New Stars",
   description: "Emit new event when a repository is starred",
-  version: "1.0.14",
+  version: "1.0.15",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-team/new-team.mjs
+++ b/components/github/sources/new-team/new-team.mjs
@@ -5,7 +5,7 @@ export default {
   key: "github-new-team",
   name: "New Team",
   description: "Emit new event when the authenticated user is added to a new team. [See the documentation](https://docs.github.com/en/rest/teams/teams?apiVersion=20.2.71-28#list-teams-for-the-authenticated-user)",
-  version: "0.2.8",
+  version: "0.2.9",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-workflow-job-completed/new-workflow-job-completed.mjs
+++ b/components/github/sources/new-workflow-job-completed/new-workflow-job-completed.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Workflow Job Completed (Instant)",
   description: "Emit new event when a job in a workflow is completed, regardless of whether the job was successful or unsuccessful.",
   type: "source",
-  version: "0.0.8",
+  version: "0.0.9",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/github/sources/new-workflow-run-completed/new-workflow-run-completed.mjs
+++ b/components/github/sources/new-workflow-run-completed/new-workflow-run-completed.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Workflow Run Completed (Instant)",
   description: "Emit new event when a GitHub Actions workflow run completes",
   type: "source",
-  version: "0.0.8",
+  version: "0.0.9",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/github/sources/webhook-events/webhook-events.mjs
+++ b/components/github/sources/webhook-events/webhook-events.mjs
@@ -8,7 +8,7 @@ export default {
   name: "New Webhook Event (Instant)",
   description: "Emit new event for each selected event type",
   type: "source",
-  version: "1.0.15",
+  version: "1.0.16",
   dedupe: "unique",
   props: {
     docsInfo: {


### PR DESCRIPTION
## Summary

Phase 2 of the AI-optimized GitHub action set for MCP, building on the Phase 1 set merged in #21250. Focuses on the highest-value GitHub agent workflows that Phase 1 and the legacy registry actions didn't cover: **PR review & merge**, **branch/commit authoring**, and **CI/Actions triage**.

In production the MCP server exposes only the AI-optimized actions and hides legacy registry actions, so any capability not covered here is effectively unavailable to MCP users. This PR closes those gaps.

### New tools (5 new keys)
| Tool | Purpose |
|---|---|
| `github-get-pull-request-files` | List a PR's changed files (the diff at file level, with patches) |
| `github-create-pull-request-review` | Submit a review — approve / request changes / comment, with optional inline comments |
| `github-merge-pull-request` | Merge a PR (`merge` / `squash` / `rebase`) |
| `github-list-workflows` | Discover GitHub Actions workflows in a repo |
| `github-run-workflow` | Dispatch a workflow **or** re-run its failed jobs |

### Enhanced
- **`github-get-pull-request`** now returns `mergeable` / `mergeable_state` plus a `checksSummary` CI rollup (combined commit status + check-runs summarized to an overall state and pass/fail counts), so "can I merge? is CI green?" is answerable in one call. Switched to the static `pullNumberStatic` prop.

### Modernized to static (MCP-friendly) schemas
Dropped `async options()` dropdowns and now accept `owner/repo` strings and plain numbers/branch names directly (resolving in a single MCP call):
`github-update-pull-request`, `github-create-branch`, `github-list-branches`, `github-get-commit`, `github-list-workflow-runs`, `github-get-workflow-run`.

### App file
Adds the `pullNumberStatic` propDefinition and methods `mergePullRequest`, `createPullRequestReview`, `getPullRequestFiles`, `getCommitStatus`, `getCheckRunsForRef`, `getRef`, `getWorkflowRunJobs`, `rerunFailedJobs`; `listWorkflowRuns` now forwards `branch`/`status` filters (additive, backward-compatible). No existing methods modified.

### Versioning
`@pipedream/github` bumped **2.0.0 → 3.0.0** (major — the modernized actions rename/drop props, a breaking change for existing workflow configs).

### Notes
- `github-run-workflow` is a **new key** consolidating `workflow_dispatch` + `rerun-failed-jobs` into one tool. The legacy `github-create-workflow-dispatch` is left on disk for deprecation in a follow-up (registry keys are immutable).

## Testing
Validated end-to-end against a live GitHub account through Pipedream's MCP server using an automated eval suite (24 evals spanning all 24 AI-optimized tools): **24/24 passing, all 24 tools exercised, 0% clarifying-question rate.** Coverage includes the full PR lifecycle (create branch → commit file → open PR → merge), PR review submission, PR file diffs, and the CI triage chain (list workflows → list runs → get run → dispatch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GitHub actions for merging pull requests, creating PR reviews, fetching PR files, listing workflows, and dispatching or rerunning workflows.
* **Breaking Changes**
  * Updated action inputs across the suite: branch creation now uses `sourceBranch`, commit lookup uses `ref`, workflow run retrieval uses `runId`, and branch/run listings use `maxResults` (with new optional `branch`/`status` filters for run listing).
* **Improvements**
  * Enhanced pull request outputs with merge readiness + aggregated checks summary, and workflow run outputs with job-level summaries.
* **Chores**
  * Version bumps across multiple GitHub actions and sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->