### PR TITLE
feat(slack_v2): read direct messages by user ID + deprecate List Messages

### DIFF
--- a/components/slack_v2/actions/add-emoji-reaction/add-emoji-reaction.mjs
+++ b/components/slack_v2/actions/add-emoji-reaction/add-emoji-reaction.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-add-emoji-reaction",
   name: "Add Emoji Reaction",
   description: "Add an emoji reaction to a message. [See the documentation](https://api.slack.com/methods/reactions.add)",
-  version: "0.0.22",
+  version: "0.0.23",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/add-reaction/add-reaction.mjs
+++ b/components/slack_v2/actions/add-reaction/add-reaction.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 
 export default {

--- a/components/slack_v2/actions/add-reaction/add-reaction.mjs
+++ b/components/slack_v2/actions/add-reaction/add-reaction.mjs
@@ -9,7 +9,7 @@ export default {
     + " Use **Get Channel History** or **Search** to find the message timestamp."
     + " Emoji name should be without colons (e.g. `thumbsup`, `fire`, `heart`)."
     + " [See the documentation](https://api.slack.com/methods/reactions.add)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/archive-channel/archive-channel.mjs
+++ b/components/slack_v2/actions/archive-channel/archive-channel.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-archive-channel",
   name: "Archive Channel",
   description: "Archive a channel. [See the documentation](https://api.slack.com/methods/conversations.archive)",
-  version: "0.0.30",
+  version: "0.0.31",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/slack_v2/actions/browse-files/browse-files.mjs
+++ b/components/slack_v2/actions/browse-files/browse-files.mjs
@@ -9,7 +9,7 @@ export default {
     + " Filter by file type (e.g. `images`, `pdfs`, `snippets`)."
     + " Returns file metadata including name, type, size, and download URL."
     + " [See the documentation](https://api.slack.com/methods/files.list)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/browse-files/browse-files.mjs
+++ b/components/slack_v2/actions/browse-files/browse-files.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 
 export default {

--- a/components/slack_v2/actions/create-channel/create-channel.mjs
+++ b/components/slack_v2/actions/create-channel/create-channel.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-create-channel",
   name: "Create a Channel",
   description: "Create a new channel. [See the documentation](https://api.slack.com/methods/conversations.create)",
-  version: "0.0.30",
+  version: "0.0.31",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/create-reminder/create-reminder.mjs
+++ b/components/slack_v2/actions/create-reminder/create-reminder.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-create-reminder",
   name: "Create Reminder",
   description: "Create a reminder. [See the documentation](https://api.slack.com/methods/reminders.add)",
-  version: "0.0.31",
+  version: "0.0.32",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/delete-file/delete-file.mjs
+++ b/components/slack_v2/actions/delete-file/delete-file.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-delete-file",
   name: "Delete File",
   description: "Delete a file. [See the documentation](https://api.slack.com/methods/files.delete)",
-  version: "0.0.30",
+  version: "0.0.31",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/slack_v2/actions/delete-message/delete-message.mjs
+++ b/components/slack_v2/actions/delete-message/delete-message.mjs
@@ -11,7 +11,7 @@ export default {
     + " lets an identity delete its own messages, so this deletes as whichever identity posted:"
     + " it retries automatically with the other identity if the first attempt returns"
     + " `cant_delete_message`. [See the documentation](https://api.slack.com/methods/chat.delete)",
-  version: "0.2.0",
+  version: "0.2.1",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/slack_v2/actions/delete-message/delete-message.mjs
+++ b/components/slack_v2/actions/delete-message/delete-message.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 
 export default {

--- a/components/slack_v2/actions/edit-message/edit-message.mjs
+++ b/components/slack_v2/actions/edit-message/edit-message.mjs
@@ -10,7 +10,7 @@ export default {
     + " Requires the message timestamp (`ts`) from **Get Channel History** or **Post Message**."
     + " You can only edit messages posted by the same token/user."
     + " [See the documentation](https://api.slack.com/methods/chat.update)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/edit-message/edit-message.mjs
+++ b/components/slack_v2/actions/edit-message/edit-message.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 import { ConfigurationError } from "@pipedream/platform";
 

--- a/components/slack_v2/actions/find-message/find-message.mjs
+++ b/components/slack_v2/actions/find-message/find-message.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-find-message",
   name: "Find Message",
   description: "Find a Slack message. [See the documentation](https://api.slack.com/methods/assistant.search.context)",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/find-user-by-email/find-user-by-email.mjs
+++ b/components/slack_v2/actions/find-user-by-email/find-user-by-email.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-find-user-by-email",
   name: "Find User by Email",
   description: "Find a user by matching against their email. [See the documentation](https://api.slack.com/methods/users.lookupByEmail)",
-  version: "0.0.29",
+  version: "0.0.30",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/find-user-by-id/find-user-by-id.mjs
+++ b/components/slack_v2/actions/find-user-by-id/find-user-by-id.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-find-user-by-id",
   name: "Find User by ID",
   description: "Find a user by their ID. Returns user profile information including name, email (requires `users:read.email` scope), timezone, and status. [See the documentation](https://api.slack.com/methods/users.info)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/get-channel-details/get-channel-details.mjs
+++ b/components/slack_v2/actions/get-channel-details/get-channel-details.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-get-channel-details",
   name: "Get Channel Details",
   description: "Retrieve details for a Slack channel, specified by ID or by name — names are resolved automatically. [See the documentation](https://api.slack.com/methods/conversations.info)",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/get-channel-history/get-channel-history.mjs
+++ b/components/slack_v2/actions/get-channel-history/get-channel-history.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import utils from "../../common/utils.mjs";
 import slack from "../../slack_v2.app.mjs";
 

--- a/components/slack_v2/actions/get-channel-history/get-channel-history.mjs
+++ b/components/slack_v2/actions/get-channel-history/get-channel-history.mjs
@@ -5,16 +5,17 @@ export default {
   key: "slack_v2-get-channel-history",
   name: "Get Channel History",
   description:
-    "Read the recent message history from a specific channel."
+    "Read the recent message history from a specific channel or direct message (DM)."
     + " Accepts a channel ID or channel name (resolved automatically)."
-    + " Use this when you want to see a channel's latest messages — unlike **Search** which finds messages by keyword."
+    + " To read a DM, pass the other person's **user ID** (e.g. `U1234567890`) as the channel — pass your OWN user ID to read your conversation with yourself."
+    + " Use this when you want to see a channel's or DM's latest messages — unlike **Search** which finds messages by keyword."
     + " Returns messages with text, timestamps (ts), reactions, and user IDs."
     + " Message timestamps can be used with **Get Thread Replies**, **Edit Message**, and **Add Reaction**."
     + " **Pass `fields`** (e.g. `text,ts,user`) unless you need full message objects — raw Slack"
     + " messages carry blocks, attachments and edit metadata, so a busy channel can run to tens"
     + " of thousands of characters and be truncated before you see any of it."
     + " [See the documentation](https://api.slack.com/methods/conversations.history)",
-  version: "0.1.0",
+  version: "0.2.0",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -26,7 +27,7 @@ export default {
     channel: {
       type: "string",
       label: "Channel",
-      description: "Channel ID (e.g. `C1234567890`) or channel name (e.g. `general` or `#general`). Resolved automatically.",
+      description: "Channel ID (e.g. `C1234567890`) or channel name (e.g. `general` or `#general`). For a direct message, pass a user ID (e.g. `U1234567890`) — including your own, to read your self-DM. Resolved automatically.",
     },
     limit: {
       type: "integer",

--- a/components/slack_v2/actions/get-current-user/get-current-user.mjs
+++ b/components/slack_v2/actions/get-current-user/get-current-user.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-get-current-user",
   name: "Get Current User",
   description: "Do NOT use for a plain \"who am I\" / \"what's my user ID\" question — call **Get User Details** for that; it answers the same question with a far smaller payload. Use this ONLY when you specifically need the full member profile: locale, timezone, presence/status, admin and owner flags, name variants, or workspace domain and enterprise metadata. Combines `auth.test`, `users.info`, `users.profile.get` and `team.info`. [See Slack API docs](https://api.slack.com/methods/auth.test).",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/get-file/get-file.mjs
+++ b/components/slack_v2/actions/get-file/get-file.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-get-file",
   name: "Get File",
   description: "Return information about a file. [See the documentation](https://api.slack.com/methods/files.info)",
-  version: "0.1.5",
+  version: "0.1.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/get-thread-replies/get-thread-replies.mjs
+++ b/components/slack_v2/actions/get-thread-replies/get-thread-replies.mjs
@@ -13,7 +13,7 @@ export default {
     + " Slack messages carry blocks, attachments and edit metadata, so a long thread can run"
     + " to tens of thousands of characters and be truncated before you see any of it."
     + " [See the documentation](https://api.slack.com/methods/conversations.replies)",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/get-thread-replies/get-thread-replies.mjs
+++ b/components/slack_v2/actions/get-thread-replies/get-thread-replies.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import utils from "../../common/utils.mjs";
 import slack from "../../slack_v2.app.mjs";
 

--- a/components/slack_v2/actions/get-user-details/get-user-details.mjs
+++ b/components/slack_v2/actions/get-user-details/get-user-details.mjs
@@ -13,7 +13,7 @@ export default {
     + " Prefer this over **Get Current User**, which returns a much larger payload and is only"
     + " needed for full profile detail (locale, status, admin flags)."
     + " [See the documentation](https://api.slack.com/methods/auth.test)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/get-user-details/get-user-details.mjs
+++ b/components/slack_v2/actions/get-user-details/get-user-details.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 
 export default {

--- a/components/slack_v2/actions/invite-user-to-channel/invite-user-to-channel.mjs
+++ b/components/slack_v2/actions/invite-user-to-channel/invite-user-to-channel.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-invite-user-to-channel",
   name: "Invite User to Channel",
   description: "Invite one or more users to an existing channel. Accepts a channel ID or NAME, and a user ID, EMAIL address or display name — all resolved automatically. Pass several users as a comma-separated list. [See the documentation](https://api.slack.com/methods/conversations.invite)",
-  version: "0.1.0",
+  version: "0.1.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/kick-user/kick-user.mjs
+++ b/components/slack_v2/actions/kick-user/kick-user.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-kick-user",
   name: "Kick User",
   description: "Remove a user from a conversation. [See the documentation](https://api.slack.com/methods/conversations.kick)",
-  version: "0.0.30",
+  version: "0.0.31",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/slack_v2/actions/list-channels/list-channels.mjs
+++ b/components/slack_v2/actions/list-channels/list-channels.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import utils from "../../common/utils.mjs";
 import slack from "../../slack_v2.app.mjs";
 

--- a/components/slack_v2/actions/list-channels/list-channels.mjs
+++ b/components/slack_v2/actions/list-channels/list-channels.mjs
@@ -14,7 +14,7 @@ export default {
     + " fetched — when you see that, raise `numPages` (or pass `cursor`) before answering"
     + " any 'how many' or 'list every' question, otherwise your answer is silently incomplete."
     + " [See the documentation](https://api.slack.com/methods/conversations.list)",
-  version: "0.2.0",
+  version: "0.2.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/list-emojis/list-emojis.mjs
+++ b/components/slack_v2/actions/list-emojis/list-emojis.mjs
@@ -5,7 +5,7 @@ export default {
   name: "List Emojis",
   description:
     "List all available emojis in the Slack workspace. Optionally include emoji image URLs. [See the documentation](https://api.slack.com/methods/emoji.list)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/list-files/list-files.mjs
+++ b/components/slack_v2/actions/list-files/list-files.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-list-files",
   name: "List Files",
   description: "Return a list of files within a team. [See the documentation](https://api.slack.com/methods/files.list)",
-  version: "0.1.5",
+  version: "0.1.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/list-group-members/list-group-members.mjs
+++ b/components/slack_v2/actions/list-group-members/list-group-members.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-list-group-members",
   name: "List Group Members",
   description: "List all users in a User Group. [See the documentation](https://api.slack.com/methods/usergroups.users.list)",
-  version: "0.0.14",
+  version: "0.0.15",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/list-icon-emoji-options/list-icon-emoji-options.mjs
+++ b/components/slack_v2/actions/list-icon-emoji-options/list-icon-emoji-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-list-icon-emoji-options",
   name: "List Icon (emoji) Options",
   description: "Retrieves available options for the Icon (emoji) field.",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/list-members-in-channel/list-members-in-channel.mjs
+++ b/components/slack_v2/actions/list-members-in-channel/list-members-in-channel.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-list-members-in-channel",
   name: "List Members in Channel",
   description: "Retrieve members of a channel. Accepts a channel ID or NAME (e.g. general or #general) — names are resolved automatically. [See the documentation](https://api.slack.com/methods/conversations.members)",
-  version: "0.1.0",
+  version: "0.1.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/list-messages/list-messages.mjs
+++ b/components/slack_v2/actions/list-messages/list-messages.mjs
@@ -2,10 +2,14 @@ import slack from "../../slack_v2.app.mjs";
 
 export default {
   key: "slack_v2-list-messages",
-  name: "List Messages",
+  name: "List Messages (Deprecated)",
   description:
-    "Retrieve messages from a Slack conversation, including reactions. [See the documentation](https://api.slack.com/methods/conversations.history)",
-  version: "0.0.5",
+    "DEPRECATED — do NOT use for reading a channel's or DM's messages. Use **Get Channel History** instead:"
+    + " it resolves channel names, channel IDs, and direct messages (by user ID), supports `fields`"
+    + " selection to keep responses small, and returns the same message data."
+    + " This legacy tool remains only for existing workflows: it accepts a raw conversation ID and"
+    + " returns full, untrimmed message objects. [See the documentation](https://api.slack.com/methods/conversations.history)",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/list-reminder-options/list-reminder-options.mjs
+++ b/components/slack_v2/actions/list-reminder-options/list-reminder-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-list-reminder-options",
   name: "List Reminder Options",
   description: "Retrieves available options for the Reminder field.",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/list-replies/list-replies.mjs
+++ b/components/slack_v2/actions/list-replies/list-replies.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-list-replies",
   name: "List Replies",
   description: "Retrieve a thread of messages posted to a conversation. [See the documentation](https://api.slack.com/methods/conversations.replies)",
-  version: "0.0.30",
+  version: "0.0.31",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/list-user-group-options/list-user-group-options.mjs
+++ b/components/slack_v2/actions/list-user-group-options/list-user-group-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-list-user-group-options",
   name: "List User Group Options",
   description: "Retrieves available options for the User Group field.",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/list-users/list-users.mjs
+++ b/components/slack_v2/actions/list-users/list-users.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-list-users",
   name: "List Users",
   description: "Return a list of all users in a workspace. [See the documentation](https://api.slack.com/methods/users.list)",
-  version: "0.0.29",
+  version: "0.0.30",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/post-message/post-message.mjs
+++ b/components/slack_v2/actions/post-message/post-message.mjs
@@ -10,7 +10,7 @@ export default {
     + " To reply to a thread, provide `thread_ts` from **Get Channel History**."
     + " Supports plain text with Slack mrkdwn formatting and Block Kit blocks."
     + " [See the documentation](https://api.slack.com/methods/chat.postMessage)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/post-message/post-message.mjs
+++ b/components/slack_v2/actions/post-message/post-message.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 import { ConfigurationError } from "@pipedream/platform";
 

--- a/components/slack_v2/actions/reply-to-a-message/reply-to-a-message.mjs
+++ b/components/slack_v2/actions/reply-to-a-message/reply-to-a-message.mjs
@@ -6,7 +6,7 @@ export default {
   key: "slack_v2-reply-to-a-message",
   name: "Reply to a Message Thread",
   description: "Send a message as a threaded reply. See [postMessage](https://api.slack.com/methods/chat.postMessage) or [scheduleMessage](https://api.slack.com/methods/chat.scheduleMessage) docs here",
-  version: "0.2.5",
+  version: "0.2.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/search/search.mjs
+++ b/components/slack_v2/actions/search/search.mjs
@@ -9,7 +9,7 @@ export default {
     + " Use **Get User Details** first to find your user ID for filtering by 'my' messages."
     + " Returns matching messages with channel context, timestamps, and permalinks."
     + " [See the documentation](https://api.slack.com/methods/assistant.search.context)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/search/search.mjs
+++ b/components/slack_v2/actions/search/search.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 
 export default {

--- a/components/slack_v2/actions/send-block-kit-message/send-block-kit-message.mjs
+++ b/components/slack_v2/actions/send-block-kit-message/send-block-kit-message.mjs
@@ -7,7 +7,7 @@ export default {
   key: "slack_v2-send-block-kit-message",
   name: "Build and Send a Block Kit Message",
   description: "Configure custom blocks and send to a channel, group, or user. [See the documentation](https://api.slack.com/tools/block-kit-builder).",
-  version: "0.5.5",
+  version: "0.5.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/send-large-message/send-large-message.mjs
+++ b/components/slack_v2/actions/send-large-message/send-large-message.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-send-large-message",
   name: "Send a Large Message (3000+ characters)",
   description: "Send a large message (more than 3000 characters) to a channel, group or user. See [postMessage](https://api.slack.com/methods/chat.postMessage) or [scheduleMessage](https://api.slack.com/methods/chat.scheduleMessage) docs here",
-  version: "0.1.5",
+  version: "0.1.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/send-message-advanced/send-message-advanced.mjs
+++ b/components/slack_v2/actions/send-message-advanced/send-message-advanced.mjs
@@ -7,7 +7,7 @@ export default {
   key: "slack_v2-send-message-advanced",
   name: "Send Message (Advanced)",
   description: "Customize advanced settings and send a message to a channel, group or user. See [postMessage](https://api.slack.com/methods/chat.postMessage) or [scheduleMessage](https://api.slack.com/methods/chat.scheduleMessage) docs here",
-  version: "0.1.5",
+  version: "0.1.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/send-message-to-channel/send-message-to-channel.mjs
+++ b/components/slack_v2/actions/send-message-to-channel/send-message-to-channel.mjs
@@ -6,7 +6,7 @@ export default {
   key: "slack_v2-send-message-to-channel",
   name: "Send Message to Channel",
   description: "Send a message to a public or private channel. [See the documentation](https://api.slack.com/methods/chat.postMessage)",
-  version: "0.1.5",
+  version: "0.1.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/send-message-to-user-or-group/send-message-to-user-or-group.mjs
+++ b/components/slack_v2/actions/send-message-to-user-or-group/send-message-to-user-or-group.mjs
@@ -7,7 +7,7 @@ export default {
   key: "slack_v2-send-message-to-user-or-group",
   name: "Send Message to User or Group",
   description: "Send a message to a user or group. [See the documentation](https://api.slack.com/methods/chat.postMessage)",
-  version: "0.1.5",
+  version: "0.1.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/send-message/send-message.mjs
+++ b/components/slack_v2/actions/send-message/send-message.mjs
@@ -6,7 +6,7 @@ export default {
   key: "slack_v2-send-message",
   name: "Send Message",
   description: "Send a message to a user, group, private channel or public channel. [See the documentation](https://api.slack.com/methods/chat.postMessage)",
-  version: "0.1.5",
+  version: "0.1.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/set-channel-description/set-channel-description.mjs
+++ b/components/slack_v2/actions/set-channel-description/set-channel-description.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-set-channel-description",
   name: "Set Channel Description",
   description: "Change the description or purpose of a channel. [See the documentation](https://api.slack.com/methods/conversations.setPurpose)",
-  version: "0.0.15",
+  version: "0.0.16",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/set-channel-topic/set-channel-topic.mjs
+++ b/components/slack_v2/actions/set-channel-topic/set-channel-topic.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-set-channel-topic",
   name: "Set Channel Topic",
   description: "Set the topic on a channel, specified by ID or by name — names are resolved automatically. [See the documentation](https://api.slack.com/methods/conversations.setTopic)",
-  version: "0.1.0",
+  version: "0.1.1",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/slack_v2/actions/set-status/set-status.mjs
+++ b/components/slack_v2/actions/set-status/set-status.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-set-status",
   name: "Set Status",
   description: "Set the current status for a user. [See the documentation](https://api.slack.com/methods/users.profile.set)",
-  version: "0.0.14",
+  version: "0.0.15",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/slack_v2/actions/update-group-members/update-group-members.mjs
+++ b/components/slack_v2/actions/update-group-members/update-group-members.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-update-group-members",
   name: "Update Group Members",
   description: "Update the list of users for a User Group. [See the documentation](https://api.slack.com/methods/usergroups.users.update)",
-  version: "0.0.15",
+  version: "0.0.16",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/slack_v2/actions/update-message/update-message.mjs
+++ b/components/slack_v2/actions/update-message/update-message.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-update-message",
   name: "Update Message",
   description: "Update a message. [See the documentation](https://api.slack.com/methods/chat.update)",
-  version: "0.2.5",
+  version: "0.2.6",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/slack_v2/actions/update-profile/update-profile.mjs
+++ b/components/slack_v2/actions/update-profile/update-profile.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-update-profile",
   name: "Update Profile",
   description: "Update basic profile field such as name or title. [See the documentation](https://api.slack.com/methods/users.profile.set)",
-  version: "0.0.30",
+  version: "0.0.31",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/slack_v2/actions/upload-file/upload-file.mjs
+++ b/components/slack_v2/actions/upload-file/upload-file.mjs
@@ -8,7 +8,7 @@ export default {
   key: "slack_v2-upload-file",
   name: "Upload File",
   description: "Upload a file. [See the documentation](https://api.slack.com/messaging/files#uploading_files)",
-  version: "0.1.9",
+  version: "0.1.10",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/verify-slack-signature/verify-slack-signature.mjs
+++ b/components/slack_v2/actions/verify-slack-signature/verify-slack-signature.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-verify-slack-signature",
   name: "Verify Slack Signature",
   description: "Verifying requests from Slack, slack signs its requests using a secret that's unique to your app. [See the documentation](https://api.slack.com/authentication/verifying-requests-from-slack)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/package.json
+++ b/components/slack_v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/slack_v2",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Pipedream Slack_v2 Components",
   "main": "slack_v2.app.mjs",
   "keywords": [

--- a/components/slack_v2/slack_v2.app.mjs
+++ b/components/slack_v2/slack_v2.app.mjs
@@ -1110,6 +1110,12 @@ export default {
         ...args,
       });
     },
+    openConversation(args = {}) {
+      return this.makeRequest({
+        method: "conversations.open",
+        ...args,
+      });
+    },
     inviteToConversation(args = {}) {
       return this.makeRequest({
         method: "conversations.invite",
@@ -1278,7 +1284,22 @@ export default {
      * @returns {Promise<string>} The resolved channel ID
      */
     async resolveChannelId(input) {
-      if (/^[CDGU][A-Z0-9]{8,}$/i.test(input)) return input;
+      // Slack ids are UPPERCASE-only (e.g. `C0123ABCD`, `U0123ABCD`). Match case-sensitively:
+      // channel names are lowercased by Slack, so a `/i` match would misclassify an all-alnum
+      // name like `welcomeaboard` or `developers` (no hyphen, 9+ chars) as an id.
+      // Channel, private-group, and DM ids are already conversation ids — pass through.
+      if (/^[CDG][A-Z0-9]{8,}$/.test(input)) return input;
+      // A user id is NOT a conversation id — conversations.* answers `channel_not_found`
+      // for it. Open (idempotently) the DM with that user and use the returned IM channel.
+      // This is the read-side counterpart to chat.postMessage accepting a user id: an agent
+      // asked to read "my DMs" resolves its own user id and passes it here, and history,
+      // thread replies, and reactions now accept it the way posting already does.
+      if (/^[UW][A-Z0-9]{8,}$/.test(input)) {
+        const { channel } = await this.openConversation({
+          users: input,
+        });
+        return channel.id;
+      }
       const name = input.replace(/^#/, "").toLowerCase();
       let cursor;
       do {

--- a/components/slack_v2/slack_v2.app.mjs
+++ b/components/slack_v2/slack_v2.app.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import { WebClient } from "@slack/web-api";
 import constants from "./common/constants.mjs";
 import get from "lodash/get.js";

--- a/components/slack_v2/sources/new-channel-created/new-channel-created.mjs
+++ b/components/slack_v2/sources/new-channel-created/new-channel-created.mjs
@@ -5,7 +5,7 @@ export default {
   ...common,
   key: "slack_v2-new-channel-created",
   name: "New Channel Created (Instant)",
-  version: "0.0.15",
+  version: "0.0.16",
   description: "Emit new event when a new channel is created.",
   type: "source",
   dedupe: "unique",

--- a/components/slack_v2/sources/new-interaction-event-received/new-interaction-event-received.mjs
+++ b/components/slack_v2/sources/new-interaction-event-received/new-interaction-event-received.mjs
@@ -3,7 +3,7 @@ import sampleEmit from "./test-event.mjs";
 
 export default {
   name: "New Interaction Events (Instant)",
-  version: "0.0.26",
+  version: "0.0.27",
   key: "slack_v2-new-interaction-event-received",
   description: "Emit new events on new Slack [interactivity events](https://api.slack.com/interactivity) sourced from [Block Kit interactive elements](https://api.slack.com/interactivity/components), [Slash commands](https://api.slack.com/interactivity/slash-commands), or [Shortcuts](https://api.slack.com/interactivity/shortcuts).",
   type: "source",

--- a/components/slack_v2/sources/new-keyword-mention/new-keyword-mention.mjs
+++ b/components/slack_v2/sources/new-keyword-mention/new-keyword-mention.mjs
@@ -7,7 +7,7 @@ export default {
   ...common,
   key: "slack_v2-new-keyword-mention",
   name: "New Keyword Mention (Instant)",
-  version: "0.1.5",
+  version: "0.1.6",
   description: "Emit new event when a specific keyword is mentioned in a channel",
   type: "source",
   dedupe: "unique",

--- a/components/slack_v2/sources/new-message-in-channels/new-message-in-channels.mjs
+++ b/components/slack_v2/sources/new-message-in-channels/new-message-in-channels.mjs
@@ -7,7 +7,7 @@ export default {
   ...common,
   key: "slack_v2-new-message-in-channels",
   name: "New Message In Channels (Instant)",
-  version: "1.1.5",
+  version: "1.1.6",
   description: "Emit new event when a new message is posted to one or more channels",
   type: "source",
   dedupe: "unique",

--- a/components/slack_v2/sources/new-private-channel-created/new-private-channel-created.mjs
+++ b/components/slack_v2/sources/new-private-channel-created/new-private-channel-created.mjs
@@ -4,7 +4,7 @@ export default {
   ...common,
   key: "slack_v2-new-private-channel-created",
   name: "New Private Channel Created",
-  version: "0.0.5",
+  version: "0.0.6",
   description: "Emit new event when a new private channel is created. [See the documentation](https://api.slack.com/methods/conversations.list)",
   type: "source",
   dedupe: "unique",

--- a/components/slack_v2/sources/new-reaction-added/new-reaction-added.mjs
+++ b/components/slack_v2/sources/new-reaction-added/new-reaction-added.mjs
@@ -5,7 +5,7 @@ export default {
   ...common,
   key: "slack_v2-new-reaction-added",
   name: "New Reaction Added (Instant)",
-  version: "1.2.5",
+  version: "1.2.6",
   description: "Emit new event when a member has added an emoji reaction to a message",
   type: "source",
   dedupe: "unique",

--- a/components/slack_v2/sources/new-saved-message/new-saved-message.mjs
+++ b/components/slack_v2/sources/new-saved-message/new-saved-message.mjs
@@ -5,7 +5,7 @@ export default {
   ...common,
   key: "slack_v2-new-saved-message",
   name: "New Saved Message (Instant)",
-  version: "0.0.11",
+  version: "0.0.12",
   description: "Emit new event when a message is saved. Note: The endpoint is marked as deprecated, and Slack might shut this off at some point down the line.",
   type: "source",
   dedupe: "unique",

--- a/components/slack_v2/sources/new-user-added/new-user-added.mjs
+++ b/components/slack_v2/sources/new-user-added/new-user-added.mjs
@@ -5,7 +5,7 @@ export default {
   ...common,
   key: "slack_v2-new-user-added",
   name: "New User Added (Instant)",
-  version: "0.0.9",
+  version: "0.0.10",
   description: "Emit new event when a new member joins a workspace.",
   type: "source",
   dedupe: "unique",

--- a/components/slack_v2/sources/new-user-mention/new-user-mention.mjs
+++ b/components/slack_v2/sources/new-user-mention/new-user-mention.mjs
@@ -7,7 +7,7 @@ export default {
   ...common,
   key: "slack_v2-new-user-mention",
   name: "New User Mention (Instant)",
-  version: "0.1.5",
+  version: "0.1.6",
   description: "Emit new event when a username or specific keyword is mentioned in a channel",
   type: "source",
   dedupe: "unique",


### PR DESCRIPTION
## What & why

AI-optimized slack_v2 read tools now support **direct messages**, hardened against the
eval suite in `pd-connect-eval-monster/evals/slack_v2`. Reading a DM by user ID was the
one gap left: writing to a DM already worked (chat.postMessage auto-opens the IM), but
the read tools forwarded a `U…` user id straight to conversations.history, which only
accepts a conversation id and answered `channel_not_found`.

## Changes (per component)

- **slack_v2.app.mjs** — added `openConversation()` (conversations.open); `resolveChannelId`
  now opens the DM for a `U…`/`W…` user id (the read-side counterpart to posting) so history,
  thread-replies, and reactions accept a user id; id regexes made case-sensitive so a lowercase
  channel *name* isn't misread as an id. Shared by 10 actions.
- **get-channel-history** (`0.1.0` → `0.2.0`, minor) — description + `channel` prop document
  reading a DM by user id.
- **list-messages** (`0.0.5` → `0.0.6`, patch) — deprecated in favor of Get Channel History
  (it was winning routing on channel-read evals, precision 0%); renamed + steered, `run()`
  unchanged so existing workflows still work.
- **get-thread-replies, browse-files, set-channel-topic, get-channel-details,
  invite-user-to-channel, delete-message, add-reaction, edit-message, list-members-in-channel**
  (patch) — version bumps for the shared `resolveChannelId` behavioral change.

## Verification

- Suite: `evals/slack_v2` — latest run 3/3 (pass^2, Sonnet 5).
- Reconciliation in `requirements.md`: eval #36 FAIL→PASS; #3/#25 routing fixed; #22 was an
  eval bug (system `channel_join` message), criterion now accepts 33 or 34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving channel history from direct messages, including self-DMs, using user IDs.
  * Improved conversation resolution for direct-message interactions.

* **Documentation**
  * Marked the legacy “List Messages” action as deprecated and directed users to “Get Channel History” instead.

* **Chores**
  * Updated Slack action, event source, and package versions across the integration.
  * Applied general optimization updates to selected Slack capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->