### PR TITLE
Google Drive - changesPageSize standardizing and removing some unnecessary logs

### DIFF
--- a/components/google_drive/google_drive.app.mjs
+++ b/components/google_drive/google_drive.app.mjs
@@ -156,6 +156,15 @@ export default {
       optional: true,
       default: false,
     },
+    changesPageSize: {
+      type: "integer",
+      label: "Changes Page Size",
+      description: "Maximum number of changes to fetch per API call (1-1000). Lower values reduce memory usage and the risk of execution timeouts or out-of-memory errors on active drives.",
+      min: 1,
+      max: 1000,
+      default: 100,
+      optional: true,
+    },
     filePath: {
       type: "string",
       label: "File Path or URL",

--- a/components/google_drive/package.json
+++ b/components/google_drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_drive",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Pipedream Google_drive Components",
   "main": "google_drive.app.mjs",
   "keywords": [

--- a/components/google_drive/sources/changes-to-files-in-drive/changes-to-files-in-drive.mjs
+++ b/components/google_drive/sources/changes-to-files-in-drive/changes-to-files-in-drive.mjs
@@ -14,7 +14,7 @@ export default {
   key: "google_drive-changes-to-files-in-drive",
   name: "Changes to Files in Drive",
   description: "Emit new event when a change is made to one of the specified files. [See the documentation](https://developers.google.com/drive/api/v3/reference/changes/watch)",
-  version: "0.0.10",
+  version: "0.0.11",
   type: "source",
   dedupe: "unique",
   props: {
@@ -132,8 +132,6 @@ export default {
     },
     async processChanges(changedFiles, headers) {
       console.log(`Processing ${changedFiles.length} changed files`);
-      console.log(`Changed files: ${JSON.stringify(changedFiles, null, 2)}!!!`);
-      console.log(`Files: ${this.files}!!!`);
 
       const filteredFiles = this.checkMinimumInterval(changedFiles);
       for (const file of filteredFiles) {

--- a/components/google_drive/sources/changes-to-specific-files-shared-drive/changes-to-specific-files-shared-drive.mjs
+++ b/components/google_drive/sources/changes-to-specific-files-shared-drive/changes-to-specific-files-shared-drive.mjs
@@ -29,7 +29,7 @@ export default {
   key: "google_drive-changes-to-specific-files-shared-drive",
   name: "Changes to Specific Files (Shared Drive)",
   description: "Watches for changes to specific files in a shared drive, emitting an event when a change is made to one of those files",
-  version: "0.3.10",
+  version: "0.3.11",
   type: "source",
   // Dedupe events based on the "x-goog-message-number" header for the target channel:
   // https://developers.google.com/drive/api/v3/push#making-watch-requests
@@ -137,8 +137,6 @@ export default {
     },
     async processChanges(changedFiles, headers) {
       console.log(`Processing ${changedFiles.length} changed files`);
-      console.log(`Changed files: ${JSON.stringify(changedFiles, null, 2)}!!!`);
-      console.log(`Files: ${this.files}!!!`);
 
       const filteredFiles = this.checkMinimumInterval(changedFiles);
       for (const file of filteredFiles) {

--- a/components/google_drive/sources/common-webhook.mjs
+++ b/components/google_drive/sources/common-webhook.mjs
@@ -33,11 +33,10 @@ export default {
       hidden: true,
     },
     changesPageSize: {
-      type: "integer",
-      label: "Changes Page Size",
-      description: "Maximum number of changes to fetch per API call. Lower values reduce the risk of execution timeouts on active drives.",
-      default: 1000,
-      optional: true,
+      propDefinition: [
+        googleDrive,
+        "changesPageSize",
+      ],
     },
   },
   hooks: {

--- a/components/google_drive/sources/new-files-instant-polling/new-files-instant-polling.mjs
+++ b/components/google_drive/sources/new-files-instant-polling/new-files-instant-polling.mjs
@@ -8,7 +8,7 @@ export default {
   key: "google_drive-new-files-instant-polling",
   name: "New Files (Polling)",
   description: "Emit new event when a new file is added in your linked Google Drive",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "source",
   dedupe: "unique",
   props: {
@@ -46,11 +46,10 @@ export default {
       default: [],
     },
     changesPageSize: {
-      type: "integer",
-      label: "Changes Page Size",
-      description: "Maximum number of changes to fetch per API call. Lower values reduce the risk of execution timeouts on active drives.",
-      default: 1000,
-      optional: true,
+      propDefinition: [
+        googleDrive,
+        "changesPageSize",
+      ],
     },
   },
   hooks: {
@@ -151,7 +150,6 @@ export default {
       this.googleDrive.listChanges(pageToken, driveId, this.changesPageSize);
 
     for await (const changedFilesPage of changedFilesStream) {
-      console.log("Changed files page:", changedFilesPage);
       const {
         changedFiles,
         nextPageToken,

--- a/components/google_drive/sources/new-files-instant/new-files-instant.mjs
+++ b/components/google_drive/sources/new-files-instant/new-files-instant.mjs
@@ -11,7 +11,7 @@ export default {
   key: "google_drive-new-files-instant",
   name: "New Files (Instant)",
   description: "Emit new event when a new file is added in your linked Google Drive",
-  version: "0.2.10",
+  version: "0.2.11",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_drive/sources/new-files-shared-drive/new-files-shared-drive.mjs
+++ b/components/google_drive/sources/new-files-shared-drive/new-files-shared-drive.mjs
@@ -7,7 +7,7 @@ export default {
   key: "google_drive-new-files-shared-drive",
   name: "New Files (Shared Drive)",
   description: "Emit new event when a new file is added in your shared Google Drive",
-  version: "0.1.10",
+  version: "0.1.11",
   type: "source",
   dedupe: "unique",
   props: {
@@ -50,11 +50,10 @@ export default {
       optional: true,
     },
     changesPageSize: {
-      type: "integer",
-      label: "Changes Page Size",
-      description: "Maximum number of changes to fetch per API call. Lower values reduce the risk of execution timeouts on active drives.",
-      default: 1000,
-      optional: true,
+      propDefinition: [
+        googleDrive,
+        "changesPageSize",
+      ],
     },
   },
   hooks: {

--- a/components/google_drive/sources/new-or-modified-comments/new-or-modified-comments.mjs
+++ b/components/google_drive/sources/new-or-modified-comments/new-or-modified-comments.mjs
@@ -18,7 +18,7 @@ export default {
   name: "New or Modified Comments (Instant)",
   description:
     "Emit new event when a comment is created or modified in the selected file",
-  version: "1.0.19",
+  version: "1.0.20",
   type: "source",
   // Dedupe events based on the "x-goog-message-number" header for the target channel:
   // https://developers.google.com/drive/api/v3/push#making-watch-requests

--- a/components/google_drive/sources/new-or-modified-files-polling/new-or-modified-files-polling.mjs
+++ b/components/google_drive/sources/new-or-modified-files-polling/new-or-modified-files-polling.mjs
@@ -9,7 +9,7 @@ export default {
   key: "google_drive-new-or-modified-files-polling",
   name: "New or Modified Files (Polling)",
   description: "Emit new event when a file in the selected Drive is created, modified or trashed. [See the documentation](https://developers.google.com/drive/api/v3/reference/changes/list)",
-  version: "0.0.10",
+  version: "0.0.11",
   type: "source",
   dedupe: "unique",
   props: {
@@ -67,11 +67,10 @@ export default {
       optional: true,
     },
     changesPageSize: {
-      type: "integer",
-      label: "Changes Page Size",
-      description: "Maximum number of changes to fetch per API call. Lower values reduce the risk of execution timeouts on active drives.",
-      default: 1000,
-      optional: true,
+      propDefinition: [
+        googleDrive,
+        "changesPageSize",
+      ],
     },
   },
   hooks: {
@@ -189,7 +188,6 @@ export default {
       this.googleDrive.listChanges(pageToken, driveId, this.changesPageSize);
 
     for await (const changedFilesPage of changedFilesStream) {
-      console.log("Changed files page:", changedFilesPage);
       const {
         changedFiles,
         nextPageToken,

--- a/components/google_drive/sources/new-or-modified-files/new-or-modified-files.mjs
+++ b/components/google_drive/sources/new-or-modified-files/new-or-modified-files.mjs
@@ -26,7 +26,7 @@ export default {
   key: "google_drive-new-or-modified-files",
   name: "New or Modified Files (Instant)",
   description: "Emit new event when a file in the selected Drive is created, modified or trashed.",
-  version: "0.4.10",
+  version: "0.4.11",
   type: "source",
   // Dedupe events based on the "x-goog-message-number" header for the target channel:
   // https://developers.google.com/drive/api/v3/push#making-watch-requests
@@ -154,8 +154,6 @@ export default {
         file.parents = (await this.googleDrive.getFile(file.id, {
           fields: "parents",
         })).parents;
-
-        console.log(file); // see what file was processed
 
         if (!this.shouldProcess(file)) {
           console.log(`Skipping file ${file.name}`);

--- a/components/google_drive/sources/new-or-modified-folders-polling/new-or-modified-folders-polling.mjs
+++ b/components/google_drive/sources/new-or-modified-folders-polling/new-or-modified-folders-polling.mjs
@@ -12,7 +12,7 @@ export default {
   key: "google_drive-new-or-modified-folders-polling",
   name: "New or Modified Folders (Polling)",
   description: "Emit new event when a folder is created or modified in the selected Drive",
-  version: "0.0.9",
+  version: "0.0.10",
   type: "source",
   dedupe: "unique",
   props: {
@@ -51,11 +51,10 @@ export default {
       optional: true,
     },
     changesPageSize: {
-      type: "integer",
-      label: "Changes Page Size",
-      description: "Maximum number of changes to fetch per API call. Lower values reduce the risk of execution timeouts on active drives.",
-      default: 1000,
-      optional: true,
+      propDefinition: [
+        googleDrive,
+        "changesPageSize",
+      ],
     },
   },
   hooks: {
@@ -192,7 +191,6 @@ export default {
       this.googleDrive.listChanges(pageToken, driveId, this.changesPageSize);
 
     for await (const changedFilesPage of changedFilesStream) {
-      console.log("Changed files page:", changedFilesPage);
       const {
         changedFiles,
         nextPageToken,

--- a/components/google_drive/sources/new-or-modified-folders/new-or-modified-folders.mjs
+++ b/components/google_drive/sources/new-or-modified-folders/new-or-modified-folders.mjs
@@ -21,7 +21,7 @@ export default {
   key: "google_drive-new-or-modified-folders",
   name: "New or Modified Folders (Instant)",
   description: "Emit new event when a folder is created or modified in the selected Drive",
-  version: "0.2.13",
+  version: "0.2.14",
   type: "source",
   // Dedupe events based on the "x-goog-message-number" header for the target channel:
   // https://developers.google.com/drive/api/v3/push#making-watch-requests

--- a/components/google_drive/sources/new-spreadsheet-polling/new-spreadsheet-polling.mjs
+++ b/components/google_drive/sources/new-spreadsheet-polling/new-spreadsheet-polling.mjs
@@ -8,7 +8,7 @@ export default {
   key: "google_drive-new-spreadsheet-polling",
   name: "New Spreadsheet (Polling)",
   description: "Emit new event when a new spreadsheet is created in a drive.",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "source",
   dedupe: "unique",
   props: {
@@ -45,11 +45,10 @@ export default {
       optional: true,
     },
     changesPageSize: {
-      type: "integer",
-      label: "Changes Page Size",
-      description: "Maximum number of changes to fetch per API call. Lower values reduce the risk of execution timeouts on active drives.",
-      default: 1000,
-      optional: true,
+      propDefinition: [
+        googleDrive,
+        "changesPageSize",
+      ],
     },
   },
   hooks: {
@@ -149,7 +148,6 @@ export default {
       this.googleDrive.listChanges(pageToken, driveId, this.changesPageSize);
 
     for await (const changedFilesPage of changedFilesStream) {
-      console.log("Changed files page:", changedFilesPage);
       const {
         changedFiles,
         nextPageToken,


### PR DESCRIPTION
Closes #21300 

Intentionally bumped only the triggers' versions for this one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared “changes page size” setting for Google Drive sources, controlling how many Drive changes are fetched per request (1–1000, default 100).
* **Bug Fixes**
  * Reduced noisy debug logging across multiple Drive sources to keep console output cleaner.
* **Chores**
  * Updated versions for several Google Drive source components and the Google Drive package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->