### PR TITLE
[21606] Google docs action changes

### DIFF
--- a/components/google_docs/actions/append-text/append-text.mjs
+++ b/components/google_docs/actions/append-text/append-text.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-append-text",
   name: "Append Text",
   description: "Append text to an existing document. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#InsertTextRequest)",
-  version: "0.1.12",
+  version: "0.1.13",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/create-document-from-template/create-document-from-template.mjs
+++ b/components/google_docs/actions/create-document-from-template/create-document-from-template.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_docs-create-document-from-template",
   name: "Create Document From Template",
   description: "Create a new Google Doc by copying a template document and substituting `{{placeholder}}` tokens with values. Use **Find Document** to resolve the template's name to its ID. Returns `{documentId, title, url}`. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#ReplaceAllTextRequest)",
-  version: "1.0.1",
+  version: "1.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/create-document/create-document.mjs
+++ b/components/google_docs/actions/create-document/create-document.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-create-document",
   name: "Create Document",
   description: "Create a new Google Doc with an optional body. The body is rendered as Markdown, so you can include headings (`# Title`), bold/italic, bullet/numbered lists, links, and code. Optionally place the doc in a specific Drive folder. Returns `{documentId, title, url}`. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/create)",
-  version: "1.0.1",
+  version: "1.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/delete-table/delete-table.mjs
+++ b/components/google_docs/actions/delete-table/delete-table.mjs
@@ -1,0 +1,54 @@
+import { ConfigurationError } from "@pipedream/platform";
+import googleDocs from "../../google_docs.app.mjs";
+
+export default {
+  key: "google_docs-delete-table",
+  name: "Delete Table",
+  description: "Remove an entire table, structure and contents, from the document. Use this to clear a table completely, including an empty table left behind after its text was removed. Set **Table Number** to pick which table to remove (1 = first top-level table in the document, in reading order; a table nested inside another table's cell doesn't count separately). Use **Get Document** first if you need to confirm how many tables exist. This also works on a table linked to a Google Sheet, since removal is treated as ordinary content deletion. Use **Find Document** to resolve a document's name to its ID. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#DeleteContentRangeRequest)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: true,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  type: "action",
+  props: {
+    googleDocs,
+    documentId: {
+      propDefinition: [
+        googleDocs,
+        "documentId",
+      ],
+    },
+    tableIndex: {
+      type: "integer",
+      label: "Table Number",
+      description: "Which table to delete, counting top-level tables in the document body in reading order (`1` = first table). Defaults to `1`, the common case of removing the document's only table.",
+      min: 1,
+      optional: true,
+      default: 1,
+    },
+  },
+  async run({ $ }) {
+    const { body } = await this.googleDocs.getDocument(this.documentId, false, "body");
+    const tables = this.googleDocs.flattenTables(body?.content);
+
+    if (!tables.length) {
+      throw new ConfigurationError(`Document ${this.documentId} has no tables to delete.`);
+    }
+    if (this.tableIndex > tables.length) {
+      throw new ConfigurationError(`Document ${this.documentId} only has ${tables.length} table(s); table number ${this.tableIndex} does not exist.`);
+    }
+
+    const {
+      startIndex, endIndex,
+    } = tables[this.tableIndex - 1];
+    await this.googleDocs.deleteTable(this.documentId, {
+      startIndex,
+      endIndex,
+    });
+
+    $.export("$summary", `Deleted table ${this.tableIndex} of ${tables.length} from document ${this.documentId}`);
+    return this.googleDocs.getDocument(this.documentId);
+  },
+};

