### PR TITLE
openphone: AI-optimize MCP action set

### DIFF
--- a/components/openphone/actions/create-contact/create-contact.mjs
+++ b/components/openphone/actions/create-contact/create-contact.mjs
@@ -1,11 +1,14 @@
-import { parseObject } from "../../common/utils.mjs";
+// x-pd-ai: optimized
+import {
+  normalizeNameValueList, parseObject,
+} from "../../common/utils.mjs";
 import openphone from "../../openphone.app.mjs";
 
 export default {
   key: "openphone-create-contact",
   name: "Create Contact",
-  description: "Create a new contact in OpenPhone. [See the documentation](https://www.openphone.com/docs/api-reference/contacts/create-a-contact)",
-  version: "0.0.4",
+  description: "Create a new contact in OpenPhone. Example: call with firstName=\"Jane\", lastName=\"Doe\", phoneNumbers=`[{\"name\": \"Mobile\", \"value\": \"+15551234567\"}]` → returns the created contact record, including its `id`. [See the documentation](https://www.openphone.com/docs/api-reference/contacts/create-a-contact)",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -72,8 +75,8 @@ export default {
           lastName: this.lastName,
           company: this.company,
           role: this.role,
-          emails: parseObject(this.emails),
-          phoneNumbers: parseObject(this.phoneNumbers),
+          emails: normalizeNameValueList(parseObject(this.emails), "Email"),
+          phoneNumbers: normalizeNameValueList(parseObject(this.phoneNumbers), "Phone"),
         },
         customFields: parseObject(this.customFields),
       },

--- a/components/openphone/actions/create-task/create-task.mjs
+++ b/components/openphone/actions/create-task/create-task.mjs
@@ -1,0 +1,60 @@
+// x-pd-ai: optimized
+import openphone from "../../openphone.app.mjs";
+
+export default {
+  key: "openphone-create-task",
+  name: "Create Task",
+  description: "Create a task tied to an OpenPhone conversation. Example: call with conversationId=\"CN123abc\", title=\"Follow up with customer re: onboarding\", description=\"Customer asked about pricing tiers.\" → returns the created task record, including its `id`. Use **List Conversations** or **List Messages** to find the `conversationId`. [See the documentation](https://www.openphone.com/docs/api-reference/tasks/create-a-task)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    openphone,
+    conversationId: {
+      propDefinition: [
+        openphone,
+        "conversationId",
+      ],
+    },
+    title: {
+      type: "string",
+      label: "Title",
+      description: "The task title (e.g. `Follow up with customer re: onboarding`).",
+    },
+    description: {
+      type: "string",
+      label: "Description",
+      description: "Task description/details. Required by the API.",
+    },
+    dueDate: {
+      type: "string",
+      label: "Due Date",
+      description: "Optional due date as an ISO 8601 date-time (e.g. `2026-08-20T00:00:00Z`).",
+      optional: true,
+    },
+    assignedTo: {
+      type: "string",
+      label: "Assigned To",
+      description: "Optional OpenPhone user ID (format `US...`) to assign the task to. Run the **List Users** action to find user IDs.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const response = await this.openphone.createTask({
+      $,
+      data: {
+        conversationId: this.conversationId,
+        title: this.title,
+        description: this.description,
+        dueDate: this.dueDate,
+        assignedTo: this.assignedTo,
+      },
+    });
+    $.export("$summary", `Created task "${this.title}" with ID: ${response.data?.taskId}`);
+    return response;
+  },
+};

--- a/components/openphone/actions/delete-contact/delete-contact.mjs
+++ b/components/openphone/actions/delete-contact/delete-contact.mjs
@@ -1,0 +1,31 @@
+// x-pd-ai: optimized
+import openphone from "../../openphone.app.mjs";
+
+export default {
+  key: "openphone-delete-contact",
+  name: "Delete Contact",
+  description: "Permanently delete a contact by ID. This cannot be undone. Example: call with contactId from **List Contacts** → the contact is removed and the response confirms deletion. [See the documentation](https://www.openphone.com/docs/api-reference/contacts/delete-a-contact)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    openWorldHint: true,
+  },
+  props: {
+    openphone,
+    contactId: {
+      type: "string",
+      label: "Contact ID",
+      description: "The ID of the contact to permanently delete. Run the **List Contacts** action to find contact IDs.",
+    },
+  },
+  async run({ $ }) {
+    const response = await this.openphone.deleteContact({
+      contactId: this.contactId,
+      $,
+    });
+    $.export("$summary", `Deleted contact ${this.contactId}`);
+    return response;
+  },
+};

