### PR TITLE
fix(speak_ai): read the webhook id the API actually returns, restore folder-scoped AI Chat

### DIFF
--- a/components/speak_ai/actions/list-folder-id-options/list-folder-id-options.mjs
+++ b/components/speak_ai/actions/list-folder-id-options/list-folder-id-options.mjs
@@ -3,7 +3,7 @@ import speak_ai from "../../speak_ai.app.mjs";
 export default {
   key: "speak_ai-list-folder-id-options",
   name: "List Folder ID Options",
-  description: "Retrieves available options for the Folder ID field.",
+  description: "Retrieves available options for the Folder ID field. [See the documentation](https://docs.speakai.co/api/folders/#get-folder).",
   version: "0.0.2",
   type: "action",
   annotations: {

--- a/components/speak_ai/actions/run-ai-chat/run-ai-chat.mjs
+++ b/components/speak_ai/actions/run-ai-chat/run-ai-chat.mjs
@@ -1,10 +1,11 @@
+import { ConfigurationError } from "@pipedream/platform";
 import app from "../../speak_ai.app.mjs";
 import constants from "../../common/constants.mjs";
 
 export default {
   key: "speak_ai-run-ai-chat",
   name: "Run AI Chat",
-  description: "Ask a question about one or more Speak AI media files and get the answer back. Requires at least one media file, and answers are only as good as the prompt, so be specific about the output wanted. Media must finish analyzing first. [See the documentation](https://docs.speakai.co/api/ai-chat/#post-prompt).",
+  description: "Ask a question about Speak AI media and get the answer back. Scope the question to specific media files, to a whole folder, or to both. Answers are only as good as the prompt, so be specific about the output wanted. Media must finish analyzing first. [See the documentation](https://docs.speakai.co/api/ai-chat/#post-prompt).",
   version: "0.0.1",
   annotations: {
     destructiveHint: false,
@@ -20,16 +21,28 @@ export default {
         "prompt",
       ],
     },
+    folderId: {
+      propDefinition: [
+        app,
+        "folderId",
+      ],
+      description: "Answer the prompt from every media file in this folder. Set this, **Media IDs**, or both",
+      optional: true,
+    },
     mediaIds: {
       propDefinition: [
         app,
         "mediaIds",
+        ({ folderId }) => ({
+          folderId,
+        }),
       ],
+      optional: true,
     },
     assistantType: {
       type: "string",
       label: "Assistant Type",
-      description: "The assistant persona used to answer the prompt. Defaults to `general`",
+      description: "The assistant persona used to answer the prompt: `general` (default), `researcher` for academic analysis, `marketer` for content, `sales` for deal insights, or `recruiter` for hiring",
       options: constants.ASSISTANT_TYPES,
       optional: true,
       default: "general",
@@ -39,20 +52,29 @@ export default {
     const {
       app,
       prompt,
+      folderId,
       mediaIds,
       assistantType,
     } = this;
+
+    if (!folderId && !mediaIds?.length) {
+      throw new ConfigurationError("Set **Folder ID**, **Media IDs**, or both, so the prompt has media to answer from.");
+    }
 
     const response = await app.runPrompt({
       $,
       data: {
         prompt,
+        folderId,
         mediaIds,
         assistantType,
       },
     });
 
-    $.export("$summary", `Successfully ran AI Chat against ${mediaIds.length} media file(s)`);
+    const promptId = response?.data?.promptId;
+    $.export("$summary", promptId
+      ? `Successfully ran AI Chat \`${promptId}\``
+      : "Successfully ran AI Chat");
     return response;
   },
 };

--- a/components/speak_ai/common/constants.mjs
+++ b/components/speak_ai/common/constants.mjs
@@ -7,6 +7,11 @@ const WEBHOOK_ID = "webhookId";
 
 const WEBHOOK_DESCRIPTION = "Created by Pipedream";
 
+// Attributes the subscription to Pipedream in Speak AI. The API defaults this to
+// `speak` when omitted, which makes Pipedream sources indistinguishable from
+// webhooks a user created by hand.
+const WEBHOOK_SOURCE = "pipedream";
+
 const ASSISTANT_TYPES = [
   "general",
   "researcher",
@@ -26,6 +31,7 @@ export default {
   DEFAULT_LIMIT,
   WEBHOOK_ID,
   WEBHOOK_DESCRIPTION,
+  WEBHOOK_SOURCE,
   ASSISTANT_TYPES,
   CAPTION_FILE_TYPES,
 };

--- a/components/speak_ai/sources/common/webhook.mjs
+++ b/components/speak_ai/sources/common/webhook.mjs
@@ -22,10 +22,18 @@ export default {
           data: {
             callbackUrl,
             events: getEvents(),
+            source: constants.WEBHOOK_SOURCE,
           },
         });
 
-      setWebhookId(response.data._id);
+      // `POST /v1/webhook` returns the new id as `data.webhookId`. `data._id` is
+      // read as a fallback only because an older API doc example showed it.
+      const webhookId = response?.data?.webhookId ?? response?.data?._id;
+      if (!webhookId) {
+        throw new ConfigurationError("Speak AI did not return a webhook ID, so this source could not be enabled.");
+      }
+
+      setWebhookId(webhookId);
     },
     async deactivate() {
       const {

--- a/components/speak_ai/speak_ai.app.mjs
+++ b/components/speak_ai/speak_ai.app.mjs
@@ -45,7 +45,7 @@ export default {
     prompt: {
       type: "string",
       label: "Prompt",
-      description: "The instruction or question to run against the selected media, e.g. `Summarize the key action items from this transcript`. Be as descriptive as possible to get an accurate answer",
+      description: "The question or instruction for the AI to answer about the media, e.g. `Summarize the key action items from this transcript`. Be as descriptive as possible to get an accurate answer",
     },
     mediaIds: {
       type: "string[]",


### PR DESCRIPTION
Targets `feat/speak_ai` so it can be merged into #21579 before that PR lands.

Thanks for picking this up and re-opening it as #21579. I went back through the review against the Speak AI server source and found one issue in the current branch that would ship a real bug, plus a couple of endpoint details where the API reference misled us. Everything below is checked against the route and validation code, not the docs.

## 1. The webhook id is read from the wrong field

`sources/common/webhook.mjs` stores `response.data._id`, but `POST /v1/webhook` returns the new subscription id as `data.webhookId`:

```js
return res.status(200).json(createSuccessResponse({ webhookId: webhook._id }));
```

So `data._id` is `undefined`, `setWebhookId()` persists nothing, and `deactivate()` hits its `if (webhookId)` guard and returns without calling `DELETE /v1/webhook/:webhookId`. **Disabling any of these sources leaves a live subscription on the user's account that keeps delivering forever.** Because this is the shared source base, it also regresses `new-media-created-instant` and `new-text-analyzed-instant`, which were reading `data.webhookId` correctly before.

This one is my fault for not flagging it earlier: the `_id` in our Create Webhook 200 example is stale. I'm fixing that example on our side so it doesn't catch anyone again.

This PR reads `data.webhookId` with `data._id` as a fallback, and throws instead of silently registering a webhook it can never remove.

## 2. `source: "pipedream"` on create

`webhookCreation` accepts an optional `source`, validated against a `WebhookEventSource` enum that already has a `pipedream` member, and defaults to `speak`. Without it, subscriptions created by these sources look identical to hand-made ones in the user's account. Now sent.

## 3. Folder-scoped AI Chat still works and is worth keeping

On the earlier review round the read was that `POST /v1/prompt` takes only `prompt`, `mediaIds` and `assistantType`, with `mediaIds` required. The endpoint's validation is:

```js
export const runChatRequest = Joi.object()
  .keys({
    folderId: Joi.string().optional().allow('').allow(null).default(''),
    mediaIds: Joi.array().items(Joi.string()).optional().allow(null),
    prompt: Joi.string().required(),
    assistantType: Joi.string().optional().allow(AssistantTypes).default(AssistantTypes.GENERAL),
    // ...
  })
  .or('folderId', 'mediaIds');
```

`folderId` is accepted, and `.or('folderId', 'mediaIds')` means either satisfies the request while neither is required alone. So "ask this question across a whole folder" is a supported call that the current props can't express. Our MCP docs for the same endpoint describe it the same way: https://docs.speakai.co/mcp/tools/magic-prompt/ask_ai_chat/

Both props are now optional, with a `ConfigurationError` if neither is set. `mediaIds` options are scoped by `folderId` when one is picked.

## 4. `promptId` is in the response

The 200 example in our API reference is abbreviated. The controller returns:

```js
return res.status(200).json(response.createSuccessResponse({ promptId, messageId, state, answer, totalMedia, references }));
```

The summary now uses `promptId` when present. I'm adding `promptId` and `messageId` to that doc example too.

## 5. `deliveryId` and `eventType` are on every delivery, so the current dedupe is right

Recording this so it doesn't get "fixed" later. The dispatcher builds each body as:

```js
const deliveryId = new Types.ObjectId().toHexString();
const body = { ...webhook.metaData, eventType: event, deliveryId };
```

Every delivery carries a fresh `deliveryId`, and retries of the same delivery reuse it. So `getEventId() => resource.deliveryId` with `dedupe: "unique"` is exactly right: `media.analyzed` and a later `media.reanalyzed` for the same media get distinct ids and both emit, while retries collapse. No change needed.

## Endpoints verified

Every path the component calls, checked against its route and validation:

| App method | Endpoint | Result |
| --- | --- | --- |
| `listFolders` | `GET /v1/folder` | ok |
| `listMedia` | `GET /v1/media` | ok |
| `getInsight` | `GET /v1/media/insight/:mediaId` | ok, `userId` is an optional query param |
| `getTextInsight` | `GET /v1/text/insight/:mediaId` | ok |
| `getTranscript` | `GET /v1/media/transcript/:mediaId` | ok |
| `exportMedia` | `POST /v1/media/export/:mediaId/:fileType` | ok, `srt` and `vtt` are valid types, body has no required keys |
| `listPrompts` | `GET /v1/prompt` | ok, returns `{ totalCount, pages, history }`, defaults to 25 per page, newest first |
| `runPrompt` | `POST /v1/prompt` | see 3 and 4 |
| `createWebhook` | `POST /v1/webhook` | see 1 and 2 |
| `deleteWebhook` | `DELETE /v1/webhook/:webhookId` | ok |
| `uploadMedia` | `POST /v1/media/upload` | ok |

All 16 event names in `sources/common/events.mjs` are valid members of the server's webhook event enum. Every documentation link in the component resolves, including the anchors, and `list-folder-id-options` now has one too.

No version bumps: everything touched here is unreleased on this branch, so the existing numbers still cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
