### PR TITLE
[21745] fix(google_docs): Markdown support in "Replace Text" action

### DIFF
--- a/components/google_docs/actions/append-text/append-text.mjs
+++ b/components/google_docs/actions/append-text/append-text.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-append-text",
   name: "Append Text",
   description: "Append text to an existing document. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#InsertTextRequest)",
-  version: "0.1.14",
+  version: "0.1.15",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/create-document-from-template/create-document-from-template.mjs
+++ b/components/google_docs/actions/create-document-from-template/create-document-from-template.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_docs-create-document-from-template",
   name: "Create Document From Template",
   description: "Create a new Google Doc by copying a template document and substituting `{{placeholder}}` tokens with values. Use **Find Document** to resolve the template's name to its ID. Returns `{documentId, title, url}`. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#ReplaceAllTextRequest)",
-  version: "1.0.3",
+  version: "1.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/create-document/create-document.mjs
+++ b/components/google_docs/actions/create-document/create-document.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-create-document",
   name: "Create Document",
   description: "Create a new Google Doc with an optional body. The body is rendered as Markdown, so you can include headings (`# Title`), bold/italic, bullet/numbered lists, links, and code. Optionally place the doc in a specific Drive folder. Returns `{documentId, title, url}`. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/create)",
-  version: "1.0.3",
+  version: "1.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/delete-table/delete-table.mjs
+++ b/components/google_docs/actions/delete-table/delete-table.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_docs-delete-table",
   name: "Delete Table",
   description: "Remove an entire table, structure and contents, from the document. Use this to clear a table completely, including an empty table left behind after its text was removed. Set **Table Number** to pick which table to remove (1 = first top-level table in the document, in reading order; a table nested inside another table's cell doesn't count separately). Use **Get Document** first if you need to confirm how many tables exist. This also works on a table linked to a Google Sheet, since removal is treated as ordinary content deletion. Use **Find Document** to resolve a document's name to its ID. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#DeleteContentRangeRequest)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_docs/actions/export-document/export-document.mjs
