### PR TITLE
[21746] feat(google_docs): add text, paragraph, and table styling actions

### DIFF
--- a/components/google_docs/actions/update-paragraph-style/update-paragraph-style.mjs
+++ b/components/google_docs/actions/update-paragraph-style/update-paragraph-style.mjs
@@ -22,21 +22,22 @@ export default {
       ],
     },
     startIndex: {
-      type: "integer",
-      label: "Start Index",
+      propDefinition: [
+        googleDocs,
+        "startIndex",
+      ],
       description: "The character index where the range begins, counting from the start of the document body. Must be at least `1`. Every paragraph that overlaps the range is restyled, even if the range covers only part of it.",
-      min: 1,
     },
     endIndex: {
-      type: "integer",
-      label: "End Index",
-      description: "The character index where the range ends, exclusive. Must be greater than **Start Index**.",
-      min: 2,
+      propDefinition: [
+        googleDocs,
+        "endIndex",
+      ],
     },
     namedStyleType: {
       type: "string",
       label: "Named Style",
-      description: "Apply a built-in Google Docs paragraph style, such as a heading level. This is what the style dropdown in the Docs toolbar sets.",
+      description: "The named paragraph style to apply. `NORMAL_TEXT` is body text, `TITLE` and `SUBTITLE` are document-level styles, and `HEADING_1` through `HEADING_6` are section headings in descending order of prominence.",
       optional: true,
       options: [
         "NORMAL_TEXT",
@@ -53,7 +54,7 @@ export default {
     alignment: {
       type: "string",
       label: "Alignment",
-      description: "How the paragraph's text is aligned. `START` is left-aligned in a left-to-right document.",
+      description: "How the paragraph text is aligned. `START` and `END` align to the leading and trailing margin for the text direction (left and right respectively in a left-to-right document), `CENTER` centers it, and `JUSTIFIED` stretches it to both margins.",
       optional: true,
       options: [
         "START",
@@ -107,13 +108,13 @@ export default {
     keepLinesTogether: {
       type: "boolean",
       label: "Keep Lines Together",
-      description: "Set `true` to stop the paragraph from being split across a page break where possible.",
+      description: "`true` keeps the paragraph lines on a single page where possible; `false` allows it to break across pages. Omit to leave the paragraph current setting untouched.",
       optional: true,
     },
     keepWithNext: {
       type: "boolean",
       label: "Keep With Next",
-      description: "Set `true` to keep at least part of this paragraph on the same page as the paragraph that follows it.",
+      description: "`true` keeps at least part of this paragraph on the same page as the paragraph that follows it; `false` allows them to be separated. Omit to leave the paragraph current setting untouched.",
       optional: true,
     },
     tabId: {

--- a/components/google_docs/actions/update-paragraph-style/update-paragraph-style.mjs
+++ b/components/google_docs/actions/update-paragraph-style/update-paragraph-style.mjs
@@ -1,0 +1,157 @@
+import { ConfigurationError } from "@pipedream/platform";
+import googleDocs from "../../google_docs.app.mjs";
+import styling from "../../common/styling.mjs";
+
+export default {
+  key: "google_docs-update-paragraph-style",
+  name: "Update Paragraph Style",
+  description: "Apply paragraph formatting — heading level, alignment, line spacing, indentation, or spacing above and below — to every paragraph overlapping a range in a Google Doc. Only the options you fill in are changed; everything you leave blank keeps its current formatting. Use **Get Document** to find the start and end index of the paragraphs you want to style. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#UpdateParagraphStyleRequest)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  type: "action",
+  props: {
+    googleDocs,
+    documentId: {
+      propDefinition: [
+        googleDocs,
+        "documentId",
+      ],
+    },
+    startIndex: {
+      type: "integer",
+      label: "Start Index",
+      description: "The character index where the range begins, counting from the start of the document body. Must be at least `1`. Every paragraph that overlaps the range is restyled, even if the range covers only part of it.",
+      min: 1,
+    },
+    endIndex: {
+      type: "integer",
+      label: "End Index",
+      description: "The character index where the range ends, exclusive. Must be greater than **Start Index**.",
+      min: 2,
+    },
+    namedStyleType: {
+      type: "string",
+      label: "Named Style",
+      description: "Apply a built-in Google Docs paragraph style, such as a heading level. This is what the style dropdown in the Docs toolbar sets.",
+      optional: true,
+      options: [
+        "NORMAL_TEXT",
+        "TITLE",
+        "SUBTITLE",
+        "HEADING_1",
+        "HEADING_2",
+        "HEADING_3",
+        "HEADING_4",
+        "HEADING_5",
+        "HEADING_6",
+      ],
+    },
+    alignment: {
+      type: "string",
+      label: "Alignment",
+      description: "How the paragraph's text is aligned. `START` is left-aligned in a left-to-right document.",
+      optional: true,
+      options: [
+        "START",
+        "CENTER",
+        "END",
+        "JUSTIFIED",
+      ],
+    },
+    lineSpacing: {
+      type: "integer",
+      label: "Line Spacing",
+      description: "Line spacing as a percentage of normal, where `100` is single-spaced, `150` is one-and-a-half, and `200` is double-spaced.",
+      optional: true,
+      min: 1,
+    },
+    spaceAbove: {
+      type: "integer",
+      label: "Space Above",
+      description: "Extra space above the paragraph, in points.",
+      optional: true,
+      min: 0,
+    },
+    spaceBelow: {
+      type: "integer",
+      label: "Space Below",
+      description: "Extra space below the paragraph, in points.",
+      optional: true,
+      min: 0,
+    },
+    indentStart: {
+      type: "integer",
+      label: "Indent Start",
+      description: "Indentation of the whole paragraph from the start-side margin, in points (the left margin in a left-to-right document).",
+      optional: true,
+      min: 0,
+    },
+    indentEnd: {
+      type: "integer",
+      label: "Indent End",
+      description: "Indentation of the whole paragraph from the end-side margin, in points.",
+      optional: true,
+      min: 0,
+    },
+    indentFirstLine: {
+      type: "integer",
+      label: "First Line Indent",
+      description: "Indentation of the paragraph's first line only, in points.",
+      optional: true,
+      min: 0,
+    },
+    keepLinesTogether: {
+      type: "boolean",
+      label: "Keep Lines Together",
+      description: "Set `true` to stop the paragraph from being split across a page break where possible.",
+      optional: true,
+    },
+    keepWithNext: {
+      type: "boolean",
+      label: "Keep With Next",
+      description: "Set `true` to keep at least part of this paragraph on the same page as the paragraph that follows it.",
+      optional: true,
+    },
+    tabId: {
+      propDefinition: [
+        googleDocs,
+        "tabId",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const range = styling.buildRange(this.startIndex, this.endIndex, this.tabId);
+
+    const {
+      style, fields, isEmpty,
+    } = styling.buildStyle({
+      namedStyleType: this.namedStyleType,
+      alignment: this.alignment,
+      lineSpacing: this.lineSpacing,
+      keepLinesTogether: this.keepLinesTogether,
+      keepWithNext: this.keepWithNext,
+      spaceAbove: styling.points(this.spaceAbove),
+      spaceBelow: styling.points(this.spaceBelow),
+      indentStart: styling.points(this.indentStart),
+      indentEnd: styling.points(this.indentEnd),
+      indentFirstLine: styling.points(this.indentFirstLine),
+    });
+
+    if (isEmpty) {
+      throw new ConfigurationError("Set at least one style option (e.g. Named Style, Alignment, or Line Spacing) — otherwise there is nothing to update.");
+    }
+
+    await this.googleDocs._batchUpdate(this.documentId, "updateParagraphStyle", {
+      range,
+      paragraphStyle: style,
+      fields,
+    });
+
+    $.export("$summary", `Updated paragraph style for characters ${range.startIndex}–${range.endIndex} in document ${this.documentId}`);
+    return this.googleDocs.getDocument(this.documentId);
+  },
+};

--- a/components/google_docs/actions/update-paragraph-style/update-paragraph-style.mjs
+++ b/components/google_docs/actions/update-paragraph-style/update-paragraph-style.mjs
@@ -152,7 +152,7 @@ export default {
       fields,
     });
 
-    $.export("$summary", `Updated paragraph style for characters ${range.startIndex}–${range.endIndex} in document ${this.documentId}`);
+    $.export("$summary", `Updated the style of every paragraph overlapping indexes ${range.startIndex}–${range.endIndex} in document ${this.documentId}`);
     return this.googleDocs.getDocumentOrTab(this.documentId, this.tabId);
   },
 };

--- a/components/google_docs/actions/update-paragraph-style/update-paragraph-style.mjs
+++ b/components/google_docs/actions/update-paragraph-style/update-paragraph-style.mjs
@@ -26,7 +26,7 @@ export default {
         googleDocs,
         "startIndex",
       ],
-      description: "The character index where the range begins, counting from the start of the document body. Must be at least `1`. Every paragraph that overlaps the range is restyled, even if the range covers only part of it.",
+      description: "The index where the range begins, counted in zero-based UTF-16 code units from the start of the document body — not in Unicode characters, so astral characters such as emoji count as two. Must be at least `1`. Every paragraph that overlaps the range is restyled, even if the range covers only part of it.",
     },
     endIndex: {
       propDefinition: [
@@ -146,13 +146,13 @@ export default {
       throw new ConfigurationError("Set at least one style option (e.g. Named Style, Alignment, or Line Spacing) — otherwise there is nothing to update.");
     }
 
-    await this.googleDocs._batchUpdate(this.documentId, "updateParagraphStyle", {
+    await this.googleDocs.updateParagraphStyle(this.documentId, {
       range,
       paragraphStyle: style,
       fields,
     });
 
     $.export("$summary", `Updated paragraph style for characters ${range.startIndex}–${range.endIndex} in document ${this.documentId}`);
-    return this.googleDocs.getDocument(this.documentId);
+    return this.googleDocs.getDocumentOrTab(this.documentId, this.tabId);
   },
 };

--- a/components/google_docs/actions/update-table-cell-style/update-table-cell-style.mjs
+++ b/components/google_docs/actions/update-table-cell-style/update-table-cell-style.mjs
@@ -24,7 +24,7 @@ export default {
     tableStartIndex: {
       type: "integer",
       label: "Table Start Index",
-      description: "The character index at which the table begins. Use **Get Document** and read the `startIndex` of the element whose `table` field you want to style.",
+      description: "The index at which the table begins, in zero-based UTF-16 code units. Use **Get Document** and read the `startIndex` of the element whose `table` field you want to style.",
       min: 1,
     },
     rowIndex: {
@@ -202,7 +202,7 @@ export default {
       throw new ConfigurationError("Set at least one style option (e.g. Background Color, Border Width, or Padding Top) — otherwise there is nothing to update.");
     }
 
-    await this.googleDocs._batchUpdate(this.documentId, "updateTableCellStyle", {
+    await this.googleDocs.updateTableCellStyle(this.documentId, {
       ...target,
       tableCellStyle: style,
       fields,
@@ -212,6 +212,6 @@ export default {
       ? `cells at row ${this.rowIndex}, column ${this.columnIndex}`
       : "all cells";
     $.export("$summary", `Updated ${scope} in the table at index ${this.tableStartIndex} of document ${this.documentId}`);
-    return this.googleDocs.getDocument(this.documentId);
+    return this.googleDocs.getDocumentOrTab(this.documentId, this.tabId);
   },
 };

--- a/components/google_docs/actions/update-table-cell-style/update-table-cell-style.mjs
+++ b/components/google_docs/actions/update-table-cell-style/update-table-cell-style.mjs
@@ -1,0 +1,217 @@
+import { ConfigurationError } from "@pipedream/platform";
+import googleDocs from "../../google_docs.app.mjs";
+import styling from "../../common/styling.mjs";
+
+export default {
+  key: "google_docs-update-table-cell-style",
+  name: "Update Table Cell Style",
+  description: "Apply cell formatting — background color, borders, padding, or vertical alignment — to one cell, a block of cells, or an entire table in a Google Doc. Leave **Row Index** and **Column Index** blank to restyle the whole table. Only the options you fill in are changed. Use **Get Document** to find the table's start index. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#UpdateTableCellStyleRequest)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  type: "action",
+  props: {
+    googleDocs,
+    documentId: {
+      propDefinition: [
+        googleDocs,
+        "documentId",
+      ],
+    },
+    tableStartIndex: {
+      type: "integer",
+      label: "Table Start Index",
+      description: "The character index at which the table begins. Use **Get Document** and read the `startIndex` of the element whose `table` field you want to style.",
+      min: 1,
+    },
+    rowIndex: {
+      type: "integer",
+      label: "Row Index",
+      description: "Zero-based index of the first row to style. Leave blank — along with **Column Index** — to style every cell in the table.",
+      optional: true,
+      min: 0,
+    },
+    columnIndex: {
+      type: "integer",
+      label: "Column Index",
+      description: "Zero-based index of the first column to style. Leave blank — along with **Row Index** — to style every cell in the table.",
+      optional: true,
+      min: 0,
+    },
+    rowSpan: {
+      type: "integer",
+      label: "Row Span",
+      description: "How many rows the styled block covers, starting at **Row Index**. Defaults to `1`. Ignored when styling the whole table.",
+      optional: true,
+      min: 1,
+    },
+    columnSpan: {
+      type: "integer",
+      label: "Column Span",
+      description: "How many columns the styled block covers, starting at **Column Index**. Defaults to `1`. Ignored when styling the whole table.",
+      optional: true,
+      min: 1,
+    },
+    backgroundColor: {
+      type: "string",
+      label: "Background Color",
+      description: "Cell background color as a 6-digit hex code (e.g. `#EEEEEE`).",
+      optional: true,
+    },
+    borderColor: {
+      type: "string",
+      label: "Border Color",
+      description: "Border color as a 6-digit hex code (e.g. `#000000`). Applied to all four sides of each cell in range.",
+      optional: true,
+    },
+    borderWidth: {
+      type: "integer",
+      label: "Border Width",
+      description: "Border width in points (e.g. `1`). Applied to all four sides of each cell in range.",
+      optional: true,
+      min: 0,
+    },
+    borderDashStyle: {
+      type: "string",
+      label: "Border Dash Style",
+      description: "Border line style. Applied to all four sides of each cell in range.",
+      optional: true,
+      options: [
+        "SOLID",
+        "DOT",
+        "DASH",
+      ],
+    },
+    paddingTop: {
+      type: "integer",
+      label: "Padding Top",
+      description: "Space between the cell's top border and its content, in points.",
+      optional: true,
+      min: 0,
+    },
+    paddingBottom: {
+      type: "integer",
+      label: "Padding Bottom",
+      description: "Space between the cell's bottom border and its content, in points.",
+      optional: true,
+      min: 0,
+    },
+    paddingLeft: {
+      type: "integer",
+      label: "Padding Left",
+      description: "Space between the cell's left border and its content, in points.",
+      optional: true,
+      min: 0,
+    },
+    paddingRight: {
+      type: "integer",
+      label: "Padding Right",
+      description: "Space between the cell's right border and its content, in points.",
+      optional: true,
+      min: 0,
+    },
+    contentAlignment: {
+      type: "string",
+      label: "Content Alignment",
+      description: "How content sits vertically within the cell.",
+      optional: true,
+      options: [
+        "TOP",
+        "MIDDLE",
+        "BOTTOM",
+      ],
+    },
+    tabId: {
+      propDefinition: [
+        googleDocs,
+        "tabId",
+      ],
+    },
+  },
+  methods: {
+    // `updateTableCellStyle` targets either a block of cells (`tableRange`) or the
+    // whole table (`tableStartLocation`) — never both. Row and column index have to
+    // arrive together, since a range anchored on only one axis is meaningless.
+    buildTarget() {
+      const tableStartLocation = {
+        index: this.tableStartIndex,
+      };
+      if (this.tabId) {
+        tableStartLocation.tabId = this.tabId;
+      }
+
+      const hasRow = this.rowIndex !== undefined && this.rowIndex !== null;
+      const hasColumn = this.columnIndex !== undefined && this.columnIndex !== null;
+
+      if (hasRow !== hasColumn) {
+        throw new ConfigurationError("Set both Row Index and Column Index to style a specific block of cells, or leave both blank to style the entire table.");
+      }
+
+      if (!hasRow) {
+        return {
+          tableStartLocation,
+        };
+      }
+
+      return {
+        tableRange: {
+          tableCellLocation: {
+            tableStartLocation,
+            rowIndex: this.rowIndex,
+            columnIndex: this.columnIndex,
+          },
+          rowSpan: this.rowSpan ?? 1,
+          columnSpan: this.columnSpan ?? 1,
+        },
+      };
+    },
+  },
+  async run({ $ }) {
+    const target = this.buildTarget();
+
+    // The API models each side separately, but a per-side editor would mean twelve
+    // more props for a case the Docs UI itself treats as one control.
+    const border = styling.buildStyle({
+      color: styling.optionalColor(this.borderColor, "Border Color"),
+      width: styling.points(this.borderWidth),
+      dashStyle: this.borderDashStyle,
+    });
+    const sideBorder = border.isEmpty
+      ? undefined
+      : border.style;
+
+    const {
+      style, fields, isEmpty,
+    } = styling.buildStyle({
+      contentAlignment: this.contentAlignment,
+      backgroundColor: styling.optionalColor(this.backgroundColor, "Background Color"),
+      borderTop: sideBorder,
+      borderBottom: sideBorder,
+      borderLeft: sideBorder,
+      borderRight: sideBorder,
+      paddingTop: styling.points(this.paddingTop),
+      paddingBottom: styling.points(this.paddingBottom),
+      paddingLeft: styling.points(this.paddingLeft),
+      paddingRight: styling.points(this.paddingRight),
+    });
+
+    if (isEmpty) {
+      throw new ConfigurationError("Set at least one style option (e.g. Background Color, Border Width, or Padding Top) — otherwise there is nothing to update.");
+    }
+
+    await this.googleDocs._batchUpdate(this.documentId, "updateTableCellStyle", {
+      ...target,
+      tableCellStyle: style,
+      fields,
+    });
+
+    const scope = target.tableRange
+      ? `cells at row ${this.rowIndex}, column ${this.columnIndex}`
+      : "all cells";
+    $.export("$summary", `Updated ${scope} in the table at index ${this.tableStartIndex} of document ${this.documentId}`);
+    return this.googleDocs.getDocument(this.documentId);
+  },
+};

--- a/components/google_docs/actions/update-text-style/update-text-style.mjs
+++ b/components/google_docs/actions/update-text-style/update-text-style.mjs
@@ -5,7 +5,7 @@ import styling from "../../common/styling.mjs";
 export default {
   key: "google_docs-update-text-style",
   name: "Update Text Style",
-  description: "Apply character formatting — bold, italic, underline, font, size, color, or a link — to a range of text in a Google Doc. Only the options you fill in are changed; everything you leave blank keeps its current formatting. Use **Get Document** to find the start and end index of the text you want to style, or **Find Document** to resolve a document's name to its ID. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#UpdateTextStyleRequest)",
+  description: "Apply character formatting — bold, italic, underline, font, size, color, or a link — to a range of text in a Google Doc. Only the options you fill in are changed; everything you leave blank keeps its current formatting — except that setting **Font Family** without **Font Weight** resets the range weight to the API default of `400`. Use **Get Document** to find the start and end index of the text you want to style, or **Find Document** to resolve a document's name to its ID. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#UpdateTextStyleRequest)",
   version: "0.0.1",
   annotations: {
     destructiveHint: false,
@@ -22,51 +22,51 @@ export default {
       ],
     },
     startIndex: {
-      type: "integer",
-      label: "Start Index",
-      description: "The character index where the styled range begins, counting from the start of the document body. Must be at least `1`. Use **Get Document** to inspect the document's structure and locate the range.",
-      min: 1,
+      propDefinition: [
+        googleDocs,
+        "startIndex",
+      ],
     },
     endIndex: {
-      type: "integer",
-      label: "End Index",
-      description: "The character index where the styled range ends, exclusive. Must be greater than **Start Index**.",
-      min: 2,
+      propDefinition: [
+        googleDocs,
+        "endIndex",
+      ],
     },
     bold: {
       type: "boolean",
       label: "Bold",
-      description: "Set `true` to bold the range, or `false` to explicitly remove bold. Leave blank to keep the current setting.",
+      description: "`true` bolds the range; `false` removes bold. Omit to leave the range current bold setting untouched.",
       optional: true,
     },
     italic: {
       type: "boolean",
       label: "Italic",
-      description: "Set `true` to italicize the range, or `false` to explicitly remove italics. Leave blank to keep the current setting.",
+      description: "`true` italicizes the range; `false` removes italics. Omit to leave the range current italic setting untouched.",
       optional: true,
     },
     underline: {
       type: "boolean",
       label: "Underline",
-      description: "Set `true` to underline the range, or `false` to explicitly remove the underline. Leave blank to keep the current setting.",
+      description: "`true` underlines the range; `false` removes the underline. Omit to leave the range current underline setting untouched.",
       optional: true,
     },
     strikethrough: {
       type: "boolean",
       label: "Strikethrough",
-      description: "Set `true` to strike through the range, or `false` to explicitly remove it. Leave blank to keep the current setting.",
+      description: "`true` strikes through the range; `false` removes the strikethrough. Omit to leave the range current setting untouched.",
       optional: true,
     },
     smallCaps: {
       type: "boolean",
       label: "Small Caps",
-      description: "Set `true` to render the range in small capitals, or `false` to explicitly remove it. Leave blank to keep the current setting.",
+      description: "`true` renders the range in small capitals; `false` returns it to normal casing. Omit to leave the range current setting untouched.",
       optional: true,
     },
     fontFamily: {
       type: "string",
       label: "Font Family",
-      description: "The font to apply, named exactly as it appears in the Google Docs font menu (e.g. `Roboto`, `Times New Roman`).",
+      description: "The font family to apply, as a font name Google Docs recognizes (e.g. `Roboto`, `Times New Roman`, `Arial`). Setting this without **Font Weight** applies the API default weight of `400`, which clears an existing bold weight on the range.",
       optional: true,
     },
     fontSize: {
@@ -75,6 +75,14 @@ export default {
       description: "The font size in points (e.g. `12`).",
       optional: true,
       min: 1,
+    },
+    fontWeight: {
+      type: "integer",
+      label: "Font Weight",
+      description: "Weight of the font as a multiple of 100 between `100` and `900`, where `400` is normal and `700` is bold. Only valid alongside **Font Family**. Set it whenever you change the font on text that should stay heavy, since the API otherwise defaults the weight to `400`.",
+      optional: true,
+      min: 100,
+      max: 900,
     },
     foregroundColor: {
       type: "string",
@@ -91,7 +99,7 @@ export default {
     baselineOffset: {
       type: "string",
       label: "Baseline Offset",
-      description: "Render the range raised or lowered relative to the normal baseline.",
+      description: "Vertical offset of the range relative to the normal baseline. `NONE` sits on the baseline, `SUPERSCRIPT` raises it, `SUBSCRIPT` lowers it.",
       optional: true,
       options: [
         "NONE",
@@ -115,11 +123,24 @@ export default {
   async run({ $ }) {
     const range = styling.buildRange(this.startIndex, this.endIndex, this.tabId);
 
+    if (this.fontWeight != null && !this.fontFamily) {
+      throw new ConfigurationError("Font Weight only applies alongside Font Family. Set Font Family as well, or use Bold to embolden the range in its existing font.");
+    }
+    if (this.fontWeight != null && this.fontWeight % 100 !== 0) {
+      throw new ConfigurationError(`Font Weight must be a multiple of 100 between 100 and 900, got \`${this.fontWeight}\`.`);
+    }
+
+    // The API applies weightedFontFamily before bold and defaults an omitted
+    // weight to 400, so changing only the family silently unbolds the range.
+    // Sending the weight the user asked for keeps that explicit.
     const weightedFontFamily = this.fontFamily
       ? {
         fontFamily: this.fontFamily,
       }
       : undefined;
+    if (weightedFontFamily && this.fontWeight != null) {
+      weightedFontFamily.weight = this.fontWeight;
+    }
     const link = this.linkUrl
       ? {
         url: this.linkUrl,

--- a/components/google_docs/actions/update-text-style/update-text-style.mjs
+++ b/components/google_docs/actions/update-text-style/update-text-style.mjs
@@ -1,0 +1,158 @@
+import { ConfigurationError } from "@pipedream/platform";
+import googleDocs from "../../google_docs.app.mjs";
+import styling from "../../common/styling.mjs";
+
+export default {
+  key: "google_docs-update-text-style",
+  name: "Update Text Style",
+  description: "Apply character formatting — bold, italic, underline, font, size, color, or a link — to a range of text in a Google Doc. Only the options you fill in are changed; everything you leave blank keeps its current formatting. Use **Get Document** to find the start and end index of the text you want to style, or **Find Document** to resolve a document's name to its ID. [See the documentation](https://developers.google.com/docs/api/reference/rest/v1/documents/request#UpdateTextStyleRequest)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  type: "action",
+  props: {
+    googleDocs,
+    documentId: {
+      propDefinition: [
+        googleDocs,
+        "documentId",
+      ],
+    },
+    startIndex: {
+      type: "integer",
+      label: "Start Index",
+      description: "The character index where the styled range begins, counting from the start of the document body. Must be at least `1`. Use **Get Document** to inspect the document's structure and locate the range.",
+      min: 1,
+    },
+    endIndex: {
+      type: "integer",
+      label: "End Index",
+      description: "The character index where the styled range ends, exclusive. Must be greater than **Start Index**.",
+      min: 2,
+    },
+    bold: {
+      type: "boolean",
+      label: "Bold",
+      description: "Set `true` to bold the range, or `false` to explicitly remove bold. Leave blank to keep the current setting.",
+      optional: true,
+    },
+    italic: {
+      type: "boolean",
+      label: "Italic",
+      description: "Set `true` to italicize the range, or `false` to explicitly remove italics. Leave blank to keep the current setting.",
+      optional: true,
+    },
+    underline: {
+      type: "boolean",
+      label: "Underline",
+      description: "Set `true` to underline the range, or `false` to explicitly remove the underline. Leave blank to keep the current setting.",
+      optional: true,
+    },
+    strikethrough: {
+      type: "boolean",
+      label: "Strikethrough",
+      description: "Set `true` to strike through the range, or `false` to explicitly remove it. Leave blank to keep the current setting.",
+      optional: true,
+    },
+    smallCaps: {
+      type: "boolean",
+      label: "Small Caps",
+      description: "Set `true` to render the range in small capitals, or `false` to explicitly remove it. Leave blank to keep the current setting.",
+      optional: true,
+    },
+    fontFamily: {
+      type: "string",
+      label: "Font Family",
+      description: "The font to apply, named exactly as it appears in the Google Docs font menu (e.g. `Roboto`, `Times New Roman`).",
+      optional: true,
+    },
+    fontSize: {
+      type: "integer",
+      label: "Font Size",
+      description: "The font size in points (e.g. `12`).",
+      optional: true,
+      min: 1,
+    },
+    foregroundColor: {
+      type: "string",
+      label: "Text Color",
+      description: "The text color as a 6-digit hex code (e.g. `#FF0000` for red).",
+      optional: true,
+    },
+    backgroundColor: {
+      type: "string",
+      label: "Highlight Color",
+      description: "The text highlight color as a 6-digit hex code (e.g. `#FFFF00` for yellow).",
+      optional: true,
+    },
+    baselineOffset: {
+      type: "string",
+      label: "Baseline Offset",
+      description: "Render the range raised or lowered relative to the normal baseline.",
+      optional: true,
+      options: [
+        "NONE",
+        "SUPERSCRIPT",
+        "SUBSCRIPT",
+      ],
+    },
+    linkUrl: {
+      type: "string",
+      label: "Link URL",
+      description: "Turn the range into a hyperlink pointing at this URL (e.g. `https://example.com`).",
+      optional: true,
+    },
+    tabId: {
+      propDefinition: [
+        googleDocs,
+        "tabId",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const range = styling.buildRange(this.startIndex, this.endIndex, this.tabId);
+
+    const weightedFontFamily = this.fontFamily
+      ? {
+        fontFamily: this.fontFamily,
+      }
+      : undefined;
+    const link = this.linkUrl
+      ? {
+        url: this.linkUrl,
+      }
+      : undefined;
+
+    const {
+      style, fields, isEmpty,
+    } = styling.buildStyle({
+      bold: this.bold,
+      italic: this.italic,
+      underline: this.underline,
+      strikethrough: this.strikethrough,
+      smallCaps: this.smallCaps,
+      baselineOffset: this.baselineOffset,
+      weightedFontFamily,
+      fontSize: styling.points(this.fontSize),
+      foregroundColor: styling.optionalColor(this.foregroundColor, "Text Color"),
+      backgroundColor: styling.optionalColor(this.backgroundColor, "Highlight Color"),
+      link,
+    });
+
+    if (isEmpty) {
+      throw new ConfigurationError("Set at least one style option (e.g. Bold, Font Size, or Text Color) — otherwise there is nothing to update.");
+    }
+
+    await this.googleDocs._batchUpdate(this.documentId, "updateTextStyle", {
+      range,
+      textStyle: style,
+      fields,
+    });
+
+    $.export("$summary", `Updated text style for characters ${range.startIndex}–${range.endIndex} in document ${this.documentId}`);
+    return this.googleDocs.getDocument(this.documentId);
+  },
+};

--- a/components/google_docs/actions/update-text-style/update-text-style.mjs
+++ b/components/google_docs/actions/update-text-style/update-text-style.mjs
@@ -167,13 +167,13 @@ export default {
       throw new ConfigurationError("Set at least one style option (e.g. Bold, Font Size, or Text Color) — otherwise there is nothing to update.");
     }
 
-    await this.googleDocs._batchUpdate(this.documentId, "updateTextStyle", {
+    await this.googleDocs.updateTextStyle(this.documentId, {
       range,
       textStyle: style,
       fields,
     });
 
     $.export("$summary", `Updated text style for characters ${range.startIndex}–${range.endIndex} in document ${this.documentId}`);
-    return this.googleDocs.getDocument(this.documentId);
+    return this.googleDocs.getDocumentOrTab(this.documentId, this.tabId);
   },
 };

--- a/components/google_docs/common/styling.mjs
+++ b/components/google_docs/common/styling.mjs
@@ -1,0 +1,99 @@
+import { ConfigurationError } from "@pipedream/platform";
+
+const HEX_COLOR = /^#?([0-9a-fA-F]{6})$/;
+
+// Google's `Dimension` unit for every measurement these actions accept. The API
+// also allows EMU, but points are what the Docs UI shows, so props are in PT.
+const POINTS = "PT";
+
+// Convert a `#RRGGBB` string into the `OptionalColor` shape batchUpdate expects,
+// whose channels are floats in [0, 1] rather than the 0-255 bytes users think in.
+// Returns `undefined` for an unset prop so callers can pass it straight through.
+function optionalColor(hex, label) {
+  if (hex === undefined || hex === null || hex === "") {
+    return undefined;
+  }
+  const match = HEX_COLOR.exec(String(hex).trim());
+  if (!match) {
+    throw new ConfigurationError(`${label} must be a 6-digit hex color such as \`#FF0000\`, got \`${hex}\`.`);
+  }
+  const int = parseInt(match[1], 16);
+  return {
+    color: {
+      rgbColor: {
+        red: ((int >> 16) & 255) / 255,
+        green: ((int >> 8) & 255) / 255,
+        blue: (int & 255) / 255,
+      },
+    },
+  };
+}
+
+// Wrap a numeric point value in a `Dimension`. Passes `undefined` through so an
+// omitted prop stays out of the field mask instead of being sent as a zero.
+function points(magnitude) {
+  if (magnitude === undefined || magnitude === null || magnitude === "") {
+    return undefined;
+  }
+  const value = Number(magnitude);
+  if (!Number.isFinite(value)) {
+    throw new ConfigurationError(`Expected a number of points, got \`${magnitude}\`.`);
+  }
+  return {
+    magnitude: value,
+    unit: POINTS,
+  };
+}
+
+// Build a style object alongside the `fields` mask that must accompany it.
+// batchUpdate only touches properties named in the mask, so the mask has to list
+// exactly the keys the user actually set — sending a key the user left blank
+// would reset that property to its default. `false` and `0` are kept, since
+// unbolding text and zeroing an indent are both real edits.
+function buildStyle(spec) {
+  const style = {};
+  const fields = [];
+  for (const key of Object.keys(spec)) {
+    const value = spec[key];
+    if (value === undefined || value === null || value === "") {
+      continue;
+    }
+    style[key] = value;
+    fields.push(key);
+  }
+  return {
+    style,
+    fields: fields.join(","),
+    isEmpty: fields.length === 0,
+  };
+}
+
+// A `Range` over the document body, optionally scoped to a single tab.
+function buildRange(startIndex, endIndex, tabId) {
+  const start = Number(startIndex);
+  const end = Number(endIndex);
+  if (!Number.isInteger(start) || !Number.isInteger(end)) {
+    throw new ConfigurationError("Start Index and End Index must both be integers.");
+  }
+  if (start < 1) {
+    throw new ConfigurationError(`Start Index must be at least 1, got \`${start}\`. Index 0 is the document root and cannot be styled.`);
+  }
+  if (end <= start) {
+    throw new ConfigurationError(`End Index (\`${end}\`) must be greater than Start Index (\`${start}\`).`);
+  }
+  const range = {
+    startIndex: start,
+    endIndex: end,
+  };
+  if (tabId) {
+    range.tabId = tabId;
+  }
+  return range;
+}
+
+export default {
+  optionalColor,
+  points,
+  buildStyle,
+  buildRange,
+};

--- a/components/google_docs/google_docs.app.mjs
+++ b/components/google_docs/google_docs.app.mjs
@@ -24,6 +24,20 @@ export default {
       optional: true,
       default: "end",
     },
+    // Shared by the update-*-style actions, which address a span of the document
+    // body by character index rather than by an insert position.
+    startIndex: {
+      type: "integer",
+      label: "Start Index",
+      description: "The character index where the range begins, counting from the start of the document body. Must be at least `1`; index `0` is the document root and cannot be styled. Use **Get Document** to inspect the document structure and locate the range.",
+      min: 1,
+    },
+    endIndex: {
+      type: "integer",
+      label: "End Index",
+      description: "The character index where the range ends, exclusive. Must be greater than **Start Index**.",
+      min: 2,
+    },
     // Static, MCP-compatible folder selector for the create actions. Kept as a
     // separate key so the inherited Drive `folderId` (async dropdown) stays
     // available to out-of-scope consumers like the sources/triggers.

--- a/components/google_docs/google_docs.app.mjs
+++ b/components/google_docs/google_docs.app.mjs
@@ -29,13 +29,13 @@ export default {
     startIndex: {
       type: "integer",
       label: "Start Index",
-      description: "The character index where the range begins, counting from the start of the document body. Must be at least `1`; index `0` is the document root and cannot be styled. Use **Get Document** to inspect the document structure and locate the range.",
+      description: "The index where the range begins, counted in zero-based UTF-16 code units from the start of the document body — not in Unicode characters, so astral characters such as emoji count as two. Must be at least `1`; index `0` is the document root and cannot be styled. Use **Get Document** to inspect the document structure and locate the range.",
       min: 1,
     },
     endIndex: {
       type: "integer",
       label: "End Index",
-      description: "The character index where the range ends, exclusive. Must be greater than **Start Index**.",
+      description: "The index where the range ends, exclusive, in the same zero-based UTF-16 code units as **Start Index**. Must be greater than **Start Index**.",
       min: 2,
     },
     // Static, MCP-compatible folder selector for the create actions. Kept as a
@@ -193,6 +193,38 @@ export default {
           requests,
         },
       });
+    },
+    updateTextStyle(documentId, request) {
+      return this._batchUpdate(documentId, "updateTextStyle", request);
+    },
+    updateParagraphStyle(documentId, request) {
+      return this._batchUpdate(documentId, "updateParagraphStyle", request);
+    },
+    updateTableCellStyle(documentId, request) {
+      return this._batchUpdate(documentId, "updateTableCellStyle", request);
+    },
+    // Tabs can nest, so a tab is not necessarily a direct child of the document.
+    _findTab(tabs, tabId) {
+      for (const tab of tabs || []) {
+        if (tab.tabProperties?.tabId === tabId) {
+          return tab;
+        }
+        const child = this._findTab(tab.childTabs, tabId);
+        if (child) {
+          return child;
+        }
+      }
+      return undefined;
+    },
+    // A request scoped to a tab should report that tab back. Plain getDocument
+    // returns only the first tab's content, which would be the wrong document
+    // for any caller that targeted a different tab.
+    async getDocumentOrTab(documentId, tabId) {
+      if (!tabId) {
+        return this.getDocument(documentId);
+      }
+      const document = await this.getDocument(documentId, true);
+      return this._findTab(document.tabs, tabId) ?? document;
     },
     async findDocuments({
       query, limit = 25,

--- a/components/google_docs/package.json
+++ b/components/google_docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_docs",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Pipedream Google_docs Components",
   "main": "google_docs.app.mjs",
   "keywords": [


### PR DESCRIPTION
## Summary

Closes #21746

Google Docs has actions to insert and replace content, but nothing to format it. This adds the three styling actions the Docs API exposes:

| Action | Covers |
| --- | --- |
| **Update Text Style** | bold, italic, underline, strikethrough, small caps, font family, font size, text color, highlight color, baseline offset, link |
| **Update Paragraph Style** | named style (heading levels), alignment, line spacing, space above/below, start/end/first-line indent, keep-lines-together, keep-with-next |
| **Update Table Cell Style** | background color, borders, per-side padding, vertical content alignment — for one cell, a block of cells, or an entire table |

All three follow the existing action pattern and reuse the `documentId` and `tabId` prop definitions from the app file. The app file itself is unchanged, so no existing component's behavior changes.

### `common/styling.mjs`

A new helper module shared by the three actions — hex→`rgbColor` conversion (the API takes 0–1 floats, not 0–255 bytes), point `Dimension` wrapping, range validation, and the field-mask builder.

That last one is the important part. `batchUpdate` only touches properties named in `fields`, so the mask must list exactly the keys the user actually set — **naming a key the user left blank silently resets that property to its default**. The builder skips `undefined`/`null`/`""` props but deliberately keeps `false` and `0`, since unbolding text and zeroing an indent are both real edits rather than "unset".

Each action refuses to run with a `ConfigurationError` if no style option was set at all, rather than sending an empty mask.

### Notes for review

- **Borders** are exposed as one color/width/dash-style control applied to all four sides. The API models each side separately, but a per-side editor would mean twelve more props for something the Docs UI itself treats as a single control. Happy to split them out if you'd prefer.
- **Table targeting**: leaving Row Index and Column Index blank styles the whole table (`tableStartLocation`); setting both styles a block (`tableRange`). Setting only one raises a `ConfigurationError`, since a range anchored on one axis is meaningless.
- Units are points throughout, matching what the Docs UI displays.

## Checklist
Please check the following items before your PR can be reviewed:

### Versioning
- [x] All components updated in this PR had their version updated (`0.0.1` for new ones)
- [x] The app updated in this PR had its `package.json`'s version updated

### New app
If this is a new app, please submit [an app integration request](https://github.com/PipedreamHQ/pipedream/issues/new?template=app---service-integration.md) - the PR will only be reviewed after the app is integrated.
- [x] The app updated in this PR is already integrated

### CodeRabbit review
After the PR is opened, and if new changes are pushed, CodeRabbit will automatically review it. Do not 'mark as resolved' CodeRabbit's comments, but reply to them instead, whether you agree (and update the PR accordingly) or disagree.
- [ ] I have addressed or acknowledged all of CodeRabbit's review comments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added actions to update paragraph formatting, including alignment, spacing, indentation, pagination, and named styles.
  * Added actions to format table cells with background colors, borders, padding, and vertical alignment.
  * Added actions to apply text formatting, including fonts, emphasis, colors, sizing, baseline offsets, and hyperlinks.
  * Added support for applying formatting to specific document ranges and tabs.
* **Bug Fixes**
  * Added validation for formatting options, colors, measurements, and document ranges.
* **Chores**
  * Updated the Google Docs component version to 1.4.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->