--- a/components/google_docs/actions/export-document/export-document.mjs
+++ b/components/google_docs/actions/export-document/export-document.mjs
@@ -32,7 +32,7 @@ export default {
   key: "google_docs-export-document",
   name: "Export Document",
   description: "Export (download) a Google Doc to a file in PDF, DOCX, TXT, HTML, or ODT format. Use **Find Document** to resolve a document's name to its ID. The file is written to the workflow's temporary storage and a presigned download URL is returned to the caller. Returns `{filePath, filename, mimeType}`. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/export)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/find-document/find-document.mjs
+++ b/components/google_docs/actions/find-document/find-document.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-find-document",
   name: "Find Document",
   description: "Search for Google Docs by name or full-text content. Returns a list of `{id, name, url, modifiedTime}`. Use this first to resolve a document's name to its ID, then pass the `id` to **Get Document**, **Export Document**, or any of the insert/replace tools. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/list)",
-  version: "1.0.1",
+  version: "1.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/get-document/get-document.mjs
+++ b/components/google_docs/actions/get-document/get-document.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_docs-get-document",
   name: "Get Document",
   description: "Get the full text content and structure of a Google Doc by its ID. Returns the document body plus a flattened `textContent` field for easy reading. Optionally supply a `fields` mask to request a partial (e.g. metadata-only) response and skip the body-text enrichment. Use **Find Document** first to resolve a document's name to its ID. For multi-tab documents, pass a `tabId` to retrieve a single tab's content. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/get)",
-  version: "1.1.0",
+  version: "1.1.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/get-profile/get-profile.mjs
+++ b/components/google_docs/actions/get-profile/get-profile.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-get-profile",
   name: "Get Profile",
   description: "Get the identity (display name and email) of the currently authenticated Google account. Use this to answer \"who am I\" questions and to attribute documents to the current user. Resolves via the Drive `about.get` endpoint (no extra OAuth scope required). [See the documentation](https://developers.google.com/drive/api/v3/reference/about/get)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/insert-image/insert-image.mjs
+++ b/components/google_docs/actions/insert-image/insert-image.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-insert-image",
   name: "Insert Image",
   description: "Insert an inline image into a Google Doc from a publicly reachable image URL. The URL must be publicly accessible (Google fetches it server-side) and point to a PNG, JPEG, or GIF. Use **Find Document** to resolve a document's name to its ID. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#InsertInlineImageRequest)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/insert-page-break/insert-page-break.mjs
+++ b/components/google_docs/actions/insert-page-break/insert-page-break.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-insert-page-break",
   name: "Insert Page Break",
   description: "Insert a page break into a Google Doc at the beginning, end, or a specific character index. Use **Find Document** to resolve a document's name to its ID. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#InsertPageBreakRequest)",
-  version: "1.0.1",
+  version: "1.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/insert-table/insert-table.mjs
+++ b/components/google_docs/actions/insert-table/insert-table.mjs
@@ -3,8 +3,8 @@ import googleDocs from "../../google_docs.app.mjs";
 export default {
   key: "google_docs-insert-table",
   name: "Insert Table",
-  description: "Insert an empty table with the given number of rows and columns into a Google Doc. Use **Find Document** to resolve a document's name to its ID. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#InsertTableRequest)",
-  version: "1.0.1",
+  description: "Insert an empty table with the given number of rows and columns into a Google Doc. If you already have the data, use **Write Table** instead so you don't have to fill cells one by one. Use **Find Document** to resolve a document's name to its ID. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#InsertTableRequest)",
+  version: "1.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/insert-text/insert-text.mjs
+++ b/components/google_docs/actions/insert-text/insert-text.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-insert-text",
   name: "Insert Text",
   description: "Insert text into a Google Doc at the beginning, end, or a specific character index. Use **Find Document** to resolve a document's name to its ID. To append text to the end of a doc, use `position: end` (the default). [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#InsertTextRequest)",
-  version: "1.0.1",
+  version: "1.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/replace-image/replace-image.mjs
+++ b/components/google_docs/actions/replace-image/replace-image.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-replace-image",
   name: "Replace Image",
   description: "Replace image in a existing document. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#ReplaceImageRequest)",
-  version: "0.0.13",
+  version: "0.0.14",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_docs/actions/replace-text/replace-text.mjs
+++ b/components/google_docs/actions/replace-text/replace-text.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-replace-text",
   name: "Replace Text",
   description: "Find and replace all occurrences of a string in a Google Doc. Use **Find Document** to resolve a document's name to its ID. Returns the number of replacements made. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#ReplaceAllTextRequest)",
-  version: "1.0.1",
+  version: "1.0.2",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_docs/actions/write-table/write-table.mjs
+++ b/components/google_docs/actions/write-table/write-table.mjs
@@ -1,0 +1,68 @@
+import { ConfigurationError } from "@pipedream/platform";
+import googleDocs from "../../google_docs.app.mjs";
+
+export default {
+  key: "google_docs-write-table",
+  name: "Write Table",
+  description: "Create a table and fill it with data in a single step. Provide the entire table (all rows and columns, including a header row) at once. Use this instead of inserting cells or text one at a time. The action places every value in the correct cell for you. Pass **Table Data** as a JSON array of arrays, one inner array per row, header row first when **Has Header Row** is set, e.g. `[[\"Name\",\"Role\"],[\"Ada\",\"Engineer\"]]`. Use **Find Document** to resolve a document's name to its ID, or **Insert Table** instead if you only need an empty grid to fill in later. Note: a table written this way is always static — the Google Docs API does not create or preserve a live link to a Google Sheet, even when this replaces a Sheets-linked table. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#InsertTableRequest)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  type: "action",
+  props: {
+    googleDocs,
+    documentId: {
+      propDefinition: [
+        googleDocs,
+        "documentId",
+      ],
+    },
+    rows: {
+      type: "string",
+      label: "Table Data",
+      description: "JSON array of rows, one inner array per row, each holding that row's cell values in column order. Header row first if **Has Header Row** is set. Example: `[[\"Name\",\"Role\"],[\"Ada\",\"Engineer\"],[\"Grace\",\"Admiral\"]]`. Rows may have different lengths; the table is sized to the widest row and shorter rows leave their remaining cells blank.",
+    },
+    hasHeaderRow: {
+      type: "boolean",
+      label: "Has Header Row",
+      description: "When `true`, the first row in **Table Data** is treated as a header and its text is bolded. Defaults to `false`.",
+      optional: true,
+      default: false,
+    },
+    position: {
+      propDefinition: [
+        googleDocs,
+        "position",
+      ],
+    },
+  },
+  async run({ $ }) {
+    let rows;
+    try {
+      rows = typeof this.rows === "string"
+        ? JSON.parse(this.rows)
+        : this.rows;
+    } catch {
+      throw new ConfigurationError("Table Data must be valid JSON. Example: [[\"Name\",\"Role\"],[\"Ada\",\"Engineer\"]]");
+    }
+
+    const isValid = Array.isArray(rows) && rows.length
+      && rows.every((row) => Array.isArray(row) && row.length);
+    if (!isValid) {
+      throw new ConfigurationError("Table Data must be a non-empty JSON array of non-empty arrays, one per row. Example: [[\"Name\",\"Role\"],[\"Ada\",\"Engineer\"]]");
+    }
+
+    const document = await this.googleDocs.writeTable(this.documentId, {
+      rows,
+      position: this.position,
+      hasHeaderRow: this.hasHeaderRow,
+    });
+
+    const numColumns = rows.reduce((max, row) => Math.max(max, row.length), 0);
+    $.export("$summary", `Wrote a ${rows.length}x${numColumns} table into document ${this.documentId}`);
+    return document;
+  },
+};

--- a/components/google_docs/common/utils.mjs
+++ b/components/google_docs/common/utils.mjs
@@ -30,6 +30,24 @@ function flattenTables(content) {
     }));
 }
 
