### PR TITLE
New Components - katto

### DIFF
--- a/components/katto/README.md
+++ b/components/katto/README.md
@@ -1,0 +1,26 @@
+# Katto
+
+Turn long videos, podcasts and Twitch VODs into scored, captioned **9:16 clips**
+from any Pipedream workflow or AI agent, using the [Katto](https://katto.tech) API.
+
+# Example Use Cases
+
+- **Auto-clip new uploads**: when a YouTube/Twitch VOD is published, create a
+  Katto clip job, then post the finished clips to TikTok, Reels and Shorts.
+- **Podcast repurposing**: fetch a job's timestamped transcript and its scored
+  clips to draft social captions with an LLM step.
+- **Agent tool**: let a Pipedream AI agent clip a URL, poll the job and return the
+  top clips on demand.
+
+# Authentication
+
+Create an API key at **https://katto.tech** -> Dashboard -> API keys (it starts
+with `sk_live_`). Keys can be scoped **read-only** to reduce blast radius.
+
+Supported sources: YouTube, Twitch, Vimeo, Rumble, Zoom and Dailymotion.
+
+# Links
+
+- Website: https://katto.tech
+- API docs: https://katto.tech/docs/api
+- Hosted MCP server: https://mcp.katto.tech

--- a/components/katto/actions/cancel-job/cancel-job.mjs
+++ b/components/katto/actions/cancel-job/cancel-job.mjs
@@ -1,0 +1,32 @@
+import katto from "../../katto.app.mjs";
+
+export default {
+  key: "katto-cancel-job",
+  name: "Cancel Job",
+  description:
+    "Cancel a running job and refund its video slot. [See the documentation](https://katto.tech/docs/api)",
+  version: "0.1.0",
+  type: "action",
+  annotations: {
+    destructiveHint: true,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    katto,
+    jobId: {
+      propDefinition: [
+        katto,
+        "jobId",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.katto.cancelJob({
+      $,
+      jobId: this.jobId,
+    });
+    $.export("$summary", `Cancelled job \`${this.jobId}\``);
+    return response;
+  },
+};

--- a/components/katto/actions/create-clip-job/create-clip-job.mjs
+++ b/components/katto/actions/create-clip-job/create-clip-job.mjs
@@ -31,7 +31,7 @@ export default {
       type: "string",
       label: "Idempotency Key",
       description:
-        "Optional. A unique key so a retried step returns the original job instead of creating a duplicate (and a duplicate charge).",
+        "Optional. Reuse the same unique key when retrying so Katto returns the original job instead of creating a duplicate (and a duplicate charge). A new key always creates a new job.",
       optional: true,
     },
   },

--- a/components/katto/actions/create-clip-job/create-clip-job.mjs
+++ b/components/katto/actions/create-clip-job/create-clip-job.mjs
@@ -1,0 +1,46 @@
+import katto from "../../katto.app.mjs";
+
+export default {
+  key: "katto-create-clip-job",
+  name: "Create Clip Job",
+  description:
+    "Turn a long video, podcast or Twitch VOD into scored, captioned 9:16 clips. [See the documentation](https://katto.tech/docs/api)",
+  version: "0.1.0",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    katto,
+    url: {
+      type: "string",
+      label: "Video URL",
+      description:
+        "A YouTube, Twitch, Vimeo, Rumble, Zoom or Dailymotion URL to clip.",
+    },
+    webhookUrl: {
+      type: "string",
+      label: "Webhook URL",
+      description:
+        "Optional. A signed (HMAC-SHA256) completion callback is delivered here instead of polling.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    if (!/^https?:\/\//i.test(this.url)) {
+      throw new Error("Invalid Video URL. It must start with http:// or https://.");
+    }
+    const data = { url: this.url };
+    if (this.webhookUrl) {
+      data.webhook_url = this.webhookUrl;
+    }
+    const response = await this.katto.createJob({
+      $,
+      data,
+    });
+    $.export("$summary", `Created clip job \`${response.id ?? ""}\``);
+    return response;
+  },
+};

--- a/components/katto/actions/create-clip-job/create-clip-job.mjs
+++ b/components/katto/actions/create-clip-job/create-clip-job.mjs
@@ -27,6 +27,13 @@ export default {
         "Optional. A signed (HMAC-SHA256) completion callback is delivered here instead of polling.",
       optional: true,
     },
