### PR TITLE
fix(google_docs): let Replace Text render Markdown again

### DIFF
--- a/components/google_docs/actions/append-text/append-text.mjs
+++ b/components/google_docs/actions/append-text/append-text.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-append-text",
   name: "Append Text",
   description: "Append text to an existing document. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#InsertTextRequest)",
-  version: "0.1.14",
+  version: "0.1.15",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/create-document-from-template/create-document-from-template.mjs
+++ b/components/google_docs/actions/create-document-from-template/create-document-from-template.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_docs-create-document-from-template",
   name: "Create Document From Template",
   description: "Create a new Google Doc by copying a template document and substituting `{{placeholder}}` tokens with values. Use **Find Document** to resolve the template's name to its ID. Returns `{documentId, title, url}`. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#ReplaceAllTextRequest)",
-  version: "1.0.3",
+  version: "1.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/create-document/create-document.mjs
+++ b/components/google_docs/actions/create-document/create-document.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-create-document",
   name: "Create Document",
   description: "Create a new Google Doc with an optional body. The body is rendered as Markdown, so you can include headings (`# Title`), bold/italic, bullet/numbered lists, links, and code. Optionally place the doc in a specific Drive folder. Returns `{documentId, title, url}`. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/create)",
-  version: "1.0.3",
+  version: "1.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/delete-table/delete-table.mjs
+++ b/components/google_docs/actions/delete-table/delete-table.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_docs-delete-table",
   name: "Delete Table",
   description: "Remove an entire table, structure and contents, from the document. Use this to clear a table completely, including an empty table left behind after its text was removed. Set **Table Number** to pick which table to remove (1 = first top-level table in the document, in reading order; a table nested inside another table's cell doesn't count separately). Use **Get Document** first if you need to confirm how many tables exist. This also works on a table linked to a Google Sheet, since removal is treated as ordinary content deletion. Use **Find Document** to resolve a document's name to its ID. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#DeleteContentRangeRequest)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_docs/actions/export-document/export-document.mjs
