### PR TITLE
New Components - whisper

### DIFF
--- a/components/whisper/actions/allocate-identity/allocate-identity.mjs
+++ b/components/whisper/actions/allocate-identity/allocate-identity.mjs
@@ -1,0 +1,41 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-allocate-identity",
+  name: "Allocate Identity",
+  description: "Allocate a routable IPv6 `/128` identity to **your own** caller account (`op:identity`) - unlike **Register Agent**, no new agent or API key is minted; the address, FQDN and PTR are bound to the calling key itself. Requires a connected Whisper account (your `whisper_live_` key). [See the documentation](https://whisper.online/platform)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    label: {
+      propDefinition: [
+        app,
+        "label",
+      ],
+    },
+    contactEmail: {
+      propDefinition: [
+        app,
+        "contactEmail",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const records = await this.app.allocateIdentity({
+      $,
+      label: this.label,
+      contactEmail: this.contactEmail,
+    });
+    const identity = records?.[0] ?? {};
+    $.export("$summary", identity.address
+      ? `Allocated identity ${identity.address} (${identity.fqdn ?? this.label})`
+      : `Allocated identity ${this.label}`);
+    return identity;
+  },
+};

--- a/components/whisper/actions/allocate-identity/allocate-identity.mjs
+++ b/components/whisper/actions/allocate-identity/allocate-identity.mjs
@@ -1,0 +1,41 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-allocate-identity",
+  name: "Allocate Identity",
+  description: "Allocate a routable IPv6 `/128` identity to **your own** caller account (`op:identity`) — unlike **Register Agent**, no new agent or API key is minted; the address, FQDN and PTR are bound to the calling key itself. Requires a connected Whisper account (your `whisper_live_` key). [See the documentation](https://whisper.online/platform)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    label: {
+      propDefinition: [
+        app,
+        "label",
+      ],
+    },
+    contactEmail: {
+      propDefinition: [
+        app,
+        "contactEmail",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const records = await this.app.allocateIdentity({
+      $,
+      label: this.label,
+      contactEmail: this.contactEmail,
+    });
+    const identity = records?.[0] ?? {};
+    $.export("$summary", identity.address
+      ? `Allocated identity ${identity.address} (${identity.fqdn ?? this.label})`
+      : `Allocated identity ${this.label}`);
+    return identity;
+  },
+};

--- a/components/whisper/actions/connect-egress/connect-egress.mjs
+++ b/components/whisper/actions/connect-egress/connect-egress.mjs
@@ -1,0 +1,59 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-connect-egress",
+  name: "Connect Egress",
+  description: "Get an egress configuration bound to an agent's routable IPv6 `/128` (`op:connect`) — a hosted SOCKS5/HTTP proxy (default) or a routed WireGuard tunnel — so the agent's traffic verifiably sources from its Whisper identity. By default the returned config is **stripped of its secrets** (proxy credential URLs, private keys) before it reaches your workflow's step exports; enable **Include Secrets** only when a downstream step consumes them directly. Requires a connected Whisper account (your `whisper_live_` key). [See the documentation](https://whisper.online/platform)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    agent: {
+      propDefinition: [
+        app,
+        "connectAgent",
+      ],
+    },
+    tier: {
+      propDefinition: [
+        app,
+        "tier",
+      ],
+    },
+    publicKey: {
+      propDefinition: [
+        app,
+        "publicKey",
+      ],
+    },
+    includeSecrets: {
+      propDefinition: [
+        app,
+        "includeSecrets",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const records = await this.app.connectEgress({
+      $,
+      agent: this.agent,
+      tier: this.tier,
+      publicKey: this.publicKey,
+    });
+    let record = records?.[0] ?? {};
+    if (!this.includeSecrets) {
+      record = this.app.stripEgressSecrets(record);
+    }
+    $.export("$summary", record.address
+      ? `${record.tier ?? this.tier ?? "socks5"} egress ready for ${record.address}${this.includeSecrets
+        ? ""
+        : " (secrets stripped)"}`
+      : "Egress configuration returned");
+    return record;
+  },
+};

--- a/components/whisper/actions/connect-egress/connect-egress.mjs
+++ b/components/whisper/actions/connect-egress/connect-egress.mjs
@@ -1,0 +1,59 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-connect-egress",
+  name: "Connect Egress",
+  description: "Get an egress configuration bound to an agent's routable IPv6 `/128` (`op:connect`) - a hosted SOCKS5/HTTP proxy (default) or a routed WireGuard tunnel - so the agent's traffic verifiably sources from its Whisper identity. By default the returned config is **stripped of its secrets** (proxy credential URLs, private keys) before it reaches your workflow's step exports; enable **Include Secrets** only when a downstream step consumes them directly. Requires a connected Whisper account (your `whisper_live_` key). [See the documentation](https://whisper.online/platform)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    agent: {
+      propDefinition: [
+        app,
+        "connectAgent",
+      ],
+    },
+    tier: {
+      propDefinition: [
+        app,
+        "tier",
+      ],
+    },
+    publicKey: {
+      propDefinition: [
+        app,
+        "publicKey",
+      ],
+    },
+    includeSecrets: {
+      propDefinition: [
+        app,
+        "includeSecrets",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const records = await this.app.connectEgress({
+      $,
+      agent: this.agent,
+      tier: this.tier,
+      publicKey: this.publicKey,
+    });
+    let record = records?.[0] ?? {};
+    if (!this.includeSecrets) {
+      record = this.app.stripEgressSecrets(record);
+    }
+    $.export("$summary", record.address
+      ? `${record.tier ?? this.tier ?? "socks5"} egress ready for ${record.address}${this.includeSecrets
+        ? ""
+        : " (secrets stripped)"}`
+      : "Egress configuration returned");
+    return record;
+  },
+};

--- a/components/whisper/actions/get-agent/get-agent.mjs
+++ b/components/whisper/actions/get-agent/get-agent.mjs
@@ -1,0 +1,34 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-get-agent",
+  name: "Get Agent",
+  description: "Fetch one agent's full detail and live counters (`op:agent`) - id, address, FQDN, PTR, label, state, allocation time, last-seen, DNS query/block counts, traffic bytes and connection counters. Select the agent by its id or its `/128` address. Requires a connected Whisper account (your `whisper_live_` key). [See the documentation](https://whisper.online/platform)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    agent: {
+      propDefinition: [
+        app,
+        "agent",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const records = await this.app.getAgent({
+      $,
+      agent: this.agent,
+    });
+    const detail = records?.[0] ?? {};
+    $.export("$summary", detail.agent
+      ? `Agent ${detail.agent} (${detail.address ?? this.agent}): ${detail.state ?? "found"}`
+      : `Agent ${this.agent} retrieved`);
+    return detail;
+  },
+};

--- a/components/whisper/actions/get-agent/get-agent.mjs
+++ b/components/whisper/actions/get-agent/get-agent.mjs
@@ -1,0 +1,34 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-get-agent",
+  name: "Get Agent",
+  description: "Fetch one agent's full detail and live counters (`op:agent`) — id, address, FQDN, PTR, label, state, allocation time, last-seen, DNS query/block counts, traffic bytes and connection counters. Select the agent by its id or its `/128` address. Requires a connected Whisper account (your `whisper_live_` key). [See the documentation](https://whisper.online/platform)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    agent: {
+      propDefinition: [
+        app,
+        "agent",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const records = await this.app.getAgent({
+      $,
+      agent: this.agent,
+    });
+    const detail = records?.[0] ?? {};
+    $.export("$summary", detail.agent
+      ? `Agent ${detail.agent} (${detail.address ?? this.agent}): ${detail.state ?? "found"}`
+      : `Agent ${this.agent} retrieved`);
+    return detail;
+  },
+};

--- a/components/whisper/actions/get-egress-ip/get-egress-ip.mjs
+++ b/components/whisper/actions/get-egress-ip/get-egress-ip.mjs
@@ -1,0 +1,24 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-get-egress-ip",
+  name: "Get Egress IP",
+  description: "Echo the source IP this request is observed to come from (`GET /egress-ip`). This is keyless and anonymous - no API key or account is required. Fetch it **through** a Whisper egress proxy to prove the traffic really sources from the agent's routable IPv6 `/128`; fetched directly, it simply reports this workflow's own egress address. [See the documentation](https://whisper.online/platform)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+  },
+  async run({ $ }) {
+    const response = await this.app.getEgressIp({
+      $,
+    });
+    $.export("$summary", `Observed egress IP: ${response.ip}`);
+    return response;
+  },
+};

--- a/components/whisper/actions/get-egress-ip/get-egress-ip.mjs
+++ b/components/whisper/actions/get-egress-ip/get-egress-ip.mjs
@@ -1,0 +1,24 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-get-egress-ip",
+  name: "Get Egress IP",
+  description: "Echo the source IP this request is observed to come from (`GET /egress-ip`). This is keyless and anonymous — no API key or account is required. Fetch it **through** a Whisper egress proxy to prove the traffic really sources from the agent's routable IPv6 `/128`; fetched directly, it simply reports this workflow's own egress address. [See the documentation](https://whisper.online/platform)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+  },
+  async run({ $ }) {
+    const response = await this.app.getEgressIp({
+      $,
+    });
+    $.export("$summary", `Observed egress IP: ${response.ip}`);
+    return response;
+  },
+};

--- a/components/whisper/actions/get-inbound-lookups/get-inbound-lookups.mjs
+++ b/components/whisper/actions/get-inbound-lookups/get-inbound-lookups.mjs
@@ -1,0 +1,31 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-get-inbound-lookups",
+  name: "Get Inbound Lookups",
+  description: "Fetch the inbound identity-lookup feed for a Whisper agent IPv6 address — the recent record of who has been resolving or verifying this identity (timestamp, query name, query type, response code, and source). This is keyless and anonymous — no API key or account is required. Use this for observability: to see whether and how often an agent's identity is being checked by counterparties. Use **Verify Agent Identity** to verify the identity itself. [See the documentation](https://nic.whisper.online)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    address: {
+      propDefinition: [
+        app,
+        "address",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.app.getInboundLookups({
+      $,
+      address: this.address,
+    });
+    $.export("$summary", `Retrieved ${response.count} inbound lookup(s) for ${this.address}`);
+    return response;
+  },
+};

--- a/components/whisper/actions/get-inbound-lookups/get-inbound-lookups.mjs
+++ b/components/whisper/actions/get-inbound-lookups/get-inbound-lookups.mjs
@@ -1,0 +1,31 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-get-inbound-lookups",
+  name: "Get Inbound Lookups",
+  description: "Fetch the inbound identity-lookup feed for a Whisper agent IPv6 address - the recent record of who has been resolving or verifying this identity (timestamp, query name, query type, response code, and source). This is keyless and anonymous - no API key or account is required. Use this for observability: to see whether and how often an agent's identity is being checked by counterparties. Use **Verify Agent Identity** to verify the identity itself. [See the documentation](https://nic.whisper.online)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    address: {
+      propDefinition: [
+        app,
+        "address",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.app.getInboundLookups({
+      $,
+      address: this.address,
+    });
+    $.export("$summary", `Retrieved ${response.count} inbound lookup(s) for ${this.address}`);
+    return response;
+  },
+};

--- a/components/whisper/actions/get-logs/get-logs.mjs
+++ b/components/whisper/actions/get-logs/get-logs.mjs
@@ -1,0 +1,59 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-get-logs",
+  name: "Get Logs",
+  description: "Query your recent DNS / connection / allocation activity from warm storage (`op:logs`), confined to your own tenant. Narrow by agent, event kind, and a time window (relative like `-1h`, epoch-ms, or RFC-3339). Returns one record per event (empty when the window has no activity). Requires a connected Whisper account (your `whisper_live_` key). [See the documentation](https://whisper.online/platform)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    logsAgent: {
+      propDefinition: [
+        app,
+        "logsAgent",
+      ],
+    },
+    logsKind: {
+      propDefinition: [
+        app,
+        "logsKind",
+      ],
+    },
+    from: {
+      propDefinition: [
+        app,
+        "from",
+      ],
+    },
+    to: {
+      propDefinition: [
+        app,
+        "to",
+      ],
+    },
+    limit: {
+      propDefinition: [
+        app,
+        "limit",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const records = await this.app.getLogs({
+      $,
+      agent: this.logsAgent,
+      kind: this.logsKind,
+      from: this.from,
+      to: this.to,
+      limit: this.limit,
+    });
+    $.export("$summary", `Retrieved ${records.length} event(s)`);
+    return records;
+  },
+};

--- a/components/whisper/actions/get-transparency-log/get-transparency-log.mjs
+++ b/components/whisper/actions/get-transparency-log/get-transparency-log.mjs
@@ -1,0 +1,31 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-get-transparency-log",
+  name: "Get Transparency Log",
+  description: "Fetch the hash-chained transparency log for a Whisper agent IPv6 address: every issuance and revocation event, each linked to the previous by proof hash, plus the signed Merkle root and its inclusion checkpoint in the public `whisper.online/ledger`. This is keyless and anonymous — no API key or account is required. Use this to audit an identity's history and prove it has not been silently re-issued or tampered with. Use **Verify Agent Identity** for the current verdict and **Lookup RDAP Record** for the registry record. [See the documentation](https://whisper.online/platform)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    address: {
+      propDefinition: [
+        app,
+        "address",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.app.getTransparencyLog({
+      $,
+      address: this.address,
+    });
+    $.export("$summary", `Retrieved ${response.count} transparency event(s) for ${this.address}`);
+    return response;
+  },
+};

--- a/components/whisper/actions/get-transparency-log/get-transparency-log.mjs
+++ b/components/whisper/actions/get-transparency-log/get-transparency-log.mjs
@@ -1,0 +1,31 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-get-transparency-log",
+  name: "Get Transparency Log",
+  description: "Fetch the hash-chained transparency log for a Whisper agent IPv6 address: every issuance and revocation event, each linked to the previous by proof hash, plus the signed Merkle root and its inclusion checkpoint in the public `whisper.online/ledger`. This is keyless and anonymous - no API key or account is required. Use this to audit an identity's history and prove it has not been silently re-issued or tampered with. Use **Verify Agent Identity** for the current verdict and **Lookup RDAP Record** for the registry record. [See the documentation](https://whisper.online/platform)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    address: {
+      propDefinition: [
+        app,
+        "address",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.app.getTransparencyLog({
+      $,
+      address: this.address,
+    });
+    $.export("$summary", `Retrieved ${response.count} transparency event(s) for ${this.address}`);
+    return response;
+  },
+};

--- a/components/whisper/actions/graph-run-cypher/graph-run-cypher.mjs
+++ b/components/whisper/actions/graph-run-cypher/graph-run-cypher.mjs
@@ -1,0 +1,37 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-graph-run-cypher",
+  name: "Graph: Run Cypher",
+  description: "Run arbitrary Cypher against the whisper.security graph (the raw escape hatch under every named recipe). POSTs `{query, parameters}` to the graph query API and returns the `{columns, rows, statistics}` envelope, where rows are objects keyed by column name. Bind user input as `$parameters` (never string-concatenate it) so a query is always injection-safe. Keyed - connect your Whisper API key. [See the documentation](https://www.whisper.security/docs/cypher-api)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    cypher: {
+      type: "string",
+      label: "Cypher",
+      description: "The Cypher query to run, e.g. `CALL whisper.identify([$v]) YIELD canonical_name, category` or `RETURN 1 AS n`. Reference inputs as `$name` and supply them under **Parameters**. [Docs](https://www.whisper.security/docs/cypher-api)",
+    },
+    parameters: {
+      type: "object",
+      label: "Parameters",
+      description: "The `$`-parameters referenced by the query, as a JSON object, e.g. `{ \"v\": \"api.openai.com\" }`. Values are bound (never interpolated), so hostile input can never escape the query. [Docs](https://www.whisper.security/docs/cypher-api)",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const result = await this.app.graphQuery({
+      $,
+      cypher: this.cypher,
+      params: this.parameters,
+    });
+    $.export("$summary", `Ran Cypher (${result.rows?.length ?? 0} rows)`);
+    return result;
+  },
+};

--- a/components/whisper/actions/list-agents/list-agents.mjs
+++ b/components/whisper/actions/list-agents/list-agents.mjs
@@ -1,0 +1,31 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-list-agents",
+  name: "List Agents",
+  description: "List your fleet (`op:list`), confined to your own tenant — your agents, identities, or DNS records. Each record carries the item's label, FQDN, address, agent id, creation time, and state. Requires a connected Whisper account (your `whisper_live_` key). [See the documentation](https://whisper.online/platform)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    kind: {
+      propDefinition: [
+        app,
+        "listKind",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const records = await this.app.listAgents({
+      $,
+      kind: this.kind,
+    });
+    $.export("$summary", `Listed ${records.length} ${this.kind || "agents"}`);
+    return records;
+  },
+};

--- a/components/whisper/actions/list-agents/list-agents.mjs
+++ b/components/whisper/actions/list-agents/list-agents.mjs
@@ -1,0 +1,31 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-list-agents",
+  name: "List Agents",
+  description: "List your fleet (`op:list`), confined to your own tenant - your agents, identities, or DNS records. Each record carries the item's label, FQDN, address, agent id, creation time, and state. Requires a connected Whisper account (your `whisper_live_` key). [See the documentation](https://whisper.online/platform)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    kind: {
+      propDefinition: [
+        app,
+        "listKind",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const records = await this.app.listAgents({
+      $,
+      kind: this.kind,
+    });
+    $.export("$summary", `Listed ${records.length} ${this.kind || "agents"}`);
+    return records;
+  },
+};

--- a/components/whisper/actions/lookup-rdap-record/lookup-rdap-record.mjs
+++ b/components/whisper/actions/lookup-rdap-record/lookup-rdap-record.mjs
@@ -1,0 +1,31 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-lookup-rdap-record",
+  name: "Lookup RDAP Record",
+  description: "Fetch the RDAP (RFC 9083) registry record for a Whisper agent IPv6 address — handle, name, registrant entity, status, country, and registration events, with `related` links to the forward/reverse DNS and the upstream RIR. This is keyless and anonymous — no API key or account is required. Returns a `404` RDAP error object if no Whisper agent identity anchors the address. Use **Verify Agent Identity** for a live verification verdict instead of the registry record. [See the documentation](https://nic.whisper.online)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    address: {
+      propDefinition: [
+        app,
+        "address",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.app.getRdapRecord({
+      $,
+      address: this.address,
+    });
+    $.export("$summary", `Retrieved RDAP record for ${this.address}`);
+    return response;
+  },
+};

--- a/components/whisper/actions/lookup-rdap-record/lookup-rdap-record.mjs
+++ b/components/whisper/actions/lookup-rdap-record/lookup-rdap-record.mjs
@@ -1,0 +1,31 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-lookup-rdap-record",
+  name: "Lookup RDAP Record",
+  description: "Fetch the RDAP (RFC 9083) registry record for a Whisper agent IPv6 address - handle, name, registrant entity, status, country, and registration events, with `related` links to the forward/reverse DNS and the upstream RIR. This is keyless and anonymous - no API key or account is required. Returns a `404` RDAP error object if no Whisper agent identity anchors the address. Use **Verify Agent Identity** for a live verification verdict instead of the registry record. [See the documentation](https://nic.whisper.online)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    address: {
+      propDefinition: [
+        app,
+        "address",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.app.getRdapRecord({
+      $,
+      address: this.address,
+    });
+    $.export("$summary", `Retrieved RDAP record for ${this.address}`);
+    return response;
+  },
+};

--- a/components/whisper/actions/register-agent/register-agent.mjs
+++ b/components/whisper/actions/register-agent/register-agent.mjs
@@ -1,0 +1,41 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-register-agent",
+  name: "Register Agent",
+  description: "Mint a brand-new Whisper agent with its own routable IPv6 `/128` identity **and** its own API key (`op:register`). Returns the agent id, address, FQDN, PTR, state, and the new agent's `api_key` — which is shown **once**, so capture it now. Requires a connected Whisper account (your `whisper_live_` key with the `admin:dns` scope). [See the documentation](https://whisper.online/platform)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    label: {
+      propDefinition: [
+        app,
+        "label",
+      ],
+    },
+    contactEmail: {
+      propDefinition: [
+        app,
+        "contactEmail",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const records = await this.app.registerAgent({
+      $,
+      label: this.label,
+      contactEmail: this.contactEmail,
+    });
+    const agent = records?.[0] ?? {};
+    $.export("$summary", agent.address
+      ? `Registered agent ${agent.agent ?? this.label} at ${agent.address}`
+      : `Registered agent ${this.label}`);
+    return agent;
+  },
+};

