### PR TITLE
New Components - sibfly

### DIFF
--- a/components/sibfly/actions/check-coverage/check-coverage.mjs
+++ b/components/sibfly/actions/check-coverage/check-coverage.mjs
@@ -1,0 +1,54 @@
+import app from "../../sibfly.app.mjs";
+
+export default {
+  key: "sibfly-check-coverage",
+  name: "Check Coverage",
+  description: "Free pre-flight: is a US address or point covered by SibFly, how stale is the data (`data_age_days`), and what would a report cost (`would_cost_usd`). Always free. [See the documentation](https://sibfly.com/docs).",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    app,
+    address: {
+      propDefinition: [
+        app,
+        "address",
+      ],
+    },
+    lat: {
+      propDefinition: [
+        app,
+        "lat",
+      ],
+    },
+    lon: {
+      propDefinition: [
+        app,
+        "lon",
+      ],
+    },
+  },
+  async run({ $ }) {
+    if (!this.address && (!this.lat || !this.lon)) {
+      throw new Error("Provide an Address, or both Latitude and Longitude.");
+    }
+    const response = await this.app.checkCoverage({
+      $,
+      address: this.address,
+      lat: this.lat,
+      lon: this.lon,
+    });
+
+    const where = this.address ?? `${this.lat},${this.lon}`;
+    const summary = response.covered
+      ? `${where}: covered, would cost $${response.would_cost_usd}, data ~${response.data_age_days} days old`
+      : `${where}: not covered (a report would be free)`;
+    $.export("$summary", summary);
+
+    return response;
+  },
+};

--- a/components/sibfly/actions/check-ground-motion/check-ground-motion.mjs
+++ b/components/sibfly/actions/check-ground-motion/check-ground-motion.mjs
@@ -1,0 +1,61 @@
+import app from "../../sibfly.app.mjs";
+
+export default {
+  key: "sibfly-check-ground-motion",
+  name: "Check Ground Motion",
+  description: "Measure how fast the ground is sinking or rising (mm/year, negative = sinking) under a US address, from NASA OPERA Sentinel-1 InSAR. Costs $0.40 for a covered report; out-of-coverage / low-quality results are free. Use Dry Run for a free coverage + price preview. [See the documentation](https://sibfly.com/docs).",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    app,
+    address: {
+      propDefinition: [
+        app,
+        "address",
+      ],
+    },
+    lat: {
+      propDefinition: [
+        app,
+        "lat",
+      ],
+    },
+    lon: {
+      propDefinition: [
+        app,
+        "lon",
+      ],
+    },
+    dryRun: {
+      propDefinition: [
+        app,
+        "dryRun",
+      ],
+    },
+  },
+  async run({ $ }) {
+    if (!this.address && (!this.lat || !this.lon)) {
+      throw new Error("Provide an Address, or both Latitude and Longitude.");
+    }
+    const response = await this.app.checkGroundMotion({
+      $,
+      address: this.address,
+      lat: this.lat,
+      lon: this.lon,
+      dryRun: this.dryRun,
+    });
+
+    const where = this.address ?? `${this.lat},${this.lon}`;
+    const summary = response.velocity_vertical_mm_yr != null
+      ? `${where}: ${response.velocity_vertical_mm_yr} mm/yr (${response.assessment_code}), cost $${response.cost_usd}`
+      : `${where}: ${response.status ?? "no data"} (free, $0)`;
+    $.export("$summary", summary);
+
+    return response;
+  },
+};

--- a/components/sibfly/package.json
+++ b/components/sibfly/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@pipedream/sibfly",
+  "version": "0.0.1",
+  "description": "Pipedream SibFly Components",
+  "main": "sibfly.app.mjs",
+  "keywords": [
+    "pipedream",
+    "sibfly"
+  ],
+  "homepage": "https://pipedream.com/apps/sibfly",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^3.0.3"
+  }
+}

--- a/components/sibfly/sibfly.app.mjs
+++ b/components/sibfly/sibfly.app.mjs
@@ -1,0 +1,101 @@
+import { axios } from "@pipedream/platform";
+
+export default {
+  type: "app",
+  app: "sibfly",
+  propDefinitions: {
+    address: {
+      type: "string",
+      label: "Address",
+      description: "A US street address, for example `1100 Congress Ave, Austin, TX`. Provide this or latitude + longitude.",
+      optional: true,
+    },
+    lat: {
+      type: "string",
+      label: "Latitude",
+      description: "Latitude (use together with Longitude instead of Address).",
+      optional: true,
+    },
+    lon: {
+      type: "string",
+      label: "Longitude",
+      description: "Longitude (use together with Latitude instead of Address).",
+      optional: true,
+    },
+    dryRun: {
+      type: "boolean",
+      label: "Dry Run (Free Preview)",
+      description: "Return a free coverage + price preview (`would_cost_usd`) without buying the report or being charged.",
+      optional: true,
+    },
+    addresses: {
+      type: "string[]",
+      label: "Addresses",
+      description: "A list of US addresses to check in a single batch (up to 1000). Only covered rows are billed.",
+    },
+  },
+  methods: {
+    _baseUrl() {
+      return "https://sibfly.com/api/v1";
+    },
+    _headers(headers = {}) {
+      return {
+        "Authorization": `Bearer ${this.$auth.api_key}`,
+        "Content-Type": "application/json",
+        ...headers,
+      };
+    },
+    _makeRequest({
+      $ = this, path, headers, ...args
+    }) {
+      return axios($, {
+        url: `${this._baseUrl()}${path}`,
+        headers: this._headers(headers),
+        ...args,
+      });
+    },
+    _location({
+      address, lat, lon,
+    }) {
+      if (address) {
+        return { address };
+      }
+      return { lat, lon };
+    },
+    checkGroundMotion({
+      address, lat, lon, dryRun, ...args
+    } = {}) {
+      const params = this._location({ address, lat, lon });
+      if (dryRun) {
+        params.dry_run = 1;
+      }
+      return this._makeRequest({
+        path: "/motion",
+        params,
+        ...args,
+      });
+    },
+    checkCoverage({
+      address, lat, lon, ...args
+    } = {}) {
+      return this._makeRequest({
+        path: "/coverage",
+        params: this._location({ address, lat, lon }),
+        ...args,
+      });
+    },
+    checkPortfolio(args = {}) {
+      return this._makeRequest({
+        method: "POST",
+        path: "/motion/batch",
+        ...args,
+      });
+    },
+    getBalance(args = {}) {
+      return this._makeRequest({
+        path: "/balance",
+        ...args,
+      });
+    },
+  },
+};


### PR DESCRIPTION
Adds a **SibFly** app + two actions.

SibFly returns satellite-**measured** ground motion (subsidence/uplift, mm/year) for any US address, from NASA OPERA Sentinel-1 InSAR.

- **Check Ground Motion** — measured velocity for an address/point ($0.40 covered; misses free; free Dry Run preview).
- **Check Coverage** — free preflight (covered? data age? would_cost).

Auth = SibFly API key (`sf_live_...`). App slug `sibfly` will need managed auth stood up. Docs: https://sibfly.com/docs · OpenAPI: https://sibfly.com/openapi.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SibFly support for checking coverage and ground motion from either an address or coordinates.
  * Added batch ground-motion requests for multiple locations.
  * Added balance lookup for the connected account.
  * Ground-motion results now include a clear human-readable summary with measurement, status, and cost details when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->