### PR TITLE
Fal.ai - allowing custom appId input

### DIFF
--- a/components/fal_ai/actions/add-request-to-queue/add-request-to-queue.mjs
+++ b/components/fal_ai/actions/add-request-to-queue/add-request-to-queue.mjs
@@ -4,7 +4,7 @@ export default {
   key: "fal_ai-add-request-to-queue",
   name: "Add Request to Queue",
   description: "Adds a request to the queue for asynchronous processing, including specifying a webhook URL for receiving updates. [See the documentation](https://fal.ai/docs/model-endpoints/queue#queue-endpoints).",
-  version: "0.0.3",
+  version: "1.0.0",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
@@ -64,7 +64,7 @@ export default {
       appId, ...args
     } = {}) {
       return this.app.post({
-        path: `/${appId}`,
+        path: `/${this.app.getAppId(appId)}`,
         ...args,
       });
     },

--- a/components/fal_ai/actions/cancel-request/cancel-request.mjs
+++ b/components/fal_ai/actions/cancel-request/cancel-request.mjs
@@ -4,7 +4,7 @@ export default {
   key: "fal_ai-cancel-request",
   name: "Cancel Request",
   description: "Cancels a request in the queue. This allows you to stop a long-running task if it's no longer needed. [See the documentation](https://fal.ai/docs/model-endpoints/queue#queue-endpoints).",
-  version: "0.0.2",
+  version: "1.0.0",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
@@ -31,7 +31,7 @@ export default {
       appId, requestId, ...args
     } = {}) {
       return this.app.put({
-        path: `/${appId}/requests/${requestId}/cancel`,
+        path: `/${this.app.getAppId(appId)}/requests/${requestId}/cancel`,
         ...args,
       });
     },

--- a/components/fal_ai/actions/get-request-response/get-request-response.mjs
+++ b/components/fal_ai/actions/get-request-response/get-request-response.mjs
@@ -4,7 +4,7 @@ export default {
   key: "fal_ai-get-request-response",
   name: "Get Request Response",
   description: "Gets the response of a completed request in the queue. This retrieves the results of your asynchronous task. [See the documentation](https://fal.ai/docs/model-endpoints/queue#queue-endpoints).",
-  version: "0.0.2",
+  version: "1.0.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/fal_ai/actions/get-request-status/get-request-status.mjs
+++ b/components/fal_ai/actions/get-request-status/get-request-status.mjs
@@ -4,7 +4,7 @@ export default {
   key: "fal_ai-get-request-status",
   name: "Get Request Status",
   description: "Gets the status of a request in the queue. This allows you to monitor the progress of your asynchronous tasks. [See the documentation](https://fal.ai/docs/model-endpoints/queue#queue-endpoints).",
-  version: "0.0.2",
+  version: "1.0.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/fal_ai/fal_ai.app.mjs
+++ b/components/fal_ai/fal_ai.app.mjs
@@ -7,7 +7,7 @@ export default {
     appId: {
       type: "string",
       label: "App ID",
-      description: "The unique identifier for the app. Eg. `lora`.",
+      description: "The full canonical ID of the model to call, including the owner namespace. E.g. `fal-ai/flux/schnell`, `rundiffusion-fal/juggernaut-flux/base`, or `your-username/your-app`. As a shorthand, a bare single-word name (e.g. `lora`) is accepted and assumed to be in the `fal-ai` namespace.",
     },
     requestId: {
       type: "string",
@@ -23,7 +23,17 @@ export default {
   },
   methods: {
     getUrl(path) {
-      return `https://queue.fal.run/fal-ai${path}`;
+      return `https://queue.fal.run${path}`;
+    },
+    getAppId(appId) {
+      // Model IDs are `owner/model` (e.g. `fal-ai/flux/schnell`,
+      // `rundiffusion-fal/juggernaut-flux/base`, `your-username/your-app`), so any
+      // input that already contains a slash is treated as a full canonical ID and
+      // left untouched. A bare single-word name has no owner segment and can only
+      // refer to a `fal-ai` model, so we prepend the default namespace for it.
+      return appId.includes("/")
+        ? appId
+        : `fal-ai/${appId}`;
     },
     getHeaders(headers) {
       return {
@@ -57,7 +67,7 @@ export default {
       appId, requestId, ...args
     } = {}) {
       return this._makeRequest({
-        path: `/${appId}/requests/${requestId}/status`,
+        path: `/${this.getAppId(appId)}/requests/${requestId}/status`,
         ...args,
       });
     },
@@ -65,7 +75,7 @@ export default {
       appId, requestId, ...args
     } = {}) {
       return this._makeRequest({
-        path: `/${appId}/requests/${requestId}`,
+        path: `/${this.getAppId(appId)}/requests/${requestId}`,
         ...args,
       });
     },

--- a/components/fal_ai/package.json
+++ b/components/fal_ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/fal_ai",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "description": "Pipedream fal.ai Components",
   "main": "fal_ai.app.mjs",
   "keywords": [


### PR DESCRIPTION
This allows custom app ids to be entered, but is unfortunately backwards-incompatible with previous appId inputs that did not include the `fal-ai/` prefix *and* had another slash in it (we are automatically prefixing the ones with no slash since these are always assumed to be `fal-ai/` prefixed, to reduce backwards incompatibility).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for canonical model identifiers, including namespaced and bare model names.
  - Requests now consistently target the correct model-specific endpoints.

- **Improvements**
  - Updated queue, cancellation, status, and response actions to use normalized model identifiers.
  - Released the integration and its actions as version 1.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->