### PR TITLE
polydoc: parse object props passed as JSON strings and surface API error details

### DIFF
--- a/components/polydoc/actions/convert-pdf/convert-pdf.mjs
+++ b/components/polydoc/actions/convert-pdf/convert-pdf.mjs
@@ -11,7 +11,7 @@ export default {
   key: "polydoc-convert-pdf",
   name: "Convert to PDF",
   description: "Convert a URL, inline HTML, or a saved template to a PDF. [See the documentation](https://docs.polydoc.tech).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/polydoc/actions/convert-screenshot/convert-screenshot.mjs
+++ b/components/polydoc/actions/convert-screenshot/convert-screenshot.mjs
@@ -11,7 +11,7 @@ export default {
   key: "polydoc-convert-screenshot",
   name: "Capture Screenshot",
   description: "Capture a screenshot of a URL, inline HTML, or a saved template. [See the documentation](https://docs.polydoc.tech).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/polydoc/actions/generate-einvoice/generate-einvoice.mjs
+++ b/components/polydoc/actions/generate-einvoice/generate-einvoice.mjs
@@ -4,14 +4,14 @@ import {
   extractApiErrorMessage, handleResponse,
 } from "../../common/output.mjs";
 import {
-  commonParams, validateParams,
+  coerceObject, commonParams, validateParams,
 } from "../../common/params.mjs";
 
 export default {
   key: "polydoc-generate-einvoice",
   name: "Generate E-Invoice",
   description: "Generate a ZUGFeRD or Factur-X hybrid PDF/A-3 e-invoice (EN 16931). [See the documentation](https://docs.polydoc.tech).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -137,7 +137,7 @@ export default {
       eInvoiceStandard: this.eInvoiceStandard,
       eInvoiceProfile: this.eInvoiceProfile,
       eInvoiceVerify: this.eInvoiceVerify,
-      invoice: this.invoice,
+      invoice: coerceObject(this.invoice, "Invoice"),
     };
 
     const {

--- a/components/polydoc/actions/test-connection/test-connection.mjs
+++ b/components/polydoc/actions/test-connection/test-connection.mjs
@@ -5,7 +5,7 @@ export default {
   key: "polydoc-test-connection",
   name: "Test Connection",
   description: "Validate the connected PolyDoc API key with a tiny sandbox screenshot. [See the documentation](https://docs.polydoc.tech).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/polydoc/common/output.mjs
+++ b/components/polydoc/common/output.mjs
@@ -41,7 +41,21 @@ export function extractApiErrorMessage(error) {
     }
   }
   if (payload && typeof payload === "object" && !Array.isArray(payload)) {
-    return payload.message ?? payload.error ?? undefined;
+    const base = payload.message ?? payload.error ?? undefined;
+    if (Array.isArray(payload.details) && payload.details.length > 0) {
+      const detail = payload.details
+        .map((d) => (d?.path
+          ? `${d.path}: ${d.message}`
+          : d?.message))
+        .filter(Boolean)
+        .join("; ");
+      if (detail) {
+        return base
+          ? `${base} (${detail})`
+          : detail;
+      }
+    }
+    return base;
   }
   return undefined;
 }

--- a/components/polydoc/common/params.mjs
+++ b/components/polydoc/common/params.mjs
@@ -6,6 +6,27 @@
  */
 
 /**
+ * Object-typed props (Invoice, Template Data, Webhook Options, Advanced) arrive
+ * as a JSON string when set through the Pipedream UI rather than bound from an
+ * expression. Parse those back to objects; pass real objects through untouched.
+ * Throws a labelled error on malformed JSON so the user sees which field is bad.
+ */
+export function coerceObject(value, label) {
+  if (typeof value !== "string") {
+    return value;
+  }
+  const trimmed = value.trim();
+  if (trimmed === "") {
+    return undefined;
+  }
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    throw new Error(`${label} must be valid JSON.`);
+  }
+}
+
+/**
  * Enforce the source and delivery field requirements that n8n expressed with
  * displayOptions. Throws once with every missing-field message joined.
  */
@@ -43,7 +64,7 @@ function deliveryFromProps(props) {
   if (mode === "webhook") {
     delivery.webhook = {
       url: props.webhookUrl,
-      ...props.webhookOptions ?? {},
+      ...coerceObject(props.webhookOptions, "Webhook Options") ?? {},
     };
   }
   return delivery;
@@ -56,11 +77,11 @@ export function commonParams(props) {
     url: props.url,
     html: props.html,
     templateId: props.templateId,
-    templateData: props.templateData,
+    templateData: coerceObject(props.templateData, "Template Data"),
     filename: props.filename,
     tag: props.tag,
     timeout: props.timeout,
-    advanced: props.advanced,
+    advanced: coerceObject(props.advanced, "Advanced (JSON)"),
     delivery: deliveryFromProps(props),
   };
 }

--- a/components/polydoc/package.json
+++ b/components/polydoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/polydoc",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream PolyDoc Components",
   "main": "polydoc.app.mjs",
   "keywords": [


### PR DESCRIPTION
## Summary

The Pipedream UI passes object-typed props to a component as a **JSON string** (not a parsed object) unless they are bound from an expression. The PolyDoc actions forwarded these verbatim, so the PolyDoc API rejected them with HTTP 400 `Request validation failed`. For example, **Generate E-Invoice** with an `Invoice` object returns `{"path":"eInvoice.invoice","message":"must be object"}`. The same affected **Template Data**, **Webhook Options**, and **Advanced (JSON)**.

**Fix:** add `coerceObject()` in `common/params.mjs` that `JSON.parse`s object props arriving as strings (empty string becomes unset; malformed JSON throws a labelled error), applied to `templateData`, `advanced`, `webhookOptions`, and the e-invoice `invoice` prop. Also surface the API's field-level `details` in the thrown error, so a validation failure names the offending field instead of the generic message.

Reproduced against the live API: the same request with `invoice` as an object returns a valid ZUGFeRD PDF/A-3 (200); as a JSON string it returns the 400 above. Covered by unit tests in the source repo.

Versions bumped: the four actions `0.0.1` -> `0.0.2`, package `0.1.0` -> `0.1.1`.

## Checklist

### Versioning
- [x] All components updated in this PR had their version updated (`0.0.1` for new ones)
- [x] The app updated in this PR had its `package.json`'s version updated

### New app
- [x] The app updated in this PR is already integrated

### CodeRabbit review
- [x] I have addressed or acknowledged all of CodeRabbit's review comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages to include more detail when requests fail, making issues easier to diagnose.
  * Fixed handling of structured input values so several actions now accept JSON-formatted data more reliably.
  * Updated action versions for PDF conversion, screenshot conversion, e-invoice generation, and connection testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->