### PR TITLE
fix(monday): expose create-column custom labels as a static prop for MCP v3

### DIFF
--- a/components/monday/actions/create-column/create-column.mjs
+++ b/components/monday/actions/create-column/create-column.mjs
@@ -2,12 +2,18 @@ import constants from "../../common/constants.mjs";
 import monday from "../../monday.app.mjs";
 import { ConfigurationError } from "@pipedream/platform";
 
+// The only two column types monday accepts custom labels for.
+const LABEL_COLUMN_TYPES = [
+  "status",
+  "dropdown",
+];
+
 export default {
   key: "monday-create-column",
   name: "Create Column",
   description: "Creates a column. [See the documentation](https://developer.monday.com/api-reference/reference/columns#create-a-column)",
   type: "action",
-  version: "0.1.5",
+  version: "0.2.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -31,7 +37,6 @@ export default {
       label: "Column Type",
       description: "The type of the new column",
       options: constants.COLUMN_TYPE_OPTIONS,
-      reloadProps: true,
     },
     description: {
       type: "string",
@@ -39,24 +44,18 @@ export default {
       description: "The description of the new column",
       optional: true,
     },
-  },
-  async additionalProps() {
-    const props = {};
-    if ([
-      "status",
-      "dropdown",
-    ].includes(this.columnType)) {
-      props.defaults = {
-        type: "string",
-        label: "Custom Labels (Defaults)",
-        description: "The new column's custom labels (defaults). For use with column types `status` or `dropdown`. Should be an object in the format `{ \"1\": \"Technology\", \"2\": \"Marketing\" }` where each key is the label ID and each value is the label text. [See the documentation](https://developer.monday.com/api-reference/reference/columns#create-a-status-or-dropdown-column-with-custom-labels) for more information.",
-        optional: true,
-      };
-    }
-    return props;
+    defaults: {
+      type: "string",
+      label: "Custom Labels (Defaults)",
+      description: "The new column's custom labels (defaults). Only applies when **Column Type** is `status` or `dropdown`; setting it for any other type raises an error. Should be an object in the format `{ \"1\": \"Technology\", \"2\": \"Marketing\" }` where each key is the label ID and each value is the label text. [See the documentation](https://developer.monday.com/api-reference/reference/columns#create-a-status-or-dropdown-column-with-custom-labels) for more information.",
+      optional: true,
+    },
   },
   async run({ $ }) {
     let { defaults } = this;
+    if (defaults && !LABEL_COLUMN_TYPES.includes(this.columnType)) {
+      throw new ConfigurationError(`\`Custom Labels (Defaults)\` only applies to the \`status\` and \`dropdown\` column types, but Column Type is \`${this.columnType}\`. Clear it, or change Column Type.`);
+    }
     if (defaults) {
       try {
         if (this.columnType === "status") {

--- a/components/monday/actions/create-column/create-column.mjs
+++ b/components/monday/actions/create-column/create-column.mjs
@@ -47,12 +47,18 @@ export default {
     defaults: {
       type: "string",
       label: "Custom Labels (Defaults)",
-      description: "The new column's custom labels (defaults). Only applies when **Column Type** is `status` or `dropdown`; setting it for any other type raises an error. Should be an object in the format `{ \"1\": \"Technology\", \"2\": \"Marketing\" }` where each key is the label ID and each value is the label text. [See the documentation](https://developer.monday.com/api-reference/reference/columns#create-a-status-or-dropdown-column-with-custom-labels) for more information.",
+      description: "The new column's custom labels (defaults), as a **JSON-encoded string** — not an object. Only applies when **Column Type** is `status` or `dropdown`; setting it for any other type raises an error. Each key is the label ID and each value is the label text, for example `{ \"1\": \"Technology\", \"2\": \"Marketing\" }` passed as a string. [See the documentation](https://developer.monday.com/api-reference/reference/columns#create-a-status-or-dropdown-column-with-custom-labels) for more information.",
       optional: true,
     },
   },
   async run({ $ }) {
     let { defaults } = this;
+    // An explicitly blank value means the same as leaving the prop unset. Without
+    // this, "" is falsy enough to skip both the column-type check and the JSON
+    // parse, and would reach the API unparsed.
+    if (typeof defaults === "string" && !defaults.trim()) {
+      defaults = undefined;
+    }
     if (defaults && !LABEL_COLUMN_TYPES.includes(this.columnType)) {
       throw new ConfigurationError(`\`Custom Labels (Defaults)\` only applies to the \`status\` and \`dropdown\` column types, but Column Type is \`${this.columnType}\`. Clear it, or change Column Type.`);
     }

--- a/components/monday/package.json
+++ b/components/monday/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/monday",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Pipedream Monday Components",
   "main": "monday.app.mjs",
   "keywords": [


### PR DESCRIPTION
## Summary

Addresses the `monday-create-column` row of #21740.

`Create Column` added its `defaults` prop through `async additionalProps()`, driven by `reloadProps` on `columnType`. An MCP tool resolves its JSON Schema once at registration, so a prop that only appears after a parent prop is set never reaches an agent — custom labels were simply unreachable from MCP.

As the issue notes, this is the low-risk row of the table: `additionalProps()` fetched nothing. It declared one static prop when `columnType` was `status` or `dropdown`. `defaults` is now declared plainly in `props` — same type, same label, same `optional: true` — and the mechanism is gone.

Net: **-18/+17**, one action and a version bump.

### Nothing became required

`defaults` was already `optional: true` inside `additionalProps()`, and it stays optional. No other prop changed, and no default changed. Only `reloadProps` came off `columnType`.

### The guard

Because the prop is now always present, a user (or an agent) can set custom labels on a column type that cannot carry them — a combination that was unreachable before, since the prop did not exist for other types. Previously `run()` would have passed the raw, untransformed string straight through to the API.

It now fails fast with a `ConfigurationError` naming the offending type:

```js
if (defaults && !LABEL_COLUMN_TYPES.includes(this.columnType)) {
  throw new ConfigurationError(`\`Custom Labels (Defaults)\` only applies to the \`status\` and \`dropdown\` column types, but Column Type is \`${this.columnType}\`. Clear it, or change Column Type.`);
}
```

The `status` and `dropdown` transforms themselves are untouched. The two type names were previously hardcoded in both `additionalProps()` and `run()`; they now live in a single local `LABEL_COLUMN_TYPES` constant.

### Deliberately out of scope

The other four rows of #21740 are left alone — `create-item` / `create-subitem` (via `common/common-create-item.mjs`), `update-column-values`, and `get-items-by-column-value`. All four fetch board or column metadata mid-chain via `listColumns()` and emit one typed prop per column, so making them static is a redesign of the input model rather than a prop declaration change — the same class of work as #21706 and #21710, not the same as this one. Happy to pick those up separately if you'd like them handled the same way.

## Checklist
Please check the following items before your PR can be reviewed:

### Versioning
- [x] All components updated in this PR had their version updated (`0.0.1` for new ones)
- [x] The app updated in this PR had its `package.json`'s version updated

### New app
If this is a new app, please submit [an app integration request](https://github.com/PipedreamHQ/pipedream/issues/new?template=app---service-integration.md) - the PR will only be reviewed after the app is integrated.
- [x] The app updated in this PR is already integrated

### CodeRabbit review
After the PR is opened, and if new changes are pushed, CodeRabbit will automatically review it. Do not 'mark as resolved' CodeRabbit's comments, but reply to them instead, whether you agree (and update the PR accordingly) or disagree.
- [ ] I have addressed or acknowledged all of CodeRabbit's review comments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring custom labels when creating status and dropdown columns.
  - Custom labels can be provided as a JSON-encoded string.

- **Bug Fixes**
  - Added validation to reject custom-label settings for unsupported column types.
  - Blank custom-label values are now handled correctly.

- **Updates**
  - Updated the create-column action to version 0.2.0.
  - Updated the Monday integration package to version 0.13.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->