### PR TITLE
Google Calendar "Create Event" addition

### DIFF
--- a/components/google_calendar/actions/create-event/create-event.mjs
+++ b/components/google_calendar/actions/create-event/create-event.mjs
@@ -142,10 +142,13 @@ export default {
       const { id: selfEmail } = await this.googleCalendar.getCalendar({
         calendarId: "primary",
       });
-      if (selfEmail && !attendees.some(({ email }) => email === selfEmail)) {
+      const selfEmailLower = selfEmail?.toLowerCase();
+      const alreadyAttendee = attendees.some(
+        ({ email }) => email?.toLowerCase() === selfEmailLower,
+      );
+      if (selfEmail && !alreadyAttendee) {
         attendees.push({
           email: selfEmail,
-          organizer: true,
           responseStatus: "accepted",
         });
       }

--- a/components/google_calendar/actions/create-event/create-event.mjs
+++ b/components/google_calendar/actions/create-event/create-event.mjs
@@ -7,7 +7,7 @@ export default {
   key: "google_calendar-create-event",
   name: "Create Event",
   description: "Create an event in a Google Calendar. [See the documentation](https://developers.google.com/calendar/api/v3/reference/events/insert)",
-  version: "1.0.4",
+  version: "1.1.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -54,6 +54,13 @@ export default {
       type: "string[]",
       description: "An array of email addresses (e.g., `[\"alice@example.com\", \"bob@example.com\"]`)",
       optional: true,
+    },
+    addSelfAsAttendee: {
+      type: "boolean",
+      label: "Add Self as Attendee",
+      description: "Whether to add the authenticated user (the event organizer) to the guest list. Default is `true`, which mirrors the Google Calendar web UI behavior of adding the creator as an attendee.",
+      optional: true,
+      default: true,
     },
     colorId: {
       propDefinition: [
@@ -130,6 +137,20 @@ export default {
   async run({ $ }) {
     const timeZone = await this.getTimeZone(this.timeZone);
     const attendees = this.formatAttendees(this.attendees);
+
+    if (this.addSelfAsAttendee) {
+      const { id: selfEmail } = await this.googleCalendar.getCalendar({
+        calendarId: "primary",
+      });
+      if (selfEmail && !attendees.some(({ email }) => email === selfEmail)) {
+        attendees.push({
+          email: selfEmail,
+          organizer: true,
+          responseStatus: "accepted",
+        });
+      }
+    }
+
     const recurrence = this.formatRecurrence({
       repeatFrequency: this.repeatFrequency,
       repeatInterval: this.repeatInterval,

--- a/components/google_calendar/package.json
+++ b/components/google_calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_calendar",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Pipedream Google_calendar Components",
   "main": "google_calendar.app.mjs",
   "keywords": [


### PR DESCRIPTION
Adding organizer as attendee by default, to match the UI behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Google Calendar event creation now optionally adds the event organizer as an attendee by default.
  * Added a setting to disable automatically adding the organizer.
* **Improvements**
  * Prevents duplicate organizer entries when the organizer is already listed as an attendee.
* **Chores**
  * Updated the Google Calendar component/package version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->