### PR TITLE
SetSmart - new components

### DIFF
--- a/components/setsmart/actions/add-notes-to-contact/add-notes-to-contact.mjs
+++ b/components/setsmart/actions/add-notes-to-contact/add-notes-to-contact.mjs
@@ -1,0 +1,60 @@
+import { ConfigurationError } from "@pipedream/platform";
+import setsmart from "../../setsmart.app.mjs";
+
+export default {
+  key: "setsmart-add-notes-to-contact",
+  name: "Add Notes To Contact",
+  description: "Append a note to a contact so your team sees the context in the inbox. [See the documentation](https://setsmart.io/api-documentation)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    setsmart,
+    contactId: {
+      propDefinition: [
+        setsmart,
+        "contactId",
+      ],
+    },
+    phone: {
+      propDefinition: [
+        setsmart,
+        "phone",
+      ],
+    },
+    email: {
+      propDefinition: [
+        setsmart,
+        "email",
+      ],
+    },
+    notes: {
+      propDefinition: [
+        setsmart,
+        "notes",
+      ],
+    },
+  },
+  async run({ $ }) {
+    if (!this.contactId && !this.phone && !this.email) {
+      throw new ConfigurationError("You must provide at least one of **Contact ID**, **Phone** or **Email** to identify the contact.");
+    }
+
+    const response = await this.setsmart.addNotes({
+      $,
+      data: {
+        contact_id: this.contactId,
+        phone: this.phone,
+        email: this.email,
+        notes: this.notes,
+      },
+    });
+
+    $.export("$summary", "Successfully added the note to the contact");
+    return response;
+  },
+};

--- a/components/setsmart/actions/add-tag-to-contact/add-tag-to-contact.mjs
+++ b/components/setsmart/actions/add-tag-to-contact/add-tag-to-contact.mjs
@@ -1,0 +1,60 @@
+import { ConfigurationError } from "@pipedream/platform";
+import setsmart from "../../setsmart.app.mjs";
+
+export default {
+  key: "setsmart-add-tag-to-contact",
+  name: "Add Tag To Contact",
+  description: "Add a tag to an existing contact. [See the documentation](https://setsmart.io/api-documentation)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    setsmart,
+    contactId: {
+      propDefinition: [
+        setsmart,
+        "contactId",
+      ],
+    },
+    phone: {
+      propDefinition: [
+        setsmart,
+        "phone",
+      ],
+    },
+    email: {
+      propDefinition: [
+        setsmart,
+        "email",
+      ],
+    },
+    tag: {
+      propDefinition: [
+        setsmart,
+        "tag",
+      ],
+    },
+  },
+  async run({ $ }) {
+    if (!this.contactId && !this.phone && !this.email) {
+      throw new ConfigurationError("You must provide at least one of **Contact ID**, **Phone** or **Email** to identify the contact.");
+    }
+
+    const response = await this.setsmart.addTag({
+      $,
+      data: {
+        conversation_id: this.contactId,
+        phone: this.phone,
+        email: this.email,
+        tag: this.tag,
+      },
+    });
+
+    $.export("$summary", `Successfully added the tag ${this.tag}`);
+    return response;
+  },
+};

--- a/components/setsmart/actions/cancel-scheduled-message/cancel-scheduled-message.mjs
+++ b/components/setsmart/actions/cancel-scheduled-message/cancel-scheduled-message.mjs
@@ -1,0 +1,33 @@
+import setsmart from "../../setsmart.app.mjs";
+
+export default {
+  key: "setsmart-cancel-scheduled-message",
+  name: "Cancel Scheduled Message",
+  description: "Cancel a message that is scheduled but not sent yet. [See the documentation](https://setsmart.io/api-documentation)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: true,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    setsmart,
+    scheduledMessageId: {
+      type: "string",
+      label: "Scheduled Message ID",
+      description: "The ID of the scheduled message, as returned by the **List Scheduled Messages** action",
+    },
+  },
+  async run({ $ }) {
+    const response = await this.setsmart.cancelScheduledMessage({
+      $,
+      data: {
+        id: this.scheduledMessageId,
+      },
+    });
+
+    $.export("$summary", `Successfully cancelled the scheduled message ${this.scheduledMessageId}`);
+    return response;
+  },
+};

