### PR TITLE
fix(mcp): stop logging sensitive request/response data to stdout

### DIFF
--- a/modelcontextprotocol/src/http.ts
+++ b/modelcontextprotocol/src/http.ts
@@ -30,7 +30,6 @@ app.get("/v1/:uuid/sessions", async (req: Request, res: Response) => {
     req.body,
     req.params,
     req.url,
-    req.headers,
     req.query
   )
   const mcpSessions = userMcpSessions[req.params.uuid] || []
@@ -240,7 +239,6 @@ app.get("/:uuid", async (req: Request, res: Response) => {
     req.body,
     req.params,
     req.url,
-    req.headers,
     req.query
   )
 
@@ -289,7 +287,6 @@ app.get("/:uuid/:app", async (req: Request, res: Response) => {
     req.body,
     req.params,
     req.url,
-    req.headers,
     req.query
   )
 
@@ -395,7 +392,6 @@ process.on("unhandledRejection", (reason, promise) => {
 // Log all requests for debugging
 app.use((req, res, next) => {
   console.log(`Received ${req.method} request for ${req.url}`)
-  console.log("Headers:", req.headers)
   next()
 })
 

--- a/modelcontextprotocol/src/lib/dynamicToolMcpServer.ts
+++ b/modelcontextprotocol/src/lib/dynamicToolMcpServer.ts
@@ -62,7 +62,7 @@ export class DynamicToolMcpServer {
         const tools = await this.getTools()
         const tool = tools[request.params.name]
 
-        console.log(">> Tool", request.params.name, request.params.arguments)
+        console.log(">> Tool", request.params.name)
 
         if (!tool) {
           throw new McpError(

--- a/modelcontextprotocol/src/lib/registerComponentTools.ts
+++ b/modelcontextprotocol/src/lib/registerComponentTools.ts
@@ -78,9 +78,7 @@ export async function registerComponentTools({
           },
           externalUserId: uuid,
         }
-        console.log(">> Running action", requestOpts)
         const response = await pd.runAction(requestOpts)
-        console.log(">> Action response", response)
         return {
           content: [
             {

--- a/modelcontextprotocol/src/lib/tools/run-action-tool.ts
+++ b/modelcontextprotocol/src/lib/tools/run-action-tool.ts
@@ -34,7 +34,7 @@ export const runActionTool = async ({
       inputSchema: z.object(fullSchema),
       isActive: (stage: ToolConfigState["stage"]) => stage === "APPS_SELECTED",
       callback: async (_args) => {
-        console.log(">> tool_callback", _args)
+        console.log(">> tool_callback", component.key)
         const appName = componentAppName(component)
 
         if (!appName) {


### PR DESCRIPTION
## Summary

Removes sensitive request/response data (headers, tool arguments, action payloads) from MCP debug console.log calls.

## Issue

Several debug `console.log` calls in the MCP server print sensitive data to stdout in plaintext:

- `http.ts`: 3 route handlers (`/v1/:uuid/sessions`, `/:uuid`, `/:uuid/:app`) and a global `app.use` middleware log the full `req.headers` object, including the `mcp-session-id`/`x-pd-mcp-chat-id` session identifiers.
- `registerComponentTools.ts`: logs the full `requestOpts` (includes `configuredProps`, i.e. whatever the end user configured -- custom-auth API keys/tokens for apps without managed OAuth -- plus the resolved `authProvisionId`) and the full action response.
- `run-action-tool.ts` / `dynamicToolMcpServer.ts`: log the raw tool call arguments.

Anyone with access to the log pipeline (ops, a shared/multi-tenant logging backend) could recover session ids or secrets belonging to other users from these logs.

## Fix

- Drop `req.headers` from the 3 route logs and the global middleware (method/url/params/query still logged for basic access-log purposes).
- Remove the `>> Running action` / `>> Action response` debug logs in `registerComponentTools.ts` entirely -- there's no generic way to redact an arbitrary `configuredProps`/response shape.
- Keep a minimal correlation log (tool/component name only) in `run-action-tool.ts` and `dynamicToolMcpServer.ts` instead of the full argument payload.

## Test plan

- [x] Reviewed each diff to confirm only the logging calls changed, no control flow affected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced diagnostic logging across request handling and tool execution.
  * Sensitive request headers, tool arguments, action requests, and action responses are no longer written to console logs.
  * Retained essential identifiers, such as route and tool names, for streamlined troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Checklist
Please check the following items before your PR can be reviewed:

### Versioning
- [x] N/A -- this PR changes shared platform/SDK/MCP-server code, not a versioned component

### New app
- [x] N/A -- not adding or updating an app integration

### CodeRabbit review
- [ ] I have addressed or acknowledged all of CodeRabbit's review comments
