### PR TITLE
fix(mcp): sanitize error message returned to MCP tool callers

### DIFF
--- a/modelcontextprotocol/src/lib/dynamicToolMcpServer.ts
+++ b/modelcontextprotocol/src/lib/dynamicToolMcpServer.ts
@@ -93,11 +93,12 @@ export class DynamicToolMcpServer {
           }
           return await tool.callback(extra)
         } catch (error) {
+          console.error(`Error calling tool ${request.params.name}:`, error)
           return {
             content: [
               {
                 type: "text",
-                text: `An error occurred while calling the tool: ${error}`, // XXX Do we need to sanitize this?
+                text: `An error occurred while calling the tool ${request.params.name}. Check the server logs for details.`,
               },
             ],
           }


### PR DESCRIPTION
## Issue

In `DynamicToolMcpServer`'s `CallToolRequestSchema` handler, the `catch` block returns the raw error directly to the calling MCP client:

```ts
text: `An error occurred while calling the tool: ${error}`, // XXX Do we need to sanitize this?
```

The comment already flags the concern. Depending on what throws (a third-party API error from `pd.runAction`/`pd.configureComponent`, a network timeout, etc.), the stringified error can include internal details -- request structure, third-party API response fragments, internal paths/ids -- that shouldn't necessarily go back to the caller.

## Fix

Log the full error server-side with `console.error` (so debugging isn't lost), and return a generic message to the client instead of the raw error string.

## Test plan

- [x] Reviewed the change in context -- only the caught-error response path changes, the happy path is untouched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when a tool call fails.
  * Error messages now provide a consistent, user-friendly response without exposing technical error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->