--- a/components/setsmart/actions/find-contact/find-contact.mjs
+++ b/components/setsmart/actions/find-contact/find-contact.mjs
@@ -1,0 +1,69 @@
+import { ConfigurationError } from "@pipedream/platform";
+import setsmart from "../../setsmart.app.mjs";
+
+export default {
+  key: "setsmart-find-contact",
+  name: "Find Contact",
+  description: "Find a contact and its conversation history by ID, phone number, email address, Instagram username or tag. [See the documentation](https://setsmart.io/api-documentation)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    setsmart,
+    contactId: {
+      propDefinition: [
+        setsmart,
+        "contactId",
+      ],
+    },
+    phone: {
+      propDefinition: [
+        setsmart,
+        "phone",
+      ],
+    },
+    email: {
+      propDefinition: [
+        setsmart,
+        "email",
+      ],
+    },
+    instagramUsername: {
+      propDefinition: [
+        setsmart,
+        "instagramUsername",
+      ],
+    },
+    tag: {
+      propDefinition: [
+        setsmart,
+        "tag",
+      ],
+      description: "Return the contacts carrying this tag",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    if (!this.contactId && !this.phone && !this.email && !this.instagramUsername && !this.tag) {
+      throw new ConfigurationError("You must provide at least one of **Contact ID**, **Phone**, **Email**, **Instagram Username** or **Tag**.");
+    }
+
+    const response = await this.setsmart.findContact({
+      $,
+      params: {
+        contact_id: this.contactId,
+        phone: this.phone,
+        email: this.email,
+        instagram_username: this.instagramUsername,
+        tag: this.tag,
+      },
+    });
+
+    $.export("$summary", "Successfully searched for the contact");
+    return response;
+  },
+};

--- a/components/setsmart/actions/import-contact/import-contact.mjs
+++ b/components/setsmart/actions/import-contact/import-contact.mjs
@@ -1,0 +1,83 @@
+import { ConfigurationError } from "@pipedream/platform";
+import setsmart from "../../setsmart.app.mjs";
+
+export default {
+  key: "setsmart-import-contact",
+  name: "Import Contact",
+  description: "Create a contact in the workspace and optionally hand it over to an AI assistant. [See the documentation](https://setsmart.io/api-documentation)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    setsmart,
+    phone: {
+      propDefinition: [
+        setsmart,
+        "phone",
+      ],
+    },
+    email: {
+      propDefinition: [
+        setsmart,
+        "email",
+      ],
+    },
+    firstName: {
+      type: "string",
+      label: "First Name",
+      description: "First name of the contact",
+      optional: true,
+    },
+    lastName: {
+      type: "string",
+      label: "Last Name",
+      description: "Last name of the contact",
+      optional: true,
+    },
+    tag: {
+      propDefinition: [
+        setsmart,
+        "tag",
+      ],
+      optional: true,
+    },
+    notes: {
+      propDefinition: [
+        setsmart,
+        "notes",
+      ],
+      optional: true,
+    },
+    assistantId: {
+      propDefinition: [
+        setsmart,
+        "assistantId",
+      ],
+    },
+  },
+  async run({ $ }) {
+    if (!this.phone && !this.email) {
+      throw new ConfigurationError("You must provide at least a **Phone** or an **Email** to import a contact.");
+    }
+
+    const response = await this.setsmart.importContact({
+      $,
+      data: {
+        number: this.phone,
+        email: this.email,
+        name: this.firstName,
+        last: this.lastName,
+        tag: this.tag,
+        notes: this.notes,
+        assistant_id: this.assistantId,
+      },
+    });
+
+    $.export("$summary", `Successfully imported the contact ${this.phone || this.email}`);
+    return response;
+  },
+};

--- a/components/setsmart/actions/list-answered-leads/list-answered-leads.mjs
+++ b/components/setsmart/actions/list-answered-leads/list-answered-leads.mjs
@@ -1,0 +1,25 @@
+import setsmart from "../../setsmart.app.mjs";
+
+export default {
+  key: "setsmart-list-answered-leads",
+  name: "List Answered Leads",
+  description: "List the leads who replied to the AI assistant. [See the documentation](https://setsmart.io/api-documentation)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    setsmart,
+  },
+  async run({ $ }) {
+    const response = await this.setsmart.listAnsweredLeads({
+      $,
+    });
+
+    $.export("$summary", `Successfully retrieved ${response?.length ?? 0} answered lead(s)`);
+    return response;
+  },
+};

