### PR TITLE
Add DeepKeep components

### DIFF
--- a/components/deepkeep/README.md
+++ b/components/deepkeep/README.md
@@ -1,0 +1,31 @@
+# Overview
+
+DeepKeep provides AI Firewall guardrails for checking model inputs and outputs before they continue through your workflow.
+
+# Example Use Cases
+
+1. Check a user prompt before sending it to OpenAI, Anthropic, Gemini, or another LLM provider.
+2. Check a model response before sending it to Slack, email, a webhook, or a database.
+3. Stop a workflow when DeepKeep returns a blocking guardrail action.
+4. Use DeepKeep redacted or modified text in downstream workflow steps.
+
+# Getting Started
+
+Connect your DeepKeep account with:
+
+- API Key
+- Base URL for your DeepKeep instance, for example `https://api.example.deepkeep.ai`
+
+Then add one of the DeepKeep actions to your workflow.
+
+The actions use Pipedream's managed DeepKeep app connection for the API key and ask for the DeepKeep Base URL as an action field.
+
+# Troubleshooting
+
+## Missing Base URL
+
+DeepKeep requires a base URL. Enter your DeepKeep instance URL without a trailing slash.
+
+## Blocked Content
+
+DeepKeep actions stop the workflow by default when the highest-priority guardrail action is `block`. Disable **Stop Workflow on Block** to return the blocked verdict instead.

--- a/components/deepkeep/actions/moderate-text/README.md
+++ b/components/deepkeep/actions/moderate-text/README.md
@@ -1,0 +1,19 @@
+# Overview
+
+Check arbitrary text with DeepKeep using either pre-model or post-model moderation.
+
+# Example Use Cases
+
+1. Test a DeepKeep firewall from Pipedream without building a full LLM workflow.
+2. Moderate non-LLM text before forwarding it to another app.
+3. Use one generic DeepKeep action when the workflow decides the moderation phase dynamically.
+
+# Getting Started
+
+Choose **Moderation Phase**, set **Model** to your DeepKeep firewall ID, and provide **Text**.
+
+# Troubleshooting
+
+## Workflow Stopped
+
+The action stops the workflow by default when DeepKeep returns a `block` action. Disable **Stop Workflow on Block** to return the verdict instead.