--- a/components/whisper/actions/register-agent/register-agent.mjs
+++ b/components/whisper/actions/register-agent/register-agent.mjs
@@ -1,0 +1,41 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-register-agent",
+  name: "Register Agent",
+  description: "Mint a brand-new Whisper agent with its own routable IPv6 `/128` identity **and** its own API key (`op:register`). Returns the agent id, address, FQDN, PTR, state, and the new agent's `api_key` - which is shown **once**, so capture it now. Requires a connected Whisper account (your `whisper_live_` key with the `admin:dns` scope). [See the documentation](https://whisper.online/platform)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    label: {
+      propDefinition: [
+        app,
+        "label",
+      ],
+    },
+    contactEmail: {
+      propDefinition: [
+        app,
+        "contactEmail",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const records = await this.app.registerAgent({
+      $,
+      label: this.label,
+      contactEmail: this.contactEmail,
+    });
+    const agent = records?.[0] ?? {};
+    $.export("$summary", agent.address
+      ? `Registered agent ${agent.agent ?? this.label} at ${agent.address}`
+      : `Registered agent ${this.label}`);
+    return agent;
+  },
+};

--- a/components/whisper/actions/revoke-agent/revoke-agent.mjs
+++ b/components/whisper/actions/revoke-agent/revoke-agent.mjs
@@ -1,0 +1,32 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-revoke-agent",
+  name: "Revoke Agent",
+  description: "Fully revoke an agent (`op:revoke`) — withdraw its IPv6 `/128`, PTR, egress tokens and its API key. This is **irreversible**. Select the agent by its id or its `/128` address. Requires a connected Whisper account (your `whisper_live_` key with the `admin:dns` scope). [See the documentation](https://whisper.online/platform)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    agent: {
+      propDefinition: [
+        app,
+        "agent",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const records = await this.app.revokeAgent({
+      $,
+      agent: this.agent,
+    });
+    const status = records?.[0]?.status ?? records?.[0]?.state ?? "submitted";
+    $.export("$summary", `Agent ${this.agent}: ${status}`);
+    return records?.[0] ?? {};
+  },
+};

--- a/components/whisper/actions/revoke-agent/revoke-agent.mjs
+++ b/components/whisper/actions/revoke-agent/revoke-agent.mjs
@@ -1,0 +1,32 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-revoke-agent",
+  name: "Revoke Agent",
+  description: "Fully revoke an agent (`op:revoke`) - withdraw its IPv6 `/128`, PTR, egress tokens and its API key. This is **irreversible**. Select the agent by its id or its `/128` address. Requires a connected Whisper account (your `whisper_live_` key with the `admin:dns` scope). [See the documentation](https://whisper.online/platform)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    agent: {
+      propDefinition: [
+        app,
+        "agent",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const records = await this.app.revokeAgent({
+      $,
+      agent: this.agent,
+    });
+    const status = records?.[0]?.status ?? records?.[0]?.state ?? "submitted";
+    $.export("$summary", `Agent ${this.agent}: ${status}`);
+    return records?.[0] ?? {};
+  },
+};

--- a/components/whisper/actions/set-policy/set-policy.mjs
+++ b/components/whisper/actions/set-policy/set-policy.mjs
@@ -1,0 +1,60 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-set-policy",
+  name: "Set Policy",
+  description: "Set your per-tenant DNS resolver policy (`op:policy`): a default action plus allow/block name lists and named graph-backed **policy bundles** — the geo (`geo:deny:RU,KP`), category and threat (`block:tor-exits`, `block:sanctions`, …) controls. Setting any field **replaces** the whole policy. With **no** fields set, it reads the current policy back. Requires a connected Whisper account (your `whisper_live_` key with the `admin:dns` scope). [See the documentation](https://whisper.online/platform)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    policyDefault: {
+      propDefinition: [
+        app,
+        "policyDefault",
+      ],
+    },
+    block: {
+      propDefinition: [
+        app,
+        "block",
+      ],
+    },
+    allow: {
+      propDefinition: [
+        app,
+        "allow",
+      ],
+    },
+    bundles: {
+      propDefinition: [
+        app,
+        "bundles",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const isWrite = Boolean(
+      this.policyDefault
+      || this.block?.length
+      || this.allow?.length
+      || this.bundles?.length,
+    );
+    const records = await this.app.setPolicy({
+      $,
+      policyDefault: this.policyDefault,
+      block: this.block,
+      allow: this.allow,
+      bundles: this.bundles,
+    });
+    $.export("$summary", isWrite
+      ? `Policy updated (${records.length} entr${records.length === 1 ? "y" : "ies"})`
+      : `Read current policy (${records.length} entr${records.length === 1 ? "y" : "ies"})`);
+    return records;
+  },
+};

--- a/components/whisper/actions/set-policy/set-policy.mjs
+++ b/components/whisper/actions/set-policy/set-policy.mjs
@@ -1,0 +1,64 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-set-policy",
+  name: "Set Policy",
+  description: "Set your per-tenant DNS resolver policy (`op:policy`): a default action plus allow/block name lists and named graph-backed **policy bundles** - the geo (`geo:deny:RU,KP`), category and threat (`block:tor-exits`, `block:sanctions`, ...) controls. Setting any field **replaces** the whole policy. With **no** fields set, it reads the current policy back. Requires a connected Whisper account (your `whisper_live_` key with the `admin:dns` scope). [See the documentation](https://whisper.online/platform)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    policyDefault: {
+      propDefinition: [
+        app,
+        "policyDefault",
+      ],
+    },
+    block: {
+      propDefinition: [
+        app,
+        "block",
+      ],
+    },
+    allow: {
+      propDefinition: [
+        app,
+        "allow",
+      ],
+    },
+    bundles: {
+      propDefinition: [
+        app,
+        "bundles",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const isWrite = Boolean(
+      this.policyDefault
+      || this.block?.length
+      || this.allow?.length
+      || this.bundles?.length,
+    );
+    const records = await this.app.setPolicy({
+      $,
+      policyDefault: this.policyDefault,
+      block: this.block,
+      allow: this.allow,
+      bundles: this.bundles,
+    });
+    $.export("$summary", isWrite
+      ? `Policy updated (${records.length} entr${records.length === 1
+        ? "y"
+        : "ies"})`
+      : `Read current policy (${records.length} entr${records.length === 1
+        ? "y"
+        : "ies"})`);
+    return records;
+  },
+};

--- a/components/whisper/actions/verify-agent-identity/verify-agent-identity.mjs
+++ b/components/whisper/actions/verify-agent-identity/verify-agent-identity.mjs
@@ -1,0 +1,33 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-verify-agent-identity",
+  name: "Verify Agent Identity",
+  description: "Verify whether an IPv6 address is a genuine Whisper agent identity and return the full verdict (`is_whisper_agent`, `fqdn`, `operator`, `tenant`, `dane_ok`, `jws_ok`, and the underlying DNS/DANE evidence). This is keyless and anonymous — no API key or account is required. Use this to answer \"is this agent who it claims to be?\". Use **Lookup RDAP Record** for the registry record, **Get Transparency Log** for the hash-chained issuance history, and **Get Inbound Lookups** for who has been checking this identity. [See the documentation](https://whisper.online/platform)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    address: {
+      propDefinition: [
+        app,
+        "address",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.app.verifyIdentity({
+      $,
+      address: this.address,
+    });
+    $.export("$summary", response.is_whisper_agent
+      ? `${this.address} is a verified Whisper agent (${response.fqdn})`
+      : `${this.address} is not a Whisper agent identity`);
+    return response;
+  },
+};

--- a/components/whisper/actions/verify-agent-identity/verify-agent-identity.mjs
+++ b/components/whisper/actions/verify-agent-identity/verify-agent-identity.mjs
@@ -1,0 +1,33 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-verify-agent-identity",
+  name: "Verify Agent Identity",
+  description: "Verify whether an IPv6 address is a genuine Whisper agent identity and return the full verdict (`is_whisper_agent`, `fqdn`, `operator`, `tenant`, `dane_ok`, `jws_ok`, and the underlying DNS/DANE evidence). This is keyless and anonymous - no API key or account is required. Use this to answer \"is this agent who it claims to be?\". Use **Lookup RDAP Record** for the registry record, **Get Transparency Log** for the hash-chained issuance history, and **Get Inbound Lookups** for who has been checking this identity. [See the documentation](https://whisper.online/platform)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    address: {
+      propDefinition: [
+        app,
+        "address",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.app.verifyIdentity({
+      $,
+      address: this.address,
+    });
+    $.export("$summary", response.is_whisper_agent
+      ? `${this.address} is a verified Whisper agent (${response.fqdn})`
+      : `${this.address} is not a Whisper agent identity`);
+    return response;
+  },
+};

--- a/components/whisper/actions/whisper-graph-anycast-dns-root-sovereignty/whisper-graph-anycast-dns-root-sovereignty.mjs
+++ b/components/whisper/actions/whisper-graph-anycast-dns-root-sovereignty/whisper-graph-anycast-dns-root-sovereignty.mjs
@@ -1,0 +1,47 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-graph-anycast-dns-root-sovereignty",
+  name: "Graph: Anycast DNS-Root Sovereignty",
+  description: "Assess how resilient a country's core DNS is if it were cut off from the world. Could a country still resolve names if it were isolated? Counts how many of the 13 root letters have in-country DNS_ROOT_INSTANCE anycast nodes, the Global-vs-Local split, the BGP origin ASNs hosting them, and a resilience grade. Runs the `anycast-dns-root-sovereignty` multi-step flow on the whisper.security graph (keyed - connect your Whisper API key). [See the documentation](https://www.whisper.security/docs/recipes/compliance)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    country: {
+      type: "string",
+      label: "Country",
+      description: "The country the recipe runs against (e.g. `BR`, `US`, `DE`). [Docs](https://www.whisper.security/docs/recipes/compliance)",
+      default: "BR",
+    },
+    instanceType: {
+      type: "string",
+      label: "Instance Type",
+      description: "Instance Type for the recipe. [Docs](https://www.whisper.security/docs/recipes/compliance)",
+      options: [
+        "ALL",
+        "Global",
+        "Local",
+      ],
+      default: "ALL",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const result = await this.app.runGraphRecipe({
+      $,
+      id: "anycast-dns-root-sovereignty",
+      values: {
+        country: this.country,
+        instanceType: this.instanceType,
+      },
+    });
+    $.export("$summary", this.app.graphSummary("anycast-dns-root-sovereignty", result));
+    return result;
+  },
+};

--- a/components/whisper/actions/whisper-graph-assess/whisper-graph-assess.mjs
+++ b/components/whisper/actions/whisper-graph-assess/whisper-graph-assess.mjs
@@ -1,0 +1,34 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-graph-assess",
+  name: "Graph: Threat Posture (whisper.assess)",
+  description: "Get a labelled threat posture for a host or IP - malicious, benign, or unknown. Returns a posture label + severity band + sub-labels + coverage + evidence for an indicator; benign-allowlisted vs malicious-evidenced, never a bare score. Runs the `assess` graph procedure on the whisper.security graph (keyed - connect your Whisper API key). [See the documentation](https://www.whisper.security/docs/whisper-graph/procedures)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    value: {
+      type: "string",
+      label: "Value",
+      description: "The value the recipe runs against (e.g. `8.8.8.8`, `theblackservicenetwork.com`, `185.220.101.33`). [Docs](https://www.whisper.security/docs/whisper-graph/procedures)",
+      default: "8.8.8.8",
+    },
+  },
+  async run({ $ }) {
+    const result = await this.app.runGraphRecipe({
+      $,
+      id: "assess",
+      values: {
+        value: this.value,
+      },
+    });
+    $.export("$summary", this.app.graphSummary("assess", result));
+    return result;
+  },
+};

--- a/components/whisper/actions/whisper-graph-asset/whisper-graph-asset.mjs
+++ b/components/whisper/actions/whisper-graph-asset/whisper-graph-asset.mjs
@@ -1,0 +1,34 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-graph-asset",
+  name: "Graph: AS-SET Membership (whisper.asSet)",
+  description: "List the member ASNs of an AS-SET macro. Expands an AS-SET name (e.g. AS-CLOUDFLARE) to its member ASNs and source RIR. Arg is a STRING as-set name, not an integer ASN. (Membership is sparsely populated in the current graph.) Runs the `asset` graph procedure on the whisper.security graph (keyed - connect your Whisper API key). [See the documentation](https://www.whisper.security/docs/whisper-graph/procedures)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    value: {
+      type: "string",
+      label: "Value",
+      description: "The value the recipe runs against. [Docs](https://www.whisper.security/docs/whisper-graph/procedures)",
+      default: "AS-CLOUDFLARE",
+    },
+  },
+  async run({ $ }) {
+    const result = await this.app.runGraphRecipe({
+      $,
+      id: "asset",
+      values: {
+        value: this.value,
+      },
+    });
+    $.export("$summary", this.app.graphSummary("asset", result));
+    return result;
+  },
+};

--- a/components/whisper/actions/whisper-graph-attack-path/whisper-graph-attack-path.mjs
+++ b/components/whisper/actions/whisper-graph-attack-path/whisper-graph-attack-path.mjs
@@ -1,0 +1,56 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-graph-attack-path",
+  name: "Graph: Attack Path & Connection Finder",
+  description: "Find the choke points an attacker would target - and how any two things connect. From a starting foothold, finds shared dependencies whose compromise reaches furthest; for any two indicators, traces how they are actually connected. Runs the `attack-path` multi-step flow on the whisper.security graph (keyed - connect your Whisper API key). [See the documentation](https://www.whisper.security/docs/recipes/attack-path)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    asset: {
+      type: "string",
+      label: "Asset",
+      description: "The asset the recipe runs against (e.g. `github.com`, `cloudflare.com`, `coinbase.com`). [Docs](https://www.whisper.security/docs/recipes/attack-path)",
+      default: "paypal.com",
+    },
+    other: {
+      type: "string",
+      label: "Other",
+      description: "The other the recipe runs against. [Docs](https://www.whisper.security/docs/recipes/attack-path)",
+      default: "paypa1.com",
+    },
+    level: {
+      type: "string",
+      label: "Level",
+      description: "Level for the recipe. [Docs](https://www.whisper.security/docs/recipes/attack-path)",
+      options: [
+        "quick",
+        "standard",
+        "deep",
+        "comprehensive",
+        "exhaustive",
+      ],
+      default: "standard",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const result = await this.app.runGraphRecipe({
+      $,
+      id: "attack-path",
+      values: {
+        asset: this.asset,
+        other: this.other,
+        level: this.level,
+      },
+    });
+    $.export("$summary", this.app.graphSummary("attack-path", result));
+    return result;
+  },
+};

--- a/components/whisper/actions/whisper-graph-attack-surface/whisper-graph-attack-surface.mjs
+++ b/components/whisper/actions/whisper-graph-attack-surface/whisper-graph-attack-surface.mjs
@@ -1,0 +1,49 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-graph-attack-surface",
+  name: "Graph: Attack-Surface Mapper",
+  description: "Map everything about a domain that's exposed to the outside world, scored for risk. Maps the full external footprint - subdomains, name/mail servers, registrant, third-party services, connected web - and scores the exposure. Runs the `attack-surface` multi-step flow on the whisper.security graph (keyed - connect your Whisper API key). [See the documentation](https://www.whisper.security/docs/recipes/pentest-recon)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    domain: {
+      type: "string",
+      label: "Domain",
+      description: "The domain the recipe runs against. [Docs](https://www.whisper.security/docs/recipes/pentest-recon)",
+      default: "github.com",
+    },
+    level: {
+      type: "string",
+      label: "Level",
+      description: "Level for the recipe. [Docs](https://www.whisper.security/docs/recipes/pentest-recon)",
+      options: [
+        "quick",
+        "standard",
+        "deep",
+        "comprehensive",
+        "exhaustive",
+      ],
+      default: "standard",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const result = await this.app.runGraphRecipe({
+      $,
+      id: "attack-surface",
+      values: {
+        domain: this.domain,
+        level: this.level,
+      },
+    });
+    $.export("$summary", this.app.graphSummary("attack-surface", result));
+    return result;
+  },
+};

--- a/components/whisper/actions/whisper-graph-bgp-hijack-exposure/whisper-graph-bgp-hijack-exposure.mjs
+++ b/components/whisper/actions/whisper-graph-bgp-hijack-exposure/whisper-graph-bgp-hijack-exposure.mjs
@@ -1,0 +1,34 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-graph-bgp-hijack-exposure",
+  name: "Graph: BGP Hijack & Routing-Hygiene Audit",
+  description: "Grade a network's routing security and trace conflicts to the domains they'd expose. Grades a network on the conflicts/gaps that make route hijacking possible, then traces any conflict to the specific domains and organisations exposed on the affected blocks. Runs the `bgp-hijack-exposure` multi-step flow on the whisper.security graph (keyed - connect your Whisper API key). [See the documentation](https://www.whisper.security/docs/recipes/bgp-routing)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    asn: {
+      type: "string",
+      label: "Asn",
+      description: "The asn the recipe runs against. [Docs](https://www.whisper.security/docs/recipes/bgp-routing)",
+      default: "AS13335",
+    },
+  },
+  async run({ $ }) {
+    const result = await this.app.runGraphRecipe({
+      $,
+      id: "bgp-hijack-exposure",
+      values: {
+        asn: this.asn,
+      },
+    });
+    $.export("$summary", this.app.graphSummary("bgp-hijack-exposure", result));
+    return result;
+  },
+};

--- a/components/whisper/actions/whisper-graph-blast-radius/whisper-graph-blast-radius.mjs
+++ b/components/whisper/actions/whisper-graph-blast-radius/whisper-graph-blast-radius.mjs
@@ -1,0 +1,42 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-graph-blast-radius",
+  name: "Graph: Dependency Blast Radius",
+  description: "Pick one asset and see what would break if it failed - and what it depends on in turn. Maps dependencies in both directions: everything that breaks if the asset fails (SPOFs) and everything it relies on (its own DNS/mail/hosting/network supply chain). Runs the `blast-radius` multi-step flow on the whisper.security graph (keyed - connect your Whisper API key). [See the documentation](https://www.whisper.security/docs/recipes/soc)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    asset: {
+      type: "string",
+      label: "Asset",
+      description: "The asset the recipe runs against (e.g. `ns1.dreamhost.com`, `dns1.p01.nsone.net`, `cloudflare.com`). [Docs](https://www.whisper.security/docs/recipes/soc)",
+      default: "ns1.dreamhost.com",
+    },
+    depth: {
+      type: "integer",
+      label: "Depth",
+      description: "Depth for the recipe. [Docs](https://www.whisper.security/docs/recipes/soc)",
+      default: 2,
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const result = await this.app.runGraphRecipe({
+      $,
+      id: "blast-radius",
+      values: {
+        asset: this.asset,
+        depth: this.depth,
+      },
+    });
+    $.export("$summary", this.app.graphSummary("blast-radius", result));
+    return result;
+  },
+};

--- a/components/whisper/actions/whisper-graph-build-takedown-evidence-package/whisper-graph-build-takedown-evidence-package.mjs
+++ b/components/whisper/actions/whisper-graph-build-takedown-evidence-package/whisper-graph-build-takedown-evidence-package.mjs
@@ -1,0 +1,34 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-graph-build-takedown-evidence-package",
+  name: "Graph: Takedown Evidence Package",
+  description: "Assemble a ready-to-submit dossier for taking down a scam or phishing domain. One-pass takedown package: reputation verdict, owner (WHOIS), abuse-list listings, and surrounding infrastructure, laid out ready to hand to a registrar/host. Runs the `build-takedown-evidence-package` multi-step flow on the whisper.security graph (keyed - connect your Whisper API key). [See the documentation](https://www.whisper.security/docs/recipes/threat-intel)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    domain: {
+      type: "string",
+      label: "Domain",
+      description: "The domain the recipe runs against (e.g. `ickaoex.com`, `bodis.com`, `paypal.com`). [Docs](https://www.whisper.security/docs/recipes/threat-intel)",
+      default: "ickaoex.com",
+    },
+  },
+  async run({ $ }) {
+    const result = await this.app.runGraphRecipe({
+      $,
+      id: "build-takedown-evidence-package",
+      values: {
+        domain: this.domain,
+      },
+    });
+    $.export("$summary", this.app.graphSummary("build-takedown-evidence-package", result));
+    return result;
+  },
+};

--- a/components/whisper/actions/whisper-graph-db-schema/whisper-graph-db-schema.mjs
+++ b/components/whisper/actions/whisper-graph-db-schema/whisper-graph-db-schema.mjs
@@ -1,0 +1,26 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-graph-db-schema",
+  name: "Graph: Graph Schema Catalog (db.schema)",
+  description: "List every node and relationship type in the graph with counts and examples. The self-describing schema: node/relationship types with counts, descriptions, examples, source/target labels and query best-practices - the map of what the graph holds. Runs the `db-schema` graph procedure on the whisper.security graph (keyed - connect your Whisper API key). [See the documentation](https://www.whisper.security/docs/whisper-graph/schema)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+  },
+  async run({ $ }) {
+    const result = await this.app.runGraphRecipe({
+      $,
+      id: "db-schema",
+      values: {},
+    });
+    $.export("$summary", this.app.graphSummary("db-schema", result));
+    return result;
+  },
+};