+++ b/components/google_docs/actions/export-document/export-document.mjs
@@ -32,7 +32,7 @@ export default {
   key: "google_docs-export-document",
   name: "Export Document",
   description: "Export (download) a Google Doc to a file in PDF, DOCX, TXT, HTML, or ODT format. Use **Find Document** to resolve a document's name to its ID. The file is written to the workflow's temporary storage and a presigned download URL is returned to the caller. Returns `{filePath, filename, mimeType}`. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/export)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/find-document/find-document.mjs
+++ b/components/google_docs/actions/find-document/find-document.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-find-document",
   name: "Find Document",
   description: "Search for Google Docs by name or full-text content. Returns a list of `{id, name, url, modifiedTime}`. Use this first to resolve a document's name to its ID, then pass the `id` to **Get Document**, **Export Document**, or any of the insert/replace tools. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/list)",
-  version: "1.0.3",
+  version: "1.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/get-document/get-document.mjs
+++ b/components/google_docs/actions/get-document/get-document.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_docs-get-document",
   name: "Get Document",
   description: "Get the full text content and structure of a Google Doc by its ID. Returns the document body plus a flattened `textContent` field for easy reading. Optionally supply a `fields` mask to request a partial (e.g. metadata-only) response and skip the body-text enrichment. Use **Find Document** first to resolve a document's name to its ID. For multi-tab documents, pass a `tabId` to retrieve a single tab's content. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/get)",
-  version: "1.1.2",
+  version: "1.1.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/get-profile/get-profile.mjs
+++ b/components/google_docs/actions/get-profile/get-profile.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-get-profile",
   name: "Get Profile",
   description: "Get the identity (display name and email) of the currently authenticated Google account. Use this to answer \"who am I\" questions and to attribute documents to the current user. Resolves via the Drive `about.get` endpoint (no extra OAuth scope required). [See the documentation](https://developers.google.com/drive/api/v3/reference/about/get)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/insert-image/insert-image.mjs
+++ b/components/google_docs/actions/insert-image/insert-image.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-insert-image",
   name: "Insert Image",
   description: "Insert an inline image into a Google Doc from a publicly reachable image URL. The URL must be publicly accessible (Google fetches it server-side) and point to a PNG, JPEG, or GIF. Use **Find Document** to resolve a document's name to its ID. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#InsertInlineImageRequest)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/insert-page-break/insert-page-break.mjs
+++ b/components/google_docs/actions/insert-page-break/insert-page-break.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-insert-page-break",
   name: "Insert Page Break",
   description: "Insert a page break into a Google Doc at the beginning, end, or a specific character index. Use **Find Document** to resolve a document's name to its ID. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#InsertPageBreakRequest)",
-  version: "1.0.3",
+  version: "1.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/insert-table/insert-table.mjs
+++ b/components/google_docs/actions/insert-table/insert-table.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-insert-table",
   name: "Insert Table",
   description: "Insert an empty table with the given number of rows and columns into a Google Doc. If you already have the data, use **Write Table** instead so you don't have to fill cells one by one. Use **Find Document** to resolve a document's name to its ID. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#InsertTableRequest)",
-  version: "1.0.3",
+  version: "1.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/insert-text/insert-text.mjs
+++ b/components/google_docs/actions/insert-text/insert-text.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-insert-text",
   name: "Insert Text",
   description: "Insert text into a Google Doc at the beginning, end, or a specific character index. Use **Find Document** to resolve a document's name to its ID. To append text to the end of a doc, use `position: end` (the default). [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#InsertTextRequest)",
-  version: "1.0.3",
+  version: "1.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/list-comments/list-comments.mjs
+++ b/components/google_docs/actions/list-comments/list-comments.mjs
@@ -9,7 +9,7 @@ export default {
   key: "google_docs-list-comments",
   name: "List Comments",
   description: "List the comments on a Google Doc, including each comment's author, plain text and HTML content, the document text it is anchored to, whether it is resolved, and its full reply thread. Comments on a Doc are served by the Drive API, so the document ID doubles as the file ID. Use **Find Document** first to resolve a document's name to its ID. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/comments/list)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/actions/replace-image/replace-image.mjs
+++ b/components/google_docs/actions/replace-image/replace-image.mjs
@@ -4,7 +4,7 @@ export default {
   key: "google_docs-replace-image",
   name: "Replace Image",
   description: "Replace image in a existing document. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#ReplaceImageRequest)",
-  version: "0.0.15",
+  version: "0.0.16",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_docs/actions/replace-text/replace-text.mjs
+++ b/components/google_docs/actions/replace-text/replace-text.mjs
@@ -3,8 +3,8 @@ import googleDocs from "../../google_docs.app.mjs";
 export default {
   key: "google_docs-replace-text",
   name: "Replace Text",
-  description: "Find and replace all occurrences of a string in a Google Doc. Use **Find Document** to resolve a document's name to its ID. Returns the number of replacements made. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#ReplaceAllTextRequest)",
-  version: "1.0.3",
+  description: "Find and replace all occurrences of a string in a Google Doc. The replacement can be written in Markdown. Use **Find Document** to resolve a document's name to its ID. Returns the number of replacements made. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#ReplaceAllTextRequest)",
+  version: "1.1.0",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
@@ -27,7 +27,14 @@ export default {
     replace: {
       type: "string",
       label: "Replace",
-      description: "The text to replace each match with.",
+      description: "The text to replace each match with. Markdown syntax in this value is converted to Google Docs formatting when **Parse as Markdown** is enabled.",
+    },
+    enableMarkdown: {
+      type: "boolean",
+      label: "Parse as Markdown",
+      description: "Convert Markdown in the replacement to Google Docs formatting, so `**bold**`, `*italic*`, `` `code` ``, `[links](url)`, headings and lists render as formatted text rather than literal characters. Defaults to `false`, which inserts the replacement exactly as written.",
+      default: false,
+      optional: true,
     },
     matchCase: {
       propDefinition: [
@@ -37,13 +44,20 @@ export default {
     },
   },
   async run({ $ }) {
-    const { data } = await this.googleDocs.replaceText(this.documentId, {
-      replaceText: this.replace,
-      containsText: {
-        text: this.find,
+    const { data } = this.enableMarkdown
+      ? await this.googleDocs.replaceTextWithMarkdown({
+        documentId: this.documentId,
+        textToReplace: this.find,
+        markdownReplacement: this.replace,
         matchCase: this.matchCase,
-      },
-    });
+      })
+      : await this.googleDocs.replaceText(this.documentId, {
+        replaceText: this.replace,
+        containsText: {
+          text: this.find,
+          matchCase: this.matchCase,
+        },
+      });
     const occurrences = data?.replies?.[0]?.replaceAllText?.occurrencesChanged ?? 0;
     $.export("$summary", `Replaced ${occurrences} occurrence${occurrences === 1
       ? ""

--- a/components/google_docs/actions/write-table/write-table.mjs
+++ b/components/google_docs/actions/write-table/write-table.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_docs-write-table",
   name: "Write Table",
   description: "Create a table and fill it with data in a single step. Provide the entire table (all rows and columns, including a header row) at once. Use this instead of inserting cells or text one at a time. The action places every value in the correct cell for you. Pass **Table Data** as a JSON array of arrays, one inner array per row, header row first when **Has Header Row** is set, e.g. `[[\"Name\",\"Role\"],[\"Ada\",\"Engineer\"]]`. Use **Find Document** to resolve a document's name to its ID, or **Insert Table** instead if you only need an empty grid to fill in later. Note: a table written this way is always static — the Google Docs API does not create or preserve a live link to a Google Sheet, even when this replaces a Sheets-linked table. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#InsertTableRequest)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_docs/google_docs.app.mjs
+++ b/components/google_docs/google_docs.app.mjs
@@ -441,41 +441,33 @@ export default {
           },
         ];
 
-        if (markdownFormatting.length === 0) {
-          // No formatting needed, just do the plain text replacement
-          return this.docs().documents.batchUpdate({
-            documentId,
-            requestBody: {
-              requests,
-            },
-          });
-        }
-
-        // For markdown with formatting, we need to find where the text will be replaced
-        // and then apply formatting to it
-        // First, do the replacement
-        await this.docs().documents.batchUpdate({
+        // Only this call reports how many matches it changed; the formatting
+        // pass that may follow does not, so keep its response to return.
+        const replacement = await this.docs().documents.batchUpdate({
           documentId,
           requestBody: {
             requests,
           },
         });
 
-        // Get the document AFTER replacement
+        const occurrencesChanged =
+          replacement?.data?.replies?.[0]?.replaceAllText?.occurrencesChanged ?? 0;
+        if (markdownFormatting.length === 0 || occurrencesChanged === 0) {
+          return replacement;
+        }
+
+        // Formatting is applied by position, so it has to be resolved against
+        // the document as it looks after the replacement.
         const { data: updatedDocData } = await this.docs().documents.get({
           documentId,
         });
-
-        // Find all occurrences of the replacement text in the updated document
         const formattingRequests = markdownParser.buildFormattingRequestsForReplacement(
           markdownFormatting,
           updatedDocData,
           replacementText,
         );
-
-        // Apply formatting if any matches were found
         if (formattingRequests.length > 0) {
-          return this.docs().documents.batchUpdate({
+          await this.docs().documents.batchUpdate({
             documentId,
             requestBody: {
               requests: formattingRequests,
@@ -483,8 +475,7 @@ export default {
           });
         }
 
-        // Return updated document even if no formatting was applied
-        return updatedDocData;
+        return replacement;
       } catch (error) {
         throw new Error(`Failed to replace text with markdown: ${error.message}`);
       }

--- a/components/google_docs/google_docs.app.mjs
+++ b/components/google_docs/google_docs.app.mjs
@@ -443,12 +443,7 @@ export default {
 
         // Only this call reports how many matches it changed; the formatting
         // pass that may follow does not, so keep its response to return.
-        const replacement = await this.docs().documents.batchUpdate({
-          documentId,
-          requestBody: {
-            requests,
-          },
-        });
+        const replacement = await this.batchUpdate(documentId, requests);
 
         const occurrencesChanged =
           replacement?.data?.replies?.[0]?.replaceAllText?.occurrencesChanged ?? 0;
@@ -467,12 +462,7 @@ export default {
           replacementText,
         );
         if (formattingRequests.length > 0) {
-          await this.docs().documents.batchUpdate({
-            documentId,
-            requestBody: {
-              requests: formattingRequests,
-            },
-          });
+          await this.batchUpdate(documentId, formattingRequests);
         }
 
         return replacement;

--- a/components/google_docs/package.json
+++ b/components/google_docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_docs",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Pipedream Google_docs Components",
   "main": "google_docs.app.mjs",
   "keywords": [

--- a/components/google_docs/sources/new-document-created/new-document-created.mjs
+++ b/components/google_docs/sources/new-document-created/new-document-created.mjs
@@ -5,7 +5,7 @@ export default {
   key: "google_docs-new-document-created",
   name: "New Document Created (Instant)",
   description: "Emit new event when a new document is created in Google Docs. [See the documentation](https://developers.google.com/drive/api/reference/rest/v3/changes/watch)",
-  version: "0.0.11",
+  version: "0.0.12",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/google_docs/sources/new-or-updated-document/new-or-updated-document.mjs
+++ b/components/google_docs/sources/new-or-updated-document/new-or-updated-document.mjs
@@ -9,7 +9,7 @@ export default {
   key: "google_docs-new-or-updated-document",
   name: "New or Updated Document (Instant)",
   description: "Emit new event when a document is created or updated in Google Docs. [See the documentation](https://developers.google.com/drive/api/reference/rest/v3/changes/watch)",
-  version: "0.0.11",
+  version: "0.0.12",
   type: "source",
   dedupe: "unique",
   methods: {


### PR DESCRIPTION
## Summary

Closes #21745.

**Replace Text** used to convert a Markdown replacement into Google Docs formatting. It stopped when #21273 rewrote the action for MCP: moving it from `0.0.11` to `1.0.0` dropped the `enableMarkdown` prop, the branch that called `replaceTextWithMarkdown`, and the sentence in the description that promised the feature. `replaceTextWithMarkdown` itself was left in `google_docs.app.mjs` with **no callers anywhere in the repo**, which is what makes this look like collateral damage rather than an intentional removal — `create-document` kept its Markdown path (`insertMarkdownText`) through the same rewrite.

The effect today: replacing a placeholder with `**Quarterly report** is ready` puts the asterisks in the document.

Two changes:

- **The option is back**, as an optional boolean defaulting to `false`, so a plain replacement behaves exactly as it does now. The dead method is wired up again rather than reimplemented.
- **`replaceTextWithMarkdown` now returns the replacement response in every path.** It used to return whichever `batchUpdate` ran last — the *formatting* pass whenever there was formatting to apply — and that response carries no `occurrencesChanged`, so the count this action reports since `1.0.0` would have come back as `0` for exactly the cases the option exists for. It also no longer fetches the document to place formatting when nothing matched.

`tabIds`, the other prop that rewrite dropped, is left alone — that is a separate question from the one the issue raises.

## Checklist

### Versioning
- [x] All components updated in this PR had their version updated (`0.0.1` for new ones)
- [x] The app updated in this PR had its `package.json`'s version updated

`replace-text` `1.0.3 → 1.1.0` for the new optional prop. `google_docs.app.mjs` changed, and every component in the app imports it, so the other 16 carry a patch bump and the two sources that reach it through `sources/common/base.mjs` do too. App `1.3.0 → 1.4.0`.

### New app
- [x] The app updated in this PR is already integrated

### CodeRabbit review
- [x] I have addressed or acknowledged all of CodeRabbit's review comments

CodeRabbit raised one point, answered in thread. It was half right and that half is applied in c2ffa6ef: both writes in `replaceTextWithMarkdown` now go through the app's existing `batchUpdate(documentId, requests)` helper instead of reaching past it to the client. I did not take the other half — moving the method to `axios` from `@pipedream/platform` via a `_makeRequest()` helper — because neither exists in this app (0 hits for each) while `this.docs()` / `this.drive()` are used in 10 places, so it would make this one method the only part of the file not using the official client. That is an app-wide decision for a maintainer, not something to fold into a bug fix.

## How this was checked

I have no Google account connected to this repo, so this was not run against the Docs API. Instead I ran the action from both `master` and this branch against a stub that records the requests it is handed, and compared:

```
the prop the issue is about:
  before: no Parse as Markdown prop                     v1.0.3
  after:  prop is back, optional, defaults to off       v1.1.0

what reaches the Docs API for replace = "**Quarterly report** is ready":
  before:            replaceText = "**Quarterly report** is ready"   <- the bug
  after, Markdown off: replaceText = "**Quarterly report** is ready"  <- unchanged
  after, Markdown on:  replaceText = "Quarterly report is ready\n"
                       + updateTextStyle request with textStyle.bold

the count the action reports:
  plain path     {"documentId":"doc-1","occurrencesChanged":2}
  markdown path  {"documentId":"doc-1","occurrencesChanged":2}
  summary        Replaced 2 occurrences of "PLACEHOLDER" in document doc-1
```

`node --check` passes on every changed module.

One thing a reviewer with a real document should confirm: the parser appends a trailing newline to the replacement text (`"Quarterly report is ready\n"`). That comes from `markdown-parser.mjs` and predates this change — it is how the feature behaved before #21273 too — but it is the kind of detail that only shows up in a live document.

## AI assistance disclosure

The diagnosis, the change and this description were produced by Claude Opus 5 running in Claude Code, directed by @MLuc24. The regression was traced to a specific commit by reading its diff, and the before/after behaviour above was measured by executing both versions rather than reasoned about.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional Markdown support when replacing text in Google Docs.
  - Replacement formatting is applied only when matching text is found.
  - Existing plain-text replacement remains the default.

- **Improvements**
  - Improved response handling for Markdown replacements.
  - Updated Google Docs actions and triggers to their latest versions.
  - Updated the Google Docs integration release to version 1.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->