### PR TITLE
Google Slides - 'Get Presentation' action

### DIFF
--- a/components/google_slides/actions/create-image/create-image.mjs
+++ b/components/google_slides/actions/create-image/create-image.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_slides-create-image",
   name: "Create Image",
   description: "Creates an image in a slide. [See the documentation](https://developers.google.com/workspace/slides/api/reference/rest/v1/presentations/request#CreateImageRequest)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_slides/actions/create-page-element/create-page-element.mjs
+++ b/components/google_slides/actions/create-page-element/create-page-element.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_slides-create-page-element",
   name: "Create Page Element",
   description: "Create a new page element in a slide. [See the documentation](https://developers.google.com/workspace/slides/api/reference/rest/v1/presentations/request#CreateShapeRequest)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_slides/actions/create-presentation/create-presentation.mjs
+++ b/components/google_slides/actions/create-presentation/create-presentation.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_slides-create-presentation",
   name: "Create Presentation",
   description: "Create a blank presentation or duplicate an existing presentation. [See the docs here](https://developers.google.com/slides/api/guides/presentations#copy_an_existing_presentation)",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_slides/actions/create-slide/create-slide.mjs
+++ b/components/google_slides/actions/create-slide/create-slide.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_slides-create-slide",
   name: "Create Slide",
   description: "Create a new slide in a presentation. [See the documentation](https://developers.google.com/workspace/slides/api/reference/rest/v1/presentations/request#CreateSlideRequest)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_slides/actions/create-table/create-table.mjs
+++ b/components/google_slides/actions/create-table/create-table.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_slides-create-table",
   name: "Create Table",
   description: "Create a new table in a slide. [See the documentation](https://developers.google.com/workspace/slides/api/reference/rest/v1/presentations/request#CreateTableRequest)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_slides/actions/delete-page-element/delete-page-element.mjs
+++ b/components/google_slides/actions/delete-page-element/delete-page-element.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_slides-delete-page-element",
   name: "Delete Page Element",
   description: "Deletes a page element from a slide. [See the documentation](https://developers.google.com/workspace/slides/api/reference/rest/v1/presentations/request#DeleteObjectRequest)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_slides/actions/delete-slide/delete-slide.mjs
+++ b/components/google_slides/actions/delete-slide/delete-slide.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_slides-delete-slide",
   name: "Delete Slide",
   description: "Deletes a slide from a presentation. [See the documentation](https://developers.google.com/workspace/slides/api/reference/rest/v1/presentations/request#DeleteObjectRequest)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_slides/actions/delete-table-column/delete-table-column.mjs
+++ b/components/google_slides/actions/delete-table-column/delete-table-column.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_slides-delete-table-column",
   name: "Delete Table Column",
   description: "Delete column from a table. [See the documentation](https://developers.google.com/workspace/slides/api/reference/rest/v1/presentations/request#DeleteTableColumnRequest)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_slides/actions/delete-table-row/delete-table-row.mjs
+++ b/components/google_slides/actions/delete-table-row/delete-table-row.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_slides-delete-table-row",
   name: "Delete Table Row",
   description: "Delete row from a table. [See the documentation](https://developers.google.com/workspace/slides/api/reference/rest/v1/presentations/request#DeleteTableRowRequest)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_slides/actions/find-presentation/find-presentation.mjs
+++ b/components/google_slides/actions/find-presentation/find-presentation.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_slides-find-presentation",
   name: "Find a Presentation",
   description: "Find a presentation on Google Drive. [See the docs here](https://developers.google.com/slides/api/samples/presentation#list_existing_presentation_files)",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_slides/actions/get-presentation/get-presentation.mjs
