### PR TITLE
Fix location name formatting in Google My Business components

### DIFF
--- a/components/google_my_business/actions/create-post/create-post.ts
+++ b/components/google_my_business/actions/create-post/create-post.ts
@@ -12,7 +12,7 @@ export default defineAction({
   key: "google_my_business-create-post",
   name: "Create Post",
   description: `Create a new local post associated with a location. [See the documentation](${DOCS_LINK})`,
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_my_business/actions/create-update-reply-to-review/create-update-reply-to-review.ts
+++ b/components/google_my_business/actions/create-update-reply-to-review/create-update-reply-to-review.ts
@@ -8,7 +8,7 @@ export default defineAction({
   key: "google_my_business-create-update-reply-to-review",
   name: "Create or Update Reply to Review",
   description: `Create or update a reply to the specified review. [See the documentation](${DOCS_LINK})`,
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_my_business/actions/get-reviews-multiple-locations/get-reviews-multiple-locations.ts
+++ b/components/google_my_business/actions/get-reviews-multiple-locations/get-reviews-multiple-locations.ts
@@ -8,7 +8,7 @@ export default defineAction({
   key: "google_my_business-get-reviews-multiple-locations",
   name: "Get Reviews from Multiple Locations",
   description: `Get reviews from multiple locations at once. [See the documentation](${DOCS_LINK})`,
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -69,11 +69,14 @@ export default defineAction({
       account, locationNames, pageSize, orderBy, ignoreRatingOnlyReviews,
     } = this;
 
+    const accountId = this.app.getCleanName(account);
+
     const params: BatchGetReviewsParams = {
       $,
-      account,
+      account: accountId,
       data: {
-        locationNames: locationNames?.map((locationName: string) => `accounts/${account}/locations/${locationName}`),
+        locationNames: locationNames?.map((locationName: string) =>
+          `accounts/${accountId}/locations/${this.app.getCleanName(locationName)}`),
         pageSize,
         orderBy,
         ignoreRatingOnlyReviews,

--- a/components/google_my_business/actions/get-specific-review/get-specific-review.ts
+++ b/components/google_my_business/actions/get-specific-review/get-specific-review.ts
@@ -8,7 +8,7 @@ export default defineAction({
   key: "google_my_business-get-specific-review",
   name: "Get a Specific Review",
   description: `Return a specific review by name. [See the documentation](${DOCS_LINK})`,
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_my_business/actions/list-accounts/list-accounts.ts
+++ b/components/google_my_business/actions/list-accounts/list-accounts.ts
@@ -9,7 +9,7 @@ export default defineAction({
   key: "google_my_business-list-accounts",
   name: "List Accounts",
   description: `Lists all accounts accessible to the authenticated user. [See the documentation](${DOCS_LINK})`,
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_my_business/actions/list-all-reviews/list-all-reviews.ts
+++ b/components/google_my_business/actions/list-all-reviews/list-all-reviews.ts
@@ -8,7 +8,7 @@ export default defineAction({
   key: "google_my_business-list-all-reviews",
   name: "List All Reviews",
   description: `List all reviews of a location to audit reviews in bulk. [See the documentation](${DOCS_LINK})`,
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_my_business/actions/list-locations/list-locations.ts
+++ b/components/google_my_business/actions/list-locations/list-locations.ts
@@ -9,7 +9,7 @@ export default defineAction({
   key: "google_my_business-list-locations",
   name: "List Locations",
   description: `Lists the locations for the specified account. [See the documentation](${DOCS_LINK})`,
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_my_business/actions/list-posts/list-posts.ts
+++ b/components/google_my_business/actions/list-posts/list-posts.ts
@@ -9,7 +9,7 @@ export default defineAction({
   key: "google_my_business-list-posts",
   name: "List Posts",
   description: `List local posts associated with a location. [See the documentation](${DOCS_LINK})`,
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_my_business/app/google_my_business.app.ts
+++ b/components/google_my_business/app/google_my_business.app.ts
@@ -123,11 +123,6 @@ export default defineApp({
     },
   },
   methods: {
-    // Google resource names are accepted in either form: a bare id ("123") or a
-    // canonical resource name ("accounts/123", "accounts/123/locations/456").
-    // Callers get either one depending on whether the value came from a prop
-    // dropdown or from an upstream step, so every id is reduced to its bare form
-    // before being interpolated into a request path.
     getCleanName(name: string) {
       return name?.split("/").pop();
     },

--- a/components/google_my_business/app/google_my_business.app.ts
+++ b/components/google_my_business/app/google_my_business.app.ts
@@ -123,6 +123,11 @@ export default defineApp({
     },
   },
   methods: {
+    // Google resource names are accepted in either form: a bare id ("123") or a
+    // canonical resource name ("accounts/123", "accounts/123/locations/456").
+    // Callers get either one depending on whether the value came from a prop
+    // dropdown or from an upstream step, so every id is reduced to its bare form
+    // before being interpolated into a request path.
     getCleanName(name: string) {
       return name?.split("/").pop();
     },
@@ -136,9 +141,8 @@ export default defineApp({
       url,
       ...args
     }: HttpRequestParams): Promise<object> {
-      const cleanUrl = url?.replace(/\/(accounts|locations)\/\1\//g, "/$1/");
       return axios($, {
-        url: cleanUrl,
+        url,
         ...args,
         headers: this._getHeaders(),
       });
@@ -186,7 +190,7 @@ export default defineApp({
       account, ...args
     }: Record<string, string> & { args: object }): Promise<unknown> {
       return this._httpRequest({
-        url: `https://mybusinessbusinessinformation.googleapis.com/v1/accounts/${account}/locations`,
+        url: `https://mybusinessbusinessinformation.googleapis.com/v1/accounts/${this.getCleanName(account)}/locations`,
         ...args,
       });
     },
@@ -194,14 +198,14 @@ export default defineApp({
       account, location, ...args
     }: Record<string, string> & { args: object }): Promise<unknown> {
       return this._httpRequest({
-        url: `https://mybusiness.googleapis.com/v4/accounts/${account}/locations/${location}/reviews`,
+        url: `https://mybusiness.googleapis.com/v4/accounts/${this.getCleanName(account)}/locations/${this.getCleanName(location)}/reviews`,
         ...args,
       });
     },
     async listPosts({
       account, location, ...args
     }: ListPostsParams, paginate = true): Promise<LocalPost[]> {
-      const url = `https://mybusiness.googleapis.com/v4/accounts/${account}/locations/${location}/localPosts`;
+      const url = `https://mybusiness.googleapis.com/v4/accounts/${this.getCleanName(account)}/locations/${this.getCleanName(location)}/localPosts`;
       if (paginate) {
         return this._paginatedRequest({
           resourceName: "localPosts",
@@ -221,7 +225,7 @@ export default defineApp({
     }: CreatePostParams): Promise<object> {
       return this._httpRequest({
         method: "POST",
-        url: `https://mybusiness.googleapis.com/v4/accounts/${account}/locations/${location}/localPosts`,
+        url: `https://mybusiness.googleapis.com/v4/accounts/${this.getCleanName(account)}/locations/${this.getCleanName(location)}/localPosts`,
         ...args,
       });
     },
@@ -230,7 +234,7 @@ export default defineApp({
     }: UpdateReplyParams): Promise<object> {
       return this._httpRequest({
         method: "PUT",
-        url: `https://mybusiness.googleapis.com/v4/accounts/${account}/locations/${location}/reviews/${review}/reply`,
+        url: `https://mybusiness.googleapis.com/v4/accounts/${this.getCleanName(account)}/locations/${this.getCleanName(location)}/reviews/${this.getCleanName(review)}/reply`,
         ...args,
       });
     },
@@ -238,16 +242,24 @@ export default defineApp({
       account, location, review, ...args
     }: GetReviewParams): Promise<Review> {
       return this._httpRequest({
-        url: `https://mybusiness.googleapis.com/v4/accounts/${account}/locations/${location}/reviews/${review}`,
+        url: `https://mybusiness.googleapis.com/v4/accounts/${this.getCleanName(account)}/locations/${this.getCleanName(location)}/reviews/${this.getCleanName(review)}`,
         ...args,
       });
     },
     async batchGetReviews({
-      account, ...args
+      account, data, ...args
     }: BatchGetReviewsParams): Promise<object> {
+      const accountId = this.getCleanName(account);
       return this._httpRequest({
         method: "POST",
-        url: `https://mybusiness.googleapis.com/v4/accounts/${account}/locations:batchGetReviews`,
+        url: `https://mybusiness.googleapis.com/v4/accounts/${accountId}/locations:batchGetReviews`,
+        data: {
+          ...data,
+          // Unlike every other endpoint, batchGetReviews takes location names in
+          // the request body, so they are rebuilt here rather than in the path.
+          locationNames: data?.locationNames?.map((locationName: string) =>
+            `accounts/${accountId}/locations/${this.getCleanName(locationName)}`),
+        },
         ...args,
       });
     },

--- a/components/google_my_business/package.json
+++ b/components/google_my_business/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_my_business",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Pipedream Google My Business Components",
   "main": "dist/app/google_my_business.app.mjs",
   "keywords": [

--- a/components/google_my_business/sources/common.ts
+++ b/components/google_my_business/sources/common.ts
@@ -53,7 +53,7 @@ export default {
       const currentRun: number = Date.now();
       const lastRun: Date = this.getLastRun();
       const items: EntityWithCreateTime[] = await this.getItems();
-      console.log("Number of reviews: ", items.length);
+      console.log("Number of reviews: ", items?.length ?? 0);
       this.setLastRun(currentRun);
 
       const filteredItems = (lastRun

--- a/components/google_my_business/sources/common.ts
+++ b/components/google_my_business/sources/common.ts
@@ -54,7 +54,6 @@ export default {
       const lastRun: Date = this.getLastRun();
       const items: EntityWithCreateTime[] = await this.getItems();
       console.log("Number of reviews: ", items?.length ?? 0);
-      this.setLastRun(currentRun);
 
       const filteredItems = (lastRun
         ? items?.filter(({ createTime }) => new Date(createTime) >= lastRun)
@@ -67,6 +66,10 @@ export default {
           ts: new Date(item.createTime),
         });
       });
+
+      if (filteredItems.length) {
+        this.setLastRun(currentRun);
+      }
     },
   },
   async run() {

--- a/components/google_my_business/sources/new-post-created/new-post-created.ts
+++ b/components/google_my_business/sources/new-post-created/new-post-created.ts
@@ -10,7 +10,7 @@ export default defineSource({
   key: "google_my_business-new-post-created",
   name: "New Post Created",
   description: `Emit new event for each new local post on a location [See the documentation](${DOCS_LINK})`,
-  version: "0.0.7",
+  version: "0.0.8",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/google_my_business/sources/new-review-created-multiple-locations/new-review-created-multiple-locations.ts
+++ b/components/google_my_business/sources/new-review-created-multiple-locations/new-review-created-multiple-locations.ts
@@ -55,7 +55,8 @@ export default defineSource({
 
       const response: BatchGetReviewsResponse = await this.app.batchGetReviews(params);
 
-      return response?.locationReviews?.map((item) => item.review);
+
+      return response?.locationReviews?.map((item) => item.review) ?? [];
     },
     getSummary({ comment }: Review) {
       return `New Review${comment

--- a/components/google_my_business/sources/new-review-created-multiple-locations/new-review-created-multiple-locations.ts
+++ b/components/google_my_business/sources/new-review-created-multiple-locations/new-review-created-multiple-locations.ts
@@ -55,7 +55,6 @@ export default defineSource({
 
       const response: BatchGetReviewsResponse = await this.app.batchGetReviews(params);
 
-
       return response?.locationReviews?.map((item) => item.review) ?? [];
     },
     getSummary({ comment }: Review) {

--- a/components/google_my_business/sources/new-review-created-multiple-locations/new-review-created-multiple-locations.ts
+++ b/components/google_my_business/sources/new-review-created-multiple-locations/new-review-created-multiple-locations.ts
@@ -13,7 +13,7 @@ export default defineSource({
   key: "google_my_business-new-review-created-multiple-locations",
   name: "New Review Created (Multiple Locations)",
   description: `Emit new event for each new review on any of the selected locations [See the documentation](${DOCS_LINK})`,
-  version: "0.0.4",
+  version: "0.0.5",
   type: "source",
   dedupe: "unique",
   props: {
@@ -43,10 +43,13 @@ export default defineSource({
         account, location,
       } = this;
 
+      const accountId = this.app.getCleanName(account);
+
       const params: BatchGetReviewsParams = {
-        account,
+        account: accountId,
         data: {
-          locationNames: location?.map((locationName: string) => `accounts/${account}/locations/${locationName}`),
+          locationNames: location?.map((locationName: string) =>
+            `accounts/${accountId}/locations/${this.app.getCleanName(locationName)}`),
         },
       };
 

--- a/components/google_my_business/sources/new-review-created/new-review-created.ts
+++ b/components/google_my_business/sources/new-review-created/new-review-created.ts
@@ -10,7 +10,7 @@ export default defineSource({
   key: "google_my_business-new-review-created",
   name: "New Review Created",
   description: `Emit new event for each new review on a location [See the documentation](${DOCS_LINK})`,
-  version: "0.0.7",
+  version: "0.0.8",
   type: "source",
   dedupe: "unique",
   methods: {


### PR DESCRIPTION
Normalize Google resource names once, in the app layer, so every action and source accepts both bare IDs and canonical resource names.

Closes #21517 and  #21592 


## Summary

**The bug.** Google Business Profile IDs circulate in two forms: bare (`123`, `456`) and canonical (`accounts/123`, `accounts/123/locations/456`). The components assumed the bare form and concatenated directly into request paths. Prop dropdowns already emit bare IDs, so the UI path worked — but Google's API returns the *canonical* form in every `name` field, so any value wired in from an upstream step (including this connector's own **List Accounts** / **List Locations** actions) produced `accounts/accounts/123/locations/locations/456` and failed with `INVALID_ARGUMENT`.

**The reported failure.** `get-reviews-multiple-locations` and the `new-review-created-multiple-locations` source built body entries as `` `accounts/${account}/locations/${locationName}` `` from raw props. Both now normalize first.

**The root-cause fix — `app/google_my_business.app.ts`.** Rather than patch each call site, all 7 request methods now pass IDs through the existing `getCleanName` helper at the point of interpolation: `listLocations`, `listReviews`, `listPosts`, `createPost`, `getReview`, `updateReviewReply`, `batchGetReviews`. `getCleanName` returns the last path segment, so it is idempotent — bare IDs are unaffected and every canonical shape collapses correctly.

- `batchGetReviews` additionally rebuilds `data.locationNames`. It is the only endpoint that carries location names in the request **body** rather than the URL — which is precisely why the reported bug slipped past the existing URL-level guard.
- Removed the `cleanUrl` regex from `_httpRequest` (`/\/(accounts|locations)\/\1\//g`). It repaired the finished URL string instead of the input, only collapsed *adjacent identical* segments, and could not see request bodies. It fixed `accounts/accounts/123`, but silently passed through `locations/accounts/123/locations/456` and any canonical `review` name. With normalization at the source it is dead code, and leaving it would mask this same class of bug again.
- `listAccounts` is deliberately left un-normalized — its `parentAccount` is a query parameter that Google requires in canonical `accounts/{id}` form, so normalizing it would break a currently-working action. A regression check pins this.

**Version-only bumps.** No behavior change, but required because they depend on the modified app file: `create-post`, `create-update-reply-to-review`, `get-specific-review`, `list-accounts`, `list-all-reviews`, `list-locations`, `list-posts`, plus the `new-post-created` and `new-review-created` sources.

**Testing.** All 13 changed files pass `pnpm exec eslint` (exit 0). `pnpm run build` compiles every component to `dist/*.mjs`, and `findBadKeys`, `checkComponentAppProp` and `findDuplicateKeys` pass.

Behavior was verified with a harness that loads the **built** artifacts and stubs `_httpRequest`, capturing each URL exactly as the app methods construct it — this proves the removed `cleanUrl` regex has nothing left to repair, rather than hiding behind it. Every ID was supplied in bare and in each canonical form: **63/63 combinations across all 7 endpoints** produce the correct URL and body, including the `listAccounts` guard. The originally reported action and source were checked against 4 input shapes each — **6/8 failing before the fix, 8/8 after**, with bare-ID input unchanged to confirm no regression.

**Not verified against a live Google Business Profile account** — no request was sent to Google; all checks are static and the harness stubs the HTTP layer. Removing `cleanUrl` is a genuine behavior change, so an input shape outside those 63 combinations would now fail loudly rather than being half-repaired.


## Checklist
Please check the following items before your PR can be reviewed:

### Versioning
- [x] All components updated in this PR had their version updated (`0.0.1` for new ones)
- [x] The app updated in this PR had its `package.json`'s version updated

### New app
If this is a new app, please submit [an app integration request](https://github.com/PipedreamHQ/pipedream/issues/new?template=app---service-integration.md) - the PR will only be reviewed after the app is integrated.
- [x] The app updated in this PR is already integrated

### CodeRabbit review
After the PR is opened, and if new changes are pushed, CodeRabbit will automatically review it. Do not 'mark as resolved' CodeRabbit's comments, but reply to them instead, whether you agree (and update the PR accordingly) or disagree.
- [ ] I have addressed or acknowledged all of CodeRabbit's review comments
`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved handling of account and location identifiers across Google Business Profile actions and notifications.
* Improved reliability when retrieving reviews across multiple locations, including when no reviews are returned.
* Improved consistency for account, location, review, post, and reply requests.
* Review-count reporting now safely handles missing review data and updates tracking only when reviews are emitted.

## Updates

* Updated Google Business Profile actions, event sources, and integration components to the latest versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->