### PR TITLE
fix(sharepoint): carry per-item driveId through file picker

### DIFF
--- a/components/sharepoint/actions/create-folder/create-folder.mjs
+++ b/components/sharepoint/actions/create-folder/create-folder.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sharepoint-create-folder",
   name: "Create Folder",
   description: "Create a new folder in SharePoint. [See the documentation](https://learn.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_post_children?view=odsp-graph-online)",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/create-item/create-item.mjs
+++ b/components/sharepoint/actions/create-item/create-item.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sharepoint-create-item",
   name: "Create Item",
   description: "Create a new item in Microsoft Sharepoint. [See the documentation](https://learn.microsoft.com/en-us/graph/api/listitem-create?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.14",
+  version: "0.0.15",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/sharepoint/actions/create-link/create-link.mjs
+++ b/components/sharepoint/actions/create-link/create-link.mjs
@@ -5,7 +5,7 @@ export default {
   key: "sharepoint-create-link",
   name: "Create Link",
   description: "Create a sharing link for a DriveItem. [See the documentation](https://docs.microsoft.com/en-us/graph/api/driveitem-createlink?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.10",
+  version: "0.0.11",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/create-list/create-list.mjs
+++ b/components/sharepoint/actions/create-list/create-list.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sharepoint-create-list",
   name: "Create List",
   description: "Create a new list in Microsoft Sharepoint. [See the documentation](https://learn.microsoft.com/en-us/graph/api/list-create?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.14",
+  version: "0.0.15",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/sharepoint/actions/download-file/download-file.mjs
+++ b/components/sharepoint/actions/download-file/download-file.mjs
@@ -8,7 +8,7 @@ export default {
   key: "sharepoint-download-file",
   name: "Download File",
   description: "Download a Microsoft Sharepoint file to the /tmp directory. [See the documentation](https://learn.microsoft.com/en-us/graph/api/driveitem-get-content?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.15",
+  version: "0.0.16",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/sharepoint/actions/download-files/download-files.mjs
+++ b/components/sharepoint/actions/download-files/download-files.mjs
@@ -6,7 +6,7 @@ export default {
   key: "sharepoint-download-files",
   name: "Download Files",
   description: "Browse and select files from SharePoint and get their metadata along with pre-authenticated download URLs (valid ~1 hour). [See the documentation](https://learn.microsoft.com/en-us/graph/api/driveitem-get)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/find-file-by-name/find-file-by-name.mjs
+++ b/components/sharepoint/actions/find-file-by-name/find-file-by-name.mjs
@@ -16,7 +16,7 @@ export default {
     + "\n- **Search and Filter Files** for OData `$filter` against a list/document library"
     + "\n\n"
     + "[See the documentation](https://learn.microsoft.com/en-us/graph/api/driveitem-search?view=graph-rest-1.0&tabs=http)",
-  version: "0.1.7",
+  version: "0.1.8",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/find-files-with-metadata/find-files-with-metadata.mjs
+++ b/components/sharepoint/actions/find-files-with-metadata/find-files-with-metadata.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Find Files in List with Metadata",
   description:
     "Search and filter items in a SharePoint list based on metadata and custom columns. [See docs here](https://learn.microsoft.com/en-us/graph/api/listitem-list)",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/get-current-user/get-current-user.mjs
+++ b/components/sharepoint/actions/get-current-user/get-current-user.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sharepoint-get-current-user",
   name: "Get Current User",
   description: "Returns the authenticated Microsoft user's ID, display name, email, and principal name via Microsoft Graph. Call this first when the user says 'my files', 'my documents', or needs identity context. Use the returned `id` to identify file ownership in **List Files in Folder** or **Find File by Name** results. [See the documentation](https://learn.microsoft.com/en-us/graph/api/user-get).",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/get-excel-table/get-excel-table.mjs
+++ b/components/sharepoint/actions/get-excel-table/get-excel-table.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sharepoint-get-excel-table",
   name: "Get Excel Table",
   description: "Retrieve a table from an Excel spreadsheet stored in Sharepoint [See the documentation](https://learn.microsoft.com/en-us/graph/api/table-range?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.9",
+  version: "0.0.10",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/get-file-by-id/get-file-by-id.mjs
+++ b/components/sharepoint/actions/get-file-by-id/get-file-by-id.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sharepoint-get-file-by-id",
   name: "Get File by ID",
   description: "Retrieves a file by ID. [See the documentation](https://learn.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_get)",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/get-file-contents/get-file-contents.mjs
+++ b/components/sharepoint/actions/get-file-contents/get-file-contents.mjs
@@ -24,7 +24,7 @@ export default {
   key: "sharepoint-get-file-contents",
   name: "Get File Contents",
   description: "Retrieves a Microsoft SharePoint file and returns its contents as extracted plain text or markdown. Supports plain text formats, HTML, DOCX, PDF, and other Office documents convertible to PDF (xlsx, pptx, etc.). [See the documentation](https://learn.microsoft.com/en-us/graph/api/driveitem-get-content?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/get-site/get-site.mjs
+++ b/components/sharepoint/actions/get-site/get-site.mjs
@@ -10,7 +10,7 @@ export default {
     + "Use this when you know the site path; for discovery, use **Search Sites** or **List Sites**."
     + "\n\n"
     + "[See the documentation](https://learn.microsoft.com/en-us/graph/api/site-get?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/list-drives/list-drives.mjs
+++ b/components/sharepoint/actions/list-drives/list-drives.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sharepoint-list-drives",
   name: "List Drives",
   description: "List the drives available within a Microsoft Sharepoint site. [See the documentation](https://learn.microsoft.com/en-us/graph/api/drive-list?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/list-files-in-folder/list-files-in-folder.mjs
+++ b/components/sharepoint/actions/list-files-in-folder/list-files-in-folder.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sharepoint-list-files-in-folder",
   name: "List Files in Folder",
   description: "Retrieves a list of the files and/or folders directly within a folder. [See the documentation](https://learn.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_list_children)",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/list-sites/list-sites.mjs
+++ b/components/sharepoint/actions/list-sites/list-sites.mjs
@@ -10,7 +10,7 @@ export default {
     + "To resolve a known site by path, prefer **Get Site** for an immediate lookup."
     + "\n\n"
     + "[See the documentation](https://learn.microsoft.com/en-us/graph/api/site-search?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/retrieve-file-metadata/retrieve-file-metadata.mjs
+++ b/components/sharepoint/actions/retrieve-file-metadata/retrieve-file-metadata.mjs
@@ -8,7 +8,7 @@ export default {
   key: "sharepoint-retrieve-file-metadata",
   name: "Retrieve File Metadata",
   description: "Browse and select files from SharePoint to retrieve their metadata (name, size, dates, etc.) without download URLs. [See the documentation](https://learn.microsoft.com/en-us/graph/api/driveitem-get)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/search-and-filter-files/search-and-filter-files.mjs
+++ b/components/sharepoint/actions/search-and-filter-files/search-and-filter-files.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Search and Filter Files",
   description:
     "Search and filter SharePoint files based on metadata and custom columns. This action allows you to query files using SharePoint's custom properties, managed metadata, and other column values. [See the documentation](https://learn.microsoft.com/en-us/graph/api/listitem-list)",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/search-files/search-files.mjs
+++ b/components/sharepoint/actions/search-files/search-files.mjs
@@ -15,7 +15,7 @@ export default {
     + "\n- **Search and Filter Files** for OData `$filter` against a document library"
     + "\n\n"
     + "[See the documentation](https://learn.microsoft.com/en-us/graph/api/search-query?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/search-sites/search-sites.mjs
+++ b/components/sharepoint/actions/search-sites/search-sites.mjs
@@ -12,7 +12,7 @@ export default {
     + "To resolve a known site by path, prefer **Get Site** for an immediate, exact lookup."
     + "\n\n"
     + "[See the documentation](https://learn.microsoft.com/en-us/graph/api/site-search?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/update-item/update-item.mjs
+++ b/components/sharepoint/actions/update-item/update-item.mjs
@@ -5,7 +5,7 @@ export default {
   key: "sharepoint-update-item",
   name: "Update Item",
   description: "Updates an existing item in Microsoft Sharepoint. [See the documentation](https://learn.microsoft.com/en-us/graph/api/listitem-update?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.14",
+  version: "0.0.15",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/sharepoint/actions/upload-file/upload-file.mjs
+++ b/components/sharepoint/actions/upload-file/upload-file.mjs
@@ -5,7 +5,7 @@ export default {
   key: "sharepoint-upload-file",
   name: "Upload File",
   description: "Upload a file to OneDrive. [See the documentation](https://learn.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_put_content?view=odsp-graph-online)",
-  version: "0.0.9",
+  version: "0.0.10",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/common/file-picker-base.mjs
+++ b/components/sharepoint/common/file-picker-base.mjs
@@ -187,10 +187,16 @@ export const filePickerMethods = {
             $expand: LIST_ITEM_FIELDS_EXPAND,
           };
 
+        // Use the per-item driveId (from parentReference) when available so files
+        // that live in a different drive than the top-level driveId prop resolve
+        // correctly. Falls back to the top-level driveId; when that is also absent,
+        // getDriveItem uses the /sites/{siteId}/drive/items/{id} default-drive path.
+        const resolvedDriveId = selected.driveId || driveId;
+
         const file = await this.sharepoint.getDriveItem({
           $,
           siteId,
-          driveId,
+          driveId: resolvedDriveId,
           fileId: selected.id,
           params,
         });
@@ -205,7 +211,7 @@ export const filePickerMethods = {
           }),
           _meta: {
             siteId,
-            driveId,
+            driveId: resolvedDriveId,
             fileId: selected.id,
           },
         };

--- a/components/sharepoint/package.json
+++ b/components/sharepoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/sharepoint",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Pipedream Microsoft Sharepoint Online Components",
   "main": "sharepoint.app.mjs",
   "keywords": [

--- a/components/sharepoint/sharepoint.app.mjs
+++ b/components/sharepoint/sharepoint.app.mjs
@@ -267,10 +267,14 @@ export default {
         return response.value
           ?.filter(({ folder }) => !folder)
           .map(({
-            id, name,
+            id, name, parentReference,
           }) => ({
             label: name,
-            value: id,
+            value: JSON.stringify({
+              id,
+              name,
+              driveId: parentReference?.driveId,
+            }),
           })) || [];
       },
     },
@@ -369,7 +373,7 @@ export default {
             driveId: resolvedDriveId,
           });
         return response.value?.map(({
-          id, name, folder, size, lastModifiedDateTime, webUrl, description,
+          id, name, folder, size, lastModifiedDateTime, webUrl, description, parentReference,
         }) => ({
           value: JSON.stringify({
             id,
@@ -380,6 +384,7 @@ export default {
             lastModifiedDateTime,
             webUrl,
             description,
+            driveId: parentReference?.driveId,
           }),
           label: name,
         })) || [];

--- a/components/sharepoint/sources/new-file-created/new-file-created.mjs
+++ b/components/sharepoint/sources/new-file-created/new-file-created.mjs
@@ -5,7 +5,7 @@ export default {
   key: "sharepoint-new-file-created",
   name: "New File Created",
   description: "Emit new event when a new file is created in Microsoft Sharepoint.",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/sharepoint/sources/new-folder-created/new-folder-created.mjs
+++ b/components/sharepoint/sources/new-folder-created/new-folder-created.mjs
@@ -5,7 +5,7 @@ export default {
   key: "sharepoint-new-folder-created",
   name: "New Folder Created",
   description: "Emit new event when a new folder is created in Microsoft Sharepoint.",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/sharepoint/sources/new-list-item/new-list-item.mjs
+++ b/components/sharepoint/sources/new-list-item/new-list-item.mjs
@@ -5,7 +5,7 @@ export default {
   key: "sharepoint-new-list-item",
   name: "New List Item",
   description: "Emit new event when a new list item is created in Microsoft Sharepoint.",
-  version: "0.0.13",
+  version: "0.0.14",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/sharepoint/sources/updated-file-instant/updated-file-instant.mjs
+++ b/components/sharepoint/sources/updated-file-instant/updated-file-instant.mjs
@@ -9,7 +9,7 @@ export default {
   key: "sharepoint-updated-file-instant",
   name: "File Updated or Deleted (Instant)",
   description: "Emit a new event when specific files are updated or deleted in a SharePoint document library",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/sharepoint/sources/updated-list-item/updated-list-item.mjs
+++ b/components/sharepoint/sources/updated-list-item/updated-list-item.mjs
@@ -5,7 +5,7 @@ export default {
   key: "sharepoint-updated-list-item",
   name: "Updated List Item",
   description: "Emit new event when a list item is updated in Microsoft Sharepoint.",
-  version: "0.0.13",
+  version: "0.0.14",
   type: "source",
   dedupe: "unique",
   props: {


### PR DESCRIPTION
## Summary

- Carries each selected item's `parentReference.driveId` through the SharePoint file picker so `Download Files` and `Retrieve File Metadata` resolve each file against its own drive instead of the top-level `driveId` prop.
- Falls back to the top-level `driveId` when the per-item value is absent; when both are absent, `getDriveItem` falls through to the existing `/sites/{siteId}/drive/items/{id}` default-drive path.
- Versions bumped: `sharepoint-download-files` 0.0.4 → 0.0.5, `sharepoint-retrieve-file-metadata` 0.0.4 → 0.0.5, `@pipedream/sharepoint` 0.10.0 → 0.10.1.

Both actions go through the same shared `file-picker-base.mjs`, so the fix lands in one place and covers both.

Closes #21280

## Why

Both actions previously called `GET /drives/{driveId}/items/{fileId}` with the top-level `driveId` for every selection. A valid Graph item ID paired with a mismatched `driveId` returns "ObjectHandle is Invalid" (404), which is easy for an agent or programmatic caller to hit since Graph item IDs carry no drive context.

## Test plan

- [x] Happy-path evals via the MCP eval harness — `sharepoint-download-files` and `sharepoint-retrieve-file-metadata` exercised end-to-end (site → drive → folder → file → action), 3/3 pass.
- [x] Direct MCP probe with `driveId` divergence (top-level `driveId` deliberately set to a different site's drive while the per-item JSON carries the correct drive). Result table:

  | Scenario | top-level `driveId` | per-item `driveId` | result |
  |---|---|---|---|
  | Correct top-level, no per-item | correct | absent | pass |
  | Wrong top-level, correct per-item (the fix) | wrong | correct | **pass** |
  | Wrong top-level, no per-item (old behavior) | wrong | absent | **fail**: `The resource could not be found` |

  The third row is exactly the bug from the issue; the second row shows the fix recovers from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SharePoint file and folder selections now include drive context, improving downstream handling and metadata accuracy.
  * File metadata retrieval now uses the correct drive per selected item when available, with a fallback to the configured drive.

* **Chores**
  * Updated versions across SharePoint actions, sources, and the SharePoint package to the latest release levels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->