+++ b/components/google_slides/actions/get-presentation/get-presentation.mjs
@@ -1,0 +1,34 @@
+import app from "../../google_slides.app.mjs";
+
+export default {
+  key: "google_slides-get-presentation",
+  name: "Get Presentation",
+  description: "Get a Google Slides presentation by its ID. Returns the presentation's metadata and structure (title, slides, masters, layouts, page size, etc.) according to requested `fields`. Use **Find a Presentation** first to resolve a presentation's name to its ID. [See the documentation](https://developers.google.com/slides/api/reference/rest/v1/presentations/get)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  type: "action",
+  props: {
+    app,
+    presentationId: {
+      type: "string",
+      label: "Presentation ID",
+      description: "The ID of the presentation to retrieve. This is the long string in the presentation's URL: `https://docs.google.com/presentation/d/{PRESENTATION_ID}/edit`. You can also paste the full URL. Use **Find a Presentation** to resolve a presentation's name to its ID.",
+    },
+    fields: {
+      type: "string",
+      label: "Fields",
+      description: "Optional partial-response [field mask](https://developers.google.com/slides/api/guides/field-masks) to limit the response to specific fields. Comma-separated, e.g. `presentationId,title` for just basic metadata, or `slides.objectId,title` to also list slide IDs. Omit to return the full presentation.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const presentationId = this.app.getPresentationId(this.presentationId);
+    const presentation = await this.app.getPresentation(presentationId, this.fields);
+    $.export("$summary", `Successfully retrieved presentation with ID: ${presentationId}`);
+    return presentation;
+  },
+};

--- a/components/google_slides/actions/insert-table-columns/insert-table-columns.mjs
+++ b/components/google_slides/actions/insert-table-columns/insert-table-columns.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_slides-insert-table-columns",
   name: "Insert Table Columns",
   description: "Insert new columns into a table. [See the documentation](https://developers.google.com/workspace/slides/api/reference/rest/v1/presentations/request#InsertTableColumnsRequest)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_slides/actions/insert-table-rows/insert-table-rows.mjs
+++ b/components/google_slides/actions/insert-table-rows/insert-table-rows.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_slides-insert-table-rows",
   name: "Insert Table Rows",
   description: "Insert new rows into a table. [See the documentation](https://developers.google.com/workspace/slides/api/reference/rest/v1/presentations/request#InsertTableRowsRequest)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_slides/actions/insert-text-into-table/insert-text-into-table.mjs
+++ b/components/google_slides/actions/insert-text-into-table/insert-text-into-table.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_slides-insert-text-into-table",
   name: "Insert Text into Table",
   description: "Insert text into a table cell. [See the documentation](https://developers.google.com/workspace/slides/api/reference/rest/v1/presentations/request#InsertTextRequest)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_slides/actions/insert-text/insert-text.mjs
+++ b/components/google_slides/actions/insert-text/insert-text.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_slides-insert-text",
   name: "Insert Text",
   description: "Insert text into a shape. [See the documentation](https://developers.google.com/workspace/slides/api/reference/rest/v1/presentations/request#InsertTextRequest)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_slides/actions/merge-data/merge-data.mjs
+++ b/components/google_slides/actions/merge-data/merge-data.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_slides-merge-data",
   name: "Merge Data",
   description: "Merge data into a presentation. [See the docs here](https://developers.google.com/slides/api/guides/merge)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_slides/actions/refresh-chart/refresh-chart.mjs
+++ b/components/google_slides/actions/refresh-chart/refresh-chart.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_slides-refresh-chart",
   name: "Refresh a chart",
   description: "Refresh a chart from Sheets. [See the docs here](https://developers.google.com/slides/api/samples/elements#refresh_a_chart_from_sheets)",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_slides/actions/replace-all-text/replace-all-text.mjs
+++ b/components/google_slides/actions/replace-all-text/replace-all-text.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_slides-replace-all-text",
   name: "Replace All Text",
   description: "Replace all text in a presentation. [See the documentation](https://developers.google.com/workspace/slides/api/reference/rest/v1/presentations/request#ReplaceAllTextRequest)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_slides/google_slides.app.mjs
+++ b/components/google_slides/google_slides.app.mjs
@@ -251,10 +251,21 @@ export default {
       }
       return this.listFilesOptions(pageToken, request);
     },
