### PR TITLE
feat(caesar): new app with search-web and get-document actions

### DIFF
--- a/components/caesar/actions/get-document/get-document.mjs
+++ b/components/caesar/actions/get-document/get-document.mjs
@@ -1,0 +1,57 @@
+import { ConfigurationError } from "@pipedream/platform";
+import app from "../../caesar.app.mjs";
+
+export default {
+  key: "caesar-get-document",
+  name: "Get Document",
+  description: "Read a document as clean markdown by Caesar `doc_id` or canonical URL. Free and anonymous, with no API key required. [See the documentation](https://docs.trycaesar.com)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    app,
+    docId: {
+      propDefinition: [
+        app,
+        "docId",
+      ],
+    },
+    canonicalUrl: {
+      propDefinition: [
+        app,
+        "canonicalUrl",
+      ],
+    },
+    query: {
+      propDefinition: [
+        app,
+        "query",
+      ],
+      optional: true,
+      description: "Optional query to focus the read on the most relevant passages.",
+    },
+    include: {
+      propDefinition: [
+        app,
+        "include",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const target = this.docId || this.canonicalUrl;
+    if (!target) {
+      throw new ConfigurationError("Provide a Document ID or a Canonical URL.");
+    }
+    const response = await this.app.read({
+      target,
+      query: this.query,
+      include: this.include,
+    });
+    $.export("$summary", `Retrieved document \`${target}\`.`);
+    return response;
+  },
+};

--- a/components/caesar/actions/get-document/get-document.mjs
+++ b/components/caesar/actions/get-document/get-document.mjs
@@ -4,7 +4,7 @@ import app from "../../caesar.app.mjs";
 export default {
   key: "caesar-get-document",
   name: "Get Document",
-  description: "Read a document as clean markdown by Caesar `doc_id` or canonical URL. Free and anonymous, with no API key required. [See the documentation](https://docs.trycaesar.com)",
+  description: "Read a document as clean markdown by Caesar `doc_id` or canonical URL. [See the documentation](https://docs.trycaesar.com)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/caesar/actions/search-web/search-web.mjs
+++ b/components/caesar/actions/search-web/search-web.mjs
@@ -3,7 +3,7 @@ import app from "../../caesar.app.mjs";
 export default {
   key: "caesar-search-web",
   name: "Search Web",
-  description: "Search the web with Caesar. Free and anonymous, with no API key required. [See the documentation](https://docs.trycaesar.com)",
+  description: "Search the web with Caesar. [See the documentation](https://docs.trycaesar.com)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/caesar/actions/search-web/search-web.mjs
+++ b/components/caesar/actions/search-web/search-web.mjs
@@ -1,0 +1,44 @@
+import app from "../../caesar.app.mjs";
+
+export default {
+  key: "caesar-search-web",
+  name: "Search Web",
+  description: "Search the web with Caesar. Free and anonymous, with no API key required. [See the documentation](https://docs.trycaesar.com)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    app,
+    query: {
+      propDefinition: [
+        app,
+        "query",
+      ],
+    },
+    maxResults: {
+      propDefinition: [
+        app,
+        "maxResults",
+      ],
+    },
+    mode: {
+      propDefinition: [
+        app,
+        "mode",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.app.search({
+      query: this.query,
+      maxResults: this.maxResults,
+      mode: this.mode,
+    });
+    $.export("$summary", `Found ${response.results?.length ?? 0} result(s) for "${this.query}".`);
+    return response;
+  },
+};

--- a/components/caesar/caesar.app.mjs
+++ b/components/caesar/caesar.app.mjs
@@ -1,0 +1,104 @@
+import { Caesar } from "caesar-search";
+
+export default {
+  type: "app",
+  app: "caesar",
+  propDefinitions: {
+    query: {
+      type: "string",
+      label: "Query",
+      description: "The search query.",
+    },
+    maxResults: {
+      type: "integer",
+      label: "Max Results",
+      description: "Maximum number of ranked results to return, from 1 to 50.",
+      optional: true,
+      min: 1,
+      max: 50,
+      default: 10,
+    },
+    mode: {
+      type: "string",
+      label: "Mode",
+      description: "Search mode. `standard` is the recommended default, `fast` lowers latency, and `research` does deeper retrieval.",
+      optional: true,
+      options: [
+        "fast",
+        "standard",
+        "research",
+      ],
+      default: "standard",
+    },
+    docId: {
+      type: "string",
+      label: "Document ID",
+      description: "A Caesar `doc_id` returned by a previous **Search Web** result. Provide this or a Canonical URL.",
+      optional: true,
+    },
+    canonicalUrl: {
+      type: "string",
+      label: "Canonical URL",
+      description: "The URL of the document to read. Provide this or a Document ID.",
+      optional: true,
+    },
+    include: {
+      type: "string[]",
+      label: "Include",
+      description: "Which parts of the document to return.",
+      optional: true,
+      options: [
+        "metadata",
+        "passages",
+        "content",
+      ],
+    },
+  },
+  methods: {
+    /**
+     * Creates a Caesar SDK client. The API key is optional: when it is unset,
+     * the client uses Caesar's free anonymous tier.
+     * @returns {Caesar} A configured Caesar client.
+     */
+    _client() {
+      if (!this._caesarClient) {
+        this._caesarClient = new Caesar({
+          apiKey: this.$auth?.api_key,
+        });
+      }
+      return this._caesarClient;
+    },
+    /**
+     * Runs a ranked web search over Caesar.
+     * @param {object} opts - Search options.
+     * @param {string} opts.query - The search query.
+     * @param {number} [opts.maxResults] - Maximum number of results, from 1 to 50.
+     * @param {string} [opts.mode] - Search mode: `fast`, `standard`, or `research`.
+     * @returns {Promise<object>} The search response, including a `results` array.
+     */
+    search({
+      query, maxResults, mode,
+    }) {
+      return this._client().search(query, {
+        maxResults,
+        mode,
+      });
+    },
+    /**
+     * Reads a document as clean markdown by `doc_id` or canonical URL.
+     * @param {object} opts - Read options.
+     * @param {string} opts.target - A Caesar `doc_id` or a canonical URL.
+     * @param {string} [opts.query] - Optional query to focus the most relevant passages.
+     * @param {string[]} [opts.include] - Which parts of the document to return.
+     * @returns {Promise<object>} The document response, including `content` and provenance.
+     */
+    read({
+      target, query, include,
+    }) {
+      return this._client().read(target, {
+        query,
+        include,
+      });
+    },
+  },
+};

--- a/components/caesar/caesar.app.mjs
+++ b/components/caesar/caesar.app.mjs
@@ -56,14 +56,14 @@ export default {
   },
   methods: {
     /**
-     * Creates a Caesar SDK client. The API key is optional: when it is unset,
-     * the client uses Caesar's free anonymous tier.
+     * Creates a Caesar SDK client authenticated with the connected account's
+     * API key. Caesar requires a key on every request.
      * @returns {Caesar} A configured Caesar client.
      */
     _client() {
       if (!this._caesarClient) {
         this._caesarClient = new Caesar({
-          apiKey: this.$auth?.api_key,
+          apiKey: this.$auth.api_key,
         });
       }
       return this._caesarClient;

--- a/components/caesar/package.json
+++ b/components/caesar/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@pipedream/caesar",
+  "version": "0.0.1",
+  "description": "Pipedream Caesar Components",
+  "main": "caesar.app.mjs",
+  "keywords": [
+    "pipedream",
+    "caesar"
+  ],
+  "homepage": "https://pipedream.com/apps/caesar",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^3.1.1",
+    "caesar-search": "^0.1.3"
+  }
+}


### PR DESCRIPTION
Adds a new `caesar` app with two read-only actions.

- **Search Web** (`caesar-search-web`): ranked web search via `POST /v1/search`.
- **Get Document** (`caesar-get-document`): read a result as clean markdown via `POST /v1/document`, by `doc_id` or canonical URL.

Caesar is a web search and page-reading API for agents, sitting alongside the search providers already in the registry (exa, tavily, serpapi, perplexity, firecrawl, linkup). Both actions use the official `caesar-search` SDK and authenticate with the connected account's API key as `Authorization: Bearer <key>`.

Built to mirror the existing search components: `propDefinition` references, `readOnlyHint` annotations, and `$summary` exports.

### What Search Web returns

Each result carries a `passages` array: the spans Caesar selected **for that query**, rather than a fixed chunking of the page. So a workflow step can act on the relevant text without a follow-up fetch. The `snippet` field is the page's meta description, identical for every query that surfaces the document, so the passages are the part worth binding to.

A live call on `why did tokio avoid the atomic increment in wake_by_ref` returned a top result with 4 passages totalling 1,202 characters, against a 296-character meta description. The action exports the full response, so both are available downstream.

### Testing

- `npx eslint components/caesar`: 0 errors, 0 warnings.
- Both actions verified live **against a keyed account**, with output posted in the comments below. Search returned `results[]` (title, `canonical_url`, `snippet`, `doc_id`, `passages`, `metadata`), and Get Document returned `content` plus provenance for a `canonical_url` taken from a search result.
- The original description showed a keyless run. Caesar removed its anonymous tier on 2026-07-07, so that transcript no longer reproduces and has been replaced by the keyed one.

### Auth note

Caesar requires an API key on every request. Users create one by signing up at https://app.trycaesar.com, and it is sent as `Authorization: Bearer <key>`. The app declares `api_key` as required. App registration is tracked in #21345.

Disclosure: I work on Caesar. Docs: https://docs.trycaesar.com
