### PR TITLE
[21715] fix(telegram_bot_api): pin node-telegram-bot-api sdk version to 1.2.0

### DIFF
--- a/components/telegram_bot_api/actions/create-chat-invite-link/create-chat-invite-link.mjs
+++ b/components/telegram_bot_api/actions/create-chat-invite-link/create-chat-invite-link.mjs
@@ -4,7 +4,7 @@ export default {
   key: "telegram_bot_api-create-chat-invite-link",
   name: "Create Chat Invite Link",
   description: "Create an additional invite link for a chat, [See the docs](https://core.telegram.org/bots/api#createchatinvitelink) for more information",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/telegram_bot_api/actions/delete-message/delete-message.mjs
+++ b/components/telegram_bot_api/actions/delete-message/delete-message.mjs
@@ -4,7 +4,7 @@ export default {
   key: "telegram_bot_api-delete-message",
   name: "Delete a Message",
   description: "Deletes a message. [See the docs](https://core.telegram.org/bots/api#deletemessage) for more information",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/telegram_bot_api/actions/download-voice-message/download-voice-message.mjs
+++ b/components/telegram_bot_api/actions/download-voice-message/download-voice-message.mjs
@@ -7,7 +7,7 @@ export default {
   key: "telegram_bot_api-download-voice-message",
   name: "Download Voice Message",
   description: "Downloads a Telegram voice message to the `/tmp` directory using its `file_id`. Use this after receiving a voice message update to persist the audio locally. [See the documentation](https://core.telegram.org/bots/api#getfile)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/telegram_bot_api/actions/edit-media-message/edit-media-message.mjs
+++ b/components/telegram_bot_api/actions/edit-media-message/edit-media-message.mjs
@@ -8,7 +8,7 @@ export default {
   key: "telegram_bot_api-edit-media-message",
   name: "Edit a Media Message",
   description: "Edits photo or video messages. [See the docs](https://core.telegram.org/bots/api#editmessagemedia) for more information",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/telegram_bot_api/actions/edit-text-message/edit-text-message.mjs
+++ b/components/telegram_bot_api/actions/edit-text-message/edit-text-message.mjs
@@ -4,7 +4,7 @@ export default {
   key: "telegram_bot_api-edit-text-message",
   name: "Edit a Text Message",
   description: "Edits text or game messages. [See the docs](https://core.telegram.org/bots/api#editmessagetext) for more information",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/telegram_bot_api/actions/export-chat-invite-link/export-chat-invite-link.mjs
+++ b/components/telegram_bot_api/actions/export-chat-invite-link/export-chat-invite-link.mjs
@@ -4,7 +4,7 @@ export default {
   key: "telegram_bot_api-export-chat-invite-link",
   name: "Export Chat Invite Link",
   description: "Generate a new primary invite link for a chat, [See the docs](https://core.telegram.org/bots/api#createchatinvitelink) for more information",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/telegram_bot_api/actions/forward-message/forward-message.mjs
+++ b/components/telegram_bot_api/actions/forward-message/forward-message.mjs
@@ -4,7 +4,7 @@ export default {
   key: "telegram_bot_api-forward-message",
   name: "Forward a Message",
   description: "Forwards messages of any kind. [See the docs](https://core.telegram.org/bots/api#forwardmessage) for more information",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/telegram_bot_api/actions/get-num-members-in-chat/get-num-members-in-chat.mjs
+++ b/components/telegram_bot_api/actions/get-num-members-in-chat/get-num-members-in-chat.mjs
@@ -4,7 +4,7 @@ export default {
   key: "telegram_bot_api-get-num-members-in-chat",
   name: "Get the Number of Members in a Chat",
   description: "Use this module to get the number of members in a chat. [See the docs](https://core.telegram.org/bots/api#getchatmembercount) for more information",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/telegram_bot_api/actions/kick-chat-member/kick-chat-member.mjs
+++ b/components/telegram_bot_api/actions/kick-chat-member/kick-chat-member.mjs
@@ -4,7 +4,7 @@ export default {
   key: "telegram_bot_api-kick-chat-member",
   name: "Kick a Chat Member",
   description: "Use this method to kick a user from a group, a supergroup or channel. [See the docs](https://core.telegram.org/bots/api#banchatmember) for more information",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/telegram_bot_api/actions/list-administrators-in-chat/list-administrators-in-chat.mjs
+++ b/components/telegram_bot_api/actions/list-administrators-in-chat/list-administrators-in-chat.mjs
@@ -4,7 +4,7 @@ export default {
   key: "telegram_bot_api-list-administrators-in-chat",
   name: "List Administrators In Chat",
   description: "Use this module to get a list of administrators in a chat. [See the docs](https://core.telegram.org/bots/api#getchatadministrators) for more information",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/telegram_bot_api/actions/list-chats/list-chats.mjs
+++ b/components/telegram_bot_api/actions/list-chats/list-chats.mjs
@@ -4,7 +4,7 @@ export default {
   key: "telegram_bot_api-list-chats",
   name: "List Chats",
   description: "List available Telegram chats. [See the docs](https://core.telegram.org/bots/api#getupdates) for more information",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/telegram_bot_api/actions/list-commands-options/list-commands-options.mjs
+++ b/components/telegram_bot_api/actions/list-commands-options/list-commands-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "telegram_bot_api-list-commands-options",
   name: "List Commands Options",
   description: "Retrieves available options for the Commands field.",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/telegram_bot_api/actions/list-updates/list-updates.mjs
+++ b/components/telegram_bot_api/actions/list-updates/list-updates.mjs
@@ -4,7 +4,7 @@ export default {
   key: "telegram_bot_api-list-updates",
   name: "List Updates",
   description: "Retrieves a list of updates from the Telegram server. [See the docs](https://core.telegram.org/bots/api#getupdates) for more information",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/telegram_bot_api/actions/pin-message/pin-message.mjs
+++ b/components/telegram_bot_api/actions/pin-message/pin-message.mjs
@@ -4,7 +4,7 @@ export default {
   key: "telegram_bot_api-pin-message",
   name: "Pin a Message",
   description: "Pins a message. [See the docs](https://core.telegram.org/bots/api#pinchatmessage) for more information",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/telegram_bot_api/actions/promote-chat-member/promote-chat-member.mjs
+++ b/components/telegram_bot_api/actions/promote-chat-member/promote-chat-member.mjs
@@ -4,7 +4,7 @@ export default {
   key: "telegram_bot_api-promote-chat-member",
   name: "Promote a Chat Member",
   description: "Use this method to promote or demote a user in a supergroup or a channel. [See the docs](https://core.telegram.org/bots/api#promotechatmember) for more information",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/telegram_bot_api/actions/restrict-chat-member/restrict-chat-member.mjs
+++ b/components/telegram_bot_api/actions/restrict-chat-member/restrict-chat-member.mjs
@@ -4,7 +4,7 @@ export default {
   key: "telegram_bot_api-restrict-chat-member",
   name: "Restrict a Chat Member",
   description: "Use this method to restrict a user in a supergroup. [See the docs](https://core.telegram.org/bots/api#restrictchatmember) for more information",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/telegram_bot_api/actions/send-album/send-album.mjs
+++ b/components/telegram_bot_api/actions/send-album/send-album.mjs
@@ -5,7 +5,7 @@ export default {
   key: "telegram_bot_api-send-album",
   name: "Send an Album (Media Group)",
   description: "Sends a group of photos or videos as an album. [See the docs](https://core.telegram.org/bots/api#sendmediagroup) for more information",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/telegram_bot_api/actions/send-audio-file/send-audio-file.mjs
+++ b/components/telegram_bot_api/actions/send-audio-file/send-audio-file.mjs
@@ -5,7 +5,7 @@ export default {
   key: "telegram_bot_api-send-audio-file",
   name: "Send an Audio File",
   description: "Sends an audio file to your Telegram Desktop application. [See the docs](https://core.telegram.org/bots/api#sendaudio) for more information",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/telegram_bot_api/actions/send-document-or-image/send-document-or-image.mjs
+++ b/components/telegram_bot_api/actions/send-document-or-image/send-document-or-image.mjs
@@ -5,7 +5,7 @@ export default {
   key: "telegram_bot_api-send-document-or-image",
   name: "Send a Document/Image",
   description: "Sends a document or an image to your Telegram Desktop application. [See the docs](https://core.telegram.org/bots/api#senddocument) for more information",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/telegram_bot_api/actions/send-media-by-url-or-id/send-media-by-url-or-id.mjs
+++ b/components/telegram_bot_api/actions/send-media-by-url-or-id/send-media-by-url-or-id.mjs
@@ -5,7 +5,7 @@ export default {
   key: "telegram_bot_api-send-media-by-url-or-id",
   name: "Send Media by URL or ID",
   description: "Sends a file (document, photo, video, audio, ...) by HTTP URL or by ID that exists on the Telegram servers. [See the docs](https://core.telegram.org/bots/api#inputmedia) for more information",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/telegram_bot_api/actions/send-photo/send-photo.mjs
+++ b/components/telegram_bot_api/actions/send-photo/send-photo.mjs
@@ -5,7 +5,7 @@ export default {
   key: "telegram_bot_api-send-photo",
   name: "Send a Photo",
   description: "Sends a photo to your Telegram Desktop application. [See the docs](https://core.telegram.org/bots/api#sendphoto) for more information",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/telegram_bot_api/actions/send-sticker/send-sticker.mjs
+++ b/components/telegram_bot_api/actions/send-sticker/send-sticker.mjs
@@ -4,7 +4,7 @@ export default {
   key: "telegram_bot_api-send-sticker",
   name: "Send a Sticker",
   description: "Sends a .webp sticker to you Telegram Desktop application. [See the docs](https://core.telegram.org/bots/api#sendsticker) for more information",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/telegram_bot_api/actions/send-text-message-or-reply/send-text-message-or-reply.mjs
+++ b/components/telegram_bot_api/actions/send-text-message-or-reply/send-text-message-or-reply.mjs
@@ -4,7 +4,7 @@ export default {
   key: "telegram_bot_api-send-text-message-or-reply",
   name: "Send a Text Message or Reply",
   description: "Sends a text message or a reply to your Telegram Desktop application. [See the docs](https://core.telegram.org/bots/api#sendmessage) for more information",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/telegram_bot_api/actions/send-video-note/send-video-note.mjs
+++ b/components/telegram_bot_api/actions/send-video-note/send-video-note.mjs
@@ -5,7 +5,7 @@ export default {
   key: "telegram_bot_api-send-video-note",
   name: "Send a Video Note",
   description: "As of v.4.0, Telegram clients support rounded square mp4 videos of up to 1 minute long. Use this method to send video messages. [See the docs](https://core.telegram.org/bots/api#sendvideonote) for more information",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/telegram_bot_api/actions/send-video/send-video.mjs
+++ b/components/telegram_bot_api/actions/send-video/send-video.mjs
@@ -5,7 +5,7 @@ export default {
   key: "telegram_bot_api-send-video",
   name: "Send a Video",
   description: "Sends a video file to your Telegram Desktop application. [See the docs](https://core.telegram.org/bots/api#sendvideo) for more information",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/telegram_bot_api/actions/send-voice-message/send-voice-message.mjs
+++ b/components/telegram_bot_api/actions/send-voice-message/send-voice-message.mjs
@@ -5,7 +5,7 @@ export default {
   key: "telegram_bot_api-send-voice-message",
   name: "Send a Voice Message",
   description: "Sends a voice message. [See the docs](https://core.telegram.org/bots/api#sendvoice) for more information",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/telegram_bot_api/actions/set-chat-permissions/set-chat-permissions.mjs
+++ b/components/telegram_bot_api/actions/set-chat-permissions/set-chat-permissions.mjs
@@ -4,7 +4,7 @@ export default {
   key: "telegram_bot_api-set-chat-permissions",
   name: "Set Chat Permissions",
   description: "Set default chat permissions for all members. [See the docs](https://core.telegram.org/bots/api#setchatpermissions) for more information",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/telegram_bot_api/actions/unpin-message/unpin-message.mjs
+++ b/components/telegram_bot_api/actions/unpin-message/unpin-message.mjs
@@ -4,7 +4,7 @@ export default {
   key: "telegram_bot_api-unpin-message",
   name: "Unpin a Message",
   description: "Unpins a message. [See the docs](https://core.telegram.org/bots/api#unpinchatmessage) for more information",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/telegram_bot_api/package.json
+++ b/components/telegram_bot_api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/telegram_bot_api",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Pipedream Telegram_bot_api Components",
   "main": "telegram_bot_api.app.mjs",
   "keywords": [
@@ -11,7 +11,7 @@
   "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
   "dependencies": {
     "@pipedream/platform": "^3.1.1",
-    "node-telegram-bot-api": "^0.54.0",
+    "node-telegram-bot-api": "1.2.0",
     "uuid": "^8.3.2"
   },
   "gitHead": "e12480b94cc03bed4808ebc6b13e7fdb3a1ba535",

--- a/components/telegram_bot_api/sources/channel-updates/channel-updates.mjs
+++ b/components/telegram_bot_api/sources/channel-updates/channel-updates.mjs
@@ -6,7 +6,7 @@ export default {
   key: "telegram_bot_api-channel-updates",
   name: "New Channel Updates (Instant)",
   description: "Emit new event each time a channel post is created or updated.",
-  version: "0.1.7",
+  version: "0.1.8",
 
   type: "source",
   dedupe: "unique",

--- a/components/telegram_bot_api/sources/message-updates/message-updates.mjs
+++ b/components/telegram_bot_api/sources/message-updates/message-updates.mjs
@@ -6,7 +6,7 @@ export default {
   key: "telegram_bot_api-message-updates",
   name: "New Message Updates (Instant)",
   description: "Emit new event each time a Telegram message is created or updated.",
-  version: "0.1.8",
+  version: "0.1.9",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/telegram_bot_api/sources/new-bot-command-received/new-bot-command-received.mjs
+++ b/components/telegram_bot_api/sources/new-bot-command-received/new-bot-command-received.mjs
@@ -6,7 +6,7 @@ export default {
   key: "telegram_bot_api-new-bot-command-received",
   name: "New Bot Command Received (Instant)",
   description: "Emit new event each time a Telegram Bot command is received.",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/telegram_bot_api/sources/new-updates/new-updates.mjs
+++ b/components/telegram_bot_api/sources/new-updates/new-updates.mjs
@@ -6,7 +6,7 @@ export default {
   key: "telegram_bot_api-new-updates",
   name: "New Updates (Instant)",
   description: "Emit new event for each new Telegram event.",
-  version: "0.1.7",
+  version: "0.1.8",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/telegram_bot_api/telegram_bot_api.app.mjs
+++ b/components/telegram_bot_api/telegram_bot_api.app.mjs
@@ -1,5 +1,10 @@
 import "./common/env.mjs";
-import TelegramBot from "node-telegram-bot-api";
+// Pinned to 1.2.0. The component builder resolves npm dependencies from the
+// import specifier alone (never from package.json), so an unpinned specifier
+// installs the `latest` dist-tag. node-telegram-bot-api 2.0.0 removed the
+// default export and replaced the `TelegramBot` class with a new `Bot`/`Api`
+// design, so every build since 2026-08-16 failed to load this module.
+import TelegramBot from "node-telegram-bot-api@1.2.0";
 import { axios } from "@pipedream/platform";
 import {
   TELEGRAM_BOT_API_UI_MEDIA_AUDIO,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,7 +147,7 @@ importers:
         version: 4.0.0
       ts-jest:
         specifier: ^29.1.1
-        version: 29.4.5(@babel/core@8.0.0-rc.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@8.0.0-rc.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.25)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.6.3)))(typescript@5.6.3)
+        version: 29.4.5(@babel/core@8.0.0-rc.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@8.0.0-rc.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.25)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.6.3)))(typescript@5.6.3)
       typescript:
         specifier: '>=5.5.0 <5.7.0'
         version: 5.6.3
@@ -16069,8 +16069,8 @@ importers:
         specifier: ^3.1.1
         version: 3.1.1
       node-telegram-bot-api:
-        specifier: ^0.54.0
-        version: 0.54.0
+        specifier: 1.2.0
+        version: 1.2.0
       uuid:
         specifier: ^8.3.2
         version: 8.3.2
@@ -18854,7 +18854,7 @@ importers:
         version: 3.1.11
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.25)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.6.3)))(typescript@5.6.3)
+        version: 29.4.5(@babel/core@8.0.0-rc.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@8.0.0-rc.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.25)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.6.3)))(typescript@5.6.3)
       tsup:
         specifier: ^8.3.6
         version: 8.5.1(@microsoft/api-extractor@7.55.0(@types/node@20.19.25))(jiti@2.6.1)(postcss@8.5.15)(tsx@4.20.6)(typescript@5.6.3)(yaml@2.8.1)
@@ -25620,10 +25620,6 @@ packages:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
 
-  array.prototype.findindex@2.2.4:
-    resolution: {integrity: sha512-LLm4mhxa9v8j0A/RPnpQAP4svXToJFh+Hp1pNYl5ZD5qpB4zdx/D4YjpVcETkhFbUKWO3iGMVLvrOnnmkAJT6A==}
-    engines: {node: '>= 0.4'}
-
   array.prototype.findlast@1.2.5:
     resolution: {integrity: sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==}
     engines: {node: '>= 0.4'}
@@ -25983,9 +25979,6 @@ packages:
 
   birpc@2.8.0:
     resolution: {integrity: sha512-Bz2a4qD/5GRhiHSwj30c/8kC8QGj12nNDwz3D4ErQ4Xhy35dsSDvF+RA/tWpjyU0pdGtSDiEk6B5fBGE1qNVhw==}
-
-  bl@1.2.3:
-    resolution: {integrity: sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -28118,10 +28111,6 @@ packages:
   file-type@21.3.2:
     resolution: {integrity: sha512-DLkUvGwep3poOV2wpzbHCOnSKGk1LzyXTv+aHFgN2VFl96wnp8YA9YjO2qPzg5PuL8q/SW9Pdi6WTkYOIh995w==}
     engines: {node: '>=20'}
-
-  file-type@3.9.0:
-    resolution: {integrity: sha512-RLoqTXE8/vPmMuTI88DAzhMYC99I8BWv7zYP4A1puo5HIjEJ5EX48ighy4ZyKMG9EDXxBgW6e++cn7d1xuFghA==}
-    engines: {node: '>=0.10.0'}
 
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
@@ -31333,9 +31322,9 @@ packages:
     resolution: {integrity: sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw==}
     engines: {node: '>=0.12.0'}
 
-  node-telegram-bot-api@0.54.0:
-    resolution: {integrity: sha512-ckrpY/ABFLwA1DUzEc9iEQtsgQs8WcGC6m7iJ1bbnH+c7EOLnMdCfw+hUesyfuwOfAkkECYFxvoW4lJNy+Oztw==}
-    engines: {node: '>=0.12'}
+  node-telegram-bot-api@1.2.0:
+    resolution: {integrity: sha512-M6S61LZn1FQMQnZSdFlc4oV+mwDGlPTbLzq/GUaSH4ew40wGTaKPtAaLp5oOhl/C3k0ylGqMIppJsVulwTCePg==}
+    engines: {node: '>=18'}
 
   nodemailer@7.0.10:
     resolution: {integrity: sha512-Us/Se1WtT0ylXgNFfyFSx4LElllVLJXQjWi2Xz17xWw7amDKO2MLtFnVp1WACy7GkVGs+oBlRopVNUzlrGSw1w==}
@@ -32437,9 +32426,6 @@ packages:
 
   pump@1.0.3:
     resolution: {integrity: sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==}
-
-  pump@2.0.1:
-    resolution: {integrity: sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==}
 
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
@@ -45695,15 +45681,6 @@ snapshots:
 
   array-union@2.1.0: {}
 
-  array.prototype.findindex@2.2.4:
-    dependencies:
-      call-bind: 1.0.8
-      call-bound: 1.0.4
-      define-properties: 1.2.1
-      es-abstract: 1.24.0
-      es-object-atoms: 1.1.1
-      es-shim-unscopables: 1.1.0
-
   array.prototype.findlast@1.2.5:
     dependencies:
       call-bind: 1.0.8
@@ -46169,11 +46146,6 @@ snapshots:
       '@noble/hashes': 1.8.0
 
   birpc@2.8.0: {}
-
-  bl@1.2.3:
-    dependencies:
-      readable-stream: 2.3.8
-      safe-buffer: 5.2.1
 
   bl@4.1.0:
     dependencies:
@@ -48902,8 +48874,6 @@ snapshots:
       uint8array-extras: 1.5.0
     transitivePeerDependencies:
       - supports-color
-
-  file-type@3.9.0: {}
 
   file-uri-to-path@1.0.0: {}
 
@@ -53299,21 +53269,7 @@ snapshots:
 
   node-stream-zip@1.15.0: {}
 
-  node-telegram-bot-api@0.54.0:
-    dependencies:
-      array.prototype.findindex: 2.2.4
-      bl: 1.2.3
-      bluebird: 3.7.2
-      debug: 3.2.7
-      depd: 1.1.2
-      eventemitter3: 3.1.2
-      file-type: 3.9.0
-      mime: 1.6.0
-      pump: 2.0.1
-      request: 2.88.2
-      request-promise: 4.2.6(request@2.88.2)
-    transitivePeerDependencies:
-      - supports-color
+  node-telegram-bot-api@1.2.0: {}
 
   nodemailer@7.0.10: {}
 
@@ -54538,11 +54494,6 @@ snapshots:
   pstree.remy@1.1.8: {}
 
   pump@1.0.3:
-    dependencies:
-      end-of-stream: 1.4.5
-      once: 1.4.0
-
-  pump@2.0.1:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
@@ -57127,28 +57078,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.4.5(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.25)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.6.3)))(typescript@5.6.3):
-    dependencies:
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      handlebars: 4.7.9
-      jest: 29.7.0(@types/node@20.19.25)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.6.3))
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.7.4
-      type-fest: 4.41.0
-      typescript: 5.6.3
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.29.7
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.7)
-      esbuild: 0.27.0
-      jest-util: 29.7.0
-
-  ts-jest@29.4.5(@babel/core@8.0.0-rc.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@8.0.0-rc.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.25)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.6.3)))(typescript@5.6.3):
+  ts-jest@29.4.5(@babel/core@8.0.0-rc.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@8.0.0-rc.6))(esbuild@0.27.0)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.25)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.25)(typescript@5.6.3)))(typescript@5.6.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -57166,6 +57096,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@8.0.0-rc.6)
+      esbuild: 0.27.0
       jest-util: 29.7.0
 
   ts-node@10.9.2(@types/node@20.19.25)(typescript@5.6.3):


### PR DESCRIPTION
## Summary

<!-- Add your PR description here -->
Closes #21715 by pinning `node-telegram-bot-api` sdk version to `1.2.0` instead of the breaking `2.0.0`
sdk v1 to v2 migration guide: https://github.com/yagop/node-telegram-bot-api/blob/HEAD/CHANGELOG.md


## Checklist
Please check the following items before your PR can be reviewed:

### Versioning
- [x] All components updated in this PR had their version updated (`0.0.1` for new ones)
- [x] The app updated in this PR had its `package.json`'s version updated

### New app
If this is a new app, please submit [an app integration request](https://github.com/PipedreamHQ/pipedream/issues/new?template=app---service-integration.md) - the PR will only be reviewed after the app is integrated.
- [x] The app updated in this PR is already integrated

### CodeRabbit review
After the PR is opened, and if new changes are pushed, CodeRabbit will automatically review it. Do not 'mark as resolved' CodeRabbit's comments, but reply to them instead, whether you agree (and update the PR accordingly) or disagree.
- [ ] I have addressed or acknowledged all of CodeRabbit's review comments



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Telegram Bot API component and its available actions and event sources to newer releases.
  - Improved release tracking across messaging, media, chat management, and update-handling capabilities.
  - Standardized component version metadata for more consistent upgrades and compatibility management.
  - No user-facing functionality or workflow behavior changed in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->