### PR TITLE
Google Sheets - fix additionalProps returning undefined when sheet has no headers

### DIFF
--- a/components/google_sheets/actions/add-multiple-rows/add-multiple-rows.mjs
+++ b/components/google_sheets/actions/add-multiple-rows/add-multiple-rows.mjs
@@ -11,7 +11,7 @@ export default {
   key: "google_sheets-add-multiple-rows",
   name: "Add Multiple Rows",
   description: "Add multiple rows of data to a Google Sheet. [See the documentation](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/append)",
-  version: "0.2.20",
+  version: "0.2.21",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -92,6 +92,7 @@ export default {
         },
       };
     }
+    return props;
   },
   async run() {
     let inputValidated = true;

--- a/components/google_sheets/actions/update-multiple-rows/update-multiple-rows.mjs
+++ b/components/google_sheets/actions/update-multiple-rows/update-multiple-rows.mjs
@@ -9,7 +9,7 @@ export default {
   key: "google_sheets-update-multiple-rows",
   name: "Update Multiple Rows",
   description: "Update multiple rows in a spreadsheet defined by a range. [See the documentation](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/update)",
-  version: "0.1.18",
+  version: "0.1.19",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
@@ -88,6 +88,7 @@ export default {
         },
       };
     }
+    return props;
   },
   async run() {
     let inputValidated = true;

--- a/components/google_sheets/package.json
+++ b/components/google_sheets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_sheets",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Pipedream Google_sheets Components",
   "main": "google_sheets.app.mjs",
   "keywords": [


### PR DESCRIPTION
## WHY

`google_sheets-add-multiple-rows` and `google_sheets-update-multiple-rows` define `additionalProps()` as:

```js
async additionalProps() {
  const props = {};
  if (!this.sheetId || !this.worksheetId) {
    return props;
  }
  const worksheet = await this.getWorksheetById(this.sheetId, this.worksheetId);
  const rowHeaders = await getWorksheetHeaders(this, this.sheetId, worksheet?.properties?.title);
  if (rowHeaders.length) {
    return { headersDisplay: { /* alert */ } };
  }
  // <-- falls through: returns undefined
}
```

When `sheetId` and `worksheetId` are both set but the worksheet has **no header row** (e.g. a freshly created spreadsheet/worksheet), the function falls through and returns `undefined` instead of an object.

Through the Connect API, that `undefined` return makes the props reload fail with:

```
{"code":"UserError","message":"bad reloadProps response","name":"UserError"}
```

so dynamic-prop configuration (`components/props` reload after setting `worksheetId`) can never complete for an empty worksheet — which is exactly the state you're in when following the natural "create a spreadsheet, then add rows" flow. The sibling actions `add-single-row` and `update-row` already end their `additionalProps()` with `return props;` and are unaffected.

## Fix

Return the empty `props` object on the no-headers path in both actions. Patch version bumps included (component + `package.json`).

## Repro

1. Create a new spreadsheet with an empty worksheet.
2. Via the Connect API, configure `google_sheets-add-multiple-rows`: set `sheetId`, then set `worksheetId` (triggers `reloadProps`).
3. Reload fails with `bad reloadProps response`. With this patch, it returns the props catalog normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when adding or updating multiple spreadsheet rows without worksheet headers.
  * Prevented errors by safely handling cases where worksheet headers are unavailable or empty.

* **Chores**
  * Updated the Google Sheets integration and action versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->