### PR TITLE
feat(github): add six read-only list actions

### DIFF
--- a/components/github/actions/create-branch/create-branch.mjs
+++ b/components/github/actions/create-branch/create-branch.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-create-branch",
   name: "Create Branch",
   description: "Create a new branch in a repository, pointing at the tip of a source branch. Provide the repository as an `owner/repo` string, the new `branchName`, and optionally the `sourceBranch` to branch from (defaults to the repository's default branch). Use **Create or Update File Contents** to add commits to the new branch, then **Create Pull Request** to open a PR. [See the documentation](https://docs.github.com/en/rest/git/refs#create-a-reference)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/create-gist/create-gist.mjs
+++ b/components/github/actions/create-gist/create-gist.mjs
@@ -5,7 +5,7 @@ export default {
   key: "github-create-gist",
   name: "Create Gist",
   description: "Allows you to add a new gist with one or more files. [See the documentation](https://docs.github.com/en/rest/gists/gists?apiVersion=2022-11-28#create-a-gist)",
-  version: "0.0.17",
+  version: "0.0.18",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/create-issue-comment/create-issue-comment.mjs
+++ b/components/github/actions/create-issue-comment/create-issue-comment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-create-issue-comment",
   name: "Create Issue Comment",
   description: "Add a comment to an existing issue **or pull request** (GitHub treats PRs as issues for comments, so the same `number` works for both). Provide the repository as an `owner/repo` string, the issue/PR number, and the comment body. If you only know the issue/PR by title, call **Search Issues and Pull Requests** first to resolve its number. [See the documentation](https://docs.github.com/en/rest/issues/comments#create-an-issue-comment)",
-  version: "0.1.1",
+  version: "0.1.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/create-issue/create-issue.mjs
+++ b/components/github/actions/create-issue/create-issue.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-create-issue",
   name: "Create Issue",
   description: "Create a new issue in a repository, optionally with labels, assignees, and a milestone. Provide the repository as an `owner/repo` string. Labels and assignees are passed by name/login (e.g. `bug`, `octocat`) — setting them requires push access to the repo. To comment on an existing issue instead, use **Create Issue Comment**; to change an existing issue, use **Update Issue**. [See the documentation](https://docs.github.com/en/rest/issues/issues#create-an-issue)",
-  version: "0.4.1",
+  version: "0.4.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/create-or-update-file-contents/create-or-update-file-contents.mjs
+++ b/components/github/actions/create-or-update-file-contents/create-or-update-file-contents.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-create-or-update-file-contents",
   name: "Create or Update File Contents",
   description: "Create a new file or overwrite an existing one in a repository with a single commit. Provide the repository as an `owner/repo` string, the file `path`, the raw text `content` (passed as-is — do not base64-encode it yourself), and a commit message. If the file already exists on the target branch it is overwritten; the required blob SHA is resolved for you automatically. Defaults to the repository's default branch unless `branch` is set. [See the documentation](https://docs.github.com/en/rest/repos/contents#create-or-update-file-contents)",
-  version: "1.0.1",
+  version: "1.0.2",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/github/actions/create-pull-request-review/create-pull-request-review.mjs
+++ b/components/github/actions/create-pull-request-review/create-pull-request-review.mjs
@@ -5,7 +5,7 @@ export default {
   key: "github-create-pull-request-review",
   name: "Create Pull Request Review",
   description: "Submit a review on a pull request: approve it, request changes, or leave a general comment. Set `event` to `APPROVE`, `REQUEST_CHANGES`, or `COMMENT` — a `body` is required for `REQUEST_CHANGES` and `COMMENT`. Optionally attach inline `comments` tied to specific lines of the diff. GitHub forbids approving your own pull request, so use `COMMENT` to leave feedback on PRs you authored. Provide the repository as an `owner/repo` string and the PR number. Use **Get Pull Request Files** to find the file paths and lines to comment on, and **Search Issues and Pull Requests** with `is:pr` to resolve the PR number from a title. [See the documentation](https://docs.github.com/en/rest/pulls/reviews#create-a-review-for-a-pull-request)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/create-pull-request/create-pull-request.mjs
+++ b/components/github/actions/create-pull-request/create-pull-request.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-create-pull-request",
   name: "Create Pull Request",
   description: "Open a pull request proposing to merge one branch into another within a repository. Provide the repository as an `owner/repo` string, the `head` branch (the source containing your changes) and the `base` branch (the target, e.g. `main`), plus a title. The head and base branches must already exist and differ. For a cross-fork PR, set `head` to `username:branch`. Use **Create or Update File Contents** to push changes to a branch before opening the PR. [See the documentation](https://docs.github.com/en/rest/pulls/pulls#create-a-pull-request)",
-  version: "1.0.1",
+  version: "1.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/create-repository/create-repository.mjs
+++ b/components/github/actions/create-repository/create-repository.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-create-repository",
   name: "Create Repository",
   description: "Creates a new repository for the authenticated user. [See the documentation](https://docs.github.com/en/rest/repos/repos#create-a-repository-for-the-authenticated-user)",
-  version: "0.0.22",
+  version: "0.0.23",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/create-workflow-dispatch/create-workflow-dispatch.mjs
+++ b/components/github/actions/create-workflow-dispatch/create-workflow-dispatch.mjs
@@ -5,7 +5,7 @@ export default {
   key: "github-create-workflow-dispatch",
   name: "Create Workflow Dispatch",
   description: "Creates a new workflow dispatch event. [See the documentation](https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event)",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/disable-workflow/disable-workflow.mjs
+++ b/components/github/actions/disable-workflow/disable-workflow.mjs
@@ -5,7 +5,7 @@ export default {
   key: "github-disable-workflow",
   name: "Disable Workflow",
   description: "Disables a workflow and sets the **state** of the workflow to **disabled_manually**. [See the documentation](https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#disable-a-workflow)",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/github/actions/enable-workflow/enable-workflow.mjs
+++ b/components/github/actions/enable-workflow/enable-workflow.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-enable-workflow",
   name: "Enable Workflow",
   description: "Enables a workflow and sets the **state** of the workflow to **active**. [See the documentation](https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#enable-a-workflow)",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/github/actions/get-commit/get-commit.mjs
+++ b/components/github/actions/get-commit/get-commit.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-get-commit",
   name: "Get Commit",
   description: "Get the details of a single commit, including the list of files it changed (with per-file additions/deletions and patches) and aggregate stats. Provide the repository as an `owner/repo` string and a `ref` — a commit SHA, branch name, or tag. Use **List Commits** to find a commit SHA, or pass a branch name like `main` to get its latest commit. [See the documentation](https://docs.github.com/en/rest/commits/commits#get-a-commit)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/get-current-user/get-current-user.mjs
+++ b/components/github/actions/get-current-user/get-current-user.mjs
@@ -7,7 +7,7 @@ export default {
   key: "github-get-current-user",
   name: "Get Current User",
   description: "Gather a full snapshot of the authenticated GitHub actor, combining `/user`, `/user/orgs`, and `/user/teams`. Returns profile metadata (login, name, email, company, plan, creation timestamps) and trimmed lists of organizations and teams for quick role awareness. Helpful when you need to validate which user is calling the API, adapt behavior based on their org/team memberships, or provide LLMs with grounding before repository operations. [See the documentation](https://docs.github.com/en/rest/users/users?apiVersion=2022-11-28#get-the-authenticated-user).",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/github/actions/get-issue-assignees/get-issue-assignees.mjs
+++ b/components/github/actions/get-issue-assignees/get-issue-assignees.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-get-issue-assignees",
   name: "Get Issue Assignees",
   description: "Get assignees for an issue in a GitHub repo. [See the documentation](https://docs.github.com/en/rest/issues/issues#get-an-issue)",
-  version: "0.0.28",
+  version: "0.0.29",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/get-issue/get-issue.mjs
+++ b/components/github/actions/get-issue/get-issue.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-get-issue",
   name: "Get Issue",
   description: "Get the full details of a single issue: title, body, state, labels, assignees, milestone, comment count, and timestamps. Provide the repository as an `owner/repo` string and the issue number. If you only know the issue by title or topic, call **Search Issues and Pull Requests** first to resolve its number. [See the documentation](https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#get-an-issue)",
-  version: "0.1.1",
+  version: "0.1.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/get-pull-request-files/get-pull-request-files.mjs
+++ b/components/github/actions/get-pull-request-files/get-pull-request-files.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-get-pull-request-files",
   name: "Get Pull Request Files",
   description: "List the files changed in a pull request (the PR diff at the file level). Returns each file's `filename`, `status` (added/modified/removed/renamed), additions/deletions/changes counts, and the unified `patch` when available — use this to review what a PR changes before approving or merging it. Provide the repository as an `owner/repo` string and the PR number. If you only know the PR by title, call **Get Pull Request** or **Search Issues and Pull Requests** with `is:pr` first to resolve its number. [See the documentation](https://docs.github.com/en/rest/pulls/pulls#list-pull-requests-files)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/get-pull-request/get-pull-request.mjs
+++ b/components/github/actions/get-pull-request/get-pull-request.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-get-pull-request",
   name: "Get Pull Request",
   description: "Get the full details of a single pull request along with its reviews and a CI/merge readiness summary. Returns PR metadata (title, body, state, head/base branches, draft flag, timestamps), the `mergeable`/`mergeable_state` flags, a `checksSummary` rollup of CI status for the head commit (combined commit status + check runs, summarized to an overall state and pass/fail counts), the list of reviews, and a deduplicated list of reviewers with their review states (e.g. `APPROVED`, `CHANGES_REQUESTED`). Use this to answer \"can I merge this?\" and \"is CI green?\" before calling **Merge Pull Request**. Provide the repository as an `owner/repo` string and the PR number. If you only know the PR by title, call **Search Issues and Pull Requests** with `is:pr` first to resolve its number. [See the documentation](https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request)",
-  version: "0.1.0",
+  version: "0.1.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/get-repository-content/get-repository-content.mjs
+++ b/components/github/actions/get-repository-content/get-repository-content.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-get-repository-content",
   name: "Get Repository Content",
   description: "Read a file's contents or list a directory in a repository. For a file, the base64 payload is decoded for you and returned as plain text in the `content` field. For a directory, returns the list of entries (name, path, type). Provide the repository as an `owner/repo` string and the `path` to the file or directory (omit `path` for the repo root). Use **Get Repository** first if you need to know the default branch. [See the documentation](https://docs.github.com/en/rest/repos/contents#get-repository-content)",
-  version: "1.0.1",
+  version: "1.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/get-repository/get-repository.mjs
+++ b/components/github/actions/get-repository/get-repository.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-get-repository",
   name: "Get Repository Info",
   description: "Get metadata for a single repository: description, default branch, visibility, topics, star/fork/open-issue counts, your permission level, and timestamps. Use this to discover a repo's default branch before reading files with **Get Repository Content** or listing history with **List Commits**. Provide the repository as an `owner/repo` string (e.g. `PipedreamHQ/pipedream`). [See the documentation](https://docs.github.com/en/rest/repos/repos#get-a-repository)",
-  version: "0.1.1",
+  version: "0.1.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/get-reviewers/get-reviewers.mjs
+++ b/components/github/actions/get-reviewers/get-reviewers.mjs
@@ -6,7 +6,7 @@ export default {
   key: "github-get-reviewers",
   name: "Get Reviewers",
   description: "Get reviewers for a PR ([see documentation](https://docs.github.com/en/rest/pulls/reviews#list-reviews-for-a-pull-request)) or Commit SHA ([see documentation](https://docs.github.com/en/rest/commits/commits#list-pull-requests-associated-with-a-commit)).",
-  version: "0.1.9",
+  version: "0.1.10",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/get-workflow-run/get-workflow-run.mjs
+++ b/components/github/actions/get-workflow-run/get-workflow-run.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-get-workflow-run",
   name: "Get Workflow Run",
   description: "Get the details of a single GitHub Actions workflow run, including its per-job conclusions and a link to the run's logs. Returns the run's `status`/`conclusion` and timestamps plus a `jobs` array (each job's name, status, conclusion, and `logsUrl`) so you can see exactly which job failed. Provide the repository as an `owner/repo` string and the run ID. Use **List Workflow Runs** to find a run ID, then **Run Workflow** to re-run the failed jobs. [See the documentation](https://docs.github.com/en/rest/actions/workflow-runs#get-a-workflow-run)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/list-branches/list-branches.mjs
+++ b/components/github/actions/list-branches/list-branches.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-list-branches",
   name: "List Branches",
   description: "List the branches in a repository. Provide the repository as an `owner/repo` string. Optionally filter to only protected (or only unprotected) branches. If you need to discover repository names first, use **List Repositories**. [See the documentation](https://docs.github.com/en/rest/branches/branches#list-branches)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/list-branches/list-branches.mjs
+++ b/components/github/actions/list-branches/list-branches.mjs
@@ -26,11 +26,10 @@ export default {
       optional: true,
     },
     maxResults: {
-      type: "integer",
-      label: "Max Results",
-      description: "The maximum number of branches to return. Defaults: `100`",
-      default: 100,
-      optional: true,
+      propDefinition: [
+        github,
+        "maxResults",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/github/actions/list-commits/list-commits.mjs
+++ b/components/github/actions/list-commits/list-commits.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-list-commits",
   name: "List Commits",
   description: "List commits in a repository, most recent first. Optionally scope to a branch or starting SHA, a file path, an author, or a date range. Provide the repository as an `owner/repo` string. Use **Get Repository** to find the default branch name if needed. [See the documentation](https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#list-commits)",
-  version: "0.1.1",
+  version: "0.1.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/list-commits/list-commits.mjs
+++ b/components/github/actions/list-commits/list-commits.mjs
@@ -56,11 +56,10 @@ export default {
       optional: true,
     },
     maxResults: {
-      type: "integer",
-      label: "Max Results",
-      description: "The maximum number of results to return. Defaults: `100`",
-      default: 100,
-      optional: true,
+      propDefinition: [
+        github,
+        "maxResults",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/github/actions/list-gist-id-options/list-gist-id-options.mjs
+++ b/components/github/actions/list-gist-id-options/list-gist-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-list-gist-id-options",
   name: "List Gist Id Options",
   description: "Retrieves available options for the Gist Id field.",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/github/actions/list-gists-for-a-user/list-gists-for-a-user.mjs
+++ b/components/github/actions/list-gists-for-a-user/list-gists-for-a-user.mjs
@@ -5,7 +5,7 @@ export default {
   key: "github-list-gists-for-a-user",
   name: "List Gists for a User",
   description: "Lists public gists for the specified user. [See the documentation](https://docs.github.com/en/rest/gists/gists?apiVersion=2022-11-28#list-gists-for-a-user)",
-  version: "0.1.9",
+  version: "0.1.10",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/list-milestones/list-milestones.mjs
+++ b/components/github/actions/list-milestones/list-milestones.mjs
@@ -32,11 +32,10 @@ export default {
       optional: true,
     },
     maxResults: {
-      type: "integer",
-      label: "Max Results",
-      description: "The maximum number of milestones to return. Defaults: `100`",
-      default: 100,
-      optional: true,
+      propDefinition: [
+        github,
+        "maxResults",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/github/actions/list-milestones/list-milestones.mjs
+++ b/components/github/actions/list-milestones/list-milestones.mjs
@@ -42,12 +42,11 @@ export default {
   async run({ $ }) {
     const repoFullname = await this.github._resolveRepoFullname(this.repoFullname);
 
-    let milestones = await this.github.getRepositoryMilestones({
+    const milestones = await this.github.getRepositoryMilestones({
       repoFullname,
       state: this.state,
+      maxResults: this.maxResults,
     });
-
-    milestones = milestones.slice(0, this.maxResults);
 
     $.export("$summary", `Found ${milestones.length} ${this.state} milestone(s) in ${repoFullname}`);
 

--- a/components/github/actions/list-milestones/list-milestones.mjs
+++ b/components/github/actions/list-milestones/list-milestones.mjs
@@ -1,0 +1,56 @@
+import github from "../../github.app.mjs";
+
+export default {
+  key: "github-list-milestones",
+  name: "List Milestones",
+  description: "List the milestones in a repository (title, state, due date, and open/closed issue counts). Use this to discover a milestone's title or number before filtering or updating issues. Provide the repository as an `owner/repo` string; if you pass only a repo name, the authenticated user is assumed as the owner. Discover repository names with **List Repositories**. [See the documentation](https://docs.github.com/en/rest/issues/milestones#list-milestones)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  type: "action",
+  props: {
+    github,
+    repoFullname: {
+      propDefinition: [
+        github,
+        "repoFullnameStatic",
+      ],
+    },
+    state: {
+      type: "string",
+      label: "State",
+      description: "Filter milestones by state. Defaults to `open`.",
+      options: [
+        "open",
+        "closed",
+        "all",
+      ],
+      default: "open",
+      optional: true,
+    },
+    maxResults: {
+      type: "integer",
+      label: "Max Results",
+      description: "The maximum number of milestones to return. Defaults: `100`",
+      default: 100,
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const repoFullname = await this.github._resolveRepoFullname(this.repoFullname);
+
+    let milestones = await this.github.getRepositoryMilestones({
+      repoFullname,
+      state: this.state,
+    });
+
+    milestones = milestones.slice(0, this.maxResults);
+
+    $.export("$summary", `Found ${milestones.length} ${this.state} milestone(s) in ${repoFullname}`);
+
+    return milestones;
+  },
+};

--- a/components/github/actions/list-org-name-options/list-org-name-options.mjs
+++ b/components/github/actions/list-org-name-options/list-org-name-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-list-org-name-options",
   name: "List Organization Options",
   description: "Retrieves available options for the Organization field.",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/github/actions/list-organization-repositories/list-organization-repositories.mjs
+++ b/components/github/actions/list-organization-repositories/list-organization-repositories.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-list-organization-repositories",
   name: "List Organization Repositories",
   description: "List repositories for an organization. [See the documentation](https://docs.github.com/en/rest/repos/repos?apiVersion=2026-03-10#list-organization-repositories)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/github/actions/list-organizations/list-organizations.mjs
+++ b/components/github/actions/list-organizations/list-organizations.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-list-organizations",
   name: "List Organizations",
   description: "List all organizations in the authenticated user's account. [See the documentation](https://docs.github.com/en/rest/orgs/orgs?apiVersion=2026-03-10#list-organizations-for-the-authenticated-user)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/github/actions/list-project-items/list-project-items.mjs
+++ b/components/github/actions/list-project-items/list-project-items.mjs
@@ -3,7 +3,7 @@ import github from "../../github.app.mjs";
 export default {
   key: "github-list-project-items",
   name: "List Project Items",
-  description: "List the items in a Project (V2). Each item has an `id`, a `type`, and its title under `fieldValueByName.text` (not a flat `title` field). Use the returned item `id` with **Update Project (V2) Item Status** to change an item's status. Get the project number from **List Projects** and its valid statuses from **List Project Statuses**. Discover organization logins with **List Organizations**. [See the documentation](https://docs.github.com/en/graphql/reference/projects#object-projectv2item)",
+  description: "List the items in a Project (V2). Each item has an `id`, a `type`, and its title under `fieldValueByName.text` (not a flat `title` field). Use the returned item `id` with **Update Project (V2) Item Status** to change an item's status. Get the project number from **List Projects** and its valid statuses from **List Project Statuses**. Discover organization logins with **List Organizations**. Returns at most 100 items with no pagination — a project with more than 100 items exposes only the last 100 (the tail of the item connection, in the connection's own order), so earlier items can't be retrieved. [See the documentation](https://docs.github.com/en/graphql/reference/projects#object-projectv2item)",
   version: "0.0.1",
   annotations: {
     destructiveHint: false,

--- a/components/github/actions/list-project-items/list-project-items.mjs
+++ b/components/github/actions/list-project-items/list-project-items.mjs
@@ -49,8 +49,9 @@ export default {
       repoOwner,
       repoName,
       project,
-      // GitHub GraphQL connections reject last/first > 100, so cap it.
-      amount: Math.min(maxResults, 100),
+      // Fall back to 100 when unset, then cap: GitHub GraphQL connections
+      // reject last/first > 100, and an undefined value would yield NaN.
+      amount: Math.min(maxResults ?? 100, 100),
     }) ?? [];
 
     $.export("$summary", `Found ${items.length} item(s) in project #${project}`);

--- a/components/github/actions/list-project-items/list-project-items.mjs
+++ b/components/github/actions/list-project-items/list-project-items.mjs
@@ -1,0 +1,58 @@
+import github from "../../github.app.mjs";
+
+export default {
+  key: "github-list-project-items",
+  name: "List Project Items",
+  description: "List the items in a Project (V2), returning each item's id, type, and title. Use the returned item id with **Update Project (V2) Item Status** to change an item's status. Get the project number from **List Projects** and its valid statuses from **List Project Statuses**. Discover organization logins with **List Organizations**. [See the documentation](https://docs.github.com/en/graphql/reference/projects#object-projectv2item)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  type: "action",
+  props: {
+    github,
+    owner: {
+      propDefinition: [
+        github,
+        "projectOwnerStatic",
+      ],
+    },
+    repo: {
+      propDefinition: [
+        github,
+        "projectRepoStatic",
+      ],
+    },
+    project: {
+      propDefinition: [
+        github,
+        "projectNumberStatic",
+      ],
+    },
+    maxResults: {
+      type: "integer",
+      label: "Max Results",
+      description: "The maximum number of items to return. Defaults: `100`",
+      default: 100,
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const {
+      github, owner: repoOwner, repo: repoName, project, maxResults,
+    } = this;
+
+    const items = await github.getProjectV2Items({
+      repoOwner,
+      repoName,
+      project,
+      amount: maxResults,
+    }) ?? [];
+
+    $.export("$summary", `Found ${items.length} item(s) in project #${project}`);
+
+    return items;
+  },
+};

--- a/components/github/actions/list-project-items/list-project-items.mjs
+++ b/components/github/actions/list-project-items/list-project-items.mjs
@@ -3,7 +3,7 @@ import github from "../../github.app.mjs";
 export default {
   key: "github-list-project-items",
   name: "List Project Items",
-  description: "List the items in a Project (V2), returning each item's id, type, and title. Use the returned item id with **Update Project (V2) Item Status** to change an item's status. Get the project number from **List Projects** and its valid statuses from **List Project Statuses**. Discover organization logins with **List Organizations**. [See the documentation](https://docs.github.com/en/graphql/reference/projects#object-projectv2item)",
+  description: "List the items in a Project (V2). Each item has an `id`, a `type`, and its title under `fieldValueByName.text` (not a flat `title` field). Use the returned item `id` with **Update Project (V2) Item Status** to change an item's status. Get the project number from **List Projects** and its valid statuses from **List Project Statuses**. Discover organization logins with **List Organizations**. [See the documentation](https://docs.github.com/en/graphql/reference/projects#object-projectv2item)",
   version: "0.0.1",
   annotations: {
     destructiveHint: false,
@@ -34,7 +34,7 @@ export default {
     maxResults: {
       type: "integer",
       label: "Max Results",
-      description: "The maximum number of items to return (the most recent items). GitHub caps this at `100` per request. Defaults: `100`",
+      description: "The maximum number of items to return. GitHub caps this at `100` per request. Defaults: `100`",
       default: 100,
       max: 100,
       optional: true,

--- a/components/github/actions/list-project-items/list-project-items.mjs
+++ b/components/github/actions/list-project-items/list-project-items.mjs
@@ -34,8 +34,9 @@ export default {
     maxResults: {
       type: "integer",
       label: "Max Results",
-      description: "The maximum number of items to return. Defaults: `100`",
+      description: "The maximum number of items to return (the most recent items). GitHub caps this at `100` per request. Defaults: `100`",
       default: 100,
+      max: 100,
       optional: true,
     },
   },
@@ -48,7 +49,8 @@ export default {
       repoOwner,
       repoName,
       project,
-      amount: maxResults,
+      // GitHub GraphQL connections reject last/first > 100, so cap it.
+      amount: Math.min(maxResults, 100),
     }) ?? [];
 
     $.export("$summary", `Found ${items.length} item(s) in project #${project}`);

--- a/components/github/actions/list-project-items/list-project-items.mjs
+++ b/components/github/actions/list-project-items/list-project-items.mjs
@@ -32,12 +32,12 @@ export default {
       ],
     },
     maxResults: {
-      type: "integer",
-      label: "Max Results",
+      propDefinition: [
+        github,
+        "maxResults",
+      ],
       description: "The maximum number of items to return. GitHub caps this at `100` per request. Defaults: `100`",
-      default: 100,
       max: 100,
-      optional: true,
     },
   },
   async run({ $ }) {

--- a/components/github/actions/list-project-statuses/list-project-statuses.mjs
+++ b/components/github/actions/list-project-statuses/list-project-statuses.mjs
@@ -1,0 +1,52 @@
+import github from "../../github.app.mjs";
+
+export default {
+  key: "github-list-project-statuses",
+  name: "List Project Statuses",
+  description: "List the options of a Project (V2) Status field (e.g. `Todo`, `In Progress`, `Done`), returning each option's name and id. Use this to discover the valid status values for a project before calling **Update Project (V2) Item Status**. Get the project number from **List Projects**. Discover organization logins with **List Organizations**. [See the documentation](https://docs.github.com/en/graphql/reference/projects#object-projectv2singleselectfield)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  type: "action",
+  props: {
+    github,
+    owner: {
+      propDefinition: [
+        github,
+        "projectOwnerStatic",
+      ],
+    },
+    repo: {
+      propDefinition: [
+        github,
+        "projectRepoStatic",
+      ],
+    },
+    project: {
+      propDefinition: [
+        github,
+        "projectNumberStatic",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const {
+      github, owner: repoOwner, repo: repoName, project,
+    } = this;
+
+    const field = await github.getProjectV2StatusField({
+      repoOwner,
+      repoName,
+      project,
+    });
+
+    const options = field?.options ?? [];
+
+    $.export("$summary", `Found ${options.length} status option(s) for project #${project}`);
+
+    return options;
+  },
+};

--- a/components/github/actions/list-project-statuses/list-project-statuses.mjs
+++ b/components/github/actions/list-project-statuses/list-project-statuses.mjs
@@ -37,6 +37,7 @@ export default {
       github, owner: repoOwner, repo: repoName, project,
     } = this;
 
+    // queries the project's ProjectV2SingleSelectField (Status field)
     const field = await github.getProjectV2StatusField({
       repoOwner,
       repoName,

--- a/components/github/actions/list-projects/list-projects.mjs
+++ b/components/github/actions/list-projects/list-projects.mjs
@@ -41,8 +41,12 @@ export default {
   },
   async run({ $ }) {
     const {
-      github, owner: repoOwner, repo: repoName, maxResults,
+      github, owner: repoOwner, repo: repoName,
     } = this;
+    // Fall back to the prop default so an undefined limit doesn't make
+    // `projects.length < maxResults` false on the first iteration (which would
+    // skip the loop and return nothing).
+    const maxResults = this.maxResults ?? 100;
 
     let projects = [];
     let cursor = this.cursor ?? null;

--- a/components/github/actions/list-projects/list-projects.mjs
+++ b/components/github/actions/list-projects/list-projects.mjs
@@ -3,7 +3,7 @@ import github from "../../github.app.mjs";
 export default {
   key: "github-list-projects",
   name: "List Projects",
-  description: "List the Projects (V2) owned by an organization, or scoped to a specific repository (returns each project's number and title). This is the entry point for the Projects (V2) discovery chain: use the returned project **number** with **List Project Statuses**, **List Project Items**, or **Update Project (V2) Item Status**. Discover organization logins with **List Organizations**. Note: user-owned Projects are not supported. Returns `{ projects, nextCursor }`; when `nextCursor` is non-null there are more results — pass it back as **Cursor** to fetch the next page. [See the documentation](https://docs.github.com/en/graphql/reference/projects#object-projectv2)",
+  description: "List the Projects (V2) owned by an organization, or scoped to a specific repository (returns each project's number and title). This is the entry point for the Projects (V2) discovery chain: use the returned project **number** with **List Project Statuses**, **List Project Items**, or **Update Project (V2) Item Status**. Discover organization logins with **List Organizations**. Note: user-owned Projects are not supported. Returns `{ projects, nextCursor }`; when `nextCursor` is non-null there are more results — pass it back as **Cursor** to fetch the next page. Do NOT call this with a guessed or assumed **Owner**: if the user hasn't named the organization/owner, ask them first rather than trying multiple organizations. [See the documentation](https://docs.github.com/en/graphql/reference/projects#object-projectv2)",
   version: "0.0.2",
   annotations: {
     destructiveHint: false,

--- a/components/github/actions/list-projects/list-projects.mjs
+++ b/components/github/actions/list-projects/list-projects.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-list-projects",
   name: "List Projects",
   description: "List the Projects (V2) owned by an organization, or scoped to a specific repository (returns each project's number and title). This is the entry point for the Projects (V2) discovery chain: use the returned project **number** with **List Project Statuses**, **List Project Items**, or **Update Project (V2) Item Status**. Discover organization logins with **List Organizations**. Note: user-owned Projects are not supported. Returns `{ projects, nextCursor }`; when `nextCursor` is non-null there are more results — pass it back as **Cursor** to fetch the next page. [See the documentation](https://docs.github.com/en/graphql/reference/projects#object-projectv2)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -26,16 +26,15 @@ export default {
       ],
     },
     maxResults: {
-      type: "integer",
-      label: "Max Results",
-      description: "The maximum number of projects to return. Defaults: `100`",
-      default: 100,
-      optional: true,
+      propDefinition: [
+        github,
+        "maxResults",
+      ],
     },
     cursor: {
       type: "string",
       label: "Cursor",
-      description: "Pagination cursor to fetch the next page of results. Omit for the first page; to get more, pass the `nextCursor` value returned by a previous call. Note: results are fetched in pages of 10, so for cursor continuation to work set **Max Results** to a multiple of 10 — a value that lands mid-page returns a null `nextCursor` on the final (partial) page, and the remaining items can only be reached by raising **Max Results**.",
+      description: "Pagination cursor to fetch the next page of results. Omit for the first page; to get more, pass the `nextCursor` value returned by a previous call.",
       optional: true,
     },
   },
@@ -55,36 +54,34 @@ export default {
     let nextCursor = null;
 
     while (projects.length < maxResults) {
+      const remaining = maxResults - projects.length;
       const {
         projects: batch, nextCursor: endCursor, hasNextPage,
       } = await github.getProjectsV2({
         repoOwner,
         repoName,
         cursor,
+        first: remaining,
       });
 
       if (!batch?.length) {
-        nextCursor = null;
         break;
       }
 
       projects = projects.concat(batch);
-      nextCursor = hasNextPage
-        ? endCursor
-        : null;
 
       if (!hasNextPage) {
+        nextCursor = null;
         break;
       }
-      cursor = endCursor;
-    }
 
-    if (projects.length > maxResults) {
-      // The final page overshot maxResults. The discarded items sit between the
-      // last returned project and nextCursor, so handing back nextCursor would
-      // silently skip them. Clear it — better to stop than to skip results.
-      projects = projects.slice(0, maxResults);
-      nextCursor = null;
+      nextCursor = endCursor;
+
+      if (projects.length >= maxResults) {
+        break;
+      }
+
+      cursor = endCursor;
     }
 
     $.export("$summary", `Found ${projects.length} project(s) for ${repoName

--- a/components/github/actions/list-projects/list-projects.mjs
+++ b/components/github/actions/list-projects/list-projects.mjs
@@ -61,7 +61,7 @@ export default {
         repoOwner,
         repoName,
         cursor,
-        first: remaining,
+        first: Math.min(remaining, 100),
       });
 
       if (!batch?.length) {

--- a/components/github/actions/list-projects/list-projects.mjs
+++ b/components/github/actions/list-projects/list-projects.mjs
@@ -35,7 +35,7 @@ export default {
     cursor: {
       type: "string",
       label: "Cursor",
-      description: "Pagination cursor to fetch the next page of results. Omit for the first page; to get more, pass the `nextCursor` value returned by a previous call.",
+      description: "Pagination cursor to fetch the next page of results. Omit for the first page; to get more, pass the `nextCursor` value returned by a previous call. Note: results are fetched in pages of 10, so for cursor continuation to work set **Max Results** to a multiple of 10 — a value that lands mid-page returns a null `nextCursor` on the final (partial) page, and the remaining items can only be reached by raising **Max Results**.",
       optional: true,
     },
   },

--- a/components/github/actions/list-projects/list-projects.mjs
+++ b/components/github/actions/list-projects/list-projects.mjs
@@ -1,0 +1,91 @@
+import github from "../../github.app.mjs";
+
+export default {
+  key: "github-list-projects",
+  name: "List Projects",
+  description: "List the Projects (V2) owned by an organization, or scoped to a specific repository (returns each project's number and title). This is the entry point for the Projects (V2) discovery chain: use the returned project **number** with **List Project Statuses**, **List Project Items**, or **Update Project (V2) Item Status**. Discover organization logins with **List Organizations**. Note: user-owned Projects are not supported. Returns `{ projects, nextCursor }`; when `nextCursor` is non-null there are more results — pass it back as **Cursor** to fetch the next page. [See the documentation](https://docs.github.com/en/graphql/reference/projects#object-projectv2)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  type: "action",
+  props: {
+    github,
+    owner: {
+      propDefinition: [
+        github,
+        "projectOwnerStatic",
+      ],
+    },
+    repo: {
+      propDefinition: [
+        github,
+        "projectRepoStatic",
+      ],
+    },
+    maxResults: {
+      type: "integer",
+      label: "Max Results",
+      description: "The maximum number of projects to return. Defaults: `100`",
+      default: 100,
+      optional: true,
+    },
+    cursor: {
+      type: "string",
+      label: "Cursor",
+      description: "Pagination cursor to fetch the next page of results. Omit for the first page; to get more, pass the `nextCursor` value returned by a previous call.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const {
+      github, owner: repoOwner, repo: repoName, maxResults,
+    } = this;
+
+    let projects = [];
+    let cursor = this.cursor ?? null;
+    // The cursor to hand back so the caller can fetch the next page. Only set
+    // when GitHub reports more results exist beyond what we return.
+    let nextCursor = null;
+
+    while (projects.length < maxResults) {
+      const {
+        projects: batch, nextCursor: endCursor, hasNextPage,
+      } = await github.getProjectsV2({
+        repoOwner,
+        repoName,
+        cursor,
+      });
+
+      if (!batch?.length) {
+        nextCursor = null;
+        break;
+      }
+
+      projects = projects.concat(batch);
+      nextCursor = hasNextPage
+        ? endCursor
+        : null;
+
+      if (!hasNextPage) {
+        break;
+      }
+      cursor = endCursor;
+    }
+
+    projects = projects.slice(0, maxResults);
+
+    $.export("$summary", `Found ${projects.length} project(s) for ${repoName
+      ? `${repoOwner}/${repoName}`
+      : repoOwner}${nextCursor
+      ? " (more available)"
+      : ""}`);
+
+    return {
+      projects,
+      nextCursor,
+    };
+  },
+};

--- a/components/github/actions/list-projects/list-projects.mjs
+++ b/components/github/actions/list-projects/list-projects.mjs
@@ -75,7 +75,13 @@ export default {
       cursor = endCursor;
     }
 
-    projects = projects.slice(0, maxResults);
+    if (projects.length > maxResults) {
+      // The final page overshot maxResults. The discarded items sit between the
+      // last returned project and nextCursor, so handing back nextCursor would
+      // silently skip them. Clear it — better to stop than to skip results.
+      projects = projects.slice(0, maxResults);
+      nextCursor = null;
+    }
 
     $.export("$summary", `Found ${projects.length} project(s) for ${repoName
       ? `${repoOwner}/${repoName}`

--- a/components/github/actions/list-releases/list-releases.mjs
+++ b/components/github/actions/list-releases/list-releases.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-list-releases",
   name: "List Releases",
   description: "List releases for a repository [See the documentation](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#list-releases)",
-  version: "0.0.15",
+  version: "0.0.16",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/list-repositories/list-repositories.mjs
+++ b/components/github/actions/list-repositories/list-repositories.mjs
@@ -5,7 +5,7 @@ export default {
   key: "github-list-repositories",
   name: "List Repositories",
   description: "List repositories the authenticated user can access, or — when `org` is provided — the repositories of a specific organization. Use this to discover a repo's `owner/repo` name before calling **Get Repository**, **Get Repository Content**, or **List Commits**. To find repos by name, set the `name` substring filter. [See the documentation](https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-repositories-for-the-authenticated-user)",
-  version: "1.0.1",
+  version: "1.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/list-repositories/list-repositories.mjs
+++ b/components/github/actions/list-repositories/list-repositories.mjs
@@ -73,11 +73,10 @@ export default {
       optional: true,
     },
     maxResults: {
-      type: "integer",
-      label: "Max Results",
-      description: "The maximum number of repositories to return. Defaults to `100`.",
-      default: 100,
-      optional: true,
+      propDefinition: [
+        github,
+        "maxResults",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/github/actions/list-repository-collaborators/list-repository-collaborators.mjs
+++ b/components/github/actions/list-repository-collaborators/list-repository-collaborators.mjs
@@ -1,0 +1,43 @@
+import github from "../../github.app.mjs";
+
+export default {
+  key: "github-list-repository-collaborators",
+  name: "List Repository Collaborators",
+  description: "List the collaborators on a repository (their login, permissions, and profile links). Use this to see who has access to a repo, or to find a valid collaborator login before assigning issues or requesting reviews. Provide the repository as an `owner/repo` string; if you pass only a repo name, the authenticated user is assumed as the owner. Discover repository names with **List Repositories**. [See the documentation](https://docs.github.com/en/rest/collaborators/collaborators#list-repository-collaborators)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  type: "action",
+  props: {
+    github,
+    repoFullname: {
+      propDefinition: [
+        github,
+        "repoFullnameStatic",
+      ],
+    },
+    maxResults: {
+      type: "integer",
+      label: "Max Results",
+      description: "The maximum number of collaborators to return. Defaults: `100`",
+      default: 100,
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const repoFullname = await this.github._resolveRepoFullname(this.repoFullname);
+
+    let collaborators = await this.github.getRepositoryCollaborators({
+      repoFullname,
+    });
+
+    collaborators = collaborators.slice(0, this.maxResults);
+
+    $.export("$summary", `Found ${collaborators.length} collaborator(s) in ${repoFullname}`);
+
+    return collaborators;
+  },
+};

--- a/components/github/actions/list-repository-collaborators/list-repository-collaborators.mjs
+++ b/components/github/actions/list-repository-collaborators/list-repository-collaborators.mjs
@@ -20,11 +20,10 @@ export default {
       ],
     },
     maxResults: {
-      type: "integer",
-      label: "Max Results",
-      description: "The maximum number of collaborators to return. Defaults: `100`",
-      default: 100,
-      optional: true,
+      propDefinition: [
+        github,
+        "maxResults",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/github/actions/list-repository-collaborators/list-repository-collaborators.mjs
+++ b/components/github/actions/list-repository-collaborators/list-repository-collaborators.mjs
@@ -30,11 +30,10 @@ export default {
   async run({ $ }) {
     const repoFullname = await this.github._resolveRepoFullname(this.repoFullname);
 
-    let collaborators = await this.github.getRepositoryCollaborators({
+    const collaborators = await this.github.getRepositoryCollaborators({
       repoFullname,
+      maxResults: this.maxResults,
     });
-
-    collaborators = collaborators.slice(0, this.maxResults);
 
     $.export("$summary", `Found ${collaborators.length} collaborator(s) in ${repoFullname}`);
 

--- a/components/github/actions/list-repository-labels/list-repository-labels.mjs
+++ b/components/github/actions/list-repository-labels/list-repository-labels.mjs
@@ -1,0 +1,43 @@
+import github from "../../github.app.mjs";
+
+export default {
+  key: "github-list-repository-labels",
+  name: "List Repository Labels",
+  description: "List the labels defined in a repository (name, color, and description). Use this to discover valid label names before filtering issues or applying labels. Provide the repository as an `owner/repo` string; if you pass only a repo name, the authenticated user is assumed as the owner. Discover repository names with **List Repositories**. [See the documentation](https://docs.github.com/en/rest/issues/labels#list-labels-for-a-repository)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  type: "action",
+  props: {
+    github,
+    repoFullname: {
+      propDefinition: [
+        github,
+        "repoFullnameStatic",
+      ],
+    },
+    maxResults: {
+      type: "integer",
+      label: "Max Results",
+      description: "The maximum number of labels to return. Defaults: `100`",
+      default: 100,
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const repoFullname = await this.github._resolveRepoFullname(this.repoFullname);
+
+    let labels = await this.github.getRepositoryLabels({
+      repoFullname,
+    });
+
+    labels = labels.slice(0, this.maxResults);
+
+    $.export("$summary", `Found ${labels.length} label(s) in ${repoFullname}`);
+
+    return labels;
+  },
+};

--- a/components/github/actions/list-repository-labels/list-repository-labels.mjs
+++ b/components/github/actions/list-repository-labels/list-repository-labels.mjs
@@ -30,11 +30,10 @@ export default {
   async run({ $ }) {
     const repoFullname = await this.github._resolveRepoFullname(this.repoFullname);
 
-    let labels = await this.github.getRepositoryLabels({
+    const labels = await this.github.getRepositoryLabels({
       repoFullname,
+      maxResults: this.maxResults,
     });
-
-    labels = labels.slice(0, this.maxResults);
 
     $.export("$summary", `Found ${labels.length} label(s) in ${repoFullname}`);
 

--- a/components/github/actions/list-repository-labels/list-repository-labels.mjs
+++ b/components/github/actions/list-repository-labels/list-repository-labels.mjs
@@ -20,11 +20,10 @@ export default {
       ],
     },
     maxResults: {
-      type: "integer",
-      label: "Max Results",
-      description: "The maximum number of labels to return. Defaults: `100`",
-      default: 100,
-      optional: true,
+      propDefinition: [
+        github,
+        "maxResults",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/github/actions/list-team-id-options/list-team-id-options.mjs
+++ b/components/github/actions/list-team-id-options/list-team-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-list-team-id-options",
   name: "List Team Id Options",
   description: "Retrieves available options for the Team Id field.",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/github/actions/list-workflow-runs/list-workflow-runs.mjs
+++ b/components/github/actions/list-workflow-runs/list-workflow-runs.mjs
@@ -43,11 +43,10 @@ export default {
       optional: true,
     },
     maxResults: {
-      type: "integer",
-      label: "Max Results",
-      description: "The maximum number of workflow runs to return. Defaults: `100`",
-      default: 100,
-      optional: true,
+      propDefinition: [
+        github,
+        "maxResults",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/github/actions/list-workflow-runs/list-workflow-runs.mjs
+++ b/components/github/actions/list-workflow-runs/list-workflow-runs.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-list-workflow-runs",
   name: "List Workflow Runs",
   description: "List GitHub Actions workflow runs for a repository, most recent first. Optionally filter by `branch` or `status` (e.g. `completed`, `in_progress`, `failure`, `success`). Returns each run's `id`, workflow name, `status`, `conclusion`, branch, and timestamps. Use this to triage CI — find a failing run, then pass its `id` to **Get Workflow Run** for job details or to **Run Workflow** to re-run its failed jobs. Provide the repository as an `owner/repo` string. [See the documentation](https://docs.github.com/en/rest/actions/workflow-runs#list-workflow-runs-for-a-repository)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/list-workflows/list-workflows.mjs
+++ b/components/github/actions/list-workflows/list-workflows.mjs
@@ -20,11 +20,10 @@ export default {
       ],
     },
     maxResults: {
-      type: "integer",
-      label: "Max Results",
-      description: "The maximum number of workflows to return. Defaults: `100`",
-      default: 100,
-      optional: true,
+      propDefinition: [
+        github,
+        "maxResults",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/github/actions/list-workflows/list-workflows.mjs
+++ b/components/github/actions/list-workflows/list-workflows.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-list-workflows",
   name: "List Workflows",
   description: "List the GitHub Actions workflows defined in a repository. Returns each workflow's `id`, `name`, `path` (e.g. `.github/workflows/ci.yml`), and `state`. Use this to discover the workflow file name or ID needed by **Run Workflow**. Provide the repository as an `owner/repo` string. [See the documentation](https://docs.github.com/en/rest/actions/workflows#list-repository-workflows)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/merge-pull-request/merge-pull-request.mjs
+++ b/components/github/actions/merge-pull-request/merge-pull-request.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-merge-pull-request",
   name: "Merge Pull Request",
   description: "Merge an open pull request into its base branch. Choose the `mergeMethod`: `merge` (a merge commit, the default), `squash` (combine all commits into one), or `rebase`. The merge fails if the PR is not mergeable (conflicts, failing required checks, or required reviews missing) — check mergeable state and CI with **Get Pull Request** first. Provide the repository as an `owner/repo` string and the PR number. To create the PR first, use **Create Pull Request**. [See the documentation](https://docs.github.com/en/rest/pulls/pulls#merge-a-pull-request)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/run-workflow/run-workflow.mjs
+++ b/components/github/actions/run-workflow/run-workflow.mjs
@@ -5,7 +5,7 @@ export default {
   key: "github-run-workflow",
   name: "Run Workflow",
   description: "Trigger a GitHub Actions workflow run, or re-run the failed jobs of a previous run. To start a new run, provide `workflow` (the workflow file name, e.g. `ci.yml`, its display name, or its numeric ID) and optionally `ref` (the branch or tag to run on — defaults to the repository's default branch) and `inputs` (for `workflow_dispatch` workflows). To re-run only the failed jobs of an existing run instead, provide `rerunFailedRunId`. The workflow must already have a `workflow_dispatch` trigger to be dispatchable. Use **List Workflows** to find the workflow file name and **List Workflow Runs** to find a run ID. Provide the repository as an `owner/repo` string. [See the documentation](https://docs.github.com/en/rest/actions/workflows#create-a-workflow-dispatch-event)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/search-issues-and-pull-requests/search-issues-and-pull-requests.mjs
+++ b/components/github/actions/search-issues-and-pull-requests/search-issues-and-pull-requests.mjs
@@ -7,7 +7,7 @@ export default {
     + "Build the `query` from space-separated qualifiers: `repo:owner/name` to scope to one repo (a bare `repo:name` with no owner is auto-resolved to your own account), `is:issue`/`is:pr`, `is:open`/`is:closed`, `label:bug`, `author:octocat`, `assignee:octocat`, `in:title`/`in:body`, and free-text keywords. "
     + "Example: `repo:PipedreamHQ/pipedream is:issue is:open label:bug raptor`. "
     + "Returns matching items (each with `number`, `title`, `state`, `labels`, `html_url`); feed a result's `number` into **Get Issue**, **Get Pull Request**, or **Create Issue Comment**. [See the query syntax](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests)",
-  version: "0.3.1",
+  version: "0.3.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/search-issues-and-pull-requests/search-issues-and-pull-requests.mjs
+++ b/components/github/actions/search-issues-and-pull-requests/search-issues-and-pull-requests.mjs
@@ -22,11 +22,13 @@ export default {
       type: "string",
     },
     maxResults: {
+      propDefinition: [
+        github,
+        "maxResults",
+      ],
       label: "Maximum Results",
       description: "The maximum number of items to retrieve. Defaults to `30`.",
-      type: "integer",
       default: 30,
-      optional: true,
     },
   },
   async run({ $ }) {

--- a/components/github/actions/star-repo/star-repo.mjs
+++ b/components/github/actions/star-repo/star-repo.mjs
@@ -5,7 +5,7 @@ export default {
   key: "github-star-repo",
   name: "Star Repo",
   description: "Star a repository. [See the docs](https://docs.github.com/en/rest/activity/starring?apiVersion=2022-11-28#star-a-repository-for-the-authenticated-user) for more info.",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/sync-fork-branch-with-upstream/sync-fork-branch-with-upstream.mjs
+++ b/components/github/actions/sync-fork-branch-with-upstream/sync-fork-branch-with-upstream.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-sync-fork-branch-with-upstream",
   name: "Sync Fork Branch with Upstream",
   description: "Sync a forked branch with the upstream branch. [See the documentation](https://docs.github.com/en/rest/branches/branches?apiVersion=2022-11-28#sync-a-fork-branch-with-the-upstream-repository)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   annotations: {
     destructiveHint: true,

--- a/components/github/actions/update-gist/update-gist.mjs
+++ b/components/github/actions/update-gist/update-gist.mjs
@@ -6,7 +6,7 @@ export default {
   key: "github-update-gist",
   name: "Update Gist",
   description: "Allows you to update a gist's description and to update, delete, or rename gist files. [See the documentation](https://docs.github.com/en/rest/gists/gists?apiVersion=2022-11-28#update-a-gist)",
-  version: "0.0.17",
+  version: "0.0.18",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/github/actions/update-issue/update-issue.mjs
+++ b/components/github/actions/update-issue/update-issue.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-update-issue",
   name: "Update Issue",
   description: "Update an existing issue: change its title, body, state (open/closed), labels, assignees, or milestone. Provide the repository as an `owner/repo` string and the issue number. Setting `labels` **replaces** the full label set (it does not append), so include any existing labels you want to keep. Closing an issue is done here by setting `state` to `closed`. Use **Get Issue** first if you need the current values. [See the documentation](https://docs.github.com/en/rest/issues/issues#update-an-issue)",
-  version: "0.3.1",
+  version: "0.3.2",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/github/actions/update-project-v2-item-status/update-project-v2-item-status.mjs
+++ b/components/github/actions/update-project-v2-item-status/update-project-v2-item-status.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-update-project-v2-item-status",
   name: "Update Project (V2) Item Status",
   description: "Update the status of an item in the selected Project (V2). [See the documentation](https://docs.github.com/en/graphql/reference/mutations#updateprojectv2itemfieldvalue)",
-  version: "0.0.12",
+  version: "0.0.13",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/github/actions/update-pull-request/update-pull-request.mjs
+++ b/components/github/actions/update-pull-request/update-pull-request.mjs
@@ -4,7 +4,7 @@ export default {
   key: "github-update-pull-request",
   name: "Update Pull Request",
   description: "Update an existing pull request's title, body, state (`open`/`closed`), or base branch. Only the fields you provide are changed. Provide the repository as an `owner/repo` string and the PR number. If you only know the PR by title, call **Get Pull Request** or **Search Issues and Pull Requests** with `is:pr` first to resolve its number. To merge a PR, use **Merge Pull Request**; to comment on it, use **Create Issue Comment**. [See the documentation](https://docs.github.com/en/rest/pulls/pulls#update-a-pull-request)",
-  version: "1.0.0",
+  version: "1.0.1",
   type: "action",
   annotations: {
     destructiveHint: true,

--- a/components/github/common/queries.mjs
+++ b/components/github/common/queries.mjs
@@ -1,9 +1,7 @@
-const DEFAULT_PAGE_SIZE = 10;
-
 const organizationProjectsQuery = `
-  query ($repoOwner: String!, $cursor: String) {
+  query ($repoOwner: String!, $cursor: String, $first: Int!) {
     organization(login: $repoOwner) {
-      projectsV2(first: ${DEFAULT_PAGE_SIZE}, after: $cursor) {
+      projectsV2(first: $first, after: $cursor) {
         nodes {
           number
           title
@@ -18,9 +16,9 @@ const organizationProjectsQuery = `
 `;
 
 const projectsQuery = `
-  query ($repoOwner: String!, $repoName: String!, $cursor: String) {
+  query ($repoOwner: String!, $repoName: String!, $cursor: String, $first: Int!) {
     repository(owner: $repoOwner, name: $repoName) {
-      projectsV2(first: ${DEFAULT_PAGE_SIZE}, after: $cursor) {
+      projectsV2(first: $first, after: $cursor) {
         nodes {
           number
           title

--- a/components/github/common/queries.mjs
+++ b/components/github/common/queries.mjs
@@ -10,6 +10,7 @@ const organizationProjectsQuery = `
         }
         pageInfo {
           endCursor
+          hasNextPage
         }
       }
     }
@@ -26,6 +27,7 @@ const projectsQuery = `
         }
         pageInfo {
           endCursor
+          hasNextPage
         }
       }
     }

--- a/components/github/github.app.mjs
+++ b/components/github/github.app.mjs
@@ -491,7 +491,7 @@ export default {
     // that only want a bounded slice don't pull every page. When `maxResults`
     // is omitted (e.g. the propDefinition option loaders), all pages are
     // fetched — preserving the previous behavior.
-    async _paginateWithLimit(route, maxResults) {
+    async _paginateWithLimit(route, maxResults, params = {}) {
       const results = [];
       // A defined, non-positive limit means "no rows" — return before paging.
       if (maxResults != null && maxResults <= 0) {
@@ -499,6 +499,7 @@ export default {
       }
       for await (const { data } of this._client().paginate.iterator(route, {
         per_page: 100,
+        ...params,
       })) {
         results.push(...data);
         if (maxResults != null && results.length >= maxResults) {
@@ -1013,18 +1014,17 @@ export default {
       return response.data;
     },
     async getRepositoryMilestones({
-      repoFullname, ...args
+      repoFullname, maxResults, ...args
     }) {
-      // Defaults come first so caller-supplied `state`/`per_page` (spread via
-      // `...args`) can override them. Without state, GitHub defaults to `open`,
-      // which preserves the behavior the `milestoneNumber` propDefinition relies on.
-      const response = await this._client().request(`GET /repos/${repoFullname}/milestones`, {
-        per_page: 100,
+      // Paginate (bounded by maxResults) rather than a single page, so large
+      // milestone sets are reachable. `state` default comes first so a
+      // caller-supplied `state` (spread via `...args`) overrides it; without
+      // one, GitHub defaults to `open`, which the `milestoneNumber`
+      // propDefinition relies on (it passes no maxResults, so all are fetched).
+      return this._paginateWithLimit(`GET /repos/${repoFullname}/milestones`, maxResults, {
         state: "open",
         ...args,
       });
-
-      return response.data;
     },
     async getRepositoryStargazers({
       repoFullname, ...args

--- a/components/github/github.app.mjs
+++ b/components/github/github.app.mjs
@@ -487,11 +487,33 @@ export default {
         ...args,
       });
     },
-    async getRepositoryLabels({ repoFullname }) {
-      return this._client().paginate(`GET /repos/${repoFullname}/labels`, {});
+    // Paginate but stop early once `maxResults` rows are collected, so callers
+    // that only want a bounded slice don't pull every page. When `maxResults`
+    // is omitted (e.g. the propDefinition option loaders), all pages are
+    // fetched — preserving the previous behavior.
+    async _paginateWithLimit(route, maxResults) {
+      const results = [];
+      for await (const { data } of this._client().paginate.iterator(route, {
+        per_page: 100,
+      })) {
+        results.push(...data);
+        if (maxResults && results.length >= maxResults) {
+          break;
+        }
+      }
+      return maxResults
+        ? results.slice(0, maxResults)
+        : results;
     },
-    async getRepositoryCollaborators({ repoFullname }) {
-      return this._client().paginate(`GET /repos/${repoFullname}/collaborators`, {});
+    async getRepositoryLabels({
+      repoFullname, maxResults,
+    }) {
+      return this._paginateWithLimit(`GET /repos/${repoFullname}/labels`, maxResults);
+    },
+    async getRepositoryCollaborators({
+      repoFullname, maxResults,
+    }) {
+      return this._paginateWithLimit(`GET /repos/${repoFullname}/collaborators`, maxResults);
     },
     async getRepositoryIssues({
       repoFullname, ...args

--- a/components/github/github.app.mjs
+++ b/components/github/github.app.mjs
@@ -660,8 +660,10 @@ export default {
         // Common LLM mistake: duplicating the repo name into the owner slot
         // (e.g. "my-repo/my-repo") when the owner is unknown. Treat the doubled
         // form as a bare name and assume the authenticated user as the owner.
+        // GitHub owner/repo names are case-insensitive, so compare accordingly
+        // (e.g. "My-Repo/my-repo" is also a doubled name).
         const parts = repoFullname.split("/");
-        if (parts.length === 2 && parts[0] && parts[0] === parts[1]) {
+        if (parts.length === 2 && parts[0] && parts[0].toLowerCase() === parts[1].toLowerCase()) {
           const { login } = await this.getAuthenticatedUser();
           return `${login}/${parts[1]}`;
         }

--- a/components/github/github.app.mjs
+++ b/components/github/github.app.mjs
@@ -54,6 +54,26 @@ export default {
       description: "The pull request number — the `#N` shown in the GitHub UI. Use **Search Issues and Pull Requests** with `is:pr` or **Get Pull Request** to find it when you only know the title.",
       type: "integer",
     },
+    // Static, MCP-friendly props for the Projects (V2) discovery chain
+    // (List Projects → List Project Statuses / List Project Items). No
+    // `async options()` dropdowns — Projects V2 are addressed by their
+    // human-readable org login + number. User-owned Projects are not supported.
+    projectOwnerStatic: {
+      label: "Owner",
+      description: "The account that owns the Project (V2). Provide an organization login (e.g. `my-org`) to list organization-owned projects, or a repository owner when **Repository** is also set. Discover org logins with **List Organizations**. User-owned Projects are not supported.",
+      type: "string",
+    },
+    projectRepoStatic: {
+      label: "Repository",
+      description: "Optional. The repository name **without** the owner (e.g. `my-repo`, not `my-org/my-repo`) when the Project (V2) is repository-scoped. Leave blank to target an organization-owned Project.",
+      type: "string",
+      optional: true,
+    },
+    projectNumberStatic: {
+      label: "Project Number",
+      description: "The Project (V2) number as shown in the project URL and UI (e.g. `5` in `/orgs/my-org/projects/5`) — not the node ID. Get it from **List Projects**.",
+      type: "integer",
+    },
     repoOrg: {
       label: "Organization Repository",
       description: "The repository in a organization",
@@ -495,11 +515,13 @@ export default {
         repoName,
         cursor,
       });
+      const pageInfo = response?.repository?.projectsV2?.pageInfo ??
+        response?.organization?.projectsV2?.pageInfo;
       return {
         projects: response?.repository?.projectsV2?.nodes ??
           response?.organization?.projectsV2?.nodes,
-        nextCursor: response?.repository?.projectsV2?.pageInfo?.endCursor ??
-          response?.organization?.projectsV2?.pageInfo?.endCursor,
+        nextCursor: pageInfo?.endCursor,
+        hasNextPage: pageInfo?.hasNextPage ?? false,
       };
     },
     async getProjectV2StatusField({
@@ -966,10 +988,13 @@ export default {
     async getRepositoryMilestones({
       repoFullname, ...args
     }) {
+      // Defaults come first so caller-supplied `state`/`per_page` (spread via
+      // `...args`) can override them. Without state, GitHub defaults to `open`,
+      // which preserves the behavior the `milestoneNumber` propDefinition relies on.
       const response = await this._client().request(`GET /repos/${repoFullname}/milestones`, {
-        ...args,
         per_page: 100,
         state: "open",
+        ...args,
       });
 
       return response.data;

--- a/components/github/github.app.mjs
+++ b/components/github/github.app.mjs
@@ -74,6 +74,13 @@ export default {
       description: "The Project (V2) number as shown in the project URL and UI (e.g. `5` in `/orgs/my-org/projects/5`) — not the node ID. Get it from **List Projects**.",
       type: "integer",
     },
+    maxResults: {
+      type: "integer",
+      label: "Max Results",
+      description: "The maximum number of results to return. Defaults to `100`.",
+      default: 100,
+      optional: true,
+    },
     repoOrg: {
       label: "Organization Repository",
       description: "The repository in a organization",
@@ -534,7 +541,7 @@ export default {
       return this._client().paginate(`GET /repos/${repoFullname}/projects`, {});
     },
     async getProjectsV2({
-      repoOwner, repoName, cursor,
+      repoOwner, repoName, cursor, first = 10,
     }) {
       const response = await this.graphql(repoName
         ? queries.projectsQuery
@@ -542,6 +549,7 @@ export default {
         repoOwner,
         repoName,
         cursor,
+        first,
       });
       const pageInfo = response?.repository?.projectsV2?.pageInfo ??
         response?.organization?.projectsV2?.pageInfo;

--- a/components/github/github.app.mjs
+++ b/components/github/github.app.mjs
@@ -493,15 +493,20 @@ export default {
     // fetched — preserving the previous behavior.
     async _paginateWithLimit(route, maxResults) {
       const results = [];
+      // A defined, non-positive limit means "no rows" — return before paging.
+      if (maxResults != null && maxResults <= 0) {
+        return results;
+      }
       for await (const { data } of this._client().paginate.iterator(route, {
         per_page: 100,
       })) {
         results.push(...data);
-        if (maxResults && results.length >= maxResults) {
+        if (maxResults != null && results.length >= maxResults) {
           break;
         }
       }
-      return maxResults
+      // Only `undefined`/`null` means unlimited; slice for any defined limit.
+      return maxResults != null
         ? results.slice(0, maxResults)
         : results;
     },

--- a/components/github/github.app.mjs
+++ b/components/github/github.app.mjs
@@ -41,7 +41,7 @@ export default {
     // round-trips. GitHub identifiers are human-readable, so dropdowns add no value.
     repoFullnameStatic: {
       label: "Repository",
-      description: "The repository in `owner/repo` format, for example `PipedreamHQ/pipedream` (not case sensitive). If you pass just a repository name with no owner (e.g. `my-repo`), the authenticated user is assumed as the owner — convenient for \"my repo\" requests.",
+      description: "The repository in `owner/repo` format, for example `PipedreamHQ/pipedream` (not case sensitive). If you pass just a repository name with no owner (e.g. `my-repo`), the authenticated user is assumed as the owner — convenient for \"my repo\" requests. Do NOT repeat the repository name as the owner (e.g. `my-repo/my-repo`); if you don't know the owner, pass only the name or run **List Repositories** to find it.",
       type: "string",
     },
     issueNumberStatic: {
@@ -60,7 +60,7 @@ export default {
     // human-readable org login + number. User-owned Projects are not supported.
     projectOwnerStatic: {
       label: "Owner",
-      description: "The account that owns the Project (V2). Provide an organization login (e.g. `my-org`) to list organization-owned projects, or a repository owner when **Repository** is also set. Discover org logins with **List Organizations**. User-owned Projects are not supported.",
+      description: "The account that owns the Project (V2) — an organization login (e.g. `my-org`), or a repository owner when **Repository** is also set. **Required, and it must come from the user.** If the user has not said which owner/organization the project belongs to, ask them — do NOT guess an owner or enumerate organizations to find one. If they named an organization but you need its exact login, use **List Organizations**. User-owned Projects are not supported.",
       type: "string",
     },
     projectRepoStatic: {
@@ -71,7 +71,7 @@ export default {
     },
     projectNumberStatic: {
       label: "Project Number",
-      description: "The Project (V2) number as shown in the project URL and UI (e.g. `5` in `/orgs/my-org/projects/5`) — not the node ID. Get it from **List Projects**.",
+      description: "The Project (V2) number as shown in the project URL and UI (e.g. `5` in `/orgs/my-org/projects/5`) — not the node ID. **Required.** If the user has not provided it, ask them — do NOT guess. Once you know the owner, you can look up numbers with **List Projects**.",
       type: "integer",
     },
     maxResults: {
@@ -651,9 +651,20 @@ export default {
     // "my repo X" it often passes just `X`; GitHub needs `owner/repo`, so we
     // assume the authenticated user as the owner when no `/` is present.
     async _resolveRepoFullname(repoFullname) {
-      if (typeof repoFullname === "string" && repoFullname && !repoFullname.includes("/")) {
-        const { login } = await this.getAuthenticatedUser();
-        return `${login}/${repoFullname}`;
+      if (typeof repoFullname === "string" && repoFullname) {
+        // Bare repo name (no owner) → assume the authenticated user.
+        if (!repoFullname.includes("/")) {
+          const { login } = await this.getAuthenticatedUser();
+          return `${login}/${repoFullname}`;
+        }
+        // Common LLM mistake: duplicating the repo name into the owner slot
+        // (e.g. "my-repo/my-repo") when the owner is unknown. Treat the doubled
+        // form as a bare name and assume the authenticated user as the owner.
+        const parts = repoFullname.split("/");
+        if (parts.length === 2 && parts[0] && parts[0] === parts[1]) {
+          const { login } = await this.getAuthenticatedUser();
+          return `${login}/${parts[1]}`;
+        }
       }
       return repoFullname;
     },

--- a/components/github/package.json
+++ b/components/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/github",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Pipedream GitHub Components",
   "main": "github.app.mjs",
   "keywords": [

--- a/components/github/sources/new-branch/new-branch.mjs
+++ b/components/github/sources/new-branch/new-branch.mjs
@@ -8,7 +8,7 @@ export default {
   key: "github-new-branch",
   name: "New Branch Created",
   description: "Emit new event when a branch is created.",
-  version: "1.0.15",
+  version: "1.0.16",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-card-in-column/new-card-in-column.mjs
+++ b/components/github/sources/new-card-in-column/new-card-in-column.mjs
@@ -7,7 +7,7 @@ export default {
   key: "github-new-card-in-column",
   name: "New Card in Column (Classic Projects)",
   description: "Emit new event when a (classic) project card is created or moved to a specific column. For Projects V2 use `New Issue with Status` trigger. [More information here](https://docs.github.com/en/issues/organizing-your-work-with-project-boards/tracking-work-with-project-boards/adding-issues-and-pull-requests-to-a-project-board)",
-  version: "1.0.14",
+  version: "1.0.15",
   type: "source",
   props: {
     ...common.props,

--- a/components/github/sources/new-collaborator/new-collaborator.mjs
+++ b/components/github/sources/new-collaborator/new-collaborator.mjs
@@ -8,7 +8,7 @@ export default {
   key: "github-new-collaborator",
   name: "New Collaborator",
   description: "Emit new event when a collaborator is added",
-  version: "1.0.15",
+  version: "1.0.16",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-commit-comment/new-commit-comment.mjs
+++ b/components/github/sources/new-commit-comment/new-commit-comment.mjs
@@ -8,7 +8,7 @@ export default {
   key: "github-new-commit-comment",
   name: "New Commit Comment",
   description: "Emit new event when a commit comment is created",
-  version: "1.0.15",
+  version: "1.0.16",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/github/sources/new-commit/new-commit.mjs
+++ b/components/github/sources/new-commit/new-commit.mjs
@@ -8,7 +8,7 @@ export default {
   key: "github-new-commit",
   name: "New Commit",
   description: "Emit new event when commits are pushed to a branch",
-  version: "1.0.16",
+  version: "1.0.17",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/github/sources/new-discussion/new-discussion.mjs
+++ b/components/github/sources/new-discussion/new-discussion.mjs
@@ -8,7 +8,7 @@ export default {
   key: "github-new-discussion",
   name: "New Discussion",
   description: "Emit new event when a discussion is created",
-  version: "1.0.15",
+  version: "1.0.16",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-fork/new-fork.mjs
+++ b/components/github/sources/new-fork/new-fork.mjs
@@ -8,7 +8,7 @@ export default {
   key: "github-new-fork",
   name: "New Fork",
   description: "Emit new event when a repository is forked",
-  version: "1.0.15",
+  version: "1.0.16",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-gist/new-gist.mjs
+++ b/components/github/sources/new-gist/new-gist.mjs
@@ -5,7 +5,7 @@ export default {
   key: "github-new-gist",
   name: "New Gist",
   description: "Emit new events when new gists are created by the authenticated user. [See the documentation](https://docs.github.com/en/rest/gists/gists?apiVersion=20.2.61-28#list-gists-for-the-authenticated-user)",
-  version: "0.2.10",
+  version: "0.2.11",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-issue-comment/new-issue-comment.mjs
+++ b/components/github/sources/new-issue-comment/new-issue-comment.mjs
@@ -8,7 +8,7 @@ export default {
   key: "github-new-issue-comment",
   name: "New Issue Comment",
   description: "Emit new event when a new comment is added to an issue or pull request",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-issue-with-status/new-issue-with-status.mjs
+++ b/components/github/sources/new-issue-with-status/new-issue-with-status.mjs
@@ -8,7 +8,7 @@ export default {
   key: "github-new-issue-with-status",
   name: "Project Item Status Changed",
   description: "Emit new event when a project item is tagged with a specific status. Currently supports Organization Projects only. [More information here](https://docs.github.com/en/issues/planning-and-tracking-with-projects/managing-items-in-your-project/adding-items-to-your-project)",
-  version: "0.1.13",
+  version: "0.1.14",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/github/sources/new-label/new-label.mjs
+++ b/components/github/sources/new-label/new-label.mjs
@@ -8,7 +8,7 @@ export default {
   key: "github-new-label",
   name: "New Label",
   description: "Emit new event when a new label is created",
-  version: "1.0.15",
+  version: "1.0.16",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-mention/new-mention.mjs
+++ b/components/github/sources/new-mention/new-mention.mjs
@@ -5,7 +5,7 @@ export default {
   key: "github-new-mention",
   name: "New Mention",
   description: "Emit new event when you are @mentioned in a new commit, comment, issue or pull request. [See the documentation](https://docs.github.com/en/rest/activity/notifications?apiVersion=20.2.71-28#list-notifications-for-the-authenticated-user)",
-  version: "0.2.9",
+  version: "0.2.10",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-notification/new-notification.mjs
+++ b/components/github/sources/new-notification/new-notification.mjs
@@ -5,7 +5,7 @@ export default {
   key: "github-new-notification",
   name: "New Notification",
   description: "Emit new event when the authenticated user receives a new notification. [See the documentation](https://docs.github.com/en/rest/activity/notifications?apiVersion=20.2.71-28#list-notifications-for-the-authenticated-user)",
-  version: "0.2.9",
+  version: "0.2.10",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-or-updated-issue/new-or-updated-issue.mjs
+++ b/components/github/sources/new-or-updated-issue/new-or-updated-issue.mjs
@@ -9,7 +9,7 @@ export default {
   key: "github-new-or-updated-issue",
   name: "New or Updated Issue",
   description: "Emit new events when an issue is created or updated",
-  version: "1.1.12",
+  version: "1.1.13",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-or-updated-milestone/new-or-updated-milestone.mjs
+++ b/components/github/sources/new-or-updated-milestone/new-or-updated-milestone.mjs
@@ -9,7 +9,7 @@ export default {
   key: "github-new-or-updated-milestone",
   name: "New or Updated Milestone",
   description: "Emit new event when a milestone is created or updated",
-  version: "1.1.12",
+  version: "1.1.13",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-or-updated-pull-request/new-or-updated-pull-request.mjs
+++ b/components/github/sources/new-or-updated-pull-request/new-or-updated-pull-request.mjs
@@ -9,7 +9,7 @@ export default {
   key: "github-new-or-updated-pull-request",
   name: "New or Updated Pull Request",
   description: "Emit new event when a pull request is opened or updated",
-  version: "1.2.12",
+  version: "1.2.13",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-organization/new-organization.mjs
+++ b/components/github/sources/new-organization/new-organization.mjs
@@ -5,7 +5,7 @@ export default {
   key: "github-new-organization",
   name: "New Organization",
   description: "Emit new event when the authenticated user is added to a new organization. [See the documentation](https://docs.github.com/en/rest/orgs/orgs?apiVersion=20.2.71-28#list-organizations-for-the-authenticated-user)",
-  version: "0.2.9",
+  version: "0.2.10",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-release/new-release.mjs
+++ b/components/github/sources/new-release/new-release.mjs
@@ -8,7 +8,7 @@ export default {
   key: "github-new-release",
   name: "New release",
   description: "Emit new event when a new release is created",
-  version: "1.0.15",
+  version: "1.0.16",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-repository/new-repository.mjs
+++ b/components/github/sources/new-repository/new-repository.mjs
@@ -5,7 +5,7 @@ export default {
   key: "github-new-repository",
   name: "New Repository",
   description: "Emit new event when a new repository is created or when the authenticated user receives access. [See the documentation](https://docs.github.com/en/rest/repos/repos?apiVersion=20.2.71-28#list-repositories-for-the-authenticated-user)",
-  version: "0.2.9",
+  version: "0.2.10",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-review-request/new-review-request.mjs
+++ b/components/github/sources/new-review-request/new-review-request.mjs
@@ -7,7 +7,7 @@ export default {
   key: "github-new-review-request",
   name: "New Review Request",
   description: "Emit new events when you or a team you're a member of are requested to review a pull request across repositories accessible to the connected account. [See the documentation](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests#search-by-pull-request-review-status-and-reviewer)",
-  version: "0.2.10",
+  version: "0.2.11",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-security-alert/new-security-alert.mjs
+++ b/components/github/sources/new-security-alert/new-security-alert.mjs
@@ -5,7 +5,7 @@ export default {
   key: "github-new-security-alert",
   name: "New Security Alert",
   description: "Emit new event for security alert notifications. [See the documentation](https://docs.github.com/en/rest/activity/notifications?apiVersion=20.2.71-28#list-notifications-for-the-authenticated-user)",
-  version: "0.2.9",
+  version: "0.2.10",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-star-by-user/new-star-by-user.mjs
+++ b/components/github/sources/new-star-by-user/new-star-by-user.mjs
@@ -5,7 +5,7 @@ export default {
   key: "github-new-star-by-user",
   name: "New Star By User",
   description: "Emit new events when the specified user stars a repository. [See the documentation](https://docs.github.com/en/rest/activity/starring?apiVersion=2022-11-28#list-repositories-starred-by-a-user)",
-  version: "0.0.14",
+  version: "0.0.15",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/github/sources/new-star/new-star.mjs
+++ b/components/github/sources/new-star/new-star.mjs
@@ -8,7 +8,7 @@ export default {
   key: "github-new-star",
   name: "New Stars",
   description: "Emit new event when a repository is starred",
-  version: "1.0.15",
+  version: "1.0.16",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-team/new-team.mjs
+++ b/components/github/sources/new-team/new-team.mjs
@@ -5,7 +5,7 @@ export default {
   key: "github-new-team",
   name: "New Team",
   description: "Emit new event when the authenticated user is added to a new team. [See the documentation](https://docs.github.com/en/rest/teams/teams?apiVersion=20.2.71-28#list-teams-for-the-authenticated-user)",
-  version: "0.2.9",
+  version: "0.2.10",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/github/sources/new-workflow-job-completed/new-workflow-job-completed.mjs
+++ b/components/github/sources/new-workflow-job-completed/new-workflow-job-completed.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Workflow Job Completed (Instant)",
   description: "Emit new event when a job in a workflow is completed, regardless of whether the job was successful or unsuccessful.",
   type: "source",
-  version: "0.0.9",
+  version: "0.0.10",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/github/sources/new-workflow-run-completed/new-workflow-run-completed.mjs
+++ b/components/github/sources/new-workflow-run-completed/new-workflow-run-completed.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Workflow Run Completed (Instant)",
   description: "Emit new event when a GitHub Actions workflow run completes",
   type: "source",
-  version: "0.0.9",
+  version: "0.0.10",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/github/sources/webhook-events/webhook-events.mjs
+++ b/components/github/sources/webhook-events/webhook-events.mjs
@@ -8,7 +8,7 @@ export default {
   name: "New Webhook Event (Instant)",
   description: "Emit new event for each selected event type",
   type: "source",
-  version: "1.0.16",
+  version: "1.0.17",
   dedupe: "unique",
   props: {
     docsInfo: {


### PR DESCRIPTION
## What

Adds six AI-optimized, read-only GitHub list actions. These expose data that was previously only reachable through `async options()` dropdowns on prop definitions — which are unusable via MCP / AI tool-calling — so there was no standalone action to retrieve them.

New actions:
- `github-list-repository-labels` — REST `GET /repos/{owner}/{repo}/labels`
- `github-list-repository-collaborators` — REST `GET /repos/{owner}/{repo}/collaborators`
- `github-list-milestones` — REST `GET /repos/{owner}/{repo}/milestones` (open/closed/all)
- `github-list-projects` — GraphQL, Projects (V2) for an org or repo, cursor-paginated
- `github-list-project-statuses` — GraphQL, a Project (V2) Status field's options
- `github-list-project-items` — GraphQL, items in a Project (V2)

## Details

- All six are static-schema (no `additionalProps` / `reloadProps` / async-options), so they resolve in a single MCP call. GitHub identifiers are human-readable, so dropdowns add no value.
- Descriptions cross-reference related tools to form a discovery chain (e.g. **List Projects** → **List Project Statuses** / **List Project Items** → **Update Project (V2) Item Status**).
- `getRepositoryMilestones`: reordered so a caller-supplied `state` flows through (still defaults to `open`) — previously a hardcoded `state: "open"` overrode the argument.
- Added static `propDefinitions` (`projectOwnerStatic`, `projectRepoStatic`, `projectNumberStatic`) shared by the Projects (V2) actions.
- Added `hasNextPage` to the Projects (V2) list queries; `list-projects` accepts a `cursor` prop and returns `{ projects, nextCursor }` (cursor set only when more results exist) for reliable pagination. Change is additive — the existing `projectV2` async-options propDefinition is unaffected.
- Bumped `components/github` to `3.1.0`.

## Testing

Exercised end-to-end via an MCP eval harness against a live GitHub account (labels/collaborators/milestones on a seeded repo; Projects V2 against a real org project with default statuses and items). All six actions pass, each with a single tool call.

Note: user-owned Projects (V2) are not supported — consistent with the existing GraphQL queries, which only cover the `organization(login:)` and `repository(owner,name:)` roots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new GitHub Actions to list: repository milestones, GitHub Projects (V2), project items, project status options, repository collaborators, and repository labels.
* **Improvements**
  * Improved Projects (V2) discovery pagination and “has more results” behavior.
  * Enhanced listing actions to respect a `maxResults` limit and return clearer counts in summaries.
* **Release**
  * Updated the GitHub integration to version **3.1.0** and refreshed action/source versions across the bundle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->