### PR TITLE
Fixing hubspot new-deal-property-change trigger

### DIFF
--- a/components/hubspot/package.json
+++ b/components/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/hubspot",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "description": "Pipedream Hubspot Components",
   "main": "hubspot.app.mjs",
   "keywords": [

--- a/components/hubspot/sources/new-deal-property-change/new-deal-property-change.mjs
+++ b/components/hubspot/sources/new-deal-property-change/new-deal-property-change.mjs
@@ -102,7 +102,7 @@ export default {
         },
       });
     },
-    async processEvents(resources, after) {
+    async processEvents(resources, after, initialTs = Date.now()) {
       // Initial (deploy) run: no cursor yet. Emit only the newest
       // MAX_INITIAL_EVENTS as a sample, then store the cursor so subsequent
       // run()s never re-emit this historical backfill.
@@ -119,7 +119,7 @@ export default {
           // No usable timestamps to derive a cursor from, but still advance it
           // so the first run() does not treat itself as an initial run and emit
           // everything.
-          this._setAfter(Date.now());
+          this._setAfter(initialTs);
           return;
         }
 
@@ -157,6 +157,7 @@ export default {
         );
       }
 
+      const initialTs = Date.now();
       const updatedDeals = await this.getPaginatedItems(
         this.hubspot.searchCRM,
         params,
@@ -168,7 +169,7 @@ export default {
         // cursor so the first run() does not fall into the "emit everything"
         // branch.
         if (!after) {
-          this._setAfter(Date.now());
+          this._setAfter(initialTs);
         }
         return;
       }
@@ -178,7 +179,7 @@ export default {
         chunks: this.getChunks(updatedDeals),
       });
 
-      await this.processEvents(results, after);
+      await this.processEvents(results, after, initialTs);
     },
   },
   sampleEmit,

--- a/components/hubspot/sources/new-deal-property-change/new-deal-property-change.mjs
+++ b/components/hubspot/sources/new-deal-property-change/new-deal-property-change.mjs
@@ -1,4 +1,6 @@
-import { DEFAULT_LIMIT } from "../../common/constants.mjs";
+import {
+  DEFAULT_LIMIT, MAX_INITIAL_EVENTS,
+} from "../../common/constants.mjs";
 import common from "../common/common.mjs";
 import sampleEmit from "./test-event.mjs";
 
@@ -7,7 +9,7 @@ export default {
   key: "hubspot-new-deal-property-change",
   name: "New Deal Property Change",
   description: "Emit new event when a specified property is provided or updated on a deal. [See the documentation](https://developers.hubspot.com/docs/api/crm/deals)",
-  version: "0.0.38",
+  version: "0.0.39",
   dedupe: "unique",
   type: "source",
   props: {
@@ -20,6 +22,14 @@ export default {
         const properties = await this.hubspot.getDealProperties();
         return properties.map((property) => property.name);
       },
+    },
+  },
+  hooks: {
+    async deploy() {
+      // Emit a capped, newest-first sample of already-changed deals on deploy
+      // and store the cursor.
+      const params = await this.getParams();
+      await this.processResults(null, params);
     },
   },
   methods: {
@@ -92,6 +102,52 @@ export default {
         },
       });
     },
+    async processEvents(resources, after) {
+      // Initial (deploy) run: no cursor yet. Emit only the newest
+      // MAX_INITIAL_EVENTS as a sample, then store the cursor so subsequent
+      // run()s never re-emit this historical backfill.
+      if (!after) {
+        const withTs = resources
+          .map((deal) => ({
+            deal,
+            ts: this.getTs(deal),
+          }))
+          .filter(({ ts }) => ts)
+          .sort((a, b) => a.ts - b.ts);
+
+        if (!withTs.length) {
+          // No usable timestamps to derive a cursor from, but still advance it
+          // so the first run() does not treat itself as an initial run and emit
+          // everything.
+          this._setAfter(Date.now());
+          return;
+        }
+
+        // withTs is oldest-first; take the newest sample from the tail and emit
+        // it in chronological order (oldest first), matching the natural order
+        // events would normally arrive in.
+        for (const { deal } of withTs.slice(-MAX_INITIAL_EVENTS)) {
+          this.emitEvent(deal);
+        }
+        // Store the newest timestamp actually observed in the response (the last
+        // element, since withTs is oldest-first) as the cursor
+        this._setAfter(withTs[withTs.length - 1].ts);
+        return;
+      }
+
+      // Subsequent runs: emit everything changed after the stored cursor.
+      let maxTs = after;
+      for (const result of resources) {
+        if (await this.isRelevant(result, after)) {
+          this.emitEvent(result);
+          const ts = this.getTs(result);
+          if (ts > maxTs) {
+            maxTs = ts;
+          }
+        }
+      }
+      this._setAfter(maxTs);
+    },
     async processResults(after, params) {
       const properties = await this.hubspot.getDealProperties();
       const propertyNames = properties.map((property) => property.name);
@@ -108,6 +164,12 @@ export default {
       );
 
       if (!updatedDeals.length) {
+        // On the initial (deploy) run with no matching deals, still set a
+        // cursor so the first run() does not fall into the "emit everything"
+        // branch.
+        if (!after) {
+          this._setAfter(Date.now());
+        }
         return;
       }
 
@@ -116,7 +178,7 @@ export default {
         chunks: this.getChunks(updatedDeals),
       });
 
-      this.processEvents(results, after);
+      await this.processEvents(results, after);
     },
   },
   sampleEmit,


### PR DESCRIPTION
Now correctly emits retroactive events on deploy rather than on first run (so that the opt-out parameter of emitting on deploy is honored when set)

Closes #21267 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initial sync to cap how many recent deal updates are emitted during deploy/backfill, reducing large backfill bursts.
  * Refined cursor behavior so first-time runs advance correctly even when no updated deals are found, preventing repeated reprocessing.
  * Improved event emission logic to reliably sort and limit initial events, and to update the cursor based on emitted timestamps.

* **Chores**
  * Bumped package version(s).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->