### PR TITLE
[21693] feat(google_docs): add google-docs list-comments action

### DIFF
--- a/components/google_docs/actions/append-text/append-text.mjs
+++ b/components/google_docs/actions/append-text/append-text.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-append-text",
   name: "Append Text",
   description: "Append text to an existing document. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#InsertTextRequest)",
-  version: "0.1.13",
+  version: "0.1.14",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/create-document-from-template/create-document-from-template.mjs
+++ b/components/google_docs/actions/create-document-from-template/create-document-from-template.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_docs-create-document-from-template",
   name: "Create Document From Template",
   description: "Create a new Google Doc by copying a template document and substituting `{{placeholder}}` tokens with values. Use **Find Document** to resolve the template's name to its ID. Returns `{documentId, title, url}`. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#ReplaceAllTextRequest)",
-  version: "1.0.2",
+  version: "1.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/create-document/create-document.mjs
+++ b/components/google_docs/actions/create-document/create-document.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-create-document",
   name: "Create Document",
   description: "Create a new Google Doc with an optional body. The body is rendered as Markdown, so you can include headings (`# Title`), bold/italic, bullet/numbered lists, links, and code. Optionally place the doc in a specific Drive folder. Returns `{documentId, title, url}`. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/create)",
-  version: "1.0.2",
+  version: "1.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/delete-table/delete-table.mjs
+++ b/components/google_docs/actions/delete-table/delete-table.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_docs-delete-table",
   name: "Delete Table",
   description: "Remove an entire table, structure and contents, from the document. Use this to clear a table completely, including an empty table left behind after its text was removed. Set **Table Number** to pick which table to remove (1 = first top-level table in the document, in reading order; a table nested inside another table's cell doesn't count separately). Use **Get Document** first if you need to confirm how many tables exist. This also works on a table linked to a Google Sheet, since removal is treated as ordinary content deletion. Use **Find Document** to resolve a document's name to its ID. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#DeleteContentRangeRequest)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_docs/actions/export-document/export-document.mjs
