### PR TITLE
MS Outlook attachments fix

### DIFF
--- a/components/microsoft_outlook/microsoft_outlook.app.mjs
+++ b/components/microsoft_outlook/microsoft_outlook.app.mjs
@@ -190,8 +190,6 @@ export default {
           params: {
             $top: limit,
             $skip: limit * page,
-            // Without $select, Graph returns the full base64 contentBytes for every
-            // fileAttachment — megabytes per option just to label a dropdown.
             $select: "id,name",
           },
         });

--- a/components/microsoft_outlook/microsoft_outlook.app.mjs
+++ b/components/microsoft_outlook/microsoft_outlook.app.mjs
@@ -190,6 +190,9 @@ export default {
           params: {
             $top: limit,
             $skip: limit * page,
+            // Without $select, Graph returns the full base64 contentBytes for every
+            // fileAttachment — megabytes per option just to label a dropdown.
+            $select: "id,name",
           },
         });
         return attachments?.map(({

--- a/components/microsoft_outlook/package.json
+++ b/components/microsoft_outlook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/microsoft_outlook",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "description": "Pipedream Microsoft Outlook Components",
   "main": "microsoft_outlook.app.mjs",
   "keywords": [

--- a/components/microsoft_outlook/sources/common/common-new-email.mjs
+++ b/components/microsoft_outlook/sources/common/common-new-email.mjs
@@ -60,6 +60,9 @@ export default {
     async getMessageAttachments(message) {
       const { value: attachments } = await this.microsoftOutlook.listAttachments({
         messageId: message.id,
+        params: {
+          $select: "id,name,contentType,size,isInline,lastModifiedDateTime",
+        },
       });
       if (!attachments?.length) {
         return [];

--- a/components/microsoft_outlook/sources/new-attachment-received/new-attachment-received.mjs
+++ b/components/microsoft_outlook/sources/new-attachment-received/new-attachment-received.mjs
@@ -7,7 +7,7 @@ export default {
   key: "microsoft_outlook-new-attachment-received",
   name: "New Attachment Received (Instant)",
   description: "Emit new event when a new email containing one or more attachments arrives in a specified Microsoft Outlook folder.",
-  version: "0.1.21",
+  version: "0.1.22",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/microsoft_outlook/sources/new-email/new-email.mjs
+++ b/components/microsoft_outlook/sources/new-email/new-email.mjs
@@ -7,7 +7,7 @@ export default {
   key: "microsoft_outlook-new-email",
   name: "New Email Event (Instant)",
   description: "Emit new event when an email is received in specified folders.",
-  version: "0.1.21",
+  version: "0.1.22",
   type: "source",
   dedupe: "unique",
   methods: {


### PR DESCRIPTION
The attachments' content was being fetched and discarded, which could result in out-of-memory issues for large attachments.

Slight change on the app file makes the GH actions check require bumping all components, but this was only a change in one propDefinition and it's only used by one component (already bumped).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced the amount of Microsoft Outlook attachment data retrieved when viewing attachments and processing new emails.
  * Attachment requests now fetch only the fields needed for identification and display.
* **Maintenance**
  * Updated Microsoft Outlook component and source versions to include the latest attachment and email processing improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->