+++ b/components/google_docs/actions/export-document/export-document.mjs
@@ -32,7 +32,7 @@ export default {
   key: "google_docs-export-document",
   name: "Export Document",
   description: "Export (download) a Google Doc to a file in PDF, DOCX, TXT, HTML, or ODT format. Use **Find Document** to resolve a document's name to its ID. The file is written to the workflow's temporary storage and a presigned download URL is returned to the caller. Returns `{filePath, filename, mimeType}`. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/export)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/find-document/find-document.mjs
+++ b/components/google_docs/actions/find-document/find-document.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-find-document",
   name: "Find Document",
   description: "Search for Google Docs by name or full-text content. Returns a list of `{id, name, url, modifiedTime}`. Use this first to resolve a document's name to its ID, then pass the `id` to **Get Document**, **Export Document**, or any of the insert/replace tools. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/list)",
-  version: "1.0.3",
+  version: "1.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/get-document/get-document.mjs
+++ b/components/google_docs/actions/get-document/get-document.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_docs-get-document",
   name: "Get Document",
   description: "Get the full text content and structure of a Google Doc by its ID. Returns the document body plus a flattened `textContent` field for easy reading. Optionally supply a `fields` mask to request a partial (e.g. metadata-only) response and skip the body-text enrichment. Use **Find Document** first to resolve a document's name to its ID. For multi-tab documents, pass a `tabId` to retrieve a single tab's content. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/get)",
-  version: "1.1.2",
+  version: "1.1.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/get-profile/get-profile.mjs
+++ b/components/google_docs/actions/get-profile/get-profile.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-get-profile",
   name: "Get Profile",
   description: "Get the identity (display name and email) of the currently authenticated Google account. Use this to answer \"who am I\" questions and to attribute documents to the current user. Resolves via the Drive `about.get` endpoint (no extra OAuth scope required). [See the documentation](https://developers.google.com/drive/api/v3/reference/about/get)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/insert-image/insert-image.mjs
+++ b/components/google_docs/actions/insert-image/insert-image.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-insert-image",
   name: "Insert Image",
   description: "Insert an inline image into a Google Doc from a publicly reachable image URL. The URL must be publicly accessible (Google fetches it server-side) and point to a PNG, JPEG, or GIF. Use **Find Document** to resolve a document's name to its ID. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#InsertInlineImageRequest)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/insert-page-break/insert-page-break.mjs
+++ b/components/google_docs/actions/insert-page-break/insert-page-break.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-insert-page-break",
   name: "Insert Page Break",
   description: "Insert a page break into a Google Doc at the beginning, end, or a specific character index. Use **Find Document** to resolve a document's name to its ID. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#InsertPageBreakRequest)",
-  version: "1.0.3",
+  version: "1.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/insert-table/insert-table.mjs
+++ b/components/google_docs/actions/insert-table/insert-table.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-insert-table",
   name: "Insert Table",
   description: "Insert an empty table with the given number of rows and columns into a Google Doc. If you already have the data, use **Write Table** instead so you don't have to fill cells one by one. Use **Find Document** to resolve a document's name to its ID. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#InsertTableRequest)",
-  version: "1.0.3",
+  version: "1.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/insert-text/insert-text.mjs
+++ b/components/google_docs/actions/insert-text/insert-text.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-insert-text",
   name: "Insert Text",
   description: "Insert text into a Google Doc at the beginning, end, or a specific character index. Use **Find Document** to resolve a document's name to its ID. To append text to the end of a doc, use `position: end` (the default). [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#InsertTextRequest)",
-  version: "1.0.3",
+  version: "1.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/list-comments/list-comments.mjs
+++ b/components/google_docs/actions/list-comments/list-comments.mjs
@@ -9,7 +9,7 @@ export default {
   key: "google_docs-list-comments",
   name: "List Comments",
   description: "List the comments on a Google Doc, including each comment's author, plain text and HTML content, the document text it is anchored to, whether it is resolved, and its full reply thread. Comments on a Doc are served by the Drive API, so the document ID doubles as the file ID. Use **Find Document** first to resolve a document's name to its ID. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/comments/list)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/replace-image/replace-image.mjs
+++ b/components/google_docs/actions/replace-image/replace-image.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-replace-image",
   name: "Replace Image",
   description: "Replace image in a existing document. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#ReplaceImageRequest)",
-  version: "0.0.15",
+  version: "0.0.16",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_docs/actions/replace-text/replace-text.mjs
+++ b/components/google_docs/actions/replace-text/replace-text.mjs
@@ -3,8 +3,8 @@ import googleDocs from "../../google_docs.app.mjs";
 export default {
   key: "google_docs-replace-text",
   name: "Replace Text",
-  description: "Find and replace all occurrences of a string in a Google Doc. Use **Find Document** to resolve a document's name to its ID. Returns the number of replacements made. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#ReplaceAllTextRequest)",
-  version: "1.0.3",
+  description: "Find and replace all occurrences of a string in a Google Doc. Set **Replacement Format** to `markdown` to convert Markdown in the replacement into native Google Docs formatting. Use **Find Document** to resolve a document's name to its ID. Returns the number of replacements made. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#ReplaceAllTextRequest)",
+  version: "1.1.0",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
@@ -29,6 +29,12 @@ export default {
       label: "Replace",
       description: "The text to replace each match with.",
     },
+    format: {
+      propDefinition: [
+        googleDocs,
+        "replacementFormat",
+      ],
+    },
     matchCase: {
       propDefinition: [
         googleDocs,
@@ -37,19 +43,49 @@ export default {
     },
   },
   async run({ $ }) {
-    const { data } = await this.googleDocs.replaceText(this.documentId, {
-      replaceText: this.replace,
+    const {
+      googleDocs,
+      documentId,
+      find,
+      replace,
+      format,
+      matchCase,
+    } = this;
+
+    if (format === "markdown") {
+      const {
+        occurrencesChanged, formattingRequestsApplied,
+      } = await googleDocs.replaceTextWithMarkdown({
+        documentId,
+        textToReplace: find,
+        markdownReplacement: replace,
+        matchCase,
+      });
+      $.export("$summary", `Replaced ${occurrencesChanged} occurrence${occurrencesChanged === 1
+        ? ""
+        : "s"} of "${find}" in document ${documentId}, applying ${formattingRequestsApplied} formatting request${formattingRequestsApplied === 1
+        ? ""
+        : "s"}`);
+      return {
+        documentId,
+        occurrencesChanged,
+        formattingRequestsApplied,
+      };
+    }
+
+    const { data } = await googleDocs.replaceText(documentId, {
+      replaceText: replace,
       containsText: {
-        text: this.find,
-        matchCase: this.matchCase,
+        text: find,
+        matchCase,
       },
     });
     const occurrences = data?.replies?.[0]?.replaceAllText?.occurrencesChanged ?? 0;
     $.export("$summary", `Replaced ${occurrences} occurrence${occurrences === 1
       ? ""
-      : "s"} of "${this.find}" in document ${this.documentId}`);
+      : "s"} of "${find}" in document ${documentId}`);
     return {
-      documentId: this.documentId,
+      documentId,
       occurrencesChanged: occurrences,
     };
   },

--- a/components/google_docs/actions/write-table/write-table.mjs
+++ b/components/google_docs/actions/write-table/write-table.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_docs-write-table",
   name: "Write Table",
   description: "Create a table and fill it with data in a single step. Provide the entire table (all rows and columns, including a header row) at once. Use this instead of inserting cells or text one at a time. The action places every value in the correct cell for you. Pass **Table Data** as a JSON array of arrays, one inner array per row, header row first when **Has Header Row** is set, e.g. `[[\"Name\",\"Role\"],[\"Ada\",\"Engineer\"]]`. Use **Find Document** to resolve a document's name to its ID, or **Insert Table** instead if you only need an empty grid to fill in later. Note: a table written this way is always static — the Google Docs API does not create or preserve a live link to a Google Sheet, even when this replaces a Sheets-linked table. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#InsertTableRequest)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/common/markdown-parser.mjs
+++ b/components/google_docs/common/markdown-parser.mjs
@@ -371,6 +371,8 @@ function collectAllDocumentText(elements, allText, indexMap, state) {
     if (element.paragraph) {
       if (element.paragraph.elements && Array.isArray(element.paragraph.elements)) {
         element.paragraph.elements.forEach((el) => {
+          const docStart = el.startIndex ?? state.currentIndex;
+
           if (el.textRun && el.textRun.content) {
             const text = el.textRun.content;
             const startOfText = state.allTextIndex;
@@ -379,24 +381,24 @@ function collectAllDocumentText(elements, allText, indexMap, state) {
 
             // Record the document index for this position in allText
             for (let i = 0; i < text.length; i++) {
-              indexMap[startOfText + i] = state.currentIndex + i;
+              indexMap[startOfText + i] = docStart + i;
             }
 
             state.allTextIndex += text.length;
-            state.currentIndex += text.length;
+            state.currentIndex = docStart + text.length;
           } else if (el.inlineObject) {
-            indexMap[state.allTextIndex] = state.currentIndex;
+            indexMap[state.allTextIndex] = docStart;
             state.allTextIndex += 1;
-            state.currentIndex += 1;
+            state.currentIndex = docStart + 1;
           } else if (
             el.pageBreak
             || el.columnBreak
             || el.footnoteReference
             || el.endnoteReference
           ) {
-            indexMap[state.allTextIndex] = state.currentIndex;
+            indexMap[state.allTextIndex] = docStart;
             state.allTextIndex += 1;
-            state.currentIndex += 1;
+            state.currentIndex = docStart + 1;
           }
         });
       }
@@ -484,10 +486,12 @@ function buildFormattingRequestsForReplacement(
   let matchPos = fullText.indexOf(replacementText, searchPos);
 
   while (matchPos !== -1) {
-    const docIndex = indexMap[matchPos] || (state.currentIndex + matchPos);
+    const docIndex = indexMap[matchPos] ?? (state.currentIndex + matchPos);
+    const lastCharIndex = indexMap[matchPos + replacementText.length - 1]
+      ?? (docIndex + replacementText.length - 1);
     matches.push({
       startIndex: docIndex,
-      endIndex: docIndex + replacementText.length,
+      endIndex: lastCharIndex + 1,
     });
     searchPos = matchPos + 1;
     matchPos = fullText.indexOf(replacementText, searchPos);

--- a/components/google_docs/common/markdown-parser.mjs
+++ b/components/google_docs/common/markdown-parser.mjs
@@ -423,12 +423,45 @@ function collectTableText(table, allText, indexMap, state) {
   });
 }
 
+function findTextOccurrences(doc, needle, matchCase = false) {
+  const allText = [];
+  const indexMap = [];
+  const state = {
+    currentIndex: 1,
+    allTextIndex: 0,
+  };
+  collectAllDocumentText(doc?.body?.content || [], allText, indexMap, state);
+  const fullText = allText.join("");
+
+  const target = matchCase
+    ? needle
+    : needle.toLowerCase();
+  const starts = [];
+
+  for (let i = 0; needle.length && i + needle.length <= fullText.length; i++) {
+    const window = fullText.substr(i, needle.length);
+    const candidate = matchCase
+      ? window
+      : window.toLowerCase();
+    if (candidate !== target) {
+      continue;
+    }
+    starts.push(indexMap[i] ?? (state.currentIndex + i));
+    i += needle.length - 1;
+  }
+  return starts;
+}
+
 /**
  * Build formatting requests for replaced text with recursive document scanning
  * Scans the entire document including nested structures (tables, lists) and finds
- * all occurrences of replacementText, applying formatting to each match.
+ * all occurrences of replacementText. Pass `insertedStartIndices` to format only
+ * the occurrences a replacement actually inserted; without it every occurrence is
+ * formatted, including identical text that was already in the document.
  */
-function buildFormattingRequestsForReplacement(markdownFormatting, doc, replacementText) {
+function buildFormattingRequestsForReplacement(
+  markdownFormatting, doc, replacementText, insertedStartIndices,
+) {
   const requests = [];
   const bodyContent = doc?.body?.content || [];
 
@@ -464,7 +497,11 @@ function buildFormattingRequestsForReplacement(markdownFormatting, doc, replacem
   const bulletRequests = [];
 
   // For each match found, generate formatting requests
-  matches.forEach((match) => {
+  const targetMatches = insertedStartIndices
+    ? matches.filter(({ startIndex }) => insertedStartIndices.has(startIndex))
+    : matches;
+
+  targetMatches.forEach((match) => {
     markdownFormatting.forEach((req) => {
       // Handle bullet list formatting separately
       if (req.type === "createParagraphBullets") {
@@ -685,6 +722,7 @@ function findAllMatches(haystack, needle, baseIndex, matches) {
 
 export default {
   parseMarkdown,
+  findTextOccurrences,
   convertToGoogleDocsRequests,
   buildFormattingRequestsForReplacement,
 };

--- a/components/google_docs/common/markdown-parser.mjs
+++ b/components/google_docs/common/markdown-parser.mjs
@@ -5,6 +5,10 @@
 
 import MarkdownIt from "markdown-it";
 
+// Keeps the search string index-aligned with the document; NUL cannot occur in
+// Docs content, so it never forms part of a real match.
+const NON_TEXT_PLACEHOLDER = "\u0000";
+
 /**
  * Create a custom markdown-it instance configured for Google Docs conversion
  * @returns {MarkdownIt} Configured markdown-it instance
@@ -386,20 +390,21 @@ function collectAllDocumentText(elements, allText, indexMap, state) {
 
             state.allTextIndex += text.length;
             state.currentIndex = docStart + text.length;
-          } else if (el.inlineObject) {
-            indexMap[state.allTextIndex] = docStart;
-            state.allTextIndex += 1;
-            state.currentIndex = docStart + 1;
-          } else if (
-            el.pageBreak
-            || el.columnBreak
-            || el.footnoteReference
-            || el.endnoteReference
-          ) {
-            indexMap[state.allTextIndex] = docStart;
-            state.allTextIndex += 1;
-            state.currentIndex = docStart + 1;
+            return;
           }
+
+          // Page breaks, inline images, equations and the like occupy indices
+          // without contributing text. Width comes from startIndex/endIndex so
+          // every element kind is covered.
+          const width = Math.max(1, (el.endIndex ?? (docStart + 1)) - docStart);
+
+          allText.push(NON_TEXT_PLACEHOLDER.repeat(width));
+          for (let i = 0; i < width; i++) {
+            indexMap[state.allTextIndex + i] = docStart + i;
+          }
+
+          state.allTextIndex += width;
+          state.currentIndex = docStart + width;
         });
       }
     } else if (element.table) {

--- a/components/google_docs/common/markdown-parser.mjs
+++ b/components/google_docs/common/markdown-parser.mjs
@@ -431,6 +431,9 @@ function collectTableText(table, allText, indexMap, state) {
 }
 
 function findTextOccurrences(doc, needle, matchCase = false) {
+  if (!needle || needle.includes(NON_TEXT_PLACEHOLDER)) {
+    return [];
+  }
   const allText = [];
   const indexMap = [];
   const state = {
@@ -445,7 +448,7 @@ function findTextOccurrences(doc, needle, matchCase = false) {
     : needle.toLowerCase();
   const starts = [];
 
-  for (let i = 0; needle.length && i + needle.length <= fullText.length; i++) {
+  for (let i = 0; i + needle.length <= fullText.length; i++) {
     const window = fullText.substr(i, needle.length);
     const candidate = matchCase
       ? window
@@ -487,6 +490,9 @@ function buildFormattingRequestsForReplacement(
 
   // Now search for the replacement text in the full text
   const matches = [];
+  if (!replacementText || replacementText.includes(NON_TEXT_PLACEHOLDER)) {
+    return requests;
+  }
   let searchPos = 0;
   let matchPos = fullText.indexOf(replacementText, searchPos);
 

--- a/components/google_docs/common/markdown-parser.mjs
+++ b/components/google_docs/common/markdown-parser.mjs
@@ -449,7 +449,7 @@ function findTextOccurrences(doc, needle, matchCase = false) {
   const starts = [];
 
   for (let i = 0; i + needle.length <= fullText.length; i++) {
-    const window = fullText.substr(i, needle.length);
+    const window = fullText.slice(i, i + needle.length);
     const candidate = matchCase
       ? window
       : window.toLowerCase();

--- a/components/google_docs/google_docs.app.mjs
+++ b/components/google_docs/google_docs.app.mjs
@@ -451,6 +451,25 @@ export default {
         ? parsedText
         : parsedText.replace(/\n+$/, "");
 
+      const insertedStartsByTab = new Map();
+      if (markdownFormatting.length) {
+        const beforeDoc = await this.getDocument(documentId, true);
+        const lengthDelta = replacementText.length - textToReplace.length;
+        this._flattenDocumentTabs(beforeDoc.tabs)
+          .filter(({ tabProperties }) => !tabIds?.length || tabIds.includes(tabProperties?.tabId))
+          .forEach((tab) => {
+            const starts = markdownParser.findTextOccurrences(
+              tab.documentTab,
+              textToReplace,
+              matchCase,
+            );
+            insertedStartsByTab.set(
+              tab.tabProperties?.tabId,
+              new Set(starts.map((start, index) => start + (index * lengthDelta))),
+            );
+          });
+      }
+
       const { data: replaceData } = await this.batchUpdate(documentId, [
         {
           replaceAllText: {
@@ -488,6 +507,7 @@ export default {
           markdownFormatting,
           tab.documentTab,
           replacementText,
+          insertedStartsByTab.get(tabId),
         );
         return requests.map((request) => {
           const [

--- a/components/google_docs/google_docs.app.mjs
+++ b/components/google_docs/google_docs.app.mjs
@@ -183,11 +183,14 @@ export default {
         },
       });
     },
-    batchUpdate(documentId, requests) {
+    batchUpdate(documentId, requests, writeControl) {
       return this.docs().documents.batchUpdate({
         documentId,
         requestBody: {
           requests,
+          ...(writeControl && {
+            writeControl,
+          }),
         },
       });
     },
@@ -526,7 +529,9 @@ export default {
       });
 
       if (formattingRequests.length) {
-        await this.batchUpdate(documentId, formattingRequests);
+        await this.batchUpdate(documentId, formattingRequests, updatedDoc.revisionId && {
+          requiredRevisionId: updatedDoc.revisionId,
+        });
       }
 
       return {

--- a/components/google_docs/google_docs.app.mjs
+++ b/components/google_docs/google_docs.app.mjs
@@ -97,6 +97,17 @@ export default {
       default: false,
       optional: true,
     },
+    replacementFormat: {
+      type: "string",
+      label: "Replacement Format",
+      description: "How to interpret the replacement text. `plain` inserts it exactly as typed (default). `markdown` converts Markdown syntax (bold, italic, inline code, links, headings, bullet and numbered lists) into native Google Docs formatting. Note that block-level Markdown (headings, lists) restyles the entire paragraph containing the match, since Google Docs applies paragraph styles per paragraph.",
+      options: [
+        "plain",
+        "markdown",
+      ],
+      default: "plain",
+      optional: true,
+    },
   },
   methods: {
     ...googleDrive.methods,
@@ -248,6 +259,12 @@ export default {
     // inside another table's cell are not included.
     flattenTables(content) {
       return utils.flattenTables(content);
+    },
+    _flattenDocumentTabs(tabs) {
+      return (tabs || []).flatMap((tab) => [
+        tab,
+        ...this._flattenDocumentTabs(tab.childTabs),
+      ]);
     },
     async deleteTable(documentId, {
       startIndex, endIndex,
@@ -408,6 +425,11 @@ export default {
         throw new Error(`Failed to insert markdown text: ${error.message}`);
       }
     },
+    // Replaces text and applies the formatting implied by the Markdown in the
+    // replacement string. `replaceAllText` reports how many occurrences it
+    // changed but not where they landed, so the ranges to style can only be
+    // found by re-reading the document afterwards and locating the inserted
+    // text by value.
     async replaceTextWithMarkdown({
       documentId,
       textToReplace,
@@ -415,79 +437,82 @@ export default {
       matchCase = false,
       tabIds = null,
     }) {
-      try {
-        // Parse the markdown replacement text
-        const parseResult = markdownParser.parseMarkdown(markdownReplacement);
-        const {
-          text: replacementText,
-          formattingRequests: markdownFormatting,
-        } = parseResult;
+      const {
+        text: parsedText,
+        formattingRequests: markdownFormatting,
+      } = markdownParser.parseMarkdown(markdownReplacement);
 
-        // Build the initial replace request
-        const requests = [
-          {
-            replaceAllText: {
-              containsText: {
-                text: textToReplace,
-                matchCase: matchCase || false,
-              },
-              replaceText: replacementText,
-              tabsCriteria: tabIds
-                ? {
-                  tabIds,
-                }
-                : undefined,
+      // parseMarkdown closes every paragraph with a newline, which is right when
+      // the markdown is a document body but wrong for an inline replacement: it
+      // splits the host sentence across two paragraphs.
+      const isBlockLevel = markdownFormatting.some(({ type }) =>
+        type === "updateParagraphStyle" || type === "createParagraphBullets");
+      const replacementText = isBlockLevel
+        ? parsedText
+        : parsedText.replace(/\n+$/, "");
+
+      const { data: replaceData } = await this.batchUpdate(documentId, [
+        {
+          replaceAllText: {
+            containsText: {
+              text: textToReplace,
+              matchCase,
             },
+            replaceText: replacementText,
+            tabsCriteria: tabIds?.length
+              ? {
+                tabIds,
+              }
+              : undefined,
           },
-        ];
+        },
+      ]);
+      const occurrencesChanged =
+        replaceData?.replies?.[0]?.replaceAllText?.occurrencesChanged ?? 0;
 
-        if (markdownFormatting.length === 0) {
-          // No formatting needed, just do the plain text replacement
-          return this.docs().documents.batchUpdate({
-            documentId,
-            requestBody: {
-              requests,
-            },
-          });
-        }
+      if (!occurrencesChanged || !markdownFormatting.length) {
+        return {
+          occurrencesChanged,
+          formattingRequestsApplied: 0,
+        };
+      }
 
-        // For markdown with formatting, we need to find where the text will be replaced
-        // and then apply formatting to it
-        // First, do the replacement
-        await this.docs().documents.batchUpdate({
-          documentId,
-          requestBody: {
-            requests,
-          },
-        });
+      const updatedDoc = await this.getDocument(documentId, true);
 
-        // Get the document AFTER replacement
-        const { data: updatedDocData } = await this.docs().documents.get({
-          documentId,
-        });
+      const targetTabs = this._flattenDocumentTabs(updatedDoc.tabs)
+        .filter(({ tabProperties }) => !tabIds?.length || tabIds.includes(tabProperties?.tabId));
 
-        // Find all occurrences of the replacement text in the updated document
-        const formattingRequests = markdownParser.buildFormattingRequestsForReplacement(
+      const formattingRequests = targetTabs.flatMap((tab) => {
+        const tabId = tab.tabProperties?.tabId;
+        const requests = markdownParser.buildFormattingRequestsForReplacement(
           markdownFormatting,
-          updatedDocData,
+          tab.documentTab,
           replacementText,
         );
-
-        // Apply formatting if any matches were found
-        if (formattingRequests.length > 0) {
-          return this.docs().documents.batchUpdate({
-            documentId,
-            requestBody: {
-              requests: formattingRequests,
+        return requests.map((request) => {
+          const [
+            requestName,
+          ] = Object.keys(request);
+          return {
+            [requestName]: {
+              ...request[requestName],
+              range: {
+                ...request[requestName].range,
+                tabId,
+              },
             },
-          });
-        }
+          };
+        });
+      });
 
-        // Return updated document even if no formatting was applied
-        return updatedDocData;
-      } catch (error) {
-        throw new Error(`Failed to replace text with markdown: ${error.message}`);
+      if (formattingRequests.length) {
+        await this.batchUpdate(documentId, formattingRequests);
       }
+
+      return {
+        occurrencesChanged,
+        formattingRequestsApplied: formattingRequests.length,
+      };
     },
   },
 };

--- a/components/google_docs/package.json
+++ b/components/google_docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_docs",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Pipedream Google_docs Components",
   "main": "google_docs.app.mjs",
   "keywords": [

--- a/components/google_docs/sources/new-document-created/new-document-created.mjs
+++ b/components/google_docs/sources/new-document-created/new-document-created.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_docs-new-document-created",
   name: "New Document Created (Instant)",
   description: "Emit new event when a new document is created in Google Docs. [See the documentation](https://developers.google.com/drive/api/reference/rest/v3/changes/watch)",
-  version: "0.0.11",
+  version: "0.0.12",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/google_docs/sources/new-or-updated-document/new-or-updated-document.mjs
+++ b/components/google_docs/sources/new-or-updated-document/new-or-updated-document.mjs
@@ -9,7 +9,7 @@ export default {
   key: "google_docs-new-or-updated-document",
   name: "New or Updated Document (Instant)",
   description: "Emit new event when a document is created or updated in Google Docs. [See the documentation](https://developers.google.com/drive/api/reference/rest/v3/changes/watch)",
-  version: "0.0.11",
+  version: "0.0.12",
   type: "source",
   dedupe: "unique",
   methods: {


### PR DESCRIPTION
## Summary

<!-- Add your PR description here -->
Closes #21745 
Restore `Markdown` support in the `Replace Text` action.

## Checklist
Please check the following items before your PR can be reviewed:

### Versioning
- [x] All components updated in this PR had their version updated (`0.0.1` for new ones)
- [x] The app updated in this PR had its `package.json`'s version updated

### New app
If this is a new app, please submit [an app integration request](https://github.com/PipedreamHQ/pipedream/issues/new?template=app---service-integration.md) - the PR will only be reviewed after the app is integrated.
- [x] The app updated in this PR is already integrated

### CodeRabbit review
After the PR is opened, and if new changes are pushed, CodeRabbit will automatically review it. Do not 'mark as resolved' CodeRabbit's comments, but reply to them instead, whether you agree (and update the PR accordingly) or disagree.
- [x] I have addressed or acknowledged all of CodeRabbit's review comments



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Google Docs text replacement now supports Markdown formatting.
  - Choose between plain-text and Markdown replacement behavior.
  - Markdown replacements report replacement and formatting counts.
  - Formatting is applied accurately across matching document tabs.

- **Improvements**
  - Improved inline Markdown handling, text matching, and complex document content support.
  - Enhanced compatibility with multi-tab documents.
  - Updated Google Docs actions, sources, and package versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->