### PR TITLE
fix(slack_v2): wire up link_names, parse, attachments props in send-message

### DIFF
--- a/components/slack_v2/actions/common/send-message.mjs
+++ b/components/slack_v2/actions/common/send-message.mjs
@@ -9,6 +9,24 @@ export default {
         "as_user",
       ],
     },
+    link_names: {
+      propDefinition: [
+        slack,
+        "link_names",
+      ],
+    },
+    parse: {
+      propDefinition: [
+        slack,
+        "parse",
+      ],
+    },
+    attachments: {
+      propDefinition: [
+        slack,
+        "attachments",
+      ],
+    },
     addToChannel: {
       propDefinition: [
         slack,

--- a/components/slack_v2/actions/send-message/send-message.mjs
+++ b/components/slack_v2/actions/send-message/send-message.mjs
@@ -6,7 +6,7 @@ export default {
   key: "slack_v2-send-message",
   name: "Send Message",
   description: "Send a message to a user, group, private channel or public channel. [See the documentation](https://api.slack.com/methods/chat.postMessage)",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/package.json
+++ b/components/slack_v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/slack_v2",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Pipedream Slack_v2 Components",
   "main": "slack_v2.app.mjs",
   "keywords": [


### PR DESCRIPTION
## Summary

`slack_v2.app.mjs` declares `link_names`, `parse`, and `attachments` as reusable propDefinitions, and `common/send-message.mjs`'s `run()` already references `this.link_names`, `this.parse`, and `this.attachments` when building the Slack API payload — but none of the three are actually declared in the action's `props` object.
Since Pipedream only binds `configured_props` for declared prop keys, these three values were always `undefined` at runtime, silently ignoring anything a caller configured for them.

This PR adds the missing `propDefinition` entries so the values a user configures actually reach the Slack API call, matching how `unfurl_links`/`unfurl_media`/`as_user` are already wired up.
  
Fixes #21353

  **Changes:**
  - Added `link_names`, `parse`, and `attachments` props (via `propDefinition: [slack, "..."]`) to `components/slack_v2/actions/common/send-message.mjs`.
  - Bumped `version` on `components/slack_v2/actions/send-message/send-message.mjs`.
  - Bumped `components/slack_v2/package.json` version.

  **Testing:** 
  - Published the fix as a dev version via `pd publish ... --dev` and ran it against a real Slack workspace.
  - Set `attachments` to `[{"pretext":"pre-hello","text":"text-world"}]` — the attachment block rendered correctly on the posted message (previously had no effect at all).
  - `link_names`/`parse` follow the identical code path (same propDefinition-import fix), but weren't independently re-verified due to Slack's own username-matching being
  workspace-dependent for `link_names` specifically.


## Checklist
Please check the following items before your PR can be reviewed:

### Versioning
- [x] All components updated in this PR had their version updated (`0.0.1` for new ones)
- [x] The app updated in this PR had its `package.json`'s version updated

### New app
If this is a new app, please submit [an app integration request](https://github.com/PipedreamHQ/pipedream/issues/new?template=app---service-integration.md) - the PR will only be reviewed after the app is integrated.
- [x] The app updated in this PR is already integrated

### CodeRabbit review
After the PR is opened, and if new changes are pushed, CodeRabbit will automatically review it. Do not 'mark as resolved' CodeRabbit's comments, but reply to them instead, whether you agree (and update the PR accordingly) or disagree.
- [ ] I have addressed or acknowledged all of CodeRabbit's review comments



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more options when sending Slack messages, including link name handling, message parsing, and attachments.
* **Chores**
  * Updated the Slack send-message action to a new version.
  * Bumped the Slack v2 package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->