### PR TITLE
New Components - loopquest

### DIFF
--- a/components/loopquest/actions/create-review-task/create-review-task.mjs
+++ b/components/loopquest/actions/create-review-task/create-review-task.mjs
@@ -3,9 +3,14 @@ import app from "../../loopquest.app.mjs";
 export default {
   key: "loopquest-create-review-task",
   name: "Create Review Task",
-  description: "Send AI/automation output to a human. Gate a downstream action until it's approved, or monitor quality in the background. [See the docs](https://loopquest.tomphillips.uk/docs).",
+  description: "Send AI/automation output to a human. Gate a downstream action until it's approved, or monitor quality in the background. [See the documentation](https://loopquest.tomphillips.uk/docs).",
   version: "0.0.1",
   type: "action",
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
   props: {
     loopquest: app,
     content: { propDefinition: [app, "content"] },

--- a/components/loopquest/actions/create-review-task/create-review-task.mjs
+++ b/components/loopquest/actions/create-review-task/create-review-task.mjs
@@ -1,0 +1,45 @@
+import app from "../../loopquest.app.mjs";
+
+export default {
+  key: "loopquest-create-review-task",
+  name: "Create Review Task",
+  description: "Send AI/automation output to a human. Gate a downstream action until it's approved, or monitor quality in the background. [See the docs](https://loopquest.tomphillips.uk/docs).",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    loopquest: app,
+    content: { propDefinition: [app, "content"] },
+    title: { propDefinition: [app, "title"] },
+    module: { propDefinition: [app, "module"] },
+    mode: { propDefinition: [app, "mode"] },
+    claim: { propDefinition: [app, "claim"] },
+    sourceText: { propDefinition: [app, "sourceText"] },
+    timeoutSeconds: { propDefinition: [app, "timeoutSeconds"] },
+    onTimeout: { propDefinition: [app, "onTimeout"] },
+    source: { propDefinition: [app, "source"] },
+    externalId: { propDefinition: [app, "externalId"] },
+    callbackUrl: { propDefinition: [app, "callbackUrl"] },
+    reviewsRequired: { propDefinition: [app, "reviewsRequired"] },
+  },
+  async run({ $ }) {
+    const res = await this.loopquest.createTask({
+      $,
+      props: {
+        content: this.content,
+        title: this.title,
+        module: this.module,
+        mode: this.mode,
+        claim: this.claim,
+        sourceText: this.sourceText,
+        timeoutSeconds: this.timeoutSeconds,
+        onTimeout: this.onTimeout,
+        source: this.source,
+        externalId: this.externalId,
+        callbackUrl: this.callbackUrl,
+        reviewsRequired: this.reviewsRequired,
+      },
+    });
+    $.export("$summary", `Submitted review task ${res.id}`);
+    return res;
+  },
+};

--- a/components/loopquest/actions/get-task-status/get-task-status.mjs
+++ b/components/loopquest/actions/get-task-status/get-task-status.mjs
@@ -3,9 +3,14 @@ import app from "../../loopquest.app.mjs";
 export default {
   key: "loopquest-get-task-status",
   name: "Get Task Status",
-  description: "Check a LoopQuest task's status / verdict. [See the docs](https://loopquest.tomphillips.uk/docs).",
+  description: "Check a LoopQuest task's status / verdict. [See the documentation](https://loopquest.tomphillips.uk/docs).",
   version: "0.0.1",
   type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
   props: {
     loopquest: app,
     taskId: { propDefinition: [app, "taskId"] },

--- a/components/loopquest/actions/get-task-status/get-task-status.mjs
+++ b/components/loopquest/actions/get-task-status/get-task-status.mjs
@@ -1,0 +1,18 @@
+import app from "../../loopquest.app.mjs";
+
+export default {
+  key: "loopquest-get-task-status",
+  name: "Get Task Status",
+  description: "Check a LoopQuest task's status / verdict. [See the docs](https://loopquest.tomphillips.uk/docs).",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    loopquest: app,
+    taskId: { propDefinition: [app, "taskId"] },
+  },
+  async run({ $ }) {
+    const res = await this.loopquest.getTask({ $, taskId: this.taskId });
+    $.export("$summary", `Task ${this.taskId} is ${res.status}`);
+    return res;
+  },
+};

--- a/components/loopquest/common/body.mjs
+++ b/components/loopquest/common/body.mjs
@@ -1,0 +1,20 @@
+/** Build the POST /api/v1/tasks body from action props. Pure — unit tested. */
+export function buildTaskBody(p = {}) {
+  const payload = { content: p.content, body: p.content };
+  if (p.claim) payload.claim = p.claim;
+  if (p.sourceText) payload.source = p.sourceText;
+
+  const body = {
+    module: p.module || "swiper",
+    mode: p.mode || "monitor",
+    payload,
+    card: { title: p.title || "Review", body: p.content },
+  };
+  if (p.source) body.source = p.source;
+  if (p.externalId) body.external_id = p.externalId;
+  if (p.callbackUrl) body.callback_url = p.callbackUrl;
+  if (p.timeoutSeconds) body.timeout_seconds = p.timeoutSeconds;
+  if (p.onTimeout) body.on_timeout = p.onTimeout;
+  if (p.reviewsRequired) body.reviews_required = p.reviewsRequired;
+  return body;
+}

--- a/components/loopquest/loopquest.app.mjs
+++ b/components/loopquest/loopquest.app.mjs
@@ -1,0 +1,89 @@
+import { axios } from "@pipedream/platform";
+import { buildTaskBody } from "./common/body.mjs";
+
+export default {
+  type: "app",
+  app: "loopquest",
+  propDefinitions: {
+    content: { type: "string", label: "Content", description: "The AI/automation output a human should review." },
+    title: { type: "string", label: "Title", optional: true },
+    module: {
+      type: "string",
+      label: "Game",
+      optional: true,
+      default: "swiper",
+      description: "How the reviewer sees the item.",
+      options: [
+        { label: "Swiper — approve or reject", value: "swiper" },
+        { label: "Versus — pick the better of two", value: "versus" },
+        { label: "Sorter — bucket into categories", value: "sorter" },
+        { label: "Detective — spot the problem", value: "detective" },
+        { label: "Fixer — correct the output", value: "fixer" },
+        { label: "Redact — mask sensitive text", value: "redact" },
+        { label: "Grounding — verify a claim against a source", value: "grounding" },
+      ],
+    },
+    mode: {
+      type: "string",
+      label: "Mode",
+      optional: true,
+      default: "monitor",
+      description: "`gate` blocks a downstream step until a human approves (pair with the New Verdict trigger). `monitor` reviews in the background without pausing.",
+      options: ["monitor", "gate"],
+    },
+    claim: { type: "string", label: "Claim", optional: true, description: "Grounding only: the statement to verify." },
+    sourceText: { type: "string", label: "Source Text", optional: true, description: "Grounding only: the reference text the claim is checked against." },
+    timeoutSeconds: { type: "integer", label: "Timeout (seconds)", optional: true, description: "Gate only: apply the fallback if no one reviews in time (30–2592000)." },
+    onTimeout: {
+      type: "string",
+      label: "On Timeout",
+      optional: true,
+      description: "Gate only: what to do if the timeout is hit. Defaults to escalate (fail-closed).",
+      options: ["escalate", "reject", "approve"],
+    },
+    source: { type: "string", label: "Source", optional: true, default: "pipedream", description: "A label for where this came from." },
+    externalId: { type: "string", label: "External ID", optional: true, description: "Your own id for the item — echoed back in the verdict so you can correlate it." },
+    callbackUrl: { type: "string", label: "Callback URL", optional: true, description: "Optional. A single webhook for this task's verdict. Leave blank if you use the New Verdict trigger." },
+    reviewsRequired: { type: "integer", label: "Reviewers Required", optional: true },
+    taskId: { type: "string", label: "Task ID" },
+  },
+  methods: {
+    _baseUrl() {
+      return (this.$auth.base_url || "https://loopquest.tomphillips.uk").replace(/\/+$/, "");
+    },
+    _headers() {
+      return { authorization: `Bearer ${this.$auth.api_key}`, "content-type": "application/json" };
+    },
+    async createTask({ $, props }) {
+      return axios($, {
+        method: "POST",
+        url: `${this._baseUrl()}/api/v1/tasks`,
+        headers: this._headers(),
+        data: buildTaskBody(props),
+      });
+    },
+    async getTask({ $, taskId }) {
+      return axios($, {
+        method: "GET",
+        url: `${this._baseUrl()}/api/v1/tasks/${taskId}`,
+        headers: this._headers(),
+      });
+    },
+    // Verdict subscriptions — power the New Verdict source (REST-hook style).
+    async subscribeVerdicts($, url) {
+      return axios($, {
+        method: "POST",
+        url: `${this._baseUrl()}/api/v1/hooks`,
+        headers: this._headers(),
+        data: { url },
+      });
+    },
+    async unsubscribeVerdicts($, id) {
+      return axios($, {
+        method: "DELETE",
+        url: `${this._baseUrl()}/api/v1/hooks/${id}`,
+        headers: this._headers(),
+      });
+    },
+  },
+};

--- a/components/loopquest/loopquest.app.mjs
+++ b/components/loopquest/loopquest.app.mjs
@@ -6,7 +6,7 @@ export default {
   app: "loopquest",
   propDefinitions: {
     content: { type: "string", label: "Content", description: "The AI/automation output a human should review." },
-    title: { type: "string", label: "Title", optional: true },
+    title: { type: "string", label: "Title", optional: true, description: "Optional heading shown on the review card." },
     module: {
       type: "string",
       label: "Game",
@@ -44,8 +44,8 @@ export default {
     source: { type: "string", label: "Source", optional: true, default: "pipedream", description: "A label for where this came from." },
     externalId: { type: "string", label: "External ID", optional: true, description: "Your own id for the item — echoed back in the verdict so you can correlate it." },
     callbackUrl: { type: "string", label: "Callback URL", optional: true, description: "Optional. A single webhook for this task's verdict. Leave blank if you use the New Verdict trigger." },
-    reviewsRequired: { type: "integer", label: "Reviewers Required", optional: true },
-    taskId: { type: "string", label: "Task ID" },
+    reviewsRequired: { type: "integer", label: "Reviewers Required", optional: true, description: "How many people must review before the verdict resolves. Defaults to 1." },
+    taskId: { type: "string", label: "Task ID", description: "The task id returned by **Create Review Task** — used by **Get Task Status**." },
   },
   methods: {
     _baseUrl() {
@@ -54,36 +54,26 @@ export default {
     _headers() {
       return { authorization: `Bearer ${this.$auth.api_key}`, "content-type": "application/json" };
     },
-    async createTask({ $, props }) {
+    // Single place that constructs the axios call — every method delegates here.
+    _makeRequest({ $, path, ...opts }) {
       return axios($, {
-        method: "POST",
-        url: `${this._baseUrl()}/api/v1/tasks`,
+        url: `${this._baseUrl()}${path}`,
         headers: this._headers(),
-        data: buildTaskBody(props),
+        ...opts,
       });
+    },
+    async createTask({ $, props }) {
+      return this._makeRequest({ $, method: "POST", path: "/api/v1/tasks", data: buildTaskBody(props) });
     },
     async getTask({ $, taskId }) {
-      return axios($, {
-        method: "GET",
-        url: `${this._baseUrl()}/api/v1/tasks/${taskId}`,
-        headers: this._headers(),
-      });
+      return this._makeRequest({ $, method: "GET", path: `/api/v1/tasks/${taskId}` });
     },
     // Verdict subscriptions — power the New Verdict source (REST-hook style).
-    async subscribeVerdicts($, url) {
-      return axios($, {
-        method: "POST",
-        url: `${this._baseUrl()}/api/v1/hooks`,
-        headers: this._headers(),
-        data: { url },
-      });
+    async subscribeVerdicts({ $, url }) {
+      return this._makeRequest({ $, method: "POST", path: "/api/v1/hooks", data: { url } });
     },
-    async unsubscribeVerdicts($, id) {
-      return axios($, {
-        method: "DELETE",
-        url: `${this._baseUrl()}/api/v1/hooks/${id}`,
-        headers: this._headers(),
-      });
+    async unsubscribeVerdicts({ $, id }) {
+      return this._makeRequest({ $, method: "DELETE", path: `/api/v1/hooks/${id}` });
     },
   },
 };

--- a/components/loopquest/package.json
+++ b/components/loopquest/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@pipedream/loopquest",
+  "version": "0.0.1",
+  "description": "Pipedream components for LoopQuest — human-in-the-loop review.",
+  "main": "loopquest.app.mjs",
+  "type": "module",
+  "keywords": [
+    "pipedream",
+    "loopquest"
+  ],
+  "homepage": "https://pipedream.com/apps/loopquest",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^3.1.1"
+  }
+}

--- a/components/loopquest/sources/new-verdict/new-verdict.mjs
+++ b/components/loopquest/sources/new-verdict/new-verdict.mjs
@@ -3,7 +3,7 @@ import app from "../../loopquest.app.mjs";
 export default {
   key: "loopquest-new-verdict",
   name: "New Verdict",
-  description: "Emit an event the moment a human reviewer resolves a task — approve, flag, escalate or timeout. Use it to resume a gated action or act on a monitored review. [See the docs](https://loopquest.tomphillips.uk/docs).",
+  description: "Emit an event the moment a human reviewer resolves a task — approve, flag, escalate or timeout. Use it to resume a gated action or act on a monitored review. [See the documentation](https://loopquest.tomphillips.uk/docs).",
   version: "0.0.1",
   type: "source",
   dedupe: "unique",
@@ -16,12 +16,12 @@ export default {
     // Register this source's HTTP endpoint as a verdict subscription. LoopQuest
     // then POSTs every resolved verdict here (idempotent by URL server-side).
     async activate() {
-      const { id } = await this.loopquest.subscribeVerdicts(this, this.http.endpoint);
+      const { id } = await this.loopquest.subscribeVerdicts({ $: this, url: this.http.endpoint });
       this.db.set("hookId", id);
     },
     async deactivate() {
       const hookId = this.db.get("hookId");
-      if (hookId) await this.loopquest.unsubscribeVerdicts(this, hookId);
+      if (hookId) await this.loopquest.unsubscribeVerdicts({ $: this, id: hookId });
     },
   },
   async run(event) {
@@ -38,7 +38,9 @@ export default {
             : "resolved";
 
     this.$emit(body, {
-      id: body.task_id,
+      // Unique per delivery: a task's state (approved/flagged/escalated) makes
+      // the id stable for the same resolution but distinct if state ever differs.
+      id: `${body.task_id}:${verdict}`,
       summary: `Verdict: ${verdict}${body.external_id ? ` (${body.external_id})` : ""}`,
       ts: Date.now(),
     });

--- a/components/loopquest/sources/new-verdict/new-verdict.mjs
+++ b/components/loopquest/sources/new-verdict/new-verdict.mjs
@@ -1,0 +1,46 @@
+import app from "../../loopquest.app.mjs";
+
+export default {
+  key: "loopquest-new-verdict",
+  name: "New Verdict",
+  description: "Emit an event the moment a human reviewer resolves a task — approve, flag, escalate or timeout. Use it to resume a gated action or act on a monitored review. [See the docs](https://loopquest.tomphillips.uk/docs).",
+  version: "0.0.1",
+  type: "source",
+  dedupe: "unique",
+  props: {
+    loopquest: app,
+    http: { type: "$.interface.http", customResponse: true },
+    db: "$.service.db",
+  },
+  hooks: {
+    // Register this source's HTTP endpoint as a verdict subscription. LoopQuest
+    // then POSTs every resolved verdict here (idempotent by URL server-side).
+    async activate() {
+      const { id } = await this.loopquest.subscribeVerdicts(this, this.http.endpoint);
+      this.db.set("hookId", id);
+    },
+    async deactivate() {
+      const hookId = this.db.get("hookId");
+      if (hookId) await this.loopquest.unsubscribeVerdicts(this, hookId);
+    },
+  },
+  async run(event) {
+    // Ack immediately so LoopQuest marks the delivery successful.
+    this.http.respond({ status: 200 });
+
+    const body = event.body;
+    if (!body || !body.task_id) return;
+
+    const verdict =
+      body.verdict === true ? "approved"
+        : body.verdict === false ? "flagged"
+          : body.escalated ? "escalated"
+            : "resolved";
+
+    this.$emit(body, {
+      id: body.task_id,
+      summary: `Verdict: ${verdict}${body.external_id ? ` (${body.external_id})` : ""}`,
+      ts: Date.now(),
+    });
+  },
+};


### PR DESCRIPTION
## LoopQuest

Adds components for [LoopQuest](https://loopquest.tomphillips.uk) — a human-in-the-loop review layer for AI/automation output. Send an item to a person to review, **gate** a downstream action until it's approved, or **monitor** quality in the background.

### Components
- **Create Review Task** (action) — `POST /api/v1/tasks`. Pick a review game (swiper, versus, sorter, detective, fixer, redact, grounding) and a mode (`gate` blocks until approval, `monitor` reviews out-of-band), with an optional timeout + on-timeout fallback.
- **New Verdict** (source) — a webhook source. Registers its endpoint with LoopQuest (`POST /api/v1/hooks`) on deploy and unsubscribes on teardown; emits each resolved verdict deduped by `task_id`.
- **Get Task Status** (action) — `GET /api/v1/tasks/{id}`.

### Auth
API key (`api_key`), sent as `Authorization: Bearer`. Connection test hits `GET /api/v1/me`. Optional `base_url` for self-hosted deployments.

### Notes
- New app — the `loopquest` app will need registering on the platform (happy to provide auth config / a PD key as needed).
- API docs: https://loopquest.tomphillips.uk/docs · OpenAPI: https://loopquest.tomphillips.uk/openapi.json
- All new components are versioned `0.0.1`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added LoopQuest actions to create review tasks and check task status.
  * Added a new LoopQuest source to receive verdict updates and emit corresponding events.
  * Introduced LoopQuest app support for creating tasks, fetching task status, and managing verdict webhook subscriptions.
* **Bug Fixes**
  * Improved verdict handling by validating incoming task data and acknowledging requests immediately.
  * Enhanced task summaries by including external identifiers when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->