### PR TITLE
fix(ai): make the generated Zod shape immune to a __proto__ prop name

### DIFF
--- a/packages/ai/src/configurablePropsToZod.ts
+++ b/packages/ai/src/configurablePropsToZod.ts
@@ -16,7 +16,7 @@ export const configurablePropsToZod = (
     configurableProps?: ConfigurableProps;
   },
 ) => {
-  const schema: ZodRawShape = {};
+  const schema: ZodRawShape = Object.create(null) as ZodRawShape;
 
   for (const cp of options?.configurableProps ||
     (component.configurable_props as ConfigurableProps)) {


### PR DESCRIPTION
## Issue

`configurablePropsToZod()` builds the Zod shape via `schema[cp.name] = ...` on a plain `{}` object. If a component (including a community-published one) defines a configurable prop literally named `__proto__`, this assignment invokes the legacy Annex B `Object.prototype.__proto__` accessor instead of creating an own property -- it silently replaces the *local* `schema` object's prototype with the Zod type instance.

This is **not** a global `Object.prototype` pollution (verified: the object is local to each `configurablePropsToZod` call, nothing leaks to other schemas/components/users). The real impact is a silent validation regression: the `__proto__`-named field disappears from `Object.keys(schema)`, from the JSON Schema exposed to the LLM (via `zod-to-json-schema`), and from `.parse()` validation -- so a potentially required field for that component's action silently stops being enforced or exposed.

## Fix

One-line change: build `schema` via `Object.create(null)` instead of `{}`. A null-prototype object has no `__proto__` accessor, so the assignment behaves like a normal property write regardless of the prop's name.

## Test plan

- [x] Reasoned through the fix: `ZodRawShape` is a plain index-signature type, and `Object.create(null)` output is structurally compatible; `z.object()`/`zod-to-json-schema` only use `Object.keys`/enumeration on the shape, which work identically regardless of prototype

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema handling to avoid unintended inherited properties during configuration validation.
  * Preserved existing validation behavior and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->