### PR TITLE
fix(linear): require linear_app ^0.12.0 + move `fields` to app propDefinitions (follow-up to #21569)

### DIFF
--- a/components/linear/package.json
+++ b/components/linear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/linear",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Pipedream Linear Components",
   "main": "linear.app.mjs",
   "keywords": [
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@linear/sdk": "^55.1.0",
-    "@pipedream/linear_app": "^0.11.1",
+    "@pipedream/linear_app": "^0.12.0",
     "@pipedream/platform": "^3.3.0"
   }
 }

--- a/components/linear_app/actions/get-teams/get-teams.mjs
+++ b/components/linear_app/actions/get-teams/get-teams.mjs
@@ -64,11 +64,17 @@ export default {
       ],
       description: "Maximum number of teams to return. Defaults to 20 if not specified.",
     },
-    fields: fields.fieldsProp({
-      resource: "teams",
-      compact: COMPACT_FIELDS,
-      guidance: "Cycle settings (`cycleDuration`, `cycleCooldownTime`, `cycleStartDay`, …) and the auto-archive/auto-close periods are what make this response large; request them only when the question is about a team's configuration.",
-    }),
+    fields: {
+      propDefinition: [
+        linearApp,
+        "fields",
+      ],
+      description: fields.fieldsDescription({
+        resource: "teams",
+        compact: COMPACT_FIELDS,
+        guidance: "Cycle settings (`cycleDuration`, `cycleCooldownTime`, `cycleStartDay`, …) and the auto-archive/auto-close periods are what make this response large; request them only when the question is about a team's configuration.",
+      }),
+    },
   },
   async run({ $ }) {
     // Use the specified limit or default to a reasonable number

--- a/components/linear_app/actions/get-view-issues/get-view-issues.mjs
+++ b/components/linear_app/actions/get-view-issues/get-view-issues.mjs
@@ -45,11 +45,17 @@ export default {
       description: "The cursor to return the next page of issues",
       optional: true,
     },
-    fields: fields.fieldsProp({
-      resource: "issues",
-      compact: fieldSets.issue.compact,
-      guidance: fieldSets.issue.guidance,
-    }),
+    fields: {
+      propDefinition: [
+        linearApp,
+        "fields",
+      ],
+      description: fields.fieldsDescription({
+        resource: "issues",
+        compact: fieldSets.issue.compact,
+        guidance: fieldSets.issue.guidance,
+      }),
+    },
   },
   async run({ $ }) {
     const { filterData } = await this.linearApp.getCustomView(this.viewId);

--- a/components/linear_app/actions/list-comments/list-comments.mjs
+++ b/components/linear_app/actions/list-comments/list-comments.mjs
@@ -86,11 +86,17 @@ export default {
       description: "The cursor to return the next page of comments",
       optional: true,
     },
-    fields: fields.fieldsProp({
-      resource: "comments",
-      compact: COMPACT_FIELDS,
-      guidance: "The nested `issue` object and `reactionData` are repeated on every comment; request them only when you need more than the thread itself.",
-    }),
+    fields: {
+      propDefinition: [
+        linearApp,
+        "fields",
+      ],
+      description: fields.fieldsDescription({
+        resource: "comments",
+        compact: COMPACT_FIELDS,
+        guidance: "The nested `issue` object and `reactionData` are repeated on every comment; request them only when you need more than the thread itself.",
+      }),
+    },
   },
   async run({ $ }) {
     const variables = {

--- a/components/linear_app/actions/list-initiatives/list-initiatives.mjs
+++ b/components/linear_app/actions/list-initiatives/list-initiatives.mjs
@@ -75,11 +75,17 @@ export default {
       description: "The cursor to return the next page of initiatives",
       optional: true,
     },
-    fields: fields.fieldsProp({
-      resource: "initiatives",
-      compact: COMPACT_FIELDS,
-      guidance: "`content` is the initiative's full markdown body and is usually the largest field; request it only when the initiative's write-up is what you need.",
-    }),
+    fields: {
+      propDefinition: [
+        linearApp,
+        "fields",
+      ],
+      description: fields.fieldsDescription({
+        resource: "initiatives",
+        compact: COMPACT_FIELDS,
+        guidance: "`content` is the initiative's full markdown body and is usually the largest field; request it only when the initiative's write-up is what you need.",
+      }),
+    },
   },
   async run({ $ }) {
     const variables = {

--- a/components/linear_app/actions/list-projects/list-projects.mjs
+++ b/components/linear_app/actions/list-projects/list-projects.mjs
@@ -81,11 +81,17 @@ export default {
       description: "The cursor to return the next page of projects",
       optional: true,
     },
-    fields: fields.fieldsProp({
-      resource: "projects",
-      compact: COMPACT_FIELDS,
-      guidance: "The `*History` arrays (`issueCountHistory`, `scopeHistory`, `completedScopeHistory`, `completedIssueCountHistory`, `inProgressScopeHistory`) are the bulk of the response — request them only when charting a project's progress over time.",
-    }),
+    fields: {
+      propDefinition: [
+        linearApp,
+        "fields",
+      ],
+      description: fields.fieldsDescription({
+        resource: "projects",
+        compact: COMPACT_FIELDS,
+        guidance: "The `*History` arrays (`issueCountHistory`, `scopeHistory`, `completedScopeHistory`, `completedIssueCountHistory`, `inProgressScopeHistory`) are the bulk of the response — request them only when charting a project's progress over time.",
+      }),
+    },
   },
   async run({ $ }) {
     const variables = utils.buildVariables(this.after, {

--- a/components/linear_app/actions/list-views/list-views.mjs
+++ b/components/linear_app/actions/list-views/list-views.mjs
@@ -72,11 +72,17 @@ export default {
       description: "The cursor to return the next page of views",
       optional: true,
     },
-    fields: fields.fieldsProp({
-      resource: "views",
-      compact: COMPACT_FIELDS,
-      guidance: "`filterData`, `projectFilterData` and `filters` are serialized filter definitions and are the bulk of the response; request them only when inspecting how a view is configured.",
-    }),
+    fields: {
+      propDefinition: [
+        linearApp,
+        "fields",
+      ],
+      description: fields.fieldsDescription({
+        resource: "views",
+        compact: COMPACT_FIELDS,
+        guidance: "`filterData`, `projectFilterData` and `filters` are serialized filter definitions and are the bulk of the response; request them only when inspecting how a view is configured.",
+      }),
+    },
   },
   async run({ $ }) {
     const variables = {

--- a/components/linear_app/actions/list-workflow-states/list-workflow-states.mjs
+++ b/components/linear_app/actions/list-workflow-states/list-workflow-states.mjs
@@ -68,11 +68,17 @@ export default {
         "includeArchived",
       ],
     },
-    fields: fields.fieldsProp({
-      resource: "workflow states",
-      compact: COMPACT_FIELDS,
-      guidance: "The nested `team` object is repeated on every state and is the bulk of an unfiltered response; request it only when you need to know which team a state belongs to.",
-    }),
+    fields: {
+      propDefinition: [
+        linearApp,
+        "fields",
+      ],
+      description: fields.fieldsDescription({
+        resource: "workflow states",
+        compact: COMPACT_FIELDS,
+        guidance: "The nested `team` object is repeated on every state and is the bulk of an unfiltered response; request it only when you need to know which team a state belongs to.",
+      }),
+    },
   },
   async run({ $ }) {
     const variables = {

--- a/components/linear_app/actions/search-issues/search-issues.mjs
+++ b/components/linear_app/actions/search-issues/search-issues.mjs
@@ -98,11 +98,17 @@ export default {
       ],
       description: "Maximum issues to return across all pages. Defaults to 25 when a `query` is given and 20 when it is not. Raise it only when you genuinely need more, and pair a raised limit with `fields: \"compact\"` — full-width issues in the hundreds will not fit in an AI agent's tool result.",
     },
-    fields: fields.fieldsProp({
-      resource: "issues",
-      compact: fieldSets.issue.compact,
-      guidance: fieldSets.issue.guidance,
-    }),
+    fields: {
+      propDefinition: [
+        linearApp,
+        "fields",
+      ],
+      description: fields.fieldsDescription({
+        resource: "issues",
+        compact: fieldSets.issue.compact,
+        guidance: fieldSets.issue.guidance,
+      }),
+    },
   },
   async run({ $ }) {
     const issues = [];

--- a/components/linear_app/common/fields.mjs
+++ b/components/linear_app/common/fields.mjs
@@ -25,20 +25,19 @@ import { ConfigurationError } from "@pipedream/platform";
 /**
  * Build the `fields` prop for an action.
  *
+ * The prop SCHEMA lives in the app file's `propDefinitions` (shared by every action
+ * that returns a record collection); this builds only the per-resource description
+ * that overrides it, naming that resource's compact set and its expensive fields.
+ *
  * @param {object} options
  * @param {string} options.resource - plural resource name used in the description ("teams")
  * @param {string[]} options.compact - what `compact` expands to
  * @param {string} options.guidance - one sentence naming this resource's expensive fields
  */
-function fieldsProp({
+function fieldsDescription({
   resource, compact, guidance,
 }) {
-  return {
-    type: "string",
-    label: "Fields",
-    description: `Which fields to return for each of the ${resource}, as a comma-separated list (e.g. \`${compact.slice(0, 3).join(",")}\`) — use this to keep the response small enough to work with. Shorthand: \`compact\` returns \`${compact.join(",")}\`, which is what most questions about ${resource} need. ${guidance} The \`id\` is always returned, so the record can still be referenced by later actions without listing again. **Leave blank to return every field** (the default, and the largest possible response).`,
-    optional: true,
-  };
+  return `Which fields to return for each of the ${resource}, as a comma-separated list (e.g. \`${compact.slice(0, 3).join(",")}\`) — use this to keep the response small enough to work with. Shorthand: \`compact\` returns \`${compact.join(",")}\`, which is what most questions about ${resource} need. ${guidance} The \`id\` is always returned, so the record can still be referenced by later actions without listing again. **Leave blank to return every field** (the default, and the largest possible response).`;
 }
 
 /** Parse the raw prop value into a field list, or undefined when blank. */
@@ -122,7 +121,7 @@ function projectRecords(records, raw, {
 }
 
 export default {
-  fieldsProp,
+  fieldsDescription,
   parseFields,
   projectRecords,
 };

--- a/components/linear_app/linear_app.app.mjs
+++ b/components/linear_app/linear_app.app.mjs
@@ -8,6 +8,20 @@ export default {
   type: "app",
   app: "linear_app",
   propDefinitions: {
+    // Shared by every action that returns a collection of records. The schema lives
+    // here because a prop used by more than one component belongs in the app file;
+    // each action overrides `description` with its own resource's compact set and
+    // expensive fields (built by common/fields.mjs `fieldsDescription`).
+    //
+    // No `options()`: the valid values differ per resource and are enumerated in the
+    // per-action description, and an async options call would not be reachable over
+    // MCP anyway.
+    fields: {
+      type: "string",
+      label: "Fields",
+      description: "Which fields to return for each record, as a comma-separated list. Shorthand: `compact` returns a small curated set. The `id` is always returned. Leave blank to return every field (the default, and the largest possible response).",
+      optional: true,
+    },
     teamId: {
       type: "string",
       label: "Team",

--- a/components/linear_app/package.json
+++ b/components/linear_app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/linear_app",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Pipedream Linear_app Components",
   "main": "linear_app.app.mjs",
   "keywords": [


### PR DESCRIPTION
> **🚧 DRAFT — do not merge until #21569 has merged AND `@pipedream/linear_app@0.12.0` is published to npm.**
> Based on `mcp/linear` so the diff shows only the follow-up changes. Retarget to `master` once #21569 merges.

## Why this is a separate PR

#21569 adds an optional `fields` payload param to the Linear actions. The implementation lives in `components/linear_app`; the `components/linear` OAuth actions are thin re-exports of it and carry matching descriptions.

This monorepo sets `link-workspace-packages=false`, so `@pipedream/linear_app` resolves from **npm**, not the workspace. `linear_app@0.12.0` doesn't exist there until #21569 merges and CI publishes it — so #21569 could not bump this dependency itself. Attempting it broke `pnpm install --frozen-lockfile` with `ERR_PNPM_OUTDATED_LOCKFILE` across four jobs.

Caret doesn't cross a 0.x minor, so `^0.11.1` will not pick up `0.12.0`. **Until this lands, the OAuth actions document a `fields` prop they don't actually have.** The API-key actions in `components/linear_app` are correct and complete as of #21569.

## What's here

**1. Dependency bump** — `components/linear` → `@pipedream/linear_app@^0.12.0`.

**2. The `propDefinitions` refactor CodeRabbit asked for** ([comment](https://github.com/PipedreamHQ/pipedream/pull/21569#discussion_r3718191661)). Eight actions each built the shared `fields` prop from a local helper; the schema now lives in `linear_app.app.mjs` and each action references it via `propDefinition`, overriding only `description` so per-resource guidance (compact set, expensive fields) is preserved. `fieldsProp()` becomes `fieldsDescription()`, returning just the override string.

This is why that refactor was declined on #21569 rather than skipped: `components/linear/linear.app.mjs` builds itself by spreading `...linearApp` imported from npm, so its `propDefinitions` come from the *published* package. Adding `fields` there while the OAuth app still resolved 0.11.1 would have made `getAppProps()`'s propDefinition rewrite fail and broken the OAuth actions outright. It's safe here because this PR moves the dependency in the same change.

## Before marking ready for review

1. Confirm `@pipedream/linear_app@0.12.0` is on npm.
2. Retarget this PR's base from `mcp/linear` to `master`.
3. Regenerate the lockfile — **required**, or CI fails:
   ```bash
   pnpm install --lockfile-only
   git add pnpm-lock.yaml && git commit -m "chore: update lockfile"
   ```
4. Verify the OAuth tool actually exposes the prop — MCP `listTools` on `linear-get-teams` should show `fields`.

## Verification so far

All eight actions confirmed to resolve `propDefinition: [linearApp, "fields"]` with a resource-specific description. `eslint` clean (0 errors). The live contract test can't run against these until `linear_app@0.12.0` publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)