### PR TITLE
Slack: pinning @slack/web-api to 8.0.0

### DIFF
--- a/components/slack_v2/actions/add-emoji-reaction/add-emoji-reaction.mjs
+++ b/components/slack_v2/actions/add-emoji-reaction/add-emoji-reaction.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-add-emoji-reaction",
   name: "Add Emoji Reaction",
   description: "Add an emoji reaction to a message. [See the documentation](https://api.slack.com/methods/reactions.add)",
-  version: "0.0.23",
+  version: "0.0.24",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/add-reaction/add-reaction.mjs
+++ b/components/slack_v2/actions/add-reaction/add-reaction.mjs
@@ -10,7 +10,7 @@ export default {
     + " Use **Get Channel History** or **Search** to find the message timestamp."
     + " Emoji name should be without colons (e.g. `thumbsup`, `fire`, `heart`)."
     + " [See the documentation](https://api.slack.com/methods/reactions.add)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/archive-channel/archive-channel.mjs
+++ b/components/slack_v2/actions/archive-channel/archive-channel.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-archive-channel",
   name: "Archive Channel",
   description: "Archive a channel. [See the documentation](https://api.slack.com/methods/conversations.archive)",
-  version: "0.0.31",
+  version: "0.0.32",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/slack_v2/actions/browse-files/browse-files.mjs
+++ b/components/slack_v2/actions/browse-files/browse-files.mjs
@@ -10,7 +10,7 @@ export default {
     + " Filter by file type (e.g. `images`, `pdfs`, `snippets`)."
     + " Returns file metadata including name, type, size, and download URL."
     + " [See the documentation](https://api.slack.com/methods/files.list)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/create-channel/create-channel.mjs
+++ b/components/slack_v2/actions/create-channel/create-channel.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-create-channel",
   name: "Create a Channel",
   description: "Create a new channel. [See the documentation](https://api.slack.com/methods/conversations.create)",
-  version: "0.0.31",
+  version: "0.0.32",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/create-reminder/create-reminder.mjs
+++ b/components/slack_v2/actions/create-reminder/create-reminder.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-create-reminder",
   name: "Create Reminder",
   description: "Create a reminder. [See the documentation](https://api.slack.com/methods/reminders.add)",
-  version: "0.0.32",
+  version: "0.0.33",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/delete-file/delete-file.mjs
+++ b/components/slack_v2/actions/delete-file/delete-file.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-delete-file",
   name: "Delete File",
   description: "Delete a file. [See the documentation](https://api.slack.com/methods/files.delete)",
-  version: "0.0.31",
+  version: "0.0.32",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/slack_v2/actions/delete-message/delete-message.mjs
+++ b/components/slack_v2/actions/delete-message/delete-message.mjs
@@ -12,7 +12,7 @@ export default {
     + " lets an identity delete its own messages, so this deletes as whichever identity posted:"
     + " it retries automatically with the other identity if the first attempt returns"
     + " `cant_delete_message`. [See the documentation](https://api.slack.com/methods/chat.delete)",
-  version: "0.2.1",
+  version: "0.2.2",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/slack_v2/actions/edit-message/edit-message.mjs
+++ b/components/slack_v2/actions/edit-message/edit-message.mjs
@@ -11,7 +11,7 @@ export default {
     + " Requires the message timestamp (`ts`) from **Get Channel History** or **Post Message**."
     + " You can only edit messages posted by the same token/user."
     + " [See the documentation](https://api.slack.com/methods/chat.update)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/find-message/find-message.mjs
+++ b/components/slack_v2/actions/find-message/find-message.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-find-message",
   name: "Find Message",
   description: "Find a Slack message. [See the documentation](https://api.slack.com/methods/assistant.search.context)",
-  version: "0.1.5",
+  version: "0.1.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/find-user-by-email/find-user-by-email.mjs
+++ b/components/slack_v2/actions/find-user-by-email/find-user-by-email.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-find-user-by-email",
   name: "Find User by Email",
   description: "Find a user by matching against their email. [See the documentation](https://api.slack.com/methods/users.lookupByEmail)",
-  version: "0.0.30",
+  version: "0.0.31",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/find-user-by-id/find-user-by-id.mjs
+++ b/components/slack_v2/actions/find-user-by-id/find-user-by-id.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-find-user-by-id",
   name: "Find User by ID",
   description: "Find a user by their ID. Returns user profile information including name, email (requires `users:read.email` scope), timezone, and status. [See the documentation](https://api.slack.com/methods/users.info)",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/get-channel-details/get-channel-details.mjs
+++ b/components/slack_v2/actions/get-channel-details/get-channel-details.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-get-channel-details",
   name: "Get Channel Details",
   description: "Retrieve details for a Slack channel, specified by ID or by name — names are resolved automatically. [See the documentation](https://api.slack.com/methods/conversations.info)",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/get-channel-history/get-channel-history.mjs
+++ b/components/slack_v2/actions/get-channel-history/get-channel-history.mjs
@@ -16,7 +16,7 @@ export default {
     + " messages carry blocks, attachments and edit metadata, so a busy channel can run to tens"
     + " of thousands of characters and be truncated before you see any of it."
     + " [See the documentation](https://api.slack.com/methods/conversations.history)",
-  version: "0.2.0",
+  version: "0.2.1",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/get-current-user/get-current-user.mjs
+++ b/components/slack_v2/actions/get-current-user/get-current-user.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-get-current-user",
   name: "Get Current User",
   description: "Do NOT use for a plain \"who am I\" / \"what's my user ID\" question — call **Get User Details** for that; it answers the same question with a far smaller payload. Use this ONLY when you specifically need the full member profile: locale, timezone, presence/status, admin and owner flags, name variants, or workspace domain and enterprise metadata. Combines `auth.test`, `users.info`, `users.profile.get` and `team.info`. [See Slack API docs](https://api.slack.com/methods/auth.test).",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/get-file/get-file.mjs
+++ b/components/slack_v2/actions/get-file/get-file.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-get-file",
   name: "Get File",
   description: "Return information about a file. [See the documentation](https://api.slack.com/methods/files.info)",
-  version: "0.1.6",
+  version: "0.1.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/get-thread-replies/get-thread-replies.mjs
+++ b/components/slack_v2/actions/get-thread-replies/get-thread-replies.mjs
@@ -14,7 +14,7 @@ export default {
     + " Slack messages carry blocks, attachments and edit metadata, so a long thread can run"
     + " to tens of thousands of characters and be truncated before you see any of it."
     + " [See the documentation](https://api.slack.com/methods/conversations.replies)",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/get-user-details/get-user-details.mjs
+++ b/components/slack_v2/actions/get-user-details/get-user-details.mjs
@@ -14,7 +14,7 @@ export default {
     + " Prefer this over **Get Current User**, which returns a much larger payload and is only"
     + " needed for full profile detail (locale, status, admin flags)."
     + " [See the documentation](https://api.slack.com/methods/auth.test)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/invite-user-to-channel/invite-user-to-channel.mjs
+++ b/components/slack_v2/actions/invite-user-to-channel/invite-user-to-channel.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-invite-user-to-channel",
   name: "Invite User to Channel",
   description: "Invite one or more users to an existing channel. Accepts a channel ID or NAME, and a user ID, EMAIL address or display name — all resolved automatically. Pass several users as a comma-separated list. [See the documentation](https://api.slack.com/methods/conversations.invite)",
-  version: "0.1.1",
+  version: "0.1.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/kick-user/kick-user.mjs
+++ b/components/slack_v2/actions/kick-user/kick-user.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-kick-user",
   name: "Kick User",
   description: "Remove a user from a conversation. [See the documentation](https://api.slack.com/methods/conversations.kick)",
-  version: "0.0.31",
+  version: "0.0.32",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/slack_v2/actions/list-channels/list-channels.mjs
+++ b/components/slack_v2/actions/list-channels/list-channels.mjs
@@ -15,7 +15,7 @@ export default {
     + " fetched — when you see that, raise `numPages` (or pass `cursor`) before answering"
     + " any 'how many' or 'list every' question, otherwise your answer is silently incomplete."
     + " [See the documentation](https://api.slack.com/methods/conversations.list)",
-  version: "0.2.1",
+  version: "0.2.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/list-emojis/list-emojis.mjs
+++ b/components/slack_v2/actions/list-emojis/list-emojis.mjs
@@ -5,7 +5,7 @@ export default {
   name: "List Emojis",
   description:
     "List all available emojis in the Slack workspace. Optionally include emoji image URLs. [See the documentation](https://api.slack.com/methods/emoji.list)",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/list-files/list-files.mjs
+++ b/components/slack_v2/actions/list-files/list-files.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-list-files",
   name: "List Files",
   description: "Return a list of files within a team. [See the documentation](https://api.slack.com/methods/files.list)",
-  version: "0.1.6",
+  version: "0.1.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/list-group-members/list-group-members.mjs
+++ b/components/slack_v2/actions/list-group-members/list-group-members.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-list-group-members",
   name: "List Group Members",
   description: "List all users in a User Group. [See the documentation](https://api.slack.com/methods/usergroups.users.list)",
-  version: "0.0.15",
+  version: "0.0.16",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/list-icon-emoji-options/list-icon-emoji-options.mjs
+++ b/components/slack_v2/actions/list-icon-emoji-options/list-icon-emoji-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-list-icon-emoji-options",
   name: "List Icon (emoji) Options",
   description: "Retrieves available options for the Icon (emoji) field.",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/list-members-in-channel/list-members-in-channel.mjs
+++ b/components/slack_v2/actions/list-members-in-channel/list-members-in-channel.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-list-members-in-channel",
   name: "List Members in Channel",
   description: "Retrieve members of a channel. Accepts a channel ID or NAME (e.g. general or #general) — names are resolved automatically. [See the documentation](https://api.slack.com/methods/conversations.members)",
-  version: "0.1.1",
+  version: "0.1.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/list-messages/list-messages.mjs
+++ b/components/slack_v2/actions/list-messages/list-messages.mjs
@@ -9,7 +9,7 @@ export default {
     + " selection to keep responses small, and returns the same message data."
     + " This legacy tool remains only for existing workflows: it accepts a raw conversation ID and"
     + " returns full, untrimmed message objects. [See the documentation](https://api.slack.com/methods/conversations.history)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/list-reminder-options/list-reminder-options.mjs
+++ b/components/slack_v2/actions/list-reminder-options/list-reminder-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-list-reminder-options",
   name: "List Reminder Options",
   description: "Retrieves available options for the Reminder field.",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/list-replies/list-replies.mjs
+++ b/components/slack_v2/actions/list-replies/list-replies.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-list-replies",
   name: "List Replies",
   description: "Retrieve a thread of messages posted to a conversation. [See the documentation](https://api.slack.com/methods/conversations.replies)",
-  version: "0.0.31",
+  version: "0.0.32",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/list-user-group-options/list-user-group-options.mjs
+++ b/components/slack_v2/actions/list-user-group-options/list-user-group-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-list-user-group-options",
   name: "List User Group Options",
   description: "Retrieves available options for the User Group field.",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/list-users/list-users.mjs
+++ b/components/slack_v2/actions/list-users/list-users.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-list-users",
   name: "List Users",
   description: "Return a list of all users in a workspace. [See the documentation](https://api.slack.com/methods/users.list)",
-  version: "0.0.30",
+  version: "0.0.31",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/post-message/post-message.mjs
+++ b/components/slack_v2/actions/post-message/post-message.mjs
@@ -11,7 +11,7 @@ export default {
     + " To reply to a thread, provide `thread_ts` from **Get Channel History**."
     + " Supports plain text with Slack mrkdwn formatting and Block Kit blocks."
     + " [See the documentation](https://api.slack.com/methods/chat.postMessage)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/reply-to-a-message/reply-to-a-message.mjs
+++ b/components/slack_v2/actions/reply-to-a-message/reply-to-a-message.mjs
@@ -6,7 +6,7 @@ export default {
   key: "slack_v2-reply-to-a-message",
   name: "Reply to a Message Thread",
   description: "Send a message as a threaded reply. See [postMessage](https://api.slack.com/methods/chat.postMessage) or [scheduleMessage](https://api.slack.com/methods/chat.scheduleMessage) docs here",
-  version: "0.2.6",
+  version: "0.2.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/search/search.mjs
+++ b/components/slack_v2/actions/search/search.mjs
@@ -10,7 +10,7 @@ export default {
     + " Use **Get User Details** first to find your user ID for filtering by 'my' messages."
     + " Returns matching messages with channel context, timestamps, and permalinks."
     + " [See the documentation](https://api.slack.com/methods/assistant.search.context)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/send-block-kit-message/send-block-kit-message.mjs
+++ b/components/slack_v2/actions/send-block-kit-message/send-block-kit-message.mjs
@@ -7,7 +7,7 @@ export default {
   key: "slack_v2-send-block-kit-message",
   name: "Build and Send a Block Kit Message",
   description: "Configure custom blocks and send to a channel, group, or user. [See the documentation](https://api.slack.com/tools/block-kit-builder).",
-  version: "0.5.6",
+  version: "0.5.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/send-large-message/send-large-message.mjs
+++ b/components/slack_v2/actions/send-large-message/send-large-message.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-send-large-message",
   name: "Send a Large Message (3000+ characters)",
   description: "Send a large message (more than 3000 characters) to a channel, group or user. See [postMessage](https://api.slack.com/methods/chat.postMessage) or [scheduleMessage](https://api.slack.com/methods/chat.scheduleMessage) docs here",
-  version: "0.1.6",
+  version: "0.1.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/send-message-advanced/send-message-advanced.mjs
+++ b/components/slack_v2/actions/send-message-advanced/send-message-advanced.mjs
@@ -7,7 +7,7 @@ export default {
   key: "slack_v2-send-message-advanced",
   name: "Send Message (Advanced)",
   description: "Customize advanced settings and send a message to a channel, group or user. See [postMessage](https://api.slack.com/methods/chat.postMessage) or [scheduleMessage](https://api.slack.com/methods/chat.scheduleMessage) docs here",
-  version: "0.1.6",
+  version: "0.1.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/send-message-to-channel/send-message-to-channel.mjs
+++ b/components/slack_v2/actions/send-message-to-channel/send-message-to-channel.mjs
@@ -6,7 +6,7 @@ export default {
   key: "slack_v2-send-message-to-channel",
   name: "Send Message to Channel",
   description: "Send a message to a public or private channel. [See the documentation](https://api.slack.com/methods/chat.postMessage)",
-  version: "0.1.6",
+  version: "0.1.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/send-message-to-user-or-group/send-message-to-user-or-group.mjs
+++ b/components/slack_v2/actions/send-message-to-user-or-group/send-message-to-user-or-group.mjs
@@ -7,7 +7,7 @@ export default {
   key: "slack_v2-send-message-to-user-or-group",
   name: "Send Message to User or Group",
   description: "Send a message to a user or group. [See the documentation](https://api.slack.com/methods/chat.postMessage)",
-  version: "0.1.6",
+  version: "0.1.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/send-message/send-message.mjs
+++ b/components/slack_v2/actions/send-message/send-message.mjs
@@ -6,7 +6,7 @@ export default {
   key: "slack_v2-send-message",
   name: "Send Message",
   description: "Send a message to a user, group, private channel or public channel. [See the documentation](https://api.slack.com/methods/chat.postMessage)",
-  version: "0.1.6",
+  version: "0.1.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/set-channel-description/set-channel-description.mjs
+++ b/components/slack_v2/actions/set-channel-description/set-channel-description.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-set-channel-description",
   name: "Set Channel Description",
   description: "Change the description or purpose of a channel. [See the documentation](https://api.slack.com/methods/conversations.setPurpose)",
-  version: "0.0.16",
+  version: "0.0.17",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/set-channel-topic/set-channel-topic.mjs
+++ b/components/slack_v2/actions/set-channel-topic/set-channel-topic.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-set-channel-topic",
   name: "Set Channel Topic",
   description: "Set the topic on a channel, specified by ID or by name — names are resolved automatically. [See the documentation](https://api.slack.com/methods/conversations.setTopic)",
-  version: "0.1.1",
+  version: "0.1.2",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/slack_v2/actions/set-status/set-status.mjs
+++ b/components/slack_v2/actions/set-status/set-status.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-set-status",
   name: "Set Status",
   description: "Set the current status for a user. [See the documentation](https://api.slack.com/methods/users.profile.set)",
-  version: "0.0.15",
+  version: "0.0.16",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/slack_v2/actions/update-group-members/update-group-members.mjs
+++ b/components/slack_v2/actions/update-group-members/update-group-members.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-update-group-members",
   name: "Update Group Members",
   description: "Update the list of users for a User Group. [See the documentation](https://api.slack.com/methods/usergroups.users.update)",
-  version: "0.0.16",
+  version: "0.0.17",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/slack_v2/actions/update-message/update-message.mjs
+++ b/components/slack_v2/actions/update-message/update-message.mjs
@@ -4,7 +4,7 @@ export default {
   key: "slack_v2-update-message",
   name: "Update Message",
   description: "Update a message. [See the documentation](https://api.slack.com/methods/chat.update)",
-  version: "0.2.6",
+  version: "0.2.7",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/slack_v2/actions/update-profile/update-profile.mjs
+++ b/components/slack_v2/actions/update-profile/update-profile.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-update-profile",
   name: "Update Profile",
   description: "Update basic profile field such as name or title. [See the documentation](https://api.slack.com/methods/users.profile.set)",
-  version: "0.0.31",
+  version: "0.0.32",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/slack_v2/actions/upload-file/upload-file.mjs
+++ b/components/slack_v2/actions/upload-file/upload-file.mjs
@@ -8,7 +8,7 @@ export default {
   key: "slack_v2-upload-file",
   name: "Upload File",
   description: "Upload a file. [See the documentation](https://api.slack.com/messaging/files#uploading_files)",
-  version: "0.1.10",
+  version: "0.1.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/verify-slack-signature/verify-slack-signature.mjs
+++ b/components/slack_v2/actions/verify-slack-signature/verify-slack-signature.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-verify-slack-signature",
   name: "Verify Slack Signature",
   description: "Verifying requests from Slack, slack signs its requests using a secret that's unique to your app. [See the documentation](https://api.slack.com/authentication/verifying-requests-from-slack)",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/package.json
+++ b/components/slack_v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/slack_v2",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Pipedream Slack_v2 Components",
   "main": "slack_v2.app.mjs",
   "keywords": [
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@pipedream/platform": "^3.2.5",
-    "@slack/web-api": "^7.9.0",
+    "@slack/web-api": "8.0.0",
     "async-retry": "^1.3.3",
     "lodash": "^4.18.1"
   }

--- a/components/slack_v2/slack_v2.app.mjs
+++ b/components/slack_v2/slack_v2.app.mjs
@@ -1,5 +1,5 @@
 // x-pd-ai: optimized
-import { WebClient } from "@slack/web-api";
+import { WebClient } from "@slack/web-api@8.0.0";
 import constants from "./common/constants.mjs";
 import get from "lodash/get.js";
 import retry from "async-retry";

--- a/components/slack_v2/sources/new-channel-created/new-channel-created.mjs
+++ b/components/slack_v2/sources/new-channel-created/new-channel-created.mjs
@@ -5,7 +5,7 @@ export default {
   ...common,
   key: "slack_v2-new-channel-created",
   name: "New Channel Created (Instant)",
-  version: "0.0.16",
+  version: "0.0.17",
   description: "Emit new event when a new channel is created.",
   type: "source",
   dedupe: "unique",

--- a/components/slack_v2/sources/new-interaction-event-received/new-interaction-event-received.mjs
+++ b/components/slack_v2/sources/new-interaction-event-received/new-interaction-event-received.mjs
@@ -3,7 +3,7 @@ import sampleEmit from "./test-event.mjs";
 
 export default {
   name: "New Interaction Events (Instant)",
-  version: "0.0.27",
+  version: "0.0.28",
   key: "slack_v2-new-interaction-event-received",
   description: "Emit new events on new Slack [interactivity events](https://api.slack.com/interactivity) sourced from [Block Kit interactive elements](https://api.slack.com/interactivity/components), [Slash commands](https://api.slack.com/interactivity/slash-commands), or [Shortcuts](https://api.slack.com/interactivity/shortcuts).",
   type: "source",

--- a/components/slack_v2/sources/new-keyword-mention/new-keyword-mention.mjs
+++ b/components/slack_v2/sources/new-keyword-mention/new-keyword-mention.mjs
@@ -7,7 +7,7 @@ export default {
   ...common,
   key: "slack_v2-new-keyword-mention",
   name: "New Keyword Mention (Instant)",
-  version: "0.1.6",
+  version: "0.1.7",
   description: "Emit new event when a specific keyword is mentioned in a channel",
   type: "source",
   dedupe: "unique",

--- a/components/slack_v2/sources/new-message-in-channels/new-message-in-channels.mjs
+++ b/components/slack_v2/sources/new-message-in-channels/new-message-in-channels.mjs
@@ -7,7 +7,7 @@ export default {
   ...common,
   key: "slack_v2-new-message-in-channels",
   name: "New Message In Channels (Instant)",
-  version: "1.1.6",
+  version: "1.1.7",
   description: "Emit new event when a new message is posted to one or more channels",
   type: "source",
   dedupe: "unique",

--- a/components/slack_v2/sources/new-private-channel-created/new-private-channel-created.mjs
+++ b/components/slack_v2/sources/new-private-channel-created/new-private-channel-created.mjs
@@ -4,7 +4,7 @@ export default {
   ...common,
   key: "slack_v2-new-private-channel-created",
   name: "New Private Channel Created",
-  version: "0.0.6",
+  version: "0.0.7",
   description: "Emit new event when a new private channel is created. [See the documentation](https://api.slack.com/methods/conversations.list)",
   type: "source",
   dedupe: "unique",

--- a/components/slack_v2/sources/new-reaction-added/new-reaction-added.mjs
+++ b/components/slack_v2/sources/new-reaction-added/new-reaction-added.mjs
@@ -5,7 +5,7 @@ export default {
   ...common,
   key: "slack_v2-new-reaction-added",
   name: "New Reaction Added (Instant)",
-  version: "1.2.6",
+  version: "1.2.7",
   description: "Emit new event when a member has added an emoji reaction to a message",
   type: "source",
   dedupe: "unique",

--- a/components/slack_v2/sources/new-saved-message/new-saved-message.mjs
+++ b/components/slack_v2/sources/new-saved-message/new-saved-message.mjs
@@ -5,7 +5,7 @@ export default {
   ...common,
   key: "slack_v2-new-saved-message",
   name: "New Saved Message (Instant)",
-  version: "0.0.12",
+  version: "0.0.13",
   description: "Emit new event when a message is saved. Note: The endpoint is marked as deprecated, and Slack might shut this off at some point down the line.",
   type: "source",
   dedupe: "unique",

--- a/components/slack_v2/sources/new-user-added/new-user-added.mjs
+++ b/components/slack_v2/sources/new-user-added/new-user-added.mjs
@@ -5,7 +5,7 @@ export default {
   ...common,
   key: "slack_v2-new-user-added",
   name: "New User Added (Instant)",
-  version: "0.0.10",
+  version: "0.0.11",
   description: "Emit new event when a new member joins a workspace.",
   type: "source",
   dedupe: "unique",

--- a/components/slack_v2/sources/new-user-mention/new-user-mention.mjs
+++ b/components/slack_v2/sources/new-user-mention/new-user-mention.mjs
@@ -7,7 +7,7 @@ export default {
   ...common,
   key: "slack_v2-new-user-mention",
   name: "New User Mention (Instant)",
-  version: "0.1.6",
+  version: "0.1.7",
   description: "Emit new event when a username or specific keyword is mentioned in a channel",
   type: "source",
   dedupe: "unique",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6820,8 +6820,7 @@ importers:
         specifier: ^4.0.7
         version: 4.1.0
 
-  components/google_health:
-    specifiers: {}
+  components/google_health: {}
 
   components/google_identity: {}
 
@@ -15014,8 +15013,8 @@ importers:
         specifier: ^3.2.5
         version: 3.3.0
       '@slack/web-api':
-        specifier: ^7.9.0
-        version: 7.12.0
+        specifier: 8.0.0
+        version: 8.0.0
       async-retry:
         specifier: ^1.3.3
         version: 1.3.3
@@ -24138,6 +24137,10 @@ packages:
     resolution: {integrity: sha512-Wz7QYfPAlG/DR+DfABddUZeNgoeY7d1J39OCR2jR+v7VBsB8ezulDK5szTnDDPDwLH5IWhLvXIHlCFZV7MSKgA==}
     engines: {node: '>= 18', npm: '>= 8.6.0'}
 
+  '@slack/logger@5.0.0':
+    resolution: {integrity: sha512-VGXhmmgsAo9shdQYh4tFDndd+7nsgp0Y5h0UPDaUp8K359pBasI6YdkMqFW3mCOxLQkq09qj7o7cq6f3DuXcJQ==}
+    engines: {node: '>= 20', npm: '>=9.6.4'}
+
   '@slack/types@1.10.0':
     resolution: {integrity: sha512-tA7GG7Tj479vojfV3AoxbckalA48aK6giGjNtgH6ihpLwTyHE3fIgRrvt8TWfLwW8X8dyu7vgmAsGLRG7hWWOg==}
     engines: {node: '>= 8.9.0', npm: '>= 5.5.1'}
@@ -24146,6 +24149,10 @@ packages:
     resolution: {integrity: sha512-ZKrdeoppbM+3l2KKOi4/3oFYKCEwiW3dQfdHZDcecJ9rAmEqWPnARYmac9taZNitb0xnSgu6GOpHgwaKI8se2g==}
     engines: {node: '>= 12.13.0', npm: '>= 6.12.0'}
 
+  '@slack/types@3.1.0':
+    resolution: {integrity: sha512-bTzqrO3lxJ5iWedo1eJKNAs1koyEhaTwKLJUkD3KETnPeQvD978AAE4jvWstUws8Gbbc4JR6iYE6F7XjE8UGmw==}
+    engines: {node: '>= 20', npm: '>=9.6.4'}
+
   '@slack/web-api@5.15.0':
     resolution: {integrity: sha512-tjQ8Zqv/Fmj9SOL9yIEd7IpTiKfKHi9DKAkfRVeotoX0clMr3SqQtBqO+KZMX27gm7dmgJsQaDKlILyzdCO+IA==}
     engines: {node: '>= 8.9.0', npm: '>= 5.5.1'}
@@ -24153,6 +24160,10 @@ packages:
   '@slack/web-api@7.12.0':
     resolution: {integrity: sha512-LrDxjYyqjeYYQGVdVZ6EYHunFmzveOr2pFpShr6TzW4KNFpdNNnpKekjtMg0PJlOsMibSySLGQqiBZQDasmRCA==}
     engines: {node: '>= 18', npm: '>= 8.6.0'}
+
+  '@slack/web-api@8.0.0':
+    resolution: {integrity: sha512-ORx3XQryQPq2Jnxv5giSKXVoQRUeylrrymIR2S9fPzLjPcCts8RayMeBSZMcpfpAqp6fnBRuPW2UB6dUPUTEZA==}
+    engines: {node: '>= 20', npm: '>=9.6.4'}
 
   '@smiirl/smiirl-library-js@1.0.5':
     resolution: {integrity: sha512-xaOV2aLYlx9jFtJzIPl0uv3/bSTcbBIlv778sWf2b3GxbL+RM70nIn4i8c2hzXzAR5dlAg++zBnbl6n8j3bchA==}
@@ -25912,9 +25923,6 @@ packages:
       bare-events:
         optional: true
 
-  bare-url@2.4.5:
-    resolution: {integrity: sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==}
-
   bare-url@2.5.1:
     resolution: {integrity: sha512-cD5ciQuKlx+eumTCfqbfiL+fhQm+dHbVNB/cX4+d+I/nx4JsVop9VoFEPAs5RJ6I84QR6bZIBjpd2kjDOYeWcg==}
 
@@ -26036,9 +26044,6 @@ packages:
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
-
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
   brace-expansion@2.1.4:
     resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
@@ -28559,11 +28564,6 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
-  glob@10.4.5:
-    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-    hasBin: true
-
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
@@ -30981,10 +30981,6 @@ packages:
   minimatch@5.1.9:
     resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
     engines: {node: '>=10'}
-
-  minimatch@9.0.5:
-    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
-    engines: {node: '>=16 || 14 >=14.17'}
 
   minimatch@9.0.9:
     resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
@@ -39347,7 +39343,7 @@ snapshots:
       content-disposition: 0.5.4
       fastify-plugin: 4.5.1
       fastq: 1.19.1
-      glob: 10.4.5
+      glob: 10.5.0
 
   '@firebase/app-check-interop-types@0.3.3': {}
 
@@ -40359,11 +40355,11 @@ snapshots:
       '@iarna/toml': 2.2.5
       dot-prop: 9.0.0
       find-up: 7.0.0
-      minimatch: 9.0.5
+      minimatch: 9.0.9
       read-pkg: 9.0.1
       semver: 7.8.5
       yaml: 2.8.1
-      yargs: 17.7.2
+      yargs: 17.7.3
 
   '@netlify/build@35.3.1(@opentelemetry/api@1.8.0)(@types/node@26.2.0)(encoding@0.1.13)(picomatch@4.0.4)(rollup@4.62.0)':
     dependencies:
@@ -40393,7 +40389,7 @@ snapshots:
       keep-func-props: 6.0.0
       log-process-errors: 11.0.1
       memoize-one: 6.0.0
-      minimatch: 9.0.5
+      minimatch: 9.0.9
       os-name: 6.1.0
       p-event: 6.0.1
       p-filter: 4.1.0
@@ -40417,7 +40413,7 @@ snapshots:
       typescript: 5.6.3
       uuid: 11.1.0
       yaml: 2.8.1
-      yargs: 17.7.2
+      yargs: 17.7.3
       zod: 3.25.76
     transitivePeerDependencies:
       - '@swc/core'
@@ -40465,7 +40461,7 @@ snapshots:
       tomlify-j0.4: 3.0.0
       validate-npm-package-name: 5.0.1
       yaml: 2.8.1
-      yargs: 17.7.2
+      yargs: 17.7.3
       zod: 4.1.12
 
   '@netlify/dev-utils@4.3.0':
@@ -40522,7 +40518,7 @@ snapshots:
       parse-imports: 2.2.1
       path-key: 4.0.0
       semver: 7.8.5
-      tar: 7.5.7
+      tar: 7.5.20
       tmp-promise: 3.0.3
       urlpattern-polyfill: 8.0.2
       uuid: 11.1.0
@@ -40672,7 +40668,7 @@ snapshots:
       junk: 4.0.1
       locate-path: 7.2.0
       merge-options: 3.0.4
-      minimatch: 9.0.5
+      minimatch: 9.0.9
       normalize-path: 3.0.0
       p-map: 7.0.4
       path-exists: 5.0.0
@@ -40684,7 +40680,7 @@ snapshots:
       toml: 3.0.0
       unixify: 1.0.0
       urlpattern-polyfill: 8.0.2
-      yargs: 17.7.2
+      yargs: 17.7.3
       zod: 3.25.76
     transitivePeerDependencies:
       - bare-abort-controller
@@ -40714,7 +40710,7 @@ snapshots:
       junk: 4.0.1
       locate-path: 7.2.0
       merge-options: 3.0.4
-      minimatch: 9.0.5
+      minimatch: 9.0.9
       normalize-path: 3.0.0
       p-map: 7.0.4
       path-exists: 5.0.0
@@ -40726,7 +40722,7 @@ snapshots:
       toml: 3.0.0
       unixify: 1.0.0
       urlpattern-polyfill: 8.0.2
-      yargs: 17.7.2
+      yargs: 17.7.3
       zod: 3.25.76
     transitivePeerDependencies:
       - bare-abort-controller
@@ -43564,15 +43560,21 @@ snapshots:
 
   '@slack/logger@2.0.0':
     dependencies:
-      '@types/node': 20.19.25
+      '@types/node': 20.19.43
 
   '@slack/logger@4.0.0':
     dependencies:
-      '@types/node': 20.19.25
+      '@types/node': 20.19.43
+
+  '@slack/logger@5.0.0':
+    dependencies:
+      '@types/node': 20.19.43
 
   '@slack/types@1.10.0': {}
 
   '@slack/types@2.18.0': {}
+
+  '@slack/types@3.1.0': {}
 
   '@slack/web-api@5.15.0':
     dependencies:
@@ -43593,7 +43595,7 @@ snapshots:
     dependencies:
       '@slack/logger': 4.0.0
       '@slack/types': 2.18.0
-      '@types/node': 20.19.25
+      '@types/node': 20.19.43
       '@types/retry': 0.12.0
       axios: 1.18.1(debug@3.2.7)
       eventemitter3: 5.0.1
@@ -43606,6 +43608,17 @@ snapshots:
     transitivePeerDependencies:
       - debug
       - supports-color
+
+  '@slack/web-api@8.0.0':
+    dependencies:
+      '@slack/logger': 5.0.0
+      '@slack/types': 3.1.0
+      '@types/node': 20.19.43
+      '@types/retry': 0.12.0
+      eventemitter3: 5.0.1
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      retry: 0.13.1
 
   '@smiirl/smiirl-library-js@1.0.5(encoding@0.1.13)':
     dependencies:
@@ -44531,7 +44544,7 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 20.19.25
+      '@types/node': 20.19.43
 
   '@types/cacheable-request@6.0.3':
     dependencies:
@@ -44556,7 +44569,7 @@ snapshots:
 
   '@types/duplexify@3.6.5':
     dependencies:
-      '@types/node': 20.19.25
+      '@types/node': 20.19.43
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -44610,7 +44623,7 @@ snapshots:
 
   '@types/is-stream@1.1.0':
     dependencies:
-      '@types/node': 20.19.25
+      '@types/node': 20.19.43
 
   '@types/isomorphic-fetch@0.0.35': {}
 
@@ -44642,7 +44655,7 @@ snapshots:
 
   '@types/jsonwebtoken@9.0.0':
     dependencies:
-      '@types/node': 20.19.25
+      '@types/node': 20.19.43
 
   '@types/jsonwebtoken@9.0.10':
     dependencies:
@@ -44733,7 +44746,7 @@ snapshots:
 
   '@types/opossum@4.1.1':
     dependencies:
-      '@types/node': 20.19.25
+      '@types/node': 20.19.43
 
   '@types/parse-json@4.0.2': {}
 
@@ -44782,7 +44795,7 @@ snapshots:
 
   '@types/sax@1.2.7':
     dependencies:
-      '@types/node': 20.19.25
+      '@types/node': 20.19.43
 
   '@types/send@0.17.6':
     dependencies:
@@ -44805,7 +44818,7 @@ snapshots:
 
   '@types/sshpk@1.10.3':
     dependencies:
-      '@types/node': 20.19.25
+      '@types/node': 20.19.43
 
   '@types/stack-utils@2.0.3': {}
 
@@ -46051,7 +46064,7 @@ snapshots:
       bare-events: 2.9.1
       bare-path: 3.1.1
       bare-stream: 2.13.3(bare-events@2.9.1)
-      bare-url: 2.4.5
+      bare-url: 2.5.1
       fast-fifo: 1.3.2
     transitivePeerDependencies:
       - bare-abort-controller
@@ -46088,11 +46101,6 @@ snapshots:
       bare-events: 2.9.1
     transitivePeerDependencies:
       - react-native-b4a
-
-  bare-url@2.4.5:
-    dependencies:
-      bare-path: 3.1.1
-    optional: true
 
   bare-url@2.5.1:
     dependencies:
@@ -46232,10 +46240,6 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
-
-  brace-expansion@2.1.2:
-    dependencies:
-      balanced-match: 1.0.2
 
   brace-expansion@2.1.4:
     dependencies:
@@ -49420,15 +49424,6 @@ snapshots:
       jackspeak: 2.3.6
       minimatch: 9.0.9
       minipass: 7.1.3
-      path-scurry: 1.11.1
-
-  glob@10.4.5:
-    dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 3.4.3
-      minimatch: 9.0.9
-      minipass: 7.1.3
-      package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
   glob@10.5.0:
@@ -52771,13 +52766,9 @@ snapshots:
     dependencies:
       brace-expansion: 2.1.4
 
-  minimatch@9.0.5:
-    dependencies:
-      brace-expansion: 2.1.2
-
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
The new 8.1.0 version caused issues, see [here](https://github.com/slackapi/node-slack-sdk/issues/2711)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Slack actions and event triggers to their latest component versions.
  * Upgraded the Slack Web API integration to version 8.0.0.
  * Released Slack integration package version 0.8.1.
  * No end-user workflow behavior changes are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->