--- a/components/setsmart/actions/list-leads/list-leads.mjs
+++ b/components/setsmart/actions/list-leads/list-leads.mjs
@@ -1,0 +1,25 @@
+import setsmart from "../../setsmart.app.mjs";
+
+export default {
+  key: "setsmart-list-leads",
+  name: "List Leads",
+  description: "List every lead in the workspace. [See the documentation](https://setsmart.io/api-documentation)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    setsmart,
+  },
+  async run({ $ }) {
+    const response = await this.setsmart.listLeads({
+      $,
+    });
+
+    $.export("$summary", `Successfully retrieved ${response?.length ?? 0} lead(s)`);
+    return response;
+  },
+};

--- a/components/setsmart/actions/list-qualified-leads/list-qualified-leads.mjs
+++ b/components/setsmart/actions/list-qualified-leads/list-qualified-leads.mjs
@@ -1,0 +1,25 @@
+import setsmart from "../../setsmart.app.mjs";
+
+export default {
+  key: "setsmart-list-qualified-leads",
+  name: "List Qualified Leads",
+  description: "List the leads the AI assistant qualified as ready to book a call. [See the documentation](https://setsmart.io/api-documentation)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    setsmart,
+  },
+  async run({ $ }) {
+    const response = await this.setsmart.listQualifiedLeads({
+      $,
+    });
+
+    $.export("$summary", `Successfully retrieved ${response?.length ?? 0} qualified lead(s)`);
+    return response;
+  },
+};

--- a/components/setsmart/actions/list-scheduled-messages/list-scheduled-messages.mjs
+++ b/components/setsmart/actions/list-scheduled-messages/list-scheduled-messages.mjs
@@ -1,0 +1,25 @@
+import setsmart from "../../setsmart.app.mjs";
+
+export default {
+  key: "setsmart-list-scheduled-messages",
+  name: "List Scheduled Messages",
+  description: "List the messages that are scheduled but not sent yet. [See the documentation](https://setsmart.io/api-documentation)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  props: {
+    setsmart,
+  },
+  async run({ $ }) {
+    const response = await this.setsmart.listScheduledMessages({
+      $,
+    });
+
+    $.export("$summary", `Successfully retrieved ${response?.length ?? 0} scheduled message(s)`);
+    return response;
+  },
+};

--- a/components/setsmart/actions/mark-contact-as-booked/mark-contact-as-booked.mjs
+++ b/components/setsmart/actions/mark-contact-as-booked/mark-contact-as-booked.mjs
@@ -1,0 +1,60 @@
+import { ConfigurationError } from "@pipedream/platform";
+import setsmart from "../../setsmart.app.mjs";
+
+export default {
+  key: "setsmart-mark-contact-as-booked",
+  name: "Mark Contact As Booked",
+  description: "Mark a contact as booked once a call has been scheduled, which stops the AI from chasing them. [See the documentation](https://setsmart.io/api-documentation)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    setsmart,
+    contactId: {
+      propDefinition: [
+        setsmart,
+        "contactId",
+      ],
+    },
+    phone: {
+      propDefinition: [
+        setsmart,
+        "phone",
+      ],
+    },
+    email: {
+      propDefinition: [
+        setsmart,
+        "email",
+      ],
+    },
+    instagramUsername: {
+      propDefinition: [
+        setsmart,
+        "instagramUsername",
+      ],
+    },
+  },
+  async run({ $ }) {
+    if (!this.contactId && !this.phone && !this.email && !this.instagramUsername) {
+      throw new ConfigurationError("You must provide at least one of **Contact ID**, **Phone**, **Email** or **Instagram Username**.");
+    }
+
+    const response = await this.setsmart.setBooked({
+      $,
+      data: {
+        contact_id: this.contactId,
+        phone: this.phone,
+        email: this.email,
+        instagram_username: this.instagramUsername,
+      },
+    });
+
+    $.export("$summary", "Successfully marked the contact as booked");
+    return response;
+  },
+};

