### PR TITLE
Hubspot trigger adjustments for retroactive events

### DIFF
--- a/components/hubspot/common/constants.mjs
+++ b/components/hubspot/common/constants.mjs
@@ -40,7 +40,9 @@ const ASSOCIATION_CATEGORY = {
 };
 
 const DEFAULT_LIMIT = 100;
-const MAX_INITIAL_EVENTS = 25;
+// Cap for the retroactive sample emitted from a source's deploy() hook, so users
+// see a small representative set of pre-existing events without a full backfill.
+const MAX_INITIAL_EVENTS = 10;
 
 // HubSpot date-based API version for the dated CRM objects endpoints
 // (e.g. /crm/2026-03/objects/{type}/search).

--- a/components/hubspot/package.json
+++ b/components/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/hubspot",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "description": "Pipedream Hubspot Components",
   "main": "hubspot.app.mjs",
   "keywords": [

--- a/components/hubspot/sources/common/common.mjs
+++ b/components/hubspot/sources/common/common.mjs
@@ -1,5 +1,6 @@
 import hubspot from "../../hubspot.app.mjs";
 import { DEFAULT_POLLING_SOURCE_TIMER_INTERVAL } from "@pipedream/platform";
+import { MAX_INITIAL_EVENTS } from "../../common/constants.mjs";
 
 export default {
   props: {
@@ -10,6 +11,22 @@ export default {
       default: {
         intervalSeconds: DEFAULT_POLLING_SOURCE_TIMER_INTERVAL,
       },
+    },
+  },
+  hooks: {
+    async deploy() {
+      // Emit a small, capped sample of pre-existing ("retroactive") events on
+      // deploy and advance the cursor, so that run() only ever emits genuinely
+      // new events. Emitting here (rather than on the first run()) is what lets
+      // the platform honor the user's deploy-time opt-out, where $emit is a
+      // no-op only during deploy().
+      const params = await this.getParams(null);
+      await this.processResults(null, params);
+      // Guarantee the cursor advances even when there were no events to emit, so
+      // the first run() is never treated as an initial (emit-everything) run.
+      if (this._getAfter() == null) {
+        this._setAfter(Date.now());
+      }
     },
   },
   methods: {
@@ -53,12 +70,17 @@ export default {
     },
     async processEvents(resources, after) {
       let maxTs = after || 0;
+      let initialEmitted = 0;
       for (const result of resources) {
         if (!after || await this.isRelevant(result, after)) {
           this.emitEvent(result);
           const ts = this.getTs(result);
           if (ts > maxTs) {
             maxTs = ts;
+          }
+          // Initial (deploy) run: emit only a small capped sample.
+          if (!after && ++initialEmitted >= MAX_INITIAL_EVENTS) {
+            break;
           }
         }
       }
@@ -67,6 +89,7 @@ export default {
     async paginate(params, resourceFn, resultType = null, after = null) {
       let results = null;
       let maxTs = after || 0;
+      let initialEmitted = 0;
       while (!results || params.after) {
         results = await resourceFn(params);
         if (results.paging) {
@@ -89,6 +112,10 @@ export default {
             if (ts > maxTs) {
               maxTs = ts;
               this._setAfter(ts);
+            }
+            // Initial (deploy) run: emit only a small capped sample.
+            if (!after && ++initialEmitted >= MAX_INITIAL_EVENTS) {
+              return;
             }
           } else {
             return;
@@ -113,6 +140,7 @@ export default {
       let results, items;
       let count = 0;
       let maxTs = after || 0;
+      let initialEmitted = 0;
       while (hasMore && (!limitRequest || count < limitRequest)) {
         count++;
         results = await resourceFn(params);
@@ -132,6 +160,10 @@ export default {
             if (ts > maxTs) {
               maxTs = ts;
               this._setAfter(ts);
+            }
+            // Initial (deploy) run: emit only a small capped sample.
+            if (!after && ++initialEmitted >= MAX_INITIAL_EVENTS) {
+              return;
             }
           }
         }

--- a/components/hubspot/sources/common/common.mjs
+++ b/components/hubspot/sources/common/common.mjs
@@ -16,17 +16,22 @@ export default {
   hooks: {
     async deploy() {
       // Emit a small, capped sample of pre-existing ("retroactive") events on
-      // deploy and advance the cursor, so that run() only ever emits genuinely
-      // new events. Emitting here (rather than on the first run()) is what lets
-      // the platform honor the user's deploy-time opt-out, where $emit is a
-      // no-op only during deploy().
+      // deploy, so that run() only ever emits genuinely new events. Emitting
+      // here (rather than on the first run()) is what lets the platform honor
+      // the user's deploy-time opt-out, where $emit is a no-op only during
+      // deploy().
+      const deployTs = Date.now();
       const params = await this.getParams(null);
       await this.processResults(null, params);
-      // Guarantee the cursor advances even when there were no events to emit, so
-      // the first run() is never treated as an initial (emit-everything) run.
-      if (this._getAfter() == null) {
-        this._setAfter(Date.now());
-      }
+      // Pin the cursor to deploy time, regardless of what the sample pass stored.
+      // Every pre-existing event has a timestamp <= deployTs, so this can never
+      // suppress a genuinely new event, and it guarantees run() never emits a
+      // pre-deploy event even when the underlying endpoint returns results
+      // oldest-first (e.g. the CRM v3 GET list endpoints used by notes/tasks),
+      // where the sample's max timestamp is NOT the newest existing record. It
+      // also covers the "no events to sample" case, where processResults would
+      // otherwise leave the cursor unset (or at 0).
+      this._setAfter(deployTs);
     },
   },
   methods: {
@@ -219,6 +224,14 @@ export default {
   },
   async run() {
     const after = this._getAfter();
+    // Safety net for instances that somehow reach run() without a cursor (e.g. a
+    // deploy() that never completed): never emit retroactively from run(); just
+    // establish the cursor so the next run() is new-events-only. deploy()
+    // normally sets this already.
+    if (after == null) {
+      this._setAfter(Date.now());
+      return;
+    }
     const params = await this.getParams(after);
     await this.processResults(after, params);
   },

--- a/components/hubspot/sources/delete-blog-article/delete-blog-article.mjs
+++ b/components/hubspot/sources/delete-blog-article/delete-blog-article.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-delete-blog-article",
   name: "Deleted Blog Posts",
   description: "Emit new event for each deleted blog post.",
-  version: "0.0.43",
+  version: "0.0.44",
   dedupe: "unique",
   type: "source",
   methods: {

--- a/components/hubspot/sources/new-company-property-change/new-company-property-change.mjs
+++ b/components/hubspot/sources/new-company-property-change/new-company-property-change.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-new-company-property-change",
   name: "New Company Property Change",
   description: "Emit new event when a specified property is provided or updated on a company. [See the documentation](https://developers.hubspot.com/docs/api/crm/companies)",
-  version: "0.0.36",
+  version: "0.0.37",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-contact-added-to-list/new-contact-added-to-list.mjs
+++ b/components/hubspot/sources/new-contact-added-to-list/new-contact-added-to-list.mjs
@@ -12,7 +12,7 @@ export default {
   name: "New Contact Added to List",
   description:
     "Emit new event when a contact is added to a HubSpot list. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/lists#get-%2Fcrm%2Fv3%2Flists%2F%7Blistid%7D%2Fmemberships%2Fjoin-order)",
-  version: "0.0.15",
+  version: "0.0.16",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/hubspot/sources/new-contact-property-change/new-contact-property-change.mjs
+++ b/components/hubspot/sources/new-contact-property-change/new-contact-property-change.mjs
@@ -8,7 +8,7 @@ export default {
   name: "New Contact Property Change",
   description:
     "Emit new event when a specified property is provided or updated on a contact. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts)",
-  version: "0.0.39",
+  version: "0.0.40",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-custom-object-property-change/new-custom-object-property-change.mjs
+++ b/components/hubspot/sources/new-custom-object-property-change/new-custom-object-property-change.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Custom Object Property Change",
   description:
     "Emit new event when a specified property is provided or updated on a custom object.",
-  version: "0.0.28",
+  version: "0.0.29",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-deal-in-stage/new-deal-in-stage.mjs
+++ b/components/hubspot/sources/new-deal-in-stage/new-deal-in-stage.mjs
@@ -2,18 +2,17 @@ import {
   API_PATH,
   DEFAULT_DEAL_PROPERTIES,
   DEFAULT_LIMIT,
+  MAX_INITIAL_EVENTS,
 } from "../../common/constants.mjs";
 import common from "../common/common.mjs";
 import sampleEmit from "./test-event.mjs";
-
-const MAX_INITIAL_EVENTS = 25;
 
 export default {
   ...common,
   key: "hubspot-new-deal-in-stage",
   name: "New Deal In Stage",
   description: "Emit new event for each new deal in a stage.",
-  version: "0.1.10",
+  version: "0.1.11",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-deal-property-change/new-deal-property-change.mjs
+++ b/components/hubspot/sources/new-deal-property-change/new-deal-property-change.mjs
@@ -9,7 +9,7 @@ export default {
   key: "hubspot-new-deal-property-change",
   name: "New Deal Property Change",
   description: "Emit new event when a specified property is provided or updated on a deal. [See the documentation](https://developers.hubspot.com/docs/api/crm/deals)",
-  version: "0.0.39",
+  version: "0.0.40",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-email-event/new-email-event.mjs
+++ b/components/hubspot/sources/new-email-event/new-email-event.mjs
@@ -8,7 +8,7 @@ export default {
   key: "hubspot-new-email-event",
   name: "New Email Event",
   description: "Emit new event for each new Hubspot email event.",
-  version: "0.0.46",
+  version: "0.0.47",
   dedupe: "unique",
   type: "source",
   props: {
@@ -54,6 +54,7 @@ export default {
         params,
         this.hubspot.getEmailEvents.bind(this),
         "events",
+        after,
       );
     },
   },

--- a/components/hubspot/sources/new-email-subscriptions-timeline/new-email-subscriptions-timeline.mjs
+++ b/components/hubspot/sources/new-email-subscriptions-timeline/new-email-subscriptions-timeline.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-new-email-subscriptions-timeline",
   name: "New Email Subscriptions Timeline",
   description: "Emit new event when a new email timeline subscription is added for the portal.",
-  version: "0.0.43",
+  version: "0.0.44",
   dedupe: "unique",
   type: "source",
   methods: {

--- a/components/hubspot/sources/new-engagement/new-engagement.mjs
+++ b/components/hubspot/sources/new-engagement/new-engagement.mjs
@@ -38,7 +38,7 @@ export default {
   + " [Postal Mail](https://developers.hubspot.com/docs/api-reference/latest/crm/activities/postal-mail/search/search-postal-mail)"
   + " [Tasks](https://developers.hubspot.com/docs/api-reference/latest/crm/activities/tasks/search/search-tasks)"
   + " [See the documentation](https://developers.hubspot.com/docs/api-reference/latest/crm/using-object-apis)",
-  version: "0.0.50",
+  version: "0.0.51",
   dedupe: "unique",
   type: "source",
   props: {
@@ -163,20 +163,18 @@ export default {
   hooks: {
     async deploy() {
       // First deployment: emit only the most recent engagements as a sample,
-      // newest-first, then advance the cursor so run() is new-events-only. This
-      // lives in deploy() (not run()) so the user's deploy-time opt-out is
-      // honored (where $emit is a no-op).
+      // newest-first, then pin the cursor to deploy time so run() is
+      // new-events-only. This lives in deploy() (not run()) so the user's
+      // deploy-time opt-out is honored (where $emit is a no-op). Pinning to
+      // deployTs (rather than the oldest sampled timestamp) is what prevents
+      // run() from re-fetching and re-emitting the sampled engagements, which
+      // would otherwise bypass the opt-out. Every pre-existing engagement was
+      // created <= deployTs, and anything created during collection has
+      // createdAt > deployTs, so run() still catches genuinely new events.
+      const deployTs = Date.now();
       const engagements = await this.collectEngagements(null);
-      if (!engagements.length) {
-        // No events to sample, but still advance the cursor so the first run()
-        // is not treated as an initial (emit-everything) run.
-        this._setAfter(Date.now());
-        return;
-      }
-      const initial = engagements.slice(0, MAX_INITIAL_EVENTS);
-      this.emitEngagements(initial);
-      const oldestEmittedTs = this.getTs(initial[initial.length - 1]);
-      this._setAfter(oldestEmittedTs - 1);
+      this.emitEngagements(engagements.slice(0, MAX_INITIAL_EVENTS));
+      this._setAfter(deployTs);
     },
   },
   async run() {

--- a/components/hubspot/sources/new-engagement/new-engagement.mjs
+++ b/components/hubspot/sources/new-engagement/new-engagement.mjs
@@ -38,7 +38,7 @@ export default {
   + " [Postal Mail](https://developers.hubspot.com/docs/api-reference/latest/crm/activities/postal-mail/search/search-postal-mail)"
   + " [Tasks](https://developers.hubspot.com/docs/api-reference/latest/crm/activities/tasks/search/search-tasks)"
   + " [See the documentation](https://developers.hubspot.com/docs/api-reference/latest/crm/using-object-apis)",
-  version: "0.0.49",
+  version: "0.0.50",
   dedupe: "unique",
   type: "source",
   props: {
@@ -150,34 +150,51 @@ export default {
         this.emitEvent(engagement);
       }
     },
+    async collectEngagements(after) {
+      const types = this.getSelectedTypes();
+      const perType = await Promise.all(
+        types.map((objectType) => this.fetchEngagementsByType(objectType, after)),
+      );
+      return perType
+        .flat()
+        .sort((a, b) => this.getTs(b) - this.getTs(a));
+    },
   },
-  async run() {
-    const after = this._getAfter();
-    const types = this.getSelectedTypes();
-
-    const perType = await Promise.all(
-      types.map((objectType) => this.fetchEngagementsByType(objectType, after)),
-    );
-    const engagements = perType
-      .flat()
-      .sort((a, b) => this.getTs(b) - this.getTs(a));
-
-    if (!engagements.length) {
-      return;
-    }
-
-    if (!after) {
+  hooks: {
+    async deploy() {
       // First deployment: emit only the most recent engagements as a sample,
-      // newest-first.
+      // newest-first, then advance the cursor so run() is new-events-only. This
+      // lives in deploy() (not run()) so the user's deploy-time opt-out is
+      // honored (where $emit is a no-op).
+      const engagements = await this.collectEngagements(null);
+      if (!engagements.length) {
+        // No events to sample, but still advance the cursor so the first run()
+        // is not treated as an initial (emit-everything) run.
+        this._setAfter(Date.now());
+        return;
+      }
       const initial = engagements.slice(0, MAX_INITIAL_EVENTS);
       this.emitEngagements(initial);
       const oldestEmittedTs = this.getTs(initial[initial.length - 1]);
       this._setAfter(oldestEmittedTs - 1);
+    },
+  },
+  async run() {
+    const after = this._getAfter();
+    if (after == null) {
+      // Safety net for instances that somehow reach run() without a cursor:
+      // never emit retroactively from run(); just establish the cursor.
+      this._setAfter(Date.now());
       return;
     }
 
     // Subsequent runs: every engagement was already filtered to created > cursor,
     // so emit them all and advance the cursor to the newest created timestamp.
+    const engagements = await this.collectEngagements(after);
+    if (!engagements.length) {
+      return;
+    }
+
     let maxTs = after;
     for (const engagement of engagements) {
       const ts = this.getTs(engagement);

--- a/components/hubspot/sources/new-engagement/new-engagement.mjs
+++ b/components/hubspot/sources/new-engagement/new-engagement.mjs
@@ -38,7 +38,7 @@ export default {
   + " [Postal Mail](https://developers.hubspot.com/docs/api-reference/latest/crm/activities/postal-mail/search/search-postal-mail)"
   + " [Tasks](https://developers.hubspot.com/docs/api-reference/latest/crm/activities/tasks/search/search-tasks)"
   + " [See the documentation](https://developers.hubspot.com/docs/api-reference/latest/crm/using-object-apis)",
-  version: "0.0.51",
+  version: "0.0.50",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-event/new-event.mjs
+++ b/components/hubspot/sources/new-event/new-event.mjs
@@ -10,7 +10,7 @@ export default {
   key: "hubspot-new-event",
   name: "New Events",
   description: "Emit new event for each new Hubspot event. Note: Only available for Marketing Hub Enterprise, Sales Hub Enterprise, Service Hub Enterprise, or CMS Hub Enterprise accounts",
-  version: "0.0.49",
+  version: "0.0.48",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-event/new-event.mjs
+++ b/components/hubspot/sources/new-event/new-event.mjs
@@ -1,5 +1,7 @@
 import { ConfigurationError } from "@pipedream/platform";
-import { DEFAULT_LIMIT } from "../../common/constants.mjs";
+import {
+  DEFAULT_LIMIT, MAX_INITIAL_EVENTS,
+} from "../../common/constants.mjs";
 import common from "../common/common.mjs";
 import sampleEmit from "./test-event.mjs";
 
@@ -8,7 +10,7 @@ export default {
   key: "hubspot-new-event",
   name: "New Events",
   description: "Emit new event for each new Hubspot event. Note: Only available for Marketing Hub Enterprise, Sales Hub Enterprise, Service Hub Enterprise, or CMS Hub Enterprise accounts",
-  version: "0.0.48",
+  version: "0.0.49",
   dedupe: "unique",
   type: "source",
   props: {
@@ -82,6 +84,31 @@ export default {
       };
     },
     async processResults(after) {
+      // Deploy (initial) pass: emit a single source-wide sample capped at
+      // MAX_INITIAL_EVENTS across ALL selected object IDs. paginate() resets its
+      // cap per call, so looping it once per objectId would emit up to
+      // MAX_INITIAL_EVENTS * objectIds.length. The deploy() hook pins the cursor
+      // to deploy time, so a representative sample is all that's needed here.
+      if (!after) {
+        let remaining = MAX_INITIAL_EVENTS;
+        for (const objectId of this.objectIds) {
+          if (remaining <= 0) {
+            break;
+          }
+          const { results = [] } = await this.hubspot.getEvents(
+            this.getEventParams(objectId, after),
+          );
+          for (const result of results) {
+            this.emitEvent(result);
+            if (--remaining <= 0) {
+              break;
+            }
+          }
+        }
+        return;
+      }
+
+      // Subsequent runs: emit every event created after the cursor, per ID.
       for (const objectId of this.objectIds) {
         const params = this.getEventParams(objectId, after);
         await this.paginate(

--- a/components/hubspot/sources/new-event/new-event.mjs
+++ b/components/hubspot/sources/new-event/new-event.mjs
@@ -43,14 +43,14 @@ export default {
           "Error occurred. Please verify that your Hubspot account is one of: Marketing Hub Enterprise, Sales Hub Enterprise, Service Hub Enterprise, or CMS Hub Enterprise",
         );
       }
-      // Emit a small, capped sample of pre-existing events on deploy and advance
-      // the cursor, so run() only ever emits genuinely new events (and the
-      // user's deploy-time opt-out is honored).
+      // Emit a small, capped sample of pre-existing events on deploy, then pin
+      // the cursor to deploy time so run() only ever emits genuinely new events
+      // (and the user's deploy-time opt-out is honored). Pinning to deploy time
+      // is safe because every pre-existing event predates it.
+      const deployTs = Date.now();
       const params = await this.getParams(null);
       await this.processResults(null, params);
-      if (this._getAfter() == null) {
-        this._setAfter(Date.now());
-      }
+      this._setAfter(deployTs);
     },
   },
   methods: {

--- a/components/hubspot/sources/new-event/new-event.mjs
+++ b/components/hubspot/sources/new-event/new-event.mjs
@@ -8,7 +8,7 @@ export default {
   key: "hubspot-new-event",
   name: "New Events",
   description: "Emit new event for each new Hubspot event. Note: Only available for Marketing Hub Enterprise, Sales Hub Enterprise, Service Hub Enterprise, or CMS Hub Enterprise accounts",
-  version: "0.0.47",
+  version: "0.0.48",
   dedupe: "unique",
   type: "source",
   props: {
@@ -42,6 +42,14 @@ export default {
         throw new ConfigurationError(
           "Error occurred. Please verify that your Hubspot account is one of: Marketing Hub Enterprise, Sales Hub Enterprise, Service Hub Enterprise, or CMS Hub Enterprise",
         );
+      }
+      // Emit a small, capped sample of pre-existing events on deploy and advance
+      // the cursor, so run() only ever emits genuinely new events (and the
+      // user's deploy-time opt-out is honored).
+      const params = await this.getParams(null);
+      await this.processResults(null, params);
+      if (this._getAfter() == null) {
+        this._setAfter(Date.now());
       }
     },
   },

--- a/components/hubspot/sources/new-form-submission/new-form-submission.mjs
+++ b/components/hubspot/sources/new-form-submission/new-form-submission.mjs
@@ -1,4 +1,5 @@
 import common from "../common/common.mjs";
+import { MAX_INITIAL_EVENTS } from "../../common/constants.mjs";
 import sampleEmit from "./test-event.mjs";
 
 export default {
@@ -6,7 +7,7 @@ export default {
   key: "hubspot-new-form-submission",
   name: "New Form Submission",
   description: "Emit new event for each new submission of a form.",
-  version: "0.0.49",
+  version: "0.0.50",
   dedupe: "unique",
   type: "source",
   props: {
@@ -24,6 +25,7 @@ export default {
     async paginate(params, resourceFn, resultType = null, after = null) {
       let results = null;
       let maxTs = after || 0;
+      let initialEmitted = 0;
       while (!results || params.after) {
         results = await resourceFn(params);
         if (results.paging) {
@@ -56,9 +58,18 @@ export default {
               maxTs = ts;
               this._setAfter(ts);
             }
+            // Initial (deploy) run: emit only a small capped sample per form.
+            if (!after && ++initialEmitted >= MAX_INITIAL_EVENTS) {
+              return;
+            }
           } else {
             return;
           }
+        }
+
+        // first run, get only the first page
+        if (!after) {
+          return;
         }
       }
     },

--- a/components/hubspot/sources/new-message-in-thread/new-message-in-thread.mjs
+++ b/components/hubspot/sources/new-message-in-thread/new-message-in-thread.mjs
@@ -1,11 +1,12 @@
 import common from "../common/common.mjs";
+import { MAX_INITIAL_EVENTS } from "../../common/constants.mjs";
 
 export default {
   ...common,
   key: "hubspot-new-message-in-thread",
   name: "New Message in Thread",
   description: "Emit new event when a new message is added to a thread. [See the documentation](https://developers.hubspot.com/docs/api-reference/conversations-conversations-inbox-&-messages-v3/public-message/get-conversations-v3-conversations-threads-threadId-messages)",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "source",
   dedupe: "unique",
   props: {
@@ -51,7 +52,7 @@ export default {
   },
   hooks: {
     async deploy() {
-      await this.processEvent(25);
+      await this.processEvent(MAX_INITIAL_EVENTS);
     },
   },
   async run() {

--- a/components/hubspot/sources/new-message-in-thread/new-message-in-thread.mjs
+++ b/components/hubspot/sources/new-message-in-thread/new-message-in-thread.mjs
@@ -1,5 +1,7 @@
 import common from "../common/common.mjs";
-import { MAX_INITIAL_EVENTS } from "../../common/constants.mjs";
+import {
+  DEFAULT_LIMIT, MAX_INITIAL_EVENTS,
+} from "../../common/constants.mjs";
 
 export default {
   ...common,
@@ -20,42 +22,74 @@ export default {
   },
   methods: {
     ...common.methods,
-    async processEvent(max) {
-      const after = this._getAfter();
-      let {
-        paging, results,
-      } = await this.hubspot.listMessages({
-        threadId: this.threadId,
-        params: {
-          after,
-          sort: "-createdAt",
-        },
-      });
-      if (!results?.length) {
-        return;
-      }
-      this._setAfter(paging?.next?.after);
-      if (max && results.length > max) {
-        results.length = max;
-      }
-      for (const message of results) {
-        this.emitEvent(message);
-      }
+    getTs(message) {
+      return Date.parse(message.createdAt);
+    },
+    // The messages endpoint only returns results oldest-first and has no
+    // server-side timestamp filter, so we page through the whole thread and
+    // filter by timestamp client-side. A single thread is bounded, so reaching
+    // the newest (last) page is cheap.
+    async fetchMessages() {
+      const messages = [];
+      const params = {
+        limit: DEFAULT_LIMIT,
+      };
+      do {
+        const {
+          results = [], paging,
+        } = await this.hubspot.listMessages({
+          threadId: this.threadId,
+          params,
+        });
+        messages.push(...results);
+        params.after = paging?.next?.after;
+      } while (params.after);
+      return messages;
     },
     generateMeta(message) {
       return {
         id: message.id,
         summary: `New Message: ${message.id}`,
-        ts: Date.parse(message.createdAt),
+        ts: this.getTs(message),
       };
     },
   },
   hooks: {
     async deploy() {
-      await this.processEvent(MAX_INITIAL_EVENTS);
+      // Emit the most recent messages as a sample (messages are oldest-first,
+      // so take the tail), then start the cursor at deploy time so run() only
+      // emits genuinely new messages.
+      const deployTs = Date.now();
+      const messages = await this.fetchMessages();
+      for (const message of messages.slice(-MAX_INITIAL_EVENTS)) {
+        this.emitEvent(message);
+      }
+      this._setAfter(deployTs);
     },
   },
   async run() {
-    await this.processEvent();
+    const after = this._getAfter();
+    // Safety net: without a cursor, never emit retroactively; just start it.
+    if (after == null) {
+      this._setAfter(Date.now());
+      return;
+    }
+
+    const messages = await this.fetchMessages();
+    let newest = after;
+    for (const message of messages) {
+      const ts = this.getTs(message);
+      if (ts > after) {
+        this.emitEvent(message);
+      }
+      if (ts > newest) {
+        newest = ts;
+      }
+    }
+    // Advance to the newest message actually seen; only fall back to now when
+    // nothing came back, so a message created mid-fetch is not skipped.
+    this._setAfter(newest > after
+      ? newest
+      : Date.now());
   },
 };

--- a/components/hubspot/sources/new-message-in-thread/new-message-in-thread.mjs
+++ b/components/hubspot/sources/new-message-in-thread/new-message-in-thread.mjs
@@ -86,10 +86,11 @@ export default {
         newest = ts;
       }
     }
-    // Advance to the newest message actually seen; only fall back to now when
-    // nothing came back, so a message created mid-fetch is not skipped.
-    this._setAfter(newest > after
-      ? newest
-      : Date.now());
+    // Advance only to the newest message actually observed. When nothing new
+    // came back, `newest` still equals `after`, so the cursor stays put rather
+    // than jumping to wall-clock time — otherwise a message created mid-fetch
+    // (timestamped before the cursor write but returned after it) would be
+    // skipped permanently.
+    this._setAfter(newest);
   },
 };

--- a/components/hubspot/sources/new-note/new-note.mjs
+++ b/components/hubspot/sources/new-note/new-note.mjs
@@ -8,7 +8,7 @@ export default {
   key: "hubspot-new-note",
   name: "New Note Created",
   description: "Emit new event for each new note created. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/engagements/notes#get-%2Fcrm%2Fv3%2Fobjects%2Fnotes)",
-  version: "1.0.24",
+  version: "1.0.25",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/hubspot/sources/new-or-updated-blog-article/new-or-updated-blog-article.mjs
+++ b/components/hubspot/sources/new-or-updated-blog-article/new-or-updated-blog-article.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-new-or-updated-blog-article",
   name: "New or Updated Blog Post",
   description: "Emit new event for each new or updated blog post in Hubspot.",
-  version: "0.0.30",
+  version: "0.0.31",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-company/new-or-updated-company.mjs
+++ b/components/hubspot/sources/new-or-updated-company/new-or-updated-company.mjs
@@ -10,7 +10,7 @@ export default {
   key: "hubspot-new-or-updated-company",
   name: "New or Updated Company",
   description: "Emit new event for each new or updated company in Hubspot.",
-  version: "0.0.30",
+  version: "0.0.31",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-contact/new-or-updated-contact.mjs
+++ b/components/hubspot/sources/new-or-updated-contact/new-or-updated-contact.mjs
@@ -10,7 +10,7 @@ export default {
   key: "hubspot-new-or-updated-contact",
   name: "New or Updated Contact",
   description: "Emit new event for each new or updated contact in Hubspot.",
-  version: "0.0.32",
+  version: "0.0.33",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-crm-object/new-or-updated-crm-object.mjs
+++ b/components/hubspot/sources/new-or-updated-crm-object/new-or-updated-crm-object.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-new-or-updated-crm-object",
   name: "New or Updated CRM Object",
   description: "Emit new event each time a CRM Object of the specified object type is updated.",
-  version: "0.0.43",
+  version: "0.0.44",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-custom-object/new-or-updated-custom-object.mjs
+++ b/components/hubspot/sources/new-or-updated-custom-object/new-or-updated-custom-object.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-new-or-updated-custom-object",
   name: "New or Updated Custom Object",
   description: "Emit new event each time a Custom Object of the specified schema is updated.",
-  version: "0.0.32",
+  version: "0.0.33",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-deal/new-or-updated-deal.mjs
+++ b/components/hubspot/sources/new-or-updated-deal/new-or-updated-deal.mjs
@@ -10,7 +10,7 @@ export default {
   key: "hubspot-new-or-updated-deal",
   name: "New or Updated Deal",
   description: "Emit new event for each new or updated deal in Hubspot",
-  version: "0.0.30",
+  version: "0.0.31",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-line-item/new-or-updated-line-item.mjs
+++ b/components/hubspot/sources/new-or-updated-line-item/new-or-updated-line-item.mjs
@@ -10,7 +10,7 @@ export default {
   key: "hubspot-new-or-updated-line-item",
   name: "New or Updated Line Item",
   description: "Emit new event for each new line item added or updated in Hubspot.",
-  version: "0.0.30",
+  version: "0.0.31",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-product/new-or-updated-product.mjs
+++ b/components/hubspot/sources/new-or-updated-product/new-or-updated-product.mjs
@@ -10,7 +10,7 @@ export default {
   key: "hubspot-new-or-updated-product",
   name: "New or Updated Product",
   description: "Emit new event for each new or updated product in Hubspot.",
-  version: "0.0.30",
+  version: "0.0.31",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-social-media-message/new-social-media-message.mjs
+++ b/components/hubspot/sources/new-social-media-message/new-social-media-message.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Social Media Message",
   description:
     "Emit new event when a message is posted from HubSpot to the specified social media channel. Note: Only available for Marketing Hub Enterprise accounts",
-  version: "0.0.43",
+  version: "0.0.44",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/hubspot/sources/new-task/new-task.mjs
+++ b/components/hubspot/sources/new-task/new-task.mjs
@@ -9,7 +9,7 @@ export default {
   name: "New Task Created",
   description:
     "Emit new event for each new task created. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/engagements/tasks#get-%2Fcrm%2Fv3%2Fobjects%2Ftasks)",
-  version: "1.0.24",
+  version: "1.0.25",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/hubspot/sources/new-thread-created/new-thread-created.mjs
+++ b/components/hubspot/sources/new-thread-created/new-thread-created.mjs
@@ -1,11 +1,12 @@
 import common from "../common/common.mjs";
+import { MAX_INITIAL_EVENTS } from "../../common/constants.mjs";
 
 export default {
   ...common,
   key: "hubspot-new-thread-created",
   name: "New Thread Created",
   description: "Emit new event when a new thread is created. [See the documentation](https://developers.hubspot.com/docs/api-reference/conversations-conversations-inbox-&-messages-v3/public-thread/get-conversations-v3-conversations-threads)",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "source",
   dedupe: "unique",
   methods: {
@@ -41,7 +42,7 @@ export default {
   },
   hooks: {
     async deploy() {
-      await this.processEvent(25);
+      await this.processEvent(MAX_INITIAL_EVENTS);
     },
   },
   async run() {

--- a/components/hubspot/sources/new-thread-created/new-thread-created.mjs
+++ b/components/hubspot/sources/new-thread-created/new-thread-created.mjs
@@ -1,5 +1,7 @@
 import common from "../common/common.mjs";
-import { MAX_INITIAL_EVENTS } from "../../common/constants.mjs";
+import {
+  DEFAULT_LIMIT, MAX_INITIAL_EVENTS,
+} from "../../common/constants.mjs";
 
 export default {
   ...common,
@@ -11,41 +13,87 @@ export default {
   dedupe: "unique",
   methods: {
     ...common.methods,
-    async processEvent(max) {
-      const after = this._getAfter();
-      let {
-        paging, results,
-      } = await this.hubspot.listThreads({
-        params: {
-          after,
-          sort: "-id",
-        },
-      });
-      if (!results?.length) {
-        return;
+    getTs(thread) {
+      return Date.parse(thread.createdAt);
+    },
+    // The threads endpoint only ever returns results in ascending order and
+    // won't honor a descending sort, so we cannot cheaply read the newest
+    // threads. When a cursor is provided we sort by latestMessageTimestamp and
+    // let the API filter server-side (latestMessageTimestampAfter), paging
+    // through every thread with activity since the cursor. Without a cursor
+    // (deploy sample) we only read the first page.
+    async fetchThreads(latestMessageTimestampAfter = null) {
+      const threads = [];
+      const params = {
+        limit: DEFAULT_LIMIT,
+      };
+      if (latestMessageTimestampAfter != null) {
+        params.sort = "latestMessageTimestamp";
+        params.latestMessageTimestampAfter = latestMessageTimestampAfter;
       }
-      this._setAfter(paging?.next?.after);
-      if (max && results.length > max) {
-        results.length = max;
-      }
-      for (const thread of results) {
-        this.emitEvent(thread);
-      }
+      do {
+        const {
+          results = [], paging,
+        } = await this.hubspot.listThreads({
+          params,
+        });
+        threads.push(...results);
+        params.after = paging?.next?.after;
+        // The deploy sample only needs the first page.
+        if (latestMessageTimestampAfter == null) {
+          break;
+        }
+      } while (params.after);
+      return threads;
     },
     generateMeta(thread) {
       return {
         id: thread.id,
         summary: `New Thread: ${thread.id}`,
-        ts: Date.parse(thread.createdAt),
+        ts: this.getTs(thread),
       };
     },
   },
   hooks: {
     async deploy() {
-      await this.processEvent(MAX_INITIAL_EVENTS);
+      // Emit a small best-effort sample of existing threads, then start the
+      // cursor at deploy time. The endpoint only returns threads oldest-first
+      // with no cheap newest-first read, so the sample is oldest-first; that is
+      // fine because run() is gated on deploy time and never re-emits these.
+      const deployTs = Date.now();
+      const threads = await this.fetchThreads();
+      for (const thread of threads.slice(0, MAX_INITIAL_EVENTS)) {
+        this.emitEvent(thread);
+      }
+      this._setAfter(deployTs);
     },
   },
   async run() {
-    await this.processEvent();
+    const after = this._getAfter();
+    // Safety net: without a cursor, never emit retroactively; just start it.
+    if (after == null) {
+      this._setAfter(Date.now());
+      return;
+    }
+
+    // Only threads with activity since the cursor are fetched (server-side); we
+    // then emit those actually *created* after the cursor, so a pre-existing
+    // thread that merely received a new message is not re-emitted as "new".
+    const threads = await this.fetchThreads(after);
+    let newest = after;
+    for (const thread of threads) {
+      const latest = Date.parse(thread.latestMessageTimestamp) || this.getTs(thread);
+      if (this.getTs(thread) > after) {
+        this.emitEvent(thread);
+      }
+      if (latest > newest) {
+        newest = latest;
+      }
+    }
+    // Advance to the newest activity actually seen; only fall back to now when
+    // nothing came back, so an item created mid-fetch is not skipped.
+    this._setAfter(newest > after
+      ? newest
+      : Date.now());
   },
 };

--- a/components/hubspot/sources/new-thread-created/new-thread-created.mjs
+++ b/components/hubspot/sources/new-thread-created/new-thread-created.mjs
@@ -90,10 +90,11 @@ export default {
         newest = latest;
       }
     }
-    // Advance to the newest activity actually seen; only fall back to now when
-    // nothing came back, so an item created mid-fetch is not skipped.
-    this._setAfter(newest > after
-      ? newest
-      : Date.now());
+    // Advance only to the newest activity actually observed. When nothing new
+    // came back, `newest` still equals `after`, so the cursor stays put rather
+    // than jumping to wall-clock time — otherwise a thread created mid-fetch
+    // (timestamped before the cursor write but returned after it) would be
+    // skipped permanently.
+    this._setAfter(newest);
   },
 };

--- a/components/hubspot/sources/new-ticket-property-change/new-ticket-property-change.mjs
+++ b/components/hubspot/sources/new-ticket-property-change/new-ticket-property-change.mjs
@@ -8,7 +8,7 @@ export default {
   name: "New Ticket Property Change",
   description:
     "Emit new event when a specified property is provided or updated on a ticket. [See the documentation](https://developers.hubspot.com/docs/api/crm/tickets)",
-  version: "0.0.37",
+  version: "0.0.38",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-ticket/new-ticket.mjs
+++ b/components/hubspot/sources/new-ticket/new-ticket.mjs
@@ -10,7 +10,7 @@ export default {
   key: "hubspot-new-ticket",
   name: "New Ticket",
   description: "Emit new event for each new ticket created.",
-  version: "0.0.43",
+  version: "0.0.44",
   dedupe: "unique",
   type: "source",
   props: {


### PR DESCRIPTION
The expected behavior is for triggers to emit retroactive events only on the `deploy()` hook, with the `run()` method only serving subsequent events, never retroactive ones. This allows users to optionally bypass retroactive events with `emit_on_deploy: true`

This was previously fixed in one Hubspot source (`new-deal-property-change` at #21266 ), but many others still behaved incorrectly, which is what this PR is fixing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HubSpot sources now emit a limited catch-up sample during initial deployment.
  * Sync begins from the deployment moment to reduce reprocessing of older events.
  * Enhanced timestamp-based syncing for engagements, emails, messages, threads, forms, and other HubSpot content.
  * More consistent initial load pagination and cursor handling.

* **Bug Fixes**
  * Reduced the initial deployment sample cap from 25 to 10.
  * Prevented retroactive emissions when deploy-time cursor information is missing.
  * Improved email pagination/cursor advancement.

* **Chores**
  * Bumped versions across affected HubSpot sources and the HubSpot package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->