### PR TITLE
fix(mcp): scope component cache lookups to the current selectedApps

### DIFF
--- a/modelcontextprotocol/src/lib/tools/toolConfigStateMachine.ts
+++ b/modelcontextprotocol/src/lib/tools/toolConfigStateMachine.ts
@@ -308,14 +308,29 @@ export class ToolConfigStateMachine {
   }
 
   async getComponent(key: string) {
+    // Cache hits are only trusted when the component's app is among this
+    // session's selectedApps -- these caches are shared module-wide across
+    // ALL sessions/uuids, so without this check a session could fetch a
+    // component belonging to an app it never selected, as long as some other
+    // session had it cached within the last 12 hours.
+    const selectedApps = this.hasAppsSelected()
+      ? this.state.selectedApps
+      : undefined
+
     // Check single component cache first
     const cachedComponent = singleComponentCache[key]
     if (cachedComponent && isValidCache(cachedComponent.timestamp)) {
-      return cachedComponent.component
+      const cachedApp = componentAppName(cachedComponent.component)
+      if (!selectedApps || (cachedApp && selectedApps.includes(cachedApp))) {
+        return cachedComponent.component
+      }
     }
 
     // If not in cache, try to find in app components cache first
-    for (const appCache of Object.values(componentsCache)) {
+    for (const [
+      app, appCache,
+    ] of Object.entries(componentsCache)) {
+      if (selectedApps && !selectedApps.includes(app)) continue
       if (isValidCache(appCache.timestamp)) {
         const component = appCache.components.find((c) => c.key === key)
         if (component) {


### PR DESCRIPTION
## Summary

Scopes the MCP component cache (componentsCache/singleComponentCache) to the current session's selectedApps.

## Issue

`componentsCache` and `singleComponentCache` in `toolConfigStateMachine.ts` are module-level, shared across every session/uuid using this MCP server.

`getComponent(key)` returned a cache hit without ever checking that the found component's app is among the *current* session's `selectedApps` -- only the `getComponents()` fallback (used when nothing is cached) is properly scoped. So a session could call `CONFIGURE_COMPONENT` with the key of a component belonging to an app it never selected via `SELECT_APPS`, as long as *some other* session had that component cached within the last 12 hours (the cache TTL).

This doesn't leak another user's connected-account credentials directly (`getAuthProvision` is still scoped to the calling session's `uuid`), but it bypasses the app-selection boundary and can expose component metadata/schema outside the flow the session is supposed to be limited to.

## Fix

Restrict both cache lookups (single-component cache and per-app cache) to the current session's `selectedApps` before trusting a hit. The already-scoped `getComponents()` fallback path is unchanged.

## Test plan

- [x] Reviewed the change: when no apps are selected yet, behavior is unchanged (no scope to check against); once apps are selected, a cache hit for a component outside `selectedApps` now falls through to the properly-scoped fallback instead of being returned directly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cached tool components appearing from apps that aren’t selected in the current session.
  * Ensured component lookups respect the active session’s app selections, preventing stale results from other sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Checklist
Please check the following items before your PR can be reviewed:

### Versioning
- [x] N/A -- this PR changes shared platform/SDK/MCP-server code, not a versioned component

### New app
- [x] N/A -- not adding or updating an app integration

### CodeRabbit review
- [ ] I have addressed or acknowledged all of CodeRabbit's review comments