-    async getPresentation(presentationId) {
+    getPresentationId(idOrUrl) {
+      // Accept a plain presentation ID or a full Slides URL
+      // (e.g. https://docs.google.com/presentation/d/{ID}/edit).
+      const match = String(idOrUrl).match(/\/presentation\/d\/([a-zA-Z0-9-_]+)/);
+      return match
+        ? match[1]
+        : idOrUrl;
+    },
+    async getPresentation(presentationId, fields) {
       const slides = this.slides();
       const request = {
         presentationId,
+        ...fields && {
+          fields,
+        },
       };
       return (await slides.presentations.get(request)).data;
     },

--- a/components/google_slides/google_slides.app.mjs
+++ b/components/google_slides/google_slides.app.mjs
@@ -253,7 +253,10 @@ export default {
       return this.listFilesOptions(pageToken, request);
     },
     getPresentationId(idOrUrl) {
-      const input = String(idOrUrl);
+      const input = String(idOrUrl).trim();
+      if (!input) {
+        throw new ConfigurationError("Presentation ID is required.");
+      }
       // Published presentations use /presentation/d/e/{token}/pub and have no
       // editable ID that presentations.get accepts, so reject them explicitly
       // rather than extracting the literal "e" segment as the ID.

--- a/components/google_slides/google_slides.app.mjs
+++ b/components/google_slides/google_slides.app.mjs
@@ -1,3 +1,4 @@
+import { ConfigurationError } from "@pipedream/platform";
 import slides from "@googleapis/slides";
 import googleDrive from "@pipedream/google_drive";
 
@@ -252,12 +253,19 @@ export default {
       return this.listFilesOptions(pageToken, request);
     },
     getPresentationId(idOrUrl) {
+      const input = String(idOrUrl);
+      // Published presentations use /presentation/d/e/{token}/pub and have no
+      // editable ID that presentations.get accepts, so reject them explicitly
+      // rather than extracting the literal "e" segment as the ID.
+      if (/\/presentation\/d\/e\//.test(input)) {
+        throw new ConfigurationError("Published presentation URLs (`/presentation/d/e/...`) are not supported. Provide the presentation's ID or its editable URL (`https://docs.google.com/presentation/d/{ID}/edit`).");
+      }
       // Accept a plain presentation ID or a full Slides URL
       // (e.g. https://docs.google.com/presentation/d/{ID}/edit).
-      const match = String(idOrUrl).match(/\/presentation\/d\/([a-zA-Z0-9-_]+)/);
+      const match = input.match(/\/presentation\/d\/([a-zA-Z0-9-_]+)/);
       return match
         ? match[1]
-        : idOrUrl;
+        : input;
     },
     async getPresentation(presentationId, fields) {
       const slides = this.slides();

--- a/components/google_slides/package.json
+++ b/components/google_slides/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_slides",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Pipedream Google Slides Components",
   "main": "google_slides.app.mjs",
   "keywords": [

--- a/components/google_slides/sources/new-presentation/new-presentation.mjs
+++ b/components/google_slides/sources/new-presentation/new-presentation.mjs
@@ -7,7 +7,7 @@ export default {
   type: "source",
   name: "New Presentation (Instant)",
   description: "Emit new event each time a new presentation is created in a drive.",
-  version: "0.0.5",
+  version: "0.0.6",
   hooks: {
     ...newFilesInstant.hooks,
     async deploy() {


### PR DESCRIPTION
Clsoes #21279

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Get Presentation** action for Google Slides.
  * Retrieve presentations using either an ID or a full editable Slides URL.
  * Supports optional **field selection** to limit returned presentation details.
* **Bug Fixes**
  * Published (non-editable) Slides URLs are now rejected with a clear configuration error.
* **Chores**
  * Updated version numbers across the Google Slides component, related actions, and the new presentation source (including component version **0.5.0**).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->