### PR TITLE
fix(hubspot): give the shared CRM bases a static prop set

### DIFF
--- a/components/hubspot/actions/add-comment/add-comment.mjs
+++ b/components/hubspot/actions/add-comment/add-comment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-add-comment",
   name: "Add Comment",
   description: "Adds a comment to a thread. [See the documentation](https://developers.hubspot.com/docs/api-reference/conversations-conversations-inbox-&-messages-v3/public-message/post-conversations-v3-conversations-threads-threadId-messages)",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/add-contact-to-list/add-contact-to-list.mjs
+++ b/components/hubspot/actions/add-contact-to-list/add-contact-to-list.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Add Contact to List",
   description:
     "Adds a contact to a specific static list. [See the documentation](https://developers.hubspot.com/docs/api-reference/crm-lists-v3/memberships/put-crm-v3-lists-listId-memberships-add)",
-  version: "0.1.3",
+  version: "0.1.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/add-note-to-contact/add-note-to-contact.mjs
+++ b/components/hubspot/actions/add-note-to-contact/add-note-to-contact.mjs
@@ -31,7 +31,7 @@ export default {
     + "Do **not** use **Create Engagement** for this workflow. "
     + "For every writable note property or non-contact associations, use **Create Note** instead. "
     + "[See the documentation](https://developers.hubspot.com/docs/api/crm/objects/notes)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/archive-thread/archive-thread.mjs
+++ b/components/hubspot/actions/archive-thread/archive-thread.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-archive-thread",
   name: "Archive Thread",
   description: "Archives a thread (soft delete). The thread is hidden from active views but can be restored via the HubSpot UI or by listing archived threads. [See the documentation](https://developers.hubspot.com/docs/reference/api/conversations/inbox-and-messages#archive-threads)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/batch-create-companies/batch-create-companies.mjs
+++ b/components/hubspot/actions/batch-create-companies/batch-create-companies.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Batch Create Companies",
   description:
     "Create a batch of companies in Hubspot. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/objects/companies#post-%2Fcrm%2Fv3%2Fobjects%2Fcompanies%2Fbatch%2Fcreate)",
-  version: "0.0.17",
+  version: "0.0.18",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/batch-create-or-update-contact/batch-create-or-update-contact.mjs
+++ b/components/hubspot/actions/batch-create-or-update-contact/batch-create-or-update-contact.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Batch Create or Update Contact",
   description:
     "Create or update a batch of contacts by its ID or email. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts)",
-  version: "0.0.31",
+  version: "0.0.32",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/hubspot/actions/batch-update-companies/batch-update-companies.mjs
+++ b/components/hubspot/actions/batch-update-companies/batch-update-companies.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Batch Update Companies",
   description:
     "Update a batch of companies in Hubspot. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/objects/companies#post-%2Fcrm%2Fv3%2Fobjects%2Fcompanies%2Fbatch%2Fupdate)",
-  version: "0.0.17",
+  version: "0.0.18",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/hubspot/actions/batch-upsert-companies/batch-upsert-companies.mjs
+++ b/components/hubspot/actions/batch-upsert-companies/batch-upsert-companies.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-batch-upsert-companies",
   name: "Batch Upsert Companies",
   description: "Upsert a batch of companies in Hubspot. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/objects/companies#post-%2Fcrm%2Fv3%2Fobjects%2Fcompanies%2Fbatch%2Fupsert)",
-  version: "0.0.16",
+  version: "0.0.17",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/hubspot/actions/book-meeting-link/book-meeting-link.mjs
+++ b/components/hubspot/actions/book-meeting-link/book-meeting-link.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-book-meeting-link",
   name: "Book Meeting on Meeting Link",
   description: "Book a meeting on a HubSpot meeting scheduling page. Creates a calendar event for the organizer and registers the booker as a contact. [See the documentation](https://developers.hubspot.com/docs/api-reference/legacy/scheduler/guide#book-a-meeting)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/clone-email/clone-email.mjs
+++ b/components/hubspot/actions/clone-email/clone-email.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Clone Marketing Email",
   description:
     "Clone a marketing email in HubSpot. [See the documentation](https://developers.hubspot.com/docs/reference/api/marketing/emails/marketing-emails#post-%2Fmarketing%2Fv3%2Femails%2Fclone)",
-  version: "0.0.15",
+  version: "0.0.16",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/clone-site-page/clone-site-page.mjs
+++ b/components/hubspot/actions/clone-site-page/clone-site-page.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Clone Site Page",
   description:
     "Clone a site page in Hubspot. [See the documentation](https://developers.hubspot.com/docs/reference/api/cms/pages#post-%2Fcms%2Fv3%2Fpages%2Fsite-pages%2Fclone)",
-  version: "0.0.15",
+  version: "0.0.16",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/common/common-app-prop.mjs
+++ b/components/hubspot/actions/common/common-app-prop.mjs
@@ -2,9 +2,6 @@ import hubspot from "../../hubspot.app.mjs";
 
 export default {
   props: {
-    hubspot: {
-      ...hubspot,
-      reloadProps: true,
-    },
+    hubspot,
   },
 };

--- a/components/hubspot/actions/common/common-create-object.mjs
+++ b/components/hubspot/actions/common/common-create-object.mjs
@@ -1,5 +1,6 @@
 import common from "./common-create.mjs";
 import hubspot from "../../hubspot.app.mjs";
+import { parseObjectProperties } from "../../common/utils.mjs";
 
 export default {
   ...common,
@@ -23,9 +24,8 @@ export default {
       hubspot,
       // control props — not object properties, must not reach the API payload
       updateIfExists,
-      customObjectType,
-      contactId,
-      $db,
+      // eslint-disable-next-line no-unused-vars
+      customObjectType, contactId, $db,
       objectProperties,
       // whatever is left is a dedicated named object property (e.g.
       // dealname/pipeline/dealstage on Create Deal, subject/hs_pipeline on
@@ -35,9 +35,7 @@ export default {
     const objectType = this.getObjectType();
 
     const parsedObjectProperties = objectProperties
-      ? typeof objectProperties === "string"
-        ? JSON.parse(objectProperties)
-        : objectProperties
+      ? parseObjectProperties(objectProperties)
       : {};
 
     // objectProperties takes precedence over the dedicated named props on conflict

--- a/components/hubspot/actions/common/common-create-object.mjs
+++ b/components/hubspot/actions/common/common-create-object.mjs
@@ -21,14 +21,30 @@ export default {
   async run({ $ }) {
     const {
       hubspot,
+      // control props — not object properties, must not reach the API payload
       updateIfExists,
+      customObjectType,
+      contactId,
+      $db,
       objectProperties,
+      // whatever is left is a dedicated named object property (e.g.
+      // dealname/pipeline/dealstage on Create Deal, subject/hs_pipeline on
+      // Create Ticket) and must be merged into the payload
+      ...otherProperties
     } = this;
     const objectType = this.getObjectType();
 
-    const properties = typeof objectProperties === "string"
-      ? JSON.parse(objectProperties)
-      : objectProperties;
+    const parsedObjectProperties = objectProperties
+      ? typeof objectProperties === "string"
+        ? JSON.parse(objectProperties)
+        : objectProperties
+      : {};
+
+    // objectProperties takes precedence over the dedicated named props on conflict
+    const properties = {
+      ...otherProperties,
+      ...parsedObjectProperties,
+    };
 
     // checkbox (string[]) props must be semicolon separated strings
     Object.keys(properties)

--- a/components/hubspot/actions/common/common-create-object.mjs
+++ b/components/hubspot/actions/common/common-create-object.mjs
@@ -6,23 +6,6 @@ export default {
   props: {
     ...common.props,
     hubspot,
-    // Re-defining propertyGroups so this.getObjectType() can be called from async options
-    // eslint-disable-next-line pipedream/props-description
-    propertyGroups: {
-      type: "string[]",
-      label: "Property Groups",
-      hidden: true,
-      reloadProps: true,
-      async options() {
-        const { results: groups } = await this.hubspot.getPropertyGroups({
-          objectType: this.getObjectType(),
-        });
-        return groups.map((group) => ({
-          label: group.label,
-          value: group.name,
-        }));
-      },
-    },
     objectProperties: {
       type: "object",
       label: "Object Properties",
@@ -31,16 +14,6 @@ export default {
   },
   methods: {
     ...common.methods,
-    isRelevantProperty(property) {
-      const isInPropertyGroups = this.propertyGroups?.includes(property.groupName);
-      const isDefaultProperty = this.isDefaultProperty(property);
-      return common.methods.isRelevantProperty(property)
-        && isInPropertyGroups
-        && !isDefaultProperty;
-    },
-    isDefaultProperty() {
-      return false;
-    },
     createObject(opts = {}) {
       return this.hubspot.createObject(opts);
     },
@@ -48,22 +21,14 @@ export default {
   async run({ $ }) {
     const {
       hubspot,
-      /* eslint-disable no-unused-vars */
-      propertyGroups,
-      customObjectType,
-      contactId,
-      $db,
       updateIfExists,
       objectProperties,
-      ...otherProperties
     } = this;
     const objectType = this.getObjectType();
 
-    const properties = objectProperties
-      ? typeof objectProperties === "string"
-        ? JSON.parse(objectProperties)
-        : objectProperties
-      : otherProperties;
+    const properties = typeof objectProperties === "string"
+      ? JSON.parse(objectProperties)
+      : objectProperties;
 
     // checkbox (string[]) props must be semicolon separated strings
     Object.keys(properties)

--- a/components/hubspot/actions/common/common-create-object.mjs
+++ b/components/hubspot/actions/common/common-create-object.mjs
@@ -34,7 +34,7 @@ export default {
     } = this;
     const objectType = this.getObjectType();
 
-    const parsedObjectProperties = objectProperties
+    const parsedObjectProperties = objectProperties != null
       ? parseObjectProperties(objectProperties)
       : {};
 

--- a/components/hubspot/actions/common/common-create.mjs
+++ b/components/hubspot/actions/common/common-create.mjs
@@ -4,8 +4,8 @@ import {
 import appProp from "./common-app-prop.mjs";
 
 /**
- * Returns an options method for a CRM object type, intended to be used in
- * additionalProps
+ * Returns an options method for a CRM object type, used when building
+ * property props for search filters
  *
  * @param {string} objectTypeName The object type name of the CRM object
  * @returns The options method
@@ -114,51 +114,5 @@ export default {
         useQuery,
       };
     },
-  },
-  async additionalProps(existingProps) {
-    const objectType = this.getObjectType();
-    try {
-      const schema = await this.hubspot.getSchema({
-        objectType,
-      });
-      const { results: properties } = await this.hubspot.getProperties({
-        objectType,
-      });
-      const relevantProperties = properties.filter(this.isRelevantProperty);
-
-      const propDefinitions = [];
-      if (this.propertyGroups && !relevantProperties?.length) {
-        propDefinitions.push({
-          type: "alert",
-          alertType: "info",
-          name: "infoAlert",
-          content: `No writable properties found for Property Group(s): ${this.propertyGroups.join(", ")}`,
-        });
-      }
-
-      for (const property of relevantProperties) {
-        propDefinitions.push(await this.makePropDefinition(property, schema.requiredProperties));
-      }
-
-      if (existingProps.objectProperties) {
-        existingProps.objectProperties.optional = true;
-      }
-      if (existingProps.propertyGroups) {
-        existingProps.propertyGroups.hidden = false;
-      }
-
-      return propDefinitions
-        .reduce((props, {
-          name, ...definition
-        }) => {
-          props[name] = definition;
-          return props;
-        }, {});
-    } catch {
-      if (existingProps.propertyGroups) {
-        existingProps.propertyGroups.optional = true;
-      }
-      return {};
-    }
   },
 };

--- a/components/hubspot/actions/common/common-create.mjs
+++ b/components/hubspot/actions/common/common-create.mjs
@@ -1,45 +1,4 @@
-import {
-  OBJECT_TYPE, HUBSPOT_OWNER,
-} from "../../common/constants.mjs";
 import appProp from "./common-app-prop.mjs";
-
-/**
- * Returns an options method for a CRM object type, used when building
- * property props for search filters
- *
- * @param {string} objectTypeName The object type name of the CRM object
- * @returns The options method
- */
-function getOptionsMethod(objectTypeName) {
-  switch (objectTypeName) {
-  case HUBSPOT_OWNER:
-    return (opts) => this.hubspot.getOwnersOptions(opts);
-  case OBJECT_TYPE.COMPANY:
-    return (opts) => this.hubspot.getCompaniesOptions(opts);
-  case OBJECT_TYPE.CONTACT:
-    return (opts) => this.hubspot.getContactsOptions(opts);
-  case OBJECT_TYPE.DEAL:
-    return (opts) => this.hubspot.getDealsOptions(opts);
-  case OBJECT_TYPE.LINE_ITEM:
-    return (opts) => this.hubspot.getLineItemsOptions(opts);
-  case OBJECT_TYPE.TICKET:
-    return (opts) => this.hubspot.getTicketsOptions(opts);
-  case OBJECT_TYPE.QUOTE:
-    return (opts) => this.hubspot.getQuotesOptions(opts);
-  case OBJECT_TYPE.CALL:
-    return (opts) => this.hubspot.getCallsOptions(opts);
-  case OBJECT_TYPE.EMAIL:
-    return (opts) => this.hubspot.getEmailsOptions(opts);
-  case OBJECT_TYPE.MEETING:
-    return (opts) => this.hubspot.getMeetingsOptions(opts);
-  case OBJECT_TYPE.NOTE:
-    return (opts) => this.hubspot.getNotesOptions(opts);
-  case OBJECT_TYPE.TASK:
-    return (opts) => this.hubspot.getTasksOptions(opts);
-  default:
-    return () => [];
-  }
-}
 
 export default {
   props: {
@@ -48,71 +7,6 @@ export default {
   methods: {
     getObjectType() {
       throw new Error("getObjectType is not implemented");
-    },
-    isRelevantProperty(property) {
-      return !property.modificationMetadata?.readOnlyValue
-        && (!property.hidden || property.name === "hs_email_direction") // hack - Hubspot's "hs_email_direction" property is hidden AND required
-        && !property.label.includes("(legacy)")
-        && (!property.options || property.options.length <= 500); // too many prop options cause the action to fail
-    },
-    makeLabelValueOptions(property) {
-      const options = property.options
-        .filter((o) => !o.hidden)
-        .map(({
-          label, value,
-        }) => ({
-          label,
-          value,
-        }))
-        .filter(({ label }) => label);
-
-      return options.length
-        ? options
-        : undefined;
-    },
-    async makePropDefinition(property, requiredProperties) {
-      let type = "string";
-      let options = this.makeLabelValueOptions(property);
-      let useQuery;
-
-      if (property.referencedObjectType) {
-        const objectTypeName = this.hubspot.getObjectTypeName(property.referencedObjectType);
-        options = getOptionsMethod(objectTypeName);
-        useQuery = true;
-      }
-
-      if (property.name === "hs_timestamp") {
-        property.description += ". Enter date in ISO-8601 format. Example: `2024-06-25T15:43:49.214Z`";
-      }
-
-      const objectType = this.hubspot.getObjectTypeName(this.getObjectType());
-      let reloadProps;
-      if (property.name === "hs_pipeline") {
-        options = await this.hubspot.getPipelinesOptions(objectType);
-        reloadProps = true;
-      }
-      if (property.name === "hs_pipeline_stage") {
-        options = await this.hubspot.getPipelineStagesOptions(objectType, this.hs_pipeline);
-      }
-      if (property.name === "hs_all_assigned_business_unit_ids") {
-        try {
-          options = await this.hubspot.getBusinessUnitOptions();
-        } catch {
-          console.log("Could not load business units");
-        }
-        property.description += " For use with the Business Units Add-On.";
-      }
-
-      return {
-        type,
-        name: property.name,
-        label: property.label,
-        description: property.description,
-        optional: !requiredProperties.includes(property.name),
-        options,
-        reloadProps,
-        useQuery,
-      };
     },
   },
 };

--- a/components/hubspot/actions/common/common-get-object.mjs
+++ b/components/hubspot/actions/common/common-get-object.mjs
@@ -25,7 +25,7 @@ export default {
     additionalProperties: {
       type: "string[]",
       label: "Additional properties to retrieve",
-      description: "Properties to return on top of the default set for this object type. Use **Get Properties** to see what a given object type offers.",
+      description: "An array of HubSpot internal property names to return in addition to the default set for this object type — e.g. `[\"custom_field\", \"lifecyclestage\"]`. Use **Get Properties** to discover the valid internal names a given object type offers.",
       optional: true,
       async options({ page }) {
         if (page !== 0) {

--- a/components/hubspot/actions/common/common-get-object.mjs
+++ b/components/hubspot/actions/common/common-get-object.mjs
@@ -21,18 +21,11 @@ export default {
       async options(opts) {
         return this.hubspot.createOptions(this.getObjectType(), opts);
       },
-      reloadProps: true,
     },
-    info: {
-      type: "alert",
-      alertType: "info",
-      content: "",
-      hidden: true,
-    },
-    // eslint-disable-next-line pipedream/props-description
     additionalProperties: {
       type: "string[]",
       label: "Additional properties to retrieve",
+      description: "Properties to return on top of the default set for this object type. Use **Get Properties** to see what a given object type offers.",
       optional: true,
       async options({ page }) {
         if (page !== 0) {
@@ -50,16 +43,6 @@ export default {
           }));
       },
     },
-  },
-  async additionalProps(props) {
-    if (!props.info) return {};
-    return {
-      info: {
-        ...props.info,
-        content: `Properties:\n\`${this.getDefaultProperties(this.getObjectType()).join(", ")}\``,
-        hidden: false,
-      },
-    };
   },
   methods: {
     getObjectType() {

--- a/components/hubspot/actions/common/common-update-object.mjs
+++ b/components/hubspot/actions/common/common-update-object.mjs
@@ -3,23 +3,6 @@ import common from "./common-create.mjs";
 export default {
   ...common,
   props: {
-    // Re-defining propertyGroups so this.getObjectType() can be called from async options
-    // eslint-disable-next-line pipedream/props-description
-    propertyGroups: {
-      type: "string[]",
-      label: "Property Groups",
-      reloadProps: true,
-      optional: true,
-      async options() {
-        const { results: groups } = await this.hubspot.getPropertyGroups({
-          objectType: this.getObjectType(),
-        });
-        return groups.map((group) => ({
-          label: group.label,
-          value: group.name,
-        }));
-      },
-    },
     objectProperties: {
       type: "object",
       label: "Object Properties",
@@ -28,29 +11,18 @@ export default {
   },
   methods: {
     ...common.methods,
-    isRelevantProperty(property) {
-      const isInPropertyGroups = this.propertyGroups?.includes(property.groupName);
-      return common.methods.isRelevantProperty(property) && isInPropertyGroups;
-    },
   },
   async run({ $ }) {
     const {
       hubspot,
-      /* eslint-disable no-unused-vars */
-      propertyGroups,
-      customObjectType,
-      $db,
       objectId,
       objectProperties,
-      ...otherProperties
     } = this;
     const objectType = this.getObjectType();
 
-    const properties = objectProperties
-      ? typeof objectProperties === "string"
-        ? JSON.parse(objectProperties)
-        : objectProperties
-      : otherProperties;
+    const properties = typeof objectProperties === "string"
+      ? JSON.parse(objectProperties)
+      : objectProperties;
 
     // checkbox (string[]) props must be semicolon separated strings
     Object.keys(properties)

--- a/components/hubspot/actions/create-association/create-association.mjs
+++ b/components/hubspot/actions/create-association/create-association.mjs
@@ -12,7 +12,7 @@ export default {
     + " deal→contact (3), contact→deal (4), deal→company (5), company→deal (6),"
     + " ticket→contact (15), contact→ticket (16), ticket→company (26), company→ticket (25)."
     + " [See the documentation](https://developers.hubspot.com/docs/api/crm/associations)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-associations/create-associations.mjs
+++ b/components/hubspot/actions/create-associations/create-associations.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Create Associations",
   description:
     "Create associations between objects. [See the documentation](https://developers.hubspot.com/docs/api/crm/associations#endpoint?spec=POST-/crm/v3/associations/{fromObjectType}/{toObjectType}/batch/create)",
-  version: "1.0.20",
+  version: "1.0.21",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-blog-post/create-blog-post.mjs
+++ b/components/hubspot/actions/create-blog-post/create-blog-post.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-create-blog-post",
   name: "Create Blog Post",
   description: "Creates a new blog post in HubSpot. [See the documentation](https://developers.hubspot.com/docs/api-reference/cms-posts-v3/basic/post-cms-v3-blogs-posts)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/create-communication/create-communication.mjs
+++ b/components/hubspot/actions/create-communication/create-communication.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import { ASSOCIATION_CATEGORY } from "../../common/constants.mjs";
 import appProp from "../common/common-app-prop.mjs";
@@ -8,8 +9,8 @@ export default {
   key: "hubspot-create-communication",
   name: "Create Communication",
   description:
-    "Create a WhatsApp, LinkedIn, or SMS message. [See the documentation](https://developers.hubspot.com/beta-docs/reference/api/crm/engagements/communications/v3#post-%2Fcrm%2Fv3%2Fobjects%2Fcommunications)",
-  version: "0.1.0",
+    "Log a WhatsApp, LinkedIn, or SMS communication in HubSpot. Put the message fields in **Object Properties** (`hs_communication_channel_type` = `SMS` | `WHATS_APP` | `LINKEDIN_MESSAGE`, `hs_communication_body`); `hs_communication_logged_from` and `hs_timestamp` are set for you. Optionally associate it with a record via **Associated Object Type/ID** + **Association Type**. Example: Object Properties `{ \"hs_communication_channel_type\": \"SMS\", \"hs_communication_body\": \"Reminder: call at 9am\" }`. Returns the created communication with its id. [See the documentation](https://developers.hubspot.com/beta-docs/reference/api/crm/engagements/communications/v3#post-%2Fcrm%2Fv3%2Fobjects%2Fcommunications)",
+  version: "1.0.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -87,6 +88,11 @@ export default {
         ? JSON.parse(objectProperties)
         : objectProperties
       : otherProperties;
+
+    // HubSpot communications require hs_timestamp; default it so an agent doesn't have to know that.
+    if (properties.hs_timestamp == null) {
+      properties.hs_timestamp = new Date().toISOString();
+    }
 
     const response = await hubspot.createObject({
       $,

--- a/components/hubspot/actions/create-communication/create-communication.mjs
+++ b/components/hubspot/actions/create-communication/create-communication.mjs
@@ -9,7 +9,7 @@ export default {
   name: "Create Communication",
   description:
     "Create a WhatsApp, LinkedIn, or SMS message. [See the documentation](https://developers.hubspot.com/beta-docs/reference/api/crm/engagements/communications/v3#post-%2Fcrm%2Fv3%2Fobjects%2Fcommunications)",
-  version: "0.0.28",
+  version: "0.1.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-communication/create-communication.mjs
+++ b/components/hubspot/actions/create-communication/create-communication.mjs
@@ -84,7 +84,7 @@ export default {
       );
     }
 
-    const properties = objectProperties
+    const properties = objectProperties != null
       ? parseObjectProperties(objectProperties)
       : otherProperties;
 

--- a/components/hubspot/actions/create-communication/create-communication.mjs
+++ b/components/hubspot/actions/create-communication/create-communication.mjs
@@ -3,6 +3,7 @@ import { ConfigurationError } from "@pipedream/platform";
 import { ASSOCIATION_CATEGORY } from "../../common/constants.mjs";
 import appProp from "../common/common-app-prop.mjs";
 import common from "../common/common-create.mjs";
+import { parseObjectProperties } from "../../common/utils.mjs";
 
 export default {
   ...common,
@@ -84,12 +85,10 @@ export default {
     }
 
     const properties = objectProperties
-      ? typeof objectProperties === "string"
-        ? JSON.parse(objectProperties)
-        : objectProperties
+      ? parseObjectProperties(objectProperties)
       : otherProperties;
 
-    // HubSpot communications require hs_timestamp; default it so an agent doesn't have to know that.
+    // HubSpot communications require hs_timestamp; default it when not provided.
     if (properties.hs_timestamp == null) {
       properties.hs_timestamp = new Date().toISOString();
     }

--- a/components/hubspot/actions/create-company/create-company.mjs
+++ b/components/hubspot/actions/create-company/create-company.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import { OBJECT_TYPE } from "../../common/constants.mjs";
 import common from "../common/common-create-object.mjs";
 
@@ -6,8 +7,8 @@ export default {
   key: "hubspot-create-company",
   name: "Create Company",
   description:
-    "Create a company in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/companies#endpoint?spec=POST-/crm/v3/objects/companies)",
-  version: "0.1.0",
+    "Create a company in HubSpot. Put the company fields in **Object Properties** as a JSON object of HubSpot internal property names (use **Get Properties** for `companies` to discover them). Example: `{ \"name\": \"InGen\", \"domain\": \"ingen.com\", \"industry\": \"BIOTECHNOLOGY\" }`. Returns the created company with its id. [See the documentation](https://developers.hubspot.com/docs/api/crm/companies#endpoint?spec=POST-/crm/v3/objects/companies)",
+  version: "1.0.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-company/create-company.mjs
+++ b/components/hubspot/actions/create-company/create-company.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Create Company",
   description:
     "Create a company in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/companies#endpoint?spec=POST-/crm/v3/objects/companies)",
-  version: "0.0.40",
+  version: "0.1.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-contact-workflow/create-contact-workflow.mjs
+++ b/components/hubspot/actions/create-contact-workflow/create-contact-workflow.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Create Contact Workflow",
   description:
     "Create a contact workflow in Hubspot. [See the documentation](https://developers.hubspot.com/docs/reference/api/automation/create-manage-workflows#post-%2Fautomation%2Fv4%2Fflows)",
-  version: "0.0.16",
+  version: "0.0.17",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-crm-object/create-crm-object.mjs
+++ b/components/hubspot/actions/create-crm-object/create-crm-object.mjs
@@ -14,7 +14,7 @@ export default {
     + " and **List Pipelines and Stages** to find valid pipeline/stage IDs for deals and tickets."
     + " Use **List Owners** to find valid `hubspot_owner_id` values."
     + " [See the documentation](https://developers.hubspot.com/docs/api/crm/objects)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-custom-object/create-custom-object.mjs
+++ b/components/hubspot/actions/create-custom-object/create-custom-object.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import common from "../common/common-create-object.mjs";
 
 const {
@@ -9,8 +10,8 @@ export default {
   key: "hubspot-create-custom-object",
   name: "Create Custom Object",
   description:
-    "Create a new custom object in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/custom-objects#create-a-custom-object)",
-  version: "1.1.0",
+    "Create a custom object record in HubSpot. Set **Custom Object Type** to the object's `fullyQualifiedName` (e.g. `p_pets`; use **List Custom Object Schemas** to find it) and put fields in **Object Properties**. Example: Custom Object Type `p_pets`, Object Properties `{ \"pet_name\": \"Rexy\" }`. Returns the created record with its id. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/custom-objects#create-a-custom-object)",
+  version: "2.0.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-custom-object/create-custom-object.mjs
+++ b/components/hubspot/actions/create-custom-object/create-custom-object.mjs
@@ -10,7 +10,7 @@ export default {
   name: "Create Custom Object",
   description:
     "Create a new custom object in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/custom-objects#create-a-custom-object)",
-  version: "1.0.22",
+  version: "1.1.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-deal/create-deal.mjs
+++ b/components/hubspot/actions/create-deal/create-deal.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Create Deal",
   description:
     "Create a deal in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/deals#endpoint?spec=POST-/crm/v3/objects/deals)",
-  version: "0.0.40",
+  version: "0.1.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -44,13 +44,6 @@ export default {
     ...common.methods,
     getObjectType() {
       return OBJECT_TYPE.DEAL;
-    },
-    isDefaultProperty(property) {
-      return (
-        property.name === "dealname" ||
-        property.name === "pipeline" ||
-        property.name === "dealstage"
-      );
     },
   },
 };

--- a/components/hubspot/actions/create-deal/create-deal.mjs
+++ b/components/hubspot/actions/create-deal/create-deal.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import { OBJECT_TYPE } from "../../common/constants.mjs";
 import common from "../common/common-create-object.mjs";
 
@@ -6,8 +7,8 @@ export default {
   key: "hubspot-create-deal",
   name: "Create Deal",
   description:
-    "Create a deal in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/deals#endpoint?spec=POST-/crm/v3/objects/deals)",
-  version: "0.1.0",
+    "Create a deal in HubSpot. Set **Deal Name**, **Pipeline**, and **Stage**, and put any extra fields in **Object Properties** as HubSpot internal names. Example: Deal Name `InGen Annual Contract`, Pipeline `default`, Stage `appointmentscheduled`, Object Properties `{ \"amount\": \"250000\", \"closedate\": \"2026-09-23\" }`. Returns the created deal with its id. [See the documentation](https://developers.hubspot.com/docs/api/crm/deals#endpoint?spec=POST-/crm/v3/objects/deals)",
+  version: "1.0.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-email/create-email.mjs
+++ b/components/hubspot/actions/create-email/create-email.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Create Marketing Email",
   description:
     "Create a marketing email in Hubspot. [See the documentation](https://developers.hubspot.com/docs/reference/api/marketing/emails/marketing-emails#post-%2Fmarketing%2Fv3%2Femails%2F)",
-  version: "0.0.15",
+  version: "0.0.16",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-engagement/create-engagement.mjs
+++ b/components/hubspot/actions/create-engagement/create-engagement.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import { ENGAGEMENT_TYPE_OPTIONS } from "../../common/constants.mjs";
 import common from "../common/common-create.mjs";
@@ -86,6 +87,7 @@ export default {
   name: "Create Engagement",
   description:
     "Create a **task, meeting, email, call, or note** engagement with optional associations. "
+    + "If the request does not make the engagement type clear, ask which type (note, task, meeting, email, or call) before creating rather than guessing. "
     + "Set **Engagement Type** and pass engagement fields in **Object Properties** (HubSpot property names, e.g. `hs_note_body` for notes). "
     + "No `reloadProps` step and no **CONFIGURE_COMPONENT** requirement: association fields accept raw HubSpot IDs (use **Search CRM** or the Associations API to resolve `associationType` when needed). "
     + "For **only** a note on a contact by ID, **Add Note to Contact** (`hubspot-add-note-to-contact`) is still simpler. "
@@ -207,7 +209,9 @@ export default {
         : objectProperties
       : otherProperties;
 
-    if (objectType === "notes" && properties && properties.hs_timestamp == null) {
+    // Every HubSpot engagement object (notes, tasks, meetings, emails, calls)
+    // requires hs_timestamp; default it so an agent doesn't have to know that.
+    if (properties && properties.hs_timestamp == null) {
       properties.hs_timestamp = new Date().toISOString();
     }
 

--- a/components/hubspot/actions/create-engagement/create-engagement.mjs
+++ b/components/hubspot/actions/create-engagement/create-engagement.mjs
@@ -92,7 +92,7 @@ export default {
     + "No `reloadProps` step and no **CONFIGURE_COMPONENT** requirement: association fields accept raw HubSpot IDs (use **Search CRM** or the Associations API to resolve `associationType` when needed). "
     + "For **only** a note on a contact by ID, **Add Note to Contact** (`hubspot-add-note-to-contact`) is still simpler. "
     + "[See the documentation](https://developers.hubspot.com/docs/api/crm/engagements)",
-  version: "0.2.0",
+  version: "1.0.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-engagement/create-engagement.mjs
+++ b/components/hubspot/actions/create-engagement/create-engagement.mjs
@@ -90,7 +90,7 @@ export default {
     + "No `reloadProps` step and no **CONFIGURE_COMPONENT** requirement: association fields accept raw HubSpot IDs (use **Search CRM** or the Associations API to resolve `associationType` when needed). "
     + "For **only** a note on a contact by ID, **Add Note to Contact** (`hubspot-add-note-to-contact`) is still simpler. "
     + "[See the documentation](https://developers.hubspot.com/docs/api/crm/engagements)",
-  version: "0.1.5",
+  version: "0.2.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -140,25 +140,11 @@ export default {
         + "Example for a note: `{ \"hs_note_body\": \"Hello from Pipedream\" }`.",
     },
   },
-  /**
-   * Skip common-create’s schema-driven `additionalProps` so engagement fields stay in
-   * `objectProperties` only — avoids `reloadProps` on `engagementType` and remote options
-   * that require CONFIGURE_COMPONENT in MCP/agent hosts.
-   */
-  async additionalProps() {
-    return {};
-  },
   methods: {
     ...common.methods,
     getObjectType() {
       const normalized = normalizeEngagementType(this.engagementType);
       return normalized ?? this.engagementType;
-    },
-    isRelevantProperty(property) {
-      return (
-        common.methods.isRelevantProperty(property) &&
-        !property.name.includes("hs_pipeline")
-      );
     },
     createEngagement(objectType, properties, associations, $) {
       return this.hubspot.createObject({

--- a/components/hubspot/actions/create-form/create-form.mjs
+++ b/components/hubspot/actions/create-form/create-form.mjs
@@ -10,7 +10,7 @@ export default {
   name: "Create Form",
   description:
     "Create a form in HubSpot. [See the documentation](https://developers.hubspot.com/docs/reference/api/marketing/forms#post-%2Fmarketing%2Fv3%2Fforms%2F)",
-  version: "0.0.15",
+  version: "0.0.16",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-landing-page/create-landing-page.mjs
+++ b/components/hubspot/actions/create-landing-page/create-landing-page.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Create Landing Page",
   description:
     "Create a landing page in Hubspot. [See the documentation](https://developers.hubspot.com/docs/reference/api/cms/pages#post-%2Fcms%2Fv3%2Fpages%2Flanding-pages)",
-  version: "0.0.16",
+  version: "0.0.17",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-lead/create-lead.mjs
+++ b/components/hubspot/actions/create-lead/create-lead.mjs
@@ -13,7 +13,7 @@ export default {
   name: "Create Lead",
   description:
     "Create a lead in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/leads#create-leads)",
-  version: "0.0.28",
+  version: "0.1.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-lead/create-lead.mjs
+++ b/components/hubspot/actions/create-lead/create-lead.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import {
   ASSOCIATION_CATEGORY, OBJECT_TYPE,
 } from "../../common/constants.mjs";
@@ -12,8 +13,8 @@ export default {
   key: "hubspot-create-lead",
   name: "Create Lead",
   description:
-    "Create a lead in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/leads#create-leads)",
-  version: "0.1.0",
+    "Create a lead in HubSpot associated with an existing contact. Set **Contact ID** (the contact to link) and put lead fields in **Object Properties** as HubSpot internal names. Example: Contact ID `12345`, Object Properties `{ \"hs_lead_name\": \"Isla Nublar Opportunity\" }`. Returns the created lead with its id. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/leads#create-leads)",
+  version: "1.0.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-meeting/create-meeting.mjs
+++ b/components/hubspot/actions/create-meeting/create-meeting.mjs
@@ -11,7 +11,7 @@ export default {
   name: "Create Meeting",
   description:
     "Creates a new meeting with optional associations to other objects. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/engagements/meetings#post-%2Fcrm%2Fv3%2Fobjects%2Fmeetings)",
-  version: "0.0.20",
+  version: "0.1.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -64,9 +64,6 @@ export default {
     ...common.methods,
     getObjectType() {
       return OBJECT_TYPE.MEETING;
-    },
-    isRelevantProperty(property) {
-      return common.methods.isRelevantProperty(property);
     },
     createMeeting(properties, associations, $) {
       return this.hubspot.createMeeting({

--- a/components/hubspot/actions/create-meeting/create-meeting.mjs
+++ b/components/hubspot/actions/create-meeting/create-meeting.mjs
@@ -93,7 +93,7 @@ export default {
       );
     }
 
-    const properties = objectProperties
+    const properties = objectProperties != null
       ? parseObjectProperties(objectProperties)
       : otherProperties;
 

--- a/components/hubspot/actions/create-meeting/create-meeting.mjs
+++ b/components/hubspot/actions/create-meeting/create-meeting.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 /* eslint-disable no-unused-vars */
 import { ConfigurationError } from "@pipedream/platform";
 import {
@@ -10,8 +11,8 @@ export default {
   key: "hubspot-create-meeting",
   name: "Create Meeting",
   description:
-    "Creates a new meeting with optional associations to other objects. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/engagements/meetings#post-%2Fcrm%2Fv3%2Fobjects%2Fmeetings)",
-  version: "0.1.0",
+    "Create a meeting engagement in HubSpot. Put meeting fields in **Object Properties** (`hs_meeting_title`, `hs_meeting_body`, `hs_meeting_start_time`, `hs_meeting_end_time` as ISO-8601); `hs_timestamp` defaults to the start time. Set **Associated Object Type** and optionally link a record via **Associated Object ID** + **Association Type**. Example: Object Properties `{ \"hs_meeting_title\": \"Kickoff\", \"hs_meeting_start_time\": \"2026-08-27T14:00:00Z\", \"hs_meeting_end_time\": \"2026-08-27T15:00:00Z\" }`. Returns the created meeting with its id. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/engagements/meetings#post-%2Fcrm%2Fv3%2Fobjects%2Fmeetings)",
+  version: "1.0.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -96,6 +97,11 @@ export default {
         ? JSON.parse(objectProperties)
         : objectProperties
       : otherProperties;
+
+    // HubSpot meetings require hs_timestamp; default it to the start time (or now).
+    if (properties.hs_timestamp == null) {
+      properties.hs_timestamp = properties.hs_meeting_start_time ?? new Date().toISOString();
+    }
 
     const associations = toObjectId
       ? [

--- a/components/hubspot/actions/create-meeting/create-meeting.mjs
+++ b/components/hubspot/actions/create-meeting/create-meeting.mjs
@@ -5,6 +5,7 @@ import {
   ASSOCIATION_CATEGORY, OBJECT_TYPE,
 } from "../../common/constants.mjs";
 import common from "../common/common-create.mjs";
+import { parseObjectProperties } from "../../common/utils.mjs";
 
 export default {
   ...common,
@@ -93,9 +94,7 @@ export default {
     }
 
     const properties = objectProperties
-      ? typeof objectProperties === "string"
-        ? JSON.parse(objectProperties)
-        : objectProperties
+      ? parseObjectProperties(objectProperties)
       : otherProperties;
 
     // HubSpot meetings require hs_timestamp; default it to the start time (or now).

--- a/components/hubspot/actions/create-note/create-note.mjs
+++ b/components/hubspot/actions/create-note/create-note.mjs
@@ -100,7 +100,7 @@ export default {
       );
     }
 
-    const properties = objectProperties
+    const properties = objectProperties != null
       ? parseObjectProperties(objectProperties)
       : otherProperties;
 

--- a/components/hubspot/actions/create-note/create-note.mjs
+++ b/components/hubspot/actions/create-note/create-note.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import { ASSOCIATION_CATEGORY } from "../../common/constants.mjs";
 import common from "../common/common-create.mjs";
@@ -7,11 +8,11 @@ export default {
   key: "hubspot-create-note",
   name: "Create Note",
   description:
-    "Create a HubSpot CRM **note** with **all writable note properties** from your portal schema (dynamic fields after connect). "
-    + "MCP/AI: For **only** contact ID + note body, use **Add Note to Contact** — fewer props and no association-type configuration. "
-    + "If associating to another record, supply `toObjectType`, `toObjectId`, and `associationType` together; use **CONFIGURE_COMPONENT** with `componentKey` `hubspot-create-note` to load dropdown options for those props when needed. "
+    "Create a HubSpot CRM **note**. Put the note text in **Object Properties** as `hs_note_body` (e.g. `{ \"hs_note_body\": \"Reviewed the Q3 numbers\" }`). "
+    + "For **only** a contact ID + note body, **Add Note to Contact** is simpler. "
+    + "To associate the note with another record, supply `toObjectType`, `toObjectId`, and `associationType` together. "
     + "[See the documentation](https://developers.hubspot.com/docs/api/crm/objects/notes)",
-  version: "0.1.0",
+  version: "1.0.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -53,8 +54,15 @@ export default {
         }),
       ],
       description:
-        "Association type ID for note → other object. Required with `toObjectId`. MCP: use **CONFIGURE_COMPONENT** with `propName` `associationType` when options are not known.",
+        "Association type ID for note → other object. Required with `toObjectId`.",
       optional: true,
+    },
+    objectProperties: {
+      type: "object",
+      label: "Object Properties",
+      description:
+        "The note properties as a JSON object. At minimum set `hs_note_body`. "
+        + "Example: `{ \"hs_note_body\": \"Followed up with the customer\" }`.",
     },
   },
   methods: {
@@ -98,6 +106,11 @@ export default {
       : otherProperties;
 
     const objectType = this.getObjectType();
+
+    // HubSpot notes require hs_timestamp; default it so an agent doesn't have to know that.
+    if (properties.hs_timestamp == null) {
+      properties.hs_timestamp = new Date().toISOString();
+    }
 
     const associations = toObjectId
       ? [

--- a/components/hubspot/actions/create-note/create-note.mjs
+++ b/components/hubspot/actions/create-note/create-note.mjs
@@ -11,7 +11,7 @@ export default {
     + "MCP/AI: For **only** contact ID + note body, use **Add Note to Contact** — fewer props and no association-type configuration. "
     + "If associating to another record, supply `toObjectType`, `toObjectId`, and `associationType` together; use **CONFIGURE_COMPONENT** with `componentKey` `hubspot-create-note` to load dropdown options for those props when needed. "
     + "[See the documentation](https://developers.hubspot.com/docs/api/crm/objects/notes)",
-  version: "0.0.20",
+  version: "0.1.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -61,12 +61,6 @@ export default {
     ...common.methods,
     getObjectType() {
       return "notes";
-    },
-    isRelevantProperty(property) {
-      return (
-        common.methods.isRelevantProperty(property) &&
-        !property.name.includes("hs_pipeline")
-      );
     },
     createEngagement(objectType, properties, associations, $) {
       return this.hubspot.createObject({

--- a/components/hubspot/actions/create-note/create-note.mjs
+++ b/components/hubspot/actions/create-note/create-note.mjs
@@ -2,6 +2,7 @@
 import { ConfigurationError } from "@pipedream/platform";
 import { ASSOCIATION_CATEGORY } from "../../common/constants.mjs";
 import common from "../common/common-create.mjs";
+import { parseObjectProperties } from "../../common/utils.mjs";
 
 export default {
   ...common,
@@ -100,9 +101,7 @@ export default {
     }
 
     const properties = objectProperties
-      ? typeof objectProperties === "string"
-        ? JSON.parse(objectProperties)
-        : objectProperties
+      ? parseObjectProperties(objectProperties)
       : otherProperties;
 
     const objectType = this.getObjectType();

--- a/components/hubspot/actions/create-or-update-contact/create-or-update-contact.mjs
+++ b/components/hubspot/actions/create-or-update-contact/create-or-update-contact.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import { OBJECT_TYPE } from "../../common/constants.mjs";
 import common from "../common/common-create-object.mjs";
 
@@ -6,8 +7,8 @@ export default {
   key: "hubspot-create-or-update-contact",
   name: "Create or Update Contact",
   description:
-    "Create or update a contact in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts#endpoint?spec=POST-/crm/v3/objects/contacts)",
-  version: "0.1.0",
+    "Create a contact in HubSpot, or update it when one with the same email already exists (enable **Update If Exists**). Put contact fields in **Object Properties** as HubSpot internal names. Example: Object Properties `{ \"email\": \"ada@example.com\", \"firstname\": \"Ada\", \"jobtitle\": \"CTO\" }`. Returns the created or updated contact with its id. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts#endpoint?spec=POST-/crm/v3/objects/contacts)",
+  version: "1.0.0",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/hubspot/actions/create-or-update-contact/create-or-update-contact.mjs
+++ b/components/hubspot/actions/create-or-update-contact/create-or-update-contact.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Create or Update Contact",
   description:
     "Create or update a contact in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts#endpoint?spec=POST-/crm/v3/objects/contacts)",
-  version: "0.0.38",
+  version: "0.1.0",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/hubspot/actions/create-page/create-page.mjs
+++ b/components/hubspot/actions/create-page/create-page.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Create Page",
   description:
     "Create a page in HubSpot. [See the documentation](https://developers.hubspot.com/docs/reference/api/cms/pages#post-%2Fcms%2Fv3%2Fpages%2Fsite-pages)",
-  version: "0.0.16",
+  version: "0.0.17",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-task/create-task.mjs
+++ b/components/hubspot/actions/create-task/create-task.mjs
@@ -93,7 +93,7 @@ export default {
       );
     }
 
-    const properties = objectProperties
+    const properties = objectProperties != null
       ? parseObjectProperties(objectProperties)
       : otherProperties;
 

--- a/components/hubspot/actions/create-task/create-task.mjs
+++ b/components/hubspot/actions/create-task/create-task.mjs
@@ -2,6 +2,7 @@
 import { ConfigurationError } from "@pipedream/platform";
 import { ASSOCIATION_CATEGORY } from "../../common/constants.mjs";
 import common from "../common/common-create.mjs";
+import { parseObjectProperties } from "../../common/utils.mjs";
 
 export default {
   ...common,
@@ -93,9 +94,7 @@ export default {
     }
 
     const properties = objectProperties
-      ? typeof objectProperties === "string"
-        ? JSON.parse(objectProperties)
-        : objectProperties
+      ? parseObjectProperties(objectProperties)
       : otherProperties;
 
     const objectType = this.getObjectType();

--- a/components/hubspot/actions/create-task/create-task.mjs
+++ b/components/hubspot/actions/create-task/create-task.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Create Task",
   description:
     "Create a new task. [See the documentation](https://developers.hubspot.com/docs/api/crm/engagements)",
-  version: "0.0.20",
+  version: "0.1.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -61,12 +61,6 @@ export default {
     ...common.methods,
     getObjectType() {
       return "tasks";
-    },
-    isRelevantProperty(property) {
-      return (
-        common.methods.isRelevantProperty(property) &&
-        !property.name.includes("hs_pipeline")
-      );
     },
     createEngagement(objectType, properties, associations, $) {
       return this.hubspot.createObject({

--- a/components/hubspot/actions/create-task/create-task.mjs
+++ b/components/hubspot/actions/create-task/create-task.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import { ASSOCIATION_CATEGORY } from "../../common/constants.mjs";
 import common from "../common/common-create.mjs";
@@ -7,8 +8,8 @@ export default {
   key: "hubspot-create-task",
   name: "Create Task",
   description:
-    "Create a new task. [See the documentation](https://developers.hubspot.com/docs/api/crm/engagements)",
-  version: "0.1.0",
+    "Create a task engagement in HubSpot. Put task fields in **Object Properties** as HubSpot internal names (`hs_task_subject`, `hs_task_body`, `hs_task_status`, `hs_task_priority`); `hs_timestamp` is defaulted for you. Optionally associate it with a record via **Associated Object Type/ID** + **Association Type**. Example: Object Properties `{ \"hs_task_subject\": \"Call Art Vandelay\", \"hs_task_status\": \"NOT_STARTED\", \"hs_task_priority\": \"HIGH\" }`. Returns the created task with its id. [See the documentation](https://developers.hubspot.com/docs/api/crm/engagements)",
+  version: "1.0.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -98,6 +99,11 @@ export default {
       : otherProperties;
 
     const objectType = this.getObjectType();
+
+    // HubSpot tasks require hs_timestamp; default it so an agent doesn't have to know that.
+    if (properties.hs_timestamp == null) {
+      properties.hs_timestamp = new Date().toISOString();
+    }
 
     const associations = toObjectId
       ? [

--- a/components/hubspot/actions/create-ticket/create-ticket.mjs
+++ b/components/hubspot/actions/create-ticket/create-ticket.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Create Ticket",
   description:
     "Create a ticket in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/tickets)",
-  version: "0.0.31",
+  version: "0.1.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -41,13 +41,6 @@ export default {
     ...common.methods,
     getObjectType() {
       return OBJECT_TYPE.TICKET;
-    },
-    isDefaultProperty(property) {
-      return (
-        property.name === "subject" ||
-        property.name === "hs_pipeline" ||
-        property.name === "hs_pipeline_stage"
-      );
     },
   },
 };

--- a/components/hubspot/actions/create-ticket/create-ticket.mjs
+++ b/components/hubspot/actions/create-ticket/create-ticket.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import { OBJECT_TYPE } from "../../common/constants.mjs";
 import common from "../common/common-create-object.mjs";
 
@@ -6,8 +7,8 @@ export default {
   key: "hubspot-create-ticket",
   name: "Create Ticket",
   description:
-    "Create a ticket in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/tickets)",
-  version: "0.1.0",
+    "Create a support ticket in HubSpot. Set **Ticket Name**, **Pipeline**, and **Pipeline Stage** (use **List Pipelines and Stages** for `tickets` to get valid ids), and put extra fields in **Object Properties**. Example: subject `Login broken`, hs_pipeline `0`, hs_pipeline_stage `1`, Object Properties `{ \"hs_ticket_priority\": \"HIGH\" }`. Returns the created ticket with its id. [See the documentation](https://developers.hubspot.com/docs/api/crm/tickets)",
+  version: "1.0.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/create-workflow/create-workflow.mjs
+++ b/components/hubspot/actions/create-workflow/create-workflow.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-create-workflow",
   name: "Create a New Workflow",
   description: "Create a new workflow. [See the documentation](https://developers.hubspot.com/docs/api-reference/legacy/create-manage-workflows-v3/post-automation-v3-workflows)",
-  version: "0.0.11",
+  version: "0.0.12",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/delete-workflow/delete-workflow.mjs
+++ b/components/hubspot/actions/delete-workflow/delete-workflow.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-delete-workflow",
   name: "Delete a Workflow",
   description: "Delete a workflow by ID. [See the documentation](https://developers.hubspot.com/docs/api-reference/legacy/create-manage-workflows-v3/delete-automation-v3-workflows-workflowId)",
-  version: "0.0.11",
+  version: "0.0.12",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/hubspot/actions/enroll-contact-in-sequence/enroll-contact-in-sequence.mjs
+++ b/components/hubspot/actions/enroll-contact-in-sequence/enroll-contact-in-sequence.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-enroll-contact-in-sequence",
   name: "Enroll Contact in Sequence",
   description: "Enroll a contact into a HubSpot sequence. [See the documentation](https://developers.hubspot.com/docs/api-reference/latest/automation/sequences/enroll-contact)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/enroll-contact-into-workflow/enroll-contact-into-workflow.mjs
+++ b/components/hubspot/actions/enroll-contact-into-workflow/enroll-contact-into-workflow.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Enroll Contact Into Workflow",
   description:
     "Add a contact to a workflow. Note: The Workflows API currently only supports contact-based workflows and is only available for Marketing Hub Enterprise accounts. [See the documentation](https://legacydocs.hubspot.com/docs/methods/workflows/add_contact)",
-  version: "0.0.34",
+  version: "0.0.35",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/get-actor/get-actor.mjs
+++ b/components/hubspot/actions/get-actor/get-actor.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-get-actor",
   name: "Get Actor",
   description: "Resolves an actor ID (e.g. the value returned by a message's `senders[].actorId` field) to its name, email, and type. [See the documentation](https://developers.hubspot.com/docs/reference/api/conversations/inbox-and-messages#get-actors)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/get-associated-emails/get-associated-emails.mjs
+++ b/components/hubspot/actions/get-associated-emails/get-associated-emails.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Get Associated Emails",
   description:
     "Retrieves emails associated with a specific object (contact, company, or deal). [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/search)",
-  version: "0.0.16",
+  version: "0.0.17",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/get-associated-meetings/get-associated-meetings.mjs
+++ b/components/hubspot/actions/get-associated-meetings/get-associated-meetings.mjs
@@ -1,4 +1,5 @@
 // x-pd-ai: optimized
+import { ConfigurationError } from "@pipedream/platform";
 import { DEFAULT_MEETING_PROPERTIES } from "../../common/constants.mjs";
 import { OBJECT_TYPE } from "../../common/object-types.mjs";
 import hubspot from "../../hubspot.app.mjs";
@@ -63,14 +64,14 @@ export default {
       type: "string",
       label: "Start Date",
       description:
-        "Start of the date range (ISO 8601, e.g. `2025-01-01T00:00:00Z`). Only used when **Timeframe** is `custom`.",
+        "Start of the date range (ISO 8601, e.g. `2025-01-01T00:00:00Z`). Required when **Timeframe** is `custom`.",
       optional: true,
     },
     endDate: {
       type: "string",
       label: "End Date",
       description:
-        "End of the date range (ISO 8601, e.g. `2025-01-31T23:59:59Z`). Only used when **Timeframe** is `custom`.",
+        "End of the date range (ISO 8601, e.g. `2025-01-31T23:59:59Z`). Required when **Timeframe** is `custom`.",
       optional: true,
     },
   },
@@ -282,9 +283,16 @@ export default {
     },
   },
   async run({ $ }) {
+    if (this.timeframe === "custom" && (!this.startDate || !this.endDate)) {
+      throw new ConfigurationError(
+        "Both **Start Date** and **End Date** are required when **Timeframe** is `custom`.",
+      );
+    }
     let resolvedObjectId = this.objectId;
     // Accept an email for contacts whether the object type is given as "contact" or "contacts".
-    const isContactType = String(this.objectType).toLowerCase().startsWith("contact");
+    const isContactType = String(this.objectType)
+      .toLowerCase()
+      .startsWith("contact");
     if (isContactType && this.objectId.includes("@")) {
       const { results } = await this.hubspot.searchCRM({
         object: OBJECT_TYPE.CONTACT,

--- a/components/hubspot/actions/get-associated-meetings/get-associated-meetings.mjs
+++ b/components/hubspot/actions/get-associated-meetings/get-associated-meetings.mjs
@@ -283,10 +283,24 @@ export default {
     },
   },
   async run({ $ }) {
-    if (this.timeframe === "custom" && (!this.startDate || !this.endDate)) {
-      throw new ConfigurationError(
-        "Both **Start Date** and **End Date** are required when **Timeframe** is `custom`.",
-      );
+    if (this.timeframe === "custom") {
+      if (!this.startDate || !this.endDate) {
+        throw new ConfigurationError(
+          "Both **Start Date** and **End Date** are required when **Timeframe** is `custom`.",
+        );
+      }
+      const start = Date.parse(this.startDate);
+      const end = Date.parse(this.endDate);
+      if (!Number.isFinite(start) || !Number.isFinite(end)) {
+        throw new ConfigurationError(
+          "**Start Date** and **End Date** must be valid ISO 8601 dates (e.g. `2025-01-01T00:00:00Z`) when **Timeframe** is `custom`.",
+        );
+      }
+      if (start >= end) {
+        throw new ConfigurationError(
+          "**Start Date** must be earlier than **End Date** when **Timeframe** is `custom`.",
+        );
+      }
     }
     let resolvedObjectId = this.objectId;
     // Accept an email for contacts whether the object type is given as "contact" or "contacts".

--- a/components/hubspot/actions/get-associated-meetings/get-associated-meetings.mjs
+++ b/components/hubspot/actions/get-associated-meetings/get-associated-meetings.mjs
@@ -4,6 +4,12 @@ import { DEFAULT_MEETING_PROPERTIES } from "../../common/constants.mjs";
 import { OBJECT_TYPE } from "../../common/object-types.mjs";
 import hubspot from "../../hubspot.app.mjs";
 
+// ISO 8601 date or date-time (optional time, optional Z / ±hh:mm offset), capturing
+// year/month/day. Date.parse alone is too lenient — it accepts `01/02/2025` and
+// `March 5 2025`, and rolls impossible dates like `2025-02-30` forward to Mar 2.
+const ISO_DATE_RE =
+  /^(\d{4})-(\d{2})-(\d{2})(?:[T ]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?(?:Z|[+-]\d{2}:\d{2})?)?$/;
+
 export default {
   key: "hubspot-get-associated-meetings",
   name: "Get Associated Meetings",
@@ -289,13 +295,26 @@ export default {
           "Both **Start Date** and **End Date** are required when **Timeframe** is `custom`.",
         );
       }
-      const start = Date.parse(this.startDate);
-      const end = Date.parse(this.endDate);
-      if (!Number.isFinite(start) || !Number.isFinite(end)) {
-        throw new ConfigurationError(
-          "**Start Date** and **End Date** must be valid ISO 8601 dates (e.g. `2025-01-01T00:00:00Z`) when **Timeframe** is `custom`.",
-        );
-      }
+      const parseCustomDate = (value, label) => {
+        const m = ISO_DATE_RE.exec(value);
+        const ms = Date.parse(value);
+        if (!m || !Number.isFinite(ms)) {
+          throw new ConfigurationError(
+            `**${label}** must be a valid ISO 8601 date (e.g. \`2025-01-01T00:00:00Z\`) when **Timeframe** is \`custom\`.`,
+          );
+        }
+        // Reject impossible calendar dates (Date.parse rolls 2025-02-30 forward).
+        const y = +m[1], mo = +m[2], d = +m[3];
+        const rt = new Date(Date.UTC(y, mo - 1, d));
+        if (rt.getUTCFullYear() !== y || rt.getUTCMonth() + 1 !== mo || rt.getUTCDate() !== d) {
+          throw new ConfigurationError(
+            `**${label}** is not a real calendar date.`,
+          );
+        }
+        return ms;
+      };
+      const start = parseCustomDate(this.startDate, "Start Date");
+      const end = parseCustomDate(this.endDate, "End Date");
       if (start >= end) {
         throw new ConfigurationError(
           "**Start Date** must be earlier than **End Date** when **Timeframe** is `custom`.",

--- a/components/hubspot/actions/get-associated-meetings/get-associated-meetings.mjs
+++ b/components/hubspot/actions/get-associated-meetings/get-associated-meetings.mjs
@@ -222,6 +222,7 @@ export default {
       }
     },
     async getAssociatedMeetings({
+      $,
       objectType,
       objectId,
       timeframe,
@@ -230,6 +231,7 @@ export default {
       mostRecent,
     }) {
       const { results: associations } = await this.hubspot.getAssociations({
+        $,
         objectType,
         objectId,
         toObjectType: OBJECT_TYPE.MEETING,
@@ -248,6 +250,7 @@ export default {
       );
 
       const { results } = await this.hubspot.searchMeetings({
+        $,
         data: {
           properties: [
             ...DEFAULT_MEETING_PROPERTIES,
@@ -328,6 +331,7 @@ export default {
       .startsWith("contact");
     if (isContactType && this.objectId.includes("@")) {
       const { results } = await this.hubspot.searchCRM({
+        $,
         object: OBJECT_TYPE.CONTACT,
         data: {
           filterGroups: [
@@ -350,6 +354,7 @@ export default {
     }
 
     const meetings = await this.getAssociatedMeetings({
+      $,
       objectType: this.objectType,
       objectId: resolvedObjectId,
       timeframe: this.timeframe,

--- a/components/hubspot/actions/get-associated-meetings/get-associated-meetings.mjs
+++ b/components/hubspot/actions/get-associated-meetings/get-associated-meetings.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import { DEFAULT_MEETING_PROPERTIES } from "../../common/constants.mjs";
 import { OBJECT_TYPE } from "../../common/object-types.mjs";
 import hubspot from "../../hubspot.app.mjs";
@@ -6,8 +7,8 @@ export default {
   key: "hubspot-get-associated-meetings",
   name: "Get Associated Meetings",
   description:
-    "Retrieves meetings associated with a specific object (contact, company, or deal) with optional time filtering. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/associations/association-details#get-%2Fcrm%2Fv4%2Fobjects%2F%7Bobjecttype%7D%2F%7Bobjectid%7D%2Fassociations%2F%7Btoobjecttype%7D)",
-  version: "0.0.19",
+    "List meetings associated with a contact, company, or deal in HubSpot. Set **From Object Type** and **Object ID** (for contacts you may pass an email instead of the numeric id). Optionally narrow with **Timeframe** (today, this_week, this_month, last_month, or custom with **Start/End Date**), or set **Most Recent** to return only the latest meeting. Returns up to 100 meetings with default meeting properties. Example: From Object Type `contacts`, Object ID `ada@example.com`, Timeframe `this_month`. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/associations/association-details)",
+  version: "1.0.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -58,26 +59,20 @@ export default {
       description: "Additional properties to retrieve for the meetings",
       optional: true,
     },
-  },
-  additionalProps() {
-    const { timeframe } = this;
-    if (timeframe !== "custom") {
-      return {};
-    }
-    return {
-      startDate: {
-        type: "string",
-        label: "Start Date",
-        description:
-          "The start date to filter meetings from (ISO 8601 format). Eg. `2025-01-01T00:00:00Z`",
-      },
-      endDate: {
-        type: "string",
-        label: "End Date",
-        description:
-          "The end date to filter meetings to (ISO 8601 format). Eg. `2025-01-31T23:59:59Z`",
-      },
-    };
+    startDate: {
+      type: "string",
+      label: "Start Date",
+      description:
+        "Start of the date range (ISO 8601, e.g. `2025-01-01T00:00:00Z`). Only used when **Timeframe** is `custom`.",
+      optional: true,
+    },
+    endDate: {
+      type: "string",
+      label: "End Date",
+      description:
+        "End of the date range (ISO 8601, e.g. `2025-01-31T23:59:59Z`). Only used when **Timeframe** is `custom`.",
+      optional: true,
+    },
   },
   methods: {
     getMeetingTimeFilter(timeframe, startDate, endDate) {
@@ -288,10 +283,9 @@ export default {
   },
   async run({ $ }) {
     let resolvedObjectId = this.objectId;
-    if (
-      this.objectType === OBJECT_TYPE.CONTACT &&
-      this.objectId.includes("@")
-    ) {
+    // Accept an email for contacts whether the object type is given as "contact" or "contacts".
+    const isContactType = String(this.objectType).toLowerCase().startsWith("contact");
+    if (isContactType && this.objectId.includes("@")) {
       const { results } = await this.hubspot.searchCRM({
         object: OBJECT_TYPE.CONTACT,
         data: {

--- a/components/hubspot/actions/get-blog-post-draft/get-blog-post-draft.mjs
+++ b/components/hubspot/actions/get-blog-post-draft/get-blog-post-draft.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-get-blog-post-draft",
   name: "Get Blog Post Draft",
   description: "Retrieves the draft version of a blog post. [See the documentation](https://developers.hubspot.com/docs/api-reference/cms-posts-v3/basic/get-cms-v3-blogs-posts-objectId-draft)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/get-channel/get-channel.mjs
+++ b/components/hubspot/actions/get-channel/get-channel.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-get-channel",
   name: "Get Channel",
   description: "Retrieves a single channel by its ID. [See the documentation](https://developers.hubspot.com/docs/api-reference/conversations-conversations-inbox-&-messages-v3/public-channel/get-conversations-v3-conversations-channels-channelId)",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/get-company/get-company.mjs
+++ b/components/hubspot/actions/get-company/get-company.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Get Company",
   description:
     "Gets a company. [See the documentation](https://developers.hubspot.com/docs/api/crm/companies#endpoint?spec=GET-/crm/v3/objects/companies/{companyId})",
-  version: "0.0.34",
+  version: "0.1.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/get-company/get-company.mjs
+++ b/components/hubspot/actions/get-company/get-company.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import { OBJECT_TYPE } from "../../common/constants.mjs";
 import common from "../common/common-get-object.mjs";
 
@@ -6,7 +7,7 @@ export default {
   key: "hubspot-get-company",
   name: "Get Company",
   description:
-    "Gets a company. [See the documentation](https://developers.hubspot.com/docs/api/crm/companies#endpoint?spec=GET-/crm/v3/objects/companies/{companyId})",
+    "Get a single company from HubSpot by its id, with a default set of company properties. Add **Additional properties to retrieve** (internal names; use **Get Properties** for `companies`) to include more. Example: Object ID `123`, Additional properties `[\"industry\", \"numberofemployees\"]`. Returns the company record. [See the documentation](https://developers.hubspot.com/docs/api/crm/companies#endpoint?spec=GET-/crm/v3/objects/companies/{companyId})",
   version: "0.1.0",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/get-contact/get-contact.mjs
+++ b/components/hubspot/actions/get-contact/get-contact.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Get Contact",
   description:
     "Gets a contact. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts#endpoint?spec=GET-/crm/v3/objects/contacts/{contactId})",
-  version: "0.0.34",
+  version: "0.1.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/get-contact/get-contact.mjs
+++ b/components/hubspot/actions/get-contact/get-contact.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import { OBJECT_TYPE } from "../../common/constants.mjs";
 import common from "../common/common-get-object.mjs";
 
@@ -6,7 +7,7 @@ export default {
   key: "hubspot-get-contact",
   name: "Get Contact",
   description:
-    "Gets a contact. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts#endpoint?spec=GET-/crm/v3/objects/contacts/{contactId})",
+    "Get a single contact from HubSpot by its id, with a default set of contact properties. Add **Additional properties to retrieve** to include more (use **Get Properties** for `contacts`). Look up the id with **Search CRM** by email if you only have an address. Example: Object ID `123`, Additional properties `[\"jobtitle\"]`. Returns the contact record. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts#endpoint?spec=GET-/crm/v3/objects/contacts/{contactId})",
   version: "0.1.0",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/get-crm-objects/get-crm-objects.mjs
+++ b/components/hubspot/actions/get-crm-objects/get-crm-objects.mjs
@@ -13,7 +13,7 @@ export default {
     + " Supports standard object types only."
     + " For custom objects, use **Get Custom Object** instead."
     + " [See the documentation](https://developers.hubspot.com/docs/api/crm/objects)",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/get-custom-object/get-custom-object.mjs
+++ b/components/hubspot/actions/get-custom-object/get-custom-object.mjs
@@ -10,7 +10,7 @@ export default {
     + " Use **List Custom Object Schemas** to get the correct `objectType` identifier."
     + " Max 100 IDs per request."
     + " [See the documentation](https://developers.hubspot.com/docs/api-reference/latest/crm/objects/objects/batch/get-objects)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/get-deal/get-deal.mjs
+++ b/components/hubspot/actions/get-deal/get-deal.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import { OBJECT_TYPE } from "../../common/constants.mjs";
 import common from "../common/common-get-object.mjs";
 
@@ -6,7 +7,7 @@ export default {
   key: "hubspot-get-deal",
   name: "Get Deal",
   description:
-    "Gets a deal. [See the documentation](https://developers.hubspot.com/docs/api/crm/deals#endpoint?spec=GET-/crm/v3/objects/deals/{dealId})",
+    "Get a single deal from HubSpot by its id, with a default set of deal properties. Add **Additional properties to retrieve** to include more (use **Get Properties** for `deals`). Example: Object ID `123`, Additional properties `[\"amount\", \"dealstage\"]`. Returns the deal record. [See the documentation](https://developers.hubspot.com/docs/api/crm/deals#endpoint?spec=GET-/crm/v3/objects/deals/{dealId})",
   version: "0.1.0",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/get-deal/get-deal.mjs
+++ b/components/hubspot/actions/get-deal/get-deal.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Get Deal",
   description:
     "Gets a deal. [See the documentation](https://developers.hubspot.com/docs/api/crm/deals#endpoint?spec=GET-/crm/v3/objects/deals/{dealId})",
-  version: "0.0.34",
+  version: "0.1.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/get-engagements/get-engagements.mjs
+++ b/components/hubspot/actions/get-engagements/get-engagements.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-get-engagements",
   name: "Get Engagements",
   description: "Retrieves one or more engagements by their IDs. Use this action to fetch details about multiple engagements, such as their types, timestamps, and associated CRM objects. Requires engagement IDs, which you can obtain from the **List CRM Objects** action. [See the documentation](https://developers.hubspot.com/docs/api-reference/legacy/crm/objects/objects/batch/get-objects)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/get-file-public-url/get-file-public-url.mjs
+++ b/components/hubspot/actions/get-file-public-url/get-file-public-url.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Get File Public URL",
   description:
     "Get a publicly available URL for a file that was uploaded using a Hubspot form. [See the documentation](https://developers.hubspot.com/docs/api/files/files#endpoint?spec=GET-/files/v3/files/{fileId}/signed-url)",
-  version: "0.0.34",
+  version: "0.0.35",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/get-inbox/get-inbox.mjs
+++ b/components/hubspot/actions/get-inbox/get-inbox.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-get-inbox",
   name: "Get Inbox",
   description: "Retrieves a single inbox by its ID. [See the documentation](https://developers.hubspot.com/docs/api-reference/conversations-conversations-inbox-&-messages-v3/public-inbox/get-conversations-v3-conversations-inboxes-inboxId)",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/get-meeting-link-availability/get-meeting-link-availability.mjs
+++ b/components/hubspot/actions/get-meeting-link-availability/get-meeting-link-availability.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-get-meeting-link-availability",
   name: "Get Meeting Link Availability",
   description: "Fetch the upcoming availability windows (and busy times) for a meeting scheduling page. Use this when you only need the open slots; use **Get Meeting Link Booking Info** for the full booking configuration. [See the documentation](https://developers.hubspot.com/docs/api-reference/legacy/scheduler/guide#list-availability)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/get-meeting-link-booking-info/get-meeting-link-booking-info.mjs
+++ b/components/hubspot/actions/get-meeting-link-booking-info/get-meeting-link-booking-info.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-get-meeting-link-booking-info",
   name: "Get Meeting Link Booking Info",
   description: "Retrieve the booking configuration and availability for a meeting scheduling page. Returns link metadata, availability windows by duration, busy times, branding, and organizer details. [See the documentation](https://developers.hubspot.com/docs/api-reference/legacy/scheduler/guide#list-booking-information)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/get-meeting/get-meeting.mjs
+++ b/components/hubspot/actions/get-meeting/get-meeting.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import { OBJECT_TYPE } from "../../common/constants.mjs";
 import common from "../common/common-get-object.mjs";
 
@@ -6,7 +7,7 @@ export default {
   key: "hubspot-get-meeting",
   name: "Get Meeting",
   description:
-    "Retrieves a specific meeting by its ID. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/engagements/meetings#get-%2Fcrm%2Fv3%2Fobjects%2Fmeetings%2F%7Bmeetingid%7D)",
+    "Get a single meeting engagement from HubSpot by its id, with a default set of meeting properties. Add **Additional properties to retrieve** to include more. Example: Object ID `123`. Returns the meeting record (title, body, start/end time). [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/engagements/meetings#get-%2Fcrm%2Fv3%2Fobjects%2Fmeetings%2F%7Bmeetingid%7D)",
   version: "0.1.0",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/get-meeting/get-meeting.mjs
+++ b/components/hubspot/actions/get-meeting/get-meeting.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Get Meeting",
   description:
     "Retrieves a specific meeting by its ID. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/engagements/meetings#get-%2Fcrm%2Fv3%2Fobjects%2Fmeetings%2F%7Bmeetingid%7D)",
-  version: "0.0.19",
+  version: "0.1.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/get-owner/get-owner.mjs
+++ b/components/hubspot/actions/get-owner/get-owner.mjs
@@ -6,7 +6,7 @@ export default {
   description:
     "Get a single HubSpot owner (user) by ID. Provide an owner ID or use **List Owners** to fetch IDs."
     + " [See the documentation](https://developers.hubspot.com/docs/api-reference/crm-owners-v3/owners/get-crm-v3-owners-ownerId)",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/get-properties/get-properties.mjs
+++ b/components/hubspot/actions/get-properties/get-properties.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Get Properties",
   description:
     "Get detailed property definitions for specific properties on a CRM object type. Returns full metadata including data types, enum options with valid values, referenced object types, and read-only status. Use this after **Search Properties** to get valid values for specific fields (e.g. enum options for `dealstage` or `hs_pipeline`). Property details can be large — fetch only the properties you need rather than all of them. For custom object properties, use **List Custom Object Properties** instead (custom object types are not in the standard type list). [See the documentation](https://developers.hubspot.com/docs/api/crm/properties)",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/get-sequence-enrollment/get-sequence-enrollment.mjs
+++ b/components/hubspot/actions/get-sequence-enrollment/get-sequence-enrollment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-get-sequence-enrollment",
   name: "Get Sequence Enrollment",
   description: "Retrieve a contact's sequence enrollment status. [See the documentation](https://developers.hubspot.com/docs/api-reference/latest/automation/sequences/get-enrollment)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/get-subscription-preferences/get-subscription-preferences.mjs
+++ b/components/hubspot/actions/get-subscription-preferences/get-subscription-preferences.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Get Subscription Preferences",
   description:
     "Retrieves the subscription preferences for a contact. [See the documentation](https://developers.hubspot.com/docs/reference/api/marketing/subscriptions#get-%2Fcommunication-preferences%2Fv4%2Fstatuses%2F%7Bsubscriberidstring%7D)",
-  version: "0.0.16",
+  version: "0.0.17",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/get-thread/get-thread.mjs
+++ b/components/hubspot/actions/get-thread/get-thread.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-get-thread",
   name: "Get Thread",
   description: "Retrieves a single thread's metadata, including status, assignee, associations, and latest-message info. [See the documentation](https://developers.hubspot.com/docs/reference/api/conversations/inbox-and-messages#retrieve-threads)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/get-user-details/get-user-details.mjs
+++ b/components/hubspot/actions/get-user-details/get-user-details.mjs
@@ -10,7 +10,7 @@ export default {
     + " (e.g. 'my deals' requires filtering by `hubspot_owner_id`)."
     + " Also returns available CRM object types for the account."
     + " [See the documentation](https://developers.hubspot.com/docs/api/oauth/tokens)",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/list-associated-engagements/list-associated-engagements.mjs
+++ b/components/hubspot/actions/list-associated-engagements/list-associated-engagements.mjs
@@ -9,7 +9,7 @@ export default {
     + " Use **Offset** for pagination when `hasMore` is true."
     + " For newer CRM v3 engagement objects, prefer v4 **List CRM Associations** from the record to `notes`, `tasks`, `calls`, etc."
     + " [See the documentation](https://developers.hubspot.com/docs/api-reference/legacy/engagements-v1/engagements/get-engagements-v1-engagements-associated-crm-object-id-paged)",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/list-association-labels/list-association-labels.mjs
+++ b/components/hubspot/actions/list-association-labels/list-association-labels.mjs
@@ -8,7 +8,7 @@ export default {
     + " Use the returned `typeId` values when creating associations with **Create Association** or **Create CRM Object** (associations JSON)."
     + " Order matters: from/to defines the direction of the relationship."
     + " [See the documentation](https://developers.hubspot.com/docs/api-reference/crm/associations-v4/definitions/get-crm-v4-associations-fromToObjectType-toToObjectType-labels)",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/list-blog-posts/list-blog-posts.mjs
+++ b/components/hubspot/actions/list-blog-posts/list-blog-posts.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-list-blog-posts",
   name: "List Blog Posts",
   description: "Retrieves a list of blog posts. [See the documentation](https://developers.hubspot.com/docs/reference/api/cms/blogs/blog-posts)",
-  version: "0.0.17",
+  version: "0.0.18",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/list-campaigns/list-campaigns.mjs
+++ b/components/hubspot/actions/list-campaigns/list-campaigns.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-list-campaigns",
   name: "List Campaigns",
   description: "Retrieves a list of campaigns. [See the documentation](https://developers.hubspot.com/docs/reference/api/marketing/campaigns#get-%2Fmarketing%2Fv3%2Fcampaigns%2F)",
-  version: "0.0.17",
+  version: "0.0.18",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/list-channels/list-channels.mjs
+++ b/components/hubspot/actions/list-channels/list-channels.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-list-channels",
   name: "List Channels",
   description: "Retrieves a list of channels. [See the documentation](https://developers.hubspot.com/docs/api-reference/conversations-conversations-inbox-&-messages-v3/public-channel/get-conversations-v3-conversations-channels)",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/list-crm-associations/list-crm-associations.mjs
+++ b/components/hubspot/actions/list-crm-associations/list-crm-associations.mjs
@@ -8,7 +8,7 @@ export default {
     + " Returns associated record IDs and association types for each link."
     + " Direction matters: `from` is the record you are querying from; swap from/to to traverse the relationship the other way."
     + " [See the documentation](https://developers.hubspot.com/docs/api-reference/crm/associations-v4/basic/get-crm-v4-objects-objectType-objectId-associations-toObjectType)",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/list-custom-object-properties/list-custom-object-properties.mjs
+++ b/components/hubspot/actions/list-custom-object-properties/list-custom-object-properties.mjs
@@ -11,7 +11,7 @@ export default {
     + " Standard object types (contacts, companies, deals, tickets) are not supported here —"
     + " use **Get Properties** or **Search Properties** for those."
     + " [See the documentation](https://developers.hubspot.com/docs/api-reference/latest/crm/properties/get-properties)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/list-custom-object-schemas/list-custom-object-schemas.mjs
+++ b/components/hubspot/actions/list-custom-object-schemas/list-custom-object-schemas.mjs
@@ -10,7 +10,7 @@ export default {
     + " Call this first before any other custom object operation to obtain the correct objectType identifier."
     + " Standard object types (contacts, companies, deals, tickets) do NOT appear here."
     + " [See the documentation](https://developers.hubspot.com/docs/api-reference/latest/crm/objects/schemas/get-schemas)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/list-custom-object-type-options/list-custom-object-type-options.mjs
+++ b/components/hubspot/actions/list-custom-object-type-options/list-custom-object-type-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-list-custom-object-type-options",
   name: "List Custom Object Type Options",
   description: "Retrieves available options for the Custom Object Type field.",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/list-custom-objects/list-custom-objects.mjs
+++ b/components/hubspot/actions/list-custom-objects/list-custom-objects.mjs
@@ -11,7 +11,7 @@ export default {
     + " (fullyQualifiedName or objectTypeId)."
     + " Use **List Custom Object Properties** to discover which properties are available to request."
     + " [See the documentation](https://developers.hubspot.com/docs/api-reference/latest/crm/objects/objects/get-objects)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/list-deal-pipeline-options/list-deal-pipeline-options.mjs
+++ b/components/hubspot/actions/list-deal-pipeline-options/list-deal-pipeline-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-list-deal-pipeline-options",
   name: "List Pipeline Options",
   description: "Retrieves available options for the Pipeline field.",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/list-file-url-options/list-file-url-options.mjs
+++ b/components/hubspot/actions/list-file-url-options/list-file-url-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-list-file-url-options",
   name: "List File URL Options",
   description: "Retrieves available options for the File URL field.",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/list-forms-options/list-forms-options.mjs
+++ b/components/hubspot/actions/list-forms-options/list-forms-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-list-forms-options",
   name: "List Form Options",
   description: "Retrieves available options for the Form field.",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/list-forms/list-forms.mjs
+++ b/components/hubspot/actions/list-forms/list-forms.mjs
@@ -5,7 +5,7 @@ export default {
   name: "List Forms",
   description:
     "Retrieves a list of forms. [See the documentation](https://developers.hubspot.com/docs/reference/api/marketing/forms#get-%2Fmarketing%2Fv3%2Fforms%2F)",
-  version: "0.0.17",
+  version: "0.0.18",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/list-inboxes/list-inboxes.mjs
+++ b/components/hubspot/actions/list-inboxes/list-inboxes.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-list-inboxes",
   name: "List Inboxes",
   description: "Retrieves a list of inboxes. [See the documentation](https://developers.hubspot.com/docs/api-reference/conversations-conversations-inbox-&-messages-v3/public-inbox/get-conversations-v3-conversations-inboxes)",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/list-marketing-emails/list-marketing-emails.mjs
+++ b/components/hubspot/actions/list-marketing-emails/list-marketing-emails.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-list-marketing-emails",
   name: "List Marketing Emails",
   description: "Retrieves a list of marketing emails. [See the documentation](https://developers.hubspot.com/docs/reference/api/marketing/emails/marketing-emails#get-%2Fmarketing%2Fv3%2Femails%2F)",
-  version: "0.0.17",
+  version: "0.0.18",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/list-marketing-events/list-marketing-events.mjs
+++ b/components/hubspot/actions/list-marketing-events/list-marketing-events.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-list-marketing-events",
   name: "List Marketing Events",
   description: "Retrieves a list of marketing events. [See the documentation](https://developers.hubspot.com/docs/reference/api/marketing/marketing-events#get-%2Fmarketing%2Fv3%2Fmarketing-events%2F)",
-  version: "0.0.17",
+  version: "0.0.18",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/list-meeting-links/list-meeting-links.mjs
+++ b/components/hubspot/actions/list-meeting-links/list-meeting-links.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-list-meeting-links",
   name: "List Meeting Links",
   description: "List meeting scheduling pages for a HubSpot organizer. Returns a single page of results; use **Limit** to control the page size and check the `(of N total)` summary to see if more results exist beyond the page returned. [See the documentation](https://developers.hubspot.com/docs/api-reference/legacy/scheduler/guide#list-meeting-scheduling-pages)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/list-messages/list-messages.mjs
+++ b/components/hubspot/actions/list-messages/list-messages.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-list-messages",
   name: "List Messages",
   description: "Retrieves a list of messages in a thread. [See the documentation](https://developers.hubspot.com/docs/api-reference/conversations-conversations-inbox-&-messages-v3/public-message/get-conversations-v3-conversations-threads-threadId-messages)",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/list-object-schema-options/list-object-schema-options.mjs
+++ b/components/hubspot/actions/list-object-schema-options/list-object-schema-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-list-object-schema-options",
   name: "List Object Schema Options",
   description: "Retrieves available options for the Object Schema field.",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/list-owners/list-owners.mjs
+++ b/components/hubspot/actions/list-owners/list-owners.mjs
@@ -6,7 +6,7 @@ export default {
   name: "List Owners",
   description:
     "List owners (users) in the HubSpot account. Returns owner IDs, names, and emails. Use this to discover valid values for the `hubspot_owner_id` property when creating or updating any CRM object (contacts, companies, deals, tickets, etc.). [See the documentation](https://developers.hubspot.com/docs/api/crm/owners)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/list-pages/list-pages.mjs
+++ b/components/hubspot/actions/list-pages/list-pages.mjs
@@ -5,7 +5,7 @@ export default {
   name: "List Pages",
   description:
     "Retrieves a list of site pages. [See the documentation](https://developers.hubspot.com/docs/reference/api/cms/pages)",
-  version: "0.0.17",
+  version: "0.0.18",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/list-pipelines-and-stages/list-pipelines-and-stages.mjs
+++ b/components/hubspot/actions/list-pipelines-and-stages/list-pipelines-and-stages.mjs
@@ -6,7 +6,7 @@ export default {
   name: "List Pipelines and Stages",
   description:
     "List all pipelines and their stages for deals or tickets. Returns pipeline IDs, labels, and each pipeline's ordered stages with stage IDs and labels. Use this to discover valid `pipeline` and `dealstage` / `hs_pipeline_stage` values before creating or updating deals and tickets. [See the documentation](https://developers.hubspot.com/docs/api/crm/pipelines)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/list-template-path-options/list-template-path-options.mjs
+++ b/components/hubspot/actions/list-template-path-options/list-template-path-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-list-template-path-options",
   name: "List Template Path Options",
   description: "Retrieves available options for the Template Path field.",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/list-templates/list-templates.mjs
+++ b/components/hubspot/actions/list-templates/list-templates.mjs
@@ -5,7 +5,7 @@ export default {
   name: "List Templates",
   description:
     "Retrieves a list of templates. [See the documentation](https://developers.hubspot.com/docs/reference/api/cms/templates)",
-  version: "0.0.16",
+  version: "0.0.17",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/list-threads/list-threads.mjs
+++ b/components/hubspot/actions/list-threads/list-threads.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-list-threads",
   name: "List Threads",
   description: "Retrieves a list of threads. [See the documentation](https://developers.hubspot.com/docs/api-reference/conversations-conversations-inbox-&-messages-v3/public-thread/get-conversations-v3-conversations-threads)",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/list-ticket-pipeline-options/list-ticket-pipeline-options.mjs
+++ b/components/hubspot/actions/list-ticket-pipeline-options/list-ticket-pipeline-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-list-ticket-pipeline-options",
   name: "List Pipeline Options",
   description: "Retrieves available options for the Pipeline field.",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/push-blog-post-draft-live/push-blog-post-draft-live.mjs
+++ b/components/hubspot/actions/push-blog-post-draft-live/push-blog-post-draft-live.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-push-blog-post-draft-live",
   name: "Push Blog Post Draft Live",
   description: "Pushes a blog post draft live, making it the published version. [See the documentation](https://developers.hubspot.com/docs/api-reference/cms-posts-v3/basic/post-cms-v3-blogs-posts-objectId-draft-push-live)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/retrieve-migrated-workflow-mappings/retrieve-migrated-workflow-mappings.mjs
+++ b/components/hubspot/actions/retrieve-migrated-workflow-mappings/retrieve-migrated-workflow-mappings.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-retrieve-migrated-workflow-mappings",
   name: "Retrieve Migrated Workflow Mappings",
   description: "Retrieve the IDs of v3 workflows that have been migrated to the v4 API. [See the documentation](https://developers.hubspot.com/docs/api-reference/automation-automation-v4-v4/workflow-id-mappings/post-automation-v4-workflow-id-mappings-batch-read)",
-  version: "0.0.11",
+  version: "0.0.12",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/retrieve-quotes/retrieve-quotes.mjs
+++ b/components/hubspot/actions/retrieve-quotes/retrieve-quotes.mjs
@@ -10,7 +10,7 @@ export default {
     "Fetch one quote by ID or list quotes with CRM v3 pagination (`after`, `limit`)."
     + " Complements **Create CRM Object** for quotes when you need read access outside **Search CRM**."
     + " [See the documentation](https://developers.hubspot.com/docs/api-reference/crm-quotes-v3/basic/get-crm-v3-objects-quotes)",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/retrieve-workflow-details/retrieve-workflow-details.mjs
+++ b/components/hubspot/actions/retrieve-workflow-details/retrieve-workflow-details.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-retrieve-workflow-details",
   name: "Retrieve Workflow Details",
   description: "Retrieve detailed information about a specific workflow. [See the documentation](https://developers.hubspot.com/docs/api-reference/legacy/create-manage-workflows-v3/get-automation-v3-workflows-workflowId)",
-  version: "0.0.11",
+  version: "0.0.12",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/retrieve-workflow-emails/retrieve-workflow-emails.mjs
+++ b/components/hubspot/actions/retrieve-workflow-emails/retrieve-workflow-emails.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-retrieve-workflow-emails",
   name: "Retrieve Workflow Emails",
   description: "Retrieve emails sent by a workflow by ID. [See the documentation](https://developers.hubspot.com/docs/api-reference/automation-automation-v4-v4/email-campaigns/get-automation-v4-flows-email-campaigns)",
-  version: "0.0.11",
+  version: "0.0.12",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/retrieve-workflows/retrieve-workflows.mjs
+++ b/components/hubspot/actions/retrieve-workflows/retrieve-workflows.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-retrieve-workflows",
   name: "Retrieve Workflows",
   description: "Retrieve a list of all workflows. [See the documentation](https://developers.hubspot.com/docs/api-reference/legacy/create-manage-workflows-v3/get-automation-v3-workflows)",
-  version: "0.0.12",
+  version: "0.0.13",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/schedule-blog-post/schedule-blog-post.mjs
+++ b/components/hubspot/actions/schedule-blog-post/schedule-blog-post.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-schedule-blog-post",
   name: "Schedule Blog Post",
   description: "Schedules a blog post to be published at a specified time. [See the documentation](https://developers.hubspot.com/docs/api-reference/cms-posts-v3/basic/post-cms-v3-blogs-posts-schedule)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/search-crm-objects/search-crm-objects.mjs
+++ b/components/hubspot/actions/search-crm-objects/search-crm-objects.mjs
@@ -38,7 +38,7 @@ export default {
     + " For custom objects, use **List Custom Object Schemas** to discover available types,"
     + " then **List Custom Objects** to list records."
     + " [See the documentation](https://developers.hubspot.com/docs/api/crm/search)",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/search-crm/search-crm.mjs
+++ b/components/hubspot/actions/search-crm/search-crm.mjs
@@ -11,6 +11,7 @@ import {
   SEARCHABLE_OBJECT_TYPES,
 } from "../../common/constants.mjs";
 import hubspot from "../../hubspot.app.mjs";
+import { parseObjectProperties } from "../../common/utils.mjs";
 const DEFAULT_LIMIT = 200;
 
 export default {
@@ -136,7 +137,14 @@ export default {
       creationProps,
     } = this;
 
-    const actualObjectType = customObjectType ?? objectType;
+    if (objectType === "custom_object" && !customObjectType?.trim()) {
+      throw new ConfigurationError(
+        "**Custom Object Type** is required when **Object Type** is `custom_object`.",
+      );
+    }
+    const actualObjectType = objectType === "custom_object"
+      ? customObjectType
+      : objectType;
 
     const schema = await this.hubspot.getSchema({
       objectType: actualObjectType,
@@ -194,9 +202,12 @@ export default {
     }
 
     if (!results?.length && createIfNotFound) {
-      const properties = typeof creationProps === "string"
-        ? JSON.parse(creationProps)
-        : (creationProps ?? {});
+      const properties = parseObjectProperties(creationProps ?? {}, "Create Properties");
+      if (!Object.keys(properties).length) {
+        throw new ConfigurationError(
+          "**Create Properties** is required when **Create if not found?** is enabled and no match was found.",
+        );
+      }
       const response = await hubspot.createObject({
         $,
         objectType: actualObjectType,

--- a/components/hubspot/actions/search-crm/search-crm.mjs
+++ b/components/hubspot/actions/search-crm/search-crm.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import {
   DEFAULT_COMPANY_PROPERTIES,
@@ -7,19 +8,17 @@ import {
   DEFAULT_LINE_ITEM_PROPERTIES,
   DEFAULT_PRODUCT_PROPERTIES,
   DEFAULT_TICKET_PROPERTIES,
-  HUBSPOT_OWNER,
   SEARCHABLE_OBJECT_TYPES,
 } from "../../common/constants.mjs";
 import hubspot from "../../hubspot.app.mjs";
-import common from "../common/common-create.mjs";
 const DEFAULT_LIMIT = 200;
 
 export default {
   key: "hubspot-search-crm",
   name: "Search CRM",
   description:
-    "Search companies, contacts, deals, feedback submissions, products, tickets, line-items, quotes, leads, or custom objects. [See the documentation](https://developers.hubspot.com/docs/api/crm/search)",
-  version: "1.2.0",
+    "Search a CRM object type by a single property. Set **Object Type**, **Search Property** (internal name, e.g. `email` or `dealname`; use **Get Properties** / **Search Properties** to find valid names), and **Search Value**. With **Exact Match** off, partial (substring) matches are returned. Results are capped per call — if `paging.next` is present in the response, call again with **Offset** advanced to fetch the next page. Example: Object Type `deal`, Search Property `dealname`, Search Value `InGen Annual Contract`. Returns matching records plus paging. [See the documentation](https://developers.hubspot.com/docs/api/crm/search)",
+  version: "2.0.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -31,7 +30,8 @@ export default {
     objectType: {
       type: "string",
       label: "Object Type",
-      description: "Type of CRM object to search for",
+      description:
+        "Type of CRM object to search. For a custom object, set this to `custom_object` and provide **Custom Object Type**.",
       options: [
         ...SEARCHABLE_OBJECT_TYPES,
         {
@@ -39,7 +39,27 @@ export default {
           value: "custom_object",
         },
       ],
-      reloadProps: true,
+    },
+    customObjectType: {
+      type: "string",
+      label: "Custom Object Type",
+      description:
+        "Required only when **Object Type** is `custom_object`: the object's `fullyQualifiedName` (e.g. `p_my_object`) or `objectTypeId`.",
+      optional: true,
+    },
+    searchProperty: {
+      type: "string",
+      label: "Search Property",
+      description:
+        "Internal name of the property to search on (e.g. `email`, `dealname`, `firstname`). "
+        + "Use **Search Properties** or **Get Properties** to discover valid names for the object type.",
+    },
+    searchValue: {
+      type: "string",
+      label: "Search Value",
+      description:
+        "The value to match. With **Exact Match** on, returns records where **Search Property** equals this exactly; "
+        + "with it off, returns partial (case-insensitive substring) matches.",
     },
     exactMatch: {
       type: "boolean",
@@ -49,14 +69,29 @@ export default {
       default: true,
       optional: true,
     },
+    additionalProperties: {
+      type: "string[]",
+      label: "Additional properties to retrieve",
+      description:
+        "Internal property names to return in addition to the default set for the object type "
+        + "(e.g. `[\"amount\", \"dealstage\"]`). Use **Get Properties** to discover valid names.",
+      optional: true,
+    },
     createIfNotFound: {
       type: "boolean",
       label: "Create if not found?",
       description:
-        "Set to `true` to create the Hubspot object if it doesn't exist",
+        "Set to `true` to create the object (from **Create Properties**) when the search returns no match.",
       default: false,
       optional: true,
-      reloadProps: true,
+    },
+    creationProps: {
+      type: "object",
+      label: "Create Properties",
+      description:
+        "Properties for the object to create when **Create if not found?** is `true` and nothing matched, "
+        + "as a JSON object of internal property name → value (e.g. `{ \"email\": \"a@b.com\", \"firstname\": \"Ada\" }`).",
+      optional: true,
     },
     offset: {
       type: "integer",
@@ -66,180 +101,7 @@ export default {
       optional: true,
     },
   },
-  async additionalProps() {
-    const props = {};
-
-    if (this.objectType === "custom_object") {
-      try {
-        props.customObjectType = {
-          type: "string",
-          label: "Custom Object Type",
-          options: async () => await this.getCustomObjectTypes(),
-          reloadProps: true,
-        };
-      } catch {
-        props.customObjectType = {
-          type: "string",
-          label: "Custom Object Type",
-          reloadProps: true,
-        };
-      }
-    }
-    if (
-      !this.objectType ||
-      (this.objectType === "custom_object" && !this.customObjectType)
-    ) {
-      return props;
-    }
-
-    let schema;
-    const objectType = this.customObjectType ?? this.objectType;
-    try {
-      schema = await this.hubspot.getSchema({
-        objectType,
-      });
-      const properties = schema.properties;
-      const searchableProperties = schema.searchableProperties?.map((prop) => {
-        const propData = properties.find(({ name }) => name === prop);
-        return {
-          label: propData.label,
-          value: propData.name,
-        };
-      });
-
-      props.searchProperty = {
-        type: "string",
-        label: "Search Property",
-        description: "The field to search",
-        options: searchableProperties,
-        reloadProps: true,
-      };
-
-      if (this.searchProperty) {
-        const selectedProp = properties.find(({ name }) => name === this.searchProperty);
-        if (selectedProp?.referencedObjectType) {
-          const objectTypeName = this.hubspot.getObjectTypeName(selectedProp.referencedObjectType);
-          if (objectTypeName === HUBSPOT_OWNER) {
-            props.searchValue = {
-              type: "string",
-              label: "Search Value",
-              description:
-                "Search for objects where the specified search field/property contains a match of the search value",
-              options: (opts) => this.hubspot.getOwnersOptions(opts),
-              useQuery: true,
-            };
-          }
-        }
-        if (!props.searchValue && selectedProp?.options?.length) {
-          const options = this.makeLabelValueOptions(selectedProp);
-          if (options) {
-            props.searchValue = {
-              type: "string",
-              label: "Search Value",
-              description:
-                "Search for objects where the specified search field/property contains a match of the search value",
-              options,
-            };
-          }
-        }
-      }
-    } catch {
-      props.searchProperty = {
-        type: "string",
-        label: "Search Property",
-        description: "The field to search",
-        reloadProps: true,
-      };
-    }
-
-    if (!props.searchValue) {
-      props.searchValue = {
-        type: "string",
-        label: "Search Value",
-        description:
-          "Search for objects where the specified search field/property contains a match of the search value",
-      };
-    }
-    const defaultProperties = this.getDefaultProperties();
-    if (defaultProperties?.length) {
-      props.info = {
-        type: "alert",
-        alertType: "info",
-        content: `Properties:\n\`${defaultProperties.join(", ")}\``,
-      };
-    }
-
-    try {
-      // eslint-disable-next-line pipedream/props-description
-      props.additionalProperties = {
-        type: "string[]",
-        label: "Additional properties to retrieve",
-        optional: true,
-        options: async ({ page }) => {
-          if (page !== 0) {
-            return [];
-          }
-          const { results: properties } = await this.hubspot.getProperties({
-            objectType: this.customObjectType ?? this.objectType,
-          });
-          const defaultProperties = this.getDefaultProperties();
-          return properties
-            .filter(({ name }) => !defaultProperties.includes(name))
-            .map((property) => ({
-              label: property.label,
-              value: property.name,
-            }));
-        },
-      };
-    } catch {
-      props.additionalProperties = {
-        type: "string[]",
-        label: "Additional properties to retrieve",
-        optional: true,
-      };
-    }
-
-    let creationProps = {};
-    if (this.createIfNotFound && objectType) {
-      try {
-        const { results: properties } = await this.hubspot.getProperties({
-          objectType,
-        });
-        const relevantProperties = properties.filter(this.isRelevantProperty);
-        const propDefinitions = [];
-        for (const property of relevantProperties) {
-          propDefinitions.push(
-            await this.makePropDefinition(property, schema.requiredProperties),
-          );
-        }
-        creationProps = propDefinitions.reduce(
-          (props, {
-            name, ...definition
-          }) => {
-            props[name] = definition;
-            return props;
-          },
-          {},
-        );
-      } catch {
-        props.creationProps = {
-          type: "object",
-          label: "Object Properties",
-          description:
-            "A JSON object containing the object to create if not found",
-        };
-      }
-    }
-    return {
-      ...props,
-      ...creationProps,
-    };
-  },
   methods: {
-    ...common.methods,
-    getObjectType() {
-      return this.objectType;
-    },
     getDefaultProperties() {
       if (this.objectType === "contact") {
         return DEFAULT_CONTACT_PROPERTIES;
@@ -259,17 +121,6 @@ export default {
         return [];
       }
     },
-    async getCustomObjectTypes() {
-      const { results } = await this.hubspot.listSchemas();
-      return (
-        results?.map(({
-          fullyQualifiedName: value, labels,
-        }) => ({
-          value,
-          label: labels.plural,
-        })) || []
-      );
-    },
   },
   async run({ $ }) {
     const {
@@ -281,11 +132,8 @@ export default {
       searchValue,
       exactMatch,
       offset,
-      /* eslint-disable no-unused-vars */
-      info,
       createIfNotFound,
       creationProps,
-      ...otherProperties
     } = this;
 
     const actualObjectType = customObjectType ?? objectType;
@@ -300,12 +148,6 @@ export default {
           `\n\nAvailable searchable properties are: \`${schema.searchableProperties.join("`, `")}\``,
       );
     }
-
-    const properties = creationProps
-      ? typeof creationProps === "string"
-        ? JSON.parse(creationProps)
-        : creationProps
-      : otherProperties;
 
     const defaultProperties = this.getDefaultProperties();
     const data = {
@@ -352,6 +194,9 @@ export default {
     }
 
     if (!results?.length && createIfNotFound) {
+      const properties = typeof creationProps === "string"
+        ? JSON.parse(creationProps)
+        : (creationProps ?? {});
       const response = await hubspot.createObject({
         $,
         objectType: actualObjectType,

--- a/components/hubspot/actions/search-crm/search-crm.mjs
+++ b/components/hubspot/actions/search-crm/search-crm.mjs
@@ -19,7 +19,7 @@ export default {
   name: "Search CRM",
   description:
     "Search companies, contacts, deals, feedback submissions, products, tickets, line-items, quotes, leads, or custom objects. [See the documentation](https://developers.hubspot.com/docs/api/crm/search)",
-  version: "1.1.11",
+  version: "1.2.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/search-crm/search-crm.mjs
+++ b/components/hubspot/actions/search-crm/search-crm.mjs
@@ -18,7 +18,7 @@ export default {
   key: "hubspot-search-crm",
   name: "Search CRM",
   description:
-    "Search a CRM object type by a single property. Set **Object Type**, **Search Property** (internal name, e.g. `email` or `dealname`; use **Get Properties** / **Search Properties** to find valid names), and **Search Value**. With **Exact Match** off, partial (substring) matches are returned. Results are capped per call — if `paging.next` is present in the response, call again with **Offset** advanced to fetch the next page. Example: Object Type `deal`, Search Property `dealname`, Search Value `InGen Annual Contract`. Returns matching records plus paging. [See the documentation](https://developers.hubspot.com/docs/api/crm/search)",
+    "Search a CRM object type by a single property. Set **Object Type**, **Search Property** (internal name, e.g. `email` or `dealname`; use **Get Properties** / **Search Properties** to find valid names), and **Search Value**. With **Exact Match** off, partial (substring) matches are returned. Results are capped per call — if `paging.next` is present in the response, call again with **Offset** advanced to fetch the next page. Example: Object Type `deal`, Search Property `dealname`, Search Value `InGen Annual Contract`. Returns matching records plus paging. For lookups, keep results small with **Limit** and **Fields** (return only the properties you need). [See the documentation](https://developers.hubspot.com/docs/api/crm/search)",
   version: "2.0.0",
   annotations: {
     destructiveHint: false,
@@ -78,6 +78,26 @@ export default {
         + "(e.g. `[\"amount\", \"dealstage\"]`). Use **Get Properties** to discover valid names.",
       optional: true,
     },
+    fields: {
+      type: "string[]",
+      label: "Fields (projection)",
+      description:
+        "Return ONLY these internal property names per record, instead of the full default set. "
+        + "Use this to keep results small when you only need a few fields (e.g. `[\"dealname\", \"amount\"]`). "
+        + "Overrides **Additional properties to retrieve**. The **Search Property** is always included.",
+      optional: true,
+    },
+    limit: {
+      type: "integer",
+      label: "Limit",
+      description:
+        "Maximum number of records to return (1–200). Lower it for lookups where you only need a few "
+        + "matches, to avoid large results. Defaults to 200.",
+      min: 1,
+      max: 200,
+      default: DEFAULT_LIMIT,
+      optional: true,
+    },
     createIfNotFound: {
       type: "boolean",
       label: "Create if not found?",
@@ -129,6 +149,8 @@ export default {
       objectType,
       customObjectType,
       additionalProperties = [],
+      fields,
+      limit,
       searchProperty,
       searchValue,
       exactMatch,
@@ -157,12 +179,25 @@ export default {
       );
     }
 
-    const defaultProperties = this.getDefaultProperties();
-    const data = {
-      properties: [
-        ...defaultProperties,
+    // `fields` (projection) overrides the default+additional set to trim payload;
+    // the search property is always included so post-filtering below still works.
+    const requestedProperties = fields?.length
+      ? [
+        ...fields,
+        searchProperty,
+      ]
+      : [
+        ...this.getDefaultProperties(),
         ...additionalProperties,
         searchProperty,
+      ];
+    const requestedLimit = Number.isFinite(limit)
+      ? limit
+      : DEFAULT_LIMIT;
+    const resolvedLimit = Math.min(Math.max(requestedLimit, 1), DEFAULT_LIMIT);
+    const data = {
+      properties: [
+        ...new Set(requestedProperties),
       ],
       sorts: [
         {
@@ -170,7 +205,7 @@ export default {
           direction: "DESCENDING",
         },
       ],
-      limit: DEFAULT_LIMIT,
+      limit: resolvedLimit,
       after: offset,
     };
 

--- a/components/hubspot/actions/search-properties/search-properties.mjs
+++ b/components/hubspot/actions/search-properties/search-properties.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Search Properties",
   description:
     "Search for property definitions (field names) on a CRM object type. Returns lightweight results: property names, labels, descriptions, and types — without enum options. Use this to discover what fields exist before creating or updating records. To get full details including valid enum values for a specific property, use **Get Properties**. To search for actual CRM data/records, use **Search CRM Objects**. For custom object properties, use **List Custom Object Properties** instead (custom object types are not in the standard type list). [See the documentation](https://developers.hubspot.com/docs/api/crm/properties)",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/send-message/send-message.mjs
+++ b/components/hubspot/actions/send-message/send-message.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-send-message",
   name: "Send Message",
   description: "Sends a message to a thread. [See the documentation](https://developers.hubspot.com/docs/api-reference/conversations-conversations-inbox-&-messages-v3/public-message/post-conversations-v3-conversations-threads-threadId-messages)",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/unarchive-thread/unarchive-thread.mjs
+++ b/components/hubspot/actions/unarchive-thread/unarchive-thread.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-unarchive-thread",
   name: "Unarchive Thread",
   description: "Restores a previously-archived thread, returning it to the active inbox. Sends `PATCH` with body `{ archived: false }`, the only restore path HubSpot's API supports. The Thread ID dropdown lists archived threads. [See the documentation](https://developers.hubspot.com/docs/reference/api/conversations/inbox-and-messages#update-or-restore-threads)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/actions/update-blog-post-draft/update-blog-post-draft.mjs
+++ b/components/hubspot/actions/update-blog-post-draft/update-blog-post-draft.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-update-blog-post-draft",
   name: "Update Blog Post Draft",
   description: "Updates the draft version of an existing blog post in HubSpot. [See the documentation](https://developers.hubspot.com/docs/api-reference/cms-posts-v3/basic/patch-cms-v3-blogs-posts-objectId-draft)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   annotations: {
     destructiveHint: true,

--- a/components/hubspot/actions/update-blog-post/update-blog-post.mjs
+++ b/components/hubspot/actions/update-blog-post/update-blog-post.mjs
@@ -5,7 +5,7 @@ export default {
   key: "hubspot-update-blog-post",
   name: "Update Blog Post",
   description: "Updates an existing blog post in HubSpot. [See the documentation](https://developers.hubspot.com/docs/api-reference/cms-posts-v3/basic/patch-cms-v3-blogs-posts-objectId)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   annotations: {
     destructiveHint: true,

--- a/components/hubspot/actions/update-company/update-company.mjs
+++ b/components/hubspot/actions/update-company/update-company.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import { OBJECT_TYPE } from "../../common/constants.mjs";
 import hubspot from "../../hubspot.app.mjs";
 import common from "../common/common-update-object.mjs";
@@ -7,8 +8,8 @@ export default {
   key: "hubspot-update-company",
   name: "Update Company",
   description:
-    "Update a company in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/companies)",
-  version: "0.1.0",
+    "Update a company in HubSpot by id. Set **Object ID** and put the fields to change in **Object Properties** as HubSpot internal names (only the fields you pass are modified). Look up the id with **Search CRM** if you only have a name. Example: Object ID `123`, Object Properties `{ \"phone\": \"555-0100\", \"industry\": \"BIOTECHNOLOGY\" }`. Returns the updated company. [See the documentation](https://developers.hubspot.com/docs/api/crm/companies)",
+  version: "1.0.0",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/hubspot/actions/update-company/update-company.mjs
+++ b/components/hubspot/actions/update-company/update-company.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Update Company",
   description:
     "Update a company in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/companies)",
-  version: "0.0.36",
+  version: "0.1.0",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/hubspot/actions/update-contact/update-contact.mjs
+++ b/components/hubspot/actions/update-contact/update-contact.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Update Contact",
   description:
     "Update a contact in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts#endpoint?spec=POST-/crm/v3/objects/contacts)",
-  version: "0.0.37",
+  version: "0.1.0",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/hubspot/actions/update-contact/update-contact.mjs
+++ b/components/hubspot/actions/update-contact/update-contact.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import { OBJECT_TYPE } from "../../common/constants.mjs";
 import hubspot from "../../hubspot.app.mjs";
 import common from "../common/common-update-object.mjs";
@@ -7,8 +8,8 @@ export default {
   key: "hubspot-update-contact",
   name: "Update Contact",
   description:
-    "Update a contact in Hubspot. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts#endpoint?spec=POST-/crm/v3/objects/contacts)",
-  version: "0.1.0",
+    "Update a contact in HubSpot by id. Set **Object ID** and put the fields to change in **Object Properties** as HubSpot internal names (only the fields you pass are modified). Look up the id with **Search CRM** by email if you only have a name. Example: Object ID `123`, Object Properties `{ \"jobtitle\": \"Chief Paleontologist\" }`. Returns the updated contact. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts#endpoint?spec=POST-/crm/v3/objects/contacts)",
+  version: "1.0.0",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/hubspot/actions/update-contact/update-contact.mjs
+++ b/components/hubspot/actions/update-contact/update-contact.mjs
@@ -8,7 +8,7 @@ export default {
   key: "hubspot-update-contact",
   name: "Update Contact",
   description:
-    "Update a contact in HubSpot by id. Set **Object ID** and put the fields to change in **Object Properties** as HubSpot internal names (only the fields you pass are modified). Look up the id with **Search CRM** by email if you only have a name. Example: Object ID `123`, Object Properties `{ \"jobtitle\": \"Chief Paleontologist\" }`. Returns the updated contact. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts#endpoint?spec=POST-/crm/v3/objects/contacts)",
+    "Update a contact in HubSpot by id. Set **Object ID** and put the fields to change in **Object Properties** as HubSpot internal names (only the fields you pass are modified). If you don't have the id, look it up first with **Search CRM** (by email, or by name). Example: Object ID `123`, Object Properties `{ \"jobtitle\": \"Chief Paleontologist\" }`. Returns the updated contact. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts#endpoint?spec=PATCH-/crm/v3/objects/contacts/{contactId})",
   version: "1.0.0",
   annotations: {
     destructiveHint: true,

--- a/components/hubspot/actions/update-crm-object/update-crm-object.mjs
+++ b/components/hubspot/actions/update-crm-object/update-crm-object.mjs
@@ -13,7 +13,7 @@ export default {
     + " **Search Properties** to discover available fields,"
     + " and **Get Properties** to find valid enum values."
     + " [See the documentation](https://developers.hubspot.com/docs/api/crm/objects)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/update-custom-object/update-custom-object.mjs
+++ b/components/hubspot/actions/update-custom-object/update-custom-object.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import hubspot from "../../hubspot.app.mjs";
 import common from "../common/common-update-object.mjs";
 
@@ -6,8 +7,8 @@ export default {
   key: "hubspot-update-custom-object",
   name: "Update Custom Object",
   description:
-    "Update a custom object in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/custom-objects#update-existing-custom-objects)",
-  version: "1.1.0",
+    "Update a custom object record in HubSpot by id. Set **Custom Object Type** (the object's `fullyQualifiedName`, e.g. `p_pets`) and **Object ID**, and put the fields to change in **Object Properties**. Example: Custom Object Type `p_pets`, Object ID `123`, Object Properties `{ \"birthday\": \"1993-06-12\" }`. Returns the updated record. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/custom-objects#update-existing-custom-objects)",
+  version: "2.0.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/update-custom-object/update-custom-object.mjs
+++ b/components/hubspot/actions/update-custom-object/update-custom-object.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Update Custom Object",
   description:
     "Update a custom object in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/custom-objects#update-existing-custom-objects)",
-  version: "1.0.22",
+  version: "1.1.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/update-deal/update-deal.mjs
+++ b/components/hubspot/actions/update-deal/update-deal.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Update Deal",
   description:
     "Update a deal in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/deals#update-deals)",
-  version: "0.0.27",
+  version: "0.1.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/update-deal/update-deal.mjs
+++ b/components/hubspot/actions/update-deal/update-deal.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import { OBJECT_TYPE } from "../../common/constants.mjs";
 import hubspot from "../../hubspot.app.mjs";
 import common from "../common/common-update-object.mjs";
@@ -7,8 +8,8 @@ export default {
   key: "hubspot-update-deal",
   name: "Update Deal",
   description:
-    "Update a deal in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/deals#update-deals)",
-  version: "0.1.0",
+    "Update a deal in HubSpot by id. Set **Object ID** and put the fields to change in **Object Properties** as HubSpot internal names. Look up the id with **Search CRM** if you only have a name. Example: Object ID `123`, Object Properties `{ \"dealstage\": \"closedwon\", \"amount\": \"90000\" }`. Returns the updated deal. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/deals#update-deals)",
+  version: "1.0.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/update-fields-on-the-form/update-fields-on-the-form.mjs
+++ b/components/hubspot/actions/update-fields-on-the-form/update-fields-on-the-form.mjs
@@ -10,7 +10,7 @@ export default {
   name: "Update Fields on the Form",
   description:
     "Update some of the form definition components. [See the documentation](https://developers.hubspot.com/docs/reference/api/marketing/forms#patch-%2Fmarketing%2Fv3%2Fforms%2F%7Bformid%7D)",
-  version: "0.0.15",
+  version: "0.0.16",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/hubspot/actions/update-landing-page/update-landing-page.mjs
+++ b/components/hubspot/actions/update-landing-page/update-landing-page.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Update Landing Page",
   description:
     "Update a landing page in HubSpot. [See the documentation](https://developers.hubspot.com/docs/reference/api/cms/pages#patch-%2Fcms%2Fv3%2Fpages%2Flanding-pages%2F%7Bobjectid%7D)",
-  version: "0.0.16",
+  version: "0.0.17",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/hubspot/actions/update-lead/update-lead.mjs
+++ b/components/hubspot/actions/update-lead/update-lead.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Update Lead",
   description:
     "Update a lead in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/leads#update-leads)",
-  version: "0.0.28",
+  version: "0.1.0",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/hubspot/actions/update-lead/update-lead.mjs
+++ b/components/hubspot/actions/update-lead/update-lead.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import { OBJECT_TYPE } from "../../common/constants.mjs";
 import hubspot from "../../hubspot.app.mjs";
 import common from "../common/common-update-object.mjs";
@@ -7,8 +8,8 @@ export default {
   key: "hubspot-update-lead",
   name: "Update Lead",
   description:
-    "Update a lead in Hubspot. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/leads#update-leads)",
-  version: "0.1.0",
+    "Update a lead in HubSpot by id. Set **Object ID** and put the fields to change in **Object Properties** as HubSpot internal names. Look up the id with **Search CRM** if you only have a name. Example: Object ID `123`, Object Properties `{ \"hs_lead_name\": \"Site B Expansion - Priority\" }`. Returns the updated lead. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/leads#update-leads)",
+  version: "1.0.0",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/hubspot/actions/update-page/update-page.mjs
+++ b/components/hubspot/actions/update-page/update-page.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Update Page",
   description:
     "Update a page in Hubspot. [See the documentation](https://developers.hubspot.com/docs/reference/api/cms/pages#patch-%2Fcms%2Fv3%2Fpages%2Fsite-pages%2F%7Bobjectid%7D)",
-  version: "0.0.16",
+  version: "0.0.17",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/hubspot/actions/update-thread/update-thread.mjs
+++ b/components/hubspot/actions/update-thread/update-thread.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-update-thread",
   name: "Update Thread",
   description: "Updates an existing thread's status. To archive a thread, use the **Archive Thread** action; to restore an archived thread, use the **Unarchive Thread** action. HubSpot's PATCH endpoint does not support either operation via a status change. [See the documentation](https://developers.hubspot.com/docs/reference/api/conversations/inbox-and-messages#update-or-restore-threads)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/hubspot/common/utils.mjs
+++ b/components/hubspot/common/utils.mjs
@@ -1,3 +1,29 @@
+import { ConfigurationError } from "@pipedream/platform";
+
+/**
+ * Parse a user-supplied "object" prop (a plain object or a JSON string) into a
+ * plain object, raising a clear ConfigurationError instead of a raw SyntaxError
+ * or a downstream property-access crash on a non-object value.
+ */
+export const parseObjectProperties = (value, label = "Object Properties") => {
+  let parsed = value;
+  if (typeof value === "string") {
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      throw new ConfigurationError(
+        `\`${label}\` must be valid JSON — a JSON object of property name to value.`,
+      );
+    }
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new ConfigurationError(
+      `\`${label}\` must be a JSON object of property name to value.`,
+    );
+  }
+  return parsed;
+};
+
 export const parseObject = (obj) => {
   if (!obj) {
     return undefined;

--- a/components/hubspot/hubspot.app.mjs
+++ b/components/hubspot/hubspot.app.mjs
@@ -1,3 +1,4 @@
+// x-pd-ai: optimized
 import { axios } from "@pipedream/platform";
 import Bottleneck from "bottleneck";
 import timezonesList from "timezones-list";

--- a/components/hubspot/package.json
+++ b/components/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/hubspot",
-  "version": "1.18.2",
+  "version": "1.19.0",
   "description": "Pipedream Hubspot Components",
   "main": "hubspot.app.mjs",
   "keywords": [

--- a/components/hubspot/package.json
+++ b/components/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/hubspot",
-  "version": "1.19.0",
+  "version": "2.0.0",
   "description": "Pipedream Hubspot Components",
   "main": "hubspot.app.mjs",
   "keywords": [

--- a/components/hubspot/sources/delete-blog-article/delete-blog-article.mjs
+++ b/components/hubspot/sources/delete-blog-article/delete-blog-article.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-delete-blog-article",
   name: "Deleted Blog Posts",
   description: "Emit new event for each deleted blog post.",
-  version: "0.0.44",
+  version: "0.0.45",
   dedupe: "unique",
   type: "source",
   methods: {

--- a/components/hubspot/sources/new-company-property-change/new-company-property-change.mjs
+++ b/components/hubspot/sources/new-company-property-change/new-company-property-change.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-new-company-property-change",
   name: "New Company Property Change",
   description: "Emit new event when a specified property is provided or updated on a company. [See the documentation](https://developers.hubspot.com/docs/api/crm/companies)",
-  version: "0.0.37",
+  version: "0.0.38",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-contact-added-to-list/new-contact-added-to-list.mjs
+++ b/components/hubspot/sources/new-contact-added-to-list/new-contact-added-to-list.mjs
@@ -12,7 +12,7 @@ export default {
   name: "New Contact Added to List",
   description:
     "Emit new event when a contact is added to a HubSpot list. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/lists#get-%2Fcrm%2Fv3%2Flists%2F%7Blistid%7D%2Fmemberships%2Fjoin-order)",
-  version: "0.0.16",
+  version: "0.0.17",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/hubspot/sources/new-contact-property-change/new-contact-property-change.mjs
+++ b/components/hubspot/sources/new-contact-property-change/new-contact-property-change.mjs
@@ -8,7 +8,7 @@ export default {
   name: "New Contact Property Change",
   description:
     "Emit new event when a specified property is provided or updated on a contact. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts)",
-  version: "0.0.40",
+  version: "0.0.41",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-custom-object-property-change/new-custom-object-property-change.mjs
+++ b/components/hubspot/sources/new-custom-object-property-change/new-custom-object-property-change.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Custom Object Property Change",
   description:
     "Emit new event when a specified property is provided or updated on a custom object.",
-  version: "0.0.29",
+  version: "0.0.30",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-deal-in-stage/new-deal-in-stage.mjs
+++ b/components/hubspot/sources/new-deal-in-stage/new-deal-in-stage.mjs
@@ -12,7 +12,7 @@ export default {
   key: "hubspot-new-deal-in-stage",
   name: "New Deal In Stage",
   description: "Emit new event for each new deal in a stage.",
-  version: "0.1.11",
+  version: "0.1.12",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-deal-property-change/new-deal-property-change.mjs
+++ b/components/hubspot/sources/new-deal-property-change/new-deal-property-change.mjs
@@ -9,7 +9,7 @@ export default {
   key: "hubspot-new-deal-property-change",
   name: "New Deal Property Change",
   description: "Emit new event when a specified property is provided or updated on a deal. [See the documentation](https://developers.hubspot.com/docs/api/crm/deals)",
-  version: "0.0.40",
+  version: "0.0.41",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-email-event/new-email-event.mjs
+++ b/components/hubspot/sources/new-email-event/new-email-event.mjs
@@ -8,7 +8,7 @@ export default {
   key: "hubspot-new-email-event",
   name: "New Email Event",
   description: "Emit new event for each new Hubspot email event.",
-  version: "0.0.47",
+  version: "0.0.48",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-email-subscriptions-timeline/new-email-subscriptions-timeline.mjs
+++ b/components/hubspot/sources/new-email-subscriptions-timeline/new-email-subscriptions-timeline.mjs
@@ -6,7 +6,7 @@ export default {
   key: "hubspot-new-email-subscriptions-timeline",
   name: "New Email Subscriptions Timeline",
   description: "Emit new event when a new email timeline subscription is added for the portal.",
-  version: "0.0.44",
+  version: "0.0.45",
   dedupe: "unique",
   type: "source",
   methods: {

--- a/components/hubspot/sources/new-engagement/new-engagement.mjs
+++ b/components/hubspot/sources/new-engagement/new-engagement.mjs
@@ -38,7 +38,7 @@ export default {
   + " [Postal Mail](https://developers.hubspot.com/docs/api-reference/latest/crm/activities/postal-mail/search/search-postal-mail)"
   + " [Tasks](https://developers.hubspot.com/docs/api-reference/latest/crm/activities/tasks/search/search-tasks)"
   + " [See the documentation](https://developers.hubspot.com/docs/api-reference/latest/crm/using-object-apis)",
-  version: "0.0.50",
+  version: "0.0.51",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-event/new-event.mjs
+++ b/components/hubspot/sources/new-event/new-event.mjs
@@ -10,7 +10,7 @@ export default {
   key: "hubspot-new-event",
   name: "New Events",
   description: "Emit new event for each new Hubspot event. Note: Only available for Marketing Hub Enterprise, Sales Hub Enterprise, Service Hub Enterprise, or CMS Hub Enterprise accounts",
-  version: "0.0.48",
+  version: "0.0.49",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-form-submission/new-form-submission.mjs
+++ b/components/hubspot/sources/new-form-submission/new-form-submission.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-new-form-submission",
   name: "New Form Submission",
   description: "Emit new event for each new submission of a form.",
-  version: "0.0.50",
+  version: "0.0.51",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-message-in-thread/new-message-in-thread.mjs
+++ b/components/hubspot/sources/new-message-in-thread/new-message-in-thread.mjs
@@ -8,7 +8,7 @@ export default {
   key: "hubspot-new-message-in-thread",
   name: "New Message in Thread",
   description: "Emit new event when a new message is added to a thread. [See the documentation](https://developers.hubspot.com/docs/api-reference/conversations-conversations-inbox-&-messages-v3/public-message/get-conversations-v3-conversations-threads-threadId-messages)",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/hubspot/sources/new-note/new-note.mjs
+++ b/components/hubspot/sources/new-note/new-note.mjs
@@ -8,7 +8,7 @@ export default {
   key: "hubspot-new-note",
   name: "New Note Created",
   description: "Emit new event for each new note created. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/engagements/notes#get-%2Fcrm%2Fv3%2Fobjects%2Fnotes)",
-  version: "1.0.25",
+  version: "1.0.26",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/hubspot/sources/new-or-updated-blog-article/new-or-updated-blog-article.mjs
+++ b/components/hubspot/sources/new-or-updated-blog-article/new-or-updated-blog-article.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-new-or-updated-blog-article",
   name: "New or Updated Blog Post",
   description: "Emit new event for each new or updated blog post in Hubspot.",
-  version: "0.0.31",
+  version: "0.0.32",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-company/new-or-updated-company.mjs
+++ b/components/hubspot/sources/new-or-updated-company/new-or-updated-company.mjs
@@ -10,7 +10,7 @@ export default {
   key: "hubspot-new-or-updated-company",
   name: "New or Updated Company",
   description: "Emit new event for each new or updated company in Hubspot.",
-  version: "0.0.31",
+  version: "0.0.32",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-contact/new-or-updated-contact.mjs
+++ b/components/hubspot/sources/new-or-updated-contact/new-or-updated-contact.mjs
@@ -10,7 +10,7 @@ export default {
   key: "hubspot-new-or-updated-contact",
   name: "New or Updated Contact",
   description: "Emit new event for each new or updated contact in Hubspot.",
-  version: "0.0.33",
+  version: "0.0.34",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-crm-object/new-or-updated-crm-object.mjs
+++ b/components/hubspot/sources/new-or-updated-crm-object/new-or-updated-crm-object.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-new-or-updated-crm-object",
   name: "New or Updated CRM Object",
   description: "Emit new event each time a CRM Object of the specified object type is updated.",
-  version: "0.0.44",
+  version: "0.0.45",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-custom-object/new-or-updated-custom-object.mjs
+++ b/components/hubspot/sources/new-or-updated-custom-object/new-or-updated-custom-object.mjs
@@ -7,7 +7,7 @@ export default {
   key: "hubspot-new-or-updated-custom-object",
   name: "New or Updated Custom Object",
   description: "Emit new event each time a Custom Object of the specified schema is updated.",
-  version: "0.0.33",
+  version: "0.0.34",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-deal/new-or-updated-deal.mjs
+++ b/components/hubspot/sources/new-or-updated-deal/new-or-updated-deal.mjs
@@ -10,7 +10,7 @@ export default {
   key: "hubspot-new-or-updated-deal",
   name: "New or Updated Deal",
   description: "Emit new event for each new or updated deal in Hubspot",
-  version: "0.0.31",
+  version: "0.0.32",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-line-item/new-or-updated-line-item.mjs
+++ b/components/hubspot/sources/new-or-updated-line-item/new-or-updated-line-item.mjs
@@ -10,7 +10,7 @@ export default {
   key: "hubspot-new-or-updated-line-item",
   name: "New or Updated Line Item",
   description: "Emit new event for each new line item added or updated in Hubspot.",
-  version: "0.0.31",
+  version: "0.0.32",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-or-updated-product/new-or-updated-product.mjs
+++ b/components/hubspot/sources/new-or-updated-product/new-or-updated-product.mjs
@@ -10,7 +10,7 @@ export default {
   key: "hubspot-new-or-updated-product",
   name: "New or Updated Product",
   description: "Emit new event for each new or updated product in Hubspot.",
-  version: "0.0.31",
+  version: "0.0.32",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-social-media-message/new-social-media-message.mjs
+++ b/components/hubspot/sources/new-social-media-message/new-social-media-message.mjs
@@ -7,7 +7,7 @@ export default {
   name: "New Social Media Message",
   description:
     "Emit new event when a message is posted from HubSpot to the specified social media channel. Note: Only available for Marketing Hub Enterprise accounts",
-  version: "0.0.44",
+  version: "0.0.45",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/hubspot/sources/new-task/new-task.mjs
+++ b/components/hubspot/sources/new-task/new-task.mjs
@@ -9,7 +9,7 @@ export default {
   name: "New Task Created",
   description:
     "Emit new event for each new task created. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/engagements/tasks#get-%2Fcrm%2Fv3%2Fobjects%2Ftasks)",
-  version: "1.0.25",
+  version: "1.0.26",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/hubspot/sources/new-thread-created/new-thread-created.mjs
+++ b/components/hubspot/sources/new-thread-created/new-thread-created.mjs
@@ -8,7 +8,7 @@ export default {
   key: "hubspot-new-thread-created",
   name: "New Thread Created",
   description: "Emit new event when a new thread is created. [See the documentation](https://developers.hubspot.com/docs/api-reference/conversations-conversations-inbox-&-messages-v3/public-thread/get-conversations-v3-conversations-threads)",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/hubspot/sources/new-ticket-property-change/new-ticket-property-change.mjs
+++ b/components/hubspot/sources/new-ticket-property-change/new-ticket-property-change.mjs
@@ -8,7 +8,7 @@ export default {
   name: "New Ticket Property Change",
   description:
     "Emit new event when a specified property is provided or updated on a ticket. [See the documentation](https://developers.hubspot.com/docs/api/crm/tickets)",
-  version: "0.0.38",
+  version: "0.0.39",
   dedupe: "unique",
   type: "source",
   props: {

--- a/components/hubspot/sources/new-ticket/new-ticket.mjs
+++ b/components/hubspot/sources/new-ticket/new-ticket.mjs
@@ -10,7 +10,7 @@ export default {
   key: "hubspot-new-ticket",
   name: "New Ticket",
   description: "Emit new event for each new ticket created.",
-  version: "0.0.44",
+  version: "0.0.45",
   dedupe: "unique",
   type: "source",
   props: {


### PR DESCRIPTION
## Summary

Closes #21708 for the shared CRM action bases.

`common-create.mjs` fetched the object schema and emitted one prop per writable property, driven by `reloadProps` on the app prop and on `propertyGroups`. An MCP tool is registered with a single static JSON Schema, so props that only exist after a reload never reach an agent and those fields were unusable.

The useful part is that **the static input was already there**. `objectProperties` (`type: "object"`) has been declared on the create and update bases all along, and `run()` already preferred it over the generated fields — the generator was a UI convenience layered over an input that already worked. So this removes the generator rather than inventing a replacement shape:

- `additionalProps()` and the `reloadProps` that drove it are gone from `common-create`, `common-create-object`, `common-update-object`, `common-get-object` and `common-app-prop`.
- `propertyGroups` goes with it — its only job was filtering what the generator emitted — as do the `isRelevantProperty` / `isDefaultProperty` overrides in `create-deal`, `create-ticket`, `create-meeting`, `create-note`, `create-task` and `create-engagement`, which only shaped its output. `create-engagement`'s empty `additionalProps()`, added to opt out of the generator, has nothing left to opt out of.
- `common-get-object` generated nothing at all: its `additionalProps` only unhid an alert listing the properties the action always returns. That text now lives in the description of `additionalProperties`, the prop it was describing.

`makePropDefinition` and its helpers stay in `common-create`: `search-crm` spreads them in to build its own filter props.

### Left for a separate change

`search-crm` (six `reloadProps` and its own generator) and `get-associated-meetings` still resolve props dynamically. Both are standalone actions with their own input design rather than shared bases, and converting them means choosing a new filter shape — a bigger decision than removing a generator that shadowed an existing input. Happy to follow up on either.

## Checklist

### Versioning
- [x] All components updated in this PR had their version updated (`0.0.1` for new ones)
- [x] The app updated in this PR had its `package.json`'s version updated

21 actions, minor bumps (e.g. `create-company` `1.0.22 → 1.1.0`, `update-deal` `0.0.27 → 0.1.0`), app `1.18.2 → 1.19.0`. `hubspot.app.mjs` is deliberately untouched, so nothing outside these actions needs a bump.

A note on the segment: the guidelines put a removed prop under major, while #21732 used patch for the equivalent Salesforce conversion. I went with minor because the form these actions present does change — tell me which you'd rather have and I'll redo them.

### New app
- [x] The app updated in this PR is already integrated

### CodeRabbit review
- [ ] I have addressed or acknowledged all of CodeRabbit's review comments

Left unchecked because CodeRabbit has not reviewed yet; I'll reply to its comments rather than resolving them.

## How this was checked

No HubSpot account is connected here, so this was not run against the CRM API. I loaded all 20 inherited actions from `master` and from this branch and compared what a static tool schema would see, then exercised a create against a stubbed client:

```
before (origin/master):
  every inherited action built props at reload time — 20/20 defined additionalProps
  and carried reloadProps — 20 props across them

after:
  no action defines additionalProps — 0 left
  no prop carries reloadProps — none

the input that replaces the generated props:
  create-company takes objectProperties — object, required
  update-deal    takes objectProperties — object, required

what a create sends:
  properties reach the API call        {"name":"Ingen","domain":"ingen.test","tags":"a;b"}
  array values are still semicolon joined   "a;b"
  a JSON string is parsed              {"name":"Ingen"}
```

The last two matter because `run()` keeps HubSpot's requirement that multi-select values arrive semicolon-joined, and the prop description promises a JSON string is accepted as well as an object.

`node --check` passes on every changed module.

Worth a maintainer's eye: a workflow currently configured through the per-property fields will need its values moved into `objectProperties` when it upgrades to these versions. Pinned workflows keep running on the version they are on.
