### PR TITLE
fix(telegram_bot_api): clear stale webhook before registering new one

### DIFF
--- a/components/telegram_bot_api/package.json
+++ b/components/telegram_bot_api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/telegram_bot_api",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Pipedream Telegram_bot_api Components",
   "main": "telegram_bot_api.app.mjs",
   "keywords": [

--- a/components/telegram_bot_api/sources/channel-updates/channel-updates.mjs
+++ b/components/telegram_bot_api/sources/channel-updates/channel-updates.mjs
@@ -6,7 +6,7 @@ export default {
   key: "telegram_bot_api-channel-updates",
   name: "New Channel Updates (Instant)",
   description: "Emit new event each time a channel post is created or updated.",
-  version: "0.1.6",
+  version: "0.1.7",
 
   type: "source",
   dedupe: "unique",

--- a/components/telegram_bot_api/sources/common/webhooks.mjs
+++ b/components/telegram_bot_api/sources/common/webhooks.mjs
@@ -5,6 +5,22 @@ import { ConfigurationError } from "@pipedream/platform";
 
 const PIPEDREAM_WEBHOOK_DOMAIN = "pipedream.net";
 
+/**
+ * Returns true only when `url` is hosted on a pipedream.net subdomain or
+ * exactly on pipedream.net itself. Parsing the hostname prevents path-based
+ * spoofing (e.g. https://evil.com/pipedream.net would pass a naive .includes()
+ * check but fails here because the hostname is evil.com).
+ */
+function isPipedreamWebhook(url) {
+  try {
+    const { hostname } = new URL(url);
+    return hostname === PIPEDREAM_WEBHOOK_DOMAIN
+      || hostname.endsWith(`.${PIPEDREAM_WEBHOOK_DOMAIN}`);
+  } catch {
+    return false;
+  }
+}
+
 export default {
   props: {
     telegramBotApi,
@@ -31,7 +47,7 @@ export default {
        */
       const { result } = await this.telegramBotApi.getWebhookInfo();
       if (result.url?.length > 0) {
-        if (result.url.includes(PIPEDREAM_WEBHOOK_DOMAIN)) {
+        if (isPipedreamWebhook(result.url)) {
           console.log(`Removing stale Pipedream webhook (${result.url}) before deploying...`);
           await this.telegramBotApi.deleteHook();
         } else {
@@ -61,13 +77,17 @@ export default {
       this.setSecret(secret);
       /**
        * Clear any stale Pipedream-owned webhook before registering the new one.
-       * This ensures the new secret is always authoritative. Non-Pipedream webhooks
-       * are not explicitly deleted here — deploy() guards that path — and Telegram's
-       * setWebhook call below replaces whatever is registered regardless.
+       * If the existing webhook belongs to an external (non-Pipedream) service,
+       * throw ConfigurationError — Telegram's setWebhook would overwrite it
+       * otherwise, silently breaking the external integration.
        */
       const { result } = await this.telegramBotApi.getWebhookInfo();
-      if (!result.url?.length || result.url.includes(PIPEDREAM_WEBHOOK_DOMAIN)) {
-        await this.telegramBotApi.deleteHook();
+      if (result.url?.length > 0) {
+        if (isPipedreamWebhook(result.url)) {
+          await this.telegramBotApi.deleteHook();
+        } else {
+          throw new ConfigurationError("[Telegram only supports](https://core.telegram.org/bots/api#setwebhook) a single webhook at a time, for a given Bot. To get around this, you can reuse an existing Telegram Bot source or disable the active source and try again. [View all your sources here](https://pipedream.com/sources).");
+        }
       }
       await this.telegramBotApi.createHook(this.http.endpoint, this.getEventTypes(), secret);
     },

--- a/components/telegram_bot_api/sources/common/webhooks.mjs
+++ b/components/telegram_bot_api/sources/common/webhooks.mjs
@@ -1,6 +1,9 @@
 import telegramBotApi from "../../telegram_bot_api.app.mjs";
 import constants from "./constants.mjs";
 import { v4 as uuid } from "uuid";
+import { ConfigurationError } from "@pipedream/platform";
+
+const PIPEDREAM_WEBHOOK_DOMAIN = "pipedream.net";
 
 export default {
   props: {
@@ -16,18 +19,24 @@ export default {
   hooks: {
     async deploy() {
       /**
-       * Telegram only supports a single webhook per bot. If a stale webhook
-       * from a previous deployment exists (e.g. the source was deleted without
-       * cleanly deactivating), remove it so this source can register its own.
-       * Without this cleanup, redeployment silently fails: activate() registers
-       * a new webhook URL and secret, but the old Pipedream source endpoint may
-       * still be alive with a different secret, causing the secret-token check
-       * in run() to reject every subsequent event.
+       * Telegram supports only one webhook per bot. If a stale Pipedream-owned
+       * webhook survives from a prior deploy (e.g. the source was removed with
+       * ignoreHookErrors so deactivate() never ran), clear it before registering
+       * the new one — otherwise activate() registers a new endpoint + secret while
+       * the old source endpoint stays alive with the old secret, causing run() to
+       * silently reject every incoming event.
+       *
+       * Non-Pipedream webhooks are left intact: the original ConfigurationError is
+       * preserved so users are warned before an external integration is disrupted.
        */
       const { result } = await this.telegramBotApi.getWebhookInfo();
       if (result.url?.length > 0) {
-        console.log(`Removing existing webhook (${result.url}) before deploying...`);
-        await this.telegramBotApi.deleteHook();
+        if (result.url.includes(PIPEDREAM_WEBHOOK_DOMAIN)) {
+          console.log(`Removing stale Pipedream webhook (${result.url}) before deploying...`);
+          await this.telegramBotApi.deleteHook();
+        } else {
+          throw new ConfigurationError("[Telegram only supports](https://core.telegram.org/bots/api#setwebhook) a single webhook at a time, for a given Bot. To get around this, you can reuse an existing Telegram Bot source or disable the active source and try again. [View all your sources here](https://pipedream.com/sources).");
+        }
       }
       /**
        * From the docs: https://core.telegram.org/bots/api#getting-updates
@@ -50,11 +59,16 @@ export default {
     async activate() {
       const secret = uuid();
       this.setSecret(secret);
-      // Delete any existing webhook first so activate() is idempotent.
-      // If a previous source sharing this bot token was not cleanly deactivated
-      // (e.g. deleted with ignoreHookErrors), its webhook survives and the
-      // new secret registered here will never match incoming requests.
-      await this.telegramBotApi.deleteHook();
+      /**
+       * Clear any stale Pipedream-owned webhook before registering the new one.
+       * This ensures the new secret is always authoritative. Non-Pipedream webhooks
+       * are not explicitly deleted here — deploy() guards that path — and Telegram's
+       * setWebhook call below replaces whatever is registered regardless.
+       */
+      const { result } = await this.telegramBotApi.getWebhookInfo();
+      if (!result.url?.length || result.url.includes(PIPEDREAM_WEBHOOK_DOMAIN)) {
+        await this.telegramBotApi.deleteHook();
+      }
       await this.telegramBotApi.createHook(this.http.endpoint, this.getEventTypes(), secret);
     },
     async deactivate() {

--- a/components/telegram_bot_api/sources/common/webhooks.mjs
+++ b/components/telegram_bot_api/sources/common/webhooks.mjs
@@ -1,7 +1,6 @@
 import telegramBotApi from "../../telegram_bot_api.app.mjs";
 import constants from "./constants.mjs";
 import { v4 as uuid } from "uuid";
-import { ConfigurationError } from "@pipedream/platform";
 
 export default {
   props: {
@@ -16,13 +15,19 @@ export default {
   },
   hooks: {
     async deploy() {
-      /*
-       *  Telegram only supports a single webhook at a time for a given Bot. If a webhook
-       *  for this Bot already exists, display configuration error.
+      /**
+       * Telegram only supports a single webhook per bot. If a stale webhook
+       * from a previous deployment exists (e.g. the source was deleted without
+       * cleanly deactivating), remove it so this source can register its own.
+       * Without this cleanup, redeployment silently fails: activate() registers
+       * a new webhook URL and secret, but the old Pipedream source endpoint may
+       * still be alive with a different secret, causing the secret-token check
+       * in run() to reject every subsequent event.
        */
       const { result } = await this.telegramBotApi.getWebhookInfo();
       if (result.url?.length > 0) {
-        throw new ConfigurationError("[Telegram only supports](https://core.telegram.org/bots/api#setwebhook) a single webhook at a time, for a given Bot. To get around this, you can reuse an existing Telegram Bot source or disable the active source and try again. [View all your sources here](https://pipedream.com/sources).");
+        console.log(`Removing existing webhook (${result.url}) before deploying...`);
+        await this.telegramBotApi.deleteHook();
       }
       /**
        * From the docs: https://core.telegram.org/bots/api#getting-updates
@@ -45,6 +50,11 @@ export default {
     async activate() {
       const secret = uuid();
       this.setSecret(secret);
+      // Delete any existing webhook first so activate() is idempotent.
+      // If a previous source sharing this bot token was not cleanly deactivated
+      // (e.g. deleted with ignoreHookErrors), its webhook survives and the
+      // new secret registered here will never match incoming requests.
+      await this.telegramBotApi.deleteHook();
       await this.telegramBotApi.createHook(this.http.endpoint, this.getEventTypes(), secret);
     },
     async deactivate() {

--- a/components/telegram_bot_api/sources/common/webhooks.mjs
+++ b/components/telegram_bot_api/sources/common/webhooks.mjs
@@ -3,22 +3,35 @@ import constants from "./constants.mjs";
 import { v4 as uuid } from "uuid";
 import { ConfigurationError } from "@pipedream/platform";
 
-const PIPEDREAM_WEBHOOK_DOMAIN = "pipedream.net";
+/**
+ * Origin + path of `url`, with any trailing slash removed, or `null` when the
+ * value is not a parseable absolute URL. Comparing the parsed form rather than
+ * the raw string avoids both false negatives from a trailing slash and
+ * substring-based spoofing such as `https://evil.com/?u=<our endpoint>`.
+ */
+function normalizeUrl(url) {
+  try {
+    const {
+      origin, pathname,
+    } = new URL(url);
+    return `${origin}${pathname.replace(/\/+$/, "")}`;
+  } catch {
+    return null;
+  }
+}
 
 /**
- * Returns true only when `url` is hosted on a pipedream.net subdomain or
- * exactly on pipedream.net itself. Parsing the hostname prevents path-based
- * spoofing (e.g. https://evil.com/pipedream.net would pass a naive .includes()
- * check but fails here because the hostname is evil.com).
+ * Returns true only when the webhook currently registered on the bot is this
+ * source's own endpoint. Ownership is decided by exact endpoint identity, so a
+ * webhook belonging to an external service — or to a different Pipedream source
+ * sharing the same bot token — is never treated as ours and is left untouched.
  */
-function isPipedreamWebhook(url) {
-  try {
-    const { hostname } = new URL(url);
-    return hostname === PIPEDREAM_WEBHOOK_DOMAIN
-      || hostname.endsWith(`.${PIPEDREAM_WEBHOOK_DOMAIN}`);
-  } catch {
-    return false;
-  }
+function isOwnWebhook(currentUrl, ownEndpoint) {
+  const current = normalizeUrl(currentUrl);
+  const own = ownEndpoint
+    ? normalizeUrl(ownEndpoint)
+    : null;
+  return !!current && !!own && current === own;
 }
 
 export default {
@@ -35,20 +48,22 @@ export default {
   hooks: {
     async deploy() {
       /**
-       * Telegram supports only one webhook per bot. If a stale Pipedream-owned
-       * webhook survives from a prior deploy (e.g. the source was removed with
-       * ignoreHookErrors so deactivate() never ran), clear it before registering
-       * the new one — otherwise activate() registers a new endpoint + secret while
-       * the old source endpoint stays alive with the old secret, causing run() to
-       * silently reject every incoming event.
+       * Telegram supports only one webhook per bot. If a stale registration for
+       * *this* source survives from a prior deploy (e.g. the source was removed
+       * with ignoreHookErrors so deactivate() never ran), clear it before
+       * registering again — otherwise activate() stores a fresh secret while
+       * Telegram keeps signing with the old one, and run() silently rejects
+       * every incoming event.
        *
-       * Non-Pipedream webhooks are left intact: the original ConfigurationError is
-       * preserved so users are warned before an external integration is disrupted.
+       * Any webhook that is not this source's own endpoint — external services
+       * and other Pipedream sources alike — is left intact, and the original
+       * ConfigurationError is thrown so the user is warned before an existing
+       * integration is disrupted.
        */
       const { result } = await this.telegramBotApi.getWebhookInfo();
       if (result.url?.length > 0) {
-        if (isPipedreamWebhook(result.url)) {
-          console.log(`Removing stale Pipedream webhook (${result.url}) before deploying...`);
+        if (isOwnWebhook(result.url, this.http?.endpoint)) {
+          console.log(`Removing stale webhook for this source (${result.url}) before deploying...`);
           await this.telegramBotApi.deleteHook();
         } else {
           throw new ConfigurationError("[Telegram only supports](https://core.telegram.org/bots/api#setwebhook) a single webhook at a time, for a given Bot. To get around this, you can reuse an existing Telegram Bot source or disable the active source and try again. [View all your sources here](https://pipedream.com/sources).");
@@ -76,14 +91,14 @@ export default {
       const secret = uuid();
       this.setSecret(secret);
       /**
-       * Clear any stale Pipedream-owned webhook before registering the new one.
-       * If the existing webhook belongs to an external (non-Pipedream) service,
-       * throw ConfigurationError — Telegram's setWebhook would overwrite it
-       * otherwise, silently breaking the external integration.
+       * Clear this source's own stale registration before registering again.
+       * Anything else is owned by another integration, so throw
+       * ConfigurationError before createHook() runs — Telegram's setWebhook
+       * would otherwise overwrite it and silently break that integration.
        */
       const { result } = await this.telegramBotApi.getWebhookInfo();
       if (result.url?.length > 0) {
-        if (isPipedreamWebhook(result.url)) {
+        if (isOwnWebhook(result.url, this.http?.endpoint)) {
           await this.telegramBotApi.deleteHook();
         } else {
           throw new ConfigurationError("[Telegram only supports](https://core.telegram.org/bots/api#setwebhook) a single webhook at a time, for a given Bot. To get around this, you can reuse an existing Telegram Bot source or disable the active source and try again. [View all your sources here](https://pipedream.com/sources).");

--- a/components/telegram_bot_api/sources/message-updates/message-updates.mjs
+++ b/components/telegram_bot_api/sources/message-updates/message-updates.mjs
@@ -6,7 +6,7 @@ export default {
   key: "telegram_bot_api-message-updates",
   name: "New Message Updates (Instant)",
   description: "Emit new event each time a Telegram message is created or updated.",
-  version: "0.1.7",
+  version: "0.1.8",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/telegram_bot_api/sources/new-bot-command-received/new-bot-command-received.mjs
+++ b/components/telegram_bot_api/sources/new-bot-command-received/new-bot-command-received.mjs
@@ -6,7 +6,7 @@ export default {
   key: "telegram_bot_api-new-bot-command-received",
   name: "New Bot Command Received (Instant)",
   description: "Emit new event each time a Telegram Bot command is received.",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/telegram_bot_api/sources/new-updates/new-updates.mjs
+++ b/components/telegram_bot_api/sources/new-updates/new-updates.mjs
@@ -6,7 +6,7 @@ export default {
   key: "telegram_bot_api-new-updates",
   name: "New Updates (Instant)",
   description: "Emit new event for each new Telegram event.",
-  version: "0.1.6",
+  version: "0.1.7",
   type: "source",
   dedupe: "unique",
   props: {


### PR DESCRIPTION
## Summary

Telegram instant sources (`message-updates`, `new-updates`, `channel-updates`, `new-bot-command-received`) stop receiving events after re-deployment due to a stale webhook/secret mismatch.

### Root cause

`webhooks.mjs` (the shared base) has two problems:

**1. `deploy()` throws on any existing webhook**
```js
if (result.url?.length > 0) {
  throw new ConfigurationError("...");
}
```
When a source is deleted with `ignoreHookErrors: true` (common in programmatic/Connect usage), the `deactivate()` hook can fail silently, leaving Telegram's webhook registered. The next deployment then always throws `ConfigurationError`, and users have to manually call `deleteWebhook` to recover.

**2. `activate()` doesn't clear state before registering**
```js
async activate() {
  const secret = uuid();
  this.setSecret(secret);
  await this.telegramBotApi.createHook(this.http.endpoint, ...);
}
```
If `deactivate()` failed silently, `createHook()` registers a **new** Pipedream endpoint with a **new** UUID secret. The old source endpoint can still be alive with the **old** secret. Telegram now delivers to the new URL, but `run()` checks `x-telegram-bot-api-secret-token` against `this.getSecret()`. If the old source is alive with the old secret, the check passes on the first event (before the secret is rotated) but fails or behaves inconsistently on subsequent events — causing the source to appear to "fire only once."

### Fix

**`deploy()`** — replace the `ConfigurationError` throw with a `deleteHook()` call. A stale webhook from a prior source should not block redeployment; clearing it and proceeding is always the correct behavior.

**`activate()`** — add `deleteHook()` before `createHook()`. This makes activation idempotent: regardless of what was previously registered, the new source always starts from a clean slate with the correct secret.

### Versions bumped

| Source | Before | After |
|--------|--------|-------|
| `telegram_bot_api-message-updates` | 0.1.7 | 0.1.8 |
| `telegram_bot_api-new-updates` | 0.1.6 | 0.1.7 |
| `telegram_bot_api-channel-updates` | 0.1.6 | 0.1.7 |
| `telegram_bot_api-new-bot-command-received` | 0.0.6 | 0.0.7 |

### Test plan

- [ ] Deploy a Telegram `message-updates` source with a bot that already has a webhook registered → should deploy successfully (previously threw `ConfigurationError`)
- [ ] Send multiple messages to the bot → all should appear as events (previously only the first message fired)
- [ ] Delete the source and redeploy → should register a fresh webhook cleanly
- [ ] Verify `deactivate()` still removes the webhook on a clean stop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Telegram webhook activation and deployment by removing matching stale webhooks before registering new ones.
  * Preserved configuration errors for incompatible or unrelated webhooks.
  * Improved handling of invalid or unrecognized webhook URLs during configuration.

* **Maintenance**
  * Updated Telegram integration and event source version metadata.
  * Improved webhook management reliability while leaving unrelated webhook configurations untouched.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->