### PR TITLE
New Components - live_tennis_api

### DIFF
--- a/components/live_tennis_api/actions/get-live-matches/get-live-matches.mjs
+++ b/components/live_tennis_api/actions/get-live-matches/get-live-matches.mjs
@@ -1,0 +1,49 @@
+import app from "../../live_tennis_api.app.mjs";
+
+export default {
+  key: "live_tennis_api-get-live-matches",
+  name: "Get Live Matches",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  description: "List matches currently in play, with the latest score. Covers ATP, WTA, Challenger, ITF and juniors. [See the documentation](https://docs.livetennisapi.com/reference.html)",
+  type: "action",
+  props: {
+    app,
+    tour: {
+      propDefinition: [
+        app,
+        "tour",
+      ],
+    },
+    limit: {
+      propDefinition: [
+        app,
+        "limit",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const {
+      app, tour, limit,
+    } = this;
+
+    const response = await app.listMatches({
+      $,
+      params: {
+        status: "live",
+        tour,
+        limit,
+      },
+    });
+
+    const matches = response?.data ?? [];
+    $.export("$summary", `Found ${matches.length} live ${matches.length === 1
+      ? "match"
+      : "matches"}`);
+    return matches;
+  },
+};

--- a/components/live_tennis_api/actions/get-live-matches/get-live-matches.mjs
+++ b/components/live_tennis_api/actions/get-live-matches/get-live-matches.mjs
@@ -9,7 +9,7 @@ export default {
     openWorldHint: true,
     readOnlyHint: true,
   },
-  description: "List matches currently in play, with the latest score. Covers ATP, WTA, Challenger, ITF and juniors. [See the documentation](https://docs.livetennisapi.com/reference.html)",
+  description: "List matches currently in play, with the latest score for each. Covers ATP, WTA, Challenger, ITF and juniors; set `tour` to restrict results to one tour. Live data changes between requests as points are played, so re-fetch rather than cache. Each match's `id` is the `matchId` the other match endpoints take. For scheduled matches that have not started yet, use **Get Upcoming Fixtures**. [See the documentation](https://docs.livetennisapi.com/reference.html)",
   type: "action",
   props: {
     app,

--- a/components/live_tennis_api/actions/get-player/get-player.mjs
+++ b/components/live_tennis_api/actions/get-player/get-player.mjs
@@ -1,0 +1,36 @@
+import app from "../../live_tennis_api.app.mjs";
+
+export default {
+  key: "live_tennis_api-get-player",
+  name: "Get Player",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  description: "Get one player's bio, current ranking and cached stats by player id. [See the documentation](https://docs.livetennisapi.com/reference.html)",
+  type: "action",
+  props: {
+    app,
+    playerId: {
+      propDefinition: [
+        app,
+        "playerId",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const {
+      app, playerId,
+    } = this;
+
+    const response = await app.getPlayer({
+      $,
+      playerId,
+    });
+
+    $.export("$summary", `Retrieved player ${response?.name ?? playerId}`);
+    return response;
+  },
+};

--- a/components/live_tennis_api/actions/get-player/get-player.mjs
+++ b/components/live_tennis_api/actions/get-player/get-player.mjs
@@ -9,7 +9,7 @@ export default {
     openWorldHint: true,
     readOnlyHint: true,
   },
-  description: "Get one player's bio, current ranking and cached stats by player id. [See the documentation](https://docs.livetennisapi.com/reference.html)",
+  description: "Get one player's bio, current ranking and stats by player id. Get the `playerId` from **Search Players** (the `id` field of each result). The `stats` object ({ratings, season}) is cached upstream, not recomputed per request, so it can lag live play. [See the documentation](https://docs.livetennisapi.com/reference.html)",
   type: "action",
   props: {
     app,

--- a/components/live_tennis_api/actions/get-upcoming-fixtures/get-upcoming-fixtures.mjs
+++ b/components/live_tennis_api/actions/get-upcoming-fixtures/get-upcoming-fixtures.mjs
@@ -1,0 +1,48 @@
+import app from "../../live_tennis_api.app.mjs";
+
+export default {
+  key: "live_tennis_api-get-upcoming-fixtures",
+  name: "Get Upcoming Fixtures",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  description: "List upcoming scheduled fixtures, earliest first, with start time and player ids where resolved. [See the documentation](https://docs.livetennisapi.com/reference.html)",
+  type: "action",
+  props: {
+    app,
+    tour: {
+      propDefinition: [
+        app,
+        "tour",
+      ],
+    },
+    limit: {
+      propDefinition: [
+        app,
+        "limit",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const {
+      app, tour, limit,
+    } = this;
+
+    const response = await app.listFixtures({
+      $,
+      params: {
+        tour,
+        limit,
+      },
+    });
+
+    const fixtures = response?.data ?? [];
+    $.export("$summary", `Found ${fixtures.length} upcoming ${fixtures.length === 1
+      ? "fixture"
+      : "fixtures"}`);
+    return fixtures;
+  },
+};

--- a/components/live_tennis_api/actions/get-upcoming-fixtures/get-upcoming-fixtures.mjs
+++ b/components/live_tennis_api/actions/get-upcoming-fixtures/get-upcoming-fixtures.mjs
@@ -9,7 +9,7 @@ export default {
     openWorldHint: true,
     readOnlyHint: true,
   },
-  description: "List upcoming scheduled fixtures, earliest first, with start time and player ids where resolved. [See the documentation](https://docs.livetennisapi.com/reference.html)",
+  description: "List upcoming scheduled fixtures, earliest first, with tournament, round and start time. Set `tour` to restrict results to one tour. `start_time`, `player1_id` and `player2_id` may be null — a date-only fixture and an unresolved participant are real states (player names are always present). For matches already in play, use **Get Live Matches**. [See the documentation](https://docs.livetennisapi.com/reference.html)",
   type: "action",
   props: {
     app,

--- a/components/live_tennis_api/actions/search-players/search-players.mjs
+++ b/components/live_tennis_api/actions/search-players/search-players.mjs
@@ -9,7 +9,7 @@ export default {
     openWorldHint: true,
     readOnlyHint: true,
   },
-  description: "Search players by name. Ranked players are returned first. [See the documentation](https://docs.livetennisapi.com/reference.html)",
+  description: "Search players by name. Ranked players are returned first; omit `search` to list players in ranking order. The list items carry no stats object — pass a result's `id` to **Get Player** for the full bio, ranking and stats. [See the documentation](https://docs.livetennisapi.com/reference.html)",
   type: "action",
   props: {
     app,

--- a/components/live_tennis_api/actions/search-players/search-players.mjs
+++ b/components/live_tennis_api/actions/search-players/search-players.mjs
@@ -1,0 +1,48 @@
+import app from "../../live_tennis_api.app.mjs";
+
+export default {
+  key: "live_tennis_api-search-players",
+  name: "Search Players",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  description: "Search players by name. Ranked players are returned first. [See the documentation](https://docs.livetennisapi.com/reference.html)",
+  type: "action",
+  props: {
+    app,
+    search: {
+      type: "string",
+      label: "Search",
+      description: "The player name (or part of it) to search for. Omit to list players, ranked first.",
+      optional: true,
+    },
+    limit: {
+      propDefinition: [
+        app,
+        "limit",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const {
+      app, search, limit,
+    } = this;
+
+    const response = await app.searchPlayers({
+      $,
+      params: {
+        search,
+        limit,
+      },
+    });
+
+    const players = response?.data ?? [];
+    $.export("$summary", `Found ${players.length} ${players.length === 1
+      ? "player"
+      : "players"}`);
+    return players;
+  },
+};

--- a/components/live_tennis_api/live_tennis_api.app.mjs
+++ b/components/live_tennis_api/live_tennis_api.app.mjs
@@ -7,7 +7,7 @@ export default {
     matchId: {
       type: "integer",
       label: "Match ID",
-      description: "The match id. Every match route shares one id space, so the same value works everywhere `matchId` appears. Ids are stable for the life of a match.",
+      description: "The match id, e.g. `184203` — the `id` field on each match returned by **Get Live Matches** or on each fixture from **Get Upcoming Fixtures**. Every match route shares one id space and ids are stable for the life of a match, so an id captured before a match starts still resolves after it finishes.",
       async options({ page }) {
         const limit = 20;
         const params = {
@@ -43,7 +43,7 @@ export default {
     playerId: {
       type: "integer",
       label: "Player ID",
-      description: "The player id, as returned by `GET /players` or carried on match objects.",
+      description: "The player id, e.g. `12045` — the `id` field on each result from **Search Players**, also carried on match objects as `players.p1.id` / `players.p2.id`.",
       useQuery: true,
       async options({
         page, query,

--- a/components/live_tennis_api/live_tennis_api.app.mjs
+++ b/components/live_tennis_api/live_tennis_api.app.mjs
@@ -1,0 +1,134 @@
+import { axios } from "@pipedream/platform";
+
+export default {
+  type: "app",
+  app: "live_tennis_api",
+  propDefinitions: {
+    matchId: {
+      type: "integer",
+      label: "Match ID",
+      description: "The match id. Every match route shares one id space, so the same value works everywhere `matchId` appears. Ids are stable for the life of a match.",
+      async options({ page }) {
+        const limit = 20;
+        const params = {
+          limit,
+          offset: limit * page,
+        };
+        const [
+          live,
+          upcoming,
+        ] = await Promise.all([
+          this.listMatches({
+            params: {
+              status: "live",
+              ...params,
+            },
+          }),
+          this.listMatches({
+            params: {
+              status: "upcoming",
+              ...params,
+            },
+          }),
+        ]);
+        return [
+          ...(live?.data ?? []),
+          ...(upcoming?.data ?? []),
+        ].map((match) => ({
+          label: `${match.players?.p1?.name ?? "TBD"} vs ${match.players?.p2?.name ?? "TBD"} (${match.tournament ?? "Unknown"}, ${match.status})`,
+          value: match.id,
+        }));
+      },
+    },
+    playerId: {
+      type: "integer",
+      label: "Player ID",
+      description: "The player id, as returned by `GET /players` or carried on match objects.",
+      useQuery: true,
+      async options({
+        page, query,
+      }) {
+        const limit = 20;
+        const { data = [] } = await this.searchPlayers({
+          params: {
+            search: query,
+            limit,
+            offset: limit * page,
+          },
+        });
+        return data.map((player) => ({
+          label: player.ranking
+            ? `${player.name} (#${player.ranking})`
+            : player.name,
+          value: player.id,
+        }));
+      },
+    },
+    tour: {
+      type: "string",
+      label: "Tour",
+      description: "Restrict results to one tour. Each value covers its singles and doubles draws, so `atp` includes ATP doubles and `juniors` covers the boys' and girls' Grand Slam draws. Omit for all tours.",
+      optional: true,
+      options: [
+        "atp",
+        "wta",
+        "challenger",
+        "itf",
+        "juniors",
+      ],
+    },
+    limit: {
+      type: "integer",
+      label: "Limit",
+      description: "Maximum number of results to return.",
+      optional: true,
+      default: 50,
+      min: 1,
+      max: 200,
+    },
+  },
+  methods: {
+    _baseUrl() {
+      return "https://api.livetennisapi.com/api/public/v1";
+    },
+    _makeRequest({
+      $ = this, path, headers = {}, ...opts
+    }) {
+      return axios($, {
+        url: `${this._baseUrl()}${path}`,
+        headers: {
+          "Authorization": `Bearer ${this.$auth.api_key}`,
+          "Accept": "application/json",
+          ...headers,
+        },
+        ...opts,
+      });
+    },
+    listMatches(args = {}) {
+      return this._makeRequest({
+        path: "/matches",
+        ...args,
+      });
+    },
+    listFixtures(args = {}) {
+      return this._makeRequest({
+        path: "/fixtures",
+        ...args,
+      });
+    },
+    searchPlayers(args = {}) {
+      return this._makeRequest({
+        path: "/players",
+        ...args,
+      });
+    },
+    getPlayer({
+      playerId, ...args
+    }) {
+      return this._makeRequest({
+        path: `/players/${playerId}`,
+        ...args,
+      });
+    },
+  },
+};

--- a/components/live_tennis_api/package.json
+++ b/components/live_tennis_api/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@pipedream/live_tennis_api",
+  "version": "0.1.0",
+  "description": "Pipedream Live Tennis API Components",
+  "main": "live_tennis_api.app.mjs",
+  "keywords": [
+    "pipedream",
+    "live_tennis_api"
+  ],
+  "homepage": "https://pipedream.com/apps/live-tennis-api",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^3.4.0"
+  }
+}

--- a/components/live_tennis_api/sources/new-live-match/new-live-match.mjs
+++ b/components/live_tennis_api/sources/new-live-match/new-live-match.mjs
@@ -5,11 +5,6 @@ export default {
   key: "live_tennis_api-new-live-match",
   name: "New Live Match",
   version: "0.0.1",
-  annotations: {
-    destructiveHint: false,
-    openWorldHint: true,
-    readOnlyHint: true,
-  },
   description: "Emit new event when a match goes live. [See the documentation](https://docs.livetennisapi.com/reference.html)",
   type: "source",
   dedupe: "unique",
@@ -36,16 +31,27 @@ export default {
       app, tour,
     } = this;
 
-    const response = await app.listMatches({
-      $,
-      params: {
-        status: "live",
-        tour,
-        limit: 200,
-      },
-    });
+    const limit = 200;
+    let offset = 0;
+    const matches = [];
+    while (true) {
+      const response = await app.listMatches({
+        $,
+        params: {
+          status: "live",
+          tour,
+          limit,
+          offset,
+        },
+      });
+      const data = response?.data ?? [];
+      matches.push(...data);
+      if (!response?.meta?.has_more || data.length === 0) {
+        break;
+      }
+      offset += limit;
+    }
 
-    const matches = response?.data ?? [];
     for (const match of matches) {
       const ts = match.scheduled_time
         ? Date.parse(match.scheduled_time)

--- a/components/live_tennis_api/sources/new-live-match/new-live-match.mjs
+++ b/components/live_tennis_api/sources/new-live-match/new-live-match.mjs
@@ -1,0 +1,60 @@
+import { DEFAULT_POLLING_SOURCE_TIMER_INTERVAL } from "@pipedream/platform";
+import app from "../../live_tennis_api.app.mjs";
+
+export default {
+  key: "live_tennis_api-new-live-match",
+  name: "New Live Match",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  description: "Emit new event when a match goes live. [See the documentation](https://docs.livetennisapi.com/reference.html)",
+  type: "source",
+  dedupe: "unique",
+  props: {
+    app,
+    db: "$.service.db",
+    timer: {
+      label: "Polling interval",
+      description: "Pipedream will poll the Live Tennis API on this schedule.",
+      type: "$.interface.timer",
+      default: {
+        intervalSeconds: DEFAULT_POLLING_SOURCE_TIMER_INTERVAL,
+      },
+    },
+    tour: {
+      propDefinition: [
+        app,
+        "tour",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const {
+      app, tour,
+    } = this;
+
+    const response = await app.listMatches({
+      $,
+      params: {
+        status: "live",
+        tour,
+        limit: 200,
+      },
+    });
+
+    const matches = response?.data ?? [];
+    for (const match of matches) {
+      const ts = match.scheduled_time
+        ? Date.parse(match.scheduled_time)
+        : Date.now();
+      this.$emit(match, {
+        id: match.id,
+        summary: `Live: ${match.players?.p1?.name ?? "TBD"} vs ${match.players?.p2?.name ?? "TBD"} (${match.tournament ?? "Unknown"})`,
+        ts,
+      });
+    }
+  },
+};


### PR DESCRIPTION
## Summary

Resolves #21495

**Disclosure: I maintain the Live Tennis API** (https://livetennisapi.com) — this PR adds first-party components for it, following the vendor precedent of #21183 (MuAPI).

Adds `components/live_tennis_api` — real-time tennis scores, players and fixtures across ATP, WTA, Challenger, ITF and juniors. API docs: https://docs.livetennisapi.com/reference.html (OpenAPI 3.1 spec: https://github.com/livetennisapi/openapi).

All components use only FREE-tier endpoints, so any key works — there is a self-serve free tier with no card required (https://livetennisapi.com/subscribe/free).

**App file** (`live_tennis_api.app.mjs`)
- `_makeRequest` via `axios` from `@pipedream/platform`, base URL `https://api.livetennisapi.com/api/public/v1`, auth `Authorization: Bearer <api_key>`
- Prop definitions: `matchId` (async options from live + upcoming matches), `playerId` (async options with search via `useQuery`), `tour` (enum: atp/wta/challenger/itf/juniors), `limit`

**Actions** (all `0.0.1`)
- **Get Live Matches** — `GET /matches?status=live`, returns the array of matches with latest score
- **Get Upcoming Fixtures** — `GET /fixtures`, earliest first
- **Search Players** — `GET /players?search=`, ranked players first
- **Get Player** — `GET /players/{playerId}`, bio + ranking + cached stats

**Source** (`0.0.1`)
- **New Live Match** — polling, `dedupe: "unique"`, emits when a match goes live

Linted clean with the repo `eslint.config.mjs` (0 errors, 0 warnings on all 7 files, including the `pipedream/*` rules).

**Note on app provisioning:** the app request (#21495) was triaged on 2026-08-10 but the `live_tennis_api` app slug is not yet integrated in the auth system — I understand from the MuAPI precedent that this PR is reviewed once the app is provisioned. Auth for the integration is a single API key sent as a Bearer token (the API also accepts it as `x-api-key`). Happy to adjust the slug or auth field naming to whatever the integration defines, and to provide test keys to the review team.

## Checklist
Please check the following items before your PR can be reviewed:

### Versioning
- [x] All components updated in this PR had their version updated (`0.0.1` for new ones)
- [x] The app updated in this PR had its `package.json`'s version updated

### New app
If this is a new app, please submit [an app integration request](https://github.com/PipedreamHQ/pipedream/issues/new?template=app---service-integration.md) - the PR will only be reviewed after the app is integrated.
- [ ] The app updated in this PR is already integrated — **not yet**: the request is #21495, triaged 2026-08-10 and awaiting app provisioning

### CodeRabbit review
After the PR is opened, and if new changes are pushed, CodeRabbit will automatically review it. Do not 'mark as resolved' CodeRabbit's comments, but reply to them instead, whether you agree (and update the PR accordingly) or disagree.
- [ ] I have addressed or acknowledged all of CodeRabbit's review comments
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Live Tennis API access for live matches, upcoming fixtures, player profiles, and player searches.
  * Added filters for tours, player names, and result limits.
  * Added match and player selection support for easier workflow configuration.
  * Added result-count summaries for match, fixture, and player listings.
  * Added a polling trigger that detects and emits newly live matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