--- a/components/setsmart/actions/remove-tag-from-contact/remove-tag-from-contact.mjs
+++ b/components/setsmart/actions/remove-tag-from-contact/remove-tag-from-contact.mjs
@@ -1,0 +1,60 @@
+import { ConfigurationError } from "@pipedream/platform";
+import setsmart from "../../setsmart.app.mjs";
+
+export default {
+  key: "setsmart-remove-tag-from-contact",
+  name: "Remove Tag From Contact",
+  description: "Remove a tag from an existing contact. [See the documentation](https://setsmart.io/api-documentation)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    setsmart,
+    contactId: {
+      propDefinition: [
+        setsmart,
+        "contactId",
+      ],
+    },
+    phone: {
+      propDefinition: [
+        setsmart,
+        "phone",
+      ],
+    },
+    email: {
+      propDefinition: [
+        setsmart,
+        "email",
+      ],
+    },
+    tag: {
+      propDefinition: [
+        setsmart,
+        "tag",
+      ],
+    },
+  },
+  async run({ $ }) {
+    if (!this.contactId && !this.phone && !this.email) {
+      throw new ConfigurationError("You must provide at least one of **Contact ID**, **Phone** or **Email** to identify the contact.");
+    }
+
+    const response = await this.setsmart.removeTag({
+      $,
+      data: {
+        conversation_id: this.contactId,
+        phone: this.phone,
+        email: this.email,
+        tag: this.tag,
+      },
+    });
+
+    $.export("$summary", `Successfully removed the tag ${this.tag}`);
+    return response;
+  },
+};

--- a/components/setsmart/actions/send-template-message/send-template-message.mjs
+++ b/components/setsmart/actions/send-template-message/send-template-message.mjs
@@ -1,0 +1,77 @@
+import { ConfigurationError } from "@pipedream/platform";
+import setsmart from "../../setsmart.app.mjs";
+
+export default {
+  key: "setsmart-send-template-message",
+  name: "Send Template Message",
+  description: "Send one of your saved message templates to a contact, immediately or at a future date. [See the documentation](https://setsmart.io/api-documentation)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    setsmart,
+    templateName: {
+      type: "string",
+      label: "Template Name",
+      description: "Name of the message template as saved in your SetSmart workspace",
+    },
+    contactId: {
+      propDefinition: [
+        setsmart,
+        "contactId",
+      ],
+      optional: false,
+    },
+    scheduleType: {
+      type: "string",
+      label: "Schedule Type",
+      description: "Send the message right away or schedule it",
+      options: [
+        {
+          label: "Immediate",
+          value: "immediate",
+        },
+        {
+          label: "Scheduled",
+          value: "scheduled",
+        },
+      ],
+      default: "immediate",
+    },
+    scheduledDateTime: {
+      type: "string",
+      label: "Scheduled Date Time",
+      description: "When to send the message, as an ISO 8601 timestamp (e.g. `2026-01-15T09:00:00Z`). Required when **Schedule Type** is `scheduled`.",
+      optional: true,
+    },
+    assistantId: {
+      propDefinition: [
+        setsmart,
+        "assistantId",
+      ],
+    },
+  },
+  async run({ $ }) {
+    if (this.scheduleType === "scheduled" && !this.scheduledDateTime) {
+      throw new ConfigurationError("**Scheduled Date Time** is required when **Schedule Type** is `scheduled`.");
+    }
+
+    const response = await this.setsmart.sendTemplate({
+      $,
+      data: {
+        template_name: this.templateName,
+        contact_id: this.contactId,
+        schedule_type: this.scheduleType,
+        scheduled_date_time: this.scheduledDateTime,
+        assistant_id: this.assistantId,
+      },
+    });
+
+    $.export("$summary", `Successfully sent the template ${this.templateName}`);
+    return response;
+  },
+};

--- a/components/setsmart/actions/turn-ai-off/turn-ai-off.mjs
+++ b/components/setsmart/actions/turn-ai-off/turn-ai-off.mjs
@@ -1,0 +1,53 @@
+import { ConfigurationError } from "@pipedream/platform";
+import setsmart from "../../setsmart.app.mjs";
+
+export default {
+  key: "setsmart-turn-ai-off",
+  name: "Turn AI Off",
+  description: "Stop the AI assistant from answering this contact, for example once a human takes over. [See the documentation](https://setsmart.io/api-documentation)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    setsmart,
+    contactId: {
+      propDefinition: [
+        setsmart,
+        "contactId",
+      ],
+    },
+    phone: {
+      propDefinition: [
+        setsmart,
+        "phone",
+      ],
+    },
+    email: {
+      propDefinition: [
+        setsmart,
+        "email",
+      ],
+    },
+  },
+  async run({ $ }) {
+    if (!this.contactId && !this.phone && !this.email) {
+      throw new ConfigurationError("You must provide at least one of **Contact ID**, **Phone** or **Email** to identify the contact.");
+    }
+
+    const response = await this.setsmart.turnAiOff({
+      $,
+      data: {
+        contact_id: this.contactId,
+        phone: this.phone,
+        email: this.email,
+      },
+    });
+
+    $.export("$summary", "Successfully turned the AI off for the contact");
+    return response;
+  },
+};

