### PR TITLE
feat(calendly_v2): AI-optimize MCP action set

### DIFF
--- a/components/calendly_v2/actions/cancel-event/cancel-event.mjs
+++ b/components/calendly_v2/actions/cancel-event/cancel-event.mjs
@@ -5,8 +5,8 @@ import calendly from "../../calendly_v2.app.mjs";
 export default {
   key: "calendly_v2-cancel-event",
   name: "Cancel Event",
-  description: "Cancel a scheduled Calendly event. Posts to `POST /scheduled_events/{uuid}/cancellation`. Run **List Events** first to obtain the event UUID. [See the documentation](https://developer.calendly.com/api-docs/afb2e9fe3a0a0-cancel-event).",
-  version: "0.0.1",
+  description: "Cancel a scheduled Calendly event. Posts to `POST /scheduled_events/{uuid}/cancellation`. Run **List Events** first to obtain the event UUID. Example: with `eventUuid` set to `a1b2c3d4-e5f6-7890-abcd-ef1234567890` and `reason` set to `Schedule conflict - rescheduling needed`, the event is canceled and all invitees are notified. [See the documentation](https://developer.calendly.com/api-docs/afb2e9fe3a0a0-cancel-event).",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: true,

--- a/components/calendly_v2/actions/cancel-event/cancel-event.mjs
+++ b/components/calendly_v2/actions/cancel-event/cancel-event.mjs
@@ -6,7 +6,7 @@ export default {
   key: "calendly_v2-cancel-event",
   name: "Cancel Event",
   description: "Cancel a scheduled Calendly event. Posts to `POST /scheduled_events/{uuid}/cancellation`. Run **List Events** first to obtain the event UUID. [See the documentation](https://developer.calendly.com/api-docs/afb2e9fe3a0a0-cancel-event).",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/calendly_v2/actions/cancel-event/cancel-event.mjs
+++ b/components/calendly_v2/actions/cancel-event/cancel-event.mjs
@@ -1,0 +1,41 @@
+// x-pd-ai: optimized
+import { MAX_CANCELLATION_REASON_LENGTH } from "../../common/constants.mjs";
+import calendly from "../../calendly_v2.app.mjs";
+
+export default {
+  key: "calendly_v2-cancel-event",
+  name: "Cancel Event",
+  description: "Cancel a scheduled Calendly event. Posts to `POST /scheduled_events/{uuid}/cancellation`. Run **List Events** first to obtain the event UUID. [See the documentation](https://developer.calendly.com/api-docs/afb2e9fe3a0a0-cancel-event).",
+  version: "0.0.2",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    calendly,
+    eventUuid: {
+      type: "string",
+      label: "Event UUID",
+      description: "The UUID of the scheduled event to cancel (the `{uuid}` path segment, e.g. `a1b2c3d4-e5f6-7890-abcd-ef1234567890`). Run **List Events** first to obtain event UUIDs. Do not pass the full URI; only the UUID.",
+    },
+    reason: {
+      type: "string",
+      label: "Reason",
+      description: `Optional reason for the cancellation (max ${MAX_CANCELLATION_REASON_LENGTH} characters), e.g. \`Schedule conflict - rescheduling needed\`. Sent as the \`reason\` field in the request body.`,
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const response = await this.calendly.cancelEvent(
+      this.eventUuid,
+      {
+        reason: this.reason,
+      },
+      $,
+    );
+    $.export("$summary", `Canceled event ${this.eventUuid}`);
+    return response;
+  },
+};

--- a/components/calendly_v2/actions/cancel-event/cancel-event.mjs
+++ b/components/calendly_v2/actions/cancel-event/cancel-event.mjs
@@ -6,7 +6,7 @@ export default {
   key: "calendly_v2-cancel-event",
   name: "Cancel Event",
   description: "Cancel a scheduled Calendly event. Posts to `POST /scheduled_events/{uuid}/cancellation`. Run **List Events** first to obtain the event UUID. Example: with `eventUuid` set to `a1b2c3d4-e5f6-7890-abcd-ef1234567890` and `reason` set to `Schedule conflict - rescheduling needed`, the event is canceled and all invitees are notified. [See the documentation](https://developer.calendly.com/api-docs/afb2e9fe3a0a0-cancel-event).",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: true,

--- a/components/calendly_v2/actions/cancel-event/cancel-event.mjs
+++ b/components/calendly_v2/actions/cancel-event/cancel-event.mjs
@@ -9,7 +9,7 @@ export default {
   version: "0.0.1",
   type: "action",
   annotations: {
-    destructiveHint: false,
+    destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },

--- a/components/calendly_v2/actions/create-invitee-no-show/create-invitee-no-show.mjs
+++ b/components/calendly_v2/actions/create-invitee-no-show/create-invitee-no-show.mjs
@@ -5,8 +5,8 @@ import calendly from "../../calendly_v2.app.mjs";
 export default {
   key: "calendly_v2-create-invitee-no-show",
   name: "Create Invitee No Show",
-  description: "Marks an Invitee as a No Show in Calendly. [See the documentation](https://calendly.stoplight.io/docs/api-docs/cebd8c3170790-create-invitee-no-show).",
-  version: "0.0.6",
+  description: "Marks an invitee as a no-show via `POST /invitee_no_shows`. Use when an invitee didn't attend a scheduled event and you want to flag it in Calendly. Run **List Events** first to obtain the event UUID, then select the invitee from the dropdown (populated from **List Event Invitees**). Example: with `eventId` set to `a1b2c3d4-e5f6-7890-abcd-ef1234567890`, selecting invitee \"Jane Doe\" marks her as a no-show for that event. [See the documentation](https://calendly.stoplight.io/docs/api-docs/cebd8c3170790-create-invitee-no-show).",
+  version: "0.0.7",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/calendly_v2/actions/create-invitee-no-show/create-invitee-no-show.mjs
+++ b/components/calendly_v2/actions/create-invitee-no-show/create-invitee-no-show.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import { axios } from "@pipedream/platform";
 import calendly from "../../calendly_v2.app.mjs";
 
@@ -5,7 +6,7 @@ export default {
   key: "calendly_v2-create-invitee-no-show",
   name: "Create Invitee No Show",
   description: "Marks an Invitee as a No Show in Calendly. [See the documentation](https://calendly.stoplight.io/docs/api-docs/cebd8c3170790-create-invitee-no-show).",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/calendly_v2/actions/create-invitee-no-show/create-invitee-no-show.mjs
+++ b/components/calendly_v2/actions/create-invitee-no-show/create-invitee-no-show.mjs
@@ -6,7 +6,7 @@ export default {
   key: "calendly_v2-create-invitee-no-show",
   name: "Create Invitee No Show",
   description: "Marks an invitee as a no-show via `POST /invitee_no_shows`. Use when an invitee didn't attend a scheduled event and you want to flag it in Calendly. Run **List Events** first to obtain the event UUID, then select the invitee from the dropdown (populated from **List Event Invitees**). Example: with `eventId` set to `a1b2c3d4-e5f6-7890-abcd-ef1234567890`, selecting invitee \"Jane Doe\" marks her as a no-show for that event. [See the documentation](https://calendly.stoplight.io/docs/api-docs/cebd8c3170790-create-invitee-no-show).",
-  version: "0.0.7",
+  version: "0.0.6",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/calendly_v2/actions/create-scheduling-link/create-scheduling-link.mjs
+++ b/components/calendly_v2/actions/create-scheduling-link/create-scheduling-link.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import calendly from "../../calendly_v2.app.mjs";
 import { ConfigurationError } from "@pipedream/platform";
 
@@ -5,7 +6,7 @@ export default {
   key: "calendly_v2-create-scheduling-link",
   name: "Create a Scheduling Link",
   description: "Creates a single-use scheduling link. [See the documentation](https://calendly.stoplight.io/docs/api-docs/b3A6MzQyNTM0OQ-create-single-use-scheduling-link)",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/calendly_v2/actions/create-scheduling-link/create-scheduling-link.mjs
+++ b/components/calendly_v2/actions/create-scheduling-link/create-scheduling-link.mjs
@@ -5,8 +5,8 @@ import { ConfigurationError } from "@pipedream/platform";
 export default {
   key: "calendly_v2-create-scheduling-link",
   name: "Create a Scheduling Link",
-  description: "Creates a single-use scheduling link. [See the documentation](https://calendly.stoplight.io/docs/api-docs/b3A6MzQyNTM0OQ-create-single-use-scheduling-link)",
-  version: "0.0.9",
+  description: "Creates a single-use scheduling link for an event type via `POST /scheduling_links`. Run **List Event Types** first to obtain the event type UUID. Example: with `owner` set to `https://api.calendly.com/event_types/AAAAAAAAAAAAAAAA`'s UUID and `maxEventCount` set to `1`, returns a booking URL like `https://calendly.com/d/ABC-123/30-minute-meeting` that can be scheduled once before expiring. [See the documentation](https://calendly.stoplight.io/docs/api-docs/b3A6MzQyNTM0OQ-create-single-use-scheduling-link)",
+  version: "0.1.0",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
@@ -20,7 +20,7 @@ export default {
         calendly,
         "eventType",
       ],
-      label: "Owner",
+      label: "Owner (Event Type UUID)",
     },
     maxEventCount: {
       propDefinition: [

--- a/components/calendly_v2/actions/get-event/get-event.mjs
+++ b/components/calendly_v2/actions/get-event/get-event.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import { URL } from "url";
 import calendly from "../../calendly_v2.app.mjs";
@@ -6,7 +7,7 @@ export default {
   key: "calendly_v2-get-event",
   name: "Get Event",
   description: "Gets information about an Event associated with a URI. [See the documentation](https://developer.calendly.com/api-docs/e2f95ebd44914-get-event).",
-  version: "0.1.7",
+  version: "0.1.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/calendly_v2/actions/get-event/get-event.mjs
+++ b/components/calendly_v2/actions/get-event/get-event.mjs
@@ -7,7 +7,7 @@ export default {
   key: "calendly_v2-get-event",
   name: "Get Event",
   description: "Gets information about a scheduled event via `GET /scheduled_events/{uuid}`. Provide either the Event UUID (from **List Events**) or the full Event URL. Example: with `eventId` set to `a1b2c3d4-e5f6-7890-abcd-ef1234567890`, returns the event's name, start/end times, status, and location. If you are using a Calendly Source in the same workflow, you would use `{{steps.trigger.event.payload.event}}` as the Event URL. [See the documentation](https://developer.calendly.com/api-docs/e2f95ebd44914-get-event).",
-  version: "0.1.9",
+  version: "0.1.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/calendly_v2/actions/get-event/get-event.mjs
+++ b/components/calendly_v2/actions/get-event/get-event.mjs
@@ -6,7 +6,7 @@ import calendly from "../../calendly_v2.app.mjs";
 export default {
   key: "calendly_v2-get-event",
   name: "Get Event",
-  description: "Gets information about a scheduled event via `GET /scheduled_events/{uuid}`. Provide either the Event UUID (from **List Events**) or the full Event URL. Example: with `eventId` set to `a1b2c3d4-e5f6-7890-abcd-ef1234567890`, returns the event's name, start/end times, status, and location. If you are using a Calendly Source in the same workflow, you would use `{{steps.trigger.event.payload.event}}` as the Event URL. [See the documentation](https://developer.calendly.com/api-docs/e2f95ebd44914-get-event).",
+  description: "Gets information about a scheduled event via `GET /scheduled_events/{uuid}`. Provide either the Event UUID (from **List Events**) or the full Event URL. Example: with `eventId` set to `a1b2c3d4-e5f6-7890-abcd-ef1234567890`, returns the event's name, start/end times, status, and location. [See the documentation](https://developer.calendly.com/api-docs/e2f95ebd44914-get-event).",
   version: "0.1.8",
   annotations: {
     destructiveHint: false,
@@ -26,7 +26,7 @@ export default {
     eventUrl: {
       type: "string",
       label: "Event URL",
-      description: "The URL of the event to retrieve information about. If you are using a Calendly Source in the same workflow, you would use ``{{steps.trigger.event.payload.event}}``.",
+      description: "The URL of the event to retrieve information about.",
       optional: true,
     },
   },

--- a/components/calendly_v2/actions/get-event/get-event.mjs
+++ b/components/calendly_v2/actions/get-event/get-event.mjs
@@ -6,8 +6,8 @@ import calendly from "../../calendly_v2.app.mjs";
 export default {
   key: "calendly_v2-get-event",
   name: "Get Event",
-  description: "Gets information about an Event associated with a URI. [See the documentation](https://developer.calendly.com/api-docs/e2f95ebd44914-get-event).",
-  version: "0.1.8",
+  description: "Gets information about a scheduled event via `GET /scheduled_events/{uuid}`. Provide either the Event UUID (from **List Events**) or the full Event URL. Example: with `eventId` set to `a1b2c3d4-e5f6-7890-abcd-ef1234567890`, returns the event's name, start/end times, status, and location. If you are using a Calendly Source in the same workflow, you would use `{{steps.trigger.event.payload.event}}` as the Event URL. [See the documentation](https://developer.calendly.com/api-docs/e2f95ebd44914-get-event).",
+  version: "0.1.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/calendly_v2/actions/get-invitee/get-invitee.mjs
+++ b/components/calendly_v2/actions/get-invitee/get-invitee.mjs
@@ -4,8 +4,8 @@ import calendly from "../../calendly_v2.app.mjs";
 export default {
   key: "calendly_v2-get-invitee",
   name: "Get Event Invitee",
-  description: "Retrieve the full invitee resource (including `email`, `name`, `status`, `reschedule_url`, and `no_show`) via `GET /scheduled_events/{event_uuid}/invitees/{invitee_uuid}`. Use the returned `reschedule_url` to direct an invitee to self-reschedule. Run **List Events** to find event UUIDs. [See the documentation](https://developer.calendly.com/api-docs/8305c0ccfac70-get-event-invitee).",
-  version: "0.0.1",
+  description: "Retrieve the full invitee resource (including `email`, `name`, `status`, `reschedule_url`, and `no_show`) via `GET /scheduled_events/{event_uuid}/invitees/{invitee_uuid}`. Use the returned `reschedule_url` to direct an invitee to self-reschedule. Run **List Events** to find event UUIDs, then **List Event Invitees** to find invitee UUIDs. Example: with `eventUuid` set to `a1b2c3d4-e5f6-7890-abcd-ef1234567890` and `inviteeUuid` set to `f7e6d5c4-b3a2-1098-fedc-ba9876543210`, returns that invitee's `email`, `name`, and `status: \"active\"`. [See the documentation](https://developer.calendly.com/api-docs/8305c0ccfac70-get-event-invitee).",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/calendly_v2/actions/get-invitee/get-invitee.mjs
+++ b/components/calendly_v2/actions/get-invitee/get-invitee.mjs
@@ -5,7 +5,7 @@ export default {
   key: "calendly_v2-get-invitee",
   name: "Get Event Invitee",
   description: "Retrieve the full invitee resource (including `email`, `name`, `status`, `reschedule_url`, and `no_show`) via `GET /scheduled_events/{event_uuid}/invitees/{invitee_uuid}`. Use the returned `reschedule_url` to direct an invitee to self-reschedule. Run **List Events** to find event UUIDs, then **List Event Invitees** to find invitee UUIDs. Example: with `eventUuid` set to `a1b2c3d4-e5f6-7890-abcd-ef1234567890` and `inviteeUuid` set to `f7e6d5c4-b3a2-1098-fedc-ba9876543210`, returns that invitee's `email`, `name`, and `status: \"active\"`. [See the documentation](https://developer.calendly.com/api-docs/8305c0ccfac70-get-event-invitee).",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/calendly_v2/actions/get-invitee/get-invitee.mjs
+++ b/components/calendly_v2/actions/get-invitee/get-invitee.mjs
@@ -1,0 +1,33 @@
+// x-pd-ai: optimized
+import calendly from "../../calendly_v2.app.mjs";
+
+export default {
+  key: "calendly_v2-get-invitee",
+  name: "Get Event Invitee",
+  description: "Retrieve the full invitee resource (including `email`, `name`, `status`, `reschedule_url`, and `no_show`) via `GET /scheduled_events/{event_uuid}/invitees/{invitee_uuid}`. Use the returned `reschedule_url` to direct an invitee to self-reschedule. Run **List Events** to find event UUIDs. [See the documentation](https://developer.calendly.com/api-docs/8305c0ccfac70-get-event-invitee).",
+  version: "0.0.2",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    calendly,
+    eventUuid: {
+      type: "string",
+      label: "Event UUID",
+      description: "The UUID of the scheduled event (the `{event_uuid}` path segment, e.g. `a1b2c3d4-e5f6-7890-abcd-ef1234567890`). Run **List Events** first to obtain event UUIDs.",
+    },
+    inviteeUuid: {
+      type: "string",
+      label: "Invitee UUID",
+      description: "The UUID of the invitee within that event (the `{invitee_uuid}` path segment, e.g. `f7e6d5c4-b3a2-1098-fedc-ba9876543210`). The invitee list is returned by **List Event Invitees**.",
+    },
+  },
+  async run({ $ }) {
+    const response = await this.calendly.getInvitee(this.eventUuid, this.inviteeUuid, $);
+    $.export("$summary", `Retrieved invitee ${this.inviteeUuid} for event ${this.eventUuid}`);
+    return response;
+  },
+};

--- a/components/calendly_v2/actions/get-invitee/get-invitee.mjs
+++ b/components/calendly_v2/actions/get-invitee/get-invitee.mjs
@@ -5,7 +5,7 @@ export default {
   key: "calendly_v2-get-invitee",
   name: "Get Event Invitee",
   description: "Retrieve the full invitee resource (including `email`, `name`, `status`, `reschedule_url`, and `no_show`) via `GET /scheduled_events/{event_uuid}/invitees/{invitee_uuid}`. Use the returned `reschedule_url` to direct an invitee to self-reschedule. Run **List Events** to find event UUIDs. [See the documentation](https://developer.calendly.com/api-docs/8305c0ccfac70-get-event-invitee).",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/calendly_v2/actions/list-event-invitees/list-event-invitees.mjs
+++ b/components/calendly_v2/actions/list-event-invitees/list-event-invitees.mjs
@@ -4,12 +4,12 @@ import calendly from "../../calendly_v2.app.mjs";
 export default {
   key: "calendly_v2-list-event-invitees",
   name: "List Event Invitees",
-  description: "List invitees for an event. [See the documentation](https://calendly.stoplight.io/docs/api-docs/b3A6NTkxNDEx-list-event-invitees)",
-  version: "0.0.8",
+  description: "List the invitees for a scheduled event via `GET /scheduled_events/{uuid}/invitees`. Run **List Events** first to obtain the event UUID. Example: call with `eventId` set to `a1b2c3d4-e5f6-7890-abcd-ef1234567890` and `status` set to `active` to return only that event's non-canceled invitees, each with a `uri` whose trailing segment is the invitee UUID used by **Get Event Invitee** and **Create Invitee No Show**. [See the documentation](https://calendly.stoplight.io/docs/api-docs/b3A6NTkxNDEx-list-event-invitees)",
+  version: "0.0.9",
   annotations: {
-    destructiveHint: true,
+    destructiveHint: false,
     openWorldHint: true,
-    readOnlyHint: false,
+    readOnlyHint: true,
   },
   type: "action",
   props: {

--- a/components/calendly_v2/actions/list-event-invitees/list-event-invitees.mjs
+++ b/components/calendly_v2/actions/list-event-invitees/list-event-invitees.mjs
@@ -1,10 +1,11 @@
+// x-pd-ai: optimized
 import calendly from "../../calendly_v2.app.mjs";
 
 export default {
   key: "calendly_v2-list-event-invitees",
   name: "List Event Invitees",
   description: "List invitees for an event. [See the documentation](https://calendly.stoplight.io/docs/api-docs/b3A6NTkxNDEx-list-event-invitees)",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/calendly_v2/actions/list-event-invitees/list-event-invitees.mjs
+++ b/components/calendly_v2/actions/list-event-invitees/list-event-invitees.mjs
@@ -5,7 +5,7 @@ export default {
   key: "calendly_v2-list-event-invitees",
   name: "List Event Invitees",
   description: "List the invitees for a scheduled event via `GET /scheduled_events/{uuid}/invitees`. Run **List Events** first to obtain the event UUID. Example: call with `eventId` set to `a1b2c3d4-e5f6-7890-abcd-ef1234567890` and `status` set to `active` to return only that event's non-canceled invitees, each with a `uri` whose trailing segment is the invitee UUID used by **Get Event Invitee** and **Create Invitee No Show**. [See the documentation](https://calendly.stoplight.io/docs/api-docs/b3A6NTkxNDEx-list-event-invitees)",
-  version: "0.0.9",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/calendly_v2/actions/list-event-types/list-event-types.mjs
+++ b/components/calendly_v2/actions/list-event-types/list-event-types.mjs
@@ -6,7 +6,7 @@ export default {
   key: "calendly_v2-list-event-types",
   name: "List Event Types",
   description: "Retrieve the event types available to a user or organization via `GET /event_types`. Use this to discover valid event type URIs and UUIDs for scheduling flows. Provide either an Organization URI or a User URI; if neither is provided the authenticated user is used. Use **List Organization Memberships** to find user and organization URIs. Example: called with no props, returns the authenticated user's event types such as `{ name: \"30 Minute Meeting\", uuid: \"AAAAAAAAAAAAAAAA\" }` — pass that `uuid` as the `owner` prop in **Create a Scheduling Link**. [See the documentation](https://developer.calendly.com/api-docs/25a4ece03c1bc-list-user-s-event-types).",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/calendly_v2/actions/list-event-types/list-event-types.mjs
+++ b/components/calendly_v2/actions/list-event-types/list-event-types.mjs
@@ -5,8 +5,8 @@ import calendly from "../../calendly_v2.app.mjs";
 export default {
   key: "calendly_v2-list-event-types",
   name: "List Event Types",
-  description: "Retrieve the event types available to a user or organization via `GET /event_types`. Use this to discover valid event type URIs and UUIDs for scheduling flows. Provide either an Organization URI or a User URI; if neither is provided the authenticated user is used. Use **List Organization Memberships** to find user and organization URIs. [See the documentation](https://developer.calendly.com/api-docs/25a4ece03c1bc-list-user-s-event-types).",
-  version: "0.0.1",
+  description: "Retrieve the event types available to a user or organization via `GET /event_types`. Use this to discover valid event type URIs and UUIDs for scheduling flows. Provide either an Organization URI or a User URI; if neither is provided the authenticated user is used. Use **List Organization Memberships** to find user and organization URIs. Example: called with no props, returns the authenticated user's event types such as `{ name: \"30 Minute Meeting\", uuid: \"AAAAAAAAAAAAAAAA\" }` — pass that `uuid` as the `owner` prop in **Create a Scheduling Link**. [See the documentation](https://developer.calendly.com/api-docs/25a4ece03c1bc-list-user-s-event-types).",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/calendly_v2/actions/list-event-types/list-event-types.mjs
+++ b/components/calendly_v2/actions/list-event-types/list-event-types.mjs
@@ -52,14 +52,11 @@ export default {
         ? await this.calendly.defaultUser($)
         : undefined);
 
-    const response = await this.calendly._makeRequest({
-      path: "/event_types",
-      params: {
-        organization: this.organization,
-        user: userUri,
-        paginate: this.paginate,
-        maxResults: this.maxResults,
-      },
+    const response = await this.calendly.listEventTypes({
+      organization: this.organization,
+      user: userUri,
+      paginate: this.paginate,
+      maxResults: this.maxResults,
     }, $);
 
     // The Calendly API returns `uri` but not a top-level `uuid` field.

--- a/components/calendly_v2/actions/list-event-types/list-event-types.mjs
+++ b/components/calendly_v2/actions/list-event-types/list-event-types.mjs
@@ -1,4 +1,5 @@
 // x-pd-ai: optimized
+import { ConfigurationError } from "@pipedream/platform";
 import calendly from "../../calendly_v2.app.mjs";
 
 export default {
@@ -15,15 +16,17 @@ export default {
   props: {
     calendly,
     organization: {
-      type: "string",
-      label: "Organization URI",
-      description: "Organization URI to filter event types by (e.g. `https://api.calendly.com/organizations/AAAAAAAAAAAAAAAA`). Run **List Organization Memberships** to find valid organization URIs. Provide either this or User.",
+      propDefinition: [
+        calendly,
+        "organization",
+      ],
       optional: true,
     },
     user: {
-      type: "string",
-      label: "User URI",
-      description: "User URI to filter event types by (e.g. `https://api.calendly.com/users/AAAAAAAAAAAAAAAA`). Run **List Organization Memberships** to find valid user URIs. Provide either this or Organization; defaults to the authenticated user when both are omitted.",
+      propDefinition: [
+        calendly,
+        "user",
+      ],
       optional: true,
     },
     paginate: {
@@ -40,6 +43,10 @@ export default {
     },
   },
   async run({ $ }) {
+    if (this.organization && this.user) {
+      throw new ConfigurationError("Provide either Organization or User, not both.");
+    }
+
     const userUri = this.user ||
       (!this.organization
         ? await this.calendly.defaultUser($)

--- a/components/calendly_v2/actions/list-event-types/list-event-types.mjs
+++ b/components/calendly_v2/actions/list-event-types/list-event-types.mjs
@@ -1,0 +1,69 @@
+// x-pd-ai: optimized
+import calendly from "../../calendly_v2.app.mjs";
+
+export default {
+  key: "calendly_v2-list-event-types",
+  name: "List Event Types",
+  description: "Retrieve the event types available to a user or organization via `GET /event_types`. Use this to discover valid event type URIs and UUIDs for scheduling flows. Provide either an Organization URI or a User URI; if neither is provided the authenticated user is used. Use **List Organization Memberships** to find user and organization URIs. [See the documentation](https://developer.calendly.com/api-docs/25a4ece03c1bc-list-user-s-event-types).",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    calendly,
+    organization: {
+      type: "string",
+      label: "Organization URI",
+      description: "Organization URI to filter event types by (e.g. `https://api.calendly.com/organizations/AAAAAAAAAAAAAAAA`). Run **List Organization Memberships** to find valid organization URIs. Provide either this or User.",
+      optional: true,
+    },
+    user: {
+      type: "string",
+      label: "User URI",
+      description: "User URI to filter event types by (e.g. `https://api.calendly.com/users/AAAAAAAAAAAAAAAA`). Run **List Organization Memberships** to find valid user URIs. Provide either this or Organization; defaults to the authenticated user when both are omitted.",
+      optional: true,
+    },
+    paginate: {
+      propDefinition: [
+        calendly,
+        "paginate",
+      ],
+    },
+    maxResults: {
+      propDefinition: [
+        calendly,
+        "maxResults",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const userUri = this.user ||
+      (!this.organization
+        ? await this.calendly.defaultUser($)
+        : undefined);
+
+    const response = await this.calendly._makeRequest({
+      path: "/event_types",
+      params: {
+        organization: this.organization,
+        user: userUri,
+        paginate: this.paginate,
+        maxResults: this.maxResults,
+      },
+    }, $);
+
+    // The Calendly API returns `uri` but not a top-level `uuid` field.
+    // Extract the UUID from the URI so downstream components and agents
+    // can reference it directly (e.g. as the eventType prop in other actions).
+    response.collection = response.collection.map((eventType) => ({
+      ...eventType,
+      uuid: eventType.uri.split("/").pop(),
+    }));
+
+    $.export("$summary", `Found ${response.pagination.count} event type(s)`);
+    return response;
+  },
+};

--- a/components/calendly_v2/actions/list-events/list-events.mjs
+++ b/components/calendly_v2/actions/list-events/list-events.mjs
@@ -6,7 +6,7 @@ export default {
   key: "calendly_v2-list-events",
   name: "List Events",
   description: "List scheduled Calendly events. Scope the results by providing at most one of Organization URI, User URI, or Group UUID; if none is provided, events for the authenticated user are returned (supplying more than one raises a configuration error). Narrow the results further with an invitee email to return only events scheduled with that invitee. Filter by date range using `Min Start Time` and/or `Max Start Time`, both ISO 8601 datetimes in UTC (e.g. `2026-08-01T00:00:00Z`). Each returned event includes a `uri`; the trailing UUID segment is the event UUID used by downstream actions such as **Get Event**, **List Event Invitees**, **Get Event Invitee**, and **Cancel Event**. Example: called with no props, returns the authenticated user's upcoming events, each like `{ name: \"30 Minute Meeting\", uri: \"https://api.calendly.com/scheduled_events/a1b2c3d4-e5f6-7890-abcd-ef1234567890\", status: \"active\" }`. [See the documentation](https://calendly.stoplight.io/docs/api-docs/b3A6NTkxNDEy-list-events)",
-  version: "0.0.9",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/calendly_v2/actions/list-events/list-events.mjs
+++ b/components/calendly_v2/actions/list-events/list-events.mjs
@@ -5,8 +5,8 @@ import calendly from "../../calendly_v2.app.mjs";
 export default {
   key: "calendly_v2-list-events",
   name: "List Events",
-  description: "List scheduled Calendly events. Scope the results by providing at most one of Organization URI, User URI, or Group UUID; if none is provided, events for the authenticated user are returned (supplying more than one raises a configuration error). Narrow the results further with an invitee email to return only events scheduled with that invitee. Filter by date range using `Min Start Time` and/or `Max Start Time`, both ISO 8601 datetimes in UTC (e.g. `2026-08-01T00:00:00Z`). Each returned event includes a `uri`; the trailing UUID segment is the event UUID used by downstream actions such as **Get Event**, **List Event Invitees**, **Get Event Invitee**, and **Cancel Event**. [See the documentation](https://calendly.stoplight.io/docs/api-docs/b3A6NTkxNDEy-list-events)",
-  version: "0.0.8",
+  description: "List scheduled Calendly events. Scope the results by providing at most one of Organization URI, User URI, or Group UUID; if none is provided, events for the authenticated user are returned (supplying more than one raises a configuration error). Narrow the results further with an invitee email to return only events scheduled with that invitee. Filter by date range using `Min Start Time` and/or `Max Start Time`, both ISO 8601 datetimes in UTC (e.g. `2026-08-01T00:00:00Z`). Each returned event includes a `uri`; the trailing UUID segment is the event UUID used by downstream actions such as **Get Event**, **List Event Invitees**, **Get Event Invitee**, and **Cancel Event**. Example: called with no props, returns the authenticated user's upcoming events, each like `{ name: \"30 Minute Meeting\", uri: \"https://api.calendly.com/scheduled_events/a1b2c3d4-e5f6-7890-abcd-ef1234567890\", status: \"active\" }`. [See the documentation](https://calendly.stoplight.io/docs/api-docs/b3A6NTkxNDEy-list-events)",
+  version: "0.0.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/calendly_v2/actions/list-events/list-events.mjs
+++ b/components/calendly_v2/actions/list-events/list-events.mjs
@@ -5,7 +5,7 @@ import calendly from "../../calendly_v2.app.mjs";
 export default {
   key: "calendly_v2-list-events",
   name: "List Events",
-  description: "List events for an user. [See the documentation](https://calendly.stoplight.io/docs/api-docs/b3A6NTkxNDEy-list-events)",
+  description: "List scheduled Calendly events. Scope the results by providing at most one of Organization URI, User URI, or Group UUID; if none is provided, events for the authenticated user are returned (supplying more than one raises a configuration error). Narrow the results further with an invitee email to return only events scheduled with that invitee. Filter by date range using `Min Start Time` and/or `Max Start Time`, both ISO 8601 datetimes in UTC (e.g. `2026-08-01T00:00:00Z`). Each returned event includes a `uri`; the trailing UUID segment is the event UUID used by downstream actions such as **Get Event**, **List Event Invitees**, **Get Event Invitee**, and **Cancel Event**. [See the documentation](https://calendly.stoplight.io/docs/api-docs/b3A6NTkxNDEy-list-events)",
   version: "0.0.8",
   annotations: {
     destructiveHint: false,

--- a/components/calendly_v2/actions/list-events/list-events.mjs
+++ b/components/calendly_v2/actions/list-events/list-events.mjs
@@ -105,9 +105,10 @@ export default {
       max_start_time: this.maxStartTime,
       organization,
       group,
+      user,
     };
 
-    const response = await this.calendly.listEvents(params, user, $);
+    const response = await this.calendly.listEvents(params, $);
     $.export("$summary", `Found ${response.pagination.count} event(s)`);
     return response;
   },

--- a/components/calendly_v2/actions/list-events/list-events.mjs
+++ b/components/calendly_v2/actions/list-events/list-events.mjs
@@ -1,10 +1,12 @@
+// x-pd-ai: optimized
+import { ConfigurationError } from "@pipedream/platform";
 import calendly from "../../calendly_v2.app.mjs";
 
 export default {
   key: "calendly_v2-list-events",
   name: "List Events",
   description: "List events for an user. [See the documentation](https://calendly.stoplight.io/docs/api-docs/b3A6NTkxNDEy-list-events)",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -13,26 +15,13 @@ export default {
   type: "action",
   props: {
     calendly,
-    alert: {
-      propDefinition: [
-        calendly,
-        "listEventsAlert",
-      ],
-    },
-    scope: {
-      propDefinition: [
-        calendly,
-        "listEventsScope",
-      ],
-      reloadProps: true,
-    },
     organization: {
       propDefinition: [
         calendly,
         "organization",
       ],
+      description: "Returns events for the specified organization. Provide only one of Organization, User, or Group.",
       optional: true,
-      hidden: true,
     },
     user: {
       propDefinition: [
@@ -42,9 +31,8 @@ export default {
           organization: c.organization,
         }),
       ],
-      description: "Returns events for a specified user",
+      description: "Returns events for the specified user. Provide only one of Organization, User, or Group.",
       optional: true,
-      hidden: true,
     },
     group: {
       propDefinition: [
@@ -54,9 +42,8 @@ export default {
           organization: c.organization,
         }),
       ],
-      description: "Returns events for a specified group",
+      description: "Returns events for the specified group. Provide only one of Organization, User, or Group.",
       optional: true,
-      hidden: true,
     },
     inviteeEmail: {
       propDefinition: [
@@ -83,29 +70,44 @@ export default {
         "maxResults",
       ],
     },
-  },
-  async additionalProps(props) {
-    return this.calendly.listEventsAdditionalProps(props, this.scope);
+    minStartTime: {
+      type: "string",
+      label: "Min Start Time",
+      description: "Include only events with start times on or after this ISO 8601 datetime in UTC, e.g. `2026-08-01T00:00:00Z`. Maps to the `min_start_time` query param.",
+      optional: true,
+    },
+    maxStartTime: {
+      type: "string",
+      label: "Max Start Time",
+      description: "Include only events with start times prior to this ISO 8601 datetime in UTC, e.g. `2026-08-31T23:59:59Z`. Maps to the `max_start_time` query param.",
+      optional: true,
+    },
   },
   async run({ $ }) {
+    const {
+      organization, user, group,
+    } = this;
+
+    if ([
+      organization,
+      user,
+      group,
+    ].filter(Boolean).length > 1) {
+      throw new ConfigurationError("Provide only one of Organization, User, or Group.");
+    }
+
     const params = {
       invitee_email: this.inviteeEmail,
       status: this.status,
       paginate: this.paginate,
       maxResults: this.maxResults,
+      min_start_time: this.minStartTime,
+      max_start_time: this.maxStartTime,
+      organization,
+      group,
     };
 
-    if (this.scope !== "authenticatedUser") {
-      params.organization = this.organization;
-    }
-    if (this.scope === "user") {
-      params.user = this.user;
-    }
-    if (this.scope === "group") {
-      params.group = this.group;
-    }
-
-    const response = await this.calendly.listEvents(params, this.user, $);
+    const response = await this.calendly.listEvents(params, user, $);
     $.export("$summary", `Found ${response.pagination.count} event(s)`);
     return response;
   },

--- a/components/calendly_v2/actions/list-groups/list-groups.mjs
+++ b/components/calendly_v2/actions/list-groups/list-groups.mjs
@@ -1,0 +1,51 @@
+// x-pd-ai: optimized
+import calendly from "../../calendly_v2.app.mjs";
+
+export default {
+  key: "calendly_v2-list-groups",
+  name: "List Groups",
+  description: "List the groups within a Calendly organization via `GET /groups` (requires organization admin/owner privilege). Use this to discover valid Group UUIDs for scoping **List Events** to a specific group. Run **List Organization Memberships** first to obtain an organization URI. Example: call with `organization` set to `https://api.calendly.com/organizations/AAAAAAAAAAAAAAAA` to get groups such as `{ name: \"Sales Team\", uri: \"https://api.calendly.com/groups/BBBBBBBBBBBBBBBB\" }`; pass the trailing `BBBBBBBBBBBBBBBB` segment as the Group UUID to **List Events**. [See the documentation](https://calendly.stoplight.io/docs/api-docs/6rb6dtdln74sy-list-groups)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    calendly,
+    organization: {
+      propDefinition: [
+        calendly,
+        "organization",
+      ],
+    },
+    paginate: {
+      propDefinition: [
+        calendly,
+        "paginate",
+      ],
+    },
+    maxResults: {
+      propDefinition: [
+        calendly,
+        "maxResults",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.calendly.listGroups({
+      organization: this.organization,
+      paginate: this.paginate,
+      maxResults: this.maxResults,
+    }, $);
+
+    response.collection = response.collection.map((group) => ({
+      ...group,
+      uuid: group.uri.split("/").pop(),
+    }));
+
+    $.export("$summary", `Found ${response.pagination.count} group(s)`);
+    return response;
+  },
+};

--- a/components/calendly_v2/actions/list-organization-members/list-organization-members.mjs
+++ b/components/calendly_v2/actions/list-organization-members/list-organization-members.mjs
@@ -6,7 +6,7 @@ export default {
   key: "calendly_v2-list-organization-members",
   name: "List Organization Memberships",
   description: "List the members of a Calendly organization via `GET /organization_memberships`, returning each membership's user URI, role, and email. Use this as the companion lookup action for user and organization URIs consumed by other tools. Supports optional `role` and `email` filters plus pagination. Example: called with no props, returns the authenticated user's memberships such as `{ user: { name: \"Jane Doe\", uri: \"https://api.calendly.com/users/AAAAAAAAAAAAAAAA\" }, organization: \"https://api.calendly.com/organizations/BBBBBBBBBBBBBBBB\", role: \"owner\" }` — pass those URIs as the `user`/`organization` props in other actions. [See the documentation](https://developer.calendly.com/api-docs/eaed2e61a6bc3-list-organization-memberships).",
-  version: "0.0.2",
+  version: "0.0.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/calendly_v2/actions/list-organization-members/list-organization-members.mjs
+++ b/components/calendly_v2/actions/list-organization-members/list-organization-members.mjs
@@ -49,15 +49,12 @@ export default {
     },
   },
   async run({ $ }) {
-    const response = await this.calendly._makeRequest({
-      path: "/organization_memberships",
-      params: {
-        organization: this.organization,
-        email: this.email,
-        role: this.role,
-        paginate: this.paginate,
-        maxResults: this.maxResults,
-      },
+    const response = await this.calendly.listOrganizationMembers({
+      organization: this.organization,
+      email: this.email,
+      role: this.role,
+      paginate: this.paginate,
+      maxResults: this.maxResults,
     }, $);
 
     $.export("$summary", `Found ${response.pagination.count} organization membership(s)`);

--- a/components/calendly_v2/actions/list-organization-members/list-organization-members.mjs
+++ b/components/calendly_v2/actions/list-organization-members/list-organization-members.mjs
@@ -5,8 +5,8 @@ import calendly from "../../calendly_v2.app.mjs";
 export default {
   key: "calendly_v2-list-organization-members",
   name: "List Organization Memberships",
-  description: "List the members of a Calendly organization via `GET /organization_memberships`, returning each membership's user URI, role, and email. Use this as the companion lookup action for user and organization URIs consumed by other tools. Supports optional `role` and `email` filters plus pagination. [See the documentation](https://developer.calendly.com/api-docs/eaed2e61a6bc3-list-organization-memberships).",
-  version: "0.0.1",
+  description: "List the members of a Calendly organization via `GET /organization_memberships`, returning each membership's user URI, role, and email. Use this as the companion lookup action for user and organization URIs consumed by other tools. Supports optional `role` and `email` filters plus pagination. Example: called with no props, returns the authenticated user's memberships such as `{ user: { name: \"Jane Doe\", uri: \"https://api.calendly.com/users/AAAAAAAAAAAAAAAA\" }, organization: \"https://api.calendly.com/organizations/BBBBBBBBBBBBBBBB\", role: \"owner\" }` — pass those URIs as the `user`/`organization` props in other actions. [See the documentation](https://developer.calendly.com/api-docs/eaed2e61a6bc3-list-organization-memberships).",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/calendly_v2/actions/list-organization-members/list-organization-members.mjs
+++ b/components/calendly_v2/actions/list-organization-members/list-organization-members.mjs
@@ -1,0 +1,65 @@
+// x-pd-ai: optimized
+import { MEMBERSHIP_ROLE_OPTIONS } from "../../common/constants.mjs";
+import calendly from "../../calendly_v2.app.mjs";
+
+export default {
+  key: "calendly_v2-list-organization-members",
+  name: "List Organization Memberships",
+  description: "List the members of a Calendly organization via `GET /organization_memberships`, returning each membership's user URI, role, and email. Use this as the companion lookup action for user and organization URIs consumed by other tools. Supports optional `role` and `email` filters plus pagination. [See the documentation](https://developer.calendly.com/api-docs/eaed2e61a6bc3-list-organization-memberships).",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    calendly,
+    organization: {
+      type: "string",
+      label: "Organization URI",
+      description: "Organization URI to filter memberships by (e.g. `https://api.calendly.com/organizations/AAAAAAAAAAAAAAAA`). Defaults to the authenticated user's organization when omitted.",
+      optional: true,
+    },
+    email: {
+      type: "string",
+      label: "Email",
+      description: "Filter memberships by member email address, e.g. `jane@acme.com`.",
+      optional: true,
+    },
+    role: {
+      type: "string",
+      label: "Role",
+      description: `Filter memberships by role. One of: ${MEMBERSHIP_ROLE_OPTIONS.map((r) => `\`${r}\``).join(", ")}.`,
+      optional: true,
+      options: MEMBERSHIP_ROLE_OPTIONS,
+    },
+    paginate: {
+      propDefinition: [
+        calendly,
+        "paginate",
+      ],
+    },
+    maxResults: {
+      propDefinition: [
+        calendly,
+        "maxResults",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.calendly._makeRequest({
+      path: "/organization_memberships",
+      params: {
+        organization: this.organization,
+        email: this.email,
+        role: this.role,
+        paginate: this.paginate,
+        maxResults: this.maxResults,
+      },
+    }, $);
+
+    $.export("$summary", `Found ${response.pagination.count} organization membership(s)`);
+    return response;
+  },
+};

--- a/components/calendly_v2/actions/list-organization-members/list-organization-members.mjs
+++ b/components/calendly_v2/actions/list-organization-members/list-organization-members.mjs
@@ -16,9 +16,10 @@ export default {
   props: {
     calendly,
     organization: {
-      type: "string",
-      label: "Organization URI",
-      description: "Organization URI to filter memberships by (e.g. `https://api.calendly.com/organizations/AAAAAAAAAAAAAAAA`). Defaults to the authenticated user's organization when omitted.",
+      propDefinition: [
+        calendly,
+        "organization",
+      ],
       optional: true,
     },
     email: {

--- a/components/calendly_v2/actions/list-user-availability-schedules/list-user-availability-schedules.mjs
+++ b/components/calendly_v2/actions/list-user-availability-schedules/list-user-availability-schedules.mjs
@@ -5,7 +5,7 @@ export default {
   key: "calendly_v2-list-user-availability-schedules",
   name: "List User Availability Schedules",
   description: "List the availability schedules of the given user via `GET /user_availability_schedules`. Run **List Organization Memberships** first to obtain a user URI. Example: call with `user` set to `https://api.calendly.com/users/AAAAAAAAAAAAAAAA` to return that user's named availability schedules (e.g. `Working Hours`) with their weekly rules. [See the documentation](https://developer.calendly.com/api-docs/8098de44af94c-list-user-availability-schedules)",
-  version: "0.0.5",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/calendly_v2/actions/list-user-availability-schedules/list-user-availability-schedules.mjs
+++ b/components/calendly_v2/actions/list-user-availability-schedules/list-user-availability-schedules.mjs
@@ -4,8 +4,8 @@ import calendly from "../../calendly_v2.app.mjs";
 export default {
   key: "calendly_v2-list-user-availability-schedules",
   name: "List User Availability Schedules",
-  description: "List the availability schedules of the given user. [See the documentation](https://developer.calendly.com/api-docs/8098de44af94c-list-user-availability-schedules)",
-  version: "0.0.4",
+  description: "List the availability schedules of the given user via `GET /user_availability_schedules`. Run **List Organization Memberships** first to obtain a user URI. Example: call with `user` set to `https://api.calendly.com/users/AAAAAAAAAAAAAAAA` to return that user's named availability schedules (e.g. `Working Hours`) with their weekly rules. [See the documentation](https://developer.calendly.com/api-docs/8098de44af94c-list-user-availability-schedules)",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -28,7 +28,7 @@ export default {
           organization: c.organization,
         }),
       ],
-      description: "The ID of the user for whom you want to retrieve availability schedules.",
+      description: "The User URI to retrieve availability schedules for (e.g. `https://api.calendly.com/users/AAAAAAAAAAAAAAAA`). Run **List Organization Memberships** to find valid user URIs.",
     },
   },
   async run({ $ }) {

--- a/components/calendly_v2/actions/list-user-availability-schedules/list-user-availability-schedules.mjs
+++ b/components/calendly_v2/actions/list-user-availability-schedules/list-user-availability-schedules.mjs
@@ -1,10 +1,11 @@
+// x-pd-ai: optimized
 import calendly from "../../calendly_v2.app.mjs";
 
 export default {
   key: "calendly_v2-list-user-availability-schedules",
   name: "List User Availability Schedules",
   description: "List the availability schedules of the given user. [See the documentation](https://developer.calendly.com/api-docs/8098de44af94c-list-user-availability-schedules)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/calendly_v2/actions/list-webhook-subscriptions/list-webhook-subscriptions.mjs
+++ b/components/calendly_v2/actions/list-webhook-subscriptions/list-webhook-subscriptions.mjs
@@ -1,11 +1,11 @@
 // x-pd-ai: optimized
-// legacy_hash_id: a_k6ij8Q
-import { axios } from "@pipedream/platform";
+import calendly from "../../calendly_v2.app.mjs";
+import { ConfigurationError } from "@pipedream/platform";
 
 export default {
   key: "calendly_v2-list-webhook-subscriptions",
   name: "List Webhook Subscriptions",
-  description: "Get a list of Webhook Subscriptions for an Organization or User via `GET /webhook_subscriptions`. Requires both `scope` and `organization_uri`; add `user_uri` when `scope` is `user`. Run **List Organization Memberships** first to obtain an organization or user URI. Example: call with `scope` set to `organization` and `organization_uri` set to `https://api.calendly.com/organizations/AAAAAAAAAAAAAAAA` to return that organization's webhook subscriptions. [See the documentation](https://developer.calendly.com/docs/api-docs/reference/calendly-api/openapi.yaml/paths/~1webhook_subscriptions/get)",
+  description: "Get a list of Webhook Subscriptions for an Organization or User via `GET /webhook_subscriptions`. Requires both `scope` and `organization_uri`; add `user_uri` when `scope` is `user`. Run **List Organization Memberships** first to obtain an organization or user URI. Example: call with `scope` set to `organization` and `organization_uri` set to `https://api.calendly.com/organizations/AAAAAAAAAAAAAAAA` to return that organization's webhook subscriptions. [See the documentation](https://calendly.stoplight.io/docs/api-docs/faac832d7c57d-list-webhook-subscriptions)",
   version: "0.1.7",
   annotations: {
     destructiveHint: false,
@@ -14,39 +14,42 @@ export default {
   },
   type: "action",
   props: {
-    calendly_v2: {
-      type: "app",
-      app: "calendly_v2",
-    },
+    calendly,
     scope: {
       type: "string",
+      label: "Scope",
       description: "Filter the list by organization or user.",
       options: [
         "organization",
         "user",
       ],
     },
-    organization_uri: {
+    organizationUri: {
       type: "string",
+      label: "Organization URI",
       description: "Filters the results by organization URI, such as `https://api.calendly.com/organizations/012345678901234567890`. Run **List Organization Memberships** first to obtain a valid organization URI.",
     },
-    user_uri: {
+    userUri: {
       type: "string",
+      label: "User URI",
       description: "Filters the results by user URI, such as `https://api.calendly.com/users/CAFHCZWDQLKQ73HX`. Required when `scope` is `user`. Run **List Organization Memberships** first to obtain a valid user URI.",
       optional: true,
     },
     count: {
       type: "string",
+      label: "Count",
       description: "The number of rows to return.",
       optional: true,
     },
-    page_token: {
+    pageToken: {
       type: "string",
+      label: "Page Token",
       description: "The token to pass to get the next portion of the collection.",
       optional: true,
     },
     sort: {
       type: "string",
+      label: "Sort",
       description: "Order results by the specified field and direction. Accepts comma-separated list of {field}:{direction} values. Supported fields are: created_at. Sort direction is specified as: asc, desc.",
       optional: true,
       options: [
@@ -56,25 +59,24 @@ export default {
     },
   },
   async run({ $ }) {
-  //See the API docs: https://developer.calendly.com/docs/api-docs/reference/calendly-api/openapi.yaml/paths/~1webhook_subscriptions/get
-
-    if (!this.scope || !this.organization_uri) {
-      throw new Error("Must provide scope, and organization_uri parameters.");
+    if (!this.scope || !this.organizationUri) {
+      throw new ConfigurationError("Must provide scope, and organization_uri parameters.");
     }
 
-    return await axios($, {
-      url: "https://api.calendly.com/webhook_subscriptions",
-      headers: {
-        Authorization: `Bearer ${this.calendly_v2.$auth.oauth_access_token}`,
-      },
-      params: {
-        scope: this.scope,
-        user: this.user_uri,
-        count: this.count,
-        organization: this.organization_uri,
-        page_token: this.page_token,
-        sort: this.sort,
-      },
-    });
+    const response = await this.calendly.listWebhookSubscriptions({
+      scope: this.scope,
+      organization: this.organizationUri,
+      user: this.userUri,
+      count: this.count,
+      page_token: this.pageToken,
+      sort: this.sort,
+    }, $);
+
+    $.export("$summary", `Successfully retrieved webhook subscriptions for ${this.scope} ${this.organizationUri
+      ? `and ${this.organizationUri}`
+      : this.userUri
+        ? `and ${this.userUri}`
+        : ""}`);
+    return response;
   },
 };

--- a/components/calendly_v2/actions/list-webhook-subscriptions/list-webhook-subscriptions.mjs
+++ b/components/calendly_v2/actions/list-webhook-subscriptions/list-webhook-subscriptions.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 // legacy_hash_id: a_k6ij8Q
 import { axios } from "@pipedream/platform";
 
@@ -5,7 +6,7 @@ export default {
   key: "calendly_v2-list-webhook-subscriptions",
   name: "List Webhook Subscriptions",
   description: "Get a list of Webhook Subscriptions for an Organization or User with a UUID.",
-  version: "0.1.6",
+  version: "0.1.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/calendly_v2/actions/list-webhook-subscriptions/list-webhook-subscriptions.mjs
+++ b/components/calendly_v2/actions/list-webhook-subscriptions/list-webhook-subscriptions.mjs
@@ -6,7 +6,7 @@ export default {
   key: "calendly_v2-list-webhook-subscriptions",
   name: "List Webhook Subscriptions",
   description: "Get a list of Webhook Subscriptions for an Organization or User via `GET /webhook_subscriptions`. Requires both `scope` and `organization_uri`; add `user_uri` when `scope` is `user`. Run **List Organization Memberships** first to obtain an organization or user URI. Example: call with `scope` set to `organization` and `organization_uri` set to `https://api.calendly.com/organizations/AAAAAAAAAAAAAAAA` to return that organization's webhook subscriptions. [See the documentation](https://developer.calendly.com/docs/api-docs/reference/calendly-api/openapi.yaml/paths/~1webhook_subscriptions/get)",
-  version: "0.1.8",
+  version: "0.1.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/calendly_v2/actions/list-webhook-subscriptions/list-webhook-subscriptions.mjs
+++ b/components/calendly_v2/actions/list-webhook-subscriptions/list-webhook-subscriptions.mjs
@@ -5,7 +5,7 @@ import { ConfigurationError } from "@pipedream/platform";
 export default {
   key: "calendly_v2-list-webhook-subscriptions",
   name: "List Webhook Subscriptions",
-  description: "Get a list of Webhook Subscriptions for an Organization or User via `GET /webhook_subscriptions`. Requires both `scope` and `organization_uri`; add `user_uri` when `scope` is `user`. Run **List Organization Memberships** first to obtain an organization or user URI. Example: call with `scope` set to `organization` and `organization_uri` set to `https://api.calendly.com/organizations/AAAAAAAAAAAAAAAA` to return that organization's webhook subscriptions. [See the documentation](https://calendly.stoplight.io/docs/api-docs/faac832d7c57d-list-webhook-subscriptions)",
+  description: "Get a list of Webhook Subscriptions for an Organization or User via `GET /webhook_subscriptions`. Requires `organizationUri` when `scope` is `organization`, or `userUri` when `scope` is `user`. Run **List Organization Memberships** first to obtain an organization or user URI. Example: call with `scope` set to `organization` and `organizationUri` set to `https://api.calendly.com/organizations/AAAAAAAAAAAAAAAA` to return that organization's webhook subscriptions. [See the documentation](https://calendly.stoplight.io/docs/api-docs/faac832d7c57d-list-webhook-subscriptions)",
   version: "0.1.7",
   annotations: {
     destructiveHint: false,
@@ -27,7 +27,8 @@ export default {
     organizationUri: {
       type: "string",
       label: "Organization URI",
-      description: "Filters the results by organization URI, such as `https://api.calendly.com/organizations/012345678901234567890`. Run **List Organization Memberships** first to obtain a valid organization URI.",
+      description: "Filters the results by organization URI, such as `https://api.calendly.com/organizations/012345678901234567890`. Required when `scope` is `organization`. Run **List Organization Memberships** first to obtain a valid organization URI.",
+      optional: true,
     },
     userUri: {
       type: "string",
@@ -59,8 +60,14 @@ export default {
     },
   },
   async run({ $ }) {
-    if (!this.scope || !this.organizationUri) {
-      throw new ConfigurationError("Must provide scope, and organization_uri parameters.");
+    if (!this.scope) {
+      throw new ConfigurationError("Must provide a scope parameter.");
+    }
+    if (this.scope === "organization" && !this.organizationUri) {
+      throw new ConfigurationError("Must provide organizationUri when scope is organization.");
+    }
+    if (this.scope === "user" && !this.userUri) {
+      throw new ConfigurationError("Must provide userUri when scope is user.");
     }
 
     const response = await this.calendly.listWebhookSubscriptions({

--- a/components/calendly_v2/actions/list-webhook-subscriptions/list-webhook-subscriptions.mjs
+++ b/components/calendly_v2/actions/list-webhook-subscriptions/list-webhook-subscriptions.mjs
@@ -5,8 +5,8 @@ import { axios } from "@pipedream/platform";
 export default {
   key: "calendly_v2-list-webhook-subscriptions",
   name: "List Webhook Subscriptions",
-  description: "Get a list of Webhook Subscriptions for an Organization or User with a UUID.",
-  version: "0.1.7",
+  description: "Get a list of Webhook Subscriptions for an Organization or User via `GET /webhook_subscriptions`. Requires both `scope` and `organization_uri`; add `user_uri` when `scope` is `user`. Run **List Organization Memberships** first to obtain an organization or user URI. Example: call with `scope` set to `organization` and `organization_uri` set to `https://api.calendly.com/organizations/AAAAAAAAAAAAAAAA` to return that organization's webhook subscriptions. [See the documentation](https://developer.calendly.com/docs/api-docs/reference/calendly-api/openapi.yaml/paths/~1webhook_subscriptions/get)",
+  version: "0.1.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -28,11 +28,11 @@ export default {
     },
     organization_uri: {
       type: "string",
-      description: "Indicates if the results should be filtered by organization, by entering an organization 's URI, such as `https://api.calendly.com/organizations/012345678901234567890`.",
+      description: "Filters the results by organization URI, such as `https://api.calendly.com/organizations/012345678901234567890`. Run **List Organization Memberships** first to obtain a valid organization URI.",
     },
     user_uri: {
       type: "string",
-      description: "Indicates if the results should be filtered by user, by entering a user's URI, such as `https://api.calendly.com/users/CAFHCZWDQLKQ73HX`. You can use the [Get User](https://developer.calendly.com/docs/api-docs/reference/calendly-api/openapi.yaml/paths/~1users~1me/get) endpoint to find a user's URI.",
+      description: "Filters the results by user URI, such as `https://api.calendly.com/users/CAFHCZWDQLKQ73HX`. Required when `scope` is `user`. Run **List Organization Memberships** first to obtain a valid user URI.",
       optional: true,
     },
     count: {

--- a/components/calendly_v2/calendly_v2.app.mjs
+++ b/components/calendly_v2/calendly_v2.app.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import { axios } from "@pipedream/platform";
 import constants from "./common/constants.mjs";
 
@@ -7,69 +8,28 @@ export default {
   propDefinitions: {
     organization: {
       type: "string",
-      label: "Organization UUID",
-      description: "An organization UUID",
-      async options({ prevContext }) {
-        return await this._makeAsyncOptionsRequest({
-          prevContext,
-          requestType: "getUserOrganizations",
-          optionsCallbackFn: this._getOrganizationOptions,
-        });
-      },
+      label: "Organization URI",
+      description: "Organization URI (e.g. `https://api.calendly.com/organizations/AAAAAAAAAAAAAAAA`). Run **List Organization Memberships** to find valid organization URIs.",
     },
     user: {
       type: "string",
-      label: "User UUID",
-      description: "An user UUID",
-      async options({
-        prevContext, organization,
-      }) {
-        prevContext.organization = organization;
-        return await this._makeAsyncOptionsRequest({
-          prevContext,
-          requestType: "listOrganizationMembers",
-          optionsCallbackFn: this._getUserOptions,
-        });
-      },
+      label: "User URI",
+      description: "User URI (e.g. `https://api.calendly.com/users/AAAAAAAAAAAAAAAA`). Run **List Organization Memberships** to find valid user URIs.",
     },
     eventId: {
       type: "string",
-      label: "Event ID",
-      description: "An event UUID",
-      async options({ prevContext }) {
-        return await this._makeAsyncOptionsRequest({
-          prevContext,
-          requestType: "listEvents",
-          optionsCallbackFn: this._getNameOptions,
-        });
-      },
+      label: "Event UUID",
+      description: "The UUID of the scheduled event. Run **List Events** first to obtain event UUIDs.",
     },
     eventType: {
       type: "string",
-      label: "Event Type",
-      description: "An event type UUID",
-      async options({ prevContext }) {
-        return await this._makeAsyncOptionsRequest({
-          prevContext,
-          requestType: "listEventTypes",
-          optionsCallbackFn: this._getNameOptions,
-        });
-      },
+      label: "Event Type UUID",
+      description: "The UUID of the event type. Run **List Event Types** first to obtain event type UUIDs.",
     },
     groupId: {
       type: "string",
-      label: "Group ID",
-      description: "A group UUID",
-      async options({
-        prevContext, organization,
-      }) {
-        prevContext.organization = organization;
-        return await this._makeAsyncOptionsRequest({
-          prevContext,
-          requestType: "listGroups",
-          optionsCallbackFn: this._getNameOptions,
-        });
-      },
+      label: "Group UUID",
+      description: "The UUID of the group. Query `GET /groups` (Calendly API) to obtain group UUIDs.",
     },
     inviteeEmail: {
       type: "string",
@@ -99,8 +59,10 @@ export default {
     maxResults: {
       type: "integer",
       label: "Max Results",
-      description: "The number of rows to return",
+      description: "Maximum number of results to return (min 1, max 1000).",
       optional: true,
+      min: 1,
+      max: 1000,
     },
     scope: {
       type: "string",
@@ -325,6 +287,28 @@ export default {
       };
 
       return this._makeRequest(opts, $);
+    },
+    async getInvitee(eventUuid, inviteeUuid, $) {
+      const opts = {
+        path: `/scheduled_events/${eventUuid}/invitees/${inviteeUuid}`,
+      };
+
+      return axios(
+        $ ?? this,
+        this._makeRequestOpts(opts),
+      );
+    },
+    async cancelEvent(eventUuid, data, $) {
+      const opts = {
+        method: "POST",
+        path: `/scheduled_events/${eventUuid}/cancellation`,
+        data,
+      };
+
+      return axios(
+        $ ?? this,
+        this._makeRequestOpts(opts),
+      );
     },
     async listEventTypes(params, $) {
       const opts = {

--- a/components/calendly_v2/calendly_v2.app.mjs
+++ b/components/calendly_v2/calendly_v2.app.mjs
@@ -29,7 +29,7 @@ export default {
     groupId: {
       type: "string",
       label: "Group UUID",
-      description: "The UUID of the group. Query `GET /groups` (Calendly API) to obtain group UUIDs.",
+      description: "The UUID of the group. Run **List Groups** first to obtain group UUIDs.",
     },
     inviteeEmail: {
       type: "string",

--- a/components/calendly_v2/calendly_v2.app.mjs
+++ b/components/calendly_v2/calendly_v2.app.mjs
@@ -202,6 +202,12 @@ export default {
         throw new Error(`${error.response.data.title} - ${error.response.data.message}`);
       }
     },
+    async _makeSingleRequest(opts, $) {
+      return axios(
+        $ ?? this,
+        this._makeRequestOpts(opts),
+      );
+    },
     async getUserInfo(user, $) {
       const opts = {
         path: `/users/${user || "me"}`,
@@ -289,26 +295,16 @@ export default {
       return this._makeRequest(opts, $);
     },
     async getInvitee(eventUuid, inviteeUuid, $) {
-      const opts = {
+      return this._makeSingleRequest({
         path: `/scheduled_events/${eventUuid}/invitees/${inviteeUuid}`,
-      };
-
-      return axios(
-        $ ?? this,
-        this._makeRequestOpts(opts),
-      );
+      }, $);
     },
     async cancelEvent(eventUuid, data, $) {
-      const opts = {
+      return this._makeSingleRequest({
         method: "POST",
         path: `/scheduled_events/${eventUuid}/cancellation`,
         data,
-      };
-
-      return axios(
-        $ ?? this,
-        this._makeRequestOpts(opts),
-      );
+      }, $);
     },
     async listEventTypes(params, $) {
       const opts = {

--- a/components/calendly_v2/calendly_v2.app.mjs
+++ b/components/calendly_v2/calendly_v2.app.mjs
@@ -239,15 +239,9 @@ export default {
         params,
       };
 
-      return axios(
-        $ ?? this,
-        this._makeRequestOpts(opts),
-      );
+      return this._makeRequest(opts, $);
     },
-    async listEvents(params, uuid, $) {
-      if (uuid) {
-        params.user = this._buildUserUri(uuid);
-      }
+    async listEvents(params, $) {
       if (params.group) {
         params.group = this._buildGroupUri(params.group);
       }
@@ -309,10 +303,7 @@ export default {
     async listEventTypes(params, $) {
       const opts = {
         path: "/event_types",
-        params: {
-          user: await this.defaultUser($),
-          ...params,
-        },
+        params,
       };
 
       return this._makeRequest(opts, $);

--- a/components/calendly_v2/calendly_v2.app.mjs
+++ b/components/calendly_v2/calendly_v2.app.mjs
@@ -316,6 +316,14 @@ export default {
 
       return this._makeRequest(opts, $);
     },
+    async listWebhookSubscriptions(params, $) {
+      const opts = {
+        path: "/webhook_subscriptions",
+        params,
+      };
+
+      return this._makeRequest(opts, $);
+    },
     async createSchedulingLink(params, $) {
       params.owner = this._buildEventType(params.owner);
 

--- a/components/calendly_v2/common/constants.mjs
+++ b/components/calendly_v2/common/constants.mjs
@@ -1,3 +1,11 @@
+export const MEMBERSHIP_ROLE_OPTIONS = [
+  "owner",
+  "admin",
+  "user",
+];
+
+export const MAX_CANCELLATION_REASON_LENGTH = 10000;
+
 export default {
   scopes: [
     "user",
@@ -13,4 +21,6 @@ export default {
     "user",
     "group",
   ],
+  MEMBERSHIP_ROLE_OPTIONS,
+  MAX_CANCELLATION_REASON_LENGTH,
 };

--- a/components/calendly_v2/package.json
+++ b/components/calendly_v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/calendly_v2",
-  "version": "1.4.1",
+  "version": "1.4.0",
   "description": "Pipedream Calendly V2 Components",
   "main": "calendly_v2.app.mjs",
   "keywords": [

--- a/components/calendly_v2/package.json
+++ b/components/calendly_v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/calendly_v2",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Pipedream Calendly V2 Components",
   "main": "calendly_v2.app.mjs",
   "keywords": [

--- a/components/calendly_v2/package.json
+++ b/components/calendly_v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/calendly_v2",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "description": "Pipedream Calendly V2 Components",
   "main": "calendly_v2.app.mjs",
   "keywords": [

--- a/components/calendly_v2/sources/invitee-canceled/invitee-canceled.mjs
+++ b/components/calendly_v2/sources/invitee-canceled/invitee-canceled.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import common from "../common/common.mjs";
 
 export default {
@@ -5,7 +6,7 @@ export default {
   key: "calendly_v2-invitee-canceled",
   name: "New Invitee Canceled",
   description: "Emit new event when an event is canceled.",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/calendly_v2/sources/invitee-created/invitee-created.mjs
+++ b/components/calendly_v2/sources/invitee-created/invitee-created.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import common from "../common/common.mjs";
 
 export default {
@@ -5,7 +6,7 @@ export default {
   key: "calendly_v2-invitee-created",
   name: "New Invitee Created",
   description: "Emit new event when a new event is scheduled.",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/calendly_v2/sources/new-event-scheduled/new-event-scheduled.mjs
+++ b/components/calendly_v2/sources/new-event-scheduled/new-event-scheduled.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import { DEFAULT_POLLING_SOURCE_TIMER_INTERVAL } from "@pipedream/platform";
 import app from "../../calendly_v2.app.mjs";
 import sampleEmit from "./test-event.mjs";
@@ -6,7 +7,7 @@ export default {
   key: "calendly_v2-new-event-scheduled",
   name: "New Event Scheduled",
   description: "Emit new event when a event is scheduled.",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/calendly_v2/sources/routing-form-submission-created/routing-form-submission-created.mjs
+++ b/components/calendly_v2/sources/routing-form-submission-created/routing-form-submission-created.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import common from "../common/common.mjs";
 
 export default {
@@ -5,7 +6,7 @@ export default {
   key: "calendly_v2-routing-form-submission-created",
   name: "New Routing Form Submission Created",
   description: "Emit new event when a new routing form submission is created.",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "source",
   dedupe: "unique",
   methods: {


### PR DESCRIPTION
## Summary

AI-optimizes the `calendly_v2` MCP action set so an agent can manage bookings end to end, addressing the gaps called out in the issue. Each component is marked with `// x-pd-ai: optimized`.

## New actions
- **Cancel Event** — cancel a scheduled event (`POST /scheduled_events/{uuid}/cancellation`)
- **Get Event Invitee** — read a specific invitee's details, including `reschedule_url` (`GET /scheduled_events/{event_uuid}/invitees/{invitee_uuid}`)
- **List Event Types** — look up the event types available to book
- **List Organization Members** — see team members and their roles

## `list-events` improvements
- Removed the `scope` selector + `additionalProps` reveal pattern. `organization`, `user`, and `group` are now plain optional props that are **mutually exclusive** — a `ConfigurationError` is thrown if more than one is provided.
- Added `min_start_time` / `max_start_time` filters so events can be found by date range.
- Continues to support finding events by invitee email.

## Other
- Moved the `cancel-event` and `get-invitee` axios calls into `calendly_v2.app.mjs` (kept HTTP logic in the app file, consistent with the rest of the component).
- Added `MEMBERSHIP_ROLE_OPTIONS` and `MAX_CANCELLATION_REASON_LENGTH` constants.
- Added the `// x-pd-ai: optimized` marker to every action, source, and the app file; bumped affected component versions.

## Testing
Ran the tools against a live Calendly account via the MCP eval harness:
- `list-events` (no filter → authenticated user) — pass
- `list-events` (date-range window) — pass
- `get-invitee` (list events → list invitees → get invitee) — pass

`cancel-event` was not exercised against live data (destructive).

Closes #21467


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cancel scheduled events with an optional, length-limited cancellation reason.
  * Get a specific event invitee’s details.
  * List event types and organization memberships with filtering and pagination.
  * List groups.
  * List webhook subscriptions.
* **Enhancements**
  * Event listing now supports optional min/max start time filters and requires providing only one of Organization, User, or Group (otherwise uses the authenticated user).
  * Updated URI labels/descriptions, refined `maxResults` bounds, and improved webhook subscription input validation/parameter naming.
* **Maintenance**
  * Updated action/source definitions and bumped the component version to **1.4.0**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->