### PR TITLE
Add batch/pagination support to Google Drive list-files and download-file

### DIFF
--- a/components/google_drive/actions/download-file/download-file.mjs
+++ b/components/google_drive/actions/download-file/download-file.mjs
@@ -1,3 +1,4 @@
+import { ConfigurationError } from "@pipedream/platform";
 import fs from "fs";
 import stream from "stream";
 import { promisify } from "util";
@@ -24,14 +25,15 @@ const SHORTCUT_MIME_TYPE = "application/vnd.google-apps.shortcut";
 export default {
   key: "google_drive-download-file",
   name: "Download File",
-  description: "Download a file from Google Drive to the `/tmp` directory or return its contents as a buffer."
+  description: "Download one or more files from Google Drive to the `/tmp` directory or return their contents as buffers."
+    + " Select multiple files to download a batch in a single run."
     + " Use to fetch a file's contents for processing in downstream steps — e.g., parsing a CSV, extracting text from a PDF, or re-uploading to another service."
     + " For Google Workspace files (Docs, Sheets, Slides, Drawings, Apps Script), exports to an Office-compatible format by default:"
     + " Docs → `.docx`, Sheets → `.xlsx`, Slides → `.pptx`, Drawings → PNG, Apps Script → JSON."
     + " Pass `mimeType` to force a specific format. Shortcuts are resolved to their target automatically."
     + " Folders, Forms, and My Maps cannot be downloaded via this action."
     + " [See the documentation](https://developers.google.com/drive/api/v3/manage-downloads)",
-  version: "0.1.27",
+  version: "0.2.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -48,6 +50,19 @@ export default {
       description: "The shared drive the file is in, if any. Leave empty for files in My Drive.",
       optional: true,
     },
+    fileIds: {
+      propDefinition: [
+        googleDrive,
+        "fileId",
+        (c) => ({
+          drive: c.drive,
+        }),
+      ],
+      type: "string[]",
+      label: "Files",
+      description: "The Google Drive file(s) to download. Select one or more files to download a batch in a single run. Accepts file IDs (opaque Drive identifiers). Shortcuts are resolved to their target automatically.",
+      optional: true,
+    },
     fileId: {
       propDefinition: [
         googleDrive,
@@ -56,7 +71,8 @@ export default {
           drive: c.drive,
         }),
       ],
