### PR TITLE
fix(slack_v2): expose message options as static props for MCP v3

### DIFF
--- a/components/slack_v2/actions/common/send-message.mjs
+++ b/components/slack_v2/actions/common/send-message.mjs
@@ -30,40 +30,23 @@ export default {
       label: "Include link to Pipedream",
       description: "Defaults to `true`, includes a link to Pipedream at the end of your Slack message.",
     },
-    customizeBotSettings: {
-      type: "boolean",
-      label: "Customize Bot Settings",
-      description: "Customize the username and/or icon of the Bot",
-      optional: true,
-      reloadProps: true,
-    },
     username: {
       propDefinition: [
         slack,
         "username",
       ],
-      hidden: true,
     },
     icon_emoji: {
       propDefinition: [
         slack,
         "icon_emoji",
       ],
-      hidden: true,
     },
     icon_url: {
       propDefinition: [
         slack,
         "icon_url",
       ],
-      hidden: true,
-    },
-    replyToThread: {
-      type: "boolean",
-      label: "Reply to Thread",
-      description: "Reply to an existing thread",
-      optional: true,
-      reloadProps: true,
     },
     thread_ts: {
       propDefinition: [
@@ -72,77 +55,37 @@ export default {
       ],
       description: "Provide another message's `ts` value to make this message a reply (e.g., if triggering on new Slack messages, enter `{{event.ts}}`). Avoid using a reply's `ts` value; use its parent instead. e.g. `1403051575.000407`.",
       optional: true,
-      hidden: true,
     },
     thread_broadcast: {
       propDefinition: [
         slack,
         "thread_broadcast",
       ],
-      hidden: true,
-    },
-    addMessageMetadata: {
-      type: "boolean",
-      label: "Add Message Metadata",
-      description: "Set the metadata event type and payload",
-      optional: true,
-      reloadProps: true,
     },
     metadata_event_type: {
       propDefinition: [
         slack,
         "metadata_event_type",
       ],
-      hidden: true,
     },
     metadata_event_payload: {
       propDefinition: [
         slack,
         "metadata_event_payload",
       ],
-      hidden: true,
-    },
-    configureUnfurlSettings: {
-      type: "boolean",
-      label: "Configure Unfurl Settings",
-      description: "Configure settings for unfurling links and media",
-      optional: true,
-      reloadProps: true,
     },
     unfurl_links: {
       propDefinition: [
         slack,
         "unfurl_links",
       ],
-      hidden: true,
     },
     unfurl_media: {
       propDefinition: [
         slack,
         "unfurl_media",
       ],
-      hidden: true,
     },
-  },
-  async additionalProps(props) {
-    if (this.conversation && this.replyToThread) {
-      props.thread_ts.hidden = false;
-      props.thread_broadcast.hidden = false;
-    }
-    if (this.customizeBotSettings) {
-      props.username.hidden = false;
-      props.icon_emoji.hidden = false;
-      props.icon_url.hidden = false;
-    }
-    if (this.addMessageMetadata) {
-      props.metadata_event_type.hidden = false;
-      props.metadata_event_payload.hidden = false;
-    }
-    if (this.configureUnfurlSettings) {
-      props.unfurl_links.hidden = false;
-      props.unfurl_media.hidden = false;
-    }
-    return {};
   },
   methods: {
     _makeSentViaPipedreamBlock() {

--- a/components/slack_v2/actions/reply-to-a-message/reply-to-a-message.mjs
+++ b/components/slack_v2/actions/reply-to-a-message/reply-to-a-message.mjs
@@ -6,7 +6,7 @@ export default {
   key: "slack_v2-reply-to-a-message",
   name: "Reply to a Message Thread",
   description: "Send a message as a threaded reply. See [postMessage](https://api.slack.com/methods/chat.postMessage) or [scheduleMessage](https://api.slack.com/methods/chat.scheduleMessage) docs here",
-  version: "0.2.6",
+  version: "0.3.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -34,10 +34,6 @@ export default {
       ],
     },
     ...common.props,
-    replyToThread: {
-      ...common.props.replyToThread,
-      hidden: true,
-    },
     thread_ts: {
       propDefinition: [
         slack,

--- a/components/slack_v2/actions/send-block-kit-message/send-block-kit-message.mjs
+++ b/components/slack_v2/actions/send-block-kit-message/send-block-kit-message.mjs
@@ -7,7 +7,7 @@ export default {
   key: "slack_v2-send-block-kit-message",
   name: "Build and Send a Block Kit Message",
   description: "Configure custom blocks and send to a channel, group, or user. [See the documentation](https://api.slack.com/tools/block-kit-builder).",
-  version: "0.5.6",
+  version: "0.6.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/send-large-message/send-large-message.mjs
+++ b/components/slack_v2/actions/send-large-message/send-large-message.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-send-large-message",
   name: "Send a Large Message (3000+ characters)",
   description: "Send a large message (more than 3000 characters) to a channel, group or user. See [postMessage](https://api.slack.com/methods/chat.postMessage) or [scheduleMessage](https://api.slack.com/methods/chat.scheduleMessage) docs here",
-  version: "0.1.6",
+  version: "0.2.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/send-message-advanced/send-message-advanced.mjs
+++ b/components/slack_v2/actions/send-message-advanced/send-message-advanced.mjs
@@ -7,7 +7,7 @@ export default {
   key: "slack_v2-send-message-advanced",
   name: "Send Message (Advanced)",
   description: "Customize advanced settings and send a message to a channel, group or user. See [postMessage](https://api.slack.com/methods/chat.postMessage) or [scheduleMessage](https://api.slack.com/methods/chat.scheduleMessage) docs here",
-  version: "0.1.6",
+  version: "0.2.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/send-message-to-channel/send-message-to-channel.mjs
+++ b/components/slack_v2/actions/send-message-to-channel/send-message-to-channel.mjs
@@ -6,7 +6,7 @@ export default {
   key: "slack_v2-send-message-to-channel",
   name: "Send Message to Channel",
   description: "Send a message to a public or private channel. [See the documentation](https://api.slack.com/methods/chat.postMessage)",
-  version: "0.1.6",
+  version: "0.2.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/send-message-to-user-or-group/send-message-to-user-or-group.mjs
+++ b/components/slack_v2/actions/send-message-to-user-or-group/send-message-to-user-or-group.mjs
@@ -7,7 +7,7 @@ export default {
   key: "slack_v2-send-message-to-user-or-group",
   name: "Send Message to User or Group",
   description: "Send a message to a user or group. [See the documentation](https://api.slack.com/methods/chat.postMessage)",
-  version: "0.1.6",
+  version: "0.2.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/send-message/send-message.mjs
+++ b/components/slack_v2/actions/send-message/send-message.mjs
@@ -6,7 +6,7 @@ export default {
   key: "slack_v2-send-message",
   name: "Send Message",
   description: "Send a message to a user, group, private channel or public channel. [See the documentation](https://api.slack.com/methods/chat.postMessage)",
-  version: "0.1.6",
+  version: "0.2.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/package.json
+++ b/components/slack_v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/slack_v2",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Pipedream Slack_v2 Components",
   "main": "slack_v2.app.mjs",
   "keywords": [


### PR DESCRIPTION
## Summary

Closes #21709 for `actions/common/send-message.mjs`.

The base module revealed `username`, `icon_emoji`, `icon_url`, `thread_ts`, `thread_broadcast`, `metadata_event_type`, `metadata_event_payload`, `unfurl_links` and `unfurl_media` through `additionalProps()`, driven by four `reloadProps` booleans. An MCP tool resolves its JSON Schema once at registration, so props that only appear after a parent prop is set never reach an agent.

As the issue notes, this base fetches nothing — `additionalProps()` only flipped `hidden` on props that were already declared, and all nine were already `optional: true`. They are now declared plainly, so nothing became required and no default changed.

The four booleans (`customizeBotSettings`, `replyToThread`, `addMessageMetadata`, `configureUnfurlSettings`) existed only to drive that reveal; `run()` never read any of them, so they are removed along with the mechanism. `reply-to-a-message` overrode `replyToThread` to keep it out of its own form, which is no longer needed — its required `thread_ts` override is untouched.

Net effect: 69 lines removed, 8 added (version bumps).

### Deliberately out of scope

`actions/common/build-blocks.mjs` is left alone. Unlike this base it generates block props dynamically — a `passArrayOrConfigure` switch, then up to five chained `nextBlockType` reloads — so making it static is a redesign of that wizard rather than a prop declaration change, and it would change what workflow users see. `send-block-kit-message` and `send-message-advanced` still extend it, so they get the send-message fix here but remain dynamic for their block props. Happy to follow up on that separately if you'd like it in the same issue.

## Checklist

### Versioning
- [x] All components updated in this PR had their version updated (`0.0.1` for new ones)
- [x] The app updated in this PR had its `package.json`'s version updated

Minor bumps, since props were removed: `send-message`, `send-message-to-channel`, `send-message-to-user-or-group`, `send-large-message`, `send-message-advanced` `0.1.6 → 0.2.0`; `send-block-kit-message` `0.5.6 → 0.6.0`; `reply-to-a-message` `0.2.6 → 0.3.0`; app `0.8.0 → 0.9.0`.

### New app
- [x] The app updated in this PR is already integrated

### CodeRabbit review
- [x] I have addressed or acknowledged all of CodeRabbit's review comments

CodeRabbit raised one point — that this only partly closes #21709 because `build-blocks.mjs` stays dynamic. I answered in thread with the reasoning above, and it withdrew the finding: *"The split is valid... I withdraw the partial-coverage finding for this PR."* No code findings were raised.

## How this was checked

I have no Slack workspace wired to this repo, so this was not exercised against the live API. What I did verify locally:

- Loaded all seven affected actions and inspected the resulting prop sets: no `reloadProps`, no `hidden`, no `additionalProps` outside the two that extend `build-blocks`, none of the nine props newly required, and none of the removed toggles left behind.
- Confirmed `reply-to-a-message` still declares `thread_ts` as required (its `messageTs` propDefinition has no `optional`), unlike the optional one in the base.
- Searched the repo for the four removed toggles: only this base module referenced them.
- `node --check` on each changed module.

I could not run the monorepo lint locally, so please treat CI as the authority on that.