--- a/components/whisper/actions/whisper-graph-discover-ai-agent-infrastructure/whisper-graph-discover-ai-agent-infrastructure.mjs
+++ b/components/whisper/actions/whisper-graph-discover-ai-agent-infrastructure/whisper-graph-discover-ai-agent-infrastructure.mjs
@@ -1,0 +1,34 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-graph-discover-ai-agent-infrastructure",
+  name: "Graph: AI / Agent Infrastructure Discovery",
+  description: "Map an organisation's externally visible AI and agent endpoints from the outside. Maps externally visible AI/agent hosts (API, model, agent) from the outside via heuristic hostname patterns (api./mcp./ai./vector./llm./agent./chat./copilot.). Best-effort leads. Runs the `discover-ai-agent-infrastructure` multi-step flow on the whisper.security graph (keyed - connect your Whisper API key). [See the documentation](https://www.whisper.security/docs/recipes/pentest-recon)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    domain: {
+      type: "string",
+      label: "Domain",
+      description: "The domain the recipe runs against. [Docs](https://www.whisper.security/docs/recipes/pentest-recon)",
+      default: "github.com",
+    },
+  },
+  async run({ $ }) {
+    const result = await this.app.runGraphRecipe({
+      $,
+      id: "discover-ai-agent-infrastructure",
+      values: {
+        domain: this.domain,
+      },
+    });
+    $.export("$summary", this.app.graphSummary("discover-ai-agent-infrastructure", result));
+    return result;
+  },
+};

--- a/components/whisper/actions/whisper-graph-explain/whisper-graph-explain.mjs
+++ b/components/whisper/actions/whisper-graph-explain/whisper-graph-explain.mjs
@@ -1,0 +1,34 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-graph-explain",
+  name: "Graph: Threat-Feed Explainer (whisper.explain / explain)",
+  description: "Score an indicator against the threat feeds and explain exactly why. Threat-intel scorer: score + level + human explanation + the feeds it is listed in (feedId, weight, firstSeen/lastSeen). Two live forms: bare CALL explain($v) (full columns) and CALL whisper.explain($v) (restricted YIELD). Runs the `explain` graph procedure on the whisper.security graph (keyed - connect your Whisper API key). [See the documentation](https://www.whisper.security/docs/whisper-graph/procedures/explain)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    value: {
+      type: "string",
+      label: "Value",
+      description: "The value the recipe runs against (e.g. `paypal.com`, `ickaoex.com`, `github.com`). [Docs](https://www.whisper.security/docs/whisper-graph/procedures/explain)",
+      default: "paypal.com",
+    },
+  },
+  async run({ $ }) {
+    const result = await this.app.runGraphRecipe({
+      $,
+      id: "explain",
+      values: {
+        value: this.value,
+      },
+    });
+    $.export("$summary", this.app.graphSummary("explain", result));
+    return result;
+  },
+};

--- a/components/whisper/actions/whisper-graph-history-whois/whisper-graph-history-whois.mjs
+++ b/components/whisper/actions/whisper-graph-history-whois/whisper-graph-history-whois.mjs
@@ -1,0 +1,34 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-graph-history-whois",
+  name: "Graph: WHOIS History (projection) (whisper.history.whois)",
+  description: "Get the WHOIS-only historical timeline for a domain. The registration-record projection of the history timeline: create/update/expiry, registrar, registrant, country, nameservers per snapshot. Runs the `history-whois` graph procedure on the whisper.security graph (keyed - connect your Whisper API key). [See the documentation](https://www.whisper.security/docs/whisper-graph/procedures/history)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    value: {
+      type: "string",
+      label: "Value",
+      description: "The value the recipe runs against. [Docs](https://www.whisper.security/docs/whisper-graph/procedures/history)",
+      default: "paypal.com",
+    },
+  },
+  async run({ $ }) {
+    const result = await this.app.runGraphRecipe({
+      $,
+      id: "history-whois",
+      values: {
+        value: this.value,
+      },
+    });
+    $.export("$summary", this.app.graphSummary("history-whois", result));
+    return result;
+  },
+};

--- a/components/whisper/actions/whisper-graph-history/whisper-graph-history.mjs
+++ b/components/whisper/actions/whisper-graph-history/whisper-graph-history.mjs
@@ -1,0 +1,34 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-graph-history",
+  name: "Graph: WHOIS History Timeline (whisper.history)",
+  description: "Get the full historical WHOIS timeline for a domain. Every observed WHOIS snapshot over time: create/update/expiry, registrar, registrant, country, nameservers - the ownership/registration story. Runs the `history` graph procedure on the whisper.security graph (keyed - connect your Whisper API key). [See the documentation](https://www.whisper.security/docs/whisper-graph/procedures/history)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    value: {
+      type: "string",
+      label: "Value",
+      description: "The value the recipe runs against. [Docs](https://www.whisper.security/docs/whisper-graph/procedures/history)",
+      default: "paypal.com",
+    },
+  },
+  async run({ $ }) {
+    const result = await this.app.runGraphRecipe({
+      $,
+      id: "history",
+      values: {
+        value: this.value,
+      },
+    });
+    $.export("$summary", this.app.graphSummary("history", result));
+    return result;
+  },
+};

--- a/components/whisper/actions/whisper-graph-identify/whisper-graph-identify.mjs
+++ b/components/whisper/actions/whisper-graph-identify/whisper-graph-identify.mjs
@@ -1,0 +1,34 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-graph-identify",
+  name: "Graph: Vendor / Operator Identity (whisper.identify)",
+  description: "Name the vendor and operator role behind a host or IP in one call. Resolves a host/IP to its canonical vendor, category and operator roles (DNS_OPERATOR / CDN / ORIGIN_AS / MAIL_RECEIVER) with a confidence band. Runs the `identify` graph procedure on the whisper.security graph (keyed - connect your Whisper API key). [See the documentation](https://www.whisper.security/docs/whisper-graph/procedures/identify)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    value: {
+      type: "string",
+      label: "Value",
+      description: "The value the recipe runs against (e.g. `cloudflare.com`, `api.openai.com`, `8.8.8.8`). [Docs](https://www.whisper.security/docs/whisper-graph/procedures/identify)",
+      default: "api.openai.com",
+    },
+  },
+  async run({ $ }) {
+    const result = await this.app.runGraphRecipe({
+      $,
+      id: "identify",
+      values: {
+        value: this.value,
+      },
+    });
+    $.export("$summary", this.app.graphSummary("identify", result));
+    return result;
+  },
+};

--- a/components/whisper/actions/whisper-graph-indicator-enrichment/whisper-graph-indicator-enrichment.mjs
+++ b/components/whisper/actions/whisper-graph-indicator-enrichment/whisper-graph-indicator-enrichment.mjs
@@ -1,0 +1,34 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-graph-indicator-enrichment",
+  name: "Graph: Indicator Enrichment",
+  description: "Turn one domain or IP into a full context card - owner, hosting, mail, location, reputation at a glance. Fills the picture for one indicator: registrant (WHOIS), hosting + country, mail/name servers, network behind it, reputation read. Runs the `indicator-enrichment` multi-step flow on the whisper.security graph (keyed - connect your Whisper API key). [See the documentation](https://www.whisper.security/docs/recipes/dns-email)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    domain: {
+      type: "string",
+      label: "Domain",
+      description: "The domain the recipe runs against (e.g. `google.com`, `cloudflare.com`, `185.220.101.33`). [Docs](https://www.whisper.security/docs/recipes/dns-email)",
+      default: "google.com",
+    },
+  },
+  async run({ $ }) {
+    const result = await this.app.runGraphRecipe({
+      $,
+      id: "indicator-enrichment",
+      values: {
+        domain: this.domain,
+      },
+    });
+    $.export("$summary", this.app.graphSummary("indicator-enrichment", result));
+    return result;
+  },
+};

--- a/components/whisper/actions/whisper-graph-indicator/whisper-graph-indicator.mjs
+++ b/components/whisper/actions/whisper-graph-indicator/whisper-graph-indicator.mjs
@@ -1,0 +1,34 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-graph-indicator",
+  name: "Graph: Threat Investigation",
+  description: "Investigate one suspicious domain, IP, or network in depth and get a clear picture of the threat and everything connected to it. Deep-dive: works outward across the whole footprint (related domains, real origins behind CDN, neighbouring infra), threat-checks each node, never inherits maliciousness from shared infra; labelled posture, no score. Runs the `indicator` multi-step flow on the whisper.security graph (keyed - connect your Whisper API key). [See the documentation](https://www.whisper.security/docs/recipes/soc)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    indicator: {
+      type: "string",
+      label: "Indicator",
+      description: "The indicator the recipe runs against (e.g. `theblackservicenetwork.com`, `185.220.101.33`, `customclothing.in`). [Docs](https://www.whisper.security/docs/recipes/soc)",
+      default: "theblackservicenetwork.com",
+    },
+  },
+  async run({ $ }) {
+    const result = await this.app.runGraphRecipe({
+      $,
+      id: "indicator",
+      values: {
+        indicator: this.indicator,
+      },
+    });
+    $.export("$summary", this.app.graphSummary("indicator", result));
+    return result;
+  },
+};

--- a/components/whisper/actions/whisper-graph-infrastructure-mapping/whisper-graph-infrastructure-mapping.mjs
+++ b/components/whisper/actions/whisper-graph-infrastructure-mapping/whisper-graph-infrastructure-mapping.mjs
@@ -1,0 +1,49 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-graph-infrastructure-mapping",
+  name: "Graph: Digital Infrastructure Mapping",
+  description: "Trace one indicator to its true owner and full estate, even behind privacy screens and CDNs. Works out the true operator (even behind privacy WHOIS), de-cloaks CDN-fronted sites to real servers, pivots to the rest of that owner’s estate across every layer. Runs the `infrastructure-mapping` multi-step flow on the whisper.security graph (keyed - connect your Whisper API key). [See the documentation](https://www.whisper.security/docs/recipes/compliance)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    target: {
+      type: "string",
+      label: "Target",
+      description: "The target the recipe runs against (e.g. `github.com`, `8.8.8.8`, `AS15169`). [Docs](https://www.whisper.security/docs/recipes/compliance)",
+      default: "cloudflare.com",
+    },
+    level: {
+      type: "string",
+      label: "Level",
+      description: "Level for the recipe. [Docs](https://www.whisper.security/docs/recipes/compliance)",
+      options: [
+        "quick",
+        "standard",
+        "deep",
+        "comprehensive",
+        "exhaustive",
+      ],
+      default: "standard",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const result = await this.app.runGraphRecipe({
+      $,
+      id: "infrastructure-mapping",
+      values: {
+        target: this.target,
+        level: this.level,
+      },
+    });
+    $.export("$summary", this.app.graphSummary("infrastructure-mapping", result));
+    return result;
+  },
+};

--- a/components/whisper/actions/whisper-graph-infrastructure-mapping/whisper-graph-infrastructure-mapping.mjs
+++ b/components/whisper/actions/whisper-graph-infrastructure-mapping/whisper-graph-infrastructure-mapping.mjs
@@ -1,0 +1,49 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-graph-infrastructure-mapping",
+  name: "Graph: Digital Infrastructure Mapping",
+  description: "Trace one indicator to its true owner and full estate, even behind privacy screens and CDNs. Works out the true operator (even behind privacy WHOIS), de-cloaks CDN-fronted sites to real servers, pivots to the rest of that owner's estate across every layer. Runs the `infrastructure-mapping` multi-step flow on the whisper.security graph (keyed - connect your Whisper API key). [See the documentation](https://www.whisper.security/docs/recipes/compliance)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    target: {
+      type: "string",
+      label: "Target",
+      description: "The target the recipe runs against (e.g. `github.com`, `8.8.8.8`, `AS15169`). [Docs](https://www.whisper.security/docs/recipes/compliance)",
+      default: "cloudflare.com",
+    },
+    level: {
+      type: "string",
+      label: "Level",
+      description: "Level for the recipe. [Docs](https://www.whisper.security/docs/recipes/compliance)",
+      options: [
+        "quick",
+        "standard",
+        "deep",
+        "comprehensive",
+        "exhaustive",
+      ],
+      default: "standard",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const result = await this.app.runGraphRecipe({
+      $,
+      id: "infrastructure-mapping",
+      values: {
+        target: this.target,
+        level: this.level,
+      },
+    });
+    $.export("$summary", this.app.graphSummary("infrastructure-mapping", result));
+    return result;
+  },
+};

--- a/components/whisper/actions/whisper-graph-lookup-tor-relay/whisper-graph-lookup-tor-relay.mjs
+++ b/components/whisper/actions/whisper-graph-lookup-tor-relay/whisper-graph-lookup-tor-relay.mjs
@@ -1,0 +1,34 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-graph-lookup-tor-relay",
+  name: "Graph: Tor Exit-Relay Lookup (whisper.lookupTorRelay)",
+  description: "Check whether an IP is a known Tor exit relay. Live Tor exit-node check: found + fingerprint + exit-address count + source + ingest time for an IPv4. Runs the `lookup-tor-relay` graph procedure on the whisper.security graph (keyed - connect your Whisper API key). [See the documentation](https://www.whisper.security/docs/whisper-graph/procedures/helpers)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    value: {
+      type: "string",
+      label: "Value",
+      description: "The value the recipe runs against. [Docs](https://www.whisper.security/docs/whisper-graph/procedures/helpers)",
+      default: "185.220.101.33",
+    },
+  },
+  async run({ $ }) {
+    const result = await this.app.runGraphRecipe({
+      $,
+      id: "lookup-tor-relay",
+      values: {
+        value: this.value,
+      },
+    });
+    $.export("$summary", this.app.graphSummary("lookup-tor-relay", result));
+    return result;
+  },
+};

--- a/components/whisper/actions/whisper-graph-map-supply-chain-concentration/whisper-graph-map-supply-chain-concentration.mjs
+++ b/components/whisper/actions/whisper-graph-map-supply-chain-concentration/whisper-graph-map-supply-chain-concentration.mjs
@@ -1,0 +1,34 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-graph-map-supply-chain-concentration",
+  name: "Graph: Infrastructure Concentration & Resilience",
+  description: "Grade an organisation for over-reliance on single providers, regions, or facilities. Grades how concentrated infra is - too much riding on one provider/region/data-centre/cable landing - surfacing SPOFs for resilience and DORA/NIS2 fourth-party risk. Runs the `map-supply-chain-concentration` multi-step flow on the whisper.security graph (keyed - connect your Whisper API key). [See the documentation](https://www.whisper.security/docs/recipes/compliance)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    domain: {
+      type: "string",
+      label: "Domain",
+      description: "The domain the recipe runs against (e.g. `atlassian.com`, `shopify.com`, `cloudflare.com`). [Docs](https://www.whisper.security/docs/recipes/compliance)",
+      default: "atlassian.com",
+    },
+  },
+  async run({ $ }) {
+    const result = await this.app.runGraphRecipe({
+      $,
+      id: "map-supply-chain-concentration",
+      values: {
+        domain: this.domain,
+      },
+    });
+    $.export("$summary", this.app.graphSummary("map-supply-chain-concentration", result));
+    return result;
+  },
+};

--- a/components/whisper/actions/whisper-graph-nameserver-hijack-dns-consistency/whisper-graph-nameserver-hijack-dns-consistency.mjs
+++ b/components/whisper/actions/whisper-graph-nameserver-hijack-dns-consistency/whisper-graph-nameserver-hijack-dns-consistency.mjs
@@ -1,0 +1,34 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-graph-nameserver-hijack-dns-consistency",
+  name: "Graph: Nameserver & DNS Delegation Audit",
+  description: "Check a domain's name servers for the misconfigurations that enable DNS hijacking. Audits delegation, flags stale/mismatched/lame nameservers, sizes each provider's share, surfaces registry facts - catches delegation weakness before exploit. Runs the `nameserver-hijack-dns-consistency` multi-step flow on the whisper.security graph (keyed - connect your Whisper API key). [See the documentation](https://www.whisper.security/docs/recipes/dns-email)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    domain: {
+      type: "string",
+      label: "Domain",
+      description: "The domain the recipe runs against. [Docs](https://www.whisper.security/docs/recipes/dns-email)",
+      default: "google.com",
+    },
+  },
+  async run({ $ }) {
+    const result = await this.app.runGraphRecipe({
+      $,
+      id: "nameserver-hijack-dns-consistency",
+      values: {
+        domain: this.domain,
+      },
+    });
+    $.export("$summary", this.app.graphSummary("nameserver-hijack-dns-consistency", result));
+    return result;
+  },
+};

--- a/components/whisper/actions/whisper-graph-nameserver-hijack-dns-consistency/whisper-graph-nameserver-hijack-dns-consistency.mjs
+++ b/components/whisper/actions/whisper-graph-nameserver-hijack-dns-consistency/whisper-graph-nameserver-hijack-dns-consistency.mjs
@@ -1,0 +1,34 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-graph-nameserver-hijack-dns-consistency",
+  name: "Graph: Nameserver & DNS Delegation Audit",
+  description: "Check a domain's name servers for the misconfigurations that enable DNS hijacking. Audits delegation, flags stale/mismatched/lame nameservers, sizes each provider’s share, surfaces registry facts - catches delegation weakness before exploit. Runs the `nameserver-hijack-dns-consistency` multi-step flow on the whisper.security graph (keyed - connect your Whisper API key). [See the documentation](https://www.whisper.security/docs/recipes/dns-email)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    domain: {
+      type: "string",
+      label: "Domain",
+      description: "The domain the recipe runs against. [Docs](https://www.whisper.security/docs/recipes/dns-email)",
+      default: "google.com",
+    },
+  },
+  async run({ $ }) {
+    const result = await this.app.runGraphRecipe({
+      $,
+      id: "nameserver-hijack-dns-consistency",
+      values: {
+        domain: this.domain,
+      },
+    });
+    $.export("$summary", this.app.graphSummary("nameserver-hijack-dns-consistency", result));
+    return result;
+  },
+};

--- a/components/whisper/actions/whisper-graph-origins/whisper-graph-origins.mjs
+++ b/components/whisper/actions/whisper-graph-origins/whisper-graph-origins.mjs
@@ -1,0 +1,34 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-graph-origins",
+  name: "Graph: CDN-Origin De-cloaker (whisper.origins)",
+  description: "Find the real origin IPs behind a CDN-fronted domain, ranked by confidence. Candidate origin IPs behind a CDN with confidence, the methods that found them (e.g. links_to), and the hosting ASN/name - de-cloaks to the real server. Runs the `origins` graph procedure on the whisper.security graph (keyed - connect your Whisper API key). [See the documentation](https://www.whisper.security/docs/whisper-graph/procedures/origins)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    value: {
+      type: "string",
+      label: "Value",
+      description: "The value the recipe runs against. [Docs](https://www.whisper.security/docs/whisper-graph/procedures/origins)",
+      default: "cloudflare.com",
+    },
+  },
+  async run({ $ }) {
+    const result = await this.app.runGraphRecipe({
+      $,
+      id: "origins",
+      values: {
+        value: this.value,
+      },
+    });
+    $.export("$summary", this.app.graphSummary("origins", result));
+    return result;
+  },
+};

--- a/components/whisper/actions/whisper-graph-psl-affiliation/whisper-graph-psl-affiliation.mjs
+++ b/components/whisper/actions/whisper-graph-psl-affiliation/whisper-graph-psl-affiliation.mjs
@@ -1,0 +1,34 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-graph-psl-affiliation",
+  name: "Graph: PSL Private-Suffix Affiliation (whisper.psl.affiliation)",
+  description: "Check whether a domain is a PSL private-section suffix and who submitted it. For a PSL private-section suffix, returns the submitting org/login and evidence kind + confidence; found=false for ordinary registrable domains. Runs the `psl-affiliation` graph procedure on the whisper.security graph (keyed - connect your Whisper API key). [See the documentation](https://www.whisper.security/docs/whisper-graph/procedures/helpers)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    value: {
+      type: "string",
+      label: "Value",
+      description: "The value the recipe runs against. [Docs](https://www.whisper.security/docs/whisper-graph/procedures/helpers)",
+      default: "paypal.com",
+    },
+  },
+  async run({ $ }) {
+    const result = await this.app.runGraphRecipe({
+      $,
+      id: "psl-affiliation",
+      values: {
+        value: this.value,
+      },
+    });
+    $.export("$summary", this.app.graphSummary("psl-affiliation", result));
+    return result;
+  },
+};

--- a/components/whisper/actions/whisper-graph-psl-tldplusone/whisper-graph-psl-tldplusone.mjs
+++ b/components/whisper/actions/whisper-graph-psl-tldplusone/whisper-graph-psl-tldplusone.mjs
@@ -1,0 +1,34 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-graph-psl-tldplusone",
+  name: "Graph: Registrable Apex (whisper.psl.tldPlusOne)",
+  description: "Reduce any hostname to its registrable apex (eTLD+1) via the Public Suffix List. PSL-correct eTLD+1: www.foo.co.uk -> foo.co.uk. The right way to group hosts by the thing someone actually registered. Runs the `psl-tldplusone` graph procedure on the whisper.security graph (keyed - connect your Whisper API key). [See the documentation](https://www.whisper.security/docs/whisper-graph/procedures/helpers)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    value: {
+      type: "string",
+      label: "Value",
+      description: "The value the recipe runs against. [Docs](https://www.whisper.security/docs/whisper-graph/procedures/helpers)",
+      default: "www.foo.co.uk",
+    },
+  },
+  async run({ $ }) {
+    const result = await this.app.runGraphRecipe({
+      $,
+      id: "psl-tldplusone",
+      values: {
+        value: this.value,
+      },
+    });
+    $.export("$summary", this.app.graphSummary("psl-tldplusone", result));
+    return result;
+  },
+};