+++ b/components/google_docs/actions/export-document/export-document.mjs
@@ -32,7 +32,7 @@ export default {
   key: "google_docs-export-document",
   name: "Export Document",
   description: "Export (download) a Google Doc to a file in PDF, DOCX, TXT, HTML, or ODT format. Use **Find Document** to resolve a document's name to its ID. The file is written to the workflow's temporary storage and a presigned download URL is returned to the caller. Returns `{filePath, filename, mimeType}`. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/export)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/find-document/find-document.mjs
+++ b/components/google_docs/actions/find-document/find-document.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-find-document",
   name: "Find Document",
   description: "Search for Google Docs by name or full-text content. Returns a list of `{id, name, url, modifiedTime}`. Use this first to resolve a document's name to its ID, then pass the `id` to **Get Document**, **Export Document**, or any of the insert/replace tools. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/list)",
-  version: "1.0.2",
+  version: "1.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/get-document/get-document.mjs
+++ b/components/google_docs/actions/get-document/get-document.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_docs-get-document",
   name: "Get Document",
   description: "Get the full text content and structure of a Google Doc by its ID. Returns the document body plus a flattened `textContent` field for easy reading. Optionally supply a `fields` mask to request a partial (e.g. metadata-only) response and skip the body-text enrichment. Use **Find Document** first to resolve a document's name to its ID. For multi-tab documents, pass a `tabId` to retrieve a single tab's content. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/get)",
-  version: "1.1.1",
+  version: "1.1.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/get-profile/get-profile.mjs
+++ b/components/google_docs/actions/get-profile/get-profile.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-get-profile",
   name: "Get Profile",
   description: "Get the identity (display name and email) of the currently authenticated Google account. Use this to answer \"who am I\" questions and to attribute documents to the current user. Resolves via the Drive `about.get` endpoint (no extra OAuth scope required). [See the documentation](https://developers.google.com/drive/api/v3/reference/about/get)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/insert-image/insert-image.mjs
+++ b/components/google_docs/actions/insert-image/insert-image.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-insert-image",
   name: "Insert Image",
   description: "Insert an inline image into a Google Doc from a publicly reachable image URL. The URL must be publicly accessible (Google fetches it server-side) and point to a PNG, JPEG, or GIF. Use **Find Document** to resolve a document's name to its ID. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#InsertInlineImageRequest)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/insert-page-break/insert-page-break.mjs
+++ b/components/google_docs/actions/insert-page-break/insert-page-break.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-insert-page-break",
   name: "Insert Page Break",
   description: "Insert a page break into a Google Doc at the beginning, end, or a specific character index. Use **Find Document** to resolve a document's name to its ID. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#InsertPageBreakRequest)",
-  version: "1.0.2",
+  version: "1.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/insert-table/insert-table.mjs
+++ b/components/google_docs/actions/insert-table/insert-table.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-insert-table",
   name: "Insert Table",
   description: "Insert an empty table with the given number of rows and columns into a Google Doc. If you already have the data, use **Write Table** instead so you don't have to fill cells one by one. Use **Find Document** to resolve a document's name to its ID. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#InsertTableRequest)",
-  version: "1.0.2",
+  version: "1.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/insert-text/insert-text.mjs
+++ b/components/google_docs/actions/insert-text/insert-text.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-insert-text",
   name: "Insert Text",
   description: "Insert text into a Google Doc at the beginning, end, or a specific character index. Use **Find Document** to resolve a document's name to its ID. To append text to the end of a doc, use `position: end` (the default). [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#InsertTextRequest)",
-  version: "1.0.2",
+  version: "1.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/list-comments/list-comments.mjs
+++ b/components/google_docs/actions/list-comments/list-comments.mjs
@@ -1,14 +1,15 @@
+// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
-import googleDrive from "../../google_drive.app.mjs";
+import googleDocs from "../../google_docs.app.mjs";
 import {
   COMMENTS_MAX_PAGE_SIZE, DEFAULT_COMMENT_LIMIT, MAX_COMMENT_LIMIT,
 } from "../../common/constants.mjs";
 
 export default {
-  key: "google_drive-list-comments",
+  key: "google_docs-list-comments",
   name: "List Comments",
-  description: "List the comments on a file, including each comment's author, plain text and HTML content, the file text it is anchored to, whether it is resolved, and its full reply thread. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/comments/list)",
-  version: "0.1.0",
+  description: "List the comments on a Google Doc, including each comment's author, plain text and HTML content, the document text it is anchored to, whether it is resolved, and its full reply thread. Comments on a Doc are served by the Drive API, so the document ID doubles as the file ID. Use **Find Document** first to resolve a document's name to its ID. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/comments/list)",
+  version: "0.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -16,22 +17,12 @@ export default {
   },
   type: "action",
   props: {
-    googleDrive,
-    drive: {
+    googleDocs,
+    documentId: {
       propDefinition: [
-        googleDrive,
-        "watchedDrive",
+        googleDocs,
+        "documentId",
       ],
-    },
-    fileId: {
-      propDefinition: [
-        googleDrive,
-        "fileId",
-        (c) => ({
-          drive: c.drive,
-        }),
-      ],
-      description: "The file to list comments for. You can select a file or use a file ID from a previous step.",
     },
     includeDeleted: {
       type: "boolean",
@@ -74,12 +65,11 @@ export default {
     let pageToken;
 
     do {
-      const { data } = await this.googleDrive.listSyncComments(
+      const { data } = await this.googleDocs.listSyncComments(
         // `comments.list` takes no `driveId` - a comment is addressed by file ID
-        // alone - so the app method's first argument is intentionally unset. The
-        // `drive` prop only scopes the **File** dropdown.
+        // alone - so the app method's first argument is intentionally unset.
         undefined,
-        this.fileId,
+        this.documentId,
         {
           ...args,
           pageSize: Math.min(COMMENTS_MAX_PAGE_SIZE, limit - comments.length),
@@ -90,7 +80,9 @@ export default {
       pageToken = data.nextPageToken;
     } while (pageToken && comments.length < limit);
 
-    $.export("$summary", `Successfully found ${comments.length} comment(s) for file ${this.fileId}`);
+    $.export("$summary", `Found ${comments.length} comment${comments.length === 1
+      ? ""
+      : "s"} on document ${this.documentId}`);
     return comments;
   },
 };

--- a/components/google_docs/actions/list-comments/list-comments.mjs
+++ b/components/google_docs/actions/list-comments/list-comments.mjs
@@ -1,6 +1,6 @@
 // x-pd-ai: optimized
-import { ConfigurationError } from "@pipedream/platform";
 import googleDocs from "../../google_docs.app.mjs";
+import utils from "../../common/utils.mjs";
 import {
   COMMENTS_MAX_PAGE_SIZE, DEFAULT_COMMENT_LIMIT, MAX_COMMENT_LIMIT,
 } from "../../common/constants.mjs";
@@ -53,11 +53,7 @@ export default {
     };
 
     if (this.startModifiedTime) {
-      const parsed = Date.parse(this.startModifiedTime);
-      if (Number.isNaN(parsed)) {
-        throw new ConfigurationError(`Invalid Start Modified Time "${this.startModifiedTime}". Use an RFC 3339 timestamp, e.g. "2026-01-31T00:00:00Z".`);
-      }
-      args.startModifiedTime = new Date(parsed).toISOString();
+      args.startModifiedTime = utils.parseRfc3339(this.startModifiedTime, "Start Modified Time");
     }
 
     const limit = this.limit || DEFAULT_COMMENT_LIMIT;

--- a/components/google_docs/actions/replace-image/replace-image.mjs
+++ b/components/google_docs/actions/replace-image/replace-image.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-replace-image",
   name: "Replace Image",
   description: "Replace image in a existing document. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#ReplaceImageRequest)",
-  version: "0.0.14",
+  version: "0.0.15",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_docs/actions/replace-text/replace-text.mjs
+++ b/components/google_docs/actions/replace-text/replace-text.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-replace-text",
   name: "Replace Text",
   description: "Find and replace all occurrences of a string in a Google Doc. Use **Find Document** to resolve a document's name to its ID. Returns the number of replacements made. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#ReplaceAllTextRequest)",
-  version: "1.0.2",
+  version: "1.0.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_docs/actions/write-table/write-table.mjs
+++ b/components/google_docs/actions/write-table/write-table.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_docs-write-table",
   name: "Write Table",
   description: "Create a table and fill it with data in a single step. Provide the entire table (all rows and columns, including a header row) at once. Use this instead of inserting cells or text one at a time. The action places every value in the correct cell for you. Pass **Table Data** as a JSON array of arrays, one inner array per row, header row first when **Has Header Row** is set, e.g. `[[\"Name\",\"Role\"],[\"Ada\",\"Engineer\"]]`. Use **Find Document** to resolve a document's name to its ID, or **Insert Table** instead if you only need an empty grid to fill in later. Note: a table written this way is always static — the Google Docs API does not create or preserve a live link to a Google Sheet, even when this replaces a Sheets-linked table. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#InsertTableRequest)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/common/constants.mjs
+++ b/components/google_docs/common/constants.mjs
@@ -1,0 +1,13 @@
+// Maximum `pageSize` accepted by the Drive API's `comments.list`; larger values are
+// coerced down to this by the API.
+// https://developers.google.com/workspace/drive/api/reference/rest/v3/comments/list
+const COMMENTS_MAX_PAGE_SIZE = 100;
+
+const DEFAULT_COMMENT_LIMIT = 100;
+const MAX_COMMENT_LIMIT = 500;
+
+export {
+  COMMENTS_MAX_PAGE_SIZE,
+  DEFAULT_COMMENT_LIMIT,
+  MAX_COMMENT_LIMIT,
+};

--- a/components/google_docs/common/utils.mjs
+++ b/components/google_docs/common/utils.mjs
@@ -95,9 +95,13 @@ function adjustPropDefinitions(props, app) {
  * RFC 3339 date (`2026-01-31`) or date-time (`2026-01-31T00:00:00Z`). A
  * date-time must carry a `Z` or numeric offset, as RFC 3339 requires: without
  * one, `Date.parse` silently reads it in the runner's local timezone.
+ *
+ * The time fields spell out their RFC 3339 ranges rather than using `\d{2}`,
+ * because `Date.parse` accepts the ISO 8601 end-of-day hour `24` and rolls it
+ * into the next day (`...T24:00:00Z` becomes the 1st of the next month).
  */
 const RFC_3339_REGEX =
-  /^(\d{4})-(\d{2})-(\d{2})(?:[Tt](\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:[Zz]|[+-]\d{2}:\d{2}))?$/;
+  /^(\d{4})-(\d{2})-(\d{2})(?:[Tt]([01]\d|2[0-3]):([0-5]\d):([0-5]\d)(?:\.\d+)?(?:[Zz]|[+-]([01]\d|2[0-3]):[0-5]\d))?$/;
 
 /**
  * Validate an RFC 3339 timestamp and normalize it to a UTC ISO string.

--- a/components/google_docs/common/utils.mjs
+++ b/components/google_docs/common/utils.mjs
@@ -1,3 +1,5 @@
+import { ConfigurationError } from "@pipedream/platform";
+
 function getTextContentFromDocument(content) {
   let textContent = "";
   content.forEach((element) => {
@@ -89,10 +91,54 @@ function adjustPropDefinitions(props, app) {
   );
 }
 
+/**
+ * RFC 3339 date (`2026-01-31`) or date-time (`2026-01-31T00:00:00Z`). A
+ * date-time must carry a `Z` or numeric offset, as RFC 3339 requires: without
+ * one, `Date.parse` silently reads it in the runner's local timezone.
+ */
+const RFC_3339_REGEX =
+  /^(\d{4})-(\d{2})-(\d{2})(?:[Tt](\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:[Zz]|[+-]\d{2}:\d{2}))?$/;
+
+/**
+ * Validate an RFC 3339 timestamp and normalize it to a UTC ISO string.
+ *
+ * `Date.parse` alone is too permissive to use as the gate: it accepts
+ * locale-ambiguous input like `01/02/2026` and bare years like `2026`, and it
+ * rolls impossible dates over (`2026-02-31` becomes March 3) rather than
+ * rejecting them. Either would silently filter from the wrong instant.
+ *
+ * @param {String} value the user-supplied timestamp
+ * @param {String} label the prop label, used in the error message
+ * @returns {String} the timestamp normalized to a UTC ISO string
+ */
+function parseRfc3339(value, label) {
+  const match = RFC_3339_REGEX.exec(String(value).trim());
+  if (!match) {
+    throw new ConfigurationError(`Invalid ${label} "${value}". Use an RFC 3339 timestamp, e.g. "2026-01-31T00:00:00Z" or "2026-01-31".`);
+  }
+  const [
+    , year,
+    month,
+    day,
+  ] = match.map(Number);
+  // The shape is right, but `2026-02-31` still parses, so confirm the calendar
+  // date round-trips unchanged before trusting it.
+  const utc = new Date(Date.UTC(year, month - 1, day));
+  const parsed = Date.parse(match[0]);
+  if (utc.getUTCFullYear() !== year
+    || utc.getUTCMonth() !== month - 1
+    || utc.getUTCDate() !== day
+    || Number.isNaN(parsed)) {
+    throw new ConfigurationError(`Invalid ${label} "${value}". That is not a real date or time.`);
+  }
+  return new Date(parsed).toISOString();
+}
+
 export default {
   getTextContentFromDocument,
   addTextContentToDocument,
   flattenTables,
   selectInsertedTable,
   adjustPropDefinitions,
+  parseRfc3339,
 };

--- a/components/google_docs/package.json
+++ b/components/google_docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_docs",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Pipedream Google_docs Components",
   "main": "google_docs.app.mjs",
   "keywords": [

--- a/components/google_docs/sources/new-document-created/new-document-created.mjs
+++ b/components/google_docs/sources/new-document-created/new-document-created.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_docs-new-document-created",
   name: "New Document Created (Instant)",
   description: "Emit new event when a new document is created in Google Docs. [See the documentation](https://developers.google.com/drive/api/reference/rest/v3/changes/watch)",
-  version: "0.0.10",
+  version: "0.0.11",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/google_docs/sources/new-or-updated-document/new-or-updated-document.mjs
+++ b/components/google_docs/sources/new-or-updated-document/new-or-updated-document.mjs
@@ -9,7 +9,7 @@ export default {
   key: "google_docs-new-or-updated-document",
   name: "New or Updated Document (Instant)",
   description: "Emit new event when a document is created or updated in Google Docs. [See the documentation](https://developers.google.com/drive/api/reference/rest/v3/changes/watch)",
-  version: "0.0.10",
+  version: "0.0.11",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/google_drive/actions/add-comment/add-comment.mjs
+++ b/components/google_drive/actions/add-comment/add-comment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-add-comment",
   name: "Add Comment",
   description: "Add an unanchored comment to a Google Doc (general feedback, no text highlighting). [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/comments/create)",
-  version: "0.1.8",
+  version: "0.1.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/add-file-sharing-preference/add-file-sharing-preference.mjs
+++ b/components/google_drive/actions/add-file-sharing-preference/add-file-sharing-preference.mjs
@@ -20,7 +20,7 @@ export default {
   name: "Share File or Folder",
   description:
     "Add a [sharing permission](https://support.google.com/drive/answer/7166529) to the sharing preferences of a file or folder and provide a sharing URL. [See the documentation](https://developers.google.com/drive/api/v3/reference/permissions/create)",
-  version: "0.2.16",
+  version: "0.2.17",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/copy-file/copy-file.mjs
+++ b/components/google_drive/actions/copy-file/copy-file.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-copy-file",
   name: "Copy File",
   description: "Create a copy of the specified file. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/copy) for more information",
-  version: "0.1.23",
+  version: "0.1.24",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/create-file-from-template/create-file-from-template.mjs
+++ b/components/google_drive/actions/create-file-from-template/create-file-from-template.mjs
@@ -9,7 +9,7 @@ export default {
   key: "google_drive-create-file-from-template",
   name: "Create New File From Template",
   description: "Create a new Google Docs file from a template. Optionally include placeholders in the template document that will get replaced from this action. [See documentation](https://www.npmjs.com/package/google-docs-mustaches)",
-  version: "0.1.26",
+  version: "0.1.27",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_drive/actions/create-file-from-text/create-file-from-text.mjs
+++ b/components/google_drive/actions/create-file-from-text/create-file-from-text.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_drive-create-file-from-text",
   name: "Create New File From Text",
   description: "Create a new file from plain text. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/create) for more information",
-  version: "0.2.16",
+  version: "0.2.17",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/create-folder/create-folder.mjs
+++ b/components/google_drive/actions/create-folder/create-folder.mjs
@@ -13,7 +13,7 @@ export default {
   key: "google_drive-create-folder",
   name: "Create Folder",
   description: "Create a new empty folder. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/create) for more information",
-  version: "0.1.24",
+  version: "0.1.25",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/create-shared-drive/create-shared-drive.mjs
+++ b/components/google_drive/actions/create-shared-drive/create-shared-drive.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-create-shared-drive",
   name: "Create Shared Drive",
   description: "Create a new shared drive. [See the documentation](https://developers.google.com/drive/api/v3/reference/drives/create) for more information",
-  version: "0.1.24",
+  version: "0.1.25",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/create-text-file/create-text-file.mjs
+++ b/components/google_drive/actions/create-text-file/create-text-file.mjs
@@ -12,7 +12,7 @@ export default {
     + " `mimeType = 'application/vnd.google-apps.folder'` to find the folder ID first."
     + " Supported content formats: plain text, Markdown, HTML, Rich Text, CSV."
     + " [See the documentation](https://developers.google.com/drive/api/v3/reference/files/create)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/google_drive/actions/delete-comment/delete-comment.mjs
+++ b/components/google_drive/actions/delete-comment/delete-comment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-delete-comment",
   name: "Delete Comment",
   description: "Delete a specific comment (Requires ownership or permissions). [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/comments/delete)",
-  version: "0.0.12",
+  version: "0.0.13",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_drive/actions/delete-file/delete-file.mjs
+++ b/components/google_drive/actions/delete-file/delete-file.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Delete File",
   description:
     "Permanently delete a file or folder without moving it to the trash. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/delete) for more information",
-  version: "0.1.24",
+  version: "0.1.25",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_drive/actions/delete-reply/delete-reply.mjs
+++ b/components/google_drive/actions/delete-reply/delete-reply.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-delete-reply",
   name: "Delete Reply",
   description: "Delete a reply on a specific comment. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/replies/delete) for more information",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_drive/actions/delete-shared-drive/delete-shared-drive.mjs
+++ b/components/google_drive/actions/delete-shared-drive/delete-shared-drive.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-delete-shared-drive",
   name: "Delete Shared Drive",
   description: "Delete a shared drive without any content. [See the documentation](https://developers.google.com/drive/api/v3/reference/drives/delete) for more information",
-  version: "0.1.23",
+  version: "0.1.24",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_drive/actions/download-file/download-file.mjs
+++ b/components/google_drive/actions/download-file/download-file.mjs
@@ -33,7 +33,7 @@ export default {
     + " Pass `mimeType` to force a specific format. Shortcuts are resolved to their target automatically."
     + " Folders, Forms, and My Maps cannot be downloaded via this action."
     + " [See the documentation](https://developers.google.com/drive/api/v3/manage-downloads)",
-  version: "0.2.0",
+  version: "0.2.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/find-file/find-file.mjs
+++ b/components/google_drive/actions/find-file/find-file.mjs
@@ -6,7 +6,7 @@ export default {
   key: "google_drive-find-file",
   name: "Find File",
   description: "Search for a specific file by name. The `Search Name` field uses Google Drive's tokenized full-text matching — pass a distinctive word or short phrase rather than the full title when the name contains special characters like `&` or `'`. [See the documentation](https://developers.google.com/drive/api/v3/search-files) for more information",
-  version: "0.1.24",
+  version: "0.1.25",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/find-folder/find-folder.mjs
+++ b/components/google_drive/actions/find-folder/find-folder.mjs
@@ -7,7 +7,7 @@ export default {
   key: "google_drive-find-folder",
   name: "Find Folder",
   description: "Search for a specific folder by name. The `Search Name` field uses Google Drive's tokenized full-text matching — pass a distinctive word or short phrase rather than the full title when the name contains special characters like `&` or `'`. [See the documentation](https://developers.google.com/drive/api/v3/search-files) for more information",
-  version: "0.1.24",
+  version: "0.1.25",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/find-forms/find-forms.mjs
+++ b/components/google_drive/actions/find-forms/find-forms.mjs
@@ -6,7 +6,7 @@ export default {
   key: "google_drive-find-forms",
   name: "Find Forms",
   description: "List Google Form documents or search for a Form by name. The `Search Name` field uses Google Drive's tokenized full-text matching — pass a distinctive word or short phrase rather than the full title when the name contains special characters like `&` or `'`. [See the documentation](https://developers.google.com/drive/api/v3/search-files) for more information",
-  version: "0.0.25",
+  version: "0.0.26",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/find-spreadsheets/find-spreadsheets.mjs
+++ b/components/google_drive/actions/find-spreadsheets/find-spreadsheets.mjs
@@ -6,7 +6,7 @@ export default {
   key: "google_drive-find-spreadsheets",
   name: "Find Spreadsheets",
   description: "Search for a specific spreadsheet by name. The `Search Name` field uses Google Drive's tokenized full-text matching — pass a distinctive word or short phrase rather than the full title when the name contains special characters like `&` or `'`. [See the documentation](https://developers.google.com/drive/api/v3/search-files) for more information",
-  version: "0.1.24",
+  version: "0.1.25",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/get-comment/get-comment.mjs
+++ b/components/google_drive/actions/get-comment/get-comment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-get-comment",
   name: "Get Comment By ID",
   description: "Get comment by ID on a specific file. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/comments/get) for more information",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/get-current-user/get-current-user.mjs
+++ b/components/google_drive/actions/get-current-user/get-current-user.mjs
@@ -6,7 +6,7 @@ export default {
   key: "google_drive-get-current-user",
   name: "Get Current User",
   description: "Retrieve Google Drive account metadata for the authenticated user via `about.get`, including display name, email, permission ID, and storage quota. Useful when flows or agents need to confirm the active Google identity or understand available storage. [See the documentation](https://developers.google.com/drive/api/v3/reference/about/get).",
-  version: "0.0.10",
+  version: "0.0.11",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/google_drive/actions/get-file-by-id/get-file-by-id.mjs
+++ b/components/google_drive/actions/get-file-by-id/get-file-by-id.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_drive-get-file-by-id",
   name: "Get File By ID",
   description: "Get info on a specific file. [See the documentation](https://developers.google.com/drive/api/reference/rest/v3/files/get) for more information",
-  version: "0.0.20",
+  version: "0.0.21",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/get-file/get-file.mjs
+++ b/components/google_drive/actions/get-file/get-file.mjs
@@ -11,7 +11,7 @@ export default {
     + "\n\nCommon fields: `id`, `name`, `mimeType`, `size`, `parents`, `webViewLink`, `webContentLink`,"
     + " `createdTime`, `modifiedTime`, `owners`, `permissions`, `description`, `trashed`."
     + " [See the documentation](https://developers.google.com/drive/api/v3/reference/files/get)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/google_drive/actions/get-folder-id-for-path/get-folder-id-for-path.mjs
+++ b/components/google_drive/actions/get-folder-id-for-path/get-folder-id-for-path.mjs
@@ -12,7 +12,7 @@ export default {
   key: "google_drive-get-folder-id-for-path",
   name: "Get Folder ID for a Path",
   description: "Retrieve a folderId for a path. [See the documentation](https://developers.google.com/drive/api/v3/search-files) for more information",
-  version: "0.1.25",
+  version: "0.1.26",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/get-reply/get-reply.mjs
+++ b/components/google_drive/actions/get-reply/get-reply.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-get-reply",
   name: "Get Reply By ID",
   description: "Get reply by ID on a specific comment. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/replies/get) for more information",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/get-shared-drive/get-shared-drive.mjs
+++ b/components/google_drive/actions/get-shared-drive/get-shared-drive.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-get-shared-drive",
   name: "Get Shared Drive",
   description: "Get metadata for one or all shared drives. [See the documentation](https://developers.google.com/drive/api/v3/reference/drives/get) for more information",
-  version: "0.1.23",
+  version: "0.1.24",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/get-user-details/get-user-details.mjs
+++ b/components/google_drive/actions/get-user-details/get-user-details.mjs
@@ -10,7 +10,7 @@ export default {
     + " When the user says 'my files' or 'my documents', call this first to get the owner email,"
     + " then pass it to **Search Files** with a query like `'user@example.com' in owners`."
     + " [See the documentation](https://developers.google.com/drive/api/v3/reference/about/get)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/google_drive/actions/is-folder-ancestor/is-folder-ancestor.mjs
+++ b/components/google_drive/actions/is-folder-ancestor/is-folder-ancestor.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-is-folder-ancestor",
   name: "Is Folder Ancestor",
   description: "Check if a specific folder is anywhere in the parent hierarchy of a file or folder. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/files/get)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/google_drive/actions/list-access-proposals/list-access-proposals.mjs
+++ b/components/google_drive/actions/list-access-proposals/list-access-proposals.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-list-access-proposals",
   name: "List Access Proposals",
   description: "List access proposals for a file or folder. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/accessproposals/list)",
-  version: "0.0.16",
+  version: "0.0.17",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/list-comments/list-comments.mjs
+++ b/components/google_drive/actions/list-comments/list-comments.mjs
@@ -1,5 +1,5 @@
-import { ConfigurationError } from "@pipedream/platform";
 import googleDrive from "../../google_drive.app.mjs";
+import { parseRfc3339 } from "../../common/utils.mjs";
 import {
   COMMENTS_MAX_PAGE_SIZE, DEFAULT_COMMENT_LIMIT, MAX_COMMENT_LIMIT,
 } from "../../common/constants.mjs";
@@ -62,11 +62,7 @@ export default {
     };
 
     if (this.startModifiedTime) {
-      const parsed = Date.parse(this.startModifiedTime);
-      if (Number.isNaN(parsed)) {
-        throw new ConfigurationError(`Invalid Start Modified Time "${this.startModifiedTime}". Use an RFC 3339 timestamp, e.g. "2026-01-31T00:00:00Z".`);
-      }
-      args.startModifiedTime = new Date(parsed).toISOString();
+      args.startModifiedTime = parseRfc3339(this.startModifiedTime, "Start Modified Time");
     }
 
     const limit = this.limit || DEFAULT_COMMENT_LIMIT;

--- a/components/google_drive/actions/list-comments/list-comments.mjs
+++ b/components/google_drive/actions/list-comments/list-comments.mjs
@@ -31,7 +31,7 @@ export default {
           drive: c.drive,
         }),
       ],
-      description: "The file to list comments for. You can select a file or use a file ID from a previous step.",
+      description: "The Google Drive file ID to list comments for, for example `1AbCDefGhIJkLmNoPqRsTuVwXyZ`. Use **List Files** to resolve a document's name to its ID.",
     },
     includeDeleted: {
       type: "boolean",

--- a/components/google_drive/actions/list-comments/list-comments.mjs
+++ b/components/google_drive/actions/list-comments/list-comments.mjs
@@ -31,7 +31,7 @@ export default {
           drive: c.drive,
         }),
       ],
-      description: "The file to list comments for. You can select a file or use a file ID from a previous step.",
+      description: "The Google Drive file ID to list comments for, for example `1AbCDefGhIJkLmNoPqRsTuVwXyZ`. Use **Find File** to look up a file ID by name.",
     },
     includeDeleted: {
       type: "boolean",

--- a/components/google_drive/actions/list-comments/list-comments.mjs
+++ b/components/google_drive/actions/list-comments/list-comments.mjs
@@ -7,7 +7,7 @@ import {
 export default {
   key: "google_drive-list-comments",
   name: "List Comments",
-  description: "List the comments on a file, including each comment's author, plain text and HTML content, the file text it is anchored to, whether it is resolved, and its full reply thread. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/comments/list)",
+  description: "List the comments on a file, including each comment's author, plain text and HTML content, the file text it is anchored to, whether it is resolved, and its full reply thread. Use **Find File** first to resolve a file's name to its ID. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/comments/list)",
   version: "0.1.0",
   annotations: {
     destructiveHint: false,

--- a/components/google_drive/actions/list-files/list-files.mjs
+++ b/components/google_drive/actions/list-files/list-files.mjs
@@ -9,7 +9,7 @@ export default {
   key: "google_drive-list-files",
   name: "List Files",
   description: "List files from a specific folder. Set `Max Results` to cap how many files are returned per run, then pass the returned `nextPageToken` back in as `Page Token` on the next run to page through a large folder in fixed-size batches. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/list) for more information",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/list-mime-type-options/list-mime-type-options.mjs
+++ b/components/google_drive/actions/list-mime-type-options/list-mime-type-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-list-mime-type-options",
   name: "List Mime Type Options",
   description: "Retrieves available options for the Mime Type field.",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/google_drive/actions/list-permissions/list-permissions.mjs
+++ b/components/google_drive/actions/list-permissions/list-permissions.mjs
@@ -10,7 +10,7 @@ export default {
     + " Use this tool when the user asks 'who has access to this file?' or needs to audit sharing."
     + " Pass permission IDs from this response to **Remove Sharing** to revoke access."
     + " [See the documentation](https://developers.google.com/drive/api/v3/reference/permissions/list)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/google_drive/actions/list-replies/list-replies.mjs
+++ b/components/google_drive/actions/list-replies/list-replies.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-list-replies",
   name: "List Replies",
   description: "List replies to a specific comment. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/replies/list) for more information",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/list-shared-drives/list-shared-drives.mjs
+++ b/components/google_drive/actions/list-shared-drives/list-shared-drives.mjs
@@ -10,7 +10,7 @@ export default {
     + " Pass a drive ID to **Search Files** `driveId` parameter to search within a specific shared drive."
     + " Optionally filter by name using the `query` parameter (e.g., `name contains 'Engineering'`)."
     + " [See the documentation](https://developers.google.com/drive/api/v3/reference/drives/list)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/google_drive/actions/list-theme-id-options/list-theme-id-options.mjs
+++ b/components/google_drive/actions/list-theme-id-options/list-theme-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-list-theme-id-options",
   name: "List Theme ID Options",
   description: "Retrieves available options for the Theme ID field.",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/google_drive/actions/move-file-to-trash/move-file-to-trash.mjs
+++ b/components/google_drive/actions/move-file-to-trash/move-file-to-trash.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_drive-move-file-to-trash",
   name: "Move File to Trash",
   description: "Move a file or folder to trash. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/update) for more information",
-  version: "0.1.23",
+  version: "0.1.24",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_drive/actions/move-file/move-file.mjs
+++ b/components/google_drive/actions/move-file/move-file.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-move-file",
   name: "Move File",
   description: "Move a file from one folder to another. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/update) for more information",
-  version: "0.1.23",
+  version: "0.1.24",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_drive/actions/remove-file-sharing-permission/remove-file-sharing-permission.mjs
+++ b/components/google_drive/actions/remove-file-sharing-permission/remove-file-sharing-permission.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Remove File Sharing Permission",
   description:
     "Remove a [sharing permission](https://support.google.com/drive/answer/7166529) from the sharing preferences of a file or folder. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/permissions/delete)",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_drive/actions/remove-sharing/remove-sharing.mjs
+++ b/components/google_drive/actions/remove-sharing/remove-sharing.mjs
@@ -10,7 +10,7 @@ export default {
     + " The owner permission cannot be removed."
     + " Use **Search Files** to find the file ID by name if needed."
     + " [See the documentation](https://developers.google.com/drive/api/v3/reference/permissions/delete)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: true,

--- a/components/google_drive/actions/reply-to-comment/reply-to-comment.mjs
+++ b/components/google_drive/actions/reply-to-comment/reply-to-comment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-reply-to-comment",
   name: "Reply to Comment",
   description: "Add a reply to an existing comment. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/replies/create)",
-  version: "0.0.12",
+  version: "0.0.13",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/resolve-access-proposal/resolve-access-proposal.mjs
+++ b/components/google_drive/actions/resolve-access-proposal/resolve-access-proposal.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_drive-resolve-access-proposal",
   name: "Resolve Access Proposals",
   description: "Accept or deny a request for access to a file or folder in Google Drive. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/accessproposals/resolve)",
-  version: "0.0.16",
+  version: "0.0.17",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/resolve-comment/resolve-comment.mjs
+++ b/components/google_drive/actions/resolve-comment/resolve-comment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-resolve-comment",
   name: "Resolve Comment",
   description: "Mark a comment as resolved. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/comments/update)",
-  version: "0.0.12",
+  version: "0.0.13",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_drive/actions/search-files/search-files.mjs
+++ b/components/google_drive/actions/search-files/search-files.mjs
@@ -22,7 +22,7 @@ export default {
     + "\n\nWhen the user says 'my files', use **Get User Details** first to get the owner email."
     + " To scope to a shared drive, pass the `driveId` from **List Shared Drives**."
     + " [See the documentation](https://developers.google.com/drive/api/v3/search-files)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/google_drive/actions/search-shared-drives/search-shared-drives.mjs
+++ b/components/google_drive/actions/search-shared-drives/search-shared-drives.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-search-shared-drives",
   name: "Search for Shared Drives",
   description: "Search for shared drives with query options. [See the documentation](https://developers.google.com/drive/api/v3/search-shareddrives) for more information",
-  version: "0.1.24",
+  version: "0.1.25",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/share-file/share-file.mjs
+++ b/components/google_drive/actions/share-file/share-file.mjs
@@ -15,7 +15,7 @@ export default {
     + "\n\n**Roles:** `reader` (view only), `commenter` (can comment), `writer` (can edit)."
     + " Use **List Permissions** to see existing sharing on a file."
     + " [See the documentation](https://developers.google.com/drive/api/v3/reference/permissions/create)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/google_drive/actions/trash-file/trash-file.mjs
+++ b/components/google_drive/actions/trash-file/trash-file.mjs
@@ -10,7 +10,7 @@ export default {
     + " Use this instead of permanent deletion as the safer default."
     + " To find trashed files, use **Search Files** with `trashed = true`."
     + " [See the documentation](https://developers.google.com/drive/api/v3/reference/files/update)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: true,

--- a/components/google_drive/actions/update-comment/update-comment.mjs
+++ b/components/google_drive/actions/update-comment/update-comment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-update-comment",
   name: "Update Comment",
   description: "Update the content of a specific comment. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/comments/update) for more information",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/update-file/update-file.mjs
+++ b/components/google_drive/actions/update-file/update-file.mjs
@@ -6,7 +6,7 @@ export default {
   key: "google_drive-update-file",
   name: "Update File",
   description: "Update a file's metadata and/or content. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/update) for more information",
-  version: "2.0.15",
+  version: "2.0.16",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_drive/actions/update-reply/update-reply.mjs
+++ b/components/google_drive/actions/update-reply/update-reply.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-update-reply",
   name: "Update Reply",
   description: "Update a reply on a specific comment. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/replies/update) for more information",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/update-shared-drive/update-shared-drive.mjs
+++ b/components/google_drive/actions/update-shared-drive/update-shared-drive.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_drive-update-shared-drive",
   name: "Update Shared Drive",
   description: "Update an existing shared drive. [See the documentation](https://developers.google.com/drive/api/v3/reference/drives/update) for more information",
-  version: "0.1.23",
+  version: "0.1.24",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_drive/actions/upload-file/upload-file.mjs
+++ b/components/google_drive/actions/upload-file/upload-file.mjs
@@ -13,7 +13,7 @@ export default {
   key: "google_drive-upload-file",
   name: "Upload File",
   description: "Upload a file to Google Drive. [See the documentation](https://developers.google.com/drive/api/v3/manage-uploads) for more information",
-  version: "2.0.16",
+  version: "2.0.17",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/common/constants.mjs
+++ b/components/google_drive/common/constants.mjs
@@ -234,6 +234,17 @@ const GOOGLE_DRIVE_UPLOAD_TYPE_OPTIONS = [
   },
 ];
 
+/**
+ * Maximum `pageSize` accepted by `comments.list`; larger values are coerced down
+ * to this by the API.
+ * https://developers.google.com/workspace/drive/api/reference/rest/v3/comments/list
+ */
+const COMMENTS_MAX_PAGE_SIZE = 100;
+
+const DEFAULT_COMMENT_LIMIT = 100;
+
+const MAX_COMMENT_LIMIT = 500;
+
 export {
   GOOGLE_DRIVE_NOTIFICATION_SYNC,
   GOOGLE_DRIVE_NOTIFICATION_ADD,
@@ -270,4 +281,8 @@ export {
   GOOGLE_DRIVE_GRANTEE_DOMAIN,
   GOOGLE_DRIVE_GRANTEE_ANYONE,
   GOOGLE_DRIVE_GRANTEE_TYPES,
+  // Comments
+  COMMENTS_MAX_PAGE_SIZE,
+  DEFAULT_COMMENT_LIMIT,
+  MAX_COMMENT_LIMIT,
 };

--- a/components/google_drive/common/utils.mjs
+++ b/components/google_drive/common/utils.mjs
@@ -342,9 +342,13 @@ async function stashFile(item, googleDrive, dir) {
  * RFC 3339 date (`2026-01-31`) or date-time (`2026-01-31T00:00:00Z`). A
  * date-time must carry a `Z` or numeric offset, as RFC 3339 requires: without
  * one, `Date.parse` silently reads it in the runner's local timezone.
+ *
+ * The time fields spell out their RFC 3339 ranges rather than using `\d{2}`,
+ * because `Date.parse` accepts the ISO 8601 end-of-day hour `24` and rolls it
+ * into the next day (`...T24:00:00Z` becomes the 1st of the next month).
  */
 const RFC_3339_REGEX =
-  /^(\d{4})-(\d{2})-(\d{2})(?:[Tt](\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:[Zz]|[+-]\d{2}:\d{2}))?$/;
+  /^(\d{4})-(\d{2})-(\d{2})(?:[Tt]([01]\d|2[0-3]):([0-5]\d):([0-5]\d)(?:\.\d+)?(?:[Zz]|[+-]([01]\d|2[0-3]):[0-5]\d))?$/;
 
 /**
  * Validate an RFC 3339 timestamp and normalize it to a UTC ISO string.

--- a/components/google_drive/common/utils.mjs
+++ b/components/google_drive/common/utils.mjs
@@ -338,6 +338,49 @@ async function stashFile(item, googleDrive, dir) {
   };
 }
 
+/**
+ * RFC 3339 date (`2026-01-31`) or date-time (`2026-01-31T00:00:00Z`). A
+ * date-time must carry a `Z` or numeric offset, as RFC 3339 requires: without
+ * one, `Date.parse` silently reads it in the runner's local timezone.
+ */
+const RFC_3339_REGEX =
+  /^(\d{4})-(\d{2})-(\d{2})(?:[Tt](\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:[Zz]|[+-]\d{2}:\d{2}))?$/;
+
+/**
+ * Validate an RFC 3339 timestamp and normalize it to a UTC ISO string.
+ *
+ * `Date.parse` alone is too permissive to use as the gate: it accepts
+ * locale-ambiguous input like `01/02/2026` and bare years like `2026`, and it
+ * rolls impossible dates over (`2026-02-31` becomes March 3) rather than
+ * rejecting them. Either would silently filter from the wrong instant.
+ *
+ * @param {String} value the user-supplied timestamp
+ * @param {String} label the prop label, used in the error message
+ * @returns {String} the timestamp normalized to a UTC ISO string
+ */
+function parseRfc3339(value, label) {
+  const match = RFC_3339_REGEX.exec(String(value).trim());
+  if (!match) {
+    throw new ConfigurationError(`Invalid ${label} "${value}". Use an RFC 3339 timestamp, e.g. "2026-01-31T00:00:00Z" or "2026-01-31".`);
+  }
+  const [
+    , year,
+    month,
+    day,
+  ] = match.map(Number);
+  // The shape is right, but `2026-02-31` still parses, so confirm the calendar
+  // date round-trips unchanged before trusting it.
+  const utc = new Date(Date.UTC(year, month - 1, day));
+  const parsed = Date.parse(match[0]);
+  if (utc.getUTCFullYear() !== year
+    || utc.getUTCMonth() !== month - 1
+    || utc.getUTCDate() !== day
+    || Number.isNaN(parsed)) {
+    throw new ConfigurationError(`Invalid ${label} "${value}". That is not a real date or time.`);
+  }
+  return new Date(parsed).toISOString();
+}
+
 export {
   buildFilePaths,
   byteToMB,
@@ -348,6 +391,7 @@ export {
   MY_DRIVE_VALUE,
   omitEmptyStringValues,
   parseObjectEntries,
+  parseRfc3339,
   stashFile,
   streamToBuffer,
   toSingleLineString,

--- a/components/google_drive/package.json
+++ b/components/google_drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_drive",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Pipedream Google_drive Components",
   "main": "google_drive.app.mjs",
   "keywords": [

--- a/components/google_drive/sources/changes-to-files-in-drive/changes-to-files-in-drive.mjs
+++ b/components/google_drive/sources/changes-to-files-in-drive/changes-to-files-in-drive.mjs
@@ -14,7 +14,7 @@ export default {
   key: "google_drive-changes-to-files-in-drive",
   name: "Changes to Files in Drive",
   description: "Emit new event when a change is made to one of the specified files. [See the documentation](https://developers.google.com/drive/api/v3/reference/changes/watch)",
-  version: "0.0.12",
+  version: "0.0.13",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_drive/sources/changes-to-specific-files-shared-drive/changes-to-specific-files-shared-drive.mjs
+++ b/components/google_drive/sources/changes-to-specific-files-shared-drive/changes-to-specific-files-shared-drive.mjs
@@ -29,7 +29,7 @@ export default {
   key: "google_drive-changes-to-specific-files-shared-drive",
   name: "Changes to Specific Files (Shared Drive)",
   description: "Watches for changes to specific files in a shared drive, emitting an event when a change is made to one of those files",
-  version: "0.3.12",
+  version: "0.3.13",
   type: "source",
   // Dedupe events based on the "x-goog-message-number" header for the target channel:
   // https://developers.google.com/drive/api/v3/push#making-watch-requests

--- a/components/google_drive/sources/changes-to-specific-files/changes-to-specific-files.mjs
+++ b/components/google_drive/sources/changes-to-specific-files/changes-to-specific-files.mjs
@@ -16,7 +16,7 @@ export default {
   key: "google_drive-changes-to-specific-files",
   name: "Changes to Specific Files",
   description: "Watches for changes to specific files, emitting an event when a change is made to one of those files. To watch for changes to [shared drive](https://support.google.com/a/users/answer/9310351) files, use the **Changes to Specific Files (Shared Drive)** source instead.",
-  version: "0.3.10",
+  version: "0.3.11",
   type: "source",
   // Dedupe events based on the "x-goog-message-number" header for the target channel:
   // https://developers.google.com/drive/api/v3/push#making-watch-requests

--- a/components/google_drive/sources/new-access-proposal/new-access-proposal.mjs
+++ b/components/google_drive/sources/new-access-proposal/new-access-proposal.mjs
@@ -6,7 +6,7 @@ export default {
   key: "google_drive-new-access-proposal",
   name: "New Access Proposal",
   description: "Emit new event when a new access proposal is requested in Google Drive",
-  version: "0.0.15",
+  version: "0.0.16",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_drive/sources/new-files-instant-polling/new-files-instant-polling.mjs
+++ b/components/google_drive/sources/new-files-instant-polling/new-files-instant-polling.mjs
@@ -8,7 +8,7 @@ export default {
   key: "google_drive-new-files-instant-polling",
   name: "New Files (Polling)",
   description: "Emit new event when a new file is added in your linked Google Drive",
-  version: "0.0.10",
+  version: "0.0.11",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_drive/sources/new-files-instant/new-files-instant.mjs
+++ b/components/google_drive/sources/new-files-instant/new-files-instant.mjs
@@ -11,7 +11,7 @@ export default {
   key: "google_drive-new-files-instant",
   name: "New Files (Instant)",
   description: "Emit new event when a new file is added in your linked Google Drive",
-  version: "0.2.12",
+  version: "0.2.13",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_drive/sources/new-files-shared-drive/new-files-shared-drive.mjs
+++ b/components/google_drive/sources/new-files-shared-drive/new-files-shared-drive.mjs
@@ -7,7 +7,7 @@ export default {
   key: "google_drive-new-files-shared-drive",
   name: "New Files (Shared Drive)",
   description: "Emit new event when a new file is added in your shared Google Drive",
-  version: "0.1.12",
+  version: "0.1.13",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_drive/sources/new-or-modified-comments-polling/new-or-modified-comments-polling.mjs
+++ b/components/google_drive/sources/new-or-modified-comments-polling/new-or-modified-comments-polling.mjs
@@ -7,7 +7,7 @@ export default {
   key: "google_drive-new-or-modified-comments-polling",
   name: "New or Modified Comments (Polling)",
   description: "Emit new event when a comment is created or modified in the selected file",
-  version: "0.0.10",
+  version: "0.0.11",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_drive/sources/new-or-modified-comments/new-or-modified-comments.mjs
+++ b/components/google_drive/sources/new-or-modified-comments/new-or-modified-comments.mjs
@@ -18,7 +18,7 @@ export default {
   name: "New or Modified Comments (Instant)",
   description:
     "Emit new event when a comment is created or modified in the selected file",
-  version: "1.0.21",
+  version: "1.0.22",
   type: "source",
   // Dedupe events based on the "x-goog-message-number" header for the target channel:
   // https://developers.google.com/drive/api/v3/push#making-watch-requests

--- a/components/google_drive/sources/new-or-modified-files-polling/new-or-modified-files-polling.mjs
+++ b/components/google_drive/sources/new-or-modified-files-polling/new-or-modified-files-polling.mjs
@@ -9,7 +9,7 @@ export default {
   key: "google_drive-new-or-modified-files-polling",
   name: "New or Modified Files (Polling)",
   description: "Emit new event when a file in the selected Drive is created, modified or trashed. [See the documentation](https://developers.google.com/drive/api/v3/reference/changes/list)",
-  version: "0.0.12",
+  version: "0.0.13",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_drive/sources/new-or-modified-files/new-or-modified-files.mjs
+++ b/components/google_drive/sources/new-or-modified-files/new-or-modified-files.mjs
@@ -26,7 +26,7 @@ export default {
   key: "google_drive-new-or-modified-files",
   name: "New or Modified Files (Instant)",
   description: "Emit new event when a file in the selected Drive is created, modified or trashed.",
-  version: "0.4.12",
+  version: "0.4.13",
   type: "source",
   // Dedupe events based on the "x-goog-message-number" header for the target channel:
   // https://developers.google.com/drive/api/v3/push#making-watch-requests

--- a/components/google_drive/sources/new-or-modified-folders-polling/new-or-modified-folders-polling.mjs
+++ b/components/google_drive/sources/new-or-modified-folders-polling/new-or-modified-folders-polling.mjs
@@ -12,7 +12,7 @@ export default {
   key: "google_drive-new-or-modified-folders-polling",
   name: "New or Modified Folders (Polling)",
   description: "Emit new event when a folder is created or modified in the selected Drive",
-  version: "0.0.11",
+  version: "0.0.12",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_drive/sources/new-or-modified-folders/new-or-modified-folders.mjs
+++ b/components/google_drive/sources/new-or-modified-folders/new-or-modified-folders.mjs
@@ -21,7 +21,7 @@ export default {
   key: "google_drive-new-or-modified-folders",
   name: "New or Modified Folders (Instant)",
   description: "Emit new event when a folder is created or modified in the selected Drive",
-  version: "0.2.15",
+  version: "0.2.16",
   type: "source",
   // Dedupe events based on the "x-goog-message-number" header for the target channel:
   // https://developers.google.com/drive/api/v3/push#making-watch-requests

--- a/components/google_drive/sources/new-shared-drive/new-shared-drive.mjs
+++ b/components/google_drive/sources/new-shared-drive/new-shared-drive.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_drive-new-shared-drive",
   name: "New Shared Drive",
   description: "Emits a new event any time a shared drive is created.",
-  version: "0.1.22",
+  version: "0.1.23",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_drive/sources/new-spreadsheet-polling/new-spreadsheet-polling.mjs
+++ b/components/google_drive/sources/new-spreadsheet-polling/new-spreadsheet-polling.mjs
@@ -8,7 +8,7 @@ export default {
   key: "google_drive-new-spreadsheet-polling",
   name: "New Spreadsheet (Polling)",
   description: "Emit new event when a new spreadsheet is created in a drive.",
-  version: "0.0.10",
+  version: "0.0.11",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/google_drive/sources/new-spreadsheet/new-spreadsheet.mjs
+++ b/components/google_drive/sources/new-spreadsheet/new-spreadsheet.mjs
@@ -6,7 +6,7 @@ export default {
   type: "source",
   name: "New Spreadsheet (Instant)",
   description: "Emit new event when a new spreadsheet is created in a drive.",
-  version: "0.1.25",
+  version: "0.1.26",
   props: {
     googleDrive: newFilesInstant.props.googleDrive,
     db: newFilesInstant.props.db,


### PR DESCRIPTION
## Summary

<!-- Add your PR description here -->
Closes #21693
Add google-docs `list comments` action
Enhance google-drive `list comments` action

## Checklist
Please check the following items before your PR can be reviewed:

### Versioning
- [x] All components updated in this PR had their version updated (`0.0.1` for new ones)
- [x] The app updated in this PR had its `package.json`'s version updated

### New app
If this is a new app, please submit [an app integration request](https://github.com/PipedreamHQ/pipedream/issues/new?template=app---service-integration.md) - the PR will only be reviewed after the app is integrated.
- [x] The app updated in this PR is already integrated

### CodeRabbit review
After the PR is opened, and if new changes are pushed, CodeRabbit will automatically review it. Do not 'mark as resolved' CodeRabbit's comments, but reply to them instead, whether you agree (and update the PR accordingly) or disagree.
- [ ] I have addressed or acknowledged all of CodeRabbit's review comments



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added actions to list comments from Google Docs and Google Drive files.
  - Supports deleted-comment inclusion, RFC 3339 modification-time filters, configurable limits, and paginated retrieval.
  - Returns collected comments with a total count.
  - Limits each request to 500 comments.

- **Bug Fixes**
  - Added validation and UTC normalization for modification-time filters, with clear errors for invalid timestamps.
  - Improved Google Drive comment retrieval reliability by using the file ID directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->