### PR TITLE
fix(ai,mcp): make the Connect token webhook_uri configurable, off by default

### DIFF
--- a/modelcontextprotocol/src/lib/authProvisions.ts
+++ b/modelcontextprotocol/src/lib/authProvisions.ts
@@ -4,9 +4,11 @@ import { Account } from "@pipedream/sdk"
 export const getAuthProvision = async ({
   app,
   uuid,
+  webhookUri,
 }: {
   app: string
   uuid: string
+  webhookUri?: string
 }): Promise<Account | string> => {
   const authProvisions = await pd.getAccounts({
     external_user_id: uuid,
@@ -19,7 +21,7 @@ export const getAuthProvision = async ({
   if (!authProvision) {
     const token = await pd.createConnectToken({
       external_user_id: uuid,
-      webhook_uri: "https://eokyfjps7uqmmrk.m.pipedream.net", // https://pipedream.com/@pd/p_G6Ck6Mk/
+      ...(webhookUri && { webhook_uri: webhookUri }),
     })
     return `
 Go to: https://pipedream.com/_static/connect.html?token=${token.token}&connectLink=true&app=${encodeURIComponent(app)} to connect your account.

--- a/packages/ai/src/tool-sets/core.ts
+++ b/packages/ai/src/tool-sets/core.ts
@@ -16,9 +16,11 @@ type Tool = {
 export class CoreTools {
   userId: string;
   tools: Tool[] = [];
+  connectWebhookUri?: string;
 
-  constructor(userId: string) {
+  constructor(userId: string, options?: { connectWebhookUri?: string }) {
     this.userId = userId;
+    this.connectWebhookUri = options?.connectWebhookUri;
   }
 
   async getTools(options?: { app?: string; query?: string }) {
@@ -90,7 +92,7 @@ export class CoreTools {
     if (!authProvision) {
       const token = await pd.createConnectToken({
         external_user_id: uuid,
-        webhook_uri: "https://eokyfjps7uqmmrk.m.pipedream.net", // https://pipedream.com/@pd/p_G6Ck6Mk/
+        ...(this.connectWebhookUri && { webhook_uri: this.connectWebhookUri }),
       });
       return `
   The user MUST be shown the following URL so they can click on it to connect their account and you MUST NOT modify the URL or it will break: https://pipedream.com/_static/connect.html?token=${token.token}&connectLink=true&app=${encodeURIComponent(app)}

--- a/packages/ai/src/tool-sets/openai.ts
+++ b/packages/ai/src/tool-sets/openai.ts
@@ -8,8 +8,8 @@ import { CoreTools } from "./core";
 
 export class OpenAiTools {
   core: CoreTools;
-  constructor(userId: string) {
-    this.core = new CoreTools(userId);
+  constructor(userId: string, options?: { connectWebhookUri?: string }) {
+    this.core = new CoreTools(userId, options);
   }
 
   async getTools(options?: {


### PR DESCRIPTION
## Summary

Makes the Connect-token webhook_uri configurable and opt-in instead of hardcoded, in both the MCP server and @pipedream/ai.

## Issue

Both `getAuthProvision()` in `modelcontextprotocol/src/lib/authProvisions.ts` and `CoreTools.getAuthProvision()` in `packages/ai/src/tool-sets/core.ts` hardcode the same internal Pipedream automation endpoint as `webhook_uri` on every `pd.createConnectToken()` call:

```ts
webhook_uri: "https://eokyfjps7uqmmrk.m.pipedream.net", // https://pipedream.com/@pd/p_G6Ck6Mk/
```

This means every third-party app built on `@pipedream/ai` or this MCP server sends a callback to Pipedream's own infra on every real account-connection flow (including the connecting end user's `external_user_id` and app name), with no documented way to disable or override it. `webhook_uri` is already an optional field on `ConnectTokenCreateOpts` in the SDK, so this isn't a required parameter.

## Fix

- `authProvisions.ts`: add an optional `webhookUri` param, only set `webhook_uri` on the request when it's provided.
- `packages/ai/src/tool-sets/core.ts`: add an optional `connectWebhookUri` constructor option on `CoreTools`, same conditional behavior.
- `packages/ai/src/tool-sets/openai.ts`: thread the same option through `OpenAiTools`'s constructor.

No webhook is sent by default now; existing single-argument constructor calls (`new CoreTools(userId)`, `new OpenAiTools(userId)`) keep working unchanged.

## Test plan

- [x] Reviewed both call sites: when the new option isn't passed, `webhook_uri` is omitted from the request object entirely (via conditional spread) rather than defaulting to the hardcoded URL
- [x] Existing single-argument constructor usage is unaffected (new param is optional)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for optionally specifying a custom webhook URL when creating authentication and connection tokens.
  - Connection tools can now receive and use a configured webhook URL across supported integrations.
  - Webhook details are omitted when no URL is provided, preserving the existing connection flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Checklist
Please check the following items before your PR can be reviewed:

### Versioning
- [x] N/A -- this PR changes shared platform/SDK/MCP-server code, not a versioned component

### New app
- [x] N/A -- not adding or updating an app integration

### CodeRabbit review
- [ ] I have addressed or acknowledged all of CodeRabbit's review comments