--- a/components/whisper/actions/whisper-graph-route-health/whisper-graph-route-health.mjs
+++ b/components/whisper/actions/whisper-graph-route-health/whisper-graph-route-health.mjs
@@ -1,0 +1,34 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-graph-route-health",
+  name: "Graph: Network & Routing Report",
+  description: "Profile a network or address block into a full routing and reachability health card. Health card for a network/block: what it announces, peers/transit, single-upstream lean, RPKI protection - the one-look reach & resilience report. Runs the `route-health` multi-step flow on the whisper.security graph (keyed - connect your Whisper API key). [See the documentation](https://www.whisper.security/docs/recipes/bgp-routing)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    target: {
+      type: "string",
+      label: "Target",
+      description: "The target the recipe runs against. [Docs](https://www.whisper.security/docs/recipes/bgp-routing)",
+      default: "1.1.1.0/24",
+    },
+  },
+  async run({ $ }) {
+    const result = await this.app.runGraphRecipe({
+      $,
+      id: "route-health",
+      values: {
+        target: this.target,
+      },
+    });
+    $.export("$summary", this.app.graphSummary("route-health", result));
+    return result;
+  },
+};

--- a/components/whisper/actions/whisper-graph-subdomain-takeover/whisper-graph-subdomain-takeover.mjs
+++ b/components/whisper/actions/whisper-graph-subdomain-takeover/whisper-graph-subdomain-takeover.mjs
@@ -1,0 +1,34 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-graph-subdomain-takeover",
+  name: "Graph: Subdomain Takeover Detection",
+  description: "Find subdomains that point at abandoned services an attacker could claim. Walks subdomains and flags ones aiming at deprovisioned targets (dangling CNAME whose target no longer resolves) so you can reclaim/remove before someone else does. CNAME layer is prod-ahead. Runs the `subdomain-takeover` multi-step flow on the whisper.security graph (keyed - connect your Whisper API key). [See the documentation](https://www.whisper.security/docs/recipes/pentest-recon)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    domain: {
+      type: "string",
+      label: "Domain",
+      description: "The domain the recipe runs against. [Docs](https://www.whisper.security/docs/recipes/pentest-recon)",
+      default: "github.com",
+    },
+  },
+  async run({ $ }) {
+    const result = await this.app.runGraphRecipe({
+      $,
+      id: "subdomain-takeover",
+      values: {
+        domain: this.domain,
+      },
+    });
+    $.export("$summary", this.app.graphSummary("subdomain-takeover", result));
+    return result;
+  },
+};

--- a/components/whisper/actions/whisper-graph-submit/whisper-graph-submit.mjs
+++ b/components/whisper/actions/whisper-graph-submit/whisper-graph-submit.mjs
@@ -1,0 +1,127 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-graph-submit",
+  name: "Graph: Submit Observation / Feedback (whisper.submit)",
+  description: "Contribute an indicator observation or feedback back into the graph (requires an API key). The write channel: submit an indicator/feedback with an attributable API key (anonymous submits are refused to preserve K-anonymity). Keyed-only by design. Runs the `submit` graph procedure on the whisper.security graph (keyed - connect your Whisper API key). [See the documentation](https://www.whisper.security/docs/cypher-api)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    kind: {
+      type: "string",
+      label: "Kind",
+      description: "The kind the recipe runs against. [Docs](https://www.whisper.security/docs/cypher-api)",
+      options: [
+        "indicator",
+        "feedback",
+      ],
+      default: "indicator",
+    },
+    identifierKind: {
+      type: "string",
+      label: "Identifier Kind",
+      description: "The identifier kind the recipe runs against. [Docs](https://www.whisper.security/docs/cypher-api)",
+      options: [
+        "ip",
+        "asn",
+        "cert_sha256",
+        "cert_ja3_hash",
+        "cert_ja4_hash",
+        "cert_jarm",
+        "cidr",
+        "whois_pattern",
+        "host_hash_rotating",
+        "url_path_hash",
+      ],
+      default: "ip",
+    },
+    value: {
+      type: "string",
+      label: "Value",
+      description: "The value the recipe runs against (e.g. `203.0.113.5`, `AS64496`, `198.51.100.0/24`). [Docs](https://www.whisper.security/docs/cypher-api)",
+      default: "203.0.113.5",
+    },
+    observationId: {
+      type: "string",
+      label: "Observation Id",
+      description: "The observation id the recipe runs against. [Docs](https://www.whisper.security/docs/cypher-api)",
+      optional: true,
+    },
+    confidence: {
+      type: "string",
+      label: "Confidence",
+      description: "The confidence the recipe runs against. [Docs](https://www.whisper.security/docs/cypher-api)",
+      optional: true,
+    },
+    firstSeen: {
+      type: "string",
+      label: "First Seen",
+      description: "The first seen the recipe runs against. [Docs](https://www.whisper.security/docs/cypher-api)",
+      optional: true,
+    },
+    provenance: {
+      type: "string",
+      label: "Provenance",
+      description: "The provenance the recipe runs against. [Docs](https://www.whisper.security/docs/cypher-api)",
+      optional: true,
+    },
+    query: {
+      type: "string",
+      label: "Query",
+      description: "The query the recipe runs against. [Docs](https://www.whisper.security/docs/cypher-api)",
+      optional: true,
+    },
+    results: {
+      type: "string",
+      label: "Results",
+      description: "The results the recipe runs against. [Docs](https://www.whisper.security/docs/cypher-api)",
+      optional: true,
+    },
+    comment: {
+      type: "string",
+      label: "Comment",
+      description: "The comment the recipe runs against. [Docs](https://www.whisper.security/docs/cypher-api)",
+      optional: true,
+    },
+    severity: {
+      type: "string",
+      label: "Severity",
+      description: "The severity the recipe runs against. [Docs](https://www.whisper.security/docs/cypher-api)",
+      optional: true,
+    },
+    v: {
+      type: "string",
+      label: "V",
+      description: "The v the recipe runs against. [Docs](https://www.whisper.security/docs/cypher-api)",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const result = await this.app.runGraphRecipe({
+      $,
+      id: "submit",
+      values: {
+        kind: this.kind,
+        identifierKind: this.identifierKind,
+        value: this.value,
+        observationId: this.observationId,
+        confidence: this.confidence,
+        firstSeen: this.firstSeen,
+        provenance: this.provenance,
+        query: this.query,
+        results: this.results,
+        comment: this.comment,
+        severity: this.severity,
+        v: this.v,
+      },
+    });
+    $.export("$summary", this.app.graphSummary("submit", result));
+    return result;
+  },
+};

--- a/components/whisper/actions/whisper-graph-typosquat/whisper-graph-typosquat.mjs
+++ b/components/whisper/actions/whisper-graph-typosquat/whisper-graph-typosquat.mjs
@@ -1,0 +1,34 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-graph-typosquat",
+  name: "Graph: Typosquat & Brand-Impersonation Scanner",
+  description: "Find registered look-alikes of your brand and check which ones are dangerous. Finds registered impersonations across misspellings/risky TLDs, separates your own defensive domains from strangers’, flags fresh/privacy/abuse-listed ones into a prioritised list. Runs the `typosquat` multi-step flow on the whisper.security graph (keyed - connect your Whisper API key). [See the documentation](https://www.whisper.security/docs/recipes/brand-protection)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    domain: {
+      type: "string",
+      label: "Domain",
+      description: "The domain the recipe runs against. [Docs](https://www.whisper.security/docs/recipes/brand-protection)",
+      default: "paypal.com",
+    },
+  },
+  async run({ $ }) {
+    const result = await this.app.runGraphRecipe({
+      $,
+      id: "typosquat",
+      values: {
+        domain: this.domain,
+      },
+    });
+    $.export("$summary", this.app.graphSummary("typosquat", result));
+    return result;
+  },
+};

--- a/components/whisper/actions/whisper-graph-typosquat/whisper-graph-typosquat.mjs
+++ b/components/whisper/actions/whisper-graph-typosquat/whisper-graph-typosquat.mjs
@@ -1,0 +1,34 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-graph-typosquat",
+  name: "Graph: Typosquat & Brand-Impersonation Scanner",
+  description: "Find registered look-alikes of your brand and check which ones are dangerous. Finds registered impersonations across misspellings/risky TLDs, separates your own defensive domains from strangers', flags fresh/privacy/abuse-listed ones into a prioritised list. Runs the `typosquat` multi-step flow on the whisper.security graph (keyed - connect your Whisper API key). [See the documentation](https://www.whisper.security/docs/recipes/brand-protection)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    domain: {
+      type: "string",
+      label: "Domain",
+      description: "The domain the recipe runs against. [Docs](https://www.whisper.security/docs/recipes/brand-protection)",
+      default: "paypal.com",
+    },
+  },
+  async run({ $ }) {
+    const result = await this.app.runGraphRecipe({
+      $,
+      id: "typosquat",
+      values: {
+        domain: this.domain,
+      },
+    });
+    $.export("$summary", this.app.graphSummary("typosquat", result));
+    return result;
+  },
+};

--- a/components/whisper/actions/whisper-graph-variants/whisper-graph-variants.mjs
+++ b/components/whisper/actions/whisper-graph-variants/whisper-graph-variants.mjs
@@ -1,0 +1,34 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-graph-variants",
+  name: "Graph: Typosquat Variant Generator (whisper.variants)",
+  description: "Generate look-alike domain variants of a brand and see which are registered. Enumerates permutations (omission, bitsquatting, ...) of a domain, flags which exist, with a per-variant confidence. Runs the `variants` graph procedure on the whisper.security graph (keyed - connect your Whisper API key). [See the documentation](https://www.whisper.security/docs/whisper-graph/procedures/variants)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    value: {
+      type: "string",
+      label: "Value",
+      description: "The value the recipe runs against. [Docs](https://www.whisper.security/docs/whisper-graph/procedures/variants)",
+      default: "paypal.com",
+    },
+  },
+  async run({ $ }) {
+    const result = await this.app.runGraphRecipe({
+      $,
+      id: "variants",
+      values: {
+        value: this.value,
+      },
+    });
+    $.export("$summary", this.app.graphSummary("variants", result));
+    return result;
+  },
+};

--- a/components/whisper/actions/whisper-graph-walk/whisper-graph-walk.mjs
+++ b/components/whisper/actions/whisper-graph-walk/whisper-graph-walk.mjs
@@ -1,0 +1,34 @@
+import app from "../../whisper.app.mjs";
+
+export default {
+  key: "whisper-graph-walk",
+  name: "Graph: Vendor Attribution Walk (whisper.walk)",
+  description: "Walk the graph to the nearest known vendors behind a host, with the channel and confidence. Structural attribution: returns nearest_known_vendors with the channel (DELEGATED_TO / ORIGIN_AS) and confidence, plus siblings and coverage - explains WHY a host maps to a vendor. Runs the `walk` graph procedure on the whisper.security graph (keyed - connect your Whisper API key). [See the documentation](https://www.whisper.security/docs/whisper-graph/procedures)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    app,
+    value: {
+      type: "string",
+      label: "Value",
+      description: "The value the recipe runs against. [Docs](https://www.whisper.security/docs/whisper-graph/procedures)",
+      default: "cloudflare.com",
+    },
+  },
+  async run({ $ }) {
+    const result = await this.app.runGraphRecipe({
+      $,
+      id: "walk",
+      values: {
+        value: this.value,
+      },
+    });
+    $.export("$summary", this.app.graphSummary("walk", result));
+    return result;
+  },
+};

--- a/components/whisper/package.json
+++ b/components/whisper/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@pipedream/whisper",
+  "version": "0.0.1",
+  "description": "Pipedream Whisper Components",
+  "main": "whisper.app.mjs",
+  "keywords": [
+    "pipedream",
+    "whisper"
+  ],
+  "homepage": "https://pipedream.com/apps/whisper",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^3.1.1"
+  }
+}

--- a/components/whisper/whisper.app.mjs
+++ b/components/whisper/whisper.app.mjs
@@ -1,0 +1,63 @@
+import { axios } from "@pipedream/platform";
+
+export default {
+  type: "app",
+  app: "whisper",
+  propDefinitions: {
+    address: {
+      type: "string",
+      label: "Agent IPv6 Address",
+      description: "The Whisper agent's routable IPv6 `/128` address to inspect, e.g. `2a04:2a01:b69a:6717:e3b0:51ff:3bf7:f478`. Whisper agent addresses live in the `2a04:2a01::/32` range (AS219419). Compressed or expanded IPv6 notation is accepted.",
+    },
+  },
+  methods: {
+    _baseUrl() {
+      return "https://rdap.whisper.online";
+    },
+    async _makeRequest({
+      $ = this,
+      path,
+      ...args
+    }) {
+      return axios($, {
+        url: `${this._baseUrl()}${path}`,
+        ...args,
+      });
+    },
+    async verifyIdentity({
+      address, ...args
+    }) {
+      return this._makeRequest({
+        path: "/verify-identity",
+        params: {
+          ip: address,
+        },
+        ...args,
+      });
+    },
+    async getRdapRecord({
+      address, ...args
+    }) {
+      return this._makeRequest({
+        path: `/ip/${address}`,
+        ...args,
+      });
+    },
+    async getTransparencyLog({
+      address, ...args
+    }) {
+      return this._makeRequest({
+        path: `/ip/${address}/transparency`,
+        ...args,
+      });
+    },
+    async getInboundLookups({
+      address, ...args
+    }) {
+      return this._makeRequest({
+        path: `/ip/${address}/lookups`,
+        ...args,
+      });
+    },
+  },
+};

