### PR TITLE
[21682] fix(gorgias): render custom field inputs on Update Ticket Field Values

### DIFF
--- a/components/gorgias_oauth/actions/add-ticket-tags/add-ticket-tags.mjs
+++ b/components/gorgias_oauth/actions/add-ticket-tags/add-ticket-tags.mjs
@@ -4,7 +4,7 @@ export default {
   key: "gorgias_oauth-add-ticket-tags",
   name: "Add Ticket Tags",
   description: "Add tags to a ticket. [See the documentation](https://developers.gorgias.com/reference/create-ticket-tags)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/gorgias_oauth/actions/create-customer/create-customer.mjs
+++ b/components/gorgias_oauth/actions/create-customer/create-customer.mjs
@@ -5,7 +5,7 @@ export default {
   key: "gorgias_oauth-create-customer",
   name: "Create Customer",
   description: "Create a new customer. [See the docs](https://developers.gorgias.com/reference/post_api-customers)",
-  version: "0.0.12",
+  version: "0.0.13",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/gorgias_oauth/actions/create-macro/create-macro.mjs
+++ b/components/gorgias_oauth/actions/create-macro/create-macro.mjs
@@ -6,7 +6,7 @@ export default {
   key: "gorgias_oauth-create-macro",
   name: "Create Macro",
   description: "Create a macro. [See the documentation](https://developers.gorgias.com/reference/create-macro)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/gorgias_oauth/actions/create-ticket-message/create-ticket-message.mjs
+++ b/components/gorgias_oauth/actions/create-ticket-message/create-ticket-message.mjs
@@ -5,7 +5,7 @@ export default {
   key: "gorgias_oauth-create-ticket-message",
   name: "Create Ticket Message",
   description: "Create a message for a ticket in the Gorgias system. [See the documentation](https://developers.gorgias.com/reference/create-ticket-message)",
-  version: "0.2.0",
+  version: "0.2.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/gorgias_oauth/actions/create-ticket/create-ticket.mjs
+++ b/components/gorgias_oauth/actions/create-ticket/create-ticket.mjs
@@ -4,7 +4,7 @@ export default {
   key: "gorgias_oauth-create-ticket",
   name: "Create Ticket",
   description: "Create a new ticket. [See the docs](https://developers.gorgias.com/reference/post_api-tickets)",
-  version: "0.0.13",
+  version: "0.0.14",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/gorgias_oauth/actions/delete-macro/delete-macro.mjs
+++ b/components/gorgias_oauth/actions/delete-macro/delete-macro.mjs
@@ -4,7 +4,7 @@ export default {
   key: "gorgias_oauth-delete-macro",
   name: "Delete Macro",
   description: "Delete a macro. [See the documentation](https://developers.gorgias.com/reference/delete-macro)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/gorgias_oauth/actions/get-macro/get-macro.mjs
+++ b/components/gorgias_oauth/actions/get-macro/get-macro.mjs
@@ -4,7 +4,7 @@ export default {
   key: "gorgias_oauth-get-macro",
   name: "Get Macro",
   description: "Get a macro by ID. [See the documentation](https://developers.gorgias.com/reference/get-macro)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/gorgias_oauth/actions/get-ticket-message/get-ticket-message.mjs
+++ b/components/gorgias_oauth/actions/get-ticket-message/get-ticket-message.mjs
@@ -4,7 +4,7 @@ export default {
   name: "Get Ticket Message",
   description: "Get a specific message from a ticket. [See the documentation](https://developers.gorgias.com/reference/get-ticket-message)",
   key: "gorgias_oauth-get-ticket-message",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/gorgias_oauth/actions/get-ticket/get-ticket.mjs
+++ b/components/gorgias_oauth/actions/get-ticket/get-ticket.mjs
@@ -4,7 +4,7 @@ export default {
   key: "gorgias_oauth-get-ticket",
   name: "Get Ticket",
   description: "Get a ticket. [See the documentation](https://developers.gorgias.com/reference/get-ticket)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/gorgias_oauth/actions/list-macros/list-macros.mjs
+++ b/components/gorgias_oauth/actions/list-macros/list-macros.mjs
@@ -4,7 +4,7 @@ export default {
   key: "gorgias_oauth-list-macros",
   name: "List Macros",
   description: "List all macros. [See the documentation](https://developers.gorgias.com/reference/list-macros)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/gorgias_oauth/actions/list-messages/list-messages.mjs
+++ b/components/gorgias_oauth/actions/list-messages/list-messages.mjs
@@ -4,7 +4,7 @@ export default {
   name: "List Messages",
   description: "List all messages. [See the documentation](https://developers.gorgias.com/reference/list-messages)",
   key: "gorgias_oauth-list-messages",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/gorgias_oauth/actions/list-ticket-field-values/list-ticket-field-values.mjs
+++ b/components/gorgias_oauth/actions/list-ticket-field-values/list-ticket-field-values.mjs
@@ -4,7 +4,7 @@ export default {
   key: "gorgias_oauth-list-ticket-field-values",
   name: "List Ticket Field Values",
   description: "List field values for a ticket. [See the documentation](https://developers.gorgias.com/reference/list-ticket-custom-fields)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/gorgias_oauth/actions/list-ticket-messages/list-ticket-messages.mjs
+++ b/components/gorgias_oauth/actions/list-ticket-messages/list-ticket-messages.mjs
@@ -4,7 +4,7 @@ export default {
   name: "List Ticket Messages",
   description: "List all messages for a specific ticket. [See the documentation](https://developers.gorgias.com/reference/list-ticket-messages)",
   key: "gorgias_oauth-list-ticket-messages",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/gorgias_oauth/actions/list-ticket-tags/list-ticket-tags.mjs
+++ b/components/gorgias_oauth/actions/list-ticket-tags/list-ticket-tags.mjs
@@ -4,7 +4,7 @@ export default {
   key: "gorgias_oauth-list-ticket-tags",
   name: "List Ticket Tags",
   description: "List tags for a ticket. [See the documentation](https://developers.gorgias.com/reference/get_api-tickets-ticket-id-tags)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/gorgias_oauth/actions/list-tickets/list-tickets.mjs
+++ b/components/gorgias_oauth/actions/list-tickets/list-tickets.mjs
@@ -4,7 +4,7 @@ export default {
   key: "gorgias_oauth-list-tickets",
   name: "List Tickets",
   description: "List all tickets. [See the docs](https://developers.gorgias.com/reference/get_api-tickets)",
-  version: "0.0.13",
+  version: "0.0.14",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/gorgias_oauth/actions/retrieve-customer/retrieve-customer.mjs
+++ b/components/gorgias_oauth/actions/retrieve-customer/retrieve-customer.mjs
@@ -4,7 +4,7 @@ export default {
   key: "gorgias_oauth-retrieve-customer",
   name: "Retrieve a Customer",
   description: "Retrieve a customer. [See the docs](https://developers.gorgias.com/reference/get_api-customers-id-)",
-  version: "0.0.12",
+  version: "0.0.13",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/gorgias_oauth/actions/send-internal-note/send-internal-note.mjs
+++ b/components/gorgias_oauth/actions/send-internal-note/send-internal-note.mjs
@@ -5,7 +5,7 @@ export default {
   key: "gorgias_oauth-send-internal-note",
   name: "Send Internal Note",
   description: "Post an internal note to a ticket on behalf of an agent. [See the documentation](https://developers.gorgias.com/reference/create-ticket-message)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/gorgias_oauth/actions/send-public-reply/send-public-reply.mjs
+++ b/components/gorgias_oauth/actions/send-public-reply/send-public-reply.mjs
@@ -6,7 +6,7 @@ export default {
   key: "gorgias_oauth-send-public-reply",
   name: "Send Public Reply",
   description: "Post a customer-facing reply to a ticket on behalf of an agent. [See the documentation](https://developers.gorgias.com/reference/create-ticket-message)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/gorgias_oauth/actions/set-ticket-tags/set-ticket-tags.mjs
+++ b/components/gorgias_oauth/actions/set-ticket-tags/set-ticket-tags.mjs
@@ -4,7 +4,7 @@ export default {
   key: "gorgias_oauth-set-ticket-tags",
   name: "Set Ticket Tags",
   description: "Set tags on a ticket. [See the documentation](https://developers.gorgias.com/reference/update-ticket-tags)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: true,

--- a/components/gorgias_oauth/actions/update-customer/update-customer.mjs
+++ b/components/gorgias_oauth/actions/update-customer/update-customer.mjs
@@ -10,7 +10,7 @@ export default {
   key: "gorgias_oauth-update-customer",
   name: "Update Customer",
   description: "Update a customer. [See the docs](https://developers.gorgias.com/reference/put_api-customers-id-)",
-  version: "0.0.12",
+  version: "0.0.13",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/gorgias_oauth/actions/update-macro/update-macro.mjs
+++ b/components/gorgias_oauth/actions/update-macro/update-macro.mjs
@@ -6,7 +6,7 @@ export default {
   key: "gorgias_oauth-update-macro",
   name: "Update Macro",
   description: "Update a macro. [See the documentation](https://developers.gorgias.com/reference/update-macro)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/gorgias_oauth/actions/update-ticket-field-values/update-ticket-field-values.mjs
+++ b/components/gorgias_oauth/actions/update-ticket-field-values/update-ticket-field-values.mjs
@@ -1,96 +1,216 @@
+import { ConfigurationError } from "@pipedream/platform";
 import gorgias from "../../gorgias_oauth.app.mjs";
+import constants from "../../common/constants.mjs";
+
+// Prefix that turns a numeric custom field ID into a valid prop name. Prop names
+// must be identifiers, so keying `additionalProps` by the raw ID renders nothing.
+const CUSTOM_FIELD_PROP_PREFIX = "customField_";
+
+// The custom fields belong to the account rather than to any one ticket, so the
+// app prop is what `additionalProps` depends on. `propDefinition` matches the app
+// by object identity, so both props must reference this same object.
+const reloadingGorgias = {
+  ...gorgias,
+  reloadProps: true,
+};
 
 export default {
   key: "gorgias_oauth-update-ticket-field-values",
   name: "Update Ticket Field Values",
-  description: "Update field values for a ticket. [See the documentation](https://developers.gorgias.com/reference/update-ticket-custom-fields)",
-  version: "0.0.3",
+  description: "Set custom field values on a ticket. The connected account's ticket custom fields are exposed as individual optional props. Each field is written on its own request, so re-running after a failure is safe. [See the documentation](https://developers.gorgias.com/reference/update-ticket-custom-field)",
+  version: "1.0.0",
   type: "action",
   annotations: {
-    destructiveHint: true,
+    destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   props: {
-    gorgias,
+    gorgias: reloadingGorgias,
     ticketId: {
       propDefinition: [
-        gorgias,
+        reloadingGorgias,
         "ticketId",
       ],
-      reloadProps: true,
+    },
+  },
+  methods: {
+    getPropName(fieldId) {
+      return `${CUSTOM_FIELD_PROP_PREFIX}${fieldId}`;
+    },
+    async getSettableCustomFields($) {
+      const customFields = await this.gorgias.listAllCustomFields({
+        $,
+        objectType: constants.CUSTOM_FIELD_OBJECT_TYPE_TICKET,
+      });
+      return customFields.filter((field) => this.isSettableField(field));
+    },
+    isSettableField(field) {
+      if (constants.UNSETTABLE_MANAGED_FIELD_TYPES.includes(field.managed_type)) {
+        return false;
+      }
+      const {
+        data_type: dataType,
+        input_settings: inputSettings,
+      } = field.definition;
+      if (dataType === constants.CUSTOM_FIELD_DATA_TYPE_BOOLEAN) {
+        return true;
+      }
+      // Gorgias rejects every value for a dropdown with no configured choices, so
+      // surfacing one as a prop could only ever produce a failed run
+      return inputSettings?.input_type !== constants.CUSTOM_FIELD_INPUT_TYPE_DROPDOWN
+        || !!inputSettings.choices?.length;
+    },
+    /**
+     * Validate and coerce one configured value. Every configured value is run
+     * through this before the first request is sent, so one bad value cannot
+     * leave the ticket half updated.
+     */
+    parseFieldValue(field, value) {
+      const {
+        data_type: dataType,
+        input_settings: inputSettings,
+      } = field.definition;
+
+      // A boolean field rejects the string "true"; the platform already hands
+      // back a real boolean, so it is passed straight through
+      if (dataType === constants.CUSTOM_FIELD_DATA_TYPE_BOOLEAN) {
+        return value;
+      }
+
+      if (dataType === constants.CUSTOM_FIELD_DATA_TYPE_NUMBER) {
+        return this.parseNumberValue(field, value, inputSettings);
+      }
+
+      if (inputSettings?.input_type === constants.CUSTOM_FIELD_INPUT_TYPE_DROPDOWN) {
+        const choices = (inputSettings.choices ?? []).map((choice) => `${choice}`);
+        if (!choices.includes(`${value}`)) {
+          throw new ConfigurationError(`Field "${field.label}" only accepts one of its ${choices.length} configured choices. Received: \`${value}\``);
+        }
+      }
+
+      return value;
+    },
+    /**
+     * Coerce a number field. Gorgias stores whatever JSON type it is sent, so a
+     * numeric string would be persisted as a string; it also accepts decimals,
+     * which is why the prop cannot be an `integer`. `min`/`max` are enforced by
+     * the API too, but checking here keeps a bad bound from aborting the run
+     * partway through.
+     */
+    parseNumberValue(field, value, inputSettings) {
+      const parsed = Number(value);
+      if (Number.isNaN(parsed)) {
+        throw new ConfigurationError(`Field "${field.label}" expects a number. Received: \`${value}\``);
+      }
+      const bounds = this.getNumberBounds(inputSettings);
+      if (bounds.min !== undefined && parsed < bounds.min) {
+        throw new ConfigurationError(`Field "${field.label}" has a minimum of ${bounds.min}. Received: \`${value}\``);
+      }
+      if (bounds.max !== undefined && parsed > bounds.max) {
+        throw new ConfigurationError(`Field "${field.label}" has a maximum of ${bounds.max}. Received: \`${value}\``);
+      }
+      return parsed;
+    },
+    getNumberBounds(inputSettings) {
+      // Gorgias types `min`/`max` as `anyOf: [number, string]` and returns them as
+      // strings, and `0` is a legitimate bound, so both need a presence check
+      const toBound = (bound) => bound === undefined || bound === null || bound === ""
+        ? undefined
+        : Number(bound);
+      return {
+        min: toBound(inputSettings?.min),
+        max: toBound(inputSettings?.max),
+      };
+    },
+    getConfiguredValue(field) {
+      const value = this[this.getPropName(field.id)];
+      // `false` and `0` are valid values, so "not configured" cannot be a falsy
+      // check. An empty string means the prop was revealed and left blank, which
+      // Gorgias has a separate delete endpoint for.
+      return value === undefined || value === ""
+        ? undefined
+        : value;
     },
   },
   async additionalProps() {
     const props = {};
-    if (!this.ticketId) {
+    if (!this.gorgias?.$auth?.oauth_access_token) {
       return props;
     }
-    const { data: customFields } = await this.gorgias.listCustomFields({
-      params: {
-        object_type: "Ticket",
-      },
-    });
-    const reservedFields = [
-      "call_status",
-      "ai_intent",
-    ];
+
+    const customFields = await this.getSettableCustomFields();
     for (const field of customFields) {
-      if (reservedFields.includes(field.managed_type)) continue;
-      const inputType = field?.definition?.input_settings?.input_type;
-      const dataType = field?.definition?.data_type;
-      props[field.id] = {
-        type: dataType === "boolean"
+      const {
+        data_type: dataType,
+        input_settings: inputSettings,
+      } = field.definition;
+      const isDropdown = inputSettings?.input_type
+        === constants.CUSTOM_FIELD_INPUT_TYPE_DROPDOWN;
+      const isNumber = dataType === constants.CUSTOM_FIELD_DATA_TYPE_NUMBER;
+      const isBoolean = dataType === constants.CUSTOM_FIELD_DATA_TYPE_BOOLEAN;
+
+      const bounds = isNumber
+        ? this.getNumberBounds(inputSettings)
+        : {};
+      const constraints = [
+        isNumber && "number",
+        bounds.min !== undefined && `min ${bounds.min}`,
+        bounds.max !== undefined && `max ${bounds.max}`,
+      ].filter(Boolean);
+
+      props[this.getPropName(field.id)] = {
+        // Gorgias number fields accept decimals, so they cannot be `integer`
+        type: isBoolean
           ? "boolean"
           : "string",
         label: field.label,
-        optional: !field.required,
+        description: [
+          field.description || `Value for the \`${field.label}\` custom field`,
+          constraints.length && `(${constraints.join(", ")})`,
+        ].filter(Boolean).join(" "),
+        optional: true,
+        ...(isDropdown && !isBoolean && {
+          options: inputSettings.choices.map((choice) => `${choice}`),
+        }),
       };
-      if (dataType === "boolean") continue;
-      if (inputType === "dropdown") {
-        props[field.id].options = field.definition.input_settings.choices.map((choice) => `${choice}`);
-      }
     }
     return props;
   },
   async run({ $ }) {
-    const { data: customFields } = await this.gorgias.listCustomFields({
-      params: {
-        object_type: "Ticket",
-      },
-    });
+    const customFields = await this.getSettableCustomFields($);
 
-    const { data: fieldValues } = await this.gorgias.listTicketFieldValues({
-      ticketId: this.ticketId,
-    });
-    const data = [];
+    const updates = [];
     for (const field of customFields) {
-      if (this[field.id] === undefined) {
-        const fieldValue = fieldValues.find((fv) => fv.field.id === field.id);
-        if (fieldValue) {
-          data.push({
-            id: field.id,
-            value: fieldValue?.value,
-          });
-        }
+      const value = this.getConfiguredValue(field);
+      if (value === undefined) {
         continue;
       }
-      const dataType = field?.definition?.data_type;
-      data.push({
-        id: field.id,
-        value: dataType === "number"
-          ? +this[field.id]
-          : this[field.id],
+      updates.push({
+        field,
+        value: this.parseFieldValue(field, value),
       });
     }
 
-    const response = await this.gorgias.updateTicketFieldValues({
-      $,
-      ticketId: this.ticketId,
-      data,
-    });
+    if (!updates.length) {
+      throw new ConfigurationError("No custom field values were provided. Expand the optional props to set at least one of this account's ticket custom fields.");
+    }
 
-    $.export("$summary", `Successfully updated ticket ${this.ticketId} field values`);
+    const response = [];
+    for (const {
+      field, value,
+    } of updates) {
+      response.push(await this.gorgias.updateTicketFieldValue({
+        $,
+        ticketId: this.ticketId,
+        fieldId: field.id,
+        value,
+      }));
+    }
+
+    $.export("$summary", `Successfully updated ${response.length} field value${response.length === 1
+      ? ""
+      : "s"} on ticket ${this.ticketId}`);
     return response;
   },
 };

--- a/components/gorgias_oauth/actions/update-ticket-field-values/update-ticket-field-values.mjs
+++ b/components/gorgias_oauth/actions/update-ticket-field-values/update-ticket-field-values.mjs
@@ -49,6 +49,12 @@ export default {
       if (constants.UNSETTABLE_MANAGED_FIELD_TYPES.includes(field.managed_type)) {
         return false;
       }
+      // `definition` carries the data type, so a field without one cannot be
+      // turned into a prop. Filtering it out here also keeps every downstream
+      // reader of `definition` safe, since they only ever see settable fields.
+      if (!field.definition) {
+        return false;
+      }
       const {
         data_type: dataType,
         input_settings: inputSettings,

--- a/components/gorgias_oauth/actions/update-ticket/update-ticket.mjs
+++ b/components/gorgias_oauth/actions/update-ticket/update-ticket.mjs
@@ -5,7 +5,7 @@ export default {
   key: "gorgias_oauth-update-ticket",
   name: "Update Ticket",
   description: "Updates a predefined ticket in the Gorgias system. [See the documentation](https://developers.gorgias.com/reference/update-ticket)",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/gorgias_oauth/common/constants.mjs
+++ b/components/gorgias_oauth/common/constants.mjs
@@ -128,9 +128,35 @@ const macroIntents = [
   "subscription/change",
 ];
 
+// `object_type` accepted by the Gorgias custom fields API
+const CUSTOM_FIELD_OBJECT_TYPE_TICKET = "Ticket";
+
+// `definition.data_type` values on a Gorgias custom field
+const CUSTOM_FIELD_DATA_TYPE_BOOLEAN = "boolean";
+const CUSTOM_FIELD_DATA_TYPE_NUMBER = "number";
+
+// `definition.input_settings.input_type` value that carries a fixed list of `choices`
+const CUSTOM_FIELD_INPUT_TYPE_DROPDOWN = "dropdown";
+
+// Max `limit` accepted by GET /api/custom-fields
+const CUSTOM_FIELDS_LIMIT_MAX = 100;
+
+// Gorgias-managed ticket fields that only Gorgias itself may write
+const UNSETTABLE_MANAGED_FIELD_TYPES = [
+  "ai_intent",
+  "ai_outcome",
+  "call_status",
+];
+
 export default {
   channels,
   vias,
   sourceTypes,
   macroIntents,
+  CUSTOM_FIELD_OBJECT_TYPE_TICKET,
+  CUSTOM_FIELD_DATA_TYPE_BOOLEAN,
+  CUSTOM_FIELD_DATA_TYPE_NUMBER,
+  CUSTOM_FIELD_INPUT_TYPE_DROPDOWN,
+  CUSTOM_FIELDS_LIMIT_MAX,
+  UNSETTABLE_MANAGED_FIELD_TYPES,
 };

--- a/components/gorgias_oauth/gorgias_oauth.app.mjs
+++ b/components/gorgias_oauth/gorgias_oauth.app.mjs
@@ -596,6 +596,7 @@ export default {
     }) {
       const fields = [];
       let cursor;
+      let previousCursor;
       do {
         const {
           data, meta,
@@ -608,9 +609,11 @@ export default {
             cursor,
           },
         });
-        fields.push(...data);
+        fields.push(...(data ?? []));
+        previousCursor = cursor;
         cursor = meta?.next_cursor;
-      } while (cursor);
+        // A cursor that repeats instead of advancing would loop forever
+      } while (cursor && cursor !== previousCursor);
       return fields;
     },
     /**

--- a/components/gorgias_oauth/gorgias_oauth.app.mjs
+++ b/components/gorgias_oauth/gorgias_oauth.app.mjs
@@ -582,12 +582,55 @@ export default {
         ...opts,
       });
     },
-    updateTicketFieldValues({
-      ticketId, ...opts
+    /**
+     * List every custom field defined for an object type, following the cursor
+     * to the end. `paginate` caps the total at `params.limit`, which would
+     * silently hide fields, so the cursor is walked directly here.
+     * @param {Object} opts - Options for the request
+     * @param {Object} opts.$ - The Pipedream step context, when available
+     * @param {string} opts.objectType - The object type the fields belong to, e.g. `Ticket`
+     * @returns {Promise<Object[]>} - Every custom field for the object type
+     */
+    async listAllCustomFields({
+      $, objectType,
+    }) {
+      const fields = [];
+      let cursor;
+      do {
+        const {
+          data, meta,
+        } = await this.listCustomFields({
+          $,
+          params: {
+            object_type: objectType,
+            archived: false,
+            limit: constants.CUSTOM_FIELDS_LIMIT_MAX,
+            cursor,
+          },
+        });
+        fields.push(...data);
+        cursor = meta?.next_cursor;
+      } while (cursor);
+      return fields;
+    },
+    /**
+     * Set a single custom field value on a ticket. The endpoint takes the bare
+     * value as the request body, so it is serialized here: axios forwards a
+     * plain string body verbatim, which would not be valid JSON.
+     * @param {Object} opts - Options for the request
+     * @param {Object} opts.$ - The Pipedream step context
+     * @param {number} opts.ticketId - The ID of the ticket
+     * @param {number} opts.fieldId - The ID of the custom field
+     * @param {string|number|boolean} opts.value - The value to set
+     * @returns {Promise<Object>} - The updated ticket custom field value
+     */
+    updateTicketFieldValue({
+      ticketId, fieldId, value, ...opts
     }) {
       return this._makeRequest({
         method: "PUT",
-        path: `/tickets/${ticketId}/custom-fields`,
+        path: `/tickets/${ticketId}/custom-fields/${fieldId}`,
+        data: JSON.stringify(value),
         ...opts,
       });
     },

--- a/components/gorgias_oauth/package.json
+++ b/components/gorgias_oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/gorgias_oauth",
-  "version": "0.13.0",
+  "version": "1.0.0",
   "description": "Pipedream Gorgias OAuth Components",
   "main": "gorgias_oauth.app.mjs",
   "keywords": [

--- a/components/gorgias_oauth/sources/internal-note-created/internal-note-created.mjs
+++ b/components/gorgias_oauth/sources/internal-note-created/internal-note-created.mjs
@@ -7,7 +7,7 @@ export default {
   key: "gorgias_oauth-internal-note-created",
   name: "New Internal Note",
   description: "Emit new event when an internal note is created on a ticket. [See the documentation](https://developers.gorgias.com/reference/the-event-object)",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "source",
   props: {
     ...base.props,

--- a/components/gorgias_oauth/sources/macro-updated/macro-updated.mjs
+++ b/components/gorgias_oauth/sources/macro-updated/macro-updated.mjs
@@ -6,7 +6,7 @@ export default {
   key: "gorgias_oauth-macro-updated",
   name: "Macro Updated",
   description: "Emit new event when a macro is updated. [See the documentation](https://developers.gorgias.com/reference/the-event-object)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/gorgias_oauth/sources/new-macro-created/new-macro-created.mjs
+++ b/components/gorgias_oauth/sources/new-macro-created/new-macro-created.mjs
@@ -6,7 +6,7 @@ export default {
   key: "gorgias_oauth-new-macro-created",
   name: "New Macro Created",
   description: "Emit new event when a macro is created. [See the documentation](https://developers.gorgias.com/reference/the-event-object)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/gorgias_oauth/sources/ticket-created/ticket-created.mjs
+++ b/components/gorgias_oauth/sources/ticket-created/ticket-created.mjs
@@ -7,7 +7,7 @@ export default {
   key: "gorgias_oauth-ticket-created",
   name: "New Ticket",
   description: "Emit new event when a ticket is created. [See the documentation](https://developers.gorgias.com/reference/the-event-object)",
-  version: "0.2.2",
+  version: "0.2.3",
   type: "source",
   props: {
     ...base.props,

--- a/components/gorgias_oauth/sources/ticket-message-created/ticket-message-created.mjs
+++ b/components/gorgias_oauth/sources/ticket-message-created/ticket-message-created.mjs
@@ -7,7 +7,7 @@ export default {
   key: "gorgias_oauth-ticket-message-created",
   name: "New Ticket Message",
   description: "Emit new event when a ticket message is created. [See the documentation](https://developers.gorgias.com/reference/the-event-object)",
-  version: "0.1.13",
+  version: "0.1.14",
   type: "source",
   props: {
     ...base.props,

--- a/components/gorgias_oauth/sources/ticket-updated/ticket-updated.mjs
+++ b/components/gorgias_oauth/sources/ticket-updated/ticket-updated.mjs
@@ -7,7 +7,7 @@ export default {
   key: "gorgias_oauth-ticket-updated",
   name: "New Updated Ticket",
   description: "Emit new event when a ticket is updated. [See the documentation](https://developers.gorgias.com/reference/the-event-object)",
-  version: "0.2.2",
+  version: "0.2.3",
   type: "source",
   props: {
     ...base.props,


### PR DESCRIPTION
## Summary

<!-- Add your PR description here -->
Closes #21682 
`additionalProps()` keyed each generated prop by the raw numeric custom field ID (`props[field.id]` -> `"302528"`). Prop names must be identifiers, so the workflow builder rendered nothing and Ticket ID was the only configurable prop.

While confirming that, two more defects surfaced:
- The action used the bulk `PUT /tickets/{id}/custom-fields`, which has replace-all semantics. It compensated with a read-modify-write merge, but only ever listed the **first page** of custom fields, so an account with more than one page would have had the rest deleted on every run.
- `reloadProps` sat on `ticketId`, so changing the ticket wiped every already-configured field value. The custom fields are account-wide, not ticket-specific, so it belongs on the app prop.

## What
- Prop keys are now `customField_<id>`.
- Writes go through the per-field `PUT /tickets/{id}/custom-fields/{fieldId}`, removing the merge round trip and the clobber risk entirely.
- `reloadProps` moved to the app prop; fields now appear as soon as an account is connected.
- Fields that can never be set are hidden (dropdowns with no configured choices, plus `ai_outcome` added to the internal-app-only list).
- Every configured value is validated before the first request, so one bad value cannot leave the ticket half updated.
- `destructiveHint` true -> false; this is no longer a full-replace operation.
- Folded in: `archived: false` on the field list, and patch bumps across the connector's other 22 actions and 6 sources for the app file change.

 ## Breaking changes (0.0.3 -> 1.0.0)
- Prop names change, so saved custom field values are dropped on upgrade.
- Return shape changes from `{ data: [...] }` to an array of per-field results.
- A step configured with **only Ticket ID** previously succeeded as a no-op. It now raises a `ConfigurationError`. Because of the bug this is the most likely existing configuration, so expect the upgrade to surface as new failures rather than as new capability.


## Checklist
Please check the following items before your PR can be reviewed:

### Versioning
- [x] All components updated in this PR had their version updated (`0.0.1` for new ones)
- [x] The app updated in this PR had its `package.json`'s version updated

### New app
If this is a new app, please submit [an app integration request](https://github.com/PipedreamHQ/pipedream/issues/new?template=app---service-integration.md) - the PR will only be reviewed after the app is integrated.
- [ ] The app updated in this PR is already integrated

### CodeRabbit review
After the PR is opened, and if new changes are pushed, CodeRabbit will automatically review it. Do not 'mark as resolved' CodeRabbit's comments, but reply to them instead, whether you agree (and update the PR accordingly) or disagree.
- [ ] I have addressed or acknowledged all of CodeRabbit's review comments



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom ticket fields are loaded dynamically for the connected account.
  * Supports dropdown, numeric, and boolean field validation.
  * Ticket custom fields can be updated individually with clear update results.
  * Blank values are ignored, and runs without valid changes are prevented.

* **Improvements**
  * Retrieves all available custom fields across paginated results.
  * Updated integration actions, event sources, and package version for the release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->