### PR TITLE
[BUG] GitHub - Fix cross-repository review request trigger

### DIFF
--- a/components/github/package.json
+++ b/components/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/github",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Pipedream GitHub Components",
   "main": "github.app.mjs",
   "keywords": [

--- a/components/github/sources/new-review-request/new-review-request.mjs
+++ b/components/github/sources/new-review-request/new-review-request.mjs
@@ -1,39 +1,80 @@
-import common from "../common/common-polling-pr-notifications.mjs";
+import common from "../common/common-polling.mjs";
+
+const MAX_RESULTS = 1000;
 
 export default {
   ...common,
   key: "github-new-review-request",
   name: "New Review Request",
-  description: "Emit new event for new review request notifications. [See the documentation](https://docs.github.com/en/rest/activity/notifications?apiVersion=20.2.71-28#list-notifications-for-the-authenticated-user)",
-  version: "0.2.9",
+  description: "Emit new events when you or a team you're a member of are requested to review a pull request across repositories accessible to the connected account. [See the documentation](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests#search-by-pull-request-review-status-and-reviewer)",
+  version: "0.2.10",
   type: "source",
   dedupe: "unique",
   methods: {
     ...common.methods,
-    _getLastDate() {
-      return this.db.get("lastDate");
+    _getUserLogin() {
+      return this.db.get("userLogin");
     },
-    _setLastDate(value) {
-      this.db.set("lastDate", value);
+    _setUserLogin(userLogin) {
+      this.db.set("userLogin", userLogin);
+    },
+    _getActiveReviewRequestIds() {
+      return this.db.get("activeReviewRequestIds") || [];
+    },
+    _setActiveReviewRequestIds(ids) {
+      this.db.set("activeReviewRequestIds", ids);
+    },
+    async retrieveUserLogin() {
+      let login = this._getUserLogin();
+      if (!login) {
+        const user = await this.github.getAuthenticatedUser();
+        login = user.login;
+        this._setUserLogin(login);
+      }
+      return login;
     },
     async getItems() {
-      const date = this._getLastDate();
-      this._setLastDate(new Date().toISOString());
-      return this.github.getFilteredNotifications({
-        reason: "review_requested",
-        data: {
-          participating: true,
-          all: true,
-          ...(date && {
-            since: date,
-          }),
-        },
+      const login = await this.retrieveUserLogin();
+      return this.github.searchIssueAndPullRequests({
+        query: `is:open is:pr review-requested:${login} sort:updated-desc`,
+        maxResults: MAX_RESULTS,
       });
+    },
+    async getAndProcessData(maxEmits = 0) {
+      const previousIds = this._getActiveReviewRequestIds();
+      const previousIdSet = new Set(previousIds);
+      const items = await this.getItems();
+      const currentIds = new Set(items.map((item) => this.getItemId(item)));
+      const nextIds = new Set(previousIds.filter((id) => currentIds.has(id)));
+      let amountEmits = 0;
+
+      for (const item of items) {
+        const itemId = this.getItemId(item);
+        if (previousIdSet.has(itemId)) {
+          continue;
+        }
+        if (maxEmits && amountEmits >= maxEmits) {
+          nextIds.add(itemId);
+          continue;
+        }
+
+        const pullRequest = await this.github.getFromUrl({
+          url: item.pull_request.url,
+        });
+        this.$emit(pullRequest, {
+          id: `${itemId}-${item.updated_at}`,
+          ...this.getItemMetadata(item),
+        });
+        nextIds.add(itemId);
+        amountEmits++;
+      }
+
+      this._setActiveReviewRequestIds(Array.from(nextIds));
     },
     getItemMetadata(item) {
       return {
         summary: `New review request: "${item.title ?? item.id}"`,
-        ts: Date.now(),
+        ts: Date.parse(item.updated_at),
       };
     },
   },

--- a/components/github/sources/new-review-request/new-review-request.mjs
+++ b/components/github/sources/new-review-request/new-review-request.mjs
@@ -48,6 +48,8 @@ export default {
       const nextIds = new Set(previousIds.filter((id) => currentIds.has(id)));
       let amountEmits = 0;
 
+      this._setActiveReviewRequestIds(Array.from(nextIds));
+
       for (const item of items) {
         const itemId = this.getItemId(item);
         if (previousIdSet.has(itemId)) {
@@ -55,6 +57,7 @@ export default {
         }
         if (maxEmits && amountEmits >= maxEmits) {
           nextIds.add(itemId);
+          this._setActiveReviewRequestIds(Array.from(nextIds));
           continue;
         }
 
@@ -66,10 +69,9 @@ export default {
           ...this.getItemMetadata(item),
         });
         nextIds.add(itemId);
+        this._setActiveReviewRequestIds(Array.from(nextIds));
         amountEmits++;
       }
-
-      this._setActiveReviewRequestIds(Array.from(nextIds));
     },
     getItemMetadata(item) {
       return {


### PR DESCRIPTION
## Summary

Fixes the GitHub **New Review Request** source silently missing active review requests across repositories.

### Reproduction and failure modes

The previous source treats GitHub's notification inbox as the source of truth for review assignments. A controlled A/B test loaded the exact source from `master` and this PR's source, then ran both with the same authenticated account and OAuth token at the same time:

- An open pull request listed the authenticated account in `requested_reviewers`, and its timeline contained the corresponding `review_requested` event.
- `GET /notifications?all=true&participating=true` returned zero threads, so the exact previous source emitted **0** events.
- `is:open is:pr review-requested:<authenticated-user>` returned that pull request, and this PR's exact source fetched the full pull request and emitted **1** event.

The OAuth request to `/notifications` returned `200 OK`, so this does **not** claim that OAuth tokens are categorically rejected. The proven failure is that the notification inbox did not reflect an active review assignment for this account, while GitHub's review-request search did.

There is also a separate deterministic cursor defect in the previous source: it stores `lastDate` before fetching notifications. A fault-injected API failure leaves that cursor advanced even though no events were processed.

GitHub documents that `review-requested:USERNAME` matches direct requests and requests for teams containing that user:
https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests#search-by-pull-request-review-status-and-reviewer

### Change

- Query GitHub's cross-repository issue search with `is:open is:pr review-requested:<authenticated-user>`
- Track the current set of active review-request PR IDs, allowing removal followed by re-request to emit a new event
- Persist progress after each successful emission or intentional deployment seed, so a later item failure cannot replay earlier items
- Preserve the existing full pull request payload and five-event deployment limit
- Use the pull request's `updated_at` value for stable event metadata within each detected active transition

### Known polling limits

- A request added and removed entirely within the default 15-minute polling interval is not observable
- GitHub's Search API exposes at most 1,000 results for a query

The source still covers repositories accessible to the connected account without requiring one repository or organization-admin webhook permissions.

## Verification

- `pnpm exec eslint . --quiet`
- `pnpm build`
- `node scripts/generate-package-report.js --package=github`
- Exact old-vs-new live integration A/B: **0 old events / 1 new event** for the same active review assignment
- Focused state-transition checks for unchanged assignments, removal, re-request, deployment limits, and mid-batch fetch failure retry behavior
- Live read-only OAuth search, full pull request retrieval, reviewer assertion, and event emission

## Checklist

### Versioning
- [x] All components updated in this PR had their version updated
- [x] The app updated in this PR had its `package.json` version updated

### New app
- [x] The app updated in this PR is already integrated

### CodeRabbit review
- [x] I have addressed or acknowledged all of CodeRabbit's review comments on the latest commit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced GitHub “new review request” detection by discovering open pull requests via search.
  * Added persistent tracking to prevent duplicate review-request events across runs.
  * Event timestamps now reflect the pull request’s latest update time.
* **Bug Fixes**
  * Improved reliability for emitting only newly requested reviews when PRs change.
* **Chores**
  * Updated the GitHub integration package version and bumped the “new review request” source version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