--- a/components/whisper/whisper.app.mjs
+++ b/components/whisper/whisper.app.mjs
@@ -1,33 +1,175 @@
-import { axios } from "@pipedream/platform";
+import { axios, ConfigurationError } from "@pipedream/platform";
+
+// Canonical public endpoints (see docs/packaging/CONTROL_API.md — the client-facing
+// contract, reverse-engineered from the `whisper` CLI reference implementation).
+//   - graph.whisper.security is the ONE keyed control endpoint (the whisper.agents verb).
+//   - rdap.whisper.online is the keyless, anonymous public identity API.
+const CONTROL_URL = "https://graph.whisper.security/api/query";
+const RDAP_URL = "https://rdap.whisper.online";
 
 export default {
   type: "app",
   app: "whisper",
   propDefinitions: {
+    // --- keyless target (verify / RDAP) ---------------------------------------------
     address: {
       type: "string",
       label: "Agent IPv6 Address",
       description: "The Whisper agent's routable IPv6 `/128` address to inspect, e.g. `2a04:2a01:b69a:6717:e3b0:51ff:3bf7:f478`. Whisper agent addresses live in the `2a04:2a01::/32` range (AS219419). Compressed or expanded IPv6 notation is accepted.",
     },
+    // --- control-plane (keyed) ------------------------------------------------------
+    label: {
+      type: "string",
+      label: "Name",
+      description: "The agent's human name — maps to the server label surfaced by **List Agents** and RDAP, e.g. `scout`.",
+    },
+    contactEmail: {
+      type: "string",
+      label: "Contact Email",
+      description: "Optional, opt-in public contact email surfaced in the agent's RDAP record.",
+      optional: true,
+    },
+    listKind: {
+      type: "string",
+      label: "Kind",
+      description: "What to list, confined to your own tenant.",
+      options: [
+        {
+          label: "Agents",
+          value: "agents",
+        },
+        {
+          label: "Identities",
+          value: "identities",
+        },
+        {
+          label: "DNS Records",
+          value: "records",
+        },
+      ],
+      default: "agents",
+      optional: true,
+    },
+    agent: {
+      type: "string",
+      label: "Agent",
+      description: "Select the agent by its id (e.g. `agent-ae3b051ff3bf7f478`) or its `/128` address.",
+    },
+    policyDefault: {
+      type: "string",
+      label: "Default Action",
+      description: "The default action for names not on a list. Leave unset (with empty lists) to just **read** the current policy back. Note: setting any policy field replaces the whole policy.",
+      options: [
+        {
+          label: "Allow",
+          value: "allow",
+        },
+        {
+          label: "Deny",
+          value: "deny",
+        },
+      ],
+      optional: true,
+    },
+    block: {
+      type: "string[]",
+      label: "Block List",
+      description: "Names to block (max 1000 combined with the allow list), e.g. `ads.example.com`.",
+      optional: true,
+    },
+    allow: {
+      type: "string[]",
+      label: "Allow List",
+      description: "Names to allow, e.g. `api.openai.com`.",
+      optional: true,
+    },
+    bundles: {
+      type: "string[]",
+      label: "Policy Bundles",
+      description: "Named graph-backed policy postures — the geo / category / threat controls. Each entry is a bundle token: `block:tor-exits`, `block:bulletproof`, `block:rpki-invalid`, `block:sanctions`, `block:newly-registered`, or `geo:deny:RU,KP` (ISO-3166 alpha-2 country codes).",
+      optional: true,
+    },
+    logsAgent: {
+      type: "string",
+      label: "Agent",
+      description: "Narrow to one agent (id or `/128` address). Leave blank for the whole tenant.",
+      optional: true,
+    },
+    logsKind: {
+      type: "string",
+      label: "Kind",
+      description: "Which event kind to return (`All` interleaves every kind).",
+      options: [
+        {
+          label: "All",
+          value: "all",
+        },
+        {
+          label: "DNS",
+          value: "dns",
+        },
+        {
+          label: "Connections",
+          value: "conn",
+        },
+        {
+          label: "Allocations",
+          value: "alloc",
+        },
+      ],
+      default: "all",
+      optional: true,
+    },
+    from: {
+      type: "string",
+      label: "From",
+      description: "Window start — a relative offset (e.g. `-1h`), epoch-ms, or an RFC-3339 timestamp.",
+      optional: true,
+    },
+    to: {
+      type: "string",
+      label: "To",
+      description: "Window end — a relative offset, epoch-ms, or an RFC-3339 timestamp.",
+      optional: true,
+    },
+    limit: {
+      type: "integer",
+      label: "Limit",
+      description: "Max rows to return.",
+      min: 1,
+      max: 10000,
+      default: 1000,
+      optional: true,
+    },
   },
   methods: {
-    _baseUrl() {
-      return "https://rdap.whisper.online";
+    // ================================================================================
+    // Keyless tier — the public, anonymous identity API (rdap.whisper.online).
+    // These take NO auth header and work whether or not a Whisper key is connected.
+    // ================================================================================
+    _rdapUrl() {
+      return RDAP_URL;
     },
-    async _makeRequest({
+    async _rdapRequest({
       $ = this,
       path,
       ...args
     }) {
       return axios($, {
-        url: `${this._baseUrl()}${path}`,
+        url: `${this._rdapUrl()}${path}`,
+        headers: {
+          // Liberal-accept (Postel): the RDAP record is served as application/rdap+json,
+          // the others as application/json. Asking only for application/json makes the
+          // RDAP endpoint answer 406 Not Acceptable.
+          Accept: "application/rdap+json, application/json;q=0.9, */*;q=0.1",
+        },
         ...args,
       });
     },
     async verifyIdentity({
       address, ...args
     }) {
-      return this._makeRequest({
+      return this._rdapRequest({
         path: "/verify-identity",
         params: {
           ip: address,
@@ -38,7 +180,7 @@ export default {
     async getRdapRecord({
       address, ...args
     }) {
-      return this._makeRequest({
+      return this._rdapRequest({
         path: `/ip/${address}`,
         ...args,
       });
@@ -46,7 +188,7 @@ export default {
     async getTransparencyLog({
       address, ...args
     }) {
-      return this._makeRequest({
+      return this._rdapRequest({
         path: `/ip/${address}/transparency`,
         ...args,
       });
@@ -54,9 +196,278 @@ export default {
     async getInboundLookups({
       address, ...args
     }) {
-      return this._makeRequest({
+      return this._rdapRequest({
         path: `/ip/${address}/lookups`,
         ...args,
+      });
+    },
+
+    // ================================================================================
+    // Control tier — the keyed control plane (graph.whisper.security). One Cypher verb,
+    // whisper.agents({op, args}), POSTed with the account key in the X-API-Key header.
+    // ================================================================================
+    _controlUrl() {
+      return CONTROL_URL;
+    },
+    _apiKey() {
+      return this.$auth?.api_key;
+    },
+    _requireApiKey() {
+      const key = this._apiKey();
+      if (!key || `${key}`.trim() === "") {
+        throw new ConfigurationError(
+          "This action needs your Whisper API key. Connect a Whisper account with your `whisper_live_…` key to unlock the control plane. (The Verify / RDAP actions work without a key.)",
+        );
+      }
+      return key;
+    },
+
+    // --- Cypher literal builder (ports the CLI's client/cypher.go exactly) -----------
+    // Conservative-emit: a single quote is doubled (openCypher escaping) and a backslash
+    // is doubled, so a hostile value can never escape the surrounding '…' literal or map.
+    _quoteCypher(s) {
+      return `'${String(s).replace(/\\/g, "\\\\").replace(/'/g, "''")}'`;
+    },
+    _litCypher(v) {
+      if (v === null || v === undefined) {
+        return "null";
+      }
+      if (typeof v === "string") {
+        return this._quoteCypher(v);
+      }
+      if (typeof v === "boolean") {
+        return v
+          ? "true"
+          : "false";
+      }
+      if (typeof v === "number") {
+        return String(v);
+      }
+      if (Array.isArray(v)) {
+        return `[${v.map((e) => this._litCypher(e)).join(",")}]`;
+      }
+      if (typeof v === "object") {
+        return this._cypherMap(v);
+      }
+      return this._quoteCypher(String(v));
+    },
+    // Keys are emitted in sorted order so the produced query is byte-stable (stable for
+    // tests, caches and logs), exactly like the CLI's CypherMap.
+    _cypherMap(m) {
+      const keys = Object.keys(m)
+        .filter((k) => m[k] !== undefined)
+        .sort();
+      if (keys.length === 0) {
+        return "{}";
+      }
+      return `{${keys.map((k) => `${k}:${this._litCypher(m[k])}`).join(",")}}`;
+    },
+    _buildAgentsQuery(op, args = {}) {
+      const inner = Object.keys(args).length
+        ? this._cypherMap(args)
+        : "{}";
+      return `CALL whisper.agents({op:${this._quoteCypher(op)}, args:${inner}})`;
+    },
+
+    // --- Envelope decoding (ports client/envelope.go — liberal in what we accept) ----
+    _problemMessage(err, status) {
+      if (err) {
+        if (err.detail) {
+          return err.detail;
+        }
+        if (err.title) {
+          return err.title;
+        }
+        if (err.type) {
+          return err.type;
+        }
+      }
+      return `control plane returned status ${status ?? "(unknown)"}`;
+    },
+    _recordsFromResult(result) {
+      if (result === null || result === undefined) {
+        return [];
+      }
+      if (Array.isArray(result)) {
+        return result;
+      }
+      const cols = result.columns;
+      const rows = result.rows;
+      if (Array.isArray(cols) && Array.isArray(rows)) {
+        return rows.map((row) => {
+          if (!Array.isArray(row)) {
+            return row;
+          }
+          const out = {};
+          cols.forEach((c, i) => {
+            out[c] = row[i];
+          });
+          return out;
+        });
+      }
+      return [
+        result,
+      ];
+    },
+    // Accepts BOTH wire shapes the control plane returns (CONTROL_API.md section 2):
+    //   A. the live procedure-row table: {columns, rows:[{op,ok,status,result,error}]}
+    //   B. the dev-guide flat envelope:  {ok, status, result, error}
+    //   + a bare {columns, rows:[[…]]} table, and a bare problem object.
+    // Returns the decoded records; throws a clear, helpful error on ok:false (Postel).
+    _decodeEnvelope(body, httpStatus) {
+      const obj = body;
+
+      // Shape B: an explicit top-level ok flag.
+      if (obj && typeof obj === "object" && "ok" in obj) {
+        if (obj.ok === false) {
+          throw new Error(this._problemMessage(obj.error, obj.status ?? httpStatus));
+        }
+        return this._recordsFromResult(obj.result);
+      }
+
+      // Shapes A & bare-table: a {columns, rows} table.
+      if (obj && typeof obj === "object" && Array.isArray(obj.rows)) {
+        const rows = obj.rows;
+        if (rows.length === 0) {
+          return [];
+        }
+        const first = rows[0];
+        // Shape A: each row is a per-op envelope object {op,ok,status,result,error,…}.
+        if (first && typeof first === "object" && !Array.isArray(first) && "ok" in first) {
+          if (first.ok === false) {
+            throw new Error(this._problemMessage(first.error, first.status ?? httpStatus));
+          }
+          if (first.result !== undefined && first.result !== null) {
+            return this._recordsFromResult(first.result);
+          }
+          return [
+            first,
+          ];
+        }
+        // Bare table: positional rows against the outer columns.
+        if (Array.isArray(obj.columns)) {
+          return this._recordsFromResult(obj);
+        }
+        return rows;
+      }
+
+      // A >=400 transport status with no usable body is itself the fault.
+      if (httpStatus >= 400) {
+        throw new Error(this._problemMessage(obj, httpStatus));
+      }
+      // A bare object → a single record.
+      return obj
+        ? [
+          obj,
+        ]
+        : [];
+    },
+
+    // Run one control op and return the decoded records (throws a helpful error on fail).
+    async _agents({
+      $ = this, op, args = {},
+    }) {
+      const apiKey = this._requireApiKey();
+      const response = await axios($, {
+        method: "POST",
+        url: this._controlUrl(),
+        headers: {
+          "X-API-Key": apiKey,
+          "Content-Type": "application/json",
+          "Accept": "application/json",
+        },
+        data: {
+          query: this._buildAgentsQuery(op, args),
+        },
+        returnFullResponse: true,
+        validateStatus: () => true,
+      });
+      return this._decodeEnvelope(response.data, response.status);
+    },
+
+    // --- control op wrappers --------------------------------------------------------
+    async registerAgent({
+      $ = this, label, contactEmail,
+    }) {
+      const args = {
+        label,
+      };
+      if (contactEmail) {
+        args.contact_email = contactEmail;
+      }
+      return this._agents({
+        $,
+        op: "register",
+        args,
+      });
+    },
+    async listAgents({
+      $ = this, kind,
+    }) {
+      return this._agents({
+        $,
+        op: "list",
+        args: {
+          kind: kind || "agents",
+        },
+      });
+    },
+    async setPolicy({
+      $ = this, block, allow, bundles, policyDefault,
+    }) {
+      const args = {};
+      if (block?.length) {
+        args.block = block;
+      }
+      if (allow?.length) {
+        args.allow = allow;
+      }
+      if (bundles?.length) {
+        args.bundles = bundles;
+      }
+      if (policyDefault) {
+        args.default = policyDefault;
+      }
+      return this._agents({
+        $,
+        op: "policy",
+        args,
+      });
+    },
+    async getLogs({
+      $ = this, agent, kind, from, to, limit,
+    }) {
+      const args = {};
+      if (agent) {
+        args.agent = agent;
+      }
+      if (kind && kind !== "all") {
+        args.kind = kind;
+      }
+      if (from) {
+        args.from = from;
+      }
+      if (to) {
+        args.to = to;
+      }
+      if (limit) {
+        args.limit = limit;
+      }
+      return this._agents({
+        $,
+        op: "logs",
+        args,
+      });
+    },
+    async revokeAgent({
+      $ = this, agent,
+    }) {
+      return this._agents({
+        $,
+        op: "revoke",
+        args: {
+          agent,
+        },
       });
     },
   },

--- a/components/whisper/whisper.app.mjs
+++ b/components/whisper/whisper.app.mjs
@@ -1,7 +1,7 @@
 import { axios, ConfigurationError } from "@pipedream/platform";
 
-// Canonical public endpoints (see docs/packaging/CONTROL_API.md — the client-facing
-// contract, reverse-engineered from the `whisper` CLI reference implementation).
+// Canonical public endpoints (matching the open-source `whisper` CLI, the
+// reference implementation of this client contract).
 //   - graph.whisper.security is the ONE keyed control endpoint (the whisper.agents verb).
 //   - rdap.whisper.online is the keyless, anonymous public identity API.
 const CONTROL_URL = "https://graph.whisper.security/api/query";
@@ -54,6 +54,46 @@ export default {
       type: "string",
       label: "Agent",
       description: "Select the agent by its id (e.g. `agent-ae3b051ff3bf7f478`) or its `/128` address.",
+    },
+    connectAgent: {
+      type: "string",
+      label: "Agent",
+      description: "The agent to bind the egress to — its id or `/128` address. Leave blank to reuse your most recently allocated agent.",
+      optional: true,
+    },
+    tier: {
+      type: "string",
+      label: "Tier",
+      description: "The egress mechanism. `SOCKS5` (default) is a hosted SOCKS5/HTTP proxy source-bound to the agent's `/128`; `WireGuard` is a routed tunnel (bring your own client public key).",
+      options: [
+        {
+          label: "SOCKS5",
+          value: "socks5",
+        },
+        {
+          label: "WireGuard",
+          value: "wireguard",
+        },
+        {
+          label: "AnyIP",
+          value: "anyip",
+        },
+      ],
+      default: "socks5",
+      optional: true,
+    },
+    publicKey: {
+      type: "string",
+      label: "WireGuard Public Key",
+      description: "Your WireGuard client's base64 public key. Required for the `WireGuard` tier; ignored otherwise.",
+      optional: true,
+    },
+    includeSecrets: {
+      type: "boolean",
+      label: "Include Secrets",
+      description: "Off by default (recommended): the returned config is **stripped of its secrets** — the proxy credential URLs and any private key — so no bearer token lands in your workflow's step exports or logs. Turn on only if a downstream step must consume the credentials directly, and treat the step export as sensitive.",
+      default: false,
+      optional: true,
     },
     policyDefault: {
       type: "string",
@@ -201,6 +241,12 @@ export default {
         ...args,
       });
     },
+    async getEgressIp(args = {}) {
+      return this._rdapRequest({
+        path: "/egress-ip",
+        ...args,
+      });
+    },
 
     // ================================================================================
     // Control tier — the keyed control plane (graph.whisper.security). One Cypher verb,
@@ -309,7 +355,7 @@ export default {
         result,
       ];
     },
-    // Accepts BOTH wire shapes the control plane returns (CONTROL_API.md section 2):
+    // Accepts BOTH wire shapes the control plane may return:
     //   A. the live procedure-row table: {columns, rows:[{op,ok,status,result,error}]}
     //   B. the dev-guide flat envelope:  {ok, status, result, error}
     //   + a bare {columns, rows:[[…]]} table, and a bare problem object.
@@ -398,6 +444,85 @@ export default {
       return this._agents({
         $,
         op: "register",
+        args,
+      });
+    },
+    async allocateIdentity({
+      $ = this, label, contactEmail,
+    }) {
+      const args = {
+        label,
+      };
+      if (contactEmail) {
+        args.contact_email = contactEmail;
+      }
+      return this._agents({
+        $,
+        op: "identity",
+        args,
+      });
+    },
+    async connectEgress({
+      $ = this, agent, tier, publicKey,
+    }) {
+      const args = {};
+      if (agent) {
+        args.agent = agent;
+      }
+      if (tier) {
+        args.tier = tier;
+      }
+      if (publicKey) {
+        args.public_key = publicKey;
+      }
+      return this._agents({
+        $,
+        op: "connect",
+        args,
+      });
+    },
+    // The connect result embeds live credentials (a bearer inside the proxy URLs, and —
+    // on the zero-key WireGuard path — a client private key). Integrations that don't
+    // consume them directly must strip them so no secret lands in step exports or logs.
+    stripEgressSecrets(record) {
+      const SECRET_FIELDS = [
+        "http_proxy",
+        "https_proxy",
+        "connection_string",
+        "socks5_endpoint",
+        "client_private_key",
+        "wireguard_config",
+      ];
+      const out = {
+        ...record,
+      };
+      const stripped = [];
+      for (const f of SECRET_FIELDS) {
+        if (out[f] !== undefined && out[f] !== null) {
+          delete out[f];
+          stripped.push(f);
+        }
+      }
+      if (stripped.length) {
+        out.secrets_stripped = stripped;
+      }
+      return out;
+    },
+    async getAgent({
+      $ = this, agent,
+    }) {
+      // The control plane keys the lookup by `agent` (an id) or `address` (a /128) —
+      // liberal-accept: anything containing a colon is an address.
+      const args = String(agent).includes(":")
+        ? {
+          address: agent,
+        }
+        : {
+          agent,
+        };
+      return this._agents({
+        $,
+        op: "agent",
         args,
       });
     },

--- a/components/whisper/whisper.app.mjs
+++ b/components/whisper/whisper.app.mjs
@@ -1,0 +1,1440 @@
+import {
+  axios, ConfigurationError,
+} from "@pipedream/platform";
+
+// Canonical public endpoints (matching the open-source `whisper` CLI, the
+// reference implementation of this client contract).
+//   - graph.whisper.online is the ONE keyed control endpoint (the whisper.agents verb).
+//   - rdap.whisper.online is the keyless, anonymous public identity API.
+const CONTROL_URL = "https://graph.whisper.online/api/query";
+const RDAP_URL = "https://rdap.whisper.online";
+
+// The whisper.security intelligence graph. GRAPH_URL is the same keyed query endpoint as
+// CONTROL_URL (one host); FLOW_RUN_URL runs a multi-step catalog flow by slug and streams
+// its steps back as Server-Sent Events. Docs pages hang off GRAPH_DOCS_BASE.
+const GRAPH_URL = "https://graph.whisper.online/api/query";
+const FLOW_RUN_URL = "https://console.whisper.security/api/gallery/run";
+const GRAPH_DOCS_BASE = "https://www.whisper.security";
+
+// BEGIN GENERATED: graph catalog (from the whisper catalog SSOT, catalog.json) - do not
+// edit by hand. 14 direct procedures (their Cypher runs as-is on /api/query) + 15 multi-
+// step flows (run by slug on the console gallery/run endpoint, SSE). `docsUrl` is the docs
+// page (GRAPH_DOCS_BASE + the catalog docPath).
+const GRAPH_CATALOG = [
+  {
+    "id": "anycast-dns-root-sovereignty",
+    "title": "Anycast DNS-Root Sovereignty",
+    "mode": "flow",
+    "docsUrl": "https://www.whisper.security/docs/recipes/compliance",
+    "inputs": [
+      {
+        "id": "country",
+        "paramName": "country",
+        "optional": false,
+      },
+    ],
+    "slug": "anycast-dns-root-sovereignty",
+    "params": [
+      "instanceType",
+    ],
+  },
+  {
+    "id": "attack-path",
+    "title": "Attack Path & Connection Finder",
+    "mode": "flow",
+    "docsUrl": "https://www.whisper.security/docs/recipes/attack-path",
+    "inputs": [
+      {
+        "id": "asset",
+        "paramName": "value",
+        "optional": false,
+      },
+      {
+        "id": "other",
+        "paramName": "other",
+        "optional": false,
+      },
+    ],
+    "slug": "attack-path",
+    "params": [
+      "level",
+    ],
+  },
+  {
+    "id": "attack-surface",
+    "title": "Attack-Surface Mapper",
+    "mode": "flow",
+    "docsUrl": "https://www.whisper.security/docs/recipes/pentest-recon",
+    "inputs": [
+      {
+        "id": "domain",
+        "paramName": "domain",
+        "optional": false,
+      },
+    ],
+    "slug": "attack-surface",
+    "params": [
+      "level",
+    ],
+  },
+  {
+    "id": "bgp-hijack-exposure",
+    "title": "BGP Hijack & Routing-Hygiene Audit",
+    "mode": "flow",
+    "docsUrl": "https://www.whisper.security/docs/recipes/bgp-routing",
+    "inputs": [
+      {
+        "id": "asn",
+        "paramName": "value",
+        "optional": false,
+      },
+    ],
+    "slug": "bgp-hijack-exposure",
+    "params": [],
+  },
+  {
+    "id": "blast-radius",
+    "title": "Dependency Blast Radius",
+    "mode": "flow",
+    "docsUrl": "https://www.whisper.security/docs/recipes/soc",
+    "inputs": [
+      {
+        "id": "asset",
+        "paramName": "indicator",
+        "optional": false,
+      },
+    ],
+    "slug": "blast-radius",
+    "params": [
+      "depth",
+    ],
+  },
+  {
+    "id": "build-takedown-evidence-package",
+    "title": "Takedown Evidence Package",
+    "mode": "flow",
+    "docsUrl": "https://www.whisper.security/docs/recipes/threat-intel",
+    "inputs": [
+      {
+        "id": "domain",
+        "paramName": "domain",
+        "optional": false,
+      },
+    ],
+    "slug": "build-takedown-evidence-package",
+    "params": [],
+  },
+  {
+    "id": "discover-ai-agent-infrastructure",
+    "title": "AI / Agent Infrastructure Discovery",
+    "mode": "flow",
+    "docsUrl": "https://www.whisper.security/docs/recipes/pentest-recon",
+    "inputs": [
+      {
+        "id": "domain",
+        "paramName": "value",
+        "optional": false,
+      },
+    ],
+    "slug": "discover-ai-agent-infrastructure",
+    "params": [],
+  },
+  {
+    "id": "indicator",
+    "title": "Threat Investigation",
+    "mode": "flow",
+    "docsUrl": "https://www.whisper.security/docs/recipes/soc",
+    "inputs": [
+      {
+        "id": "indicator",
+        "paramName": "indicator",
+        "optional": false,
+      },
+    ],
+    "slug": "indicator",
+    "params": [],
+  },
+  {
+    "id": "indicator-enrichment",
+    "title": "Indicator Enrichment",
+    "mode": "flow",
+    "docsUrl": "https://www.whisper.security/docs/recipes/dns-email",
+    "inputs": [
+      {
+        "id": "domain",
+        "paramName": "value",
+        "optional": false,
+      },
+    ],
+    "slug": "indicator-enrichment",
+    "params": [],
+  },
+  {
+    "id": "infrastructure-mapping",
+    "title": "Digital Infrastructure Mapping",
+    "mode": "flow",
+    "docsUrl": "https://www.whisper.security/docs/recipes/compliance",
+    "inputs": [
+      {
+        "id": "target",
+        "paramName": "value",
+        "optional": false,
+      },
+    ],
+    "slug": "infrastructure-mapping",
+    "params": [
+      "level",
+    ],
+  },
+  {
+    "id": "map-supply-chain-concentration",
+    "title": "Infrastructure Concentration & Resilience",
+    "mode": "flow",
+    "docsUrl": "https://www.whisper.security/docs/recipes/compliance",
+    "inputs": [
+      {
+        "id": "domain",
+        "paramName": "domain",
+        "optional": false,
+      },
+    ],
+    "slug": "map-supply-chain-concentration",
+    "params": [],
+  },
+  {
+    "id": "nameserver-hijack-dns-consistency",
+    "title": "Nameserver & DNS Delegation Audit",
+    "mode": "flow",
+    "docsUrl": "https://www.whisper.security/docs/recipes/dns-email",
+    "inputs": [
+      {
+        "id": "domain",
+        "paramName": "value",
+        "optional": false,
+      },
+    ],
+    "slug": "nameserver-hijack-dns-consistency",
+    "params": [],
+  },
+  {
+    "id": "route-health",
+    "title": "Network & Routing Report",
+    "mode": "flow",
+    "docsUrl": "https://www.whisper.security/docs/recipes/bgp-routing",
+    "inputs": [
+      {
+        "id": "target",
+        "paramName": "target",
+        "optional": false,
+      },
+    ],
+    "slug": "route-health",
+    "params": [],
+  },
+  {
+    "id": "subdomain-takeover",
+    "title": "Subdomain Takeover Detection",
+    "mode": "flow",
+    "docsUrl": "https://www.whisper.security/docs/recipes/pentest-recon",
+    "inputs": [
+      {
+        "id": "domain",
+        "paramName": "value",
+        "optional": false,
+      },
+    ],
+    "slug": "subdomain-takeover",
+    "params": [],
+  },
+  {
+    "id": "typosquat",
+    "title": "Typosquat & Brand-Impersonation Scanner",
+    "mode": "flow",
+    "docsUrl": "https://www.whisper.security/docs/recipes/brand-protection",
+    "inputs": [
+      {
+        "id": "domain",
+        "paramName": "domain",
+        "optional": false,
+      },
+    ],
+    "slug": "typosquat",
+    "params": [],
+  },
+  {
+    "id": "identify",
+    "title": "Vendor / Operator Identity (whisper.identify)",
+    "mode": "direct",
+    "docsUrl": "https://www.whisper.security/docs/whisper-graph/procedures/identify",
+    "inputs": [
+      {
+        "id": "value",
+        "paramName": "v",
+        "optional": false,
+      },
+    ],
+    "cypher": "CALL whisper.identify([$v]) YIELD host, vendor_id, canonical_name, category, roles, host_class, band",
+  },
+  {
+    "id": "assess",
+    "title": "Threat Posture (whisper.assess)",
+    "mode": "direct",
+    "docsUrl": "https://www.whisper.security/docs/whisper-graph/procedures",
+    "inputs": [
+      {
+        "id": "value",
+        "paramName": "v",
+        "optional": false,
+      },
+    ],
+    "cypher": "CALL whisper.assess([$v]) YIELD host, label, band, sub_labels, coverage, evidence",
+  },
+  {
+    "id": "variants",
+    "title": "Typosquat Variant Generator (whisper.variants)",
+    "mode": "direct",
+    "docsUrl": "https://www.whisper.security/docs/whisper-graph/procedures/variants",
+    "inputs": [
+      {
+        "id": "value",
+        "paramName": "v",
+        "optional": false,
+      },
+    ],
+    "cypher": "CALL whisper.variants($v) YIELD variant, method, exists, confidence",
+  },
+  {
+    "id": "walk",
+    "title": "Vendor Attribution Walk (whisper.walk)",
+    "mode": "direct",
+    "docsUrl": "https://www.whisper.security/docs/whisper-graph/procedures",
+    "inputs": [
+      {
+        "id": "value",
+        "paramName": "v",
+        "optional": false,
+      },
+    ],
+    "cypher": "CALL whisper.walk($v) YIELD coverage, host, nearest_known_vendors, no_atlas_match, siblings",
+  },
+  {
+    "id": "explain",
+    "title": "Threat-Feed Explainer (whisper.explain / explain)",
+    "mode": "direct",
+    "docsUrl": "https://www.whisper.security/docs/whisper-graph/procedures/explain",
+    "inputs": [
+      {
+        "id": "value",
+        "paramName": "v",
+        "optional": false,
+      },
+    ],
+    "cypher": "CALL whisper.explain($v) YIELD indicator, score, level, explanation, sources",
+  },
+  {
+    "id": "psl-tldplusone",
+    "title": "Registrable Apex (whisper.psl.tldPlusOne)",
+    "mode": "direct",
+    "docsUrl": "https://www.whisper.security/docs/whisper-graph/procedures/helpers",
+    "inputs": [
+      {
+        "id": "value",
+        "paramName": "v",
+        "optional": false,
+      },
+    ],
+    "cypher": "CALL whisper.psl.tldPlusOne($v) YIELD apex",
+  },
+  {
+    "id": "psl-affiliation",
+    "title": "PSL Private-Suffix Affiliation (whisper.psl.affiliation)",
+    "mode": "direct",
+    "docsUrl": "https://www.whisper.security/docs/whisper-graph/procedures/helpers",
+    "inputs": [
+      {
+        "id": "value",
+        "paramName": "v",
+        "optional": false,
+      },
+    ],
+    "cypher": "CALL whisper.psl.affiliation($v) YIELD found, suffix, submitterOrg, submitterLogin, evidenceKind, confidence",
+  },
+  {
+    "id": "origins",
+    "title": "CDN-Origin De-cloaker (whisper.origins)",
+    "mode": "direct",
+    "docsUrl": "https://www.whisper.security/docs/whisper-graph/procedures/origins",
+    "inputs": [
+      {
+        "id": "value",
+        "paramName": "v",
+        "optional": false,
+      },
+    ],
+    "cypher": "CALL whisper.origins($v) YIELD ip, confidence, methods, asn, asnName, kind",
+  },
+  {
+    "id": "history",
+    "title": "WHOIS History Timeline (whisper.history)",
+    "mode": "direct",
+    "docsUrl": "https://www.whisper.security/docs/whisper-graph/procedures/history",
+    "inputs": [
+      {
+        "id": "value",
+        "paramName": "v",
+        "optional": false,
+      },
+    ],
+    "cypher": "CALL whisper.history($v)",
+  },
+  {
+    "id": "history-whois",
+    "title": "WHOIS History (projection) (whisper.history.whois)",
+    "mode": "direct",
+    "docsUrl": "https://www.whisper.security/docs/whisper-graph/procedures/history",
+    "inputs": [
+      {
+        "id": "value",
+        "paramName": "v",
+        "optional": false,
+      },
+    ],
+    "cypher": "CALL whisper.history.whois($v) YIELD queryTime, createDate, updateDate, expiryDate, registrar, registrant, country, nameServers",
+  },
+  {
+    "id": "asset",
+    "title": "AS-SET Membership (whisper.asSet)",
+    "mode": "direct",
+    "docsUrl": "https://www.whisper.security/docs/whisper-graph/procedures",
+    "inputs": [
+      {
+        "id": "value",
+        "paramName": "v",
+        "optional": false,
+      },
+    ],
+    "cypher": "CALL whisper.asSet($v) YIELD asSetName, memberAsn, sourceRir",
+  },
+  {
+    "id": "lookup-tor-relay",
+    "title": "Tor Exit-Relay Lookup (whisper.lookupTorRelay)",
+    "mode": "direct",
+    "docsUrl": "https://www.whisper.security/docs/whisper-graph/procedures/helpers",
+    "inputs": [
+      {
+        "id": "value",
+        "paramName": "v",
+        "optional": false,
+      },
+    ],
+    "cypher": "CALL whisper.lookupTorRelay($v) YIELD indicator, found, fingerprint, exitAddressCount, source, ingestedAt",
+  },
+  {
+    "id": "db-schema",
+    "title": "Graph Schema Catalog (db.schema)",
+    "mode": "direct",
+    "docsUrl": "https://www.whisper.security/docs/whisper-graph/schema",
+    "inputs": [],
+    "cypher": "CALL db.schema()",
+  },
+  {
+    "id": "submit",
+    "title": "Submit Observation / Feedback (whisper.submit)",
+    "mode": "direct",
+    "docsUrl": "https://www.whisper.security/docs/cypher-api",
+    "inputs": [
+      {
+        "id": "kind",
+        "paramName": "kind",
+        "optional": false,
+      },
+      {
+        "id": "identifierKind",
+        "paramName": "identifier_kind",
+        "optional": false,
+      },
+      {
+        "id": "value",
+        "paramName": "value",
+        "optional": false,
+      },
+      {
+        "id": "observationId",
+        "paramName": "observation_id",
+        "optional": true,
+      },
+      {
+        "id": "confidence",
+        "paramName": "confidence",
+        "optional": true,
+      },
+      {
+        "id": "firstSeen",
+        "paramName": "first_seen",
+        "optional": true,
+      },
+      {
+        "id": "provenance",
+        "paramName": "provenance",
+        "optional": true,
+      },
+      {
+        "id": "query",
+        "paramName": "query",
+        "optional": true,
+      },
+      {
+        "id": "results",
+        "paramName": "results",
+        "optional": true,
+      },
+      {
+        "id": "comment",
+        "paramName": "comment",
+        "optional": true,
+      },
+      {
+        "id": "severity",
+        "paramName": "severity",
+        "optional": true,
+      },
+      {
+        "id": "v",
+        "paramName": "v",
+        "optional": true,
+      },
+    ],
+    "map": "whisper.submit",
+  },
+];
+// END GENERATED: graph catalog
+
+export default {
+  type: "app",
+  app: "whisper",
+  propDefinitions: {
+    // --- keyless target (verify / RDAP) ---------------------------------------------
+    address: {
+      type: "string",
+      label: "Agent IPv6 Address",
+      description: "The Whisper agent's routable IPv6 `/128` address to inspect, e.g. `2a04:2a01:b69a:6717:e3b0:51ff:3bf7:f478`. Whisper agent addresses live in the `2a04:2a01::/32` range (AS219419). Compressed or expanded IPv6 notation is accepted.",
+    },
+    // --- control-plane (keyed) ------------------------------------------------------
+    label: {
+      type: "string",
+      label: "Name",
+      description: "The agent's human name - maps to the server label surfaced by **List Agents** and RDAP, e.g. `scout`.",
+    },
+    contactEmail: {
+      type: "string",
+      label: "Contact Email",
+      description: "Optional, opt-in public contact email surfaced in the agent's RDAP record.",
+      optional: true,
+    },
+    listKind: {
+      type: "string",
+      label: "Kind",
+      description: "What to list, confined to your own tenant.",
+      options: [
+        {
+          label: "Agents",
+          value: "agents",
+        },
+        {
+          label: "Identities",
+          value: "identities",
+        },
+        {
+          label: "DNS Records",
+          value: "records",
+        },
+      ],
+      default: "agents",
+      optional: true,
+    },
+    agent: {
+      type: "string",
+      label: "Agent",
+      description: "Select the agent by its id (e.g. `agent-ae3b051ff3bf7f478`) or its `/128` address.",
+    },
+    connectAgent: {
+      type: "string",
+      label: "Agent",
+      description: "The agent to bind the egress to - its id or `/128` address. Leave blank to reuse your most recently allocated agent.",
+      optional: true,
+    },
+    tier: {
+      type: "string",
+      label: "Tier",
+      description: "The egress mechanism. `SOCKS5` (default) is a hosted SOCKS5/HTTP proxy source-bound to the agent's `/128`; `WireGuard` is a routed tunnel (bring your own client public key); `AnyIP` is server-side source binding of the agent's `/128` on Whisper's edge, with no tunnel or proxy client on your side.",
+      options: [
+        {
+          label: "SOCKS5",
+          value: "socks5",
+        },
+        {
+          label: "WireGuard",
+          value: "wireguard",
+        },
+        {
+          label: "AnyIP",
+          value: "anyip",
+        },
+      ],
+      default: "socks5",
+      optional: true,
+    },
+    publicKey: {
+      type: "string",
+      label: "WireGuard Public Key",
+      description: "Your WireGuard client's base64 public key. Required for the `WireGuard` tier; ignored otherwise.",
+      optional: true,
+    },
+    includeSecrets: {
+      type: "boolean",
+      label: "Include Secrets",
+      description: "Off by default (recommended): the returned config is **stripped of its secrets** - the proxy credential URLs and any private key - so no bearer token lands in your workflow's step exports or logs. Turn on only if a downstream step must consume the credentials directly, and treat the step export as sensitive.",
+      default: false,
+      optional: true,
+    },
+    policyDefault: {
+      type: "string",
+      label: "Default Action",
+      description: "The default action for names not on a list. Leave unset (with empty lists) to just **read** the current policy back. Note: setting any policy field replaces the whole policy.",
+      options: [
+        {
+          label: "Allow",
+          value: "allow",
+        },
+        {
+          label: "Deny",
+          value: "deny",
+        },
+      ],
+      optional: true,
+    },
+    block: {
+      type: "string[]",
+      label: "Block List",
+      description: "Names to block (max 1000 combined with the allow list), e.g. `ads.example.com`.",
+      optional: true,
+    },
+    allow: {
+      type: "string[]",
+      label: "Allow List",
+      description: "Names to allow, e.g. `api.openai.com`.",
+      optional: true,
+    },
+    bundles: {
+      type: "string[]",
+      label: "Policy Bundles",
+      description: "Named graph-backed policy postures - the geo / category / threat controls. Each entry is a bundle token: `block:tor-exits`, `block:bulletproof`, `block:rpki-invalid`, `block:sanctions`, `block:newly-registered`, or `geo:deny:RU,KP` (ISO-3166 alpha-2 country codes).",
+      optional: true,
+    },
+    logsAgent: {
+      type: "string",
+      label: "Agent",
+      description: "Narrow to one agent (id or `/128` address). Leave blank for the whole tenant.",
+      optional: true,
+    },
+    logsKind: {
+      type: "string",
+      label: "Kind",
+      description: "Which event kind to return (`All` interleaves every kind).",
+      options: [
+        {
+          label: "All",
+          value: "all",
+        },
+        {
+          label: "DNS",
+          value: "dns",
+        },
+        {
+          label: "Connections",
+          value: "conn",
+        },
+        {
+          label: "Allocations",
+          value: "alloc",
+        },
+      ],
+      default: "all",
+      optional: true,
+    },
+    from: {
+      type: "string",
+      label: "From",
+      description: "Window start - a relative offset (e.g. `-1h`), epoch-ms, or an RFC-3339 timestamp.",
+      optional: true,
+    },
+    to: {
+      type: "string",
+      label: "To",
+      description: "Window end - a relative offset, epoch-ms, or an RFC-3339 timestamp.",
+      optional: true,
+    },
+    limit: {
+      type: "integer",
+      label: "Limit",
+      description: "Max rows to return.",
+      min: 1,
+      max: 10000,
+      default: 1000,
+      optional: true,
+    },
+  },
+  methods: {
+    // ================================================================================
+    // Keyless tier - the public, anonymous identity API (rdap.whisper.online).
+    // These take NO auth header and work whether or not a Whisper key is connected.
+    // ================================================================================
+    _rdapUrl() {
+      return RDAP_URL;
+    },
+    async _rdapRequest({
+      $ = this,
+      path,
+      ...args
+    }) {
+      return axios($, {
+        url: `${this._rdapUrl()}${path}`,
+        headers: {
+          // Liberal-accept (Postel): the RDAP record is served as application/rdap+json,
+          // the others as application/json. Asking only for application/json makes the
+          // RDAP endpoint answer 406 Not Acceptable.
+          Accept: "application/rdap+json, application/json;q=0.9, */*;q=0.1",
+        },
+        ...args,
+      });
+    },
+    async verifyIdentity({
+      address, ...args
+    }) {
+      return this._rdapRequest({
+        path: "/verify-identity",
+        params: {
+          ip: address,
+        },
+        ...args,
+      });
+    },
+    async getRdapRecord({
+      address, ...args
+    }) {
+      return this._rdapRequest({
+        path: `/ip/${encodeURIComponent(address)}`,
+        ...args,
+      });
+    },
+    async getTransparencyLog({
+      address, ...args
+    }) {
+      return this._rdapRequest({
+        path: `/ip/${encodeURIComponent(address)}/transparency`,
+        ...args,
+      });
+    },
+    async getInboundLookups({
+      address, ...args
+    }) {
+      return this._rdapRequest({
+        path: `/ip/${encodeURIComponent(address)}/lookups`,
+        ...args,
+      });
+    },
+    async getEgressIp(args = {}) {
+      return this._rdapRequest({
+        path: "/egress-ip",
+        ...args,
+      });
+    },
+
+    // ================================================================================
+    // Control tier - the keyed control plane (graph.whisper.online). One Cypher verb,
+    // whisper.agents({op, args}), POSTed with the account key in the X-API-Key header.
+    // ================================================================================
+    _controlUrl() {
+      return CONTROL_URL;
+    },
+    _apiKey() {
+      return this.$auth?.api_key;
+    },
+    _requireApiKey() {
+      const key = this._apiKey();
+      if (!key || `${key}`.trim() === "") {
+        throw new ConfigurationError(
+          "This action needs your Whisper API key. Connect a Whisper account with your `whisper_live_...` key to unlock the control plane. (The Verify / RDAP actions work without a key.)",
+        );
+      }
+      return key;
+    },
+
+    // --- Cypher literal builder (ports the CLI's client/cypher.go exactly) -----------
+    // Conservative-emit: a single quote is doubled (openCypher escaping) and a backslash
+    // is doubled, so a hostile value can never escape the surrounding '...' literal or map.
+    _quoteCypher(s) {
+      return `'${String(s).replace(/\\/g, "\\\\")
+        .replace(/'/g, "''")}'`;
+    },
+    _litCypher(v) {
+      if (v === null || v === undefined) {
+        return "null";
+      }
+      if (typeof v === "string") {
+        return this._quoteCypher(v);
+      }
+      if (typeof v === "boolean") {
+        return v
+          ? "true"
+          : "false";
+      }
+      if (typeof v === "number") {
+        return String(v);
+      }
+      if (Array.isArray(v)) {
+        return `[${v.map((e) => this._litCypher(e)).join(",")}]`;
+      }
+      if (typeof v === "object") {
+        return this._cypherMap(v);
+      }
+      return this._quoteCypher(String(v));
+    },
+    // Keys are emitted in sorted order so the produced query is byte-stable (stable for
+    // tests, caches and logs), exactly like the CLI's CypherMap.
+    _cypherMap(m) {
+      const keys = Object.keys(m)
+        .filter((k) => m[k] !== undefined)
+        .sort();
+      if (keys.length === 0) {
+        return "{}";
+      }
+      return `{${keys.map((k) => `${k}:${this._litCypher(m[k])}`).join(",")}}`;
+    },
+    _buildAgentsQuery(op, args = {}) {
+      const inner = Object.keys(args).length
+        ? this._cypherMap(args)
+        : "{}";
+      return `CALL whisper.agents({op:${this._quoteCypher(op)}, args:${inner}})`;
+    },
+
+    // --- Envelope decoding (ports client/envelope.go - liberal in what we accept) ----
+    _problemMessage(err, status) {
+      if (err) {
+        if (err.detail) {
+          return err.detail;
+        }
+        if (err.title) {
+          return err.title;
+        }
+        if (err.type) {
+          return err.type;
+        }
+      }
+      return `control plane returned status ${status ?? "(unknown)"}`;
+    },
+    _recordsFromResult(result) {
+      if (result === null || result === undefined) {
+        return [];
+      }
+      if (Array.isArray(result)) {
+        return result;
+      }
+      const cols = result.columns;
+      const rows = result.rows;
+      if (Array.isArray(cols) && Array.isArray(rows)) {
+        return rows.map((row) => {
+          if (!Array.isArray(row)) {
+            return row;
+          }
+          const out = {};
+          cols.forEach((c, i) => {
+            out[c] = row[i];
+          });
+          return out;
+        });
+      }
+      return [
+        result,
+      ];
+    },
+    // Accepts BOTH wire shapes the control plane may return:
+    //   A. the live procedure-row table: {columns, rows:[{op,ok,status,result,error}]}
+    //   B. the dev-guide flat envelope:  {ok, status, result, error}
+    //   + a bare {columns, rows:[[...]]} table, and a bare problem object.
+    // Returns the decoded records; throws a clear, helpful error on ok:false (Postel).
+    _decodeEnvelope(body, httpStatus) {
+      const obj = body;
+
+      // Shape B: an explicit top-level ok flag.
+      if (obj && typeof obj === "object" && "ok" in obj) {
+        if (obj.ok === false) {
+          throw new Error(this._problemMessage(obj.error, obj.status ?? httpStatus));
+        }
+        return this._recordsFromResult(obj.result);
+      }
+
+      // Shapes A & bare-table: a {columns, rows} table.
+      if (obj && typeof obj === "object" && Array.isArray(obj.rows)) {
+        const rows = obj.rows;
+        if (rows.length === 0) {
+          return [];
+        }
+        const first = rows[0];
+        // Shape A: each row is a per-op envelope object {op,ok,status,result,error,...}.
+        if (first && typeof first === "object" && !Array.isArray(first) && "ok" in first) {
+          if (first.ok === false) {
+            throw new Error(this._problemMessage(first.error, first.status ?? httpStatus));
+          }
+          if (first.result !== undefined && first.result !== null) {
+            return this._recordsFromResult(first.result);
+          }
+          return [
+            first,
+          ];
+        }
+        // Bare table: positional rows against the outer columns.
+        if (Array.isArray(obj.columns)) {
+          return this._recordsFromResult(obj);
+        }
+        return rows;
+      }
+
+      // A >=400 transport status with no usable body is itself the fault.
+      if (httpStatus >= 400) {
+        throw new Error(this._problemMessage(obj, httpStatus));
+      }
+      // A bare object -> a single record.
+      return obj
+        ? [
+          obj,
+        ]
+        : [];
+    },
+
+    // Run one control op and return the decoded records (throws a helpful error on fail).
+    async _agents({
+      $ = this, op, args = {},
+    }) {
+      const apiKey = this._requireApiKey();
+      const response = await axios($, {
+        method: "POST",
+        url: this._controlUrl(),
+        headers: {
+          "X-API-Key": apiKey,
+          "Content-Type": "application/json",
+          "Accept": "application/json",
+        },
+        data: {
+          query: this._buildAgentsQuery(op, args),
+        },
+        returnFullResponse: true,
+        validateStatus: () => true,
+      });
+      return this._decodeEnvelope(response.data, response.status);
+    },
+
+    // --- control op wrappers --------------------------------------------------------
+    async registerAgent({
+      $ = this, label, contactEmail,
+    }) {
+      const args = {
+        label,
+      };
+      if (contactEmail) {
+        args.contact_email = contactEmail;
+      }
+      return this._agents({
+        $,
+        op: "register",
+        args,
+      });
+    },
+    async allocateIdentity({
+      $ = this, label, contactEmail,
+    }) {
+      const args = {
+        label,
+      };
+      if (contactEmail) {
+        args.contact_email = contactEmail;
+      }
+      return this._agents({
+        $,
+        op: "identity",
+        args,
+      });
+    },
+    async connectEgress({
+      $ = this, agent, tier, publicKey,
+    }) {
+      const args = {};
+      if (agent) {
+        args.agent = agent;
+      }
+      if (tier) {
+        args.tier = tier;
+      }
+      if (publicKey) {
+        args.public_key = publicKey;
+      }
+      return this._agents({
+        $,
+        op: "connect",
+        args,
+      });
+    },
+    // The connect result embeds live credentials (a bearer inside the proxy URLs, and -
+    // on the zero-key WireGuard path - a client private key). Integrations that don't
+    // consume them directly must strip them so no secret lands in step exports or logs.
+    stripEgressSecrets(record) {
+      const secretFields = [
+        "http_proxy",
+        "https_proxy",
+        "connection_string",
+        "socks5_endpoint",
+        "client_private_key",
+        "wireguard_config",
+      ];
+      const out = {
+        ...record,
+      };
+      const stripped = [];
+      for (const f of secretFields) {
+        if (out[f] !== undefined && out[f] !== null) {
+          delete out[f];
+          stripped.push(f);
+        }
+      }
+      if (stripped.length) {
+        out.secrets_stripped = stripped;
+      }
+      return out;
+    },
+    async getAgent({
+      $ = this, agent,
+    }) {
+      // The control plane keys the lookup by `agent` (an id) or `address` (a /128) -
+      // liberal-accept: anything containing a colon is an address.
+      const args = String(agent).includes(":")
+        ? {
+          address: agent,
+        }
+        : {
+          agent,
+        };
+      return this._agents({
+        $,
+        op: "agent",
+        args,
+      });
+    },
+    async listAgents({
+      $ = this, kind,
+    }) {
+      return this._agents({
+        $,
+        op: "list",
+        args: {
+          kind: kind || "agents",
+        },
+      });
+    },
+    async setPolicy({
+      $ = this, block, allow, bundles, policyDefault,
+    }) {
+      const args = {};
+      if (block?.length) {
+        args.block = block;
+      }
+      if (allow?.length) {
+        args.allow = allow;
+      }
+      if (bundles?.length) {
+        args.bundles = bundles;
+      }
+      if (policyDefault) {
+        args.default = policyDefault;
+      }
+      return this._agents({
+        $,
+        op: "policy",
+        args,
+      });
+    },
+    async getLogs({
+      $ = this, agent, kind, from, to, limit,
+    }) {
+      const args = {};
+      if (agent) {
+        args.agent = agent;
+      }
+      if (kind && kind !== "all") {
+        args.kind = kind;
+      }
+      if (from) {
+        args.from = from;
+      }
+      if (to) {
+        args.to = to;
+      }
+      if (limit) {
+        args.limit = limit;
+      }
+      return this._agents({
+        $,
+        op: "logs",
+        args,
+      });
+    },
+    async revokeAgent({
+      $ = this, agent,
+    }) {
+      return this._agents({
+        $,
+        op: "revoke",
+        args: {
+          agent,
+        },
+      });
+    },
+
+    // ================================================================================
+    // Graph tier - the keyed intelligence graph (graph.whisper.online/api/query). Raw
+    // Cypher plus the named catalog recipes: 14 direct procedures run their Cypher as-is
+    // and 15 multi-step flows run by slug on the console gallery/run endpoint (SSE). Reuses
+    // the same X-API-Key auth as the control plane. Every recipe links its docs page.
+    // See https://www.whisper.security/docs/cypher-api
+    // ================================================================================
+    _graphUrl() {
+      return GRAPH_URL;
+    },
+    _flowRunUrl() {
+      return FLOW_RUN_URL;
+    },
+    _graphDocsBase() {
+      return GRAPH_DOCS_BASE;
+    },
+    // The full recipe catalog (14 direct + 15 flow); each entry carries its docsUrl.
+    graphCatalog() {
+      return GRAPH_CATALOG;
+    },
+    _graphEntry(id) {
+      const entry = GRAPH_CATALOG.find((e) => e.id === id);
+      if (!entry) {
+        throw new ConfigurationError(`Unknown graph recipe "${id}".`);
+      }
+      return entry;
+    },
+    // Normalise the /api/query reply into {columns, rows, statistics}. Per the contract rows
+    // are OBJECTS keyed by column name; a positional-array row (aligned to columns) also
+    // decodes, so a liberal server shape still works. Never throws on shape.
+    _normalizeGraph(body) {
+      if (!body || typeof body !== "object") {
+        return {
+          columns: [],
+          rows: [],
+          statistics: null,
+        };
+      }
+      const columns = Array.isArray(body.columns)
+        ? body.columns
+        : [];
+      const rawRows = Array.isArray(body.rows)
+        ? body.rows
+        : [];
+      const rows = rawRows.map((row) => {
+        if (Array.isArray(row)) {
+          const out = {};
+          columns.forEach((c, i) => {
+            if (i < row.length) {
+              out[c] = row[i];
+            }
+          });
+          return out;
+        }
+        return row && typeof row === "object"
+          ? row
+          : {
+            value: row,
+          };
+      });
+      return {
+        columns,
+        rows,
+        statistics: body.statistics || null,
+      };
+    },
+    // The one place that talks to the graph query API. POSTs {query, parameters} with the
+    // account key in X-API-Key and, on an HTTP>=400 or an RFC-7807 problem body, throws a
+    // clear error carrying the server's detail (Postel: a helpful message, never a 500).
+    async _graphPost({
+      $ = this, query, parameters,
+    }) {
+      const apiKey = this._requireApiKey();
+      const response = await axios($, {
+        method: "POST",
+        url: this._graphUrl(),
+        headers: {
+          "X-API-Key": apiKey,
+          "Content-Type": "application/json",
+          "Accept": "application/json",
+        },
+        data: {
+          query,
+          parameters: parameters || {},
+        },
+        returnFullResponse: true,
+        validateStatus: () => true,
+      });
+      const body = response.data;
+      const hasTable = body && typeof body === "object"
+        && (Array.isArray(body.columns) || Array.isArray(body.rows));
+      const problem = body && typeof body === "object"
+        && (body.error || (!hasTable && (body.detail || body.title || body.type)));
+      if (response.status >= 400 || problem) {
+        const e = (body && (body.error || body)) || {};
+        throw new Error(
+          e.detail || e.title || e.message || e.type
+            || `graph query returned status ${response.status}`,
+        );
+      }
+      return this._normalizeGraph(body);
+    },
+    // Raw Cypher escape hatch: returns the full {columns, rows, statistics}. Bind user input
+    // as $parameters (never string-concatenate it) so a query is always injection-safe.
+    // @see https://www.whisper.security/docs/cypher-api
+    async graphQuery({
+      $ = this, cypher, params,
+    }) {
+      if (!cypher || `${cypher}`.trim() === "") {
+        throw new ConfigurationError("Run Cypher needs a Cypher query string.");
+      }
+      return this._graphPost({
+        $,
+        query: cypher,
+        parameters: params || {},
+      });
+    },
+    // Coerce one catalog value: reject a missing required input with a clear message, and
+    // treat an empty/blank value as absent (so an optional field is simply omitted).
+    _graphInputValue(entry, input, values) {
+      const v = values[input.id];
+      const present = v !== undefined && v !== null && `${v}`.trim() !== "";
+      if (!present && !input.optional) {
+        throw new ConfigurationError(
+          `Graph recipe "${entry.id}" needs a value for "${input.id}".`,
+        );
+      }
+      return present
+        ? v
+        : undefined;
+    },
+    // Run a named catalog recipe by its id. `values` is keyed by the catalog input/param id;
+    // the wire names come from the catalog, so a caller never has to know them. Direct
+    // procedures bind their inputs as $parameters and run the catalog Cypher; the submit
+    // map-call builds an injection-safe map; flows run by slug on the gallery/run endpoint.
+    async runGraphRecipe({
+      $ = this, id, values = {},
+    }) {
+      const entry = this._graphEntry(id);
+      if (entry.mode === "flow") {
+        const inputs = {};
+        const params = {};
+        for (const input of entry.inputs) {
+          const v = this._graphInputValue(entry, input, values);
+          if (v !== undefined) {
+            inputs[input.paramName] = v;
+          }
+        }
+        for (const name of (entry.params || [])) {
+          const v = values[name];
+          if (v !== undefined && v !== null && `${v}`.trim() !== "") {
+            params[name] = v;
+          }
+        }
+        return this.runGraphFlow({
+          $,
+          slug: entry.slug,
+          inputs,
+          params,
+        });
+      }
+      if (entry.map) {
+        return this._runGraphSubmit({
+          $,
+          entry,
+          values,
+        });
+      }
+      const parameters = {};
+      for (const input of entry.inputs) {
+        const v = this._graphInputValue(entry, input, values);
+        if (v !== undefined) {
+          parameters[input.paramName] = v;
+        }
+      }
+      const { rows } = await this._graphPost({
+        $,
+        query: entry.cypher,
+        parameters,
+      });
+      return rows;
+    },
+    // whisper.submit map-call: each provided field becomes one entry of a Cypher map with
+    // its value bound as its own $parameter (injection-safe), keys in SORTED order so the
+    // query is byte-stable. Field names are the catalog wire names (validated identifiers).
+    async _runGraphSubmit({
+      $ = this, entry, values,
+    }) {
+      const parameters = {};
+      const pairs = [];
+      for (const input of entry.inputs) {
+        const v = this._graphInputValue(entry, input, values);
+        if (v === undefined) {
+          continue;
+        }
+        if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(input.paramName)) {
+          throw new ConfigurationError(`Invalid submit field "${input.paramName}".`);
+        }
+        parameters[input.paramName] = v;
+        pairs.push(`${input.paramName}:$${input.paramName}`);
+      }
+      pairs.sort();
+      const query = `CALL ${entry.map}({${pairs.join(",")}})`;
+      const { rows } = await this._graphPost({
+        $,
+        query,
+        parameters,
+      });
+      return rows;
+    },
+    // Parse an SSE stream body into [{event, data}]; data is JSON-decoded when possible,
+    // else kept as the raw string. Never throws on shape.
+    _parseSse(text) {
+      const events = [];
+      const records = String(text)
+        .replace(/\r\n/g, "\n")
+        .split("\n\n");
+      for (const rec of records) {
+        if (rec.trim() === "") {
+          continue;
+        }
+        let event = "message";
+        const dataLines = [];
+        for (const line of rec.split("\n")) {
+          if (line.startsWith("event:")) {
+            event = line.slice(6).trim();
+          } else if (line.startsWith("data:")) {
+            dataLines.push(line.slice(5).replace(/^ /, ""));
+          }
+        }
+        let data = dataLines.join("\n");
+        try {
+          data = JSON.parse(data);
+        } catch {
+          // not JSON - keep the raw string
+        }
+        events.push({
+          event,
+          data,
+        });
+      }
+      return events;
+    },
+    _firstSseError(text) {
+      const errEv = this._parseSse(text)
+        .find((ev) => ev.event === "error");
+      if (!errEv) {
+        return null;
+      }
+      const d = errEv.data;
+      return d && typeof d === "object"
+        ? (d.detail || d.message || d.error || null)
+        : `${d}`;
+    },
+    // Run a multi-step flow by slug on the gallery/run endpoint (keyed). POSTs {slug, inputs,
+    // params}, consumes the Server-Sent-Events stream (buffered as text) and returns the
+    // collected { slug, steps, complete, events }. Flows are multi-step, so the timeout is
+    // generous; a liberal server that answers plain JSON is accepted too.
+    async runGraphFlow({
+      $ = this, slug, inputs = {}, params = {}, timeout = 300000,
+    }) {
+      const apiKey = this._requireApiKey();
+      const response = await axios($, {
+        method: "POST",
+        url: this._flowRunUrl(),
+        headers: {
+          "X-API-Key": apiKey,
+          "Content-Type": "application/json",
+          "Accept": "text/event-stream",
+        },
+        data: {
+          slug,
+          inputs,
+          params,
+        },
+        responseType: "text",
+        timeout,
+        returnFullResponse: true,
+        validateStatus: () => true,
+      });
+      if (response.status >= 400) {
+        const b = response.data;
+        let detail = `the workflow runner returned status ${response.status}`;
+        if (b && typeof b === "object") {
+          detail = b.detail || b.message || b.title || detail;
+        } else if (typeof b === "string" && b.trim() !== "") {
+          detail = this._firstSseError(b) || detail;
+        }
+        throw new Error(detail);
+      }
+      const events = typeof response.data === "string"
+        ? this._parseSse(response.data)
+        : [];
+      if (events.length === 0 && response.data && typeof response.data === "object") {
+        return {
+          slug,
+          steps: [],
+          complete: response.data,
+          events: [],
+        };
+      }
+      const steps = events
+        .filter((ev) => ev.event === "step")
+        .map((ev) => ev.data);
+      const completeEv = events.findLast((ev) => ev.event === "complete");
+      const complete = completeEv && typeof completeEv.data === "object"
+        ? completeEv.data
+        : null;
+      const errEv = events.find((ev) => ev.event === "error");
+      if (errEv && !complete && steps.length === 0) {
+        const d = errEv.data;
+        const msg = d && typeof d === "object"
+          ? (d.detail || d.message || d.error)
+          : `${d}`;
+        throw new Error(msg || `graph flow "${slug}" failed on the workflow runner`);
+      }
+      return {
+        slug,
+        steps,
+        complete,
+        events,
+      };
+    },
+    // A friendly one-line summary for either shape a recipe returns (rows or flow steps).
+    graphSummary(id, result) {
+      if (Array.isArray(result)) {
+        return `Ran graph recipe "${id}": ${result.length} row${result.length === 1
+          ? ""
+          : "s"}`;
+      }
+      if (result && Array.isArray(result.steps)) {
+        return `Ran graph flow "${id}": ${result.steps.length} step${result.steps.length === 1
+          ? ""
+          : "s"}`;
+      }
+      return `Ran graph recipe "${id}"`;
+    },
+  },
+};

--- a/components/whisper/whisper.app.mjs
+++ b/components/whisper/whisper.app.mjs
@@ -7,6 +7,506 @@ import { axios, ConfigurationError } from "@pipedream/platform";
 const CONTROL_URL = "https://graph.whisper.security/api/query";
 const RDAP_URL = "https://rdap.whisper.online";
 
+// The whisper.security intelligence graph. GRAPH_URL is the same keyed query endpoint as
+// CONTROL_URL (one host); FLOW_RUN_URL runs a multi-step catalog flow by slug and streams
+// its steps back as Server-Sent Events. Docs pages hang off GRAPH_DOCS_BASE.
+const GRAPH_URL = "https://graph.whisper.security/api/query";
+const FLOW_RUN_URL = "https://console.whisper.security/api/gallery/run";
+const GRAPH_DOCS_BASE = "https://www.whisper.security";
+
+// BEGIN GENERATED: graph catalog (from the whisper catalog SSOT, catalog.json) - do not
+// edit by hand. 14 direct procedures (their Cypher runs as-is on /api/query) + 15 multi-
+// step flows (run by slug on the console gallery/run endpoint, SSE). `docsUrl` is the docs
+// page (GRAPH_DOCS_BASE + the catalog docPath).
+const GRAPH_CATALOG = [
+  {
+    "id": "anycast-dns-root-sovereignty",
+    "title": "Anycast DNS-Root Sovereignty",
+    "mode": "flow",
+    "docsUrl": "https://www.whisper.security/docs/recipes/compliance",
+    "inputs": [
+      {
+        "id": "country",
+        "paramName": "country",
+        "optional": false,
+      },
+    ],
+    "slug": "anycast-dns-root-sovereignty",
+    "params": [
+      "instanceType",
+    ],
+  },
+  {
+    "id": "attack-path",
+    "title": "Attack Path & Connection Finder",
+    "mode": "flow",
+    "docsUrl": "https://www.whisper.security/docs/recipes/attack-path",
+    "inputs": [
+      {
+        "id": "asset",
+        "paramName": "value",
+        "optional": false,
+      },
+      {
+        "id": "other",
+        "paramName": "other",
+        "optional": false,
+      },
+    ],
+    "slug": "attack-path",
+    "params": [
+      "level",
+    ],
+  },
+  {
+    "id": "attack-surface",
+    "title": "Attack-Surface Mapper",
+    "mode": "flow",
+    "docsUrl": "https://www.whisper.security/docs/recipes/pentest-recon",
+    "inputs": [
+      {
+        "id": "domain",
+        "paramName": "domain",
+        "optional": false,
+      },
+    ],
+    "slug": "attack-surface",
+    "params": [
+      "level",
+    ],
+  },
+  {
+    "id": "bgp-hijack-exposure",
+    "title": "BGP Hijack & Routing-Hygiene Audit",
+    "mode": "flow",
+    "docsUrl": "https://www.whisper.security/docs/recipes/bgp-routing",
+    "inputs": [
+      {
+        "id": "asn",
+        "paramName": "value",
+        "optional": false,
+      },
+    ],
+    "slug": "bgp-hijack-exposure",
+    "params": [],
+  },
+  {
+    "id": "blast-radius",
+    "title": "Dependency Blast Radius",
+    "mode": "flow",
+    "docsUrl": "https://www.whisper.security/docs/recipes/soc",
+    "inputs": [
+      {
+        "id": "asset",
+        "paramName": "indicator",
+        "optional": false,
+      },
+    ],
+    "slug": "blast-radius",
+    "params": [
+      "depth",
+    ],
+  },
+  {
+    "id": "build-takedown-evidence-package",
+    "title": "Takedown Evidence Package",
+    "mode": "flow",
+    "docsUrl": "https://www.whisper.security/docs/recipes/threat-intel",
+    "inputs": [
+      {
+        "id": "domain",
+        "paramName": "domain",
+        "optional": false,
+      },
+    ],
+    "slug": "build-takedown-evidence-package",
+    "params": [],
+  },
+  {
+    "id": "discover-ai-agent-infrastructure",
+    "title": "AI / Agent Infrastructure Discovery",
+    "mode": "flow",
+    "docsUrl": "https://www.whisper.security/docs/recipes/pentest-recon",
+    "inputs": [
+      {
+        "id": "domain",
+        "paramName": "value",
+        "optional": false,
+      },
+    ],
+    "slug": "discover-ai-agent-infrastructure",
+    "params": [],
+  },
+  {
+    "id": "indicator",
+    "title": "Threat Investigation",
+    "mode": "flow",
+    "docsUrl": "https://www.whisper.security/docs/recipes/soc",
+    "inputs": [
+      {
+        "id": "indicator",
+        "paramName": "indicator",
+        "optional": false,
+      },
+    ],
+    "slug": "indicator",
+    "params": [],
+  },
+  {
+    "id": "indicator-enrichment",
+    "title": "Indicator Enrichment",
+    "mode": "flow",
+    "docsUrl": "https://www.whisper.security/docs/recipes/dns-email",
+    "inputs": [
+      {
+        "id": "domain",
+        "paramName": "value",
+        "optional": false,
+      },
+    ],
+    "slug": "indicator-enrichment",
+    "params": [],
+  },
+  {
+    "id": "infrastructure-mapping",
+    "title": "Digital Infrastructure Mapping",
+    "mode": "flow",
+    "docsUrl": "https://www.whisper.security/docs/recipes/compliance",
+    "inputs": [
+      {
+        "id": "target",
+        "paramName": "value",
+        "optional": false,
+      },
+    ],
+    "slug": "infrastructure-mapping",
+    "params": [
+      "level",
+    ],
+  },
+  {
+    "id": "map-supply-chain-concentration",
+    "title": "Infrastructure Concentration & Resilience",
+    "mode": "flow",
+    "docsUrl": "https://www.whisper.security/docs/recipes/compliance",
+    "inputs": [
+      {
+        "id": "domain",
+        "paramName": "domain",
+        "optional": false,
+      },
+    ],
+    "slug": "map-supply-chain-concentration",
+    "params": [],
+  },
+  {
+    "id": "nameserver-hijack-dns-consistency",
+    "title": "Nameserver & DNS Delegation Audit",
+    "mode": "flow",
+    "docsUrl": "https://www.whisper.security/docs/recipes/dns-email",
+    "inputs": [
+      {
+        "id": "domain",
+        "paramName": "value",
+        "optional": false,
+      },
+    ],
+    "slug": "nameserver-hijack-dns-consistency",
+    "params": [],
+  },
+  {
+    "id": "route-health",
+    "title": "Network & Routing Report",
+    "mode": "flow",
+    "docsUrl": "https://www.whisper.security/docs/recipes/bgp-routing",
+    "inputs": [
+      {
+        "id": "target",
+        "paramName": "target",
+        "optional": false,
+      },
+    ],
+    "slug": "route-health",
+    "params": [],
+  },
+  {
+    "id": "subdomain-takeover",
+    "title": "Subdomain Takeover Detection",
+    "mode": "flow",
+    "docsUrl": "https://www.whisper.security/docs/recipes/pentest-recon",
+    "inputs": [
+      {
+        "id": "domain",
+        "paramName": "value",
+        "optional": false,
+      },
+    ],
+    "slug": "subdomain-takeover",
+    "params": [],
+  },
+  {
+    "id": "typosquat",
+    "title": "Typosquat & Brand-Impersonation Scanner",
+    "mode": "flow",
+    "docsUrl": "https://www.whisper.security/docs/recipes/brand-protection",
+    "inputs": [
+      {
+        "id": "domain",
+        "paramName": "domain",
+        "optional": false,
+      },
+    ],
+    "slug": "typosquat",
+    "params": [],
+  },
+  {
+    "id": "identify",
+    "title": "Vendor / Operator Identity (whisper.identify)",
+    "mode": "direct",
+    "docsUrl": "https://www.whisper.security/docs/whisper-graph/procedures/identify",
+    "inputs": [
+      {
+        "id": "value",
+        "paramName": "v",
+        "optional": false,
+      },
+    ],
+    "cypher": "CALL whisper.identify([$v]) YIELD host, vendor_id, canonical_name, category, roles, host_class, band",
+  },
+  {
+    "id": "assess",
+    "title": "Threat Posture (whisper.assess)",
+    "mode": "direct",
+    "docsUrl": "https://www.whisper.security/docs/whisper-graph/procedures",
+    "inputs": [
+      {
+        "id": "value",
+        "paramName": "v",
+        "optional": false,
+      },
+    ],
+    "cypher": "CALL whisper.assess([$v]) YIELD host, label, band, sub_labels, coverage, evidence",
+  },
+  {
+    "id": "variants",
+    "title": "Typosquat Variant Generator (whisper.variants)",
+    "mode": "direct",
+    "docsUrl": "https://www.whisper.security/docs/whisper-graph/procedures/variants",
+    "inputs": [
+      {
+        "id": "value",
+        "paramName": "v",
+        "optional": false,
+      },
+    ],
+    "cypher": "CALL whisper.variants($v) YIELD variant, method, exists, confidence",
+  },
+  {
+    "id": "walk",
+    "title": "Vendor Attribution Walk (whisper.walk)",
+    "mode": "direct",
+    "docsUrl": "https://www.whisper.security/docs/whisper-graph/procedures",
+    "inputs": [
+      {
+        "id": "value",
+        "paramName": "v",
+        "optional": false,
+      },
+    ],
+    "cypher": "CALL whisper.walk($v) YIELD coverage, host, nearest_known_vendors, no_atlas_match, siblings",
+  },
+  {
+    "id": "explain",
+    "title": "Threat-Feed Explainer (whisper.explain / explain)",
+    "mode": "direct",
+    "docsUrl": "https://www.whisper.security/docs/whisper-graph/procedures/explain",
+    "inputs": [
+      {
+        "id": "value",
+        "paramName": "v",
+        "optional": false,
+      },
+    ],
+    "cypher": "CALL whisper.explain($v) YIELD indicator, score, level, explanation, sources",
+  },
+  {
+    "id": "psl-tldplusone",
+    "title": "Registrable Apex (whisper.psl.tldPlusOne)",
+    "mode": "direct",
+    "docsUrl": "https://www.whisper.security/docs/whisper-graph/procedures/helpers",
+    "inputs": [
+      {
+        "id": "value",
+        "paramName": "v",
+        "optional": false,
+      },
+    ],
+    "cypher": "CALL whisper.psl.tldPlusOne($v) YIELD apex",
+  },
+  {
+    "id": "psl-affiliation",
+    "title": "PSL Private-Suffix Affiliation (whisper.psl.affiliation)",
+    "mode": "direct",
+    "docsUrl": "https://www.whisper.security/docs/whisper-graph/procedures/helpers",
+    "inputs": [
+      {
+        "id": "value",
+        "paramName": "v",
+        "optional": false,
+      },
+    ],
+    "cypher": "CALL whisper.psl.affiliation($v) YIELD found, suffix, submitterOrg, submitterLogin, evidenceKind, confidence",
+  },
+  {
+    "id": "origins",
+    "title": "CDN-Origin De-cloaker (whisper.origins)",
+    "mode": "direct",
+    "docsUrl": "https://www.whisper.security/docs/whisper-graph/procedures/origins",
+    "inputs": [
+      {
+        "id": "value",
+        "paramName": "v",
+        "optional": false,
+      },
+    ],
+    "cypher": "CALL whisper.origins($v) YIELD ip, confidence, methods, asn, asnName, kind",
+  },
+  {
+    "id": "history",
+    "title": "WHOIS History Timeline (whisper.history)",
+    "mode": "direct",
+    "docsUrl": "https://www.whisper.security/docs/whisper-graph/procedures/history",
+    "inputs": [
+      {
+        "id": "value",
+        "paramName": "v",
+        "optional": false,
+      },
+    ],
+    "cypher": "CALL whisper.history($v)",
+  },
+  {
+    "id": "history-whois",
+    "title": "WHOIS History (projection) (whisper.history.whois)",
+    "mode": "direct",
+    "docsUrl": "https://www.whisper.security/docs/whisper-graph/procedures/history",
+    "inputs": [
+      {
+        "id": "value",
+        "paramName": "v",
+        "optional": false,
+      },
+    ],
+    "cypher": "CALL whisper.history.whois($v) YIELD queryTime, createDate, updateDate, expiryDate, registrar, registrant, country, nameServers",
+  },
+  {
+    "id": "asset",
+    "title": "AS-SET Membership (whisper.asSet)",
+    "mode": "direct",
+    "docsUrl": "https://www.whisper.security/docs/whisper-graph/procedures",
+    "inputs": [
+      {
+        "id": "value",
+        "paramName": "v",
+        "optional": false,
+      },
+    ],
+    "cypher": "CALL whisper.asSet($v) YIELD asSetName, memberAsn, sourceRir",
+  },
+  {
+    "id": "lookup-tor-relay",
+    "title": "Tor Exit-Relay Lookup (whisper.lookupTorRelay)",
+    "mode": "direct",
+    "docsUrl": "https://www.whisper.security/docs/whisper-graph/procedures/helpers",
+    "inputs": [
+      {
+        "id": "value",
+        "paramName": "v",
+        "optional": false,
+      },
+    ],
+    "cypher": "CALL whisper.lookupTorRelay($v) YIELD indicator, found, fingerprint, exitAddressCount, source, ingestedAt",
+  },
+  {
+    "id": "db-schema",
+    "title": "Graph Schema Catalog (db.schema)",
+    "mode": "direct",
+    "docsUrl": "https://www.whisper.security/docs/whisper-graph/schema",
+    "inputs": [],
+    "cypher": "CALL db.schema()",
+  },
+  {
+    "id": "submit",
+    "title": "Submit Observation / Feedback (whisper.submit)",
+    "mode": "direct",
+    "docsUrl": "https://www.whisper.security/docs/cypher-api",
+    "inputs": [
+      {
+        "id": "kind",
+        "paramName": "kind",
+        "optional": false,
+      },
+      {
+        "id": "identifierKind",
+        "paramName": "identifier_kind",
+        "optional": false,
+      },
+      {
+        "id": "value",
+        "paramName": "value",
+        "optional": false,
+      },
+      {
+        "id": "observationId",
+        "paramName": "observation_id",
+        "optional": true,
+      },
+      {
+        "id": "confidence",
+        "paramName": "confidence",
+        "optional": true,
+      },
+      {
+        "id": "firstSeen",
+        "paramName": "first_seen",
+        "optional": true,
+      },
+      {
+        "id": "provenance",
+        "paramName": "provenance",
+        "optional": true,
+      },
+      {
+        "id": "query",
+        "paramName": "query",
+        "optional": true,
+      },
+      {
+        "id": "results",
+        "paramName": "results",
+        "optional": true,
+      },
+      {
+        "id": "comment",
+        "paramName": "comment",
+        "optional": true,
+      },
+      {
+        "id": "severity",
+        "paramName": "severity",
+        "optional": true,
+      },
+      {
+        "id": "v",
+        "paramName": "v",
+        "optional": true,
+      },
+    ],
+    "map": "whisper.submit",
+  },
+];
+// END GENERATED: graph catalog
+
 export default {
   type: "app",
   app: "whisper",
@@ -469,6 +969,344 @@ export default {
           agent,
         },
       });
+    },
+
+    // ================================================================================
+    // Graph tier - the keyed intelligence graph (graph.whisper.security/api/query). Raw
+    // Cypher plus the named catalog recipes: 14 direct procedures run their Cypher as-is
+    // and 15 multi-step flows run by slug on the console gallery/run endpoint (SSE). Reuses
+    // the same X-API-Key auth as the control plane. Every recipe links its docs page.
+    // See https://www.whisper.security/docs/cypher-api
+    // ================================================================================
+    _graphUrl() {
+      return GRAPH_URL;
+    },
+    _flowRunUrl() {
+      return FLOW_RUN_URL;
+    },
+    _graphDocsBase() {
+      return GRAPH_DOCS_BASE;
+    },
+    // The full recipe catalog (14 direct + 15 flow); each entry carries its docsUrl.
+    graphCatalog() {
+      return GRAPH_CATALOG;
+    },
+    _graphEntry(id) {
+      const entry = GRAPH_CATALOG.find((e) => e.id === id);
+      if (!entry) {
+        throw new ConfigurationError(`Unknown graph recipe "${id}".`);
+      }
+      return entry;
+    },
+    // Normalise the /api/query reply into {columns, rows, statistics}. Per the contract rows
+    // are OBJECTS keyed by column name; a positional-array row (aligned to columns) also
+    // decodes, so a liberal server shape still works. Never throws on shape.
+    _normalizeGraph(body) {
+      if (!body || typeof body !== "object") {
+        return {
+          columns: [],
+          rows: [],
+          statistics: null,
+        };
+      }
+      const columns = Array.isArray(body.columns)
+        ? body.columns
+        : [];
+      const rawRows = Array.isArray(body.rows)
+        ? body.rows
+        : [];
+      const rows = rawRows.map((row) => {
+        if (Array.isArray(row)) {
+          const out = {};
+          columns.forEach((c, i) => {
+            if (i < row.length) {
+              out[c] = row[i];
+            }
+          });
+          return out;
+        }
+        return row && typeof row === "object"
+          ? row
+          : {
+            value: row,
+          };
+      });
+      return {
+        columns,
+        rows,
+        statistics: body.statistics || null,
+      };
+    },
+    // The one place that talks to the graph query API. POSTs {query, parameters} with the
+    // account key in X-API-Key and, on an HTTP>=400 or an RFC-7807 problem body, throws a
+    // clear error carrying the server's detail (Postel: a helpful message, never a 500).
+    async _graphPost({
+      $ = this, query, parameters,
+    }) {
+      const apiKey = this._requireApiKey();
+      const response = await axios($, {
+        method: "POST",
+        url: this._graphUrl(),
+        headers: {
+          "X-API-Key": apiKey,
+          "Content-Type": "application/json",
+          "Accept": "application/json",
+        },
+        data: {
+          query,
+          parameters: parameters || {},
+        },
+        returnFullResponse: true,
+        validateStatus: () => true,
+      });
+      const body = response.data;
+      const hasTable = body && typeof body === "object"
+        && (Array.isArray(body.columns) || Array.isArray(body.rows));
+      const problem = body && typeof body === "object"
+        && (body.error || (!hasTable && (body.detail || body.title || body.type)));
+      if (response.status >= 400 || problem) {
+        const e = (body && (body.error || body)) || {};
+        throw new Error(
+          e.detail || e.title || e.message || e.type
+            || `graph query returned status ${response.status}`,
+        );
+      }
+      return this._normalizeGraph(body);
+    },
+    // Raw Cypher escape hatch: returns the full {columns, rows, statistics}. Bind user input
+    // as $parameters (never string-concatenate it) so a query is always injection-safe.
+    // @see https://www.whisper.security/docs/cypher-api
+    async graphQuery({
+      $ = this, cypher, params,
+    }) {
+      if (!cypher || `${cypher}`.trim() === "") {
+        throw new ConfigurationError("Run Cypher needs a Cypher query string.");
+      }
+      return this._graphPost({
+        $,
+        query: cypher,
+        parameters: params || {},
+      });
+    },
+    // Coerce one catalog value: reject a missing required input with a clear message, and
+    // treat an empty/blank value as absent (so an optional field is simply omitted).
+    _graphInputValue(entry, input, values) {
+      const v = values[input.id];
+      const present = v !== undefined && v !== null && `${v}`.trim() !== "";
+      if (!present && !input.optional) {
+        throw new ConfigurationError(
+          `Graph recipe "${entry.id}" needs a value for "${input.id}".`,
+        );
+      }
+      return present
+        ? v
+        : undefined;
+    },
+    // Run a named catalog recipe by its id. `values` is keyed by the catalog input/param id;
+    // the wire names come from the catalog, so a caller never has to know them. Direct
+    // procedures bind their inputs as $parameters and run the catalog Cypher; the submit
+    // map-call builds an injection-safe map; flows run by slug on the gallery/run endpoint.
+    async runGraphRecipe({
+      $ = this, id, values = {},
+    }) {
+      const entry = this._graphEntry(id);
+      if (entry.mode === "flow") {
+        const inputs = {};
+        const params = {};
+        for (const input of entry.inputs) {
+          const v = this._graphInputValue(entry, input, values);
+          if (v !== undefined) {
+            inputs[input.paramName] = v;
+          }
+        }
+        for (const name of (entry.params || [])) {
+          const v = values[name];
+          if (v !== undefined && v !== null && `${v}`.trim() !== "") {
+            params[name] = v;
+          }
+        }
+        return this.runGraphFlow({
+          $,
+          slug: entry.slug,
+          inputs,
+          params,
+        });
+      }
+      if (entry.map) {
+        return this._runGraphSubmit({
+          $,
+          entry,
+          values,
+        });
+      }
+      const parameters = {};
+      for (const input of entry.inputs) {
+        const v = this._graphInputValue(entry, input, values);
+        if (v !== undefined) {
+          parameters[input.paramName] = v;
+        }
+      }
+      const { rows } = await this._graphPost({
+        $,
+        query: entry.cypher,
+        parameters,
+      });
+      return rows;
+    },
+    // whisper.submit map-call: each provided field becomes one entry of a Cypher map with
+    // its value bound as its own $parameter (injection-safe), keys in SORTED order so the
+    // query is byte-stable. Field names are the catalog wire names (validated identifiers).
+    async _runGraphSubmit({
+      $ = this, entry, values,
+    }) {
+      const parameters = {};
+      const pairs = [];
+      for (const input of entry.inputs) {
+        const v = this._graphInputValue(entry, input, values);
+        if (v === undefined) {
+          continue;
+        }
+        if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(input.paramName)) {
+          throw new ConfigurationError(`Invalid submit field "${input.paramName}".`);
+        }
+        parameters[input.paramName] = v;
+        pairs.push(`${input.paramName}:$${input.paramName}`);
+      }
+      pairs.sort();
+      const query = `CALL ${entry.map}({${pairs.join(",")}})`;
+      const { rows } = await this._graphPost({
+        $,
+        query,
+        parameters,
+      });
+      return rows;
+    },
+    // Parse an SSE stream body into [{event, data}]; data is JSON-decoded when possible,
+    // else kept as the raw string. Never throws on shape.
+    _parseSse(text) {
+      const events = [];
+      const records = String(text)
+        .replace(/\r\n/g, "\n")
+        .split("\n\n");
+      for (const rec of records) {
+        if (rec.trim() === "") {
+          continue;
+        }
+        let event = "message";
+        const dataLines = [];
+        for (const line of rec.split("\n")) {
+          if (line.startsWith("event:")) {
+            event = line.slice(6).trim();
+          } else if (line.startsWith("data:")) {
+            dataLines.push(line.slice(5).replace(/^ /, ""));
+          }
+        }
+        let data = dataLines.join("\n");
+        try {
+          data = JSON.parse(data);
+        } catch {
+          // not JSON - keep the raw string
+        }
+        events.push({
+          event,
+          data,
+        });
+      }
+      return events;
+    },
+    _firstSseError(text) {
+      const errEv = this._parseSse(text)
+        .find((ev) => ev.event === "error");
+      if (!errEv) {
+        return null;
+      }
+      const d = errEv.data;
+      return d && typeof d === "object"
+        ? (d.detail || d.message || d.error || null)
+        : `${d}`;
+    },
+    // Run a multi-step flow by slug on the gallery/run endpoint (keyed). POSTs {slug, inputs,
+    // params}, consumes the Server-Sent-Events stream (buffered as text) and returns the
+    // collected { slug, steps, complete, events }. Flows are multi-step, so the timeout is
+    // generous; a liberal server that answers plain JSON is accepted too.
+    async runGraphFlow({
+      $ = this, slug, inputs = {}, params = {}, timeout = 300000,
+    }) {
+      const apiKey = this._requireApiKey();
+      const response = await axios($, {
+        method: "POST",
+        url: this._flowRunUrl(),
+        headers: {
+          "X-API-Key": apiKey,
+          "Content-Type": "application/json",
+          "Accept": "text/event-stream",
+        },
+        data: {
+          slug,
+          inputs,
+          params,
+        },
+        responseType: "text",
+        timeout,
+        returnFullResponse: true,
+        validateStatus: () => true,
+      });
+      if (response.status >= 400) {
+        const b = response.data;
+        let detail = `the workflow runner returned status ${response.status}`;
+        if (b && typeof b === "object") {
+          detail = b.detail || b.message || b.title || detail;
+        } else if (typeof b === "string" && b.trim() !== "") {
+          detail = this._firstSseError(b) || detail;
+        }
+        throw new Error(detail);
+      }
+      const events = typeof response.data === "string"
+        ? this._parseSse(response.data)
+        : [];
+      if (events.length === 0 && response.data && typeof response.data === "object") {
+        return {
+          slug,
+          steps: [],
+          complete: response.data,
+          events: [],
+        };
+      }
+      const steps = events
+        .filter((ev) => ev.event === "step")
+        .map((ev) => ev.data);
+      const completeEv = events.findLast((ev) => ev.event === "complete");
+      const complete = completeEv && typeof completeEv.data === "object"
+        ? completeEv.data
+        : null;
+      const errEv = events.find((ev) => ev.event === "error");
+      if (errEv && !complete && steps.length === 0) {
+        const d = errEv.data;
+        const msg = d && typeof d === "object"
+          ? (d.detail || d.message || d.error)
+          : `${d}`;
+        throw new Error(msg || `graph flow "${slug}" failed on the workflow runner`);
+      }
+      return {
+        slug,
+        steps,
+        complete,
+        events,
+      };
+    },
+    // A friendly one-line summary for either shape a recipe returns (rows or flow steps).
+    graphSummary(id, result) {
+      if (Array.isArray(result)) {
+        return `Ran graph recipe "${id}": ${result.length} row${result.length === 1
+          ? ""
+          : "s"}`;
+      }
+      if (result && Array.isArray(result.steps)) {
+        return `Ran graph flow "${id}": ${result.steps.length} step${result.steps.length === 1
+          ? ""
+          : "s"}`;
+      }
+      return `Ran graph recipe "${id}"`;
     },
   },
 };


### PR DESCRIPTION
## Summary

Adds a new **Whisper** app (`components/whisper/`) that surfaces Whisper's agent-identity network and the whisper.security internet graph inside Pipedream workflows and as MCP tools.

The app is deliberately **two-tier**:

- **Keyless**: the identity actions read Whisper's fully public API at `https://rdap.whisper.online`. No credentials, OAuth, or account required.
- **Keyed**: connecting a Whisper API key (a single secret `api_key` auth field, sent as `X-API-Key`) unlocks the agent control plane and the intelligence graph at `https://graph.whisper.security`.

App integration request: #21298 (updated with the requested auth schema: `custom_auth`, one optional secret `api_key` field).

### Keyless actions (no connected account needed)

| Action | Endpoint |
|---|---|
| Verify Agent Identity | `GET /verify-identity?ip={address}` |
| Lookup RDAP Record | `GET /ip/{address}` |
| Get Transparency Log | `GET /ip/{address}/transparency` |
| Get Inbound Lookups | `GET /ip/{address}/lookups` |
| Get Egress IP | `GET /egress-ip` |

### Control-plane actions (API key)

Each posts the `whisper.agents({op, args})` verb to `graph.whisper.security` with the key in `X-API-Key`: **Register Agent**, **List Agents**, **Get Agent**, **Allocate Identity**, **Connect Egress**, **Set Policy**, **Get Logs**, **Revoke Agent**. Argument values are escaped literals (quotes and backslashes doubled, keys sorted), so hostile input cannot escape the query. Egress secrets (proxy credential URLs, private keys) are stripped from step exports by default.

### Graph intelligence actions (API key)

- **Graph: Run Cypher** - a raw read query; inputs are bound as `$parameters`, never concatenated.
- **29 named recipes** (`Graph: <title>`) from the Whisper catalog: 14 direct procedures and 15 multi-step flows (streamed as Server-Sent Events and returned as consolidated steps). Every action links its documentation page.

All 43 actions export a `$summary`, route through `axios` from `@pipedream/platform` via shared app methods, share `propDefinition`s, and carry accurate annotations (`readOnlyHint` / `destructiveHint` / `openWorldHint`). Verified end-to-end against the live API and linted with the repo's ESLint rules.

## Checklist
Please check the following items before your PR can be reviewed:

### Versioning
- [x] All components updated in this PR had their version updated (`0.0.1` for new ones)
- [x] The app updated in this PR had its `package.json`'s version updated

### New app
If this is a new app, please submit [an app integration request](https://github.com/PipedreamHQ/pipedream/issues/new?template=app---service-integration.md) - the PR will only be reviewed after the app is integrated.
- [ ] The app updated in this PR is already integrated - app integration request filed: #21298 (pending registration)

### CodeRabbit review
After the PR is opened, and if new changes are pushed, CodeRabbit will automatically review it. Do not 'mark as resolved' CodeRabbit's comments, but reply to them instead, whether you agree (and update the PR accordingly) or disagree.
- [x] I have addressed or acknowledged all of CodeRabbit's review comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Whisper integration with graph-based intelligence workflows and curated summaries.
  * Added actions for identity verification, RDAP records, transparency logs, inbound lookups, egress IPs, agent management, egress connections, policies, and logs.
  * Added graph investigation tools for threat analysis, infrastructure mapping, DNS, BGP, supply chains, typosquatting, Tor relays, and more.
  * Added Cypher querying and observation or feedback submission, with summaries and complete result payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->