--- a/components/deepkeep/actions/moderate-text/moderate-text.mjs
+++ b/components/deepkeep/actions/moderate-text/moderate-text.mjs
@@ -4,7 +4,7 @@ import { MODERATION_PHASES } from "../../common/constants.mjs";
 export default {
   key: "deepkeep-moderate-text",
   name: "Moderate Text",
-  description: "Check text with DeepKeep using either pre-model or post-model moderation. See the [DeepKeep documentation](https://deepkeep.ai/docs/api).",
+  description: "Check text with DeepKeep using either pre-model or post-model moderation. [See the documentation](https://deepkeep.ai/docs/api)",
   version: "0.0.1",
   type: "action",
   annotations: {
@@ -23,7 +23,7 @@ export default {
     phase: {
       type: "string",
       label: "Moderation Phase",
-      description: "Choose whether to use DeepKeep pre-model or post-model moderation.",
+      description: "The DeepKeep moderation phase. Use pre-model to check model input, or post-model to check model output.",
       options: MODERATION_PHASES,
       default: "pre",
     },
@@ -67,11 +67,11 @@ export default {
       chat: this.chat || "",
     };
     const result = this.phase === "post"
-      ? await this.deepkeep.postModerate({
+      ? await this.deepkeep.moderatePostModel({
         ...request,
         output: this.text,
       })
-      : await this.deepkeep.preModerate({
+      : await this.deepkeep.moderatePreModel({
         ...request,
         input: this.text,
       });

--- a/components/deepkeep/actions/moderate-text/moderate-text.mjs
+++ b/components/deepkeep/actions/moderate-text/moderate-text.mjs
@@ -4,7 +4,7 @@ import { MODERATION_PHASES } from "../../common/constants.mjs";
 export default {
   key: "deepkeep-moderate-text",
   name: "Moderate Text",
-  description: "Check text with DeepKeep using either pre-model or post-model moderation. [See the documentation](https://deepkeep.ai/docs/api)",
+  description: "Moderate plain text with DeepKeep before or after an LLM call. Use `pre` to check model input and `post` to check model output; include a DeepKeep firewall model ID, optional title/chat metadata, and choose whether `stopOnBlock` should halt the workflow when DeepKeep blocks content. Returns allowed, blocked, flagged, action, processedText, and the raw result. [See the documentation](https://deepkeep.ai/docs/api)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/deepkeep/actions/moderate-text/moderate-text.mjs
+++ b/components/deepkeep/actions/moderate-text/moderate-text.mjs
@@ -1,0 +1,88 @@
+import deepkeep from "../../deepkeep.app.mjs";
+import { MODERATION_PHASES } from "../../common/constants.mjs";
+
+export default {
+  key: "deepkeep-moderate-text",
+  name: "Moderate Text",
+  description: "Check text with DeepKeep using either pre-model or post-model moderation. See the [DeepKeep documentation](https://deepkeep.ai/docs/api).",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    deepkeep,
+    baseUrl: {
+      propDefinition: [
+        deepkeep,
+        "baseUrl",
+      ],
+    },
+    phase: {
+      type: "string",
+      label: "Moderation Phase",
+      description: "Choose whether to use DeepKeep pre-model or post-model moderation.",
+      options: MODERATION_PHASES,
+      default: "pre",
+    },
+    model: {
+      propDefinition: [
+        deepkeep,
+        "model",
+      ],
+    },
+    text: {
+      propDefinition: [
+        deepkeep,
+        "text",
+      ],
+    },
+    title: {
+      propDefinition: [
+        deepkeep,
+        "title",
+      ],
+    },
+    chat: {
+      propDefinition: [
+        deepkeep,
+        "chat",
+      ],
+    },
+    stopOnBlock: {
+      propDefinition: [
+        deepkeep,
+        "stopOnBlock",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const request = {
+      $,
+      baseUrl: this.baseUrl,
+      model: this.model,
+      title: this.title || "",
+      chat: this.chat || "",
+    };
+    const result = this.phase === "post"
+      ? await this.deepkeep.postModerate({
+        ...request,
+        output: this.text,
+      })
+      : await this.deepkeep.preModerate({
+        ...request,
+        input: this.text,
+      });
+    const normalized = this.deepkeep.normalizeModerationResult(result, this.text);
+
+    $.export("$summary", this.deepkeep.summary(normalized, this.phase));
+
+    if (normalized.blocked && this.stopOnBlock) {
+      throw new Error(this.deepkeep.blockReason(normalized));
+    }
+
+    return normalized;
+  },
+};

--- a/components/deepkeep/actions/post-model-check/README.md
+++ b/components/deepkeep/actions/post-model-check/README.md
@@ -1,0 +1,18 @@
+# Overview
+
+Check LLM output with DeepKeep before returning or forwarding it downstream.
+
+# Example Use Cases
+
+1. Stop unsafe model responses before sending them to Slack, email, webhooks, or databases.
+2. Use `processedText` in downstream steps when DeepKeep returns redacted or modified text.
+
+# Getting Started
+
+Configure **Model** with your DeepKeep firewall ID and **Output** with the text to check.
+
+# Troubleshooting
+
+## Workflow Stopped
+
+The action stops the workflow by default when DeepKeep returns a `block` action. Disable **Stop Workflow on Block** to return the verdict instead.

--- a/components/deepkeep/actions/post-model-check/post-model-check.mjs
+++ b/components/deepkeep/actions/post-model-check/post-model-check.mjs
@@ -3,7 +3,7 @@ import deepkeep from "../../deepkeep.app.mjs";
 export default {
   key: "deepkeep-post-model-check",
   name: "Post-Model Check",
-  description: "Check text with DeepKeep after an LLM generates a response. See the [DeepKeep documentation](https://deepkeep.ai/docs/api).",
+  description: "Check text with DeepKeep after an LLM generates a response. [See the documentation](https://deepkeep.ai/docs/api)",
   version: "0.0.1",
   type: "action",
   annotations: {
@@ -51,7 +51,7 @@ export default {
     },
   },
   async run({ $ }) {
-    const result = await this.deepkeep.postModerate({
+    const result = await this.deepkeep.moderatePostModel({
       $,
       baseUrl: this.baseUrl,
       model: this.model,

--- a/components/deepkeep/actions/post-model-check/post-model-check.mjs
+++ b/components/deepkeep/actions/post-model-check/post-model-check.mjs
@@ -1,0 +1,72 @@
+import deepkeep from "../../deepkeep.app.mjs";
+
+export default {
+  key: "deepkeep-post-model-check",
+  name: "Post-Model Check",
+  description: "Check text with DeepKeep after an LLM generates a response. See the [DeepKeep documentation](https://deepkeep.ai/docs/api).",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    deepkeep,
+    baseUrl: {
+      propDefinition: [
+        deepkeep,
+        "baseUrl",
+      ],
+    },
+    model: {
+      propDefinition: [
+        deepkeep,
+        "model",
+      ],
+    },
+    output: {
+      propDefinition: [
+        deepkeep,
+        "output",
+      ],
+    },
+    title: {
+      propDefinition: [
+        deepkeep,
+        "title",
+      ],
+    },
+    chat: {
+      propDefinition: [
+        deepkeep,
+        "chat",
+      ],
+    },
+    stopOnBlock: {
+      propDefinition: [
+        deepkeep,
+        "stopOnBlock",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const result = await this.deepkeep.postModerate({
+      $,
+      baseUrl: this.baseUrl,
+      model: this.model,
+      output: this.output,
+      title: this.title || "",
+      chat: this.chat || "",
+    });
+    const normalized = this.deepkeep.normalizeModerationResult(result, this.output);
+
+    $.export("$summary", this.deepkeep.summary(normalized, "post"));
+
+    if (normalized.blocked && this.stopOnBlock) {
+      throw new Error(this.deepkeep.blockReason(normalized));
+    }
+
+    return normalized;
+  },
+};

--- a/components/deepkeep/actions/post-model-check/post-model-check.mjs
+++ b/components/deepkeep/actions/post-model-check/post-model-check.mjs
@@ -3,7 +3,7 @@ import deepkeep from "../../deepkeep.app.mjs";
 export default {
   key: "deepkeep-post-model-check",
   name: "Post-Model Check",
-  description: "Check text with DeepKeep after an LLM generates a response. [See the documentation](https://deepkeep.ai/docs/api)",
+  description: "Moderate model output with DeepKeep after an LLM generates a response and before returning it downstream. Provide the output text and DeepKeep firewall model ID, plus optional title/chat metadata. Returns allowed, blocked, flagged, action, processedText, and the raw result; `stopOnBlock` halts the workflow when DeepKeep blocks content. [See the documentation](https://deepkeep.ai/docs/api)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/deepkeep/actions/pre-model-check/README.md
+++ b/components/deepkeep/actions/pre-model-check/README.md
@@ -1,0 +1,18 @@
+# Overview
+
+Check user or workflow input with DeepKeep before sending it to an LLM.
+
+# Example Use Cases
+
+1. Stop unsafe prompts before an OpenAI, Anthropic, or Gemini step.
+2. Use `processedText` in a downstream LLM step when DeepKeep returns redacted or modified text.
+
+# Getting Started
+
+Configure **Model** with your DeepKeep firewall ID and **Input** with the text to check.
+
+# Troubleshooting
+
+## Workflow Stopped
+
+The action stops the workflow by default when DeepKeep returns a `block` action. Disable **Stop Workflow on Block** to return the verdict instead.

--- a/components/deepkeep/actions/pre-model-check/pre-model-check.mjs
+++ b/components/deepkeep/actions/pre-model-check/pre-model-check.mjs
@@ -3,7 +3,7 @@ import deepkeep from "../../deepkeep.app.mjs";
 export default {
   key: "deepkeep-pre-model-check",
   name: "Pre-Model Check",
-  description: "Check text with DeepKeep before sending it to an LLM. See the [DeepKeep documentation](https://deepkeep.ai/docs/api).",
+  description: "Check text with DeepKeep before sending it to an LLM. [See the documentation](https://deepkeep.ai/docs/api)",
   version: "0.0.1",
   type: "action",
   annotations: {
@@ -51,7 +51,7 @@ export default {
     },
   },
   async run({ $ }) {
-    const result = await this.deepkeep.preModerate({
+    const result = await this.deepkeep.moderatePreModel({
       $,
       baseUrl: this.baseUrl,
       model: this.model,

--- a/components/deepkeep/actions/pre-model-check/pre-model-check.mjs
+++ b/components/deepkeep/actions/pre-model-check/pre-model-check.mjs
@@ -3,7 +3,7 @@ import deepkeep from "../../deepkeep.app.mjs";
 export default {
   key: "deepkeep-pre-model-check",
   name: "Pre-Model Check",
-  description: "Check text with DeepKeep before sending it to an LLM. [See the documentation](https://deepkeep.ai/docs/api)",
+  description: "Moderate model input with DeepKeep before sending it to an LLM. Provide the input text and DeepKeep firewall model ID, plus optional title/chat metadata for traceability. Returns allowed, blocked, flagged, action, processedText, and the raw result; `stopOnBlock` halts the workflow when DeepKeep blocks content. [See the documentation](https://deepkeep.ai/docs/api)",
   version: "0.0.1",
   type: "action",
   annotations: {

--- a/components/deepkeep/actions/pre-model-check/pre-model-check.mjs
+++ b/components/deepkeep/actions/pre-model-check/pre-model-check.mjs
@@ -1,0 +1,72 @@
+import deepkeep from "../../deepkeep.app.mjs";
+
+export default {
+  key: "deepkeep-pre-model-check",
+  name: "Pre-Model Check",
+  description: "Check text with DeepKeep before sending it to an LLM. See the [DeepKeep documentation](https://deepkeep.ai/docs/api).",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    deepkeep,
+    baseUrl: {
+      propDefinition: [
+        deepkeep,
+        "baseUrl",
+      ],
+    },
+    model: {
+      propDefinition: [
+        deepkeep,
+        "model",
+      ],
+    },
+    input: {
+      propDefinition: [
+        deepkeep,
+        "input",
+      ],
+    },
+    title: {
+      propDefinition: [
+        deepkeep,
+        "title",
+      ],
+    },
+    chat: {
+      propDefinition: [
+        deepkeep,
+        "chat",
+      ],
+    },
+    stopOnBlock: {
+      propDefinition: [
+        deepkeep,
+        "stopOnBlock",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const result = await this.deepkeep.preModerate({
+      $,
+      baseUrl: this.baseUrl,
+      model: this.model,
+      input: this.input,
+      title: this.title || "",
+      chat: this.chat || "",
+    });
+    const normalized = this.deepkeep.normalizeModerationResult(result, this.input);
+
+    $.export("$summary", this.deepkeep.summary(normalized, "pre"));
+
+    if (normalized.blocked && this.stopOnBlock) {
+      throw new Error(this.deepkeep.blockReason(normalized));
+    }
+
+    return normalized;
+  },
+};

--- a/components/deepkeep/common/constants.mjs
+++ b/components/deepkeep/common/constants.mjs
@@ -1,0 +1,17 @@
+export const MODERATION_PHASES = [
+  {
+    label: "Pre-Model",
+    value: "pre",
+  },
+  {
+    label: "Post-Model",
+    value: "post",
+  },
+];
+
+export const ACTION_PRIORITY = {
+  block: 3,
+  redact: 2,
+  modify: 2,
+  alert: 1,
+};

--- a/components/deepkeep/deepkeep.app.mjs
+++ b/components/deepkeep/deepkeep.app.mjs
@@ -13,7 +13,7 @@ export default {
     model: {
       type: "string",
       label: "Model",
-      description: "DeepKeep firewall ID to send as the OpenAI-compatible `model` field.",
+      description: "DeepKeep firewall ID to send as the OpenAI-compatible `model` field. Find this ID in your DeepKeep firewall settings. For example, `fw_abc123`.",
     },
     input: {
       type: "string",
@@ -86,7 +86,7 @@ export default {
         data,
       });
     },
-    preModerate({
+    moderatePreModel({
       $, baseUrl, model, input, title = "", chat = "",
     }) {
       return this._request({
@@ -101,7 +101,7 @@ export default {
         },
       });
     },
-    postModerate({
+    moderatePostModel({
       $, baseUrl, model, output, title = "", chat = "",
     }) {
       return this._request({
@@ -121,7 +121,7 @@ export default {
       for (const item of result.verbosity || []) {
         const action = item?.details?.guardrail_action;
         if (
-          action in ACTION_PRIORITY
+          Object.prototype.hasOwnProperty.call(ACTION_PRIORITY, action)
           && (!selected || ACTION_PRIORITY[action] > ACTION_PRIORITY[selected])
         ) {
           selected = action;
@@ -172,7 +172,7 @@ export default {
       for (const item of normalized.result?.verbosity || []) {
         const details = item?.details || {};
         if (details.guardrail_action === "block") {
-          return details.message || details.reason || item.message || item.name;
+          return details.message || details.reason || item.message || item.name || "DeepKeep blocked this content.";
         }
       }
       return "DeepKeep blocked this content.";

--- a/components/deepkeep/deepkeep.app.mjs
+++ b/components/deepkeep/deepkeep.app.mjs
@@ -192,7 +192,7 @@ export default {
     normalizeModerationResult(result, originalText) {
       const action = this.highestPriorityAction(result);
       const unsupportedAction = this.unsupportedGuardrailAction(result);
-      const blocked = action === "block" || Boolean(!action && unsupportedAction);
+      const blocked = action === "block" || Boolean(unsupportedAction);
       const modifiedContent = this.modifiedContent(result);
       const processedText = [
         "redact",
@@ -204,7 +204,7 @@ export default {
       return {
         allowed: !blocked,
         blocked,
-        action: action || unsupportedAction || null,
+        action: unsupportedAction || action || null,
         flagged: Boolean(result?.flagged),
         processedText,
         modified: processedText !== originalText,

--- a/components/deepkeep/deepkeep.app.mjs
+++ b/components/deepkeep/deepkeep.app.mjs
@@ -1,0 +1,196 @@
+import { axios } from "@pipedream/platform";
+import { ACTION_PRIORITY } from "./common/constants.mjs";
+
+export default {
+  type: "app",
+  app: "deepkeep",
+  propDefinitions: {
+    baseUrl: {
+      type: "string",
+      label: "Base URL",
+      description: "The base URL of your DeepKeep instance, without a trailing slash.",
+    },
+    model: {
+      type: "string",
+      label: "Model",
+      description: "DeepKeep firewall ID to send as the OpenAI-compatible `model` field.",
+    },
+    input: {
+      type: "string",
+      label: "Input",
+      description: "The input text to check before sending it to a model.",
+    },
+    output: {
+      type: "string",
+      label: "Output",
+      description: "The model output text to check before returning it downstream.",
+    },
+    text: {
+      type: "string",
+      label: "Text",
+      description: "The text to check with DeepKeep.",
+    },
+    title: {
+      type: "string",
+      label: "Title",
+      description: "Optional request title sent to DeepKeep.",
+      optional: true,
+    },
+    chat: {
+      type: "string",
+      label: "Chat",
+      description: "Optional chat identifier or context sent to DeepKeep.",
+      optional: true,
+    },
+    stopOnBlock: {
+      type: "boolean",
+      label: "Stop Workflow on Block",
+      description: "Stop the workflow when DeepKeep returns a `block` guardrail action.",
+      default: true,
+    },
+  },
+  methods: {
+    _apiKey() {
+      const key = this.$auth?.api_key;
+      if (!key) {
+        throw new Error("DeepKeep API key is required.");
+      }
+      return key;
+    },
+    _baseUrl(baseUrl) {
+      baseUrl = baseUrl || this.$auth?.base_url || this.$auth?.baseUrl;
+      if (!baseUrl) {
+        throw new Error("DeepKeep base URL is required.");
+      }
+      return baseUrl.replace(/\/+$/, "");
+    },
+    _headers() {
+      return {
+        "X-API-Key": this._apiKey(),
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+      };
+    },
+    _request({
+      $ = this,
+      path,
+      data,
+      baseUrl,
+      ...args
+    }) {
+      return axios($, {
+        method: "POST",
+        ...args,
+        url: `${this._baseUrl(baseUrl)}${path}`,
+        headers: this._headers(),
+        data,
+      });
+    },
+    preModerate({
+      $, baseUrl, model, input, title = "", chat = "",
+    }) {
+      return this._request({
+        $,
+        baseUrl,
+        path: "/api/v3/openai/moderations/pre",
+        data: {
+          model,
+          input,
+          title,
+          chat,
+        },
+      });
+    },
+    postModerate({
+      $, baseUrl, model, output, title = "", chat = "",
+    }) {
+      return this._request({
+        $,
+        baseUrl,
+        path: "/api/v3/openai/moderations/post",
+        data: {
+          model,
+          output,
+          title,
+          chat,
+        },
+      });
+    },
+    highestPriorityAction(result = {}) {
+      let selected;
+      for (const item of result.verbosity || []) {
+        const action = item?.details?.guardrail_action;
+        if (
+          action in ACTION_PRIORITY
+          && (!selected || ACTION_PRIORITY[action] > ACTION_PRIORITY[selected])
+        ) {
+          selected = action;
+        }
+      }
+      return selected;
+    },
+    modifiedContent(result = {}) {
+      let modifiedContent;
+      for (const item of result.verbosity || []) {
+        for (const modified of item?.details?.modified || []) {
+          if (typeof modified?.content === "string") {
+            modifiedContent = modified.content;
+          }
+        }
+      }
+      if (modifiedContent !== undefined) {
+        return modifiedContent;
+      }
+      const [
+        firstInput,
+      ] = result.inputs || [];
+      if (firstInput && typeof firstInput.content === "string") {
+        return firstInput.content;
+      }
+    },
+    normalizeModerationResult(result, originalText) {
+      const action = this.highestPriorityAction(result);
+      const modifiedContent = this.modifiedContent(result);
+      const processedText = [
+        "redact",
+        "modify",
+      ].includes(action) && modifiedContent !== undefined
+        ? modifiedContent
+        : originalText;
+
+      return {
+        allowed: action !== "block",
+        blocked: action === "block",
+        action: action || null,
+        flagged: Boolean(result?.flagged),
+        processedText,
+        modified: processedText !== originalText,
+        result,
+      };
+    },
+    blockReason(normalized) {
+      for (const item of normalized.result?.verbosity || []) {
+        const details = item?.details || {};
+        if (details.guardrail_action === "block") {
+          return details.message || details.reason || item.message || item.name;
+        }
+      }
+      return "DeepKeep blocked this content.";
+    },
+    summary(normalized, phase) {
+      const label = phase === "post"
+        ? "Post-model"
+        : "Pre-model";
+      if (normalized.blocked) {
+        return `${label} content blocked by DeepKeep.`;
+      }
+      if (normalized.modified) {
+        return `${label} content modified by DeepKeep.`;
+      }
+      if (normalized.flagged || normalized.action) {
+        return `${label} content flagged by DeepKeep with action ${normalized.action || "unknown"}.`;
+      }
+      return `${label} content allowed by DeepKeep.`;
+    },
+  },
+};

--- a/components/deepkeep/deepkeep.app.mjs
+++ b/components/deepkeep/deepkeep.app.mjs
@@ -50,6 +50,9 @@ export default {
     },
   },
   methods: {
+    /**
+     * Return the configured DeepKeep API key.
+     */
     _apiKey() {
       const key = this.$auth?.api_key;
       if (!key) {
@@ -57,6 +60,9 @@ export default {
       }
       return key;
     },
+    /**
+     * Return a normalized DeepKeep base URL without trailing slashes.
+     */
     _baseUrl(baseUrl) {
       baseUrl = baseUrl || this.$auth?.base_url || this.$auth?.baseUrl;
       if (!baseUrl) {
@@ -64,6 +70,9 @@ export default {
       }
       return baseUrl.replace(/\/+$/, "");
     },
+    /**
+     * Return headers required for DeepKeep API requests.
+     */
     _headers() {
       return {
         "X-API-Key": this._apiKey(),
@@ -71,6 +80,9 @@ export default {
         "Accept": "application/json",
       };
     },
+    /**
+     * Send an authenticated request to a DeepKeep endpoint.
+     */
     _request({
       $ = this,
       path,
@@ -86,6 +98,9 @@ export default {
         data,
       });
     },
+    /**
+     * Check model input with DeepKeep pre-model moderation.
+     */
     moderatePreModel({
       $, baseUrl, model, input, title = "", chat = "",
     }) {
@@ -101,6 +116,9 @@ export default {
         },
       });
     },
+    /**
+     * Check model output with DeepKeep post-model moderation.
+     */
     moderatePostModel({
       $, baseUrl, model, output, title = "", chat = "",
     }) {
@@ -116,6 +134,9 @@ export default {
         },
       });
     },
+    /**
+     * Return the highest-priority guardrail action from a DeepKeep response.
+     */
     highestPriorityAction(result = {}) {
       let selected;
       for (const item of result.verbosity || []) {
@@ -129,6 +150,9 @@ export default {
       }
       return selected;
     },
+    /**
+     * Return modified content from a DeepKeep response, when present.
+     */
     modifiedContent(result = {}) {
       let modifiedContent;
       for (const item of result.verbosity || []) {
@@ -148,6 +172,9 @@ export default {
         return firstInput.content;
       }
     },
+    /**
+     * Convert a DeepKeep moderation response into action-friendly output.
+     */
     normalizeModerationResult(result, originalText) {
       const action = this.highestPriorityAction(result);
       const modifiedContent = this.modifiedContent(result);
@@ -168,6 +195,9 @@ export default {
         result,
       };
     },
+    /**
+     * Return the best available reason for a blocked moderation result.
+     */
     blockReason(normalized) {
       for (const item of normalized.result?.verbosity || []) {
         const details = item?.details || {};
@@ -177,6 +207,9 @@ export default {
       }
       return "DeepKeep blocked this content.";
     },
+    /**
+     * Return a Pipedream summary for a normalized moderation result.
+     */
     summary(normalized, phase) {
       const label = phase === "post"
         ? "Post-model"

--- a/components/deepkeep/deepkeep.app.mjs
+++ b/components/deepkeep/deepkeep.app.mjs
@@ -151,6 +151,20 @@ export default {
       return selected;
     },
     /**
+     * Return the first unsupported guardrail action from a DeepKeep response.
+     */
+    unsupportedGuardrailAction(result = {}) {
+      for (const item of result.verbosity || []) {
+        const action = item?.details?.guardrail_action;
+        if (
+          action
+          && !Object.prototype.hasOwnProperty.call(ACTION_PRIORITY, action)
+        ) {
+          return action;
+        }
+      }
+    },
+    /**
      * Return modified content from a DeepKeep response, when present.
      */
     modifiedContent(result = {}) {
@@ -177,6 +191,8 @@ export default {
      */
     normalizeModerationResult(result, originalText) {
       const action = this.highestPriorityAction(result);
+      const unsupportedAction = this.unsupportedGuardrailAction(result);
+      const blocked = action === "block" || Boolean(!action && unsupportedAction);
       const modifiedContent = this.modifiedContent(result);
       const processedText = [
         "redact",
@@ -186,9 +202,9 @@ export default {
         : originalText;
 
       return {
-        allowed: action !== "block",
-        blocked: action === "block",
-        action: action || null,
+        allowed: !blocked,
+        blocked,
+        action: action || unsupportedAction || null,
         flagged: Boolean(result?.flagged),
         processedText,
         modified: processedText !== originalText,

--- a/components/deepkeep/package.json
+++ b/components/deepkeep/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@pipedream/deepkeep",
+  "version": "0.0.1",
+  "description": "Pipedream components for DeepKeep AI Firewall",
+  "main": "deepkeep.app.mjs",
+  "keywords": [
+    "pipedream",
+    "deepkeep",
+    "ai",
+    "guardrails",
+    "moderation"
+  ],
+  "dependencies": {
+    "@pipedream/platform": "latest"
+  }
+}

--- a/components/deepkeep/package.json
+++ b/components/deepkeep/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/deepkeep",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream components for DeepKeep AI Firewall",
   "main": "deepkeep.app.mjs",
   "keywords": [

--- a/components/deepkeep/test/normalize-moderation-result.test.mjs
+++ b/components/deepkeep/test/normalize-moderation-result.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import deepkeep from "../deepkeep.app.mjs";
+
+test("normalizeModerationResult fails closed for unsupported-only guardrail actions", () => {
+  const result = {
+    flagged: true,
+    verbosity: [
+      {
+        details: {
+          guardrail_action: "quarantine",
+        },
+      },
+    ],
+  };
+
+  const normalized = deepkeep.methods.normalizeModerationResult.call(
+    deepkeep.methods,
+    result,
+    "hello",
+  );
+
+  assert.equal(normalized.allowed, false);
+  assert.equal(normalized.blocked, true);
+  assert.equal(normalized.action, "quarantine");
+  assert.equal(normalized.processedText, "hello");
+});

--- a/components/deepkeep/test/normalize-moderation-result.test.mjs
+++ b/components/deepkeep/test/normalize-moderation-result.test.mjs
@@ -25,3 +25,37 @@ test("normalizeModerationResult fails closed for unsupported-only guardrail acti
   assert.equal(normalized.action, "quarantine");
   assert.equal(normalized.processedText, "hello");
 });
+
+test("normalizeModerationResult fails closed when supported and unsupported actions are present", () => {
+  const result = {
+    flagged: true,
+    verbosity: [
+      {
+        details: {
+          guardrail_action: "redact",
+          modified: [
+            {
+              content: "[redacted]",
+            },
+          ],
+        },
+      },
+      {
+        details: {
+          guardrail_action: "quarantine",
+        },
+      },
+    ],
+  };
+
+  const normalized = deepkeep.methods.normalizeModerationResult.call(
+    deepkeep.methods,
+    result,
+    "hello",
+  );
+
+  assert.equal(normalized.allowed, false);
+  assert.equal(normalized.blocked, true);
+  assert.equal(normalized.action, "quarantine");
+  assert.equal(normalized.processedText, "[redacted]");
+});


### PR DESCRIPTION
## Summary
- Add DeepKeep as a new Pipedream app component
- Add Pre-Model Check, Post-Model Check, and Moderate Text actions
- Support DeepKeep OpenAI-compatible pre/post moderation endpoints with block, redact, modify, and alert action handling

## Versioning
- New app component: \components/deepkeep/deepkeep.app.mjs\`n- New action \deepkeep-pre-model-check\: version \

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DeepKeep AI Firewall integration for pre-model and post-model content moderation.
  * Supports blocking, redaction, modification, alerting, and configurable workflow handling.
  * Added options for API connection, model, metadata, moderation phase, and stop-on-block behavior.
  * Returns moderation verdicts, summaries, blocked-content reasons, and modified text when applicable.

* **Documentation**
  * Added setup, use-case, configuration, and troubleshooting guides for DeepKeep and its moderation actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->