### PR TITLE
fix(sharepoint): getFile must return a stream (.getStream) — download-file & get-file-contents crash in Buffer.concat

### DIFF
--- a/components/sharepoint/actions/create-folder/create-folder.mjs
+++ b/components/sharepoint/actions/create-folder/create-folder.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sharepoint-create-folder",
   name: "Create Folder",
   description: "Create a new folder in SharePoint. [See the documentation](https://learn.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_post_children?view=odsp-graph-online)",
-  version: "0.0.9",
+  version: "0.0.10",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/create-item/create-item.mjs
+++ b/components/sharepoint/actions/create-item/create-item.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sharepoint-create-item",
   name: "Create Item",
   description: "Create a new item in Microsoft Sharepoint. [See the documentation](https://learn.microsoft.com/en-us/graph/api/listitem-create?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.15",
+  version: "0.0.16",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/sharepoint/actions/create-link/create-link.mjs
+++ b/components/sharepoint/actions/create-link/create-link.mjs
@@ -5,7 +5,7 @@ export default {
   key: "sharepoint-create-link",
   name: "Create Link",
   description: "Create a sharing link for a DriveItem. [See the documentation](https://docs.microsoft.com/en-us/graph/api/driveitem-createlink?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.11",
+  version: "0.0.12",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/create-list/create-list.mjs
+++ b/components/sharepoint/actions/create-list/create-list.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sharepoint-create-list",
   name: "Create List",
   description: "Create a new list in Microsoft Sharepoint. [See the documentation](https://learn.microsoft.com/en-us/graph/api/list-create?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.15",
+  version: "0.0.16",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/sharepoint/actions/download-file/download-file.mjs
+++ b/components/sharepoint/actions/download-file/download-file.mjs
@@ -8,7 +8,7 @@ export default {
   key: "sharepoint-download-file",
   name: "Download File",
   description: "Download a Microsoft Sharepoint file to the /tmp directory. [See the documentation](https://learn.microsoft.com/en-us/graph/api/driveitem-get-content?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.16",
+  version: "0.0.17",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/sharepoint/actions/download-files/download-files.mjs
+++ b/components/sharepoint/actions/download-files/download-files.mjs
@@ -6,7 +6,7 @@ export default {
   key: "sharepoint-download-files",
   name: "Download Files",
   description: "Browse and select files from SharePoint and get their metadata along with pre-authenticated download URLs (valid ~1 hour). [See the documentation](https://learn.microsoft.com/en-us/graph/api/driveitem-get)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/find-file-by-name/find-file-by-name.mjs
+++ b/components/sharepoint/actions/find-file-by-name/find-file-by-name.mjs
@@ -16,7 +16,7 @@ export default {
     + "\n- **Search and Filter Files** for OData `$filter` against a list/document library"
     + "\n\n"
     + "[See the documentation](https://learn.microsoft.com/en-us/graph/api/driveitem-search?view=graph-rest-1.0&tabs=http)",
-  version: "0.1.8",
+  version: "0.1.9",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/find-files-with-metadata/find-files-with-metadata.mjs
+++ b/components/sharepoint/actions/find-files-with-metadata/find-files-with-metadata.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Find Files in List with Metadata",
   description:
     "Search and filter items in a SharePoint list based on metadata and custom columns. [See docs here](https://learn.microsoft.com/en-us/graph/api/listitem-list)",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/get-current-user/get-current-user.mjs
+++ b/components/sharepoint/actions/get-current-user/get-current-user.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sharepoint-get-current-user",
   name: "Get Current User",
   description: "Returns the authenticated Microsoft user's ID, display name, email, and principal name via Microsoft Graph. Call this first when the user says 'my files', 'my documents', or needs identity context. Use the returned `id` to identify file ownership in **List Files in Folder** or **Find File by Name** results. [See the documentation](https://learn.microsoft.com/en-us/graph/api/user-get).",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/get-excel-table/get-excel-table.mjs
+++ b/components/sharepoint/actions/get-excel-table/get-excel-table.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sharepoint-get-excel-table",
   name: "Get Excel Table",
   description: "Retrieve a table from an Excel spreadsheet stored in Sharepoint [See the documentation](https://learn.microsoft.com/en-us/graph/api/table-range?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.10",
+  version: "0.0.11",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/get-file-by-id/get-file-by-id.mjs
+++ b/components/sharepoint/actions/get-file-by-id/get-file-by-id.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sharepoint-get-file-by-id",
   name: "Get File by ID",
   description: "Retrieves a file by ID. [See the documentation](https://learn.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_get)",
-  version: "0.0.9",
+  version: "0.0.10",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/get-file-contents/get-file-contents.mjs
+++ b/components/sharepoint/actions/get-file-contents/get-file-contents.mjs
@@ -24,7 +24,7 @@ export default {
   key: "sharepoint-get-file-contents",
   name: "Get File Contents",
   description: "Retrieves a Microsoft SharePoint file and returns its contents as extracted plain text or markdown. Supports plain text formats, HTML, DOCX, PDF, and other Office documents convertible to PDF (xlsx, pptx, etc.). [See the documentation](https://learn.microsoft.com/en-us/graph/api/driveitem-get-content?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/get-site/get-site.mjs
+++ b/components/sharepoint/actions/get-site/get-site.mjs
@@ -10,7 +10,7 @@ export default {
     + "Use this when you know the site path; for discovery, use **Search Sites** or **List Sites**."
     + "\n\n"
     + "[See the documentation](https://learn.microsoft.com/en-us/graph/api/site-get?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/list-drives/list-drives.mjs
+++ b/components/sharepoint/actions/list-drives/list-drives.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sharepoint-list-drives",
   name: "List Drives",
   description: "List the drives available within a Microsoft Sharepoint site. [See the documentation](https://learn.microsoft.com/en-us/graph/api/drive-list?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/list-files-in-folder/list-files-in-folder.mjs
+++ b/components/sharepoint/actions/list-files-in-folder/list-files-in-folder.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sharepoint-list-files-in-folder",
   name: "List Files in Folder",
   description: "Retrieves a list of the files and/or folders directly within a folder. [See the documentation](https://learn.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_list_children)",
-  version: "0.0.9",
+  version: "0.0.10",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/list-sites/list-sites.mjs
+++ b/components/sharepoint/actions/list-sites/list-sites.mjs
@@ -10,7 +10,7 @@ export default {
     + "To resolve a known site by path, prefer **Get Site** for an immediate lookup."
     + "\n\n"
     + "[See the documentation](https://learn.microsoft.com/en-us/graph/api/site-search?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/retrieve-file-metadata/retrieve-file-metadata.mjs
+++ b/components/sharepoint/actions/retrieve-file-metadata/retrieve-file-metadata.mjs
@@ -8,7 +8,7 @@ export default {
   key: "sharepoint-retrieve-file-metadata",
   name: "Retrieve File Metadata",
   description: "Browse and select files from SharePoint to retrieve their metadata (name, size, dates, etc.) without download URLs. [See the documentation](https://learn.microsoft.com/en-us/graph/api/driveitem-get)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/search-and-filter-files/search-and-filter-files.mjs
+++ b/components/sharepoint/actions/search-and-filter-files/search-and-filter-files.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Search and Filter Files",
   description:
     "Search and filter SharePoint files based on metadata and custom columns. This action allows you to query files using SharePoint's custom properties, managed metadata, and other column values. [See the documentation](https://learn.microsoft.com/en-us/graph/api/listitem-list)",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/search-files/search-files.mjs
+++ b/components/sharepoint/actions/search-files/search-files.mjs
@@ -15,7 +15,7 @@ export default {
     + "\n- **Search and Filter Files** for OData `$filter` against a document library"
     + "\n\n"
     + "[See the documentation](https://learn.microsoft.com/en-us/graph/api/search-query?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/search-sites/search-sites.mjs
+++ b/components/sharepoint/actions/search-sites/search-sites.mjs
@@ -12,7 +12,7 @@ export default {
     + "To resolve a known site by path, prefer **Get Site** for an immediate, exact lookup."
     + "\n\n"
     + "[See the documentation](https://learn.microsoft.com/en-us/graph/api/site-search?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/actions/update-item/update-item.mjs
+++ b/components/sharepoint/actions/update-item/update-item.mjs
@@ -5,7 +5,7 @@ export default {
   key: "sharepoint-update-item",
   name: "Update Item",
   description: "Updates an existing item in Microsoft Sharepoint. [See the documentation](https://learn.microsoft.com/en-us/graph/api/listitem-update?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.15",
+  version: "0.0.16",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/sharepoint/actions/upload-file/upload-file.mjs
+++ b/components/sharepoint/actions/upload-file/upload-file.mjs
@@ -5,7 +5,7 @@ export default {
   key: "sharepoint-upload-file",
   name: "Upload File",
   description: "Upload a file to OneDrive. [See the documentation](https://learn.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_put_content?view=odsp-graph-online)",
-  version: "0.0.10",
+  version: "0.0.11",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/sharepoint/package.json
+++ b/components/sharepoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/sharepoint",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Pipedream Microsoft Sharepoint Online Components",
   "main": "sharepoint.app.mjs",
   "keywords": [

--- a/components/sharepoint/sharepoint.app.mjs
+++ b/components/sharepoint/sharepoint.app.mjs
@@ -595,7 +595,7 @@ export default {
     } = {}) {
       return this.client().api(`/drives/${driveId}/items/${fileId}/content`)
         .query(pickBy(params))
-        .get();
+        .getStream();
     },
     createList({
       siteId, data = {},

--- a/components/sharepoint/sources/new-file-created/new-file-created.mjs
+++ b/components/sharepoint/sources/new-file-created/new-file-created.mjs
@@ -5,7 +5,7 @@ export default {
   key: "sharepoint-new-file-created",
   name: "New File Created",
   description: "Emit new event when a new file is created in Microsoft Sharepoint.",
-  version: "0.0.9",
+  version: "0.0.10",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/sharepoint/sources/new-folder-created/new-folder-created.mjs
+++ b/components/sharepoint/sources/new-folder-created/new-folder-created.mjs
@@ -5,7 +5,7 @@ export default {
   key: "sharepoint-new-folder-created",
   name: "New Folder Created",
   description: "Emit new event when a new folder is created in Microsoft Sharepoint.",
-  version: "0.0.9",
+  version: "0.0.10",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/sharepoint/sources/new-list-item/new-list-item.mjs
+++ b/components/sharepoint/sources/new-list-item/new-list-item.mjs
@@ -5,7 +5,7 @@ export default {
   key: "sharepoint-new-list-item",
   name: "New List Item",
   description: "Emit new event when a new list item is created in Microsoft Sharepoint.",
-  version: "0.0.14",
+  version: "0.0.15",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/sharepoint/sources/updated-file-instant/updated-file-instant.mjs
+++ b/components/sharepoint/sources/updated-file-instant/updated-file-instant.mjs
@@ -9,7 +9,7 @@ export default {
   key: "sharepoint-updated-file-instant",
   name: "File Updated or Deleted (Instant)",
   description: "Emit a new event when specific files are updated or deleted in a SharePoint document library",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/sharepoint/sources/updated-list-item/updated-list-item.mjs
+++ b/components/sharepoint/sources/updated-list-item/updated-list-item.mjs
@@ -5,7 +5,7 @@ export default {
   key: "sharepoint-updated-list-item",
   name: "Updated List Item",
   description: "Emit new event when a list item is updated in Microsoft Sharepoint.",
-  version: "0.0.14",
+  version: "0.0.15",
   type: "source",
   dedupe: "unique",
   props: {


### PR DESCRIPTION
## Problem

`Get File Contents` and `Download File` fail on real files with:

```
The "list[0]" argument must be an instance of Buffer or Uint8Array. Received type string ('[')
```

Both actions read the file body as a stream of byte chunks:

```js
const response = await this.sharepoint.getFile({ ... });
const chunks = [];
for await (const chunk of response) chunks.push(chunk);
const buffer = Buffer.concat(chunks);
```

But the shared helper `getFile()` in `sharepoint.app.mjs` calls the Microsoft Graph SDK with **`.get()`**:

```js
getFile({ driveId, fileId, params = {} } = {}) {
  return this.client().api(`/drives/${driveId}/items/${fileId}/content`)
    .query(pickBy(params))
    .get();
}
```

On the `/content` endpoint, `.get()` makes the Graph SDK **decode the response by content-type** — for a `text/*` file it returns a **string**, not a stream. `for await…of` over a string yields its characters, so `chunks[0]` is `"["` (the first character of the file), and `Buffer.concat` throws the error above. The `'['` is literally the first byte of the returned content.

## Fix

`getFile` should request a stream so callers get real `Buffer` chunks:

```js
getFile({ driveId, fileId, params = {} } = {}) {
  return this.client().api(`/drives/${driveId}/items/${fileId}/content`)
    .query(pickBy(params))
    .getStream();
}
```

The only callers of `getFile` are `download-file` and `get-file-contents`, and both already consume it as a stream — so this is a drop-in fix. (`upload-file` uses `getFileStreamAndMetadata` from `@pipedream/platform`, not this helper.)

## Repro

Any `Get File Contents` / `Download File` on a SharePoint text file (e.g. a `.txt` in a document library) reproduces it 100% once auth resolves.

## Changes

- `sharepoint.app.mjs`: `getFile` `.get()` → `.getStream()`
- `download-file` version 0.0.16 → 0.0.17
- `get-file-contents` version 0.0.2 → 0.0.3
- `package.json` 0.10.1 → 0.10.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SharePoint file content retrieval to use stream-based responses, making downloads more reliable for large files.

- **Chores**
  - Updated version metadata across SharePoint actions and sources, and refreshed the SharePoint package to the latest patch release (including “Download File” and “Get File Contents”).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->