### PR TITLE
New Components - verifly

### DIFF
--- a/components/verifly/actions/create-bulk-job/create-bulk-job.mjs
+++ b/components/verifly/actions/create-bulk-job/create-bulk-job.mjs
@@ -1,0 +1,51 @@
+import app from "../../verifly.app.mjs";
+
+export default {
+  key: "verifly-create-bulk-job",
+  name: "Create Bulk Job",
+  description: "Submit a list of email addresses for asynchronous bulk verification. Returns a job you can poll for status and results. [See the documentation](https://verifly.email/openapi.json).",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    app,
+    emails: {
+      propDefinition: [
+        app,
+        "emails",
+      ],
+    },
+    filename: {
+      propDefinition: [
+        app,
+        "filename",
+      ],
+    },
+    webhookUrl: {
+      propDefinition: [
+        app,
+        "webhookUrl",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.app.createBulkJob({
+      $,
+      data: {
+        emails: this.emails,
+        filename: this.filename,
+        webhook_url: this.webhookUrl,
+      },
+    });
+
+    $.export("$summary", `Successfully created bulk verification job${response.job_id
+      ? ` \`${response.job_id}\``
+      : ""}`);
+
+    return response;
+  },
+};

--- a/components/verifly/actions/verify-email/verify-email.mjs
+++ b/components/verifly/actions/verify-email/verify-email.mjs
@@ -1,0 +1,33 @@
+import app from "../../verifly.app.mjs";
+
+export default {
+  key: "verifly-verify-email",
+  name: "Verify Email",
+  description: "Verify a single email address for deliverability, syntax, MX, SMTP, disposable, role, catch-all and free-provider signals. [See the documentation](https://verifly.email/openapi.json).",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    app,
+    email: {
+      propDefinition: [
+        app,
+        "email",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.app.verifyEmail({
+      $,
+      email: this.email,
+    });
+
+    $.export("$summary", `Successfully verified \`${this.email}\` (result: ${response.result ?? "unknown"})`);
+
+    return response;
+  },
+};

--- a/components/verifly/package.json
+++ b/components/verifly/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@pipedream/verifly",
+  "version": "0.0.1",
+  "description": "Pipedream Verifly Components",
+  "main": "verifly.app.mjs",
+  "keywords": [
+    "pipedream",
+    "verifly"
+  ],
+  "homepage": "https://pipedream.com/apps/verifly",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^3.0.3"
+  }
+}

--- a/components/verifly/verifly.app.mjs
+++ b/components/verifly/verifly.app.mjs
@@ -1,0 +1,83 @@
+import { axios } from "@pipedream/platform";
+
+export default {
+  type: "app",
+  app: "verifly",
+  propDefinitions: {
+    email: {
+      type: "string",
+      label: "Email",
+      description: "The email address to verify, for example `lead@example.com`.",
+    },
+    emails: {
+      type: "string[]",
+      label: "Emails",
+      description: "The list of email addresses to verify in a single bulk job.",
+    },
+    filename: {
+      type: "string",
+      label: "Filename",
+      description: "An optional name to label the bulk job, for example `leads-2024.csv`.",
+      optional: true,
+    },
+    webhookUrl: {
+      type: "string",
+      label: "Webhook URL",
+      description: "Optional public HTTPS URL that Verifly calls when the bulk job completes.",
+      optional: true,
+    },
+  },
+  methods: {
+    _baseUrl() {
+      return "https://verifly.email/api/v1";
+    },
+    _headers(headers = {}) {
+      return {
+        "Authorization": `Bearer ${this.$auth.api_key}`,
+        "Content-Type": "application/json",
+        ...headers,
+      };
+    },
+    _makeRequest({
+      $ = this, path, headers, ...args
+    }) {
+      return axios($, {
+        url: `${this._baseUrl()}${path}`,
+        headers: this._headers(headers),
+        ...args,
+      });
+    },
+    verifyEmail({
+      email, ...args
+    } = {}) {
+      return this._makeRequest({
+        path: "/verify",
+        params: {
+          email,
+        },
+        ...args,
+      });
+    },
+    createBulkJob(args = {}) {
+      return this._makeRequest({
+        method: "POST",
+        path: "/verify/bulk",
+        ...args,
+      });
+    },
+    getJob({
+      jobId, ...args
+    } = {}) {
+      return this._makeRequest({
+        path: `/jobs/${jobId}`,
+        ...args,
+      });
+    },
+    getCredits(args = {}) {
+      return this._makeRequest({
+        path: "/credits",
+        ...args,
+      });
+    },
+  },
+};


### PR DESCRIPTION
## Verifly

Adds a new app component for [Verifly](https://verifly.email), an agent-native email verification API.

### What's included
- `verifly.app.mjs` — app definition with Bearer API-key auth (`Authorization: Bearer <key>`), a `_baseUrl()` of `https://verifly.email/api/v1`, shared `_makeRequest` helper, and methods (`verifyEmail`, `createBulkJob`, `getJob`, `getCredits`) plus reusable prop definitions.
- **Action: Verify Email** (`verifly-verify-email`) — verifies a single address (`GET /api/v1/verify`) returning deliverability, syntax, MX, SMTP, disposable, role, catch-all and free-provider signals.
- **Action: Create Bulk Job** (`verifly-create-bulk-job`) — submits a list for asynchronous bulk verification (`POST /api/v1/verify/bulk`) and returns a job to poll for results.
- `package.json`.

### Notes
- API reference: https://verifly.email/openapi.json
- Both actions were run end-to-end against the live API and return successfully.
- Server-side managed auth for the `verifly` app will need to be stood up on the Pipedream side.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Verifly support with a new app connection and API-backed actions.
  * You can now verify a single email or create a bulk verification job.
  * Added options to provide bulk email lists, output filenames, and webhook URLs.
  * Included access to job status and remaining credit information through the Verifly integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->