### PR TITLE
Add WhatsApp source support to Gorgias ticket messages

### DIFF
--- a/components/gorgias_oauth/actions/create-ticket-message/create-ticket-message.mjs
+++ b/components/gorgias_oauth/actions/create-ticket-message/create-ticket-message.mjs
@@ -1,11 +1,12 @@
 import gorgiasOauth from "../../gorgias_oauth.app.mjs";
+import constants from "../../common/constants.mjs";
 import { ConfigurationError } from "@pipedream/platform";
 
 export default {
   key: "gorgias_oauth-create-ticket-message",
   name: "Create Ticket Message",
   description: "Create a message for a ticket in the Gorgias system. [See the documentation](https://developers.gorgias.com/reference/create-ticket-message)",
-  version: "0.1.1",
+  version: "0.1.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -110,6 +111,13 @@ export default {
       ],
       optional: false,
     },
+    sourceType: {
+      type: "string",
+      label: "Source Type",
+      description: "How the message was sent or received",
+      options: constants.sourceTypes,
+      optional: true,
+    },
     subject: {
       propDefinition: [
         gorgiasOauth,
@@ -146,6 +154,7 @@ export default {
     props.fromName.hidden = isInternalNote;
     props.toAddress.hidden = isInternalNote;
     props.toName.hidden = isInternalNote;
+    props.sourceType.hidden = isInternalNote;
     return {};
   },
   methods: {
@@ -242,6 +251,9 @@ export default {
     // Only add source and receiver for non-internal notes
     if (!isInternalNote) {
       messageData.source = {
+        ...(this.sourceType && {
+          type: this.sourceType,
+        }),
         from: {
           address: this.fromAddress ?? await this.getEmail($, fromId, "from"),
           ...(this.fromName && {

--- a/components/gorgias_oauth/actions/create-ticket-message/create-ticket-message.mjs
+++ b/components/gorgias_oauth/actions/create-ticket-message/create-ticket-message.mjs
@@ -6,7 +6,7 @@ export default {
   key: "gorgias_oauth-create-ticket-message",
   name: "Create Ticket Message",
   description: "Create a message for a ticket in the Gorgias system. [See the documentation](https://developers.gorgias.com/reference/create-ticket-message)",
-  version: "0.1.2",
+  version: "0.1.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/gorgias_oauth/common/constants.mjs
+++ b/components/gorgias_oauth/common/constants.mjs
@@ -17,6 +17,7 @@ const channels = [
   "sms",
   "twitter",
   "twitter-direct-message",
+  "whatsapp",
   "yotpo-review",
 ];
 

--- a/components/gorgias_oauth/package.json
+++ b/components/gorgias_oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/gorgias_oauth",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Pipedream Gorgias OAuth Components",
   "main": "gorgias_oauth.app.mjs",
   "keywords": [


### PR DESCRIPTION
Closes #21389

## Summary

The Gorgias **Create Ticket Message** action now supports the `whatsapp` channel and exposes the API's optional source type, including `whatsapp-message`. This allows workflows to send the source metadata accepted by Gorgias instead of requiring a custom HTTP request.

The action and app package versions are incremented for release.

## Validation

- ESLint passed for the updated action and constants
- Mocked action execution verified the WhatsApp channel, source type, and source addresses in the generated API payload
- Repository pre-push hook passed

## Checklist
Please check the following items before your PR can be reviewed:

### Versioning
- [x] All components updated in this PR had their version updated (`0.0.1` for new ones)
- [x] The app updated in this PR had its `package.json`'s version updated

### New app
If this is a new app, please submit [an app integration request](https://github.com/PipedreamHQ/pipedream/issues/new?template=app---service-integration.md) - the PR will only be reviewed after the app is integrated.
- [x] The app updated in this PR is already integrated

### CodeRabbit review
After the PR is opened, and if new changes are pushed, CodeRabbit will automatically review it. Do not 'mark as resolved' CodeRabbit's comments, but reply to them instead, whether you agree (and update the PR accordingly) or disagree.
- [ ] I have addressed or acknowledged all of CodeRabbit's review comments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a message source type when creating ticket messages.
  * Added WhatsApp as a supported channel.
* **Bug Fixes**
  * Internal notes no longer display the source type option.
* **Chores**
  * Updated the integration package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->