--- a/components/setsmart/actions/turn-ai-on/turn-ai-on.mjs
+++ b/components/setsmart/actions/turn-ai-on/turn-ai-on.mjs
@@ -1,0 +1,53 @@
+import { ConfigurationError } from "@pipedream/platform";
+import setsmart from "../../setsmart.app.mjs";
+
+export default {
+  key: "setsmart-turn-ai-on",
+  name: "Turn AI On",
+  description: "Let the AI assistant answer this contact again. [See the documentation](https://setsmart.io/api-documentation)",
+  version: "0.0.1",
+  type: "action",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  props: {
+    setsmart,
+    contactId: {
+      propDefinition: [
+        setsmart,
+        "contactId",
+      ],
+    },
+    phone: {
+      propDefinition: [
+        setsmart,
+        "phone",
+      ],
+    },
+    email: {
+      propDefinition: [
+        setsmart,
+        "email",
+      ],
+    },
+  },
+  async run({ $ }) {
+    if (!this.contactId && !this.phone && !this.email) {
+      throw new ConfigurationError("You must provide at least one of **Contact ID**, **Phone** or **Email** to identify the contact.");
+    }
+
+    const response = await this.setsmart.turnAiOn({
+      $,
+      data: {
+        contact_id: this.contactId,
+        phone: this.phone,
+        email: this.email,
+      },
+    });
+
+    $.export("$summary", "Successfully turned the AI on for the contact");
+    return response;
+  },
+};

--- a/components/setsmart/package.json
+++ b/components/setsmart/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@pipedream/setsmart",
+  "version": "0.1.0",
+  "description": "Pipedream SetSmart Components",
+  "main": "setsmart.app.mjs",
+  "keywords": [
+    "pipedream",
+    "setsmart"
+  ],
+  "homepage": "https://pipedream.com/apps/setsmart",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^3.2.5"
+  }
+}

--- a/components/setsmart/setsmart.app.mjs
+++ b/components/setsmart/setsmart.app.mjs
@@ -1,0 +1,161 @@
+import { axios } from "@pipedream/platform";
+
+export default {
+  type: "app",
+  app: "setsmart",
+  propDefinitions: {
+    contactId: {
+      type: "string",
+      label: "Contact ID",
+      description: "The ID of the SetSmart contact (conversation). You can find it with the **Find Contact** action.",
+      optional: true,
+    },
+    phone: {
+      type: "string",
+      label: "Phone",
+      description: "Phone number of the contact, in international format (e.g. `+14155550100`)",
+      optional: true,
+    },
+    email: {
+      type: "string",
+      label: "Email",
+      description: "Email address of the contact",
+      optional: true,
+    },
+    instagramUsername: {
+      type: "string",
+      label: "Instagram Username",
+      description: "Instagram username of the contact, with or without the leading `@`",
+      optional: true,
+    },
+    tag: {
+      type: "string",
+      label: "Tag",
+      description: "Name of the tag",
+    },
+    notes: {
+      type: "string",
+      label: "Notes",
+      description: "Note to append to the contact",
+    },
+    assistantId: {
+      type: "string",
+      label: "Assistant ID",
+      description: "The ID of the AI assistant to assign to this contact. Defaults to the workspace's default assistant.",
+      optional: true,
+    },
+  },
+  methods: {
+    _baseUrl() {
+      return "https://setsmart.io/api";
+    },
+    _headers() {
+      return {
+        "Content-Type": "application/json",
+        "x-api-key": this.$auth.api_key,
+      };
+    },
+    _makeRequest({
+      $ = this, path, ...opts
+    }) {
+      return axios($, {
+        url: `${this._baseUrl()}${path}`,
+        headers: this._headers(),
+        ...opts,
+      });
+    },
+    listLeads(opts = {}) {
+      return this._makeRequest({
+        path: "/leads",
+        ...opts,
+      });
+    },
+    listAnsweredLeads(opts = {}) {
+      return this._makeRequest({
+        path: "/answered",
+        ...opts,
+      });
+    },
+    listQualifiedLeads(opts = {}) {
+      return this._makeRequest({
+        path: "/ok-call",
+        ...opts,
+      });
+    },
+    findContact(opts = {}) {
+      return this._makeRequest({
+        path: "/find-contact",
+        ...opts,
+      });
+    },
+    importContact(opts = {}) {
+      return this._makeRequest({
+        method: "POST",
+        path: "/import-contact",
+        ...opts,
+      });
+    },
+    addTag(opts = {}) {
+      return this._makeRequest({
+        method: "POST",
+        path: "/add-tag-to-conversation",
+        ...opts,
+      });
+    },
+    removeTag(opts = {}) {
+      return this._makeRequest({
+        method: "POST",
+        path: "/remove-tag-from-conversation",
+        ...opts,
+      });
+    },
+    addNotes(opts = {}) {
+      return this._makeRequest({
+        method: "POST",
+        path: "/add-notes",
+        ...opts,
+      });
+    },
+    setBooked(opts = {}) {
+      return this._makeRequest({
+        method: "POST",
+        path: "/set-booked",
+        ...opts,
+      });
+    },
+    turnAiOn(opts = {}) {
+      return this._makeRequest({
+        method: "POST",
+        path: "/set-ai-on",
+        ...opts,
+      });
+    },
+    turnAiOff(opts = {}) {
+      return this._makeRequest({
+        method: "POST",
+        path: "/set-ai-off",
+        ...opts,
+      });
+    },
+    sendTemplate(opts = {}) {
+      return this._makeRequest({
+        method: "POST",
+        path: "/send-template",
+        ...opts,
+      });
+    },
+    listScheduledMessages(opts = {}) {
+      return this._makeRequest({
+        path: "/list-scheduled",
+        ...opts,
+      });
+    },
+    cancelScheduledMessage(opts = {}) {
+      return this._makeRequest({
+        method: "POST",
+        path: "/cancel-scheduled",
+        ...opts,
+      });
+    },
+  },
+};


