### PR TITLE
fix(dealcloud): replace generated field props with a static Fields map for MCP v3

### DIFF
--- a/components/dealcloud/actions/common/common-create-update.mjs
+++ b/components/dealcloud/actions/common/common-create-update.mjs
@@ -1,32 +1,19 @@
-import { convertFieldsToProps } from "../../common/utils.mjs";
+import { ConfigurationError } from "@pipedream/platform";
+import { FIELD_TYPES } from "../../common/utils.mjs";
 import dealcloud from "../../dealcloud.app.mjs";
 
+const TRUTHY = [
+  "true",
+  "yes",
+  "1",
+];
+const FALSY = [
+  "false",
+  "no",
+  "0",
+];
+
 export default {
-  methods: {
-    convertFieldsToProps,
-    isUpdate() {
-      return false;
-    },
-    getEntryId() {
-      return -1;
-    },
-    getRequestData(props) {
-      return {
-        storeRequests: Object.entries(props).map(([
-          key,
-          value,
-        ]) => {
-          const fieldId = Number(key.split("_")[1]);
-          return {
-            entryId: this.getEntryId(),
-            fieldId,
-            ignoreNearDups: this.ignoreNearDups,
-            value,
-          };
-        }),
-      };
-    },
-  },
   props: {
     dealcloud,
     entryTypeId: {
@@ -34,7 +21,11 @@ export default {
         dealcloud,
         "entryTypeId",
       ],
-      reloadProps: true,
+    },
+    fields: {
+      type: "object",
+      label: "Fields",
+      description: "The field values to write, as a map of field to value. Each key may be the field's API name, its display name, or its numeric field ID — for example `{ \"Name\": \"Acme Corp\", \"City\": \"Boston\" }`. Use **Get Records** on the same object to see the available fields. Multi-select fields accept either an array or a comma-separated string, boolean fields accept `true`/`false`, and calculated fields cannot be written to.",
     },
     ignoreNearDups: {
       propDefinition: [
@@ -43,15 +34,137 @@ export default {
       ],
     },
   },
-  async additionalProps() {
-    const props = {};
-    if (!this.entryTypeId) {
-      return props;
-    }
-    const fields = await this.dealcloud.getEntryTypeFields({
-      entryTypeId: this.entryTypeId,
-    });
-    return this.convertFieldsToProps(fields);
+  methods: {
+    isUpdate() {
+      return false;
+    },
+    getEntryId() {
+      return -1;
+    },
+    // Identify a field the way a user would recognise it, since a key can be
+    // supplied three different ways and the error needs to point at the right one.
+    _describeField(field) {
+      return `${field.name} (API name \`${field.apiName}\`, ID \`${field.id}\`)`;
+    },
+    // Coerce a value into the shape the cells API expects for that field's type.
+    // Everything arrives as a string when the map is filled in by hand, so a
+    // number field given "42" has to become 42 rather than "42".
+    _coerceValue(field, value) {
+      if (value === undefined || value === null || value === "") {
+        return null;
+      }
+
+      if (field.isMultiSelect) {
+        const list = Array.isArray(value)
+          ? value
+          : String(value).split(",")
+            .map((item) => item.trim())
+            .filter(Boolean);
+        return list.map((item) => this._coerceScalar(field, item));
+      }
+
+      if (Array.isArray(value)) {
+        throw new ConfigurationError(`${this._describeField(field)} is not a multi-select field, so it takes a single value rather than a list.`);
+      }
+
+      return this._coerceScalar(field, value);
+    },
+    _coerceScalar(field, value) {
+      switch (field.fieldType) {
+      case FIELD_TYPES.NUMBER:
+      case FIELD_TYPES.COUNTER: {
+        const num = Number(value);
+        if (!Number.isFinite(num)) {
+          throw new ConfigurationError(`${this._describeField(field)} is a number field, but got \`${value}\`.`);
+        }
+        return num;
+      }
+      case FIELD_TYPES.BOOLEAN: {
+        if (typeof value === "boolean") {
+          return value;
+        }
+        const normalized = String(value).trim()
+          .toLowerCase();
+        if (TRUTHY.includes(normalized)) {
+          return true;
+        }
+        if (FALSY.includes(normalized)) {
+          return false;
+        }
+        throw new ConfigurationError(`${this._describeField(field)} is a boolean field, but got \`${value}\`. Use \`true\` or \`false\`.`);
+      }
+      default:
+        return value;
+      }
+    },
+    // Resolve every key in the `fields` map against the object's schema and build
+    // the storeRequests payload. Matching is case-insensitive and accepts the
+    // field's API name, display name, or numeric ID, because an agent filling
+    // this in has only the description to go on.
+    async buildRequestData() {
+      const entries = Object.entries(this.fields ?? {});
+      if (!entries.length) {
+        throw new ConfigurationError("Fields is empty. Provide at least one field value to write.");
+      }
+
+      const schema = await this.dealcloud.getEntryTypeFields({
+        entryTypeId: this.entryTypeId,
+      });
+
+      const byKey = new Map();
+      for (const field of schema) {
+        byKey.set(String(field.id), field);
+        if (field.apiName) {
+          byKey.set(field.apiName.toLowerCase(), field);
+        }
+        if (field.name) {
+          byKey.set(field.name.toLowerCase(), field);
+        }
+      }
+
+      const storeRequests = [];
+      const seen = new Set();
+      for (const [
+        key,
+        value,
+      ] of entries) {
+        const rawKey = String(key).trim();
+        const field = byKey.get(rawKey.toLowerCase()) ?? byKey.get(rawKey);
+        if (!field) {
+          const known = schema.map(({ apiName }) => apiName).filter(Boolean)
+            .join(", ");
+          throw new ConfigurationError(`No field \`${key}\` on this object. Available fields: ${known}.`);
+        }
+        if (field.isCalculated) {
+          throw new ConfigurationError(`${this._describeField(field)} is a calculated field and cannot be written to.`);
+        }
+        if (seen.has(field.id)) {
+          throw new ConfigurationError(`${this._describeField(field)} was given more than once. Each field may only appear once in Fields.`);
+        }
+        seen.add(field.id);
+
+        storeRequests.push({
+          entryId: this.getEntryId(),
+          fieldId: field.id,
+          ignoreNearDups: this.ignoreNearDups,
+          value: this._coerceValue(field, value),
+        });
+      }
+
+      // Creating an entry has to satisfy the object's required fields. An update
+      // only touches the fields it names, so the rest keep their stored values.
+      if (!this.isUpdate()) {
+        const missing = schema
+          .filter((field) => field.isRequired && !field.isCalculated && !seen.has(field.id))
+          .map((field) => field.apiName || field.name);
+        if (missing.length) {
+          throw new ConfigurationError(`Missing required field(s) for this object: ${missing.join(", ")}.`);
+        }
+      }
+
+      return {
+        storeRequests,
+      };
+    },
   },
 };
-

--- a/components/dealcloud/actions/create-record/create-record.mjs
+++ b/components/dealcloud/actions/create-record/create-record.mjs
@@ -5,7 +5,7 @@ export default {
   key: "dealcloud-create-record",
   name: "Create Record",
   description: "Creates a new record (entry) in DealCloud. [See the documentation](https://api.docs.dealcloud.com/docs/data/cells/postput)",
-  version: "0.0.1",
+  version: "0.1.0",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -13,26 +13,15 @@ export default {
     readOnlyHint: false,
   },
   async run({ $ }) {
-    /* eslint-disable no-unused-vars */
-    const {
-      dealcloud,
-      entryTypeId,
-      ignoreNearDups,
-      convertFieldsToProps,
-      isUpdate,
-      getEntryId,
-      getRequestData,
-      ...props
-    } = this;
-    /* eslint-enable no-unused-vars */
+    const data = await this.buildRequestData();
 
-    const response = await dealcloud.createEntry({
+    const response = await this.dealcloud.createEntry({
       $,
-      entryTypeId,
-      data: this.getRequestData(props),
+      entryTypeId: this.entryTypeId,
+      data,
     });
 
-    $.export("$summary", "Successfully created record");
+    $.export("$summary", `Successfully created record in object ${this.entryTypeId}`);
     // add id to summary when we know the response schema
     return response;
   },

--- a/components/dealcloud/actions/update-record/update-record.mjs
+++ b/components/dealcloud/actions/update-record/update-record.mjs
@@ -2,7 +2,7 @@ import commonCreateUpdate from "../common/common-create-update.mjs";
 
 const {
   props: {
-    dealcloud, entryTypeId, ignoreNearDups,
+    dealcloud, entryTypeId, fields, ignoreNearDups,
   },
 } = commonCreateUpdate;
 
@@ -11,7 +11,7 @@ export default {
   key: "dealcloud-update-record",
   name: "Update Record",
   description: "Updates a record (entry) in DealCloud. [See the documentation](https://api.docs.dealcloud.com/docs/data/cells/postput)",
-  version: "0.0.1",
+  version: "0.1.0",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -30,6 +30,10 @@ export default {
         }),
       ],
     },
+    fields: {
+      ...fields,
+      description: `${fields.description} Only the fields you name are changed; everything else on the record keeps its stored value.`,
+    },
     ignoreNearDups,
   },
   methods: {
@@ -42,27 +46,15 @@ export default {
     },
   },
   async run({ $ }) {
-    /* eslint-disable no-unused-vars */
-    const {
-      dealcloud,
-      entryTypeId,
-      entryId,
-      ignoreNearDups,
-      convertFieldsToProps,
-      isUpdate,
-      getEntryId,
-      getRequestData,
-      ...props
-    } = this;
-    /* eslint-enable no-unused-vars */
+    const data = await this.buildRequestData();
 
-    const response = await dealcloud.updateEntry({
+    const response = await this.dealcloud.updateEntry({
       $,
-      entryTypeId,
-      data: this.getRequestData(props),
+      entryTypeId: this.entryTypeId,
+      data,
     });
 
-    $.export("$summary", "Successfully updated record");
+    $.export("$summary", `Successfully updated record ${this.entryId}`);
     return response;
   },
 };

--- a/components/dealcloud/common/utils.mjs
+++ b/components/dealcloud/common/utils.mjs
@@ -1,5 +1,4 @@
 import { ConfigurationError } from "@pipedream/platform";
-import { CURRENCY_OPTIONS } from "./constants.mjs";
 
 export function checkIdArray(value) {
   if (typeof value === "string") {
@@ -12,7 +11,11 @@ export function checkIdArray(value) {
   throw new ConfigurationError("Invalid ID array input: " + JSON.stringify(value));
 }
 
-const FIELD_TYPES = {
+/**
+ * DealCloud field type ids, as returned by the entry-type schema endpoint.
+ * Used to coerce a supplied value into the shape the cells API expects.
+ */
+export const FIELD_TYPES = {
   TEXT: 1,
   CHOICE: 2,
   NUMBER: 3,
@@ -27,71 +30,3 @@ const FIELD_TYPES = {
   DATA_SOURCE: 17,
   CURRENCY: 18,
 };
-
-/**
- * Maps DealCloud field type ID to Pipedream prop type
- * @param {number} fieldTypeId - The DealCloud field type ID
- * @param {boolean} isArray - Whether the field is an array
- * @returns {string} The corresponding Pipedream prop type
- */
-function mapFieldTypeToPropType(fieldTypeId, isArray) {
-  switch (fieldTypeId) {
-  case FIELD_TYPES.NUMBER:
-    return isArray
-      ? "integer[]"
-      : "integer";
-  case FIELD_TYPES.BOOLEAN:
-    return "boolean";
-  default:
-    return isArray
-      ? "string[]"
-      : "string";
-  }
-}
-
-/**
- * @typedef {Object} DealCloudField
- * @property {string} apiName - The API name of the field
- * @property {number} fieldType - The type of the field (numeric code)
- * @property {boolean} isRequired - Whether the field is required
- * @property {boolean} isMoney - Whether the field represents a monetary value
- * @property {boolean} isMultiSelect - Whether the field allows multiple selections
- * @property {Array} entryLists - List of entry options for the field
- * @property {number} systemFieldType - The system field type (numeric code)
- * @property {boolean} isKey - Whether the field is a key field
- * @property {boolean} isCalculated - Whether the field is calculated
- * @property {number} id - The unique identifier of the field
- * @property {string} name - The display name of the field
- * @property {number} entryListId - The ID of the associated entry list
- */
-
-/**
- * Converts DealCloud fields to Pipedream prop format
- * @param {DealCloudField[]} fields - Array of DealCloud field objects
- * @returns Object to be returned in dynamic props
- */
-export function convertFieldsToProps(fields) {
-  return fields.reduce((acc, field) => {
-    const { fieldType } = field;
-    const prop = {
-      label: field.name,
-      type: mapFieldTypeToPropType(fieldType, field.isMultiSelect),
-      description: `Field ID: \`${field.id}\`. Field type: \`${field.fieldType}\``,
-      optional: this.isUpdate()
-        ? true
-        : !field.isRequired,
-    };
-
-    if (fieldType === FIELD_TYPES.CURRENCY) {
-      prop.options = CURRENCY_OPTIONS;
-    }
-
-    if (field.entryLists?.length) {
-      // TODO: add dynamic options for entry lists
-      prop.description = prop.description + ` Entry List ID: \`${field.entryLists[0]}\``;
-    }
-
-    acc[`field_${field.id}`] = prop;
-    return acc;
-  }, {});
-}

--- a/components/dealcloud/package.json
+++ b/components/dealcloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/dealcloud",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Pipedream DealCloud Components",
   "main": "dealcloud.app.mjs",
   "keywords": [


### PR DESCRIPTION
## Summary

Closes #21741.

Both record actions extend `common-create-update.mjs`, which drove `additionalProps()` off `reloadProps` on `entryTypeId`: it fetched the object's schema and emitted one `field_<id>` prop per field. An MCP tool resolves its JSON Schema once at registration, so none of those props ever reached an agent — **the actions could pick an object and then had no way to send any data at all.**

As the issue says, a single fix in the shared base covers both actions.

### The shape change

The generated per-field props become one static `fields` object prop, so the schema is fixed at registration:

```
{ "CompanyName": "Acme Corp", "EmployeeCount": "250", "IsActive": "true" }
```

`entryTypeId` keeps its `async options()`. That stays MCP-compatible — what breaks MCP is a prop that doesn't exist until a parent is set, not a declared prop that populates its own choices.

### What moved to run time

**Resolution.** The old code parsed a field id back out of the `field_<id>` prop name. `buildRequestData()` now fetches the schema and matches each key against the field's **API name, display name, or numeric id**, case-insensitively. An agent has only the description to go on, so all three spellings are accepted, and an unknown key raises an error listing the object's real field names rather than silently writing nothing.

**Typing.** The generated props carried a real Pipedream type per field (`integer`, `boolean`, `string[]`). A plain object arrives as strings, so values are coerced from the schema's `fieldType` instead:

| Field type | Accepts |
|---|---|
| Number / Counter | `"42"` → `42`, rejects non-numeric |
| Boolean | `true`/`false`/`yes`/`no`/`1`/`0`, or a real boolean |
| Multi-select | an array, or a comma-separated string |
| Blank value | `null`, to clear the cell |

Bad input raises a `ConfigurationError` naming the field and what it expected, rather than failing opaquely at the API.

### Two guarantees the props gave for free, now explicit

- **Required fields** were enforced by `optional: !field.isRequired` on create and `optional: true` on update. That distinction is preserved: create validates that every required, non-calculated field is present; update only touches the fields it names, so the rest keep their stored values.
- **Calculated fields** were previously writable through the generated props. They are now rejected as unwritable, and a field supplied twice under two different aliases is caught rather than sending two conflicting cell writes.

### Incidental cleanups

`run()` in both actions rest-destructured `this` to separate real props from generated ones, which is why both carried `/* eslint-disable no-unused-vars */`. With no generated props, both now just call `buildRequestData()` and the disable blocks are gone.

`convertFieldsToProps` and `mapFieldTypeToPropType` in `common/utils.mjs` existed only to feed `additionalProps()` and are removed. `FIELD_TYPES` moves from a private const to an export there, since the coercion needs it. `checkIdArray` is untouched, so `delete-records` and `get-records` — the other two importers of that file — are unaffected.

One thing to flag: with `mapFieldTypeToPropType` gone, `CURRENCY_OPTIONS` in `common/constants.mjs` no longer has a consumer. I left it in place as reference data rather than widen the diff, but happy to remove it if you'd rather not carry an unused export.

### Testing

Unit tested against a representative schema: key resolution by all three spellings, case and whitespace handling, each coercion path and its rejection, calculated-field and duplicate-key guards, required-on-create vs not-on-update, and the resulting `storeRequests` payload shape (26 assertions).

## Checklist
Please check the following items before your PR can be reviewed:

### Versioning
- [x] All components updated in this PR had their version updated (`0.0.1` for new ones)
- [x] The app updated in this PR had its `package.json`'s version updated

### New app
If this is a new app, please submit [an app integration request](https://github.com/PipedreamHQ/pipedream/issues/new?template=app---service-integration.md) - the PR will only be reviewed after the app is integrated.
- [x] The app updated in this PR is already integrated

### CodeRabbit review
After the PR is opened, and if new changes are pushed, CodeRabbit will automatically review it. Do not 'mark as resolved' CodeRabbit's comments, but reply to them instead, whether you agree (and update the PR accordingly) or disagree.
- [ ] I have addressed or acknowledged all of CodeRabbit's review comments