-      description: "The Google Drive file to download. Accepts a file ID (opaque Drive identifier). If a shortcut is passed, the target file is resolved and downloaded automatically.",
+      description: "A single Google Drive file to download. Kept for backwards compatibility — prefer `Files` for new configurations. If both are set, this file is included alongside the ones in `Files`.",
+      optional: true,
     },
     filePath: {
       type: "string",
@@ -82,7 +98,7 @@ export default {
       `),
       optional: true,
       async options() {
-        const fileId = this.fileId;
+        const fileId = this.fileId ?? this.fileIds?.[0];
         if (!fileId) {
           return googleWorkspaceExportFormats;
         }
@@ -127,104 +143,150 @@ export default {
     },
   },
   async run({ $ }) {
-    let fileMetadata = await this.googleDrive.getFile(this.fileId, {
-      fields: "name,mimeType,shortcutDetails,webViewLink",
-    });
+    // Combine the batch input (`fileIds`) with the legacy single `fileId`, keeping
+    // order and dropping duplicates so the same file isn't downloaded twice.
+    const requestedIds = [
+      ...(this.fileIds ?? []),
+      ...(this.fileId
+        ? [
+          this.fileId,
+        ]
+        : []),
+    ];
+    const fileIds = [
+      ...new Set(requestedIds),
+    ];
 
-    // Shortcuts point at a target file; resolve and download the target instead.
-    let downloadFileId = this.fileId;
-    let resolvedFromShortcut = false;
-    if (fileMetadata.mimeType === SHORTCUT_MIME_TYPE) {
-      const targetId = fileMetadata.shortcutDetails?.targetId;
-      if (!targetId) {
-        throw new Error(`Shortcut "${fileMetadata.name}" has no target file and cannot be downloaded.`);
-      }
-      downloadFileId = targetId;
-      resolvedFromShortcut = true;
-      fileMetadata = await this.googleDrive.getFile(targetId, {
-        fields: "name,mimeType,webViewLink",
-      });
+    if (fileIds.length === 0) {
+      throw new ConfigurationError("Select at least one file to download (`Files` or `File`).");
     }
-
-    const sourceMimeType = fileMetadata.mimeType;
-
-    if (unsupportedWorkspaceMimes[sourceMimeType]) {
-      throw new Error(
-        `Cannot download file of type "${sourceMimeType}": ${unsupportedWorkspaceMimes[sourceMimeType]}`,
-      );
-    }
-
-    const isWorkspaceDocument = sourceMimeType.includes(GOOGLE_DRIVE_MIME_TYPE_PREFIX);
-
-    // Fallback: user value -> static default -> runtime getExportFormats().
-    let effectiveMimeType = this.mimeType;
-    if (isWorkspaceDocument && !effectiveMimeType) {
-      effectiveMimeType = defaultExportMimeBySource[sourceMimeType];
-      if (!effectiveMimeType) {
-        const exportFormats = await this.googleDrive.getExportFormats();
-        effectiveMimeType = exportFormats[sourceMimeType]?.[0];
-      }
-      if (!effectiveMimeType) {
-        throw new Error(
-          `No export format available for "${sourceMimeType}". Set Conversion Format explicitly.`,
-        );
-      }
-    }
-
-    // See https://developers.google.com/drive/api/v3/mime-types for Google MIME types.
-    const file = isWorkspaceDocument
-      ? await this.googleDrive.downloadWorkspaceFile(downloadFileId, {
-        mimeType: effectiveMimeType,
-      })
-      : await this.googleDrive.getFile(downloadFileId, {
-        alt: "media",
-      });
-
-    const summaryPrefix = resolvedFromShortcut
-      ? "Resolved shortcut and downloaded"
-      : "Successfully downloaded";
-
-    if (this.getBufferResponse) {
-      $.export("$summary", `${summaryPrefix} raw content for file "${fileMetadata.name}"`);
-
-      const chunks = [];
-      for await (const chunk of file) {
-        chunks.push(chunk);
-      }
-      const buffer = Buffer.concat(chunks);
-
-      return {
-        fileId: this.fileId,
-        fileMetadata,
-        webViewLink: fileMetadata.webViewLink,
-        content: buffer,
-      };
-    }
-
-    let filePath;
-    if (this.filePath) {
-      filePath = this.filePath.includes("tmp/")
-        ? this.filePath
-        : `/tmp/${this.filePath}`;
-    } else {
-      let defaultName = fileMetadata.name;
-      if (isWorkspaceDocument) {
-        const ext = extensionByMime[effectiveMimeType];
-        if (ext && !defaultName.toLowerCase().endsWith(`.${ext.toLowerCase()}`)) {
-          defaultName = `${defaultName}.${ext}`;
-        }
-      }
-      filePath = `/tmp/${defaultName}`;
+    if (fileIds.length > 1 && this.filePath) {
+      throw new ConfigurationError("`Destination File Path` can only be used when downloading a single file. Remove it to download multiple files (each saves to `/tmp/<file name>`).");
     }
 
     const pipeline = promisify(stream.pipeline);
-    await pipeline(file, fs.createWriteStream(filePath));
-    $.export("$summary", `${summaryPrefix} the file, "${fileMetadata.name}"`);
+
+    // Downloads a single file (resolving shortcuts + Workspace export formats),
+    // either writing it to /tmp or returning its contents as a buffer.
+    const downloadOne = async (requestedFileId) => {
+      let fileMetadata = await this.googleDrive.getFile(requestedFileId, {
+        fields: "name,mimeType,shortcutDetails,webViewLink",
+      });
+
+      // Shortcuts point at a target file; resolve and download the target instead.
+      let downloadFileId = requestedFileId;
+      let resolvedFromShortcut = false;
+      if (fileMetadata.mimeType === SHORTCUT_MIME_TYPE) {
+        const targetId = fileMetadata.shortcutDetails?.targetId;
+        if (!targetId) {
+          throw new Error(`Shortcut "${fileMetadata.name}" has no target file and cannot be downloaded.`);
+        }
+        downloadFileId = targetId;
+        resolvedFromShortcut = true;
+        fileMetadata = await this.googleDrive.getFile(targetId, {
+          fields: "name,mimeType,webViewLink",
+        });
+      }
+
+      const sourceMimeType = fileMetadata.mimeType;
+
+      if (unsupportedWorkspaceMimes[sourceMimeType]) {
+        throw new Error(
+          `Cannot download file of type "${sourceMimeType}": ${unsupportedWorkspaceMimes[sourceMimeType]}`,
+        );
+      }
+
+      const isWorkspaceDocument = sourceMimeType.includes(GOOGLE_DRIVE_MIME_TYPE_PREFIX);
+
+      // Fallback: user value -> static default -> runtime getExportFormats().
+      let effectiveMimeType = this.mimeType;
+      if (isWorkspaceDocument && !effectiveMimeType) {
+        effectiveMimeType = defaultExportMimeBySource[sourceMimeType];
+        if (!effectiveMimeType) {
+          const exportFormats = await this.googleDrive.getExportFormats();
+          effectiveMimeType = exportFormats[sourceMimeType]?.[0];
+        }
+        if (!effectiveMimeType) {
+          throw new Error(
+            `No export format available for "${sourceMimeType}". Set Conversion Format explicitly.`,
+          );
+        }
+      }
+
+      // See https://developers.google.com/drive/api/v3/mime-types for Google MIME types.
+      const file = isWorkspaceDocument
+        ? await this.googleDrive.downloadWorkspaceFile(downloadFileId, {
+          mimeType: effectiveMimeType,
+        })
+        : await this.googleDrive.getFile(downloadFileId, {
+          alt: "media",
+        });
+
+      if (this.getBufferResponse) {
+        const chunks = [];
+        for await (const chunk of file) {
+          chunks.push(chunk);
+        }
+        const buffer = Buffer.concat(chunks);
+
+        return {
+          fileId: requestedFileId,
+          fileMetadata,
+          webViewLink: fileMetadata.webViewLink,
+          content: buffer,
+          resolvedFromShortcut,
+        };
+      }
+
+      let filePath;
+      if (this.filePath) {
+        filePath = this.filePath.includes("tmp/")
+          ? this.filePath
+          : `/tmp/${this.filePath}`;
+      } else {
+        let defaultName = fileMetadata.name;
+        if (isWorkspaceDocument) {
+          const ext = extensionByMime[effectiveMimeType];
+          if (ext && !defaultName.toLowerCase().endsWith(`.${ext.toLowerCase()}`)) {
+            defaultName = `${defaultName}.${ext}`;
+          }
+        }
+        filePath = `/tmp/${defaultName}`;
+      }
+
+      await pipeline(file, fs.createWriteStream(filePath));
+
+      return {
+        fileId: requestedFileId,
+        fileMetadata,
+        webViewLink: fileMetadata.webViewLink,
+        filePath,
+        resolvedFromShortcut,
+      };
+    };
+
+    // Single-file downloads keep the original (non-array) return shape for
+    // backwards compatibility; batches return an array of per-file results.
+    if (fileIds.length === 1) {
+      const result = await downloadOne(fileIds[0]);
+      const verb = result.resolvedFromShortcut
+        ? "Resolved shortcut and downloaded"
+        : "Successfully downloaded";
+      const what = this.getBufferResponse
+        ? `raw content for file "${result.fileMetadata.name}"`
+        : `the file, "${result.fileMetadata.name}"`;
+      $.export("$summary", `${verb} ${what}`);
+      return result;
+    }
+
+    const files = [];
+    for (const id of fileIds) {
+      files.push(await downloadOne(id));
+    }
+    $.export("$summary", `Successfully downloaded ${files.length} file(s).`);
     return {
-      fileId: this.fileId,
-      fileMetadata,
-      webViewLink: fileMetadata.webViewLink,
-      filePath,
+      files,
+      count: files.length,
     };
   },
 };

--- a/components/google_drive/actions/list-files/list-files.mjs
+++ b/components/google_drive/actions/list-files/list-files.mjs
@@ -9,7 +9,7 @@ export default {
   key: "google_drive-list-files",
   name: "List Files",
   description: "List files from a specific folder. Set `Max Results` to cap how many files are returned per run, then pass the returned `nextPageToken` back in as `Page Token` on the next run to page through a large folder in fixed-size batches. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/list) for more information",
-  version: "0.4.0",
+  version: "1.0.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -120,7 +120,9 @@ export default {
       opts.fields = fieldsValue;
     }
 
-    const maxResults = this.maxResults;
+    const maxResults = this.maxResults === undefined
+      ? undefined
+      : Number(this.maxResults);
     if (maxResults !== undefined && (!Number.isInteger(maxResults) || maxResults < 1)) {
       throw new ConfigurationError("`Max Results` must be a positive integer.");
     }

--- a/components/google_drive/actions/list-files/list-files.mjs
+++ b/components/google_drive/actions/list-files/list-files.mjs
@@ -8,8 +8,8 @@ import { PAGINATION_TOKEN_FIELD } from "../../common/constants.mjs";
 export default {
   key: "google_drive-list-files",
   name: "List Files",
-  description: "List files from a specific folder. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/list) for more information",
-  version: "0.3.1",
+  description: "List files from a specific folder. Set `Max Results` to cap how many files are returned per run, then pass the returned `nextPageToken` back in as `Page Token` on the next run to page through a large folder in fixed-size batches. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/list) for more information",
+  version: "0.4.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -55,7 +55,17 @@ export default {
       description: "Filter by file name that contains a specific text",
       type: "string",
       optional: true,
-      reloadProps: true,
+    },
+    filterType: {
+      type: "string",
+      label: "Filter Type",
+      description: "Whether to return files with names containing the Filter Text or files with names that match the Filter Text exactly. Defaults to \"CONTAINS\". Not relevant unless `Filter Text` is entered.",
+      options: [
+        "CONTAINS",
+        "EXACT MATCH",
+      ],
+      default: "CONTAINS",
+      optional: true,
     },
     trashed: {
       label: "Trashed",
@@ -63,22 +73,19 @@ export default {
       description: "If `true`, list **only** trashed files. If `false`, list **only** non-trashed files. Keep it empty to include both.",
       optional: true,
     },
-  },
-  async additionalProps() {
-    const props = {};
-    if (this.filterText) {
-      props.filterType = {
-        type: "string",
-        label: "Filter Type",
-        description: "Whether to return files with names containing the Filter Text or files with names that match the Filter Text exactly. Defaults to \"CONTAINS\"",
-        options: [
-          "CONTAINS",
-          "EXACT MATCH",
-        ],
-        default: "CONTAINS",
-      };
-    }
-    return props;
+    maxResults: {
+      label: "Max Results",
+      type: "integer",
+      description: "The maximum number of files to return per run. Leave empty to return every file in the folder. Combine with `Page Token` to page through a large folder in fixed-size batches across multiple runs.",
+      optional: true,
+      min: 1,
+    },
+    pageToken: {
+      label: "Page Token",
+      type: "string",
+      description: "A cursor for resuming a previous run. Pass the `nextPageToken` returned by an earlier run to continue listing from where it stopped instead of starting over. Leave empty to start from the beginning of the folder.",
+      optional: true,
+    },
   },
   async run({ $ }) {
     if (this.limitToMyDrive && this.drive && !isMyDrive(this.drive)) {
@@ -112,16 +119,51 @@ export default {
       }
       opts.fields = fieldsValue;
     }
+
+    const maxResults = this.maxResults;
+    if (maxResults !== undefined && (!Number.isInteger(maxResults) || maxResults < 1)) {
+      throw new ConfigurationError("`Max Results` must be a positive integer.");
+    }
+
+    const startToken = this.pageToken;
     const allFiles = [];
-    let pageToken;
+    let pageToken = startToken;
     do {
+      const pageOpts = {
+        ...opts,
+      };
+      if (maxResults) {
+        // Request exactly as many as we still need (Drive caps pageSize at 1000).
+        // Aligning pageSize to the remaining count means the returned
+        // nextPageToken points right after the last file we keep, so no files
+        // are skipped when resuming — we never over-fetch and discard.
+        pageOpts.pageSize = Math.min(maxResults - allFiles.length, 1000);
+      }
       const {
-        files, nextPageToken,
-      }  = await this.googleDrive.listFilesInPage(pageToken, opts);
+        files = [], nextPageToken,
+      } = await this.googleDrive.listFilesInPage(pageToken, pageOpts);
       allFiles.push(...files);
       pageToken = nextPageToken;
-    } while (pageToken);
-    $.export("$summary", `Successfully found ${allFiles.length} file(s).`);
-    return allFiles;
+    } while (pageToken && (!maxResults || allFiles.length < maxResults));
+
+    const isComplete = !pageToken;
+    const resumed = Boolean(startToken);
+    let summary = `${resumed
+      ? "Resumed and returned"
+      : "Successfully found"} ${allFiles.length} file(s).`;
+    // Only surface batch state when the caller is actually paging.
+    if (maxResults || startToken || !isComplete) {
+      summary += isComplete
+        ? " Reached the end of the folder."
+        : " More results remain — pass `nextPageToken` as `Page Token` on the next run to continue.";
+    }
+    $.export("$summary", summary);
+
+    return {
+      files: allFiles,
+      count: allFiles.length,
+      nextPageToken: pageToken ?? null,
+      isComplete,
+    };
   },
 };

--- a/components/google_drive/package.json
+++ b/components/google_drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_drive",
-  "version": "1.12.3",
+  "version": "1.13.0",
   "description": "Pipedream Google_drive Components",
   "main": "google_drive.app.mjs",
   "keywords": [

--- a/components/google_drive/package.json
+++ b/components/google_drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_drive",
-  "version": "1.13.0",
+  "version": "2.0.0",
   "description": "Pipedream Google_drive Components",
   "main": "google_drive.app.mjs",
   "keywords": [

--- a/components/google_drive/package.json
+++ b/components/google_drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_drive",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "description": "Pipedream Google_drive Components",
   "main": "google_drive.app.mjs",
   "keywords": [


### PR DESCRIPTION
## Summary

Adds batch / pagination support to the Google Drive **list-files** and **download-file** actions so large folders can be processed in set batches, per the request in #21206.

## `list-files` (0.3.1 → 0.4.0)
- **`Max Results`** — caps how many files are returned per run. `pageSize` is aligned to the number still needed, so the returned `nextPageToken` lands exactly after the last kept file — **no files are skipped** when resuming (a naive "fetch a full page then trim" approach would drop the remainder).
- **`Page Token`** input + returns **`{ files, count, nextPageToken, isComplete }`** — pass the previous run's `nextPageToken` back in to continue where it stopped (stateless cursor).
- Replaced the `additionalProps()`-based `filterType` with a static optional prop.

> **Design note:** the issue suggested persisting the cursor via a Data Store. Pipedream doesn't allow a `data_store` prop to be optional (it would become mandatory on every run, including simple "list everything" calls), so this uses a stateless `pageToken` in/out instead — fully optional and equally able to resume across runs.

> ⚠️ **Output shape change:** `list-files` now returns an object (`{ files, ... }`) instead of a bare array. Bumped as a minor version.

## `download-file` (0.1.27 → 0.2.0)
- **`Files`** (`fileIds`, string[]) — download multiple files in a single run. The legacy single **`File`** (`fileId`) is retained for backwards compatibility; both are merged and de-duped.
- A single file returns the original object shape; a batch returns `{ files, count }`. Errors if `Destination File Path` is set with multiple files.

## Testing
Published both to a private registry and ran targeted MCP evals — **5/5 passed**:
- `list-files`: folder listing; `Max Results` cap (returned exactly 2, flagged more remain); page-token resume (fetched next page with no overlap).
- `download-file`: single-file (backwards compat); batch (one call with 3 file IDs returned all three).

Closes #21206

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Download multiple Google Drive files in one run (deduplicated), while preserving the existing single-file flow.
  * List files with selectable match type, per-run `Max Results` limiting, and `Page Token` pagination with resume support.
* **Bug Fixes**
  * Improved export-format option handling for downloads when selecting batches.
  * Added validation for download/list input rules and limits.
* **Chores**
  * Updated action versions and user-facing descriptions; listing results now return `{ files, count, nextPageToken, isComplete }` to reflect pagination state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->