### PR TITLE
Fix DataForB2B reasoning search company category

### DIFF
--- a/components/dataforb2b/actions/reasoning-search/reasoning-search.mjs
+++ b/components/dataforb2b/actions/reasoning-search/reasoning-search.mjs
@@ -64,7 +64,9 @@ export default {
       $,
       data: {
         query: this.query,
-        category: this.category === "company" ? "companies" : this.category,
+        category: this.category === "company"
+          ? "companies"
+          : this.category,
         max_results: this.maxResults,
         session_id: this.sessionId,
         enrich_live: this.enrichLive,

--- a/components/dataforb2b/actions/reasoning-search/reasoning-search.mjs
+++ b/components/dataforb2b/actions/reasoning-search/reasoning-search.mjs
@@ -5,7 +5,7 @@ export default {
   key: "dataforb2b-reasoning-search",
   name: "Reasoning Search",
   description: "Run a live reasoning-based search. Use this when you want the reasoning engine to iteratively interpret a natural-language query and return relevant people or company results. This is distinct from **Agentic Search**, which performs a one-shot LLM search. Provide a natural-language `query` and a `category` (`people` or `company`). [See the documentation](https://docs.dataforb2b.ai/api-reference/reasoning-search)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -64,7 +64,7 @@ export default {
       $,
       data: {
         query: this.query,
-        category: this.category,
+        category: this.category === "company" ? "companies" : this.category,
         max_results: this.maxResults,
         session_id: this.sessionId,
         enrich_live: this.enrichLive,

--- a/components/dataforb2b/package.json
+++ b/components/dataforb2b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/dataforb2b",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream DataForB2B Components",
   "main": "dataforb2b.app.mjs",
   "keywords": [


### PR DESCRIPTION
## Summary

- Translate the shared `company` category to the API-required `companies` value only for Reasoning Search.
- Preserve `people` unchanged and leave the shared category property intact for Agentic Search and Text to Filters, which require singular `company`.
- Bump the Reasoning Search action and DataForB2B package patch versions.

## Root cause and impact

The Reasoning Search action forwarded its shared category prop unchanged. The shared prop exposes `company`, while the `/search/reasoning` endpoint accepts `people` or `companies`, causing company searches to fail validation. This scoped translation fixes company searches without changing existing saved configurations or other DataForB2B actions.

Fixes #21489

## Validation

- `git diff --check`
- `node --check components/dataforb2b/actions/reasoning-search/reasoning-search.mjs`
- Parsed `components/dataforb2b/package.json` as JSON
- Executed the action module with mocked imports and verified:
  - `people` → `people`
  - `company` → `companies`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reasoning search requests by correctly formatting the selected company category.
  * Other category selections continue to be handled as before.
* **Improvements**
  * Updated the reasoning search action and package versions to reflect the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->