### PR TITLE
[21607] feat(bitbucket): add deprecation note

### DIFF
--- a/components/bitbucket/actions/create-issue-comment/create-issue-comment.mjs
+++ b/components/bitbucket/actions/create-issue-comment/create-issue-comment.mjs
@@ -4,8 +4,8 @@ const { bitbucket } = base.props;
 export default {
   key: "bitbucket-create-issue-comment",
   name: "Create Issue Comment",
-  description: "Creates a new issue comment. [See docs here](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-issue-tracker/#api-repositories-workspace-repo-slug-issues-issue-id-comments-post)",
-  version: "0.1.4",
+  description: "Creates a new issue comment. [See docs here](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-issue-tracker/#api-repositories-workspace-repo-slug-issues-issue-id-comments-post). **Deprecated: Atlassian is removing Bitbucket Issues in mid-August 2026, and this action stops working once the feature is gone. There is no Bitbucket replacement.** [See the sunset announcement](https://community.atlassian.com/forums/Bitbucket-articles/Announcing-sunset-of-Bitbucket-Issues-and-Wikis/ba-p/3193882)",
+  version: "0.1.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/bitbucket/actions/create-issue/create-issue.mjs
+++ b/components/bitbucket/actions/create-issue/create-issue.mjs
@@ -5,8 +5,8 @@ const { bitbucket } = base.props;
 export default {
   key: "bitbucket-create-issue",
   name: "Creates a new issue",
-  description: "Creates a new issue. [See docs here](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-issue-tracker/#api-repositories-workspace-repo-slug-issues-post)",
-  version: "0.1.4",
+  description: "Creates a new issue. [See docs here](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-issue-tracker/#api-repositories-workspace-repo-slug-issues-post). **Deprecated: Atlassian is removing Bitbucket Issues in mid-August 2026, and this action stops working once the feature is gone. There is no Bitbucket replacement.** [See the sunset announcement](https://community.atlassian.com/forums/Bitbucket-articles/Announcing-sunset-of-Bitbucket-Issues-and-Wikis/ba-p/3193882)",
+  version: "0.1.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/bitbucket/actions/get-issue/get-issue.mjs
+++ b/components/bitbucket/actions/get-issue/get-issue.mjs
@@ -4,8 +4,8 @@ const { bitbucket } = base.props;
 export default {
   key: "bitbucket-get-issue",
   name: "Get issue",
-  description: "Get a issue. [See docs here](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-issue-tracker/#api-repositories-workspace-repo-slug-issues-issue-id-get)",
-  version: "0.0.4",
+  description: "Get a issue. [See docs here](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-issue-tracker/#api-repositories-workspace-repo-slug-issues-issue-id-get). **Deprecated: Atlassian is removing Bitbucket Issues in mid-August 2026, and this action stops working once the feature is gone. There is no Bitbucket replacement.** [See the sunset announcement](https://community.atlassian.com/forums/Bitbucket-articles/Announcing-sunset-of-Bitbucket-Issues-and-Wikis/ba-p/3193882)",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/bitbucket/actions/update-issue-comment/update-issue-comment.mjs
+++ b/components/bitbucket/actions/update-issue-comment/update-issue-comment.mjs
@@ -4,8 +4,8 @@ const { bitbucket } = base.props;
 export default {
   key: "bitbucket-update-issue-comment",
   name: "Update Issue Comment",
-  description: "Updates a existent issue comment. [See docs here](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-issue-tracker/#api-repositories-workspace-repo-slug-issues-issue-id-comments-comment-id-put)",
-  version: "0.1.4",
+  description: "Updates a existent issue comment. [See docs here](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-issue-tracker/#api-repositories-workspace-repo-slug-issues-issue-id-comments-comment-id-put). **Deprecated: Atlassian is removing Bitbucket Issues in mid-August 2026, and this action stops working once the feature is gone. There is no Bitbucket replacement.** [See the sunset announcement](https://community.atlassian.com/forums/Bitbucket-articles/Announcing-sunset-of-Bitbucket-Issues-and-Wikis/ba-p/3193882)",
+  version: "0.1.5",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/bitbucket/package.json
+++ b/components/bitbucket/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/bitbucket",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Pipedream Bitbucket Components",
   "main": "bitbucket.app.mjs",
   "keywords": [

--- a/components/bitbucket/sources/new-issue/new-issue.mjs
+++ b/components/bitbucket/sources/new-issue/new-issue.mjs
@@ -7,8 +7,8 @@ export default {
   type: "source",
   name: "New Issue (Instant)",
   key: "bitbucket-new-issue",
-  description: "Emit new event when a new issue receives is created in a repository. [See docs here](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-repositories/#api-repositories-workspace-repo-slug-hooks-post)",
-  version: "0.0.4",
+  description: "Emit new event when a new issue receives is created in a repository. [See docs here](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-repositories/#api-repositories-workspace-repo-slug-hooks-post). **Deprecated: Atlassian is removing Bitbucket Issues in mid-August 2026, after which no issues can be created and this source stops emitting. The historical backfill on first deploy already relies on a deprecated endpoint. There is no Bitbucket replacement.** [See the sunset announcement](https://community.atlassian.com/forums/Bitbucket-articles/Announcing-sunset-of-Bitbucket-Issues-and-Wikis/ba-p/3193882)",
+  version: "0.0.5",
   props: {
     ...common.props,
     repositoryId: {


### PR DESCRIPTION
## Summary

<!-- Add your PR description here -->
Partially closes #21607 
Adds deprecation note for multiple endpoints being sunset by bitbucket.
Action unpublish + code removal to be covered as part of a followup PR.


## Checklist
Please check the following items before your PR can be reviewed:

### Versioning
- [x] All components updated in this PR had their version updated (`0.0.1` for new ones)
- [x] The app updated in this PR had its `package.json`'s version updated

### New app
If this is a new app, please submit [an app integration request](https://github.com/PipedreamHQ/pipedream/issues/new?template=app---service-integration.md) - the PR will only be reviewed after the app is integrated.
- [ ] The app updated in this PR is already integrated

### CodeRabbit review
After the PR is opened, and if new changes are pushed, CodeRabbit will automatically review it. Do not 'mark as resolved' CodeRabbit's comments, but reply to them instead, whether you agree (and update the PR accordingly) or disagree.
- [ ] I have addressed or acknowledged all of CodeRabbit's review comments



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added notices about Bitbucket Issues’ planned deprecation and removal in August 2026.
  - Included the sunset announcement link and clarified that no replacement is currently available.
  - Documented the deprecated historical backfill endpoint.

- **Chores**
  - Updated action and source versions to reflect the latest metadata changes.
  - Incremented the Bitbucket package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->