### PR TITLE
Zoom meeting recordings update

### DIFF
--- a/components/zoom/actions/add-meeting-registrant/add-meeting-registrant.mjs
+++ b/components/zoom/actions/add-meeting-registrant/add-meeting-registrant.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoom-add-meeting-registrant",
   name: "Add Meeting Registrant",
   description: "Registers a participant or multiple participants for a meeting. [See the documentation](https://developers.zoom.us/docs/api/rest/reference/zoom-api/methods/#operation/meetingRegistrantCreate)",
-  version: "0.3.11",
+  version: "0.3.12",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zoom/actions/add-webinar-registrant/add-webinar-registrant.mjs
+++ b/components/zoom/actions/add-webinar-registrant/add-webinar-registrant.mjs
@@ -4,7 +4,7 @@ export default {
   key: "zoom-add-webinar-registrant",
   name: "Add Webinar Registrant",
   description: "Registers a participant for a webinar. [See the docs here](https://marketplace.zoom.us/docs/api-reference/zoom-api/webinars/webinarregistrantcreate).",
-  version: "0.3.11",
+  version: "0.3.12",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zoom/actions/create-meeting/create-meeting.mjs
+++ b/components/zoom/actions/create-meeting/create-meeting.mjs
@@ -5,7 +5,7 @@ export default {
   key: "zoom-create-meeting",
   name: "Create Meeting",
   description: "Creates a meeting for a user. A maximum of 100 meetings can be created for a user in a day.",
-  version: "0.1.5",
+  version: "0.1.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zoom/actions/create-user/create-user.mjs
+++ b/components/zoom/actions/create-user/create-user.mjs
@@ -5,7 +5,7 @@ export default {
   key: "zoom-create-user",
   name: "Create User",
   description: "Creates a new user in your account.",
-  version: "0.2.5",
+  version: "0.2.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zoom/actions/delete-meeting/delete-meeting.mjs
+++ b/components/zoom/actions/delete-meeting/delete-meeting.mjs
@@ -4,7 +4,7 @@ export default {
   key: "zoom-delete-meeting",
   name: "Delete Meeting",
   description: "Delete a meeting. [See the documentation](https://developers.zoom.us/docs/api/meetings/#tag/meetings/delete/meetings/{meetingId})",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   annotations: {
     destructiveHint: true,

--- a/components/zoom/actions/delete-user/delete-user.mjs
+++ b/components/zoom/actions/delete-user/delete-user.mjs
@@ -5,7 +5,7 @@ export default {
   key: "zoom-delete-user",
   name: "Delete User",
   description: "Disassociates (unlinks) a user from the associated account or permanently deletes a user.",
-  version: "0.2.5",
+  version: "0.2.6",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/zoom/actions/get-current-user/get-current-user.mjs
+++ b/components/zoom/actions/get-current-user/get-current-user.mjs
@@ -4,7 +4,7 @@ export default {
   key: "zoom-get-current-user",
   name: "Get Current User",
   description: "Returns the authenticated Zoom user's ID, name, email, account ID, and timezone. Call this first when the user says 'my meetings', 'my recordings', or needs their Zoom identity. Use `id` with **Create Meeting**, `account_id` to scope queries, and `email` to match participants in **List Past Meeting Participants**. [See the documentation](https://developers.zoom.us/docs/api/users/#tag/users/GET/users/{userId}).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/zoom/actions/get-meeting-details/get-meeting-details.mjs
+++ b/components/zoom/actions/get-meeting-details/get-meeting-details.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoom-get-meeting-details",
   name: "Get Meeting Details",
   description: "Retrieves the details of a meeting.",
-  version: "0.3.7",
+  version: "0.3.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zoom/actions/get-meeting-recordings/get-meeting-recordings.mjs
+++ b/components/zoom/actions/get-meeting-recordings/get-meeting-recordings.mjs
@@ -1,9 +1,19 @@
+// x-pd-ai: optimized
 import zoom from "../../zoom.app.mjs";
+import utils from "../../common/utils.mjs";
 
 export default {
   key: "zoom-get-meeting-recordings",
   name: "Get Meeting Recordings",
-  description: "Get the recordings of a meeting. Returns recording metadata only — to obtain a working download URL for a recording, use **Get Recording Download Link**. [See the documentation](https://developers.zoom.us/docs/api/meetings/#tag/cloud-recording/get/meetings/{meetingId}/recordings)",
+  description: "Get the cloud recording metadata for one Zoom meeting."
+    + " Use when you need to know what a meeting recorded — its video, audio, chat, and transcript files — or to pick a specific file to download."
+    + " To find a meeting ID, call **List Meetings** or **List All Recordings** first."
+    + " Returns the meeting's details plus a `recording_files` array whose entries each carry `id`, `file_type`, `file_size`, `recording_type`, and `status`."
+    + " This is metadata only: the `download_url` on each file does not work on its own — pass that file's `id` to **Get Recording Download Link** to get a usable URL."
+    + " Example: call with meetingId=`84598792483` → returns the meeting's topic and start time plus recording files such as"
+    + " `{ id: \"a1b2c3d4-5e6f-7890-abcd-ef1234567890\", file_type: \"MP4\", recording_type: \"shared_screen_with_speaker_view\", file_size: 148203910, status: \"completed\" }`."
+    + " A meeting with no cloud recordings returns an empty `recording_files` array rather than an error, so check the array's length before reporting a failure."
+    + " [See the documentation](https://developers.zoom.us/docs/api/meetings/#tag/cloud-recording/get/meetings/{meetingId}/recordings)",
   version: "0.1.0",
   annotations: {
     destructiveHint: false,
@@ -21,7 +31,7 @@ export default {
           type: "previous_meetings",
         }),
       ],
-      description: "The meeting ID to get the recordings for",
+      description: "The meeting to get the recordings for. For a recurring meeting, pass the meeting **UUID** (available from **List All Recordings**) to target a specific occurrence — the numeric meeting ID always returns the most recent one.",
       optional: false,
     },
   },
@@ -32,12 +42,19 @@ export default {
         meetingId: this.meetingId,
       });
 
-      $.export("$summary", `Retrieved recordings for meeting ${this.meetingId}`);
+      const count = recordings?.recording_files?.length ?? 0;
+      $.export("$summary", `Retrieved ${utils.summaryEnd(count, "recording file")} for meeting ${this.meetingId}`);
       return recordings;
     } catch (error) {
+      // Zoom reports "this meeting has no cloud recordings" as 404/3301. That's an empty
+      // result rather than a failure, so return the same shape a hit would have — a caller
+      // can then read `recording_files` unconditionally instead of interpreting an error.
       if ((error.response?.status === 404) && (error.response?.data?.code === 3301)) {
-        $.export("$summary", "Recordings not found");
-        return {};
+        $.export("$summary", `No cloud recordings found for meeting ${this.meetingId}`);
+        return {
+          recording_files: [],
+          message: `Meeting ${this.meetingId} has no cloud recordings.`,
+        };
       }
       throw error;
     }

--- a/components/zoom/actions/get-meeting-recordings/get-meeting-recordings.mjs
+++ b/components/zoom/actions/get-meeting-recordings/get-meeting-recordings.mjs
@@ -3,8 +3,8 @@ import zoom from "../../zoom.app.mjs";
 export default {
   key: "zoom-get-meeting-recordings",
   name: "Get Meeting Recordings",
-  description: "Get the recordings of a meeting. [See the documentation](https://developers.zoom.us/docs/api/meetings/#tag/cloud-recording/get/meetings/{meetingId}/recordings)",
-  version: "0.0.2",
+  description: "Get the recordings of a meeting. Returns recording metadata only — to obtain a working download URL for a recording, use **Get Recording Download Link**. [See the documentation](https://developers.zoom.us/docs/api/meetings/#tag/cloud-recording/get/meetings/{meetingId}/recordings)",
+  version: "0.1.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -24,23 +24,12 @@ export default {
       description: "The meeting ID to get the recordings for",
       optional: false,
     },
-    downloadAccessToken: {
-      type: "boolean",
-      label: "Download Access Token",
-      description: "Whether to include the download access token in the response",
-      optional: true,
-    },
   },
   async run({ $ }) {
     try {
       const recordings = await this.zoom.getMeetingRecordings({
         $,
         meetingId: this.meetingId,
-        params: {
-          include_fields: this.downloadAccessToken
-            ? "download_access_token"
-            : undefined,
-        },
       });
 
       $.export("$summary", `Retrieved recordings for meeting ${this.meetingId}`);

--- a/components/zoom/actions/get-meeting-summary/get-meeting-summary.mjs
+++ b/components/zoom/actions/get-meeting-summary/get-meeting-summary.mjs
@@ -4,7 +4,7 @@ export default {
   key: "zoom-get-meeting-summary",
   name: "Get Meeting Summary",
   description: "Retrieve the summary of a meeting or webinar. [See the documentation](https://developers.zoom.us/docs/api/rest/reference/zoom-api/methods/#operation/Getameetingsummary)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/zoom/actions/get-meeting-transcript/get-meeting-transcript.mjs
+++ b/components/zoom/actions/get-meeting-transcript/get-meeting-transcript.mjs
@@ -7,7 +7,7 @@ export default {
   key: "zoom-get-meeting-transcript",
   name: "Get Meeting Transcript",
   description: "Get the transcript of a past meeting. Fetches the VTT file server-side using your OAuth token and returns speaker-attributed plain text alongside the original authenticated URL. [See the documentation](https://developers.zoom.us/docs/api/meetings/#tag/cloud-recording/get/meetings/{meetingId}/transcript)",
-  version: "0.1.0",
+  version: "0.1.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zoom/actions/get-recording-download-link/get-recording-download-link.mjs
+++ b/components/zoom/actions/get-recording-download-link/get-recording-download-link.mjs
@@ -1,0 +1,95 @@
+import { ConfigurationError } from "@pipedream/platform";
+import zoom from "../../zoom.app.mjs";
+
+const DEFAULT_TTL = 900;
+
+export default {
+  key: "zoom-get-recording-download-link",
+  name: "Get Recording Download Link",
+  description: "Generate a temporary, pre-signed download link for one Zoom cloud recording file. **This link contains a credential — anyone who has it can download the file without logging in to Zoom, until it expires.** [See the documentation](https://developers.zoom.us/docs/api/meetings/#tag/cloud-recording/get/meetings/{meetingId}/recordings)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  type: "action",
+  props: {
+    zoom,
+    meetingId: {
+      propDefinition: [
+        zoom,
+        "meetingId",
+        () => ({
+          type: "previous_meetings",
+        }),
+      ],
+      description: "The meeting whose recording you want a link for. For a recurring meeting, pass the meeting **UUID** (available from **List All Recordings**) to target a specific occurrence — the numeric meeting ID always returns the most recent one.",
+      optional: false,
+    },
+    recordingFileId: {
+      propDefinition: [
+        zoom,
+        "recordingFileId",
+        ({ meetingId }) => ({
+          meetingId,
+        }),
+      ],
+    },
+    ttl: {
+      type: "integer",
+      label: "TTL (seconds)",
+      description: `How long the link stays valid, in seconds. Defaults to 15 minutes (${DEFAULT_TTL}). Zoom allows up to \`604800\` (7 days).`,
+      optional: true,
+      default: DEFAULT_TTL,
+      min: 0,
+      max: 604800,
+    },
+  },
+  async run({ $: step }) {
+    const ttl = this.ttl ?? DEFAULT_TTL;
+
+    const {
+      file, recordings,
+    } = await this.zoom.getRecordingFile({
+      step,
+      meetingId: this.meetingId,
+      recordingFileId: this.recordingFileId,
+      params: {
+        include_fields: "download_access_token",
+        ttl,
+      },
+    });
+
+    // Zoom mints the token at the meeting level, not per file.
+    const token = recordings?.download_access_token;
+    if (!token) {
+      throw new ConfigurationError(
+        "Zoom did not return a download access token for this meeting. Cloud recording downloads "
+        + "may be restricted by an account-level setting.",
+      );
+    }
+
+    step.export(
+      "$summary",
+      `Generated a download link for the ${file.file_type} recording, valid for ${ttl} seconds`,
+    );
+
+    // Return the composed URL only — never the bare token, and never the raw Zoom
+    // response, which carries every other file's download_url for this meeting.
+    return {
+      downloadUrl: `${file.download_url}?access_token=${token}`,
+      expiresInSeconds: ttl,
+      // Approximate: Zoom starts the clock when it mints the token, moments before this runs.
+      expiresAt: new Date(Date.now() + (ttl * 1000)).toISOString(),
+      recordingId: file.id,
+      meetingId: this.meetingId,
+      fileType: file.file_type,
+      fileExtension: file.file_extension,
+      fileSize: file.file_size,
+      recordingType: file.recording_type,
+      recordingStart: file.recording_start,
+      recordingEnd: file.recording_end,
+    };
+  },
+};

--- a/components/zoom/actions/get-recording-download-link/get-recording-download-link.mjs
+++ b/components/zoom/actions/get-recording-download-link/get-recording-download-link.mjs
@@ -1,5 +1,4 @@
 // x-pd-ai: optimized
-import { ConfigurationError } from "@pipedream/platform";
 import zoom from "../../zoom.app.mjs";
 
 const DEFAULT_TTL = 900;
@@ -81,7 +80,7 @@ export default {
     // Zoom mints the token at the meeting level, not per file.
     const token = recordings?.download_access_token;
     if (!token) {
-      throw new ConfigurationError(
+      throw new Error(
         "Zoom did not return a download access token for this meeting. Cloud recording downloads "
         + "may be restricted by an account-level setting.",
       );

--- a/components/zoom/actions/get-recording-download-link/get-recording-download-link.mjs
+++ b/components/zoom/actions/get-recording-download-link/get-recording-download-link.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import zoom from "../../zoom.app.mjs";
 
@@ -6,7 +7,14 @@ const DEFAULT_TTL = 900;
 export default {
   key: "zoom-get-recording-download-link",
   name: "Get Recording Download Link",
-  description: "Generate a temporary, pre-signed download link for one Zoom cloud recording file. **This link contains a credential — anyone who has it can download the file without logging in to Zoom, until it expires.** [See the documentation](https://developers.zoom.us/docs/api/meetings/#tag/cloud-recording/get/meetings/{meetingId}/recordings)",
+  description: "Generate a temporary, pre-signed download link for one Zoom cloud recording file."
+    + " Use to download, fetch, or share a recording."
+    + " Call **Get Meeting Recordings** first to list a meeting's files and pass the `id` of the one you want, or omit **Recording File** to get the meeting's main video recording automatically."
+    + " Returns `downloadUrl`, `expiresAt`, `expiresInSeconds`, and the file's `recordingId`, `fileType`, `fileExtension`, `fileSize`, and recording start/end timestamps."
+    + " **This link contains a credential — anyone who has it can download the file without logging in to Zoom, until it expires.**"
+    + " Example: call with meetingId=`84598792483` and no recording file → returns"
+    + " `{ downloadUrl: \"https://us02web.zoom.us/rec/download/abc123?access_token=eyJ...\", expiresInSeconds: 900, fileType: \"MP4\", fileSize: 148203910 }`."
+    + " [See the documentation](https://developers.zoom.us/docs/api/meetings/#tag/cloud-recording/get/meetings/{meetingId}/recordings)",
   version: "0.0.1",
   annotations: {
     destructiveHint: false,
@@ -39,10 +47,10 @@ export default {
     ttl: {
       type: "integer",
       label: "TTL (seconds)",
-      description: `How long the link stays valid, in seconds. Defaults to 15 minutes (${DEFAULT_TTL}). Zoom allows up to \`604800\` (7 days).`,
+      description: `How long the link stays valid, in seconds. Defaults to 15 minutes (${DEFAULT_TTL}). Minimum \`60\` (1 minute), maximum \`604800\` (7 days).`,
       optional: true,
       default: DEFAULT_TTL,
-      min: 0,
+      min: 60,
       max: 604800,
     },
   },

--- a/components/zoom/actions/get-recording-download-link/get-recording-download-link.mjs
+++ b/components/zoom/actions/get-recording-download-link/get-recording-download-link.mjs
@@ -38,9 +38,6 @@ export default {
       propDefinition: [
         zoom,
         "recordingFileId",
-        ({ meetingId }) => ({
-          meetingId,
-        }),
       ],
     },
     ttl: {

--- a/components/zoom/actions/get-recording-download-link/get-recording-download-link.mjs
+++ b/components/zoom/actions/get-recording-download-link/get-recording-download-link.mjs
@@ -69,6 +69,15 @@ export default {
       },
     });
 
+    // On-premise recordings can come back without a `download_url`, and there is nothing
+    // to sign a token against — fail rather than return `undefined?access_token=...`.
+    if (!file?.download_url) {
+      throw new Error(
+        `Zoom returned no download URL for the ${file?.file_type ?? "selected"} recording file. `
+        + "Files stored on-premise cannot be downloaded through the cloud recording API.",
+      );
+    }
+
     // Zoom mints the token at the meeting level, not per file.
     const token = recordings?.download_access_token;
     if (!token) {

--- a/components/zoom/actions/get-webinar-details/get-webinar-details.mjs
+++ b/components/zoom/actions/get-webinar-details/get-webinar-details.mjs
@@ -4,7 +4,7 @@ export default {
   key: "zoom-get-webinar-details",
   name: "Get Webinar Details",
   description: "Gets details of a scheduled webinar. [See the docs here](https://marketplace.zoom.us/docs/api-reference/zoom-api/methods/#operation/webinar).",
-  version: "0.3.11",
+  version: "0.3.12",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zoom/actions/list-all-recordings/list-all-recordings.mjs
+++ b/components/zoom/actions/list-all-recordings/list-all-recordings.mjs
@@ -4,8 +4,8 @@ import zoom from "../../zoom.app.mjs";
 export default {
   key: "zoom-list-all-recordings",
   name: "List All Recordings",
-  description: "List all cloud recordings for a user. [See the documentation](https://developers.zoom.us/docs/api/rest/reference/zoom-api/methods/#operation/recordingsList)",
-  version: "0.0.1",
+  description: "List all cloud recordings for a user. Returns recording metadata only — to obtain a download link for a given recording, use **Get Recording Download Link**. [See the documentation](https://developers.zoom.us/docs/api/rest/reference/zoom-api/methods/#operation/recordingsList)",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/zoom/actions/list-call-recordings/list-call-recordings.mjs
+++ b/components/zoom/actions/list-call-recordings/list-call-recordings.mjs
@@ -4,7 +4,7 @@ export default {
   name: "List Call Recordings",
   description: "Get your account's call recordings. [See the documentation](https://developers.zoom.us/docs/api/rest/reference/phone/methods/#operation/getPhoneRecordings)",
   key: "zoom-list-call-recordings",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zoom/actions/list-channels/list-channels.mjs
+++ b/components/zoom/actions/list-channels/list-channels.mjs
@@ -5,7 +5,7 @@ export default {
   key: "zoom-list-channels",
   name: "List Channels",
   description: "List a user's chat channels.",
-  version: "0.1.5",
+  version: "0.1.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zoom/actions/list-meetings/list-meetings.mjs
+++ b/components/zoom/actions/list-meetings/list-meetings.mjs
@@ -5,7 +5,7 @@ export default {
   name: "List Meetings",
   description: "List meetings for a user. [See the documentation](https://developers.zoom.us/docs/api/rest/reference/zoom-api/methods/#operation/meetings)",
   key: "zoom-list-meetings",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/zoom/actions/list-past-meeting-participants/list-past-meeting-participants.mjs
+++ b/components/zoom/actions/list-past-meeting-participants/list-past-meeting-participants.mjs
@@ -5,7 +5,7 @@ export default {
   key: "zoom-list-past-meeting-participants",
   name: "List Past Meeting Participants",
   description: "Retrieve information on participants from a past meeting. [See the docs here](https://marketplace.zoom.us/docs/api-reference/zoom-api/methods/#operation/pastMeetingParticipants).",
-  version: "0.2.11",
+  version: "0.2.12",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zoom/actions/list-past-webinar-qa/list-past-webinar-qa.mjs
+++ b/components/zoom/actions/list-past-webinar-qa/list-past-webinar-qa.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoom-list-past-webinar-qa",
   name: "List Past Webinar Q&A",
   description: "The  feature for Webinars allows attendees to ask questions during the Webinar and for the panelists, co-hosts and host to answer their questions. Use this API to list Q&A of a specific Webinar.",
-  version: "0.1.7",
+  version: "0.1.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zoom/actions/list-user-call-logs/list-user-call-logs.mjs
+++ b/components/zoom/actions/list-user-call-logs/list-user-call-logs.mjs
@@ -4,7 +4,7 @@ export default {
   name: "List User's Call Logs",
   description: "Gets a user's Zoom phone call logs. [See the documentation](https://developers.zoom.us/docs/zoom-phone/apis/#operation/phoneUserCallLogs)",
   key: "zoom-list-user-call-logs",
-  version: "0.0.11",
+  version: "0.0.12",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zoom/actions/list-webinar-participants-report/list-webinar-participants-report.mjs
+++ b/components/zoom/actions/list-webinar-participants-report/list-webinar-participants-report.mjs
@@ -5,7 +5,7 @@ export default {
   key: "zoom-list-webinar-participants-report",
   name: "List Webinar Participants Report",
   description: "Retrieves detailed report on each webinar attendee. You can get webinar participant reports for the last 6 months. [See the docs here](https://marketplace.zoom.us/docs/api-reference/zoom-api/methods/#operation/reportWebinarParticipants).",
-  version: "0.0.12",
+  version: "0.0.13",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zoom/actions/send-chat-message/send-chat-message.mjs
+++ b/components/zoom/actions/send-chat-message/send-chat-message.mjs
@@ -5,7 +5,7 @@ export default {
   key: "zoom-send-chat-message",
   name: "Send Chat Message",
   description: "Send chat messages on Zoom to either an individual user who is in your contact list or to a  of which you are a member.",
-  version: "0.1.5",
+  version: "0.1.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zoom/actions/update-meeting/update-meeting.mjs
+++ b/components/zoom/actions/update-meeting/update-meeting.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoom-update-meeting",
   name: "Update Meeting",
   description: "Updates an existing Zoom meeting",
-  version: "0.1.7",
+  version: "0.1.8",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/zoom/actions/update-webinar/update-webinar.mjs
+++ b/components/zoom/actions/update-webinar/update-webinar.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoom-update-webinar",
   name: "Update Webinar",
   description: "Update a webinar's topic, start time, or other settings",
-  version: "0.1.7",
+  version: "0.1.8",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/zoom/actions/view-user/view-user.mjs
+++ b/components/zoom/actions/view-user/view-user.mjs
@@ -5,7 +5,7 @@ export default {
   key: "zoom-view-user",
   name: "View User",
   description: "View your user information",
-  version: "0.1.5",
+  version: "0.1.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zoom/common/utils.mjs
+++ b/components/zoom/common/utils.mjs
@@ -23,6 +23,53 @@ function doubleEncode(value) {
   return value;
 }
 
+const FILE_SIZE_UNITS = [
+  "B",
+  "KB",
+  "MB",
+  "GB",
+];
+
+function formatFileSize(bytes) {
+  if (!Number.isFinite(bytes)) {
+    return "unknown size";
+  }
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < FILE_SIZE_UNITS.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value.toFixed(unit === 0
+    ? 0
+    : 1)} ${FILE_SIZE_UNITS[unit]}`;
+}
+
+// Ordered preference used when the caller doesn't name a specific recording file.
+// A single meeting usually yields 5+ files (speaker-view MP4, audio-only M4A, chat
+// TXT, transcript VTT, timeline JSON); "the recording" almost always means the video.
+const FILE_PREFERENCE = [
+  (file) => file.file_type === "MP4" && file.recording_type === "shared_screen_with_speaker_view",
+  (file) => file.file_type === "MP4",
+  (file) => file.file_type === "M4A",
+];
+
+function selectRecordingFile(files = [], recordingFileId) {
+  const completed = files.filter(({ status }) => status === "completed");
+
+  if (recordingFileId) {
+    return completed.find(({ id }) => id === recordingFileId);
+  }
+
+  for (const predicate of FILE_PREFERENCE) {
+    const matches = completed.filter(predicate);
+    if (matches.length) {
+      return matches.sort((a, b) => (b.file_size ?? 0) - (a.file_size ?? 0))[0];
+    }
+  }
+  return undefined;
+}
+
 function parseArray(value) {
   if (!value) {
     return undefined;
@@ -45,5 +92,7 @@ export default {
   streamIterator,
   summaryEnd,
   doubleEncode,
+  formatFileSize,
+  selectRecordingFile,
   parseArray,
 };

--- a/components/zoom/common/utils.mjs
+++ b/components/zoom/common/utils.mjs
@@ -23,28 +23,6 @@ function doubleEncode(value) {
   return value;
 }
 
-const FILE_SIZE_UNITS = [
-  "B",
-  "KB",
-  "MB",
-  "GB",
-];
-
-function formatFileSize(bytes) {
-  if (!Number.isFinite(bytes)) {
-    return "unknown size";
-  }
-  let value = bytes;
-  let unit = 0;
-  while (value >= 1024 && unit < FILE_SIZE_UNITS.length - 1) {
-    value /= 1024;
-    unit += 1;
-  }
-  return `${value.toFixed(unit === 0
-    ? 0
-    : 1)} ${FILE_SIZE_UNITS[unit]}`;
-}
-
 // Ordered preference used when the caller doesn't name a specific recording file.
 // A single meeting usually yields 5+ files (speaker-view MP4, audio-only M4A, chat
 // TXT, transcript VTT, timeline JSON); "the recording" almost always means the video.
@@ -92,7 +70,6 @@ export default {
   streamIterator,
   summaryEnd,
   doubleEncode,
-  formatFileSize,
   selectRecordingFile,
   parseArray,
 };

--- a/components/zoom/package.json
+++ b/components/zoom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/zoom",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Pipedream Zoom Components",
   "main": "zoom.app.mjs",
   "keywords": [

--- a/components/zoom/sources/custom-event/custom-event.mjs
+++ b/components/zoom/sources/custom-event/custom-event.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoom-custom-event",
   name: "Custom Events (Instant)",
   description: "Emit new events tied to your Zoom user or resources you own",
-  version: "0.1.10",
+  version: "0.1.11",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/zoom/sources/meeting-created/meeting-created.mjs
+++ b/components/zoom/sources/meeting-created/meeting-created.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoom-meeting-created",
   name: "Meeting Created (Instant)",
   description: "Emit new event each time a meeting is created where you're the host",
-  version: "0.1.10",
+  version: "0.1.11",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/zoom/sources/meeting-deleted/meeting-deleted.mjs
+++ b/components/zoom/sources/meeting-deleted/meeting-deleted.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoom-meeting-deleted",
   name: "Meeting Deleted (Instant)",
   description: "Emit new event each time a meeting is deleted where you're the host",
-  version: "0.1.10",
+  version: "0.1.11",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/zoom/sources/meeting-ended/meeting-ended.mjs
+++ b/components/zoom/sources/meeting-ended/meeting-ended.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoom-meeting-ended",
   name: "Meeting Ended (Instant)",
   description: "Emit new event each time a meeting ends where you're the host",
-  version: "0.1.10",
+  version: "0.1.11",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/zoom/sources/meeting-started/meeting-started.mjs
+++ b/components/zoom/sources/meeting-started/meeting-started.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoom-meeting-started",
   name: "Meeting Started (Instant)",
   description: "Emit new event each time a meeting starts where you're the host",
-  version: "0.1.11",
+  version: "0.1.12",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/zoom/sources/meeting-updated/meeting-updated.mjs
+++ b/components/zoom/sources/meeting-updated/meeting-updated.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoom-meeting-updated",
   name: "Meeting Updated (Instant)",
   description: "Emit new event each time a meeting is updated where you're the host",
-  version: "0.1.10",
+  version: "0.1.11",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/zoom/sources/new-recording-transcript-completed/new-recording-transcript-completed.mjs
+++ b/components/zoom/sources/new-recording-transcript-completed/new-recording-transcript-completed.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoom-new-recording-transcript-completed",
   name: "New Recording Transcript Completed (Instant)",
   description: "Emit new event each time a recording transcript is completed",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/zoom/sources/phone-event/phone-event.mjs
+++ b/components/zoom/sources/phone-event/phone-event.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoom-phone-event",
   name: "Zoom Phone Events (Instant)",
   description: "Emit new Zoom Phone event tied to your Zoom user or resources you own",
-  version: "0.1.10",
+  version: "0.1.11",
   type: "source",
   props: {
     ...common.props,

--- a/components/zoom/sources/recording-completed/recording-completed.mjs
+++ b/components/zoom/sources/recording-completed/recording-completed.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoom-recording-completed",
   name: "Recording Completed (Instant)",
   description: "Emit new event each time a new recording completes for a meeting or webinar where you're the host",
-  version: "0.1.10",
+  version: "0.1.11",
   type: "source",
   dedupe: "unique",
   props: {
@@ -95,7 +95,12 @@ export default {
     emitEvent(file, meeting, downloadToken = null) {
       this.$emit(
         {
-          download_url_with_token: `${file.download_url}?access_token=${downloadToken}`,
+          // Only compose the pre-signed URL when a token is actually present. The
+          // `deploy()` backfill has no token, and emitting `?access_token=null` there
+          // produced a URL that looked usable but always failed.
+          ...(downloadToken && {
+            download_url_with_token: `${file.download_url}?access_token=${downloadToken}`,
+          }),
           download_token: downloadToken,
           ...file,
           meeting_id_long: meeting.id, // Long ID is necessary for certain API operations
@@ -116,11 +121,18 @@ export default {
       console.log("Not a recording.completed event. Exiting");
       return;
     }
-    const { payload } = event;
+    // Zoom documents `download_token` at the top level of the webhook body, but this
+    // source has always read it from `payload`. Accept either, so the token is picked up
+    // regardless of which location is correct.
+    const {
+      payload,
+      download_token: topLevelToken,
+    } = event;
     const {
       object,
-      download_token: downloadToken,
+      download_token: payloadToken,
     } = payload;
+    const downloadToken = topLevelToken ?? payloadToken ?? null;
     const { recording_files: recordingFiles } = object;
 
     if (!this.isMeetingRelevant(object)) {

--- a/components/zoom/sources/recording-completed/recording-completed.mjs
+++ b/components/zoom/sources/recording-completed/recording-completed.mjs
@@ -95,10 +95,12 @@ export default {
     emitEvent(file, meeting, downloadToken = null) {
       this.$emit(
         {
-          // Only compose the pre-signed URL when a token is actually present. The
-          // `deploy()` backfill has no token, and emitting `?access_token=null` there
-          // produced a URL that looked usable but always failed.
-          ...(downloadToken && {
+          // Only compose the pre-signed URL when both a token and a download URL are
+          // present. The `deploy()` backfill has no token, and on-premise recordings can
+          // omit `download_url` — either case produced a URL that looked usable but
+          // always failed. `download_token` is always emitted separately, for consumers
+          // that use the recommended `Authorization: Bearer <download_token>` header.
+          ...(downloadToken && file.download_url && {
             download_url_with_token: `${file.download_url}?access_token=${downloadToken}`,
           }),
           download_token: downloadToken,

--- a/components/zoom/sources/webinar-created/webinar-created.mjs
+++ b/components/zoom/sources/webinar-created/webinar-created.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoom-webinar-created",
   name: "Webinar Created (Instant)",
   description: "Emit new event each time a webinar is created where you're the host",
-  version: "0.1.10",
+  version: "0.1.11",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/zoom/sources/webinar-deleted/webinar-deleted.mjs
+++ b/components/zoom/sources/webinar-deleted/webinar-deleted.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoom-webinar-deleted",
   name: "Webinar Deleted (Instant)",
   description: "Emit new event each time a webinar is deleted where you're the host",
-  version: "0.1.10",
+  version: "0.1.11",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/zoom/sources/webinar-ended/webinar-ended.mjs
+++ b/components/zoom/sources/webinar-ended/webinar-ended.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoom-webinar-ended",
   name: "Webinar Ended (Instant)",
   description: "Emit new event each time a webinar ends where you're the host",
-  version: "0.1.10",
+  version: "0.1.11",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/zoom/sources/webinar-started/webinar-started.mjs
+++ b/components/zoom/sources/webinar-started/webinar-started.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoom-webinar-started",
   name: "Webinar Started (Instant)",
   description: "Emit new event each time a webinar starts where you're the host",
-  version: "0.1.10",
+  version: "0.1.11",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/zoom/sources/webinar-updated/webinar-updated.mjs
+++ b/components/zoom/sources/webinar-updated/webinar-updated.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zoom-webinar-updated",
   name: "Webinar Updated (Instant)",
   description: "Emit new event each time a webinar is updated where you're the host",
-  version: "0.1.10",
+  version: "0.1.11",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/zoom/zoom.app.mjs
+++ b/components/zoom/zoom.app.mjs
@@ -63,22 +63,8 @@ export default {
     recordingFileId: {
       type: "string",
       label: "Recording File",
-      description: "The specific recording file to act on. Leave empty to use the meeting's main video recording (falls back to the largest MP4, then the audio-only file). To choose a file explicitly, select a meeting first, or call **Get Meeting Recordings** and pass one of the `recording_files[].id` values it returns.",
+      description: "The specific recording file to act on. Leave empty to use the meeting's main video recording (falls back to the largest MP4, then the audio-only file). To choose a file explicitly, call **Get Meeting Recordings** for the same meeting and pass one of the `recording_files[].id` values it returns (only files with `status` `completed` can be used).",
       optional: true,
-      async options({ meetingId }) {
-        if (!meetingId) {
-          return [];
-        }
-        const { recording_files: files = [] } = await this.getMeetingRecordings({
-          meetingId,
-        });
-        return files
-          .filter(({ status }) => status === "completed")
-          .map((file) => ({
-            label: `${file.recording_type ?? file.file_type} — ${file.file_type} (${utils.formatFileSize(file.file_size)})`,
-            value: file.id,
-          }));
-      },
     },
     occurrenceId: {
       type: "string",

--- a/components/zoom/zoom.app.mjs
+++ b/components/zoom/zoom.app.mjs
@@ -63,7 +63,7 @@ export default {
     recordingFileId: {
       type: "string",
       label: "Recording File",
-      description: "The specific recording file to act on. Select a meeting first. Leave empty to use the meeting's main video recording (falls back to the largest MP4, then the audio-only file).",
+      description: "The specific recording file to act on. Leave empty to use the meeting's main video recording (falls back to the largest MP4, then the audio-only file). To choose a file explicitly, select a meeting first, or call **Get Meeting Recordings** and pass one of the `recording_files[].id` values it returns.",
       optional: true,
       async options({ meetingId }) {
         if (!meetingId) {

--- a/components/zoom/zoom.app.mjs
+++ b/components/zoom/zoom.app.mjs
@@ -1,4 +1,6 @@
-import { axios } from "@pipedream/platform";
+import {
+  axios, ConfigurationError,
+} from "@pipedream/platform";
 import constants from "./common/constants.mjs";
 import utils from "./common/utils.mjs";
 
@@ -57,6 +59,26 @@ export default {
         };
       },
       optional: true,
+    },
+    recordingFileId: {
+      type: "string",
+      label: "Recording File",
+      description: "The specific recording file to act on. Select a meeting first. Leave empty to use the meeting's main video recording (falls back to the largest MP4, then the audio-only file).",
+      optional: true,
+      async options({ meetingId }) {
+        if (!meetingId) {
+          return [];
+        }
+        const { recording_files: files = [] } = await this.getMeetingRecordings({
+          meetingId,
+        });
+        return files
+          .filter(({ status }) => status === "completed")
+          .map((file) => ({
+            label: `${file.recording_type ?? file.file_type} — ${file.file_type} (${utils.formatFileSize(file.file_size)})`,
+            value: file.id,
+          }));
+      },
     },
     occurrenceId: {
       type: "string",
@@ -372,6 +394,60 @@ export default {
         path: `/meetings/${utils.doubleEncode(meetingId)}/recordings`,
         ...opts,
       });
+    },
+    /**
+     * Fetches a meeting's recordings and resolves a single file from them, failing with
+     * an actionable message when it can't. `recordingFileId` is optional — when omitted,
+     * the meeting's main video recording is selected (see `utils.selectRecordingFile`).
+     */
+    async getRecordingFile({
+      step, meetingId, recordingFileId, params,
+    }) {
+      const recordings = await this.getMeetingRecordings({
+        step,
+        meetingId,
+        params,
+      });
+      const files = recordings?.recording_files ?? [];
+
+      if (!files.length) {
+        throw new ConfigurationError(`No cloud recordings were found for meeting \`${meetingId}\`.`);
+      }
+
+      const file = utils.selectRecordingFile(files, recordingFileId);
+      if (file) {
+        return {
+          file,
+          recordings,
+        };
+      }
+
+      // Nothing usable resolved. Work out why, so the message names the next step
+      // rather than sending the caller after the wrong cause.
+      const candidates = recordingFileId
+        ? files.filter(({ id }) => id === recordingFileId)
+        : files;
+      const unfinished = candidates.filter(({ status }) => status !== "completed");
+
+      if (unfinished.length && unfinished.length === candidates.length) {
+        throw new ConfigurationError(
+          `This recording is not ready yet (status: ${unfinished[0].status}). Try again shortly.`,
+        );
+      }
+      if (recordingFileId) {
+        throw new ConfigurationError(
+          `No completed recording file with ID \`${recordingFileId}\` belongs to meeting \`${meetingId}\`. `
+          + "If this is a recurring meeting, the numeric meeting ID always resolves to the most recent "
+          + "occurrence — pass the meeting **UUID** instead to target a specific date.",
+        );
+      }
+      const available = [
+        ...new Set(files.map(({ file_type: fileType }) => fileType)),
+      ].join(", ");
+      throw new ConfigurationError(
+        "This meeting has no video or audio recording to select automatically. "
+        + `Available file types: ${available}. Set **Recording File** to choose one explicitly.`,
+      );
     },
     async listMeetingsOccurrences(meetingId) {
       try {


### PR DESCRIPTION
The main change is to remove the token/credentials from the `Get Meeting Recordings` action, since users may not even be aware that all recordings are returned here (and if they share a conversation, they'd be leaking them).

The newly added `Get Recording Download Link` action retrieves the actual download URL with a customizable TTL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generate temporary download links for selected or default Zoom recording files.
  * Select completed recording files by ID or automatically choose the most suitable file.
  * View recording metadata, including file size, expiration details, and file count.
* **Bug Fixes**
  * Improved handling for meetings without cloud recordings.
  * Prevented invalid download links when recording access details are unavailable.
* **Documentation**
  * Clarified recording listings, download workflows, and recurring-meeting ID guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->