--- a/components/openphone/actions/delete-contact/delete-contact.mjs
+++ b/components/openphone/actions/delete-contact/delete-contact.mjs
@@ -17,7 +17,7 @@ export default {
     contactId: {
       type: "string",
       label: "Contact ID",
-      description: "The ID of the contact to permanently delete. Run the **List Contacts** action to find contact IDs.",
+      description: "The string identifier of the contact to permanently delete, as returned by the OpenPhone API (e.g. `66d0d87e8dc1211467372303`). Run the **List Contacts** action to find contact IDs.",
     },
   },
   async run({ $ }) {

--- a/components/openphone/actions/delete-task/delete-task.mjs
+++ b/components/openphone/actions/delete-task/delete-task.mjs
@@ -1,0 +1,32 @@
+// x-pd-ai: optimized
+import openphone from "../../openphone.app.mjs";
+
+export default {
+  key: "openphone-delete-task",
+  name: "Delete Task",
+  description: "Permanently delete a task by ID. This cannot be undone. Use **List Tasks** to find task IDs. Example: call with taskId=\"TK123abc\" → the task is removed and the response confirms deletion. [See the documentation](https://www.openphone.com/docs/api-reference/tasks/delete-a-task-by-id)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    openWorldHint: true,
+  },
+  props: {
+    openphone,
+    taskId: {
+      propDefinition: [
+        openphone,
+        "taskId",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.openphone.deleteTask({
+      taskId: this.taskId,
+      $,
+    });
+    $.export("$summary", `Deleted task ${this.taskId}`);
+    return response;
+  },
+};

--- a/components/openphone/actions/get-call/get-call.mjs
+++ b/components/openphone/actions/get-call/get-call.mjs
@@ -1,0 +1,64 @@
+// x-pd-ai: optimized
+import openphone from "../../openphone.app.mjs";
+
+export default {
+  key: "openphone-get-call",
+  name: "Get Call",
+  description: "Retrieve a single call by its ID, including its summary and transcript when available. Summary and transcript are fetched from OpenPhone's separate `/summary` and `/transcript` endpoints and merged into the result; they are `null` if OpenPhone has not yet generated them. Use **List Calls** to find call IDs. Example: call with callId=\"AC123abc\" → returns the call record with `summary` and `transcript` fields merged in. [See the documentation](https://www.openphone.com/docs/api-reference/calls/get-a-call-by-id)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    openphone,
+    callId: {
+      type: "string",
+      label: "Call ID",
+      description: "The ID of the call to retrieve (format `AC...`). Run the **List Calls** action first to find call IDs.",
+    },
+  },
+  async run({ $ }) {
+    const [
+      callResult,
+      summaryResult,
+      transcriptResult,
+    ] = await Promise.allSettled([
+      this.openphone.getCall({
+        callId: this.callId,
+        $,
+      }),
+      this.openphone.getCallSummary({
+        callId: this.callId,
+        $,
+      }),
+      this.openphone.getCallTranscript({
+        callId: this.callId,
+        $,
+      }),
+    ]);
+
+    if (callResult.status === "rejected") {
+      throw callResult.reason;
+    }
+
+    const call = callResult.value;
+    const summary = summaryResult.status === "fulfilled"
+      ? summaryResult.value
+      : null;
+    const transcript = transcriptResult.status === "fulfilled"
+      ? transcriptResult.value
+      : null;
+
+    const result = {
+      ...call,
+      summary,
+      transcript,
+    };
+
+    $.export("$summary", `Retrieved call ${this.callId}`);
+    return result;
+  },
+};

--- a/components/openphone/actions/get-call/get-call.mjs
+++ b/components/openphone/actions/get-call/get-call.mjs
@@ -44,13 +44,18 @@ export default {
       throw callResult.reason;
     }
 
+    // A summary/transcript not yet generated 404s — that's the only rejection reason
+    // that means "null", not "failed". Anything else (auth, rate limit, 5xx) is a real
+    // failure and should propagate instead of silently reporting success.
+    const auxiliaryResultOrThrow = (result) => {
+      if (result.status === "fulfilled") return result.value;
+      if (result.reason?.status === 404) return null;
+      throw result.reason;
+    };
+
     const call = callResult.value;
-    const summary = summaryResult.status === "fulfilled"
-      ? summaryResult.value
-      : null;
-    const transcript = transcriptResult.status === "fulfilled"
-      ? transcriptResult.value
-      : null;
+    const summary = auxiliaryResultOrThrow(summaryResult);
+    const transcript = auxiliaryResultOrThrow(transcriptResult);
 
     const result = {
       ...call,

--- a/components/openphone/actions/list-calls/list-calls.mjs
+++ b/components/openphone/actions/list-calls/list-calls.mjs
@@ -1,16 +1,11 @@
 // x-pd-ai: optimized
 import { pickFields } from "../../common/utils.mjs";
 import openphone from "../../openphone.app.mjs";
-import {
-  DEFAULT_CALLS_LIMIT,
-  MAX_LIMIT,
-  MIN_LIMIT,
-} from "../../common/constants.mjs";
 
 export default {
   key: "openphone-list-calls",
   name: "List Calls",
-  description: "Retrieve a paginated list of calls from OpenPhone. Requires both a phone number ID and a participant to scope the results — the API rejects calls missing either. Use **List Phone Numbers** to find valid phone number IDs. Example: call with phoneNumberId=\"PN123abc\", participants=[\"+15551234567\"] → returns up to 10 recent calls between that number and that participant. Use `fields` to return only specific fields per call. [See the documentation](https://www.openphone.com/docs/api-reference/calls/list-calls)",
+  description: "Retrieve a paginated list of calls from OpenPhone. Requires both a phone number ID and a participant to scope the results — the API rejects calls missing either. Use **List Phone Numbers** to find valid phone number IDs. Example: call with phoneNumberId=\"PN123abc\", participants=\"+15551234567\" → returns up to 10 recent calls between that number and that participant. Use `fields` to return only specific fields per call. [See the documentation](https://www.openphone.com/docs/api-reference/calls/list-calls)",
   version: "0.0.1",
   type: "action",
   annotations: {
@@ -29,9 +24,8 @@ export default {
     participants: {
       propDefinition: [
         openphone,
-        "participants",
+        "callParticipant",
       ],
-      description: "Phone number(s) in E.164 format to filter by (e.g. `+15551234567`). Required by this endpoint — the API accepts at most 1 participant here.",
     },
     userId: {
       propDefinition: [
@@ -56,10 +50,8 @@ export default {
     maxResults: {
       propDefinition: [
         openphone,
-        "maxResults",
+        "callMaxResults",
       ],
-      description: `Maximum number of calls to return. Min ${MIN_LIMIT}, max ${MAX_LIMIT}. Defaults to ${DEFAULT_CALLS_LIMIT}.`,
-      default: DEFAULT_CALLS_LIMIT,
     },
     pageToken: {
       propDefinition: [

--- a/components/openphone/actions/list-calls/list-calls.mjs
+++ b/components/openphone/actions/list-calls/list-calls.mjs
@@ -1,0 +1,99 @@
+// x-pd-ai: optimized
+import { pickFields } from "../../common/utils.mjs";
+import openphone from "../../openphone.app.mjs";
+import {
+  DEFAULT_CALLS_LIMIT,
+  MAX_LIMIT,
+  MIN_LIMIT,
+} from "../../common/constants.mjs";
+
+export default {
+  key: "openphone-list-calls",
+  name: "List Calls",
+  description: "Retrieve a paginated list of calls from OpenPhone. Requires both a phone number ID and a participant to scope the results — the API rejects calls missing either. Use **List Phone Numbers** to find valid phone number IDs. Example: call with phoneNumberId=\"PN123abc\", participants=[\"+15551234567\"] → returns up to 10 recent calls between that number and that participant. Use `fields` to return only specific fields per call. [See the documentation](https://www.openphone.com/docs/api-reference/calls/list-calls)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    openphone,
+    phoneNumberId: {
+      propDefinition: [
+        openphone,
+        "phoneNumberId",
+      ],
+    },
+    participants: {
+      propDefinition: [
+        openphone,
+        "participants",
+      ],
+      description: "Phone number(s) in E.164 format to filter by (e.g. `+15551234567`). Required by this endpoint — the API accepts at most 1 participant here.",
+    },
+    userId: {
+      propDefinition: [
+        openphone,
+        "userId",
+      ],
+    },
+    createdAfter: {
+      propDefinition: [
+        openphone,
+        "createdAfter",
+      ],
+      description: "Optional ISO 8601 timestamp; only return calls created after this time (e.g. `2026-08-01T00:00:00Z`).",
+    },
+    createdBefore: {
+      propDefinition: [
+        openphone,
+        "createdBefore",
+      ],
+      description: "Optional ISO 8601 timestamp; only return calls created before this time (e.g. `2026-08-31T23:59:59Z`).",
+    },
+    maxResults: {
+      propDefinition: [
+        openphone,
+        "maxResults",
+      ],
+      description: `Maximum number of calls to return. Min ${MIN_LIMIT}, max ${MAX_LIMIT}. Defaults to ${DEFAULT_CALLS_LIMIT}.`,
+      default: DEFAULT_CALLS_LIMIT,
+    },
+    pageToken: {
+      propDefinition: [
+        openphone,
+        "pageToken",
+      ],
+    },
+    fields: {
+      propDefinition: [
+        openphone,
+        "fields",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.openphone.listCalls({
+      $,
+      params: {
+        phoneNumberId: this.phoneNumberId,
+        participants: this.participants,
+        userId: this.userId,
+        createdAfter: this.createdAfter,
+        createdBefore: this.createdBefore,
+        maxResults: this.maxResults,
+        pageToken: this.pageToken,
+      },
+    });
+    const calls = response?.data ?? [];
+    $.export("$summary", `Retrieved ${calls.length} call${calls.length === 1
+      ? ""
+      : "s"}`);
+    return {
+      ...response,
+      data: pickFields(calls, this.fields),
+    };
+  },
+};

--- a/components/openphone/actions/list-contacts/list-contacts.mjs
+++ b/components/openphone/actions/list-contacts/list-contacts.mjs
@@ -1,0 +1,77 @@
+// x-pd-ai: optimized
+import { pickFields } from "../../common/utils.mjs";
+import openphone from "../../openphone.app.mjs";
+import {
+  DEFAULT_CONTACTS_LIMIT,
+  MAX_CONTACTS_LIMIT,
+  MIN_LIMIT,
+} from "../../common/constants.mjs";
+
+export default {
+  key: "openphone-list-contacts",
+  name: "List Contacts",
+  description: "Retrieve a paginated list of contacts. Optionally filter by external IDs and/or sources. When no external IDs are provided, all contacts for the organization are returned. Example: call with no filters → returns up to 10 contacts for the organization. Use `fields` to return only specific fields per contact. [See the documentation](https://www.openphone.com/docs/api-reference/contacts/list-contacts)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    openphone,
+    externalIds: {
+      propDefinition: [
+        openphone,
+        "externalIds",
+      ],
+    },
+    sources: {
+      propDefinition: [
+        openphone,
+        "sources",
+      ],
+    },
+    maxResults: {
+      propDefinition: [
+        openphone,
+        "maxResults",
+      ],
+      description: `Maximum number of contacts to return per page. Min ${MIN_LIMIT}, max ${MAX_CONTACTS_LIMIT}. Defaults to ${DEFAULT_CONTACTS_LIMIT}.`,
+      min: MIN_LIMIT,
+      max: MAX_CONTACTS_LIMIT,
+      default: DEFAULT_CONTACTS_LIMIT,
+    },
+    pageToken: {
+      propDefinition: [
+        openphone,
+        "pageToken",
+      ],
+    },
+    fields: {
+      propDefinition: [
+        openphone,
+        "fields",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.openphone.listContacts({
+      $,
+      params: {
+        externalIds: this.externalIds,
+        sources: this.sources,
+        maxResults: this.maxResults,
+        pageToken: this.pageToken,
+      },
+    });
+    const contacts = response?.data ?? [];
+    $.export("$summary", `Retrieved ${contacts.length} contact${contacts.length === 1
+      ? ""
+      : "s"}`);
+    return {
+      ...response,
+      data: pickFields(contacts, this.fields),
+    };
+  },
+};

--- a/components/openphone/actions/list-contacts/list-contacts.mjs
+++ b/components/openphone/actions/list-contacts/list-contacts.mjs
@@ -10,7 +10,7 @@ import {
 export default {
   key: "openphone-list-contacts",
   name: "List Contacts",
-  description: "Retrieve a paginated list of contacts. Optionally filter by external IDs and/or sources. When no external IDs are provided, all contacts for the organization are returned. Example: call with no filters → returns up to 10 contacts for the organization. Use `fields` to return only specific fields per contact. [See the documentation](https://www.openphone.com/docs/api-reference/contacts/list-contacts)",
+  description: "Retrieve a paginated list of contacts. Optionally filter by external IDs and/or sources. All contacts for the organization are returned only when neither `externalIds` nor `sources` is provided. Example: call with no filters → returns up to 10 contacts for the organization. Use `fields` to return only specific fields per contact. [See the documentation](https://www.openphone.com/docs/api-reference/contacts/list-contacts)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/openphone/actions/list-contacts/list-contacts.mjs
+++ b/components/openphone/actions/list-contacts/list-contacts.mjs
@@ -1,11 +1,6 @@
 // x-pd-ai: optimized
 import { pickFields } from "../../common/utils.mjs";
 import openphone from "../../openphone.app.mjs";
-import {
-  DEFAULT_CONTACTS_LIMIT,
-  MAX_CONTACTS_LIMIT,
-  MIN_LIMIT,
-} from "../../common/constants.mjs";
 
 export default {
   key: "openphone-list-contacts",
@@ -35,12 +30,8 @@ export default {
     maxResults: {
       propDefinition: [
         openphone,
-        "maxResults",
+        "contactMaxResults",
       ],
-      description: `Maximum number of contacts to return per page. Min ${MIN_LIMIT}, max ${MAX_CONTACTS_LIMIT}. Defaults to ${DEFAULT_CONTACTS_LIMIT}.`,
-      min: MIN_LIMIT,
-      max: MAX_CONTACTS_LIMIT,
-      default: DEFAULT_CONTACTS_LIMIT,
     },
     pageToken: {
       propDefinition: [

--- a/components/openphone/actions/list-conversations/list-conversations.mjs
+++ b/components/openphone/actions/list-conversations/list-conversations.mjs
@@ -1,11 +1,6 @@
 // x-pd-ai: optimized
 import { pickFields } from "../../common/utils.mjs";
 import openphone from "../../openphone.app.mjs";
-import {
-  DEFAULT_CONVERSATIONS_LIMIT,
-  MAX_LIMIT,
-  MIN_LIMIT,
-} from "../../common/constants.mjs";
 
 export default {
   key: "openphone-list-conversations",
@@ -70,10 +65,8 @@ export default {
     maxResults: {
       propDefinition: [
         openphone,
-        "maxResults",
+        "conversationMaxResults",
       ],
-      description: `Maximum number of conversations to return per page. Min ${MIN_LIMIT}, max ${MAX_LIMIT}. Defaults to ${DEFAULT_CONVERSATIONS_LIMIT}.`,
-      default: DEFAULT_CONVERSATIONS_LIMIT,
     },
     pageToken: {
       propDefinition: [

--- a/components/openphone/actions/list-conversations/list-conversations.mjs
+++ b/components/openphone/actions/list-conversations/list-conversations.mjs
@@ -1,0 +1,115 @@
+// x-pd-ai: optimized
+import { pickFields } from "../../common/utils.mjs";
+import openphone from "../../openphone.app.mjs";
+import {
+  DEFAULT_CONVERSATIONS_LIMIT,
+  MAX_LIMIT,
+  MIN_LIMIT,
+} from "../../common/constants.mjs";
+
+export default {
+  key: "openphone-list-conversations",
+  name: "List Conversations",
+  description: "Retrieve a paginated list of conversations. Can be filtered by user and/or phone numbers. Defaults to all conversations in the organization. Results are returned in descending order based on the most recent conversation. Example: call with no filters → returns up to 10 of the most recently active conversations. Use `fields` to return only specific fields per conversation. [See the documentation](https://www.openphone.com/docs/api-reference/conversations/list-conversations)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    openphone,
+    phoneNumbers: {
+      propDefinition: [
+        openphone,
+        "conversationPhoneNumbers",
+      ],
+    },
+    userId: {
+      propDefinition: [
+        openphone,
+        "userId",
+      ],
+      description: "Optional OpenPhone user ID (format `US...`) whose access scope is applied to the results, scoping the response to conversations accessible to that user. Run the **List Users** action to find user IDs.",
+    },
+    createdAfter: {
+      propDefinition: [
+        openphone,
+        "createdAfter",
+      ],
+      description: "Optional ISO 8601 timestamp; only return conversations created after this time (e.g. `2026-08-01T00:00:00Z`).",
+    },
+    createdBefore: {
+      propDefinition: [
+        openphone,
+        "createdBefore",
+      ],
+      description: "Optional ISO 8601 timestamp; only return conversations created before this time (e.g. `2026-08-31T23:59:59Z`).",
+    },
+    updatedAfter: {
+      propDefinition: [
+        openphone,
+        "updatedAfter",
+      ],
+      description: "Optional ISO 8601 timestamp; only return conversations updated after this time (e.g. `2026-08-01T00:00:00Z`).",
+    },
+    updatedBefore: {
+      propDefinition: [
+        openphone,
+        "updatedBefore",
+      ],
+      description: "Optional ISO 8601 timestamp; only return conversations updated before this time (e.g. `2026-08-31T23:59:59Z`).",
+    },
+    excludeInactive: {
+      propDefinition: [
+        openphone,
+        "excludeInactive",
+      ],
+    },
+    maxResults: {
+      propDefinition: [
+        openphone,
+        "maxResults",
+      ],
+      description: `Maximum number of conversations to return per page. Min ${MIN_LIMIT}, max ${MAX_LIMIT}. Defaults to ${DEFAULT_CONVERSATIONS_LIMIT}.`,
+      default: DEFAULT_CONVERSATIONS_LIMIT,
+    },
+    pageToken: {
+      propDefinition: [
+        openphone,
+        "pageToken",
+      ],
+    },
+    fields: {
+      propDefinition: [
+        openphone,
+        "fields",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.openphone.listConversations({
+      $,
+      params: {
+        phoneNumbers: this.phoneNumbers,
+        userId: this.userId,
+        createdAfter: this.createdAfter,
+        createdBefore: this.createdBefore,
+        updatedAfter: this.updatedAfter,
+        updatedBefore: this.updatedBefore,
+        excludeInactive: this.excludeInactive,
+        maxResults: this.maxResults,
+        pageToken: this.pageToken,
+      },
+    });
+    const conversations = response?.data ?? [];
+    $.export("$summary", `Retrieved ${conversations.length} conversation${conversations.length === 1
+      ? ""
+      : "s"}`);
+    return {
+      ...response,
+      data: pickFields(conversations, this.fields),
+    };
+  },
+};

--- a/components/openphone/actions/list-from-options/list-from-options.mjs
+++ b/components/openphone/actions/list-from-options/list-from-options.mjs
@@ -1,10 +1,11 @@
+// x-pd-ai: optimized
 import openphone from "../../openphone.app.mjs";
 
 export default {
   key: "openphone-list-from-options",
   name: "List From Options",
-  description: "Retrieves available options for the From field.",
-  version: "0.0.1",
+  description: "List your OpenPhone phone numbers as selectable sender options, for use as the `from` value in **Send a Text Message**. Example: call with no inputs → returns a list of `{label, value}` pairs, one per phone number, where `value` is the phone number ID to pass as `from`. [See the documentation](https://www.openphone.com/docs/api-reference/phone-numbers/list-phone-numbers)",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -15,7 +16,17 @@ export default {
     openphone,
   },
   async run({ $ }) {
-    const options = await openphone.propDefinitions.from.options.call(this.openphone);
+    const { data } = await this.openphone.listPhoneNumbers({
+      $,
+    });
+    const options = data?.map(({
+      id: value, name, formattedNumber,
+    }) => ({
+      label: name && formattedNumber
+        ? `${name} - ${formattedNumber}`
+        : value,
+      value,
+    })) || [];
     $.export("$summary", `Successfully retrieved ${options.length} option${options.length === 1
       ? ""
       : "s"}`);

--- a/components/openphone/actions/list-messages/list-messages.mjs
+++ b/components/openphone/actions/list-messages/list-messages.mjs
@@ -1,0 +1,107 @@
+// x-pd-ai: optimized
+import { pickFields } from "../../common/utils.mjs";
+import openphone from "../../openphone.app.mjs";
+import {
+  DEFAULT_MESSAGES_LIMIT,
+  MAX_LIMIT,
+  MIN_LIMIT,
+} from "../../common/constants.mjs";
+
+export default {
+  key: "openphone-list-messages",
+  name: "List Messages",
+  description: "Retrieve a paginated list of messages from OpenPhone, scoped to a phone number and a participant — both are required by the API. Optionally narrow further to one conversation with `conversationId`. Example: call with phoneNumberId=\"PN123abc\", participants=[\"+15551234567\"] → returns up to 10 recent messages between that number and that participant. Use `fields` to return only specific fields per message. [See the documentation](https://www.openphone.com/docs/api-reference/messages/list-messages)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    openphone,
+    conversationId: {
+      propDefinition: [
+        openphone,
+        "conversationId",
+      ],
+      optional: true,
+    },
+    phoneNumberId: {
+      propDefinition: [
+        openphone,
+        "phoneNumberId",
+      ],
+    },
+    participants: {
+      propDefinition: [
+        openphone,
+        "participants",
+      ],
+      description: "Participant phone number(s) in E.164 format (e.g. `+15551234567`). Max 10 participants. Required by this endpoint.",
+    },
+    userId: {
+      propDefinition: [
+        openphone,
+        "userId",
+      ],
+    },
+    createdAfter: {
+      propDefinition: [
+        openphone,
+        "createdAfter",
+      ],
+      description: "Optional ISO 8601 timestamp; only return messages created after this time.",
+    },
+    createdBefore: {
+      propDefinition: [
+        openphone,
+        "createdBefore",
+      ],
+      description: "Optional ISO 8601 timestamp; only return messages created before this time.",
+    },
+    maxResults: {
+      propDefinition: [
+        openphone,
+        "maxResults",
+      ],
+      description: `Maximum number of messages to return. Min ${MIN_LIMIT}, max ${MAX_LIMIT}. Defaults to ${DEFAULT_MESSAGES_LIMIT}.`,
+      default: DEFAULT_MESSAGES_LIMIT,
+    },
+    pageToken: {
+      propDefinition: [
+        openphone,
+        "pageToken",
+      ],
+    },
+    fields: {
+      propDefinition: [
+        openphone,
+        "fields",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.openphone.listMessages({
+      $,
+      params: {
+        conversationId: this.conversationId,
+        phoneNumberId: this.phoneNumberId,
+        participants: this.participants,
+        userId: this.userId,
+        createdAfter: this.createdAfter,
+        createdBefore: this.createdBefore,
+        maxResults: this.maxResults,
+        pageToken: this.pageToken,
+      },
+    });
+    const messages = response?.data ?? [];
+    $.export("$summary", `Retrieved ${messages.length} message${messages.length === 1
+      ? ""
+      : "s"}`);
+    return {
+      ...response,
+      data: pickFields(messages, this.fields),
+    };
+  },
+};

--- a/components/openphone/actions/list-messages/list-messages.mjs
+++ b/components/openphone/actions/list-messages/list-messages.mjs
@@ -1,11 +1,6 @@
 // x-pd-ai: optimized
 import { pickFields } from "../../common/utils.mjs";
 import openphone from "../../openphone.app.mjs";
-import {
-  DEFAULT_MESSAGES_LIMIT,
-  MAX_LIMIT,
-  MIN_LIMIT,
-} from "../../common/constants.mjs";
 
 export default {
   key: "openphone-list-messages",
@@ -36,9 +31,8 @@ export default {
     participants: {
       propDefinition: [
         openphone,
-        "participants",
+        "messageParticipants",
       ],
-      description: "Participant phone number(s) in E.164 format (e.g. `+15551234567`). Max 10 participants. Required by this endpoint.",
     },
     userId: {
       propDefinition: [
@@ -63,10 +57,8 @@ export default {
     maxResults: {
       propDefinition: [
         openphone,
-        "maxResults",
+        "messageMaxResults",
       ],
-      description: `Maximum number of messages to return. Min ${MIN_LIMIT}, max ${MAX_LIMIT}. Defaults to ${DEFAULT_MESSAGES_LIMIT}.`,
-      default: DEFAULT_MESSAGES_LIMIT,
     },
     pageToken: {
       propDefinition: [

--- a/components/openphone/actions/list-phone-numbers/list-phone-numbers.mjs
+++ b/components/openphone/actions/list-phone-numbers/list-phone-numbers.mjs
@@ -1,10 +1,11 @@
+// x-pd-ai: optimized
 import openphone from "../../openphone.app.mjs";
 
 export default {
   key: "openphone-list-phone-numbers",
   name: "List Phone Numbers",
-  description: "Retrieve the list of phone numbers and users associated with your OpenPhone workspace. [See the documentation](https://www.openphone.com/docs/mdx/api-reference/phone-numbers/list-phone-numbers)",
-  version: "0.0.3",
+  description: "Retrieve the list of phone numbers and users associated with your OpenPhone workspace. Example: call with no inputs → returns each phone number's `id`, `number`, `name`, and the users assigned to it. [See the documentation](https://www.openphone.com/docs/mdx/api-reference/phone-numbers/list-phone-numbers)",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/openphone/actions/list-tasks/list-tasks.mjs
+++ b/components/openphone/actions/list-tasks/list-tasks.mjs
@@ -1,0 +1,69 @@
+// x-pd-ai: optimized
+import { pickFields } from "../../common/utils.mjs";
+import openphone from "../../openphone.app.mjs";
+import {
+  DEFAULT_TASKS_LIMIT,
+  MAX_LIMIT,
+  MIN_LIMIT,
+} from "../../common/constants.mjs";
+
+export default {
+  key: "openphone-list-tasks",
+  name: "List Tasks",
+  description: "Retrieve a paginated list of tasks, optionally filtered by conversation. Use **List Conversations** or **List Messages** to find a `conversationId`. Example: call with no filters → returns up to 50 recent tasks across the organization. Use `fields` to return only specific fields per task. [See the documentation](https://www.openphone.com/docs/api-reference/tasks/list-tasks)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    openphone,
+    conversationId: {
+      propDefinition: [
+        openphone,
+        "conversationId",
+      ],
+      optional: true,
+    },
+    maxResults: {
+      propDefinition: [
+        openphone,
+        "maxResults",
+      ],
+      description: `Maximum number of tasks to return. Min ${MIN_LIMIT}, max ${MAX_LIMIT}. Defaults to ${DEFAULT_TASKS_LIMIT}.`,
+      default: DEFAULT_TASKS_LIMIT,
+    },
+    pageToken: {
+      propDefinition: [
+        openphone,
+        "pageToken",
+      ],
+    },
+    fields: {
+      propDefinition: [
+        openphone,
+        "fields",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.openphone.listTasks({
+      $,
+      params: {
+        conversationId: this.conversationId,
+        maxResults: this.maxResults,
+        pageToken: this.pageToken,
+      },
+    });
+    const tasks = response?.data ?? [];
+    $.export("$summary", `Retrieved ${tasks.length} task${tasks.length === 1
+      ? ""
+      : "s"}`);
+    return {
+      ...response,
+      data: pickFields(tasks, this.fields),
+    };
+  },
+};

--- a/components/openphone/actions/list-tasks/list-tasks.mjs
+++ b/components/openphone/actions/list-tasks/list-tasks.mjs
@@ -1,11 +1,6 @@
 // x-pd-ai: optimized
 import { pickFields } from "../../common/utils.mjs";
 import openphone from "../../openphone.app.mjs";
-import {
-  DEFAULT_TASKS_LIMIT,
-  MAX_LIMIT,
-  MIN_LIMIT,
-} from "../../common/constants.mjs";
 
 export default {
   key: "openphone-list-tasks",
@@ -30,10 +25,8 @@ export default {
     maxResults: {
       propDefinition: [
         openphone,
-        "maxResults",
+        "taskMaxResults",
       ],
-      description: `Maximum number of tasks to return. Min ${MIN_LIMIT}, max ${MAX_LIMIT}. Defaults to ${DEFAULT_TASKS_LIMIT}.`,
-      default: DEFAULT_TASKS_LIMIT,
     },
     pageToken: {
       propDefinition: [

--- a/components/openphone/actions/list-users/list-users.mjs
+++ b/components/openphone/actions/list-users/list-users.mjs
@@ -1,10 +1,5 @@
 // x-pd-ai: optimized
 import openphone from "../../openphone.app.mjs";
-import {
-  DEFAULT_USERS_LIMIT,
-  MAX_USERS_LIMIT,
-  MIN_LIMIT,
-} from "../../common/constants.mjs";
 
 export default {
   key: "openphone-list-users",
@@ -22,12 +17,8 @@ export default {
     maxResults: {
       propDefinition: [
         openphone,
-        "maxResults",
+        "userMaxResults",
       ],
-      description: `Maximum number of users to return per page. Min ${MIN_LIMIT}, max ${MAX_USERS_LIMIT}. Defaults to ${DEFAULT_USERS_LIMIT}.`,
-      min: MIN_LIMIT,
-      max: MAX_USERS_LIMIT,
-      default: DEFAULT_USERS_LIMIT,
     },
     pageToken: {
       propDefinition: [

--- a/components/openphone/actions/list-users/list-users.mjs
+++ b/components/openphone/actions/list-users/list-users.mjs
@@ -1,0 +1,53 @@
+// x-pd-ai: optimized
+import openphone from "../../openphone.app.mjs";
+import {
+  DEFAULT_USERS_LIMIT,
+  MAX_USERS_LIMIT,
+  MIN_LIMIT,
+} from "../../common/constants.mjs";
+
+export default {
+  key: "openphone-list-users",
+  name: "List Users",
+  description: "Retrieve a paginated list of users in your OpenPhone workspace. Use this to find a user's ID before assigning a task or filtering calls/messages/conversations by `userId`. Example: call with no inputs → returns up to 10 users, each with `id`, `name`, and `email`. [See the documentation](https://www.openphone.com/docs/api-reference/users/list-users)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    openphone,
+    maxResults: {
+      propDefinition: [
+        openphone,
+        "maxResults",
+      ],
+      description: `Maximum number of users to return per page. Min ${MIN_LIMIT}, max ${MAX_USERS_LIMIT}. Defaults to ${DEFAULT_USERS_LIMIT}.`,
+      min: MIN_LIMIT,
+      max: MAX_USERS_LIMIT,
+      default: DEFAULT_USERS_LIMIT,
+    },
+    pageToken: {
+      propDefinition: [
+        openphone,
+        "pageToken",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.openphone.listUsers({
+      $,
+      params: {
+        maxResults: this.maxResults,
+        pageToken: this.pageToken,
+      },
+    });
+    const users = response?.data ?? [];
+    $.export("$summary", `Retrieved ${users.length} user${users.length === 1
+      ? ""
+      : "s"}`);
+    return response;
+  },
+};

--- a/components/openphone/actions/send-message/send-message.mjs
+++ b/components/openphone/actions/send-message/send-message.mjs
@@ -1,10 +1,11 @@
+// x-pd-ai: optimized
 import openphone from "../../openphone.app.mjs";
 
 export default {
   key: "openphone-send-message",
   name: "Send a Text Message",
-  description: "Send a text message from your OpenPhone number to a recipient. [See the documentation](https://www.openphone.com/docs/api-reference/messages/send-a-text-message)",
-  version: "0.0.4",
+  description: "Send a text message from one of your OpenPhone numbers to a recipient. Use **List Phone Numbers** (or **List From Options**) to find a valid `from` value. Example: call with from=\"PN123abc\", to=\"+15551234567\", content=\"Hi, following up on your request.\" → sends the message and returns the created message record. [See the documentation](https://www.openphone.com/docs/api-reference/messages/send-a-text-message)",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/openphone/actions/update-contact/update-contact.mjs
+++ b/components/openphone/actions/update-contact/update-contact.mjs
@@ -1,13 +1,16 @@
-import { parseObject } from "../../common/utils.mjs";
+// x-pd-ai: optimized
+import {
+  normalizeNameValueList, parseObject,
+} from "../../common/utils.mjs";
 import openphone from "../../openphone.app.mjs";
 
 export default {
   key: "openphone-update-contact",
   name: "Update Contact",
-  description: "Update an existing contact on OpenPhone. [See the documentation](https://www.openphone.com/docs/api-reference/contacts/update-a-contact-by-id)",
-  version: "0.0.4",
+  description: "Update one or more fields on an existing contact. Only the fields you provide are changed; omitted fields are left as-is. Run **List Contacts** to find a contactId. Example: call with contactId from **List Contacts** and company=\"Acme Corp\" → updates just the company field and returns the updated contact record. [See the documentation](https://www.openphone.com/docs/api-reference/contacts/update-a-contact-by-id)",
+  version: "0.0.5",
   annotations: {
-    destructiveHint: true,
+    destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
@@ -17,7 +20,7 @@ export default {
     contactId: {
       type: "string",
       label: "Contact ID",
-      description: "The unique identifier of the contact",
+      description: "The unique identifier of the contact. Run the **List Contacts** action to find contact IDs.",
     },
     firstName: {
       propDefinition: [
@@ -79,8 +82,8 @@ export default {
           lastName: this.lastName,
           company: this.company,
           role: this.role,
-          emails: parseObject(this.emails),
-          phoneNumbers: parseObject(this.phoneNumbers),
+          emails: normalizeNameValueList(parseObject(this.emails), "Email"),
+          phoneNumbers: normalizeNameValueList(parseObject(this.phoneNumbers), "Phone"),
         },
         customFields: parseObject(this.customFields),
       },

--- a/components/openphone/actions/update-conversation/update-conversation.mjs
+++ b/components/openphone/actions/update-conversation/update-conversation.mjs
@@ -9,7 +9,7 @@ import {
 export default {
   key: "openphone-update-conversation",
   name: "Update Conversation Status",
-  description: "Update the status of an OpenPhone conversation. Set `conversationStatus` to `done`, `open`, or `unread`; the action routes to the corresponding OpenPhone endpoint (`mark-as-done`, `mark-as-open`, `mark-as-read`). Use **List Conversations** or **List Messages** to find the `conversationId`. Example: call with conversationId=\"CN123abc\", conversationStatus=\"done\" → marks the conversation done and returns the updated conversation. [See the documentation](https://www.openphone.com/docs/api-reference/conversations/mark-conversation-as-done)",
+  description: "Update the status of an OpenPhone conversation. Set `conversationStatus` to `done`, `open`, or `read`; the action routes to the corresponding OpenPhone endpoint (`mark-as-done`, `mark-as-open`, `mark-as-read`). Use **List Conversations** or **List Messages** to find the `conversationId`. Example: call with conversationId=\"CN123abc\", conversationStatus=\"done\" → marks the conversation done and returns the updated conversation. [See the documentation](https://www.openphone.com/docs/api-reference/conversations/mark-conversation-as-done)",
   version: "0.0.1",
   type: "action",
   annotations: {
@@ -28,7 +28,7 @@ export default {
     conversationStatus: {
       type: "string",
       label: "Conversation Status",
-      description: "The status to set. One of: `done`, `open`, `unread`.",
+      description: "The status to set. One of: `done`, `open`, `read`.",
       options: CONVERSATION_STATUS_OPTIONS,
     },
   },

--- a/components/openphone/actions/update-conversation/update-conversation.mjs
+++ b/components/openphone/actions/update-conversation/update-conversation.mjs
@@ -1,0 +1,48 @@
+// x-pd-ai: optimized
+import { ConfigurationError } from "@pipedream/platform";
+import openphone from "../../openphone.app.mjs";
+import {
+  CONVERSATION_STATUS_OPTIONS,
+  CONVERSATION_STATUS_SUBPATHS,
+} from "../../common/constants.mjs";
+
+export default {
+  key: "openphone-update-conversation",
+  name: "Update Conversation Status",
+  description: "Update the status of an OpenPhone conversation. Set `conversationStatus` to `done`, `open`, or `unread`; the action routes to the corresponding OpenPhone endpoint (`mark-as-done`, `mark-as-open`, `mark-as-read`). Use **List Conversations** or **List Messages** to find the `conversationId`. Example: call with conversationId=\"CN123abc\", conversationStatus=\"done\" → marks the conversation done and returns the updated conversation. [See the documentation](https://www.openphone.com/docs/api-reference/conversations/mark-conversation-as-done)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    openphone,
+    conversationId: {
+      propDefinition: [
+        openphone,
+        "conversationId",
+      ],
+    },
+    conversationStatus: {
+      type: "string",
+      label: "Conversation Status",
+      description: "The status to set. One of: `done`, `open`, `unread`.",
+      options: CONVERSATION_STATUS_OPTIONS,
+    },
+  },
+  async run({ $ }) {
+    const subPath = CONVERSATION_STATUS_SUBPATHS[this.conversationStatus];
+    if (!subPath) {
+      throw new ConfigurationError(`Invalid status "${this.conversationStatus}". Must be one of: ${CONVERSATION_STATUS_OPTIONS.join(", ")}.`);
+    }
+    const response = await this.openphone.updateConversationStatus({
+      conversationId: this.conversationId,
+      subPath,
+      $,
+    });
+    $.export("$summary", `Updated conversation ${this.conversationId} to status "${this.conversationStatus}"`);
+    return response;
+  },
+};

--- a/components/openphone/actions/update-task/update-task.mjs
+++ b/components/openphone/actions/update-task/update-task.mjs
@@ -4,7 +4,7 @@ import openphone from "../../openphone.app.mjs";
 export default {
   key: "openphone-update-task",
   name: "Update Task",
-  description: "Update an existing task's title and description by ID. NOTE: the OpenPhone update endpoint only modifies `title` and `description`; due date and assignee are managed via other endpoints. Use **List Tasks** to find task IDs. Example: call with taskId=\"TK123abc\", title=\"Follow up (urgent)\" → updates the title and returns the updated task record. [See the documentation](https://www.openphone.com/docs/api-reference/tasks/update-a-task)",
+  description: "Update an existing task's title and description by ID. NOTE: the OpenPhone update endpoint only modifies `title` and `description` (both required on every update); due date and assignee are managed via other endpoints. Use **List Tasks** to find task IDs. Example: call with taskId=\"TK123abc\", title=\"Follow up (urgent)\", description=\"Customer asked about pricing tiers.\" → updates both fields and returns the updated task record. [See the documentation](https://www.openphone.com/docs/api-reference/tasks/update-a-task)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/openphone/actions/update-task/update-task.mjs
+++ b/components/openphone/actions/update-task/update-task.mjs
@@ -1,0 +1,46 @@
+// x-pd-ai: optimized
+import openphone from "../../openphone.app.mjs";
+
+export default {
+  key: "openphone-update-task",
+  name: "Update Task",
+  description: "Update an existing task's title and description by ID. NOTE: the OpenPhone update endpoint only modifies `title` and `description`; due date and assignee are managed via other endpoints. Use **List Tasks** to find task IDs. Example: call with taskId=\"TK123abc\", title=\"Follow up (urgent)\" → updates the title and returns the updated task record. [See the documentation](https://www.openphone.com/docs/api-reference/tasks/update-a-task)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  props: {
+    openphone,
+    taskId: {
+      propDefinition: [
+        openphone,
+        "taskId",
+      ],
+    },
+    title: {
+      type: "string",
+      label: "Title",
+      description: "The updated task title.",
+    },
+    description: {
+      type: "string",
+      label: "Description",
+      description: "The updated task description.",
+    },
+  },
+  async run({ $ }) {
+    const response = await this.openphone.updateTask({
+      taskId: this.taskId,
+      $,
+      data: {
+        title: this.title,
+        description: this.description,
+      },
+    });
+    $.export("$summary", `Updated task ${this.taskId}`);
+    return response;
+  },
+};

--- a/components/openphone/common/constants.mjs
+++ b/components/openphone/common/constants.mjs
@@ -1,13 +1,13 @@
 export const CONVERSATION_STATUS_SUBPATHS = {
   done: "mark-as-done",
   open: "mark-as-open",
-  unread: "mark-as-read",
+  read: "mark-as-read",
 };
 
 export const CONVERSATION_STATUS_OPTIONS = [
   "done",
   "open",
-  "unread",
+  "read",
 ];
 
 export const MIN_LIMIT = 1;

--- a/components/openphone/common/constants.mjs
+++ b/components/openphone/common/constants.mjs
@@ -1,0 +1,23 @@
+export const CONVERSATION_STATUS_SUBPATHS = {
+  done: "mark-as-done",
+  open: "mark-as-open",
+  unread: "mark-as-read",
+};
+
+export const CONVERSATION_STATUS_OPTIONS = [
+  "done",
+  "open",
+  "unread",
+];
+
+export const MIN_LIMIT = 1;
+export const MAX_LIMIT = 100;
+
+export const DEFAULT_CALLS_LIMIT = 10;
+export const DEFAULT_MESSAGES_LIMIT = 10;
+export const DEFAULT_TASKS_LIMIT = 50;
+export const DEFAULT_CONTACTS_LIMIT = 10;
+export const MAX_CONTACTS_LIMIT = 50;
+export const DEFAULT_USERS_LIMIT = 10;
+export const MAX_USERS_LIMIT = 50;
+export const DEFAULT_CONVERSATIONS_LIMIT = 10;

--- a/components/openphone/common/utils.mjs
+++ b/components/openphone/common/utils.mjs
@@ -24,3 +24,30 @@ export const parseObject = (obj) => {
 
   return parsedObj;
 };
+
+// The OpenPhone contacts API requires emails/phoneNumbers as arrays of {name, value}
+// objects, with BOTH fields required (confirmed via two live 400s: "Expected object" on
+// a bare string array, then "/name - Expected required property" once value alone was
+// supplied) — normalize bare strings into the required shape with a generic label
+// rather than relying on the caller to pre-format them.
+export const normalizeNameValueList = (items, defaultName = "Other") => {
+  if (!Array.isArray(items)) return items;
+  return items.map((item) =>
+    typeof item === "string"
+      ? {
+        name: defaultName,
+        value: item,
+      }
+      : item);
+};
+
+export const pickFields = (records, fields) => {
+  if (!fields?.length) return records;
+  return records.map((record) =>
+    Object.fromEntries(fields
+      .filter((field) => field in record)
+      .map((field) => [
+        field,
+        record[field],
+      ])));
+};

--- a/components/openphone/common/utils.mjs
+++ b/components/openphone/common/utils.mjs
@@ -45,7 +45,7 @@ export const pickFields = (records, fields) => {
   if (!fields?.length) return records;
   return records.map((record) =>
     Object.fromEntries(fields
-      .filter((field) => field in record)
+      .filter((field) => Object.hasOwn(record, field))
       .map((field) => [
         field,
         record[field],

--- a/components/openphone/openphone.app.mjs
+++ b/components/openphone/openphone.app.mjs
@@ -3,6 +3,18 @@ import {
   axios, ConfigurationError,
 } from "@pipedream/platform";
 import Bottleneck from "bottleneck";
+import {
+  DEFAULT_CALLS_LIMIT,
+  DEFAULT_CONTACTS_LIMIT,
+  DEFAULT_CONVERSATIONS_LIMIT,
+  DEFAULT_MESSAGES_LIMIT,
+  DEFAULT_TASKS_LIMIT,
+  DEFAULT_USERS_LIMIT,
+  MAX_CONTACTS_LIMIT,
+  MAX_LIMIT,
+  MAX_USERS_LIMIT,
+  MIN_LIMIT,
+} from "./common/constants.mjs";
 const limiter = new Bottleneck({
   minTime: 100, // 10 requests per seconds (https://www.openphone.com/docs/mdx/api-reference/rate-limits)
   maxConcurrent: 1,
@@ -91,10 +103,15 @@ export default {
       label: "Phone Number ID",
       description: "The OpenPhone phone number ID (format `PN...`). Run the **List Phone Numbers** action to find valid IDs.",
     },
-    participants: {
+    callParticipant: {
+      type: "string",
+      label: "Participant",
+      description: "Phone number, in E.164 format (e.g. `+15551234567`), to filter calls by. This endpoint accepts exactly one participant (confirmed against the live API — it's a required field, not optional).",
+    },
+    messageParticipants: {
       type: "string[]",
       label: "Participants",
-      description: "Phone number(s) in E.164 format (e.g. `+15551234567`).",
+      description: "Participant phone number(s) in E.164 format (e.g. `+15551234567`). Max 10 participants. Required by this endpoint.",
     },
     userId: {
       type: "string",
@@ -119,12 +136,58 @@ export default {
       label: "Conversation ID",
       description: "The ID of the conversation (format `CN...`). Run the **List Conversations** action to find conversation IDs (or the **List Messages** action, which returns each message's `conversationId`).",
     },
-    maxResults: {
+    callMaxResults: {
       type: "integer",
       label: "Max Results",
-      description: "Maximum number of results to return. Min 1, max 100.",
-      min: 1,
-      max: 100,
+      description: `Maximum number of calls to return. Min ${MIN_LIMIT}, max ${MAX_LIMIT}. Defaults to ${DEFAULT_CALLS_LIMIT}.`,
+      min: MIN_LIMIT,
+      max: MAX_LIMIT,
+      default: DEFAULT_CALLS_LIMIT,
+      optional: true,
+    },
+    conversationMaxResults: {
+      type: "integer",
+      label: "Max Results",
+      description: `Maximum number of conversations to return per page. Min ${MIN_LIMIT}, max ${MAX_LIMIT}. Defaults to ${DEFAULT_CONVERSATIONS_LIMIT}.`,
+      min: MIN_LIMIT,
+      max: MAX_LIMIT,
+      default: DEFAULT_CONVERSATIONS_LIMIT,
+      optional: true,
+    },
+    messageMaxResults: {
+      type: "integer",
+      label: "Max Results",
+      description: `Maximum number of messages to return. Min ${MIN_LIMIT}, max ${MAX_LIMIT}. Defaults to ${DEFAULT_MESSAGES_LIMIT}.`,
+      min: MIN_LIMIT,
+      max: MAX_LIMIT,
+      default: DEFAULT_MESSAGES_LIMIT,
+      optional: true,
+    },
+    taskMaxResults: {
+      type: "integer",
+      label: "Max Results",
+      description: `Maximum number of tasks to return. Min ${MIN_LIMIT}, max ${MAX_LIMIT}. Defaults to ${DEFAULT_TASKS_LIMIT}.`,
+      min: MIN_LIMIT,
+      max: MAX_LIMIT,
+      default: DEFAULT_TASKS_LIMIT,
+      optional: true,
+    },
+    contactMaxResults: {
+      type: "integer",
+      label: "Max Results",
+      description: `Maximum number of contacts to return per page. Min ${MIN_LIMIT}, max ${MAX_CONTACTS_LIMIT}. Defaults to ${DEFAULT_CONTACTS_LIMIT}.`,
+      min: MIN_LIMIT,
+      max: MAX_CONTACTS_LIMIT,
+      default: DEFAULT_CONTACTS_LIMIT,
+      optional: true,
+    },
+    userMaxResults: {
+      type: "integer",
+      label: "Max Results",
+      description: `Maximum number of users to return per page. Min ${MIN_LIMIT}, max ${MAX_USERS_LIMIT}. Defaults to ${DEFAULT_USERS_LIMIT}.`,
+      min: MIN_LIMIT,
+      max: MAX_USERS_LIMIT,
+      default: DEFAULT_USERS_LIMIT,
       optional: true,
     },
     pageToken: {

--- a/components/openphone/openphone.app.mjs
+++ b/components/openphone/openphone.app.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import {
   axios, ConfigurationError,
 } from "@pipedream/platform";
@@ -7,6 +8,25 @@ const limiter = new Bottleneck({
   maxConcurrent: 1,
 });
 const axiosRateLimiter = limiter.wrap(axios);
+
+// axios's default query-param serialization emits `key[]=value` for arrays, which the
+// OpenPhone API rejects ("Expected array") — confirmed against the live API that it
+// wants bare repeated keys instead (`key=value1&key=value2`).
+function serializeParams(params) {
+  const search = new URLSearchParams();
+  for (const [
+    key,
+    value,
+  ] of Object.entries(params ?? {})) {
+    if (value === undefined || value === null) continue;
+    if (Array.isArray(value)) {
+      for (const item of value) search.append(key, item);
+    } else {
+      search.append(key, value);
+    }
+  }
+  return search.toString();
+}
 
 export default {
   type: "app",
@@ -66,6 +86,100 @@ export default {
       label: "Custom Fields",
       description: "Array of objects of custom fields for the contact. **Example:** `{\"key\": \"inbound-lead\", \"value\": [\"option1\", \"option2\"]}`",
     },
+    phoneNumberId: {
+      type: "string",
+      label: "Phone Number ID",
+      description: "The OpenPhone phone number ID (format `PN...`). Run the **List Phone Numbers** action to find valid IDs.",
+    },
+    participants: {
+      type: "string[]",
+      label: "Participants",
+      description: "Phone number(s) in E.164 format (e.g. `+15551234567`).",
+    },
+    userId: {
+      type: "string",
+      label: "User ID",
+      description: "Optional OpenPhone user ID (format `US...`) to filter by. Run the **List Users** action to find user IDs.",
+      optional: true,
+    },
+    createdAfter: {
+      type: "string",
+      label: "Created After",
+      description: "Optional ISO 8601 timestamp; only return results created after this time (e.g. `2026-08-01T00:00:00Z`).",
+      optional: true,
+    },
+    createdBefore: {
+      type: "string",
+      label: "Created Before",
+      description: "Optional ISO 8601 timestamp; only return results created before this time (e.g. `2026-08-31T23:59:59Z`).",
+      optional: true,
+    },
+    conversationId: {
+      type: "string",
+      label: "Conversation ID",
+      description: "The ID of the conversation (format `CN...`). Run the **List Conversations** action to find conversation IDs (or the **List Messages** action, which returns each message's `conversationId`).",
+    },
+    maxResults: {
+      type: "integer",
+      label: "Max Results",
+      description: "Maximum number of results to return. Min 1, max 100.",
+      min: 1,
+      max: 100,
+      optional: true,
+    },
+    pageToken: {
+      type: "string",
+      label: "Page Token",
+      description: "Pagination token (`nextPageToken` from a previous response) to fetch the next page of results. If `nextPageToken` is present in a response, call this action again with `pageToken` set to that value to fetch more results.",
+      optional: true,
+    },
+    fields: {
+      type: "string[]",
+      label: "Fields",
+      description: "Optional list of fields to include in each returned record (e.g. `[\"id\", \"createdAt\"]`). When omitted, the full record is returned.",
+      optional: true,
+    },
+    taskId: {
+      type: "string",
+      label: "Task ID",
+      description: "The ID of the task (format `TK...`). Run the **List Tasks** action to find task IDs.",
+    },
+    externalIds: {
+      type: "string[]",
+      label: "External IDs",
+      description: "Optional list of unique identifiers from an external system used to retrieve specific contacts. These must match the `externalId` values supplied when the contacts were created via **Create a Contact**. When omitted, all contacts for the organization are returned.",
+      optional: true,
+    },
+    sources: {
+      type: "string[]",
+      label: "Sources",
+      description: "Optional list of sources to filter by, indicating how the contact was created or where it originated from.",
+      optional: true,
+    },
+    conversationPhoneNumbers: {
+      type: "string[]",
+      label: "Phone Numbers",
+      description: "Optional list of OpenPhone phone numbers to filter by. Each item can be either an OpenPhone phone number ID or a full phone number in E.164 format. Run the **List Phone Numbers** action to find valid IDs.",
+      optional: true,
+    },
+    excludeInactive: {
+      type: "boolean",
+      label: "Exclude Inactive",
+      description: "Exclude inactive conversations from the results.",
+      optional: true,
+    },
+    updatedAfter: {
+      type: "string",
+      label: "Updated After",
+      description: "Optional ISO 8601 timestamp; only return results updated after this time (e.g. `2026-08-01T00:00:00Z`).",
+      optional: true,
+    },
+    updatedBefore: {
+      type: "string",
+      label: "Updated Before",
+      description: "Optional ISO 8601 timestamp; only return results updated before this time (e.g. `2026-08-31T23:59:59Z`).",
+      optional: true,
+    },
   },
   methods: {
     _baseUrl() {
@@ -83,6 +197,7 @@ export default {
         return await axiosRateLimiter($, {
           url: this._baseUrl() + path,
           headers: this._headers(),
+          paramsSerializer: serializeParams,
           ...opts,
         });
       } catch ({ response }) {
@@ -96,6 +211,24 @@ export default {
     listPhoneNumbers(opts = {}) {
       return this._makeRequest({
         path: "/phone-numbers",
+        ...opts,
+      });
+    },
+    listContacts(opts = {}) {
+      return this._makeRequest({
+        path: "/contacts",
+        ...opts,
+      });
+    },
+    listUsers(opts = {}) {
+      return this._makeRequest({
+        path: "/users",
+        ...opts,
+      });
+    },
+    listConversations(opts = {}) {
+      return this._makeRequest({
+        path: "/conversations",
         ...opts,
       });
     },
@@ -133,6 +266,91 @@ export default {
     }) {
       return this._makeRequest({
         method: "PATCH",
+        path: `/contacts/${contactId}`,
+        ...opts,
+      });
+    },
+    listCalls(opts = {}) {
+      return this._makeRequest({
+        path: "/calls",
+        ...opts,
+      });
+    },
+    getCall({
+      callId, ...opts
+    }) {
+      return this._makeRequest({
+        path: `/calls/${callId}`,
+        ...opts,
+      });
+    },
+    getCallSummary({
+      callId, ...opts
+    }) {
+      return this._makeRequest({
+        path: `/calls/${callId}/summary`,
+        ...opts,
+      });
+    },
+    getCallTranscript({
+      callId, ...opts
+    }) {
+      return this._makeRequest({
+        path: `/calls/${callId}/transcript`,
+        ...opts,
+      });
+    },
+    listMessages(opts = {}) {
+      return this._makeRequest({
+        path: "/messages",
+        ...opts,
+      });
+    },
+    updateConversationStatus({
+      conversationId, subPath, ...opts
+    }) {
+      return this._makeRequest({
+        method: "POST",
+        path: `/conversations/${conversationId}/${subPath}`,
+        ...opts,
+      });
+    },
+    createTask(opts = {}) {
+      return this._makeRequest({
+        method: "POST",
+        path: "/tasks",
+        ...opts,
+      });
+    },
+    listTasks(opts = {}) {
+      return this._makeRequest({
+        path: "/tasks",
+        ...opts,
+      });
+    },
+    updateTask({
+      taskId, ...opts
+    }) {
+      return this._makeRequest({
+        method: "PUT",
+        path: `/tasks/${taskId}`,
+        ...opts,
+      });
+    },
+    deleteTask({
+      taskId, ...opts
+    }) {
+      return this._makeRequest({
+        method: "DELETE",
+        path: `/tasks/${taskId}`,
+        ...opts,
+      });
+    },
+    deleteContact({
+      contactId, ...opts
+    }) {
+      return this._makeRequest({
+        method: "DELETE",
         path: `/contacts/${contactId}`,
         ...opts,
       });

--- a/components/openphone/openphone.app.mjs
+++ b/components/openphone/openphone.app.mjs
@@ -205,7 +205,11 @@ export default {
           ? `Prop: ${response.data.errors[0].path} - ${response.data.errors[0].message}`
           : response?.data?.message;
 
-        throw new ConfigurationError(errorMessage);
+        const error = new ConfigurationError(errorMessage);
+        // Preserved so callers can distinguish "not found yet" (e.g. a call summary
+        // that hasn't been generated) from a real failure (auth, rate limit, 5xx).
+        error.status = response?.status;
+        throw error;
       }
     },
     listPhoneNumbers(opts = {}) {

--- a/components/openphone/package.json
+++ b/components/openphone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/openphone",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Pipedream OpenPhone Components",
   "main": "openphone.app.mjs",
   "keywords": [

--- a/components/openphone/sources/new-call-recording-completed-instant/new-call-recording-completed-instant.mjs
+++ b/components/openphone/sources/new-call-recording-completed-instant/new-call-recording-completed-instant.mjs
@@ -6,7 +6,7 @@ export default {
   key: "openphone-new-call-recording-completed-instant",
   name: "New Call Recording Completed (Instant)",
   description: "Emit new event when a call recording has finished.",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/openphone/sources/new-incoming-call-completed-instant/new-incoming-call-completed-instant.mjs
+++ b/components/openphone/sources/new-incoming-call-completed-instant/new-incoming-call-completed-instant.mjs
@@ -6,7 +6,7 @@ export default {
   key: "openphone-new-incoming-call-completed-instant",
   name: "New Incoming Call Completed (Instant)",
   description: "Emit new event when an incoming call is completed, including calls not picked up or voicemails left.",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/openphone/sources/new-message-received-instant/new-message-received-instant.mjs
+++ b/components/openphone/sources/new-message-received-instant/new-message-received-instant.mjs
@@ -6,7 +6,7 @@ export default {
   key: "openphone-new-message-received-instant",
   name: "New Message Received (Instant)",
   description: "Emit new event when a new message is received",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/openphone/sources/new-outgoing-call-completed-instant/new-outgoing-call-completed-instant.mjs
+++ b/components/openphone/sources/new-outgoing-call-completed-instant/new-outgoing-call-completed-instant.mjs
@@ -6,7 +6,7 @@ export default {
   key: "openphone-new-outgoing-call-completed-instant",
   name: "New Outgoing Call Completed (Instant)",
   description: "Emit new event when an outgoing call has ended.",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "source",
   dedupe: "unique",
   methods: {


### PR DESCRIPTION
## What & why

Closes #21530. OpenPhone's MCP tool surface covered only create/update-contact,
list-phone-numbers, and send-message — an agent couldn't read call or message
history, manage tasks, manage conversation status, or delete a contact. This adds
the full communication-history/workflow surface the issue asked for, plus the
discovery actions (list-contacts, list-users, list-conversations) needed so the
ID-taking props on those new actions are actually usable by an agent instead of
being blocked props.

## New actions

- **create-task, update-task, delete-task, list-tasks** — task lifecycle tied to a
  conversation. `create-task`'s `description` prop was marked optional; the live
  API rejects the create without it (confirmed via a 400 "Expected union value") —
  made required.
- **list-calls, get-call** — call history + per-call summary/transcript.
  `list-calls`' `participants` was marked optional; the API requires it (confirmed
  via a 400 "Expected required property").
- **list-messages** — message history. Its own description claimed
  `conversationId` alone was a sufficient filter; the live API requires
  `phoneNumberId` AND `participants` together instead.
- **update-conversation** — mark a conversation done/open/unread. Renamed the bare
  `status` prop to `conversationStatus` (agent-audit: generic prop names aren't
  agent-legible).
- **delete-contact** — closes the "can't delete a contact" gap from the issue.
- **list-contacts, list-users, list-conversations** — discovery actions; without
  them, `contactId`/`userId`/`conversationId` elsewhere had no way for an agent to
  find a valid value.

## Fixes to existing actions

- **create-contact, update-contact** (`0.0.4`→`0.0.5`) — `phoneNumbers`/`emails`
  silently rejected a bare phone/email string (the API requires `{name, value}`
  objects); added a `normalizeNameValueList` helper so the component accepts the
  obvious input shape. `update-contact`'s `destructiveHint` was also wrongly
  `true` for a field update.
- **list-from-options, list-phone-numbers, send-message** (patch) — agent-audit
  flagged terse/internal-sounding descriptions and missing worked examples;
  rewritten.

## Shared fixes (openphone.app.mjs / common/)

- Custom axios `paramsSerializer` — array query params were serialized as
  `key[]=value`, which the OpenPhone API rejects ("Expected array"); switched to
  bare repeated keys, confirmed against the live API. Fixes `list-calls` and
  `list-messages`, also covers the new array filters on `list-contacts`/
  `list-conversations`.
- Added a `fields` param + `pickFields` helper to the list actions (agent-audit:
  full-payload-dump finding) — additive, omitted = unchanged output.
- `pageToken` description now tells the agent to call again when `nextPageToken`
  is present (agent-audit: silent pagination truncation).

## Verification

- Suite: `evals/openphone` — 20 evals (10 multi-tool chains), 20/20 on Sonnet 5
  (single trial). `send-message` excluded from the suite — the connected test
  account isn't approved for A2P messaging (unrelated to the component).
- Report: `2026-08-11T15-41-30-820Z.report.md`.
- `/agent-audit openphone`: 100/100 (0 blocked props, 0 MCP-broken actions, 0
  silent-truncation list actions, 0 full-payload dumps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added actions to list contacts, users, conversations, calls, messages, phone numbers, and tasks.
  * Added call detail retrieval, including summaries and transcripts.
  * Added task creation, updates, and deletion, plus contact deletion.
  * Added conversation status updates with supported status options.
* **Improvements**
  * Improved contact email and phone input handling and contact updates.
  * Added filtering, pagination, field selection, and clearer usage guidance.
  * Updated the OpenPhone integration and event sources to newer versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->