+    idempotencyKey: {
+      type: "string",
+      label: "Idempotency Key",
+      description:
+        "Optional. A unique key so a retried step returns the original job instead of creating a duplicate (and a duplicate charge).",
+      optional: true,
+    },
   },
   async run({ $ }) {
     if (!/^https?:\/\//i.test(this.url)) {
@@ -36,9 +43,14 @@ export default {
     if (this.webhookUrl) {
       data.webhook_url = this.webhookUrl;
     }
+    const headers = {};
+    if (this.idempotencyKey) {
+      headers["Idempotency-Key"] = this.idempotencyKey;
+    }
     const response = await this.katto.createJob({
       $,
       data,
+      headers,
     });
     $.export("$summary", `Created clip job \`${response.id ?? ""}\``);
     return response;

--- a/components/katto/actions/get-account/get-account.mjs
+++ b/components/katto/actions/get-account/get-account.mjs
@@ -1,0 +1,25 @@
+import katto from "../../katto.app.mjs";
+
+export default {
+  key: "katto-get-account",
+  name: "Get Account",
+  description:
+    "Get the account, API key scopes and quota. [See the documentation](https://katto.tech/docs/api)",
+  version: "0.1.0",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    katto,
+  },
+  async run({ $ }) {
+    const response = await this.katto.getAccount({
+      $,
+    });
+    $.export("$summary", "Retrieved account details");
+    return response;
+  },
+};

--- a/components/katto/actions/get-clips/get-clips.mjs
+++ b/components/katto/actions/get-clips/get-clips.mjs
@@ -1,0 +1,35 @@
+import katto from "../../katto.app.mjs";
+
+export default {
+  key: "katto-get-clips",
+  name: "Get Clips",
+  description:
+    "Get the finished clips of a completed job. [See the documentation](https://katto.tech/docs/api)",
+  version: "0.1.0",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    katto,
+    jobId: {
+      propDefinition: [
+        katto,
+        "jobId",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.katto.getClips({
+      $,
+      jobId: this.jobId,
+    });
+    const count = Array.isArray(response)
+      ? response.length
+      : (response.clips?.length ?? response.data?.length ?? 0);
+    $.export("$summary", `Retrieved ${count} clip(s) for job \`${this.jobId}\``);
+    return response;
+  },
+};

--- a/components/katto/actions/get-job/get-job.mjs
+++ b/components/katto/actions/get-job/get-job.mjs
@@ -1,0 +1,32 @@
+import katto from "../../katto.app.mjs";
+
+export default {
+  key: "katto-get-job",
+  name: "Get Job",
+  description:
+    "Retrieve a clip job and its current status. [See the documentation](https://katto.tech/docs/api)",
+  version: "0.1.0",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    katto,
+    jobId: {
+      propDefinition: [
+        katto,
+        "jobId",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.katto.getJob({
+      $,
+      jobId: this.jobId,
+    });
+    $.export("$summary", `Retrieved job \`${this.jobId}\` (status: ${response.status ?? "unknown"})`);
+    return response;
+  },
+};

--- a/components/katto/actions/get-transcript/get-transcript.mjs
+++ b/components/katto/actions/get-transcript/get-transcript.mjs
@@ -1,0 +1,32 @@
+import katto from "../../katto.app.mjs";
+
+export default {
+  key: "katto-get-transcript",
+  name: "Get Transcript",
+  description:
+    "Get the timestamped transcript of a job. [See the documentation](https://katto.tech/docs/api)",
+  version: "0.1.0",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    katto,
+    jobId: {
+      propDefinition: [
+        katto,
+        "jobId",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.katto.getTranscript({
+      $,
+      jobId: this.jobId,
+    });
+    $.export("$summary", `Retrieved transcript for job \`${this.jobId}\``);
+    return response;
+  },
+};

--- a/components/katto/actions/get-usage/get-usage.mjs
+++ b/components/katto/actions/get-usage/get-usage.mjs
@@ -1,0 +1,25 @@
+import katto from "../../katto.app.mjs";
+
+export default {
+  key: "katto-get-usage",
+  name: "Get Usage",
+  description:
+    "Get your plan and remaining monthly video quota. [See the documentation](https://katto.tech/docs/api)",
+  version: "0.1.0",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    katto,
+  },
+  async run({ $ }) {
+    const response = await this.katto.getUsage({
+      $,
+    });
+    $.export("$summary", "Retrieved plan and usage");
+    return response;
+  },
+};

--- a/components/katto/actions/list-jobs/list-jobs.mjs
+++ b/components/katto/actions/list-jobs/list-jobs.mjs
@@ -1,0 +1,37 @@
+import katto from "../../katto.app.mjs";
+
+export default {
+  key: "katto-list-jobs",
+  name: "List Jobs",
+  description:
+    "List your clip jobs, newest first. [See the documentation](https://katto.tech/docs/api)",
+  version: "0.1.0",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    katto,
+    limit: {
+      propDefinition: [
+        katto,
+        "limit",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.katto.listJobs({
+      $,
+      params: {
+        limit: this.limit,
+      },
+    });
+    const count = Array.isArray(response)
+      ? response.length
+      : (response.jobs?.length ?? response.data?.length ?? 0);
+    $.export("$summary", `Retrieved ${count} job(s)`);
+    return response;
+  },
+};

--- a/components/katto/actions/list-jobs/list-jobs.mjs
+++ b/components/katto/actions/list-jobs/list-jobs.mjs
@@ -4,7 +4,7 @@ export default {
   key: "katto-list-jobs",
   name: "List Jobs",
   description:
-    "List your clip jobs, newest first. [See the documentation](https://katto.tech/docs/api)",
+    "List your clip jobs, newest first, following pagination. [See the documentation](https://katto.tech/docs/api)",
   version: "0.1.0",
   type: "action",
   annotations: {
@@ -14,24 +14,51 @@ export default {
   },
   props: {
     katto,
-    limit: {
-      propDefinition: [
-        katto,
-        "limit",
-      ],
+    status: {
+      type: "string",
+      label: "Status",
+      description:
+        "Optional. Only return jobs with this status (e.g. `completed`, `processing`, `failed`, `queued`).",
+      optional: true,
+    },
+    maxResults: {
+      type: "integer",
+      label: "Max Results",
+      description:
+        "Maximum number of jobs to return across pages. The action follows `next_cursor` until this many are collected (or there are no more).",
+      optional: true,
+      default: 100,
     },
   },
   async run({ $ }) {
-    const response = await this.katto.listJobs({
-      $,
-      params: {
-        limit: this.limit,
-      },
-    });
-    const count = Array.isArray(response)
-      ? response.length
-      : (response.jobs?.length ?? response.data?.length ?? 0);
-    $.export("$summary", `Retrieved ${count} job(s)`);
-    return response;
+    const max = this.maxResults && this.maxResults > 0
+      ? this.maxResults
+      : 100;
+    const results = [];
+    let cursor;
+
+    while (results.length < max) {
+      const resp = await this.katto.listJobs({
+        $,
+        params: {
+          limit: Math.min(100, max - results.length),
+          cursor,
+          status: this.status,
+        },
+      });
+      const jobs = Array.isArray(resp)
+        ? resp
+        : (resp.jobs ?? resp.data ?? []);
+      results.push(...jobs);
+      const next = Array.isArray(resp) ? null : resp.next_cursor;
+      if (!next || jobs.length === 0) {
+        break;
+      }
+      cursor = next;
+    }
+
+    const out = results.slice(0, max);
+    $.export("$summary", `Retrieved ${out.length} job(s)`);
+    return out;
   },
 };

--- a/components/katto/katto.app.mjs
+++ b/components/katto/katto.app.mjs
@@ -1,0 +1,98 @@
+import { axios } from "@pipedream/platform";
+
+export default {
+  type: "app",
+  app: "katto",
+  propDefinitions: {
+    jobId: {
+      type: "string",
+      label: "Job ID",
+      description: "The id of a Katto clip job (returned by Create Clip Job).",
+    },
+    limit: {
+      type: "integer",
+      label: "Limit",
+      description: "Maximum number of jobs to return.",
+      optional: true,
+      default: 20,
+    },
+  },
+  methods: {
+    _baseUrl() {
+      return "https://katto.tech/api/v1";
+    },
+    _headers() {
+      return {
+        "Authorization": `Bearer ${this.$auth.api_key}`,
+        "Content-Type": "application/json",
+      };
+    },
+    async _makeRequest({
+      $ = this, path, ...args
+    } = {}) {
+      return axios($, {
+        url: `${this._baseUrl()}${path}`,
+        headers: this._headers(),
+        ...args,
+      });
+    },
+    async createJob(args = {}) {
+      return this._makeRequest({
+        method: "POST",
+        path: "/jobs",
+        ...args,
+      });
+    },
+    async getJob({
+      jobId, ...args
+    } = {}) {
+      return this._makeRequest({
+        path: `/jobs/${jobId}`,
+        ...args,
+      });
+    },
+    async listJobs(args = {}) {
+      return this._makeRequest({
+        path: "/jobs",
+        ...args,
+      });
+    },
+    async getClips({
+      jobId, ...args
+    } = {}) {
+      return this._makeRequest({
+        path: `/jobs/${jobId}/clips`,
+        ...args,
+      });
+    },
+    async getTranscript({
+      jobId, ...args
+    } = {}) {
+      return this._makeRequest({
+        path: `/jobs/${jobId}/transcript`,
+        ...args,
+      });
+    },
+    async cancelJob({
+      jobId, ...args
+    } = {}) {
+      return this._makeRequest({
+        method: "DELETE",
+        path: `/jobs/${jobId}`,
+        ...args,
+      });
+    },
+    async getUsage(args = {}) {
+      return this._makeRequest({
+        path: "/usage",
+        ...args,
+      });
+    },
+    async getAccount(args = {}) {
+      return this._makeRequest({
+        path: "/me",
+        ...args,
+      });
+    },
+  },
+};

--- a/components/katto/katto.app.mjs
+++ b/components/katto/katto.app.mjs
@@ -28,11 +28,14 @@ export default {
       };
     },
     async _makeRequest({
-      $ = this, path, ...args
+      $ = this, path, headers = {}, ...args
     } = {}) {
       return axios($, {
         url: `${this._baseUrl()}${path}`,
-        headers: this._headers(),
+        headers: {
+          ...this._headers(),
+          ...headers,
+        },
         ...args,
       });
     },

--- a/components/katto/package.json
+++ b/components/katto/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@pipedream/katto",
+  "version": "0.1.0",
+  "description": "Pipedream Katto Components",
+  "main": "katto.app.mjs",
+  "keywords": [
+    "pipedream",
+    "katto"
+  ],
+  "homepage": "https://pipedream.com/apps/katto",
+  "author": "Katto (https://katto.tech)",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^3.1.0"
+  }
+}


### PR DESCRIPTION
## New app: Katto

[Katto](https://katto.tech) turns long videos, podcasts and Twitch VODs into scored, captioned 9:16 clips.

This PR adds the **katto** app (API key auth) with 8 actions plus Custom API Call:
Create Clip Job, Get Job, List Jobs, Get Clips, Get Transcript, Cancel Job, Get Usage, Get Account.

### Guidelines checklist
- [x] Components address specific use cases (one action per Katto API resource)
- [x] Component keys follow `katto-...` (e.g. `katto-create-clip-job`)
- [x] Standard directory structure (`components/katto/{katto.app.mjs,actions/*}`)
- [ ] Node client library vs REST: Katto has no official Node SDK yet, so the app wraps the documented REST API (`https://katto.tech/api/v1`) via `@pipedream/platform` axios
- [x] Sensitive data via a secret prop (the API key `$auth.api_key`)
- [x] Shared props/methods live in the app file (`jobId`, `limit`, request helpers)
- [x] Optional props with defaults where possible (`limit` default 20, optional webhook + idempotency)
- [x] Enable edits from maintainers

### Notes
- **Idempotency (addresses the duplicate-charge risk):** Create Clip Job now takes an optional **Idempotency Key**, forwarded as the `Idempotency-Key` header. Katto returns the original job on a repeat, so a retried step never creates a duplicate job or charge.
- **Versioning:** initial versions (app `0.1.0`, actions `0.1.0`).
- **CodeRabbit review acknowledged** — idempotency handled above; pagination on List Jobs is limit-based (newest-first), can add a cursor in a follow-up if useful.
- Auth: bearer API key (`sk_live_...`), created at katto.tech -> Dashboard -> API keys; keys can be scoped read-only. API docs: https://katto.tech/docs/api


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Katto integration for creating and managing AI-generated video clip jobs.
  * Create clips from video URLs with optional webhooks and idempotency protection.
  * Retrieve job status, clips, timestamped transcripts, usage, and account details.
  * List or cancel jobs, including video-slot refunds for canceled jobs.
* **Documentation**
  * Added guidance covering authentication, supported platforms, workflows, and API usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->