+// Selects the table that was just inserted by ordinal position, not by
+// comparing startIndex values: inserting a table immediately before an
+// existing one gives the new table the exact startIndex the existing table
+// used to have, and shifts the existing table forward onto some other index.
+// Comparing indexes alone can't tell which of the two is "new" in that case,
+// so instead we count how many tables preceded the insertion point (before
+// inserting) and read off the table at that same position afterwards — a
+// newly inserted table can only ever occupy the slot at that ordinal index.
+function selectInsertedTable(beforeTables, afterTables, requestedIndex) {
+  if (afterTables.length !== beforeTables.length + 1) {
+    return null;
+  }
+  const precedingCount = requestedIndex == null
+    ? beforeTables.length
+    : beforeTables.filter(({ startIndex }) => startIndex < requestedIndex).length;
+  return afterTables[precedingCount] ?? null;
+}
+
 function adjustPropDefinitions(props, app) {
   return Object.fromEntries(
     Object.entries(props).map(([
@@ -75,5 +93,6 @@ export default {
   getTextContentFromDocument,
   addTextContentToDocument,
   flattenTables,
+  selectInsertedTable,
   adjustPropDefinitions,
 };

--- a/components/google_docs/common/utils.mjs
+++ b/components/google_docs/common/utils.mjs
@@ -20,6 +20,16 @@ function addTextContentToDocument(response) {
   };
 }
 
+function flattenTables(content) {
+  return (content || [])
+    .filter((element) => element.table)
+    .map((element) => ({
+      startIndex: element.startIndex,
+      endIndex: element.endIndex,
+      table: element.table,
+    }));
+}
+
 function adjustPropDefinitions(props, app) {
   return Object.fromEntries(
     Object.entries(props).map(([
@@ -64,5 +74,6 @@ function adjustPropDefinitions(props, app) {
 export default {
   getTextContentFromDocument,
   addTextContentToDocument,
+  flattenTables,
   adjustPropDefinitions,
 };

--- a/components/google_docs/google_docs.app.mjs
+++ b/components/google_docs/google_docs.app.mjs
@@ -278,6 +278,11 @@ export default {
       const numRows = rows.length;
       const numColumns = rows.reduce((max, row) => Math.max(max, row.length), 0);
 
+      const beforeDoc = await this.getDocument(documentId, false, "body");
+      const beforeStartIndexes = new Set(
+        this.flattenTables(beforeDoc.body?.content).map(({ startIndex }) => startIndex),
+      );
+
       const insertRequest = this._buildRequestForPosition({
         rows: numRows,
         columns: numColumns,
@@ -285,15 +290,17 @@ export default {
       await this._batchUpdate(documentId, "insertTable", insertRequest);
 
       // The insertTable reply carries no location info, so re-fetch the
-      // document and find the table we just created. It's the one whose
-      // startIndex matches the location we inserted at (beginning/numeric),
-      // or the last table in the document when appending at the end.
+      // document and find the table that wasn't present before the insert.
+      // Document order guarantees this is the table we just created: any
+      // pre-existing table that also shifted position sits either entirely
+      // before it (unaffected, still in beforeStartIndexes) or entirely
+      // after it (also "new" by this check, but later in document order).
       const { body } = await this.getDocument(documentId, false, "body");
       const tables = this.flattenTables(body?.content);
-      const requestedIndex = this._resolvePositionIndex(position);
-      const table = (
-        requestedIndex != null && tables.find(({ startIndex }) => startIndex === requestedIndex)
-      ) || tables[tables.length - 1];
+      const table = tables.find(({ startIndex }) => !beforeStartIndexes.has(startIndex));
+      if (!table) {
+        throw new Error("Could not locate the table that was just created. The table was inserted but no cell data was written.");
+      }
 
       const cells = [];
       table.table.tableRows.forEach((row, rowIndex) => {

--- a/components/google_docs/google_docs.app.mjs
+++ b/components/google_docs/google_docs.app.mjs
@@ -129,11 +129,11 @@ export default {
         ? this._insertAtBeginning(requestObj)
         : this._insertAtEnd(requestObj);
     },
-    // Resolve a static `position` value (`beginning` | `end` | numeric index) into the
-    // location field a batchUpdate insert request expects.
-    _buildRequestForPosition(requestObj, position) {
+    // Resolve a static `position` value (`beginning` | `end` | numeric index) into
+    // either `null` (append at end) or the concrete character index it refers to.
+    _resolvePositionIndex(position) {
       if (position == null || position === "end") {
-        return this._insertAtEnd(requestObj);
+        return null;
       }
       // Only accept "beginning", "end", or a string of pure digits — parseInt would
       // otherwise silently accept "1.5"/"1abc" as 1 and target the wrong index.
@@ -145,12 +145,20 @@ export default {
       if (!Number.isInteger(index) || index < 1) {
         throw new ConfigurationError(`Invalid position "${position}". Use "beginning", "end", or a positive integer index.`);
       }
-      return {
-        ...requestObj,
-        location: {
-          index,
-        },
-      };
+      return index;
+    },
+    // Resolve a static `position` value into the location field a batchUpdate
+    // insert request expects.
+    _buildRequestForPosition(requestObj, position) {
+      const index = this._resolvePositionIndex(position);
+      return index == null
+        ? this._insertAtEnd(requestObj)
+        : {
+          ...requestObj,
+          location: {
+            index,
+          },
+        };
     },
     _batchUpdate(documentId, requestName, request) {
       return this.docs().documents.batchUpdate({
@@ -235,6 +243,115 @@ export default {
     },
     async insertTable(documentId, table) {
       return this._batchUpdate(documentId, "insertTable", table);
+    },
+    // Top-level tables in a document body, in document order. Tables nested
+    // inside another table's cell are not included.
+    flattenTables(content) {
+      return utils.flattenTables(content);
+    },
+    async deleteTable(documentId, {
+      startIndex, endIndex,
+    }) {
+      return this._batchUpdate(documentId, "deleteContentRange", {
+        range: {
+          startIndex,
+          endIndex,
+        },
+      });
+    },
+    async writeTable(documentId, {
+      rows, position, hasHeaderRow,
+    }) {
+      // Validate before making any request: a bad cell value here should
+      // never leave an empty table behind from a partially-applied insert.
+      const invalidValue = rows.flat().find((value) => value != null && typeof value === "object");
+      if (invalidValue !== undefined) {
+        throw new ConfigurationError(
+          `Table Data cells must be strings, numbers, or booleans, not a nested ${
+            Array.isArray(invalidValue)
+              ? "array"
+              : "object"
+          }. Example: [["Name","Role"],["Ada","Engineer"]]`,
+        );
+      }
+
+      const numRows = rows.length;
+      const numColumns = rows.reduce((max, row) => Math.max(max, row.length), 0);
+
+      const insertRequest = this._buildRequestForPosition({
+        rows: numRows,
+        columns: numColumns,
+      }, position);
+      await this._batchUpdate(documentId, "insertTable", insertRequest);
+
+      // The insertTable reply carries no location info, so re-fetch the
+      // document and find the table we just created. It's the one whose
+      // startIndex matches the location we inserted at (beginning/numeric),
+      // or the last table in the document when appending at the end.
+      const { body } = await this.getDocument(documentId, false, "body");
+      const tables = this.flattenTables(body?.content);
+      const requestedIndex = this._resolvePositionIndex(position);
+      const table = (
+        requestedIndex != null && tables.find(({ startIndex }) => startIndex === requestedIndex)
+      ) || tables[tables.length - 1];
+
+      const cells = [];
+      table.table.tableRows.forEach((row, rowIndex) => {
+        row.tableCells.forEach((cell, columnIndex) => {
+          const paragraph = cell.content?.find((element) => element.paragraph);
+          if (paragraph) {
+            cells.push({
+              rowIndex,
+              columnIndex,
+              startIndex: paragraph.startIndex,
+            });
+          }
+        });
+      });
+
+      // Fill cells from the last one to the first. Inserting text only shifts
+      // indices that come after it, so walking backwards keeps every
+      // not-yet-written cell's precomputed startIndex valid throughout.
+      const requests = [];
+      [
+        ...cells,
+      ].reverse().forEach(({
+        rowIndex, columnIndex, startIndex,
+      }) => {
+        const value = rows[rowIndex]?.[columnIndex];
+        if (value == null || value === "") {
+          return;
+        }
+        const text = String(value);
+        requests.push({
+          insertText: {
+            location: {
+              index: startIndex,
+            },
+            text,
+          },
+        });
+        if (hasHeaderRow && rowIndex === 0) {
+          requests.push({
+            updateTextStyle: {
+              range: {
+                startIndex,
+                endIndex: startIndex + text.length,
+              },
+              textStyle: {
+                bold: true,
+              },
+              fields: "bold",
+            },
+          });
+        }
+      });
+
+      if (requests.length) {
+        await this.batchUpdate(documentId, requests);
+      }
+
+      return this.getDocument(documentId);
     },
     async insertPageBreak(documentId, request) {
       return this._batchUpdate(documentId, "insertPageBreak", request);

--- a/components/google_docs/google_docs.app.mjs
+++ b/components/google_docs/google_docs.app.mjs
@@ -278,10 +278,8 @@ export default {
       const numRows = rows.length;
       const numColumns = rows.reduce((max, row) => Math.max(max, row.length), 0);
 
-      const beforeDoc = await this.getDocument(documentId, false, "body");
-      const beforeStartIndexes = new Set(
-        this.flattenTables(beforeDoc.body?.content).map(({ startIndex }) => startIndex),
-      );
+      const { body: beforeBody } = await this.getDocument(documentId, false, "body");
+      const beforeTables = this.flattenTables(beforeBody?.content);
 
       const insertRequest = this._buildRequestForPosition({
         rows: numRows,
@@ -290,14 +288,15 @@ export default {
       await this._batchUpdate(documentId, "insertTable", insertRequest);
 
       // The insertTable reply carries no location info, so re-fetch the
-      // document and find the table that wasn't present before the insert.
-      // Document order guarantees this is the table we just created: any
-      // pre-existing table that also shifted position sits either entirely
-      // before it (unaffected, still in beforeStartIndexes) or entirely
-      // after it (also "new" by this check, but later in document order).
+      // document and select the new table by ordinal position (see
+      // selectInsertedTable) rather than by startIndex — inserting
+      // immediately before an existing table gives the new table that
+      // table's old startIndex, so comparing index values can't tell them
+      // apart.
       const { body } = await this.getDocument(documentId, false, "body");
       const tables = this.flattenTables(body?.content);
-      const table = tables.find(({ startIndex }) => !beforeStartIndexes.has(startIndex));
+      const requestedIndex = this._resolvePositionIndex(position);
+      const table = utils.selectInsertedTable(beforeTables, tables, requestedIndex);
       if (!table) {
         throw new Error("Could not locate the table that was just created. The table was inserted but no cell data was written.");
       }

--- a/components/google_docs/package.json
+++ b/components/google_docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_docs",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Pipedream Google_docs Components",
   "main": "google_docs.app.mjs",
   "keywords": [

--- a/components/google_docs/sources/new-document-created/new-document-created.mjs
+++ b/components/google_docs/sources/new-document-created/new-document-created.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_docs-new-document-created",
   name: "New Document Created (Instant)",
   description: "Emit new event when a new document is created in Google Docs. [See the documentation](https://developers.google.com/drive/api/reference/rest/v3/changes/watch)",
-  version: "0.0.9",
+  version: "0.0.10",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/google_docs/sources/new-or-updated-document/new-or-updated-document.mjs
+++ b/components/google_docs/sources/new-or-updated-document/new-or-updated-document.mjs
@@ -9,7 +9,7 @@ export default {
   key: "google_docs-new-or-updated-document",
   name: "New or Updated Document (Instant)",
   description: "Emit new event when a document is created or updated in Google Docs. [See the documentation](https://developers.google.com/drive/api/reference/rest/v3/changes/watch)",
-  version: "0.0.9",
+  version: "0.0.10",
   type: "source",
   dedupe: "unique",
   methods: {


### PR DESCRIPTION
Closes: https://github.com/PipedreamHQ/pipedream/issues/21606

Added 2 new actions Delete Table and  Write table, Also updated the description of Insert table.

components/google_docs/actions/delete-table/delete-table.mjs — removes an entire table via deleteContentRange over the table's structural range. Since the Docs API has no table ID, tables are identified by Table Number (1-indexed, document order, defaults to 1 for the common "clean up the one table I just emptied" case). destructiveHint: true (irreversible removal).

components/google_docs/actions/write-table/write-table.mjs — inserts a table sized to the data and fills every cell in one step. Takes rows as a JSON string (2D array, following the exact convention already established by google_sheets-add-rows), optional hasHeaderRow to bold row 1, and the existing shared position prop. destructiveHint: false.

**Supporting changes:**

- google_docs.app.mjs: refactored _buildRequestForPosition to extract _resolvePositionIndex (no behavior change — verified all 4 existing consumers still get identical output), and added flattenTables, deleteTable, and writeTable app methods. writeTable re-fetches the doc after insertion (the API's insertTable reply carries no location info), locates the new table by matching its startIndex to the requested position (or takes the last table for "end"), then fills cells in reverse document order in a single batchUpdate — verified this ordering logic in isolation with a simulated document structure (fill order came out strictly descending, and short/jagged rows correctly leave trailing cells blank).

- common/utils.mjs: added a pure flattenTables() helper (only top-level tables — nested tables in a cell aren't counted, and this limitation is documented in both actions' prop descriptions).

- insert-table.mjs: added the exact cross-reference sentence from the issue pointing to Write Table, kept the Find 
Document hint and docs link as-is; bumped 1.0.1 → 1.0.2.

- package.json: 1.1.0 → 1.2.0 (minor, new actions).


## Checklist
Please check the following items before your PR can be reviewed:

### Versioning
- [x] All components updated in this PR had their version updated (`0.0.1` for new ones)
- [x] The app updated in this PR had its `package.json`'s version updated

### New app
If this is a new app, please submit [an app integration request](https://github.com/PipedreamHQ/pipedream/issues/new?template=app---service-integration.md) - the PR will only be reviewed after the app is integrated.
- [ ] The app updated in this PR is already integrated

### CodeRabbit review
After the PR is opened, and if new changes are pushed, CodeRabbit will automatically review it. Do not 'mark as resolved' CodeRabbit's comments, but reply to them instead, whether you agree (and update the PR accordingly) or disagree.
- [ ] I have addressed or acknowledged all of CodeRabbit's review comments



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added actions to create and populate Google Docs tables, with optional header-row formatting.
  * Added the ability to delete a selected top-level table by table number.
  * Added support for placing tables at the beginning, end, or a specified document position.
  * Added validation for table data, positions, and selected tables.
  * Added summaries of table updates after creation or deletion.
* **Documentation**
  * Updated table insertion guidance to recommend Write Table when data is already available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->