### PR DESCRIPTION
Adds the **SetSmart** app and 14 actions. Companion to #21775 (app request) — the `setsmart` app slug still needs to be registered on your side for the managed `$auth.api_key` connection to resolve; everything else in this PR is ready.

I work on SetSmart and own the API, so I can provide a test workspace and API key on request, and I'll maintain these components.

## Auth

A single workspace API key, sent as an `x-api-key` header. No OAuth, no expiry, no refresh.

## Actions

**Contacts**
- Find Contact — `GET /api/find-contact` (by ID, phone, email, Instagram username or tag)
- Import Contact — `POST /api/import-contact`
- Add Tag To Contact — `POST /api/add-tag-to-conversation`
- Remove Tag From Contact — `POST /api/remove-tag-from-conversation`
- Add Notes To Contact — `POST /api/add-notes`
- Mark Contact As Booked — `POST /api/set-booked`
- Turn AI On — `POST /api/set-ai-on`
- Turn AI Off — `POST /api/set-ai-off`

**Leads**
- List Leads — `GET /api/leads`
- List Answered Leads — `GET /api/answered`
- List Qualified Leads — `GET /api/ok-call`

**Messages**
- Send Template Message — `POST /api/send-template` (immediate or scheduled)
- List Scheduled Messages — `GET /api/list-scheduled`
- Cancel Scheduled Message — `POST /api/cancel-scheduled`

## Notes

- Every request was run end-to-end against the live API using a seeded sandbox workspace.
- Actions that accept several identifiers (contact ID / phone / email / Instagram username) raise a `ConfigurationError` when none is provided, rather than sending an unresolvable request.
- Follows the component guidelines: `key`, `name`, `description`, `version`, `type` and `annotations` on every action, shared `propDefinitions` on the app, and a thin `_makeRequest` wrapper.
- Lint is clean against this repo's `eslint.config.mjs` rules for `components/**/actions/**`.
- Docs for every endpoint: https://setsmart.io/api-documentation

Sources (new qualified lead, new booking, lead replied) are a natural follow-up — we emit those as webhooks today, so I can add instant sources in a second PR once the actions land.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SetSmart integration with API-key authentication.
  * Added actions to create, find, update, tag, book, and manage contacts.
  * Added actions to control AI assistance for individual contacts.
  * Added lead-listing actions, including answered and qualified leads.
  * Added actions to send, view, and cancel scheduled message templates.
  * Added support for adding notes to contacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->