### PR TITLE
feat(ringba): add list campaigns action

### DIFF
--- a/components/ringba/actions/list-campaigns/README.md
+++ b/components/ringba/actions/list-campaigns/README.md
@@ -1,0 +1,17 @@
+# Overview
+
+Retrieve all active campaigns for a Ringba account. You can optionally include campaign statistics in the response.
+
+# Example Use Cases
+
+- Synchronize active campaign settings with a reporting or analytics system.
+- Audit campaign configuration as part of an automated workflow.
+- Retrieve campaign statistics before processing or sharing performance data.
+
+# Getting Started
+
+Connect your Ringba account, enter the Account ID that owns the campaigns, and choose whether the response should include statistics.
+
+# Troubleshooting
+
+Confirm that the connected Ringba account can access the supplied Account ID. If the request is unauthorized, reconnect the account or verify its permissions in Ringba.

--- a/components/ringba/actions/list-campaigns/list-campaigns.mjs
+++ b/components/ringba/actions/list-campaigns/list-campaigns.mjs
@@ -3,7 +3,7 @@ import ringba from "../../ringba.app.mjs";
 export default {
   key: "ringba-list-campaigns",
   name: "List Campaigns",
-  description: "Retrieve all active campaigns for a Ringba account. See the [documentation](https://developers.ringba.com/).",
+  description: "Retrieve active campaigns for the specified Ringba Account ID. Set Include Stats to true only when campaign statistics are needed because the response may be larger. [See the documentation](https://developers.ringba.com/)",
   type: "action",
   version: "0.0.1",
   annotations: {
@@ -13,11 +13,7 @@ export default {
   },
   props: {
     ringba,
-    accountId: {
-      ...ringba.propDefinitions.accountId,
-      label: "Account ID",
-      description: "The ID of the Ringba account whose campaigns should be retrieved.",
-    },
+    accountId: ringba.propDefinitions.accountId,
     includeStats: ringba.propDefinitions.includeStats,
   },
   async run({ $ }) {

--- a/components/ringba/actions/list-campaigns/list-campaigns.mjs
+++ b/components/ringba/actions/list-campaigns/list-campaigns.mjs
@@ -1,0 +1,54 @@
+import ringba from "../../ringba.app.mjs";
+
+export default {
+  key: "ringba-list-campaigns",
+  name: "List Campaigns",
+  description: "Retrieve all active campaigns for a Ringba account. See the [documentation](https://developers.ringba.com/).",
+  type: "action",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    ringba,
+    accountId: {
+      type: "string",
+      label: "Account ID",
+      description: "The ID of the Ringba account whose campaigns should be retrieved.",
+    },
+    includeStats: {
+      type: "boolean",
+      label: "Include Stats",
+      description: "Whether to include campaign statistics in the response.",
+      optional: true,
+      default: false,
+    },
+  },
+  async run({ $ }) {
+    const response = await this.ringba.listCampaigns({
+      $,
+      accountId: this.accountId,
+      params: {
+        includeStats: this.includeStats || undefined,
+      },
+    });
+
+    const campaigns = Array.isArray(response)
+      ? response
+      : response?.campaigns;
+    const count = campaigns?.length;
+
+    $.export(
+      "$summary",
+      count === undefined
+        ? `Successfully retrieved campaigns for account ${this.accountId}.`
+        : `Successfully retrieved ${count} campaign${count === 1
+          ? ""
+          : "s"}.`,
+    );
+
+    return response;
+  },
+};

--- a/components/ringba/actions/list-campaigns/list-campaigns.mjs
+++ b/components/ringba/actions/list-campaigns/list-campaigns.mjs
@@ -14,17 +14,11 @@ export default {
   props: {
     ringba,
     accountId: {
-      type: "string",
+      ...ringba.propDefinitions.accountId,
       label: "Account ID",
       description: "The ID of the Ringba account whose campaigns should be retrieved.",
     },
-    includeStats: {
-      type: "boolean",
-      label: "Include Stats",
-      description: "Whether to include campaign statistics in the response.",
-      optional: true,
-      default: false,
-    },
+    includeStats: ringba.propDefinitions.includeStats,
   },
   async run({ $ }) {
     const response = await this.ringba.listCampaigns({
@@ -38,17 +32,15 @@ export default {
     const campaigns = Array.isArray(response)
       ? response
       : response?.campaigns;
-    const count = campaigns?.length;
 
-    $.export(
-      "$summary",
-      count === undefined
-        ? `Successfully retrieved campaigns for account ${this.accountId}.`
-        : `Successfully retrieved ${count} campaign${count === 1
-          ? ""
-          : "s"}.`,
-    );
+    if (!Array.isArray(campaigns)) {
+      throw new Error("Ringba returned an unexpected campaigns response.");
+    }
 
-    return response;
+    $.export("$summary", `Successfully retrieved ${campaigns.length} campaign${campaigns.length === 1
+      ? ""
+      : "s"}.`);
+
+    return campaigns;
   },
 };

--- a/components/ringba/package.json
+++ b/components/ringba/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/ringba",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Pipedream ringba Components",
   "main": "ringba.app.mjs",
   "keywords": [

--- a/components/ringba/ringba.app.mjs
+++ b/components/ringba/ringba.app.mjs
@@ -1,11 +1,37 @@
+import { axios } from "@pipedream/platform";
+
 export default {
   type: "app",
   app: "ringba",
   propDefinitions: {},
   methods: {
-    // this.$auth contains connected account data
-    authKeys() {
-      console.log(Object.keys(this.$auth));
+    _baseUrl() {
+      return "https://api.ringba.com/v2";
+    },
+    _headers() {
+      return {
+        Authorization: `Bearer ${this.$auth.oauth_access_token}`,
+      };
+    },
+    _makeRequest({
+      $ = this,
+      path,
+      ...args
+    }) {
+      return axios($, {
+        url: `${this._baseUrl()}${path}`,
+        headers: this._headers(),
+        ...args,
+      });
+    },
+    listCampaigns({
+      accountId,
+      ...args
+    }) {
+      return this._makeRequest({
+        path: `/${accountId}/campaigns`,
+        ...args,
+      });
     },
   },
 };

--- a/components/ringba/ringba.app.mjs
+++ b/components/ringba/ringba.app.mjs
@@ -3,16 +3,47 @@ import { axios } from "@pipedream/platform";
 export default {
   type: "app",
   app: "ringba",
-  propDefinitions: {},
+  propDefinitions: {
+    accountId: {
+      type: "string",
+      label: "Account ID",
+      description: "The ID of the Ringba account.",
+    },
+    includeStats: {
+      type: "boolean",
+      label: "Include Stats",
+      description: "Whether to include campaign statistics in the response.",
+      optional: true,
+      default: false,
+    },
+  },
   methods: {
+    /**
+     * Get the base URL for Ringba API requests.
+     *
+     * @returns {String} The Ringba API base URL.
+     */
     _baseUrl() {
       return "https://api.ringba.com/v2";
     },
+    /**
+     * Get the headers for authenticated Ringba API requests.
+     *
+     * @returns {Object} The request headers.
+     */
     _headers() {
       return {
         Authorization: `Bearer ${this.$auth.oauth_access_token}`,
       };
     },
+    /**
+     * Make an authenticated request to the Ringba API.
+     *
+     * @param {Object} args - The request configuration.
+     * @param {Object} [args.$] - The Pipedream execution context.
+     * @param {String} args.path - The API path.
+     * @returns {Promise<Object|Array>} The API response.
+     */
     _makeRequest({
       $ = this,
       path,
@@ -24,6 +55,13 @@ export default {
         ...args,
       });
     },
+    /**
+     * List active campaigns for a Ringba account.
+     *
+     * @param {Object} args - The request configuration.
+     * @param {String} args.accountId - The Ringba account ID.
+     * @returns {Promise<Array>} The active campaigns.
+     */
     listCampaigns({
       accountId,
       ...args

--- a/components/ringba/ringba.app.mjs
+++ b/components/ringba/ringba.app.mjs
@@ -7,7 +7,7 @@ export default {
     accountId: {
       type: "string",
       label: "Account ID",
-      description: "The ID of the Ringba account.",
+      description: "The Ringba account ID, which starts with `RA` followed by 32 characters (for example, `RA999x99xx99x999x9xx9xxx9999x9x999`). In Ringba, click the person icon above the company name, then click the copy icon next to the company name.",
     },
     includeStats: {
       type: "boolean",


### PR DESCRIPTION
## Summary

- add a reusable authenticated Ringba API request helper
- add a read-only **List Campaigns** action for `GET /v2/{accountId}/campaigns`
- support Ringba's optional `includeStats` query parameter
- return the API response with a campaign-count summary when the response shape exposes a list

This implements the first campaign-focused slice of #20743 without overlapping the call-log work discussed there.

## Validation

- `pnpm exec eslint components/ringba/ringba.app.mjs components/ringba/actions/list-campaigns/list-campaigns.mjs components/ringba/package.json`
- `node --check` for both changed `.mjs` files
- focused Node import harness covering auth headers, endpoint construction, action props, response passthrough, and summary output
- repository pre-commit `lint-staged` hook

A live Ringba request was not run because it requires a connected Ringba account.

## Checklist

### Versioning

- [x] The new action starts at `0.0.1`
- [x] The Ringba app package version was updated from `0.6.0` to `0.7.0`

### New app

- [x] Ringba is already integrated

### CodeRabbit review

- [ ] I have addressed or acknowledged all of CodeRabbit's review comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Ringba “List Campaigns” action to retrieve active campaigns.
  * Added an option to include campaign statistics.
  * Enhanced Ringba integration with authenticated API requests and clear success reporting with the campaign count.
* **Bug Fixes**
  * Added response normalization and validation to ensure campaigns data is returned in the expected format.
* **Documentation**
  * Added action documentation covering setup, example use cases, and troubleshooting guidance.
* **Chores**
  * Bumped the Ringba component package version to 0.7.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->