### PR TITLE
fix(scripts): stop the telegram_bot_api version-pinned import failing validation

### DIFF
--- a/scripts/generate-package-report.js
+++ b/scripts/generate-package-report.js
@@ -8,6 +8,11 @@ const { execSync } = require('child_process');
 // names (e.g. ['import', 'packageDependencies']) to ignore only specific ones.
 const IGNORED_VALIDATIONS = {
   e2b: true, // Uses Pipedream's version-pinned import ("@e2b/code-interpreter@1.0.3"), which the dependency/import checks misread as a missing dep / invalid URL.
+  // Same version-pinned import ("node-telegram-bot-api@1.2.0"). The pin is load-bearing:
+  // the component builder reads the version from the specifier, and 2.0.0 dropped the
+  // default export this app imports. Only the two checks that misread the specifier are
+  // suppressed, so every other check still runs for this app.
+  telegram_bot_api: ['import', 'packageDependencies'],
 };
 
 // Native Node.js modules that don't need to be in package.json


### PR DESCRIPTION
## Summary

Closes #21759 — and every scheduled report after it, since this fails daily.

`@pipedream/telegram_bot_api` is the only failure in the latest run:

```
packageDependencies: Missing dependencies: node-telegram-bot-api@1.2.0
                     (for import TelegramBot from "node-telegram-bot-api@1.2.0")
import:              Cannot find package 'node-telegram-bot-api@1.2.0'
```

**The obvious fix is the wrong one.** Dropping `@1.2.0` from the specifier makes both checks pass and breaks the app: the comment above that import, added in c4fdca3f five days ago, records that the component builder resolves the npm version from the import specifier and never from `package.json`, and that `node-telegram-bot-api` 2.0.0 removed the default export this app imports. An unpinned specifier installs `latest`, which is how every build failed from 2026-08-16 until that pin landed.

So the pin stays and the checks that misread it are suppressed — which is what `e2b` already does in `IGNORED_VALIDATIONS`, for the same reason, in the same file:

```js
e2b: true, // Uses Pipedream's version-pinned import ("@e2b/code-interpreter@1.0.3"), which the dependency/import checks misread as a missing dep / invalid URL.
```

I used the array form rather than `true`, so only `import` and `packageDependencies` are suppressed and every other check still runs for this app.

### Why not fix the checks instead

`packageDependencies` could strip a trailing `@x.y.z` from a specifier before looking it up, and that would be a real improvement. The `import` check cannot be fixed that way — it runs `node` against the module, and Node genuinely cannot resolve `node-telegram-bot-api@1.2.0`. Since one of the two needs an entry regardless, and the file already documents this exact case for `e2b`, matching that seemed better than half a general fix. Happy to do the specifier-stripping part as a follow-up if you'd like it.

## How this was checked

By running the script itself, before and after, against the failing app:

```
$ node scripts/generate-package-report.js --package=telegram_bot_api --report-only

before:  ❌ @pipedream/telegram_bot_api - FAILED (2 issues)
         ❌ Failed Validation: 1
         ⚠️  Ignored (known issues): 0
         📉 Failure Rate: 100.00%

after:   ⚠️  @pipedream/telegram_bot_api - IGNORED (2 known issue(s) suppressed)
            - packageDependencies: ... Missing dependencies: node-telegram-bot-api@1.2.0
            - import: Import test failed ...
         ✅ Failed Validation: 0
         ⚠️  Ignored (known issues): 1
         📉 Failure Rate: 0.00%
         🎉 All packages are valid! Ready for publishing.
```

The two suppressed check names are exactly the two the report names, so nothing else is being hidden.

No component changed, so no component or `package.json` version needs a bump.

## Checklist

### Versioning
- [x] All components updated in this PR had their version updated (`0.0.1` for new ones)
- [x] The app updated in this PR had its `package.json`'s version updated

Neither applies: this changes `scripts/generate-package-report.js` only.

### New app
- [x] The app updated in this PR is already integrated

### CodeRabbit review
- [ ] I have addressed or acknowledged all of CodeRabbit's review comments

Left unchecked because CodeRabbit has not reviewed yet; I'll reply to its comments rather than resolving them.
