### PR TITLE
feat(browser-use): add V4 run actions

### DIFF
--- a/components/browser_use/actions/cancel-run/cancel-run.mjs
+++ b/components/browser_use/actions/cancel-run/cancel-run.mjs
@@ -4,7 +4,7 @@ export default {
   key: "browser_use-cancel-run",
   name: "Cancel V4 Run",
   description:
-    "Cancel a Browser Use V4 run. [See the API reference](https://api.browser-use.com/api/v4/openapi.json)",
+    "Cancel an in-flight Browser Use V4 run by its Run ID. Terminal runs are returned unchanged; cancellation stops later model calls and further run billing. [See the documentation](https://api.browser-use.com/api/v4/openapi.json)",
   version: "0.0.1",
   annotations: {
     destructiveHint: true,

--- a/components/browser_use/actions/cancel-run/cancel-run.mjs
+++ b/components/browser_use/actions/cancel-run/cancel-run.mjs
@@ -27,7 +27,10 @@ export default {
       runId: this.runId,
     });
 
-    $.export("$summary", `Cancelled V4 run ${this.runId}`);
+    $.export(
+      "$summary",
+      `Run ${response.id ?? this.runId} status: ${response.status}`,
+    );
     return response;
   },
 };

--- a/components/browser_use/actions/cancel-run/cancel-run.mjs
+++ b/components/browser_use/actions/cancel-run/cancel-run.mjs
@@ -1,0 +1,33 @@
+import browserUse from "../../browser_use.app.mjs";
+
+export default {
+  key: "browser_use-cancel-run",
+  name: "Cancel V4 Run",
+  description:
+    "Cancel a Browser Use V4 run. [See the API reference](https://api.browser-use.com/api/v4/openapi.json)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: true,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  type: "action",
+  props: {
+    browserUse,
+    runId: {
+      propDefinition: [
+        browserUse,
+        "runId",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.browserUse.cancelRun({
+      $,
+      runId: this.runId,
+    });
+
+    $.export("$summary", `Cancelled V4 run ${this.runId}`);
+    return response;
+  },
+};

--- a/components/browser_use/actions/create-run/create-run.mjs
+++ b/components/browser_use/actions/create-run/create-run.mjs
@@ -1,0 +1,87 @@
+import browserUse from "../../browser_use.app.mjs";
+import {
+  cleanObject, parseOptionalObject,
+} from "../../common/utils.mjs";
+
+export default {
+  key: "browser_use-create-run",
+  name: "Create V4 Run",
+  description:
+    "Create a Browser Use V4 run. [See the API reference](https://api.browser-use.com/api/v4/openapi.json)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  type: "action",
+  props: {
+    browserUse,
+    task: {
+      type: "string",
+      label: "Task",
+      description: "What the browser agent should do.",
+    },
+    model: {
+      type: "string",
+      label: "Model",
+      description: "Current V4 model ID. Leave blank to use the API default.",
+      optional: true,
+    },
+    sessionId: {
+      type: "string",
+      label: "Session ID",
+      description: "Continue an existing V4 session.",
+      optional: true,
+    },
+    workspaceId: {
+      type: "string",
+      label: "Workspace ID",
+      description: "Attach an existing workspace.",
+      optional: true,
+    },
+    browserSettings: {
+      type: "object",
+      label: "Browser Settings",
+      description: "Optional V4 browser settings object.",
+      optional: true,
+    },
+    agentmail: {
+      type: "boolean",
+      label: "Enable AgentMail",
+      description:
+        "Provision a persistent temporary inbox for the run workspace.",
+      optional: true,
+      default: false,
+    },
+    maxCostUsd: {
+      type: "string",
+      label: "Max Cost USD",
+      description: "Maximum run cost in USD.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const response = await this.browserUse.createRun({
+      $,
+      data: cleanObject({
+        task: this.task,
+        model: this.model,
+        sessionId: this.sessionId,
+        workspaceId: this.workspaceId,
+        browserSettings: parseOptionalObject(
+          this.browserSettings,
+          "Browser Settings",
+        ),
+        agentmail: this.agentmail,
+        maxCostUsd: this.maxCostUsd,
+      }),
+    });
+
+    $.export(
+      "$summary",
+      `Created V4 run ${response.id} in session ${response.sessionId}`,
+    );
+    return response;
+  },
+};

--- a/components/browser_use/actions/create-run/create-run.mjs
+++ b/components/browser_use/actions/create-run/create-run.mjs
@@ -7,7 +7,7 @@ export default {
   key: "browser_use-create-run",
   name: "Create V4 Run",
   description:
-    "Create a Browser Use V4 run. [See the API reference](https://api.browser-use.com/api/v4/openapi.json)",
+    "Create a Browser Use V4 run for a new task, or continue an existing V4 session with a Session ID. Configure the model, browser settings, workspace, AgentMail, and cost limit; only one run can be active per session. [See the documentation](https://api.browser-use.com/api/v4/openapi.json)",
   version: "0.0.1",
   annotations: {
     destructiveHint: false,
@@ -25,14 +25,14 @@ export default {
     model: {
       type: "string",
       label: "Model",
-      description: "Current V4 model ID. Leave blank to use the API default.",
+      description: "Current V4 model ID from the API schema. Example: `gpt-5.6-luna`. Leave blank to use the API default.",
       optional: true,
     },
     sessionId: {
-      type: "string",
-      label: "Session ID",
-      description: "Continue an existing V4 session.",
-      optional: true,
+      propDefinition: [
+        browserUse,
+        "v4SessionId",
+      ],
     },
     workspaceId: {
       type: "string",
@@ -43,7 +43,7 @@ export default {
     browserSettings: {
       type: "object",
       label: "Browser Settings",
-      description: "Optional V4 browser settings object.",
+      description: "Optional V4 browser settings JSON. Example: `{\"proxyCountryCode\":\"us\"}`.",
       optional: true,
     },
     agentmail: {
@@ -57,7 +57,7 @@ export default {
     maxCostUsd: {
       type: "string",
       label: "Max Cost USD",
-      description: "Maximum run cost in USD.",
+      description: "Maximum run cost in USD. Example: `1.50`.",
       optional: true,
     },
   },

--- a/components/browser_use/actions/get-run/get-run.mjs
+++ b/components/browser_use/actions/get-run/get-run.mjs
@@ -1,0 +1,36 @@
+import browserUse from "../../browser_use.app.mjs";
+
+export default {
+  key: "browser_use-get-run",
+  name: "Get V4 Run",
+  description:
+    "Get a Browser Use V4 run, including status, result, and cost. [See the API reference](https://api.browser-use.com/api/v4/openapi.json)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  type: "action",
+  props: {
+    browserUse,
+    runId: {
+      propDefinition: [
+        browserUse,
+        "runId",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.browserUse.getRun({
+      $,
+      runId: this.runId,
+    });
+
+    $.export(
+      "$summary",
+      `Retrieved V4 run ${response.id} with status ${response.status}`,
+    );
+    return response;
+  },
+};

--- a/components/browser_use/actions/get-run/get-run.mjs
+++ b/components/browser_use/actions/get-run/get-run.mjs
@@ -4,7 +4,7 @@ export default {
   key: "browser_use-get-run",
   name: "Get V4 Run",
   description:
-    "Retrieve status, result, cost, and session details for a Browser Use V4 run. Select a run, or use the Run ID returned by Create V4 Run or List V4 Runs. [See the documentation](https://api.browser-use.com/api/v4/openapi.json)",
+    "Retrieve status, result, cost, and session details for a Browser Use V4 run. Select a run, or use the Run ID returned by **Create V4 Run** or **List V4 Runs**. [See the documentation](https://api.browser-use.com/api/v4/openapi.json)",
   version: "0.0.1",
   annotations: {
     destructiveHint: false,

--- a/components/browser_use/actions/get-run/get-run.mjs
+++ b/components/browser_use/actions/get-run/get-run.mjs
@@ -4,7 +4,7 @@ export default {
   key: "browser_use-get-run",
   name: "Get V4 Run",
   description:
-    "Get a Browser Use V4 run, including status, result, and cost. [See the API reference](https://api.browser-use.com/api/v4/openapi.json)",
+    "Retrieve status, result, cost, and session details for a Browser Use V4 run. Select a run, or use the Run ID returned by Create V4 Run or List V4 Runs. [See the documentation](https://api.browser-use.com/api/v4/openapi.json)",
   version: "0.0.1",
   annotations: {
     destructiveHint: false,

--- a/components/browser_use/actions/list-runs/list-runs.mjs
+++ b/components/browser_use/actions/list-runs/list-runs.mjs
@@ -5,7 +5,7 @@ export default {
   key: "browser_use-list-runs",
   name: "List V4 Runs",
   description:
-    "List Browser Use V4 runs with keyset pagination. [See the API reference](https://api.browser-use.com/api/v4/openapi.json)",
+    "List Browser Use V4 runs, optionally filter by V4 session, and continue with the cursor from the previous response. Use returned Run IDs with Get V4 Run or Cancel V4 Run. [See the documentation](https://api.browser-use.com/api/v4/openapi.json)",
   version: "0.0.1",
   annotations: {
     destructiveHint: false,
@@ -27,14 +27,14 @@ export default {
     cursor: {
       type: "string",
       label: "Cursor",
-      description: "Cursor returned by the previous page.",
+      description: "The `nextCursor` string returned by the previous List V4 Runs response.",
       optional: true,
     },
     sessionId: {
-      type: "string",
-      label: "Session ID",
-      description: "Return only runs from this session.",
-      optional: true,
+      propDefinition: [
+        browserUse,
+        "v4SessionId",
+      ],
     },
   },
   async run({ $ }) {

--- a/components/browser_use/actions/list-runs/list-runs.mjs
+++ b/components/browser_use/actions/list-runs/list-runs.mjs
@@ -5,7 +5,7 @@ export default {
   key: "browser_use-list-runs",
   name: "List V4 Runs",
   description:
-    "List Browser Use V4 runs, optionally filter by V4 session, and continue with the cursor from the previous response. Use returned Run IDs with Get V4 Run or Cancel V4 Run. [See the documentation](https://api.browser-use.com/api/v4/openapi.json)",
+    "List Browser Use V4 runs, optionally filter by V4 session, and continue with the cursor from the previous response. Use returned Run IDs with **Get V4 Run** or **Cancel V4 Run**. [See the documentation](https://api.browser-use.com/api/v4/openapi.json)",
   version: "0.0.1",
   annotations: {
     destructiveHint: false,

--- a/components/browser_use/actions/list-runs/list-runs.mjs
+++ b/components/browser_use/actions/list-runs/list-runs.mjs
@@ -1,0 +1,53 @@
+import browserUse from "../../browser_use.app.mjs";
+import { cleanObject } from "../../common/utils.mjs";
+
+export default {
+  key: "browser_use-list-runs",
+  name: "List V4 Runs",
+  description:
+    "List Browser Use V4 runs with keyset pagination. [See the API reference](https://api.browser-use.com/api/v4/openapi.json)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  type: "action",
+  props: {
+    browserUse,
+    limit: {
+      type: "integer",
+      label: "Limit",
+      description: "Maximum number of runs to return.",
+      optional: true,
+      default: 50,
+      min: 1,
+      max: 100,
+    },
+    cursor: {
+      type: "string",
+      label: "Cursor",
+      description: "Cursor returned by the previous page.",
+      optional: true,
+    },
+    sessionId: {
+      type: "string",
+      label: "Session ID",
+      description: "Return only runs from this session.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const response = await this.browserUse.listRuns({
+      $,
+      params: cleanObject({
+        limit: this.limit,
+        cursor: this.cursor,
+        sessionId: this.sessionId,
+      }),
+    });
+
+    $.export("$summary", `Retrieved ${response.runs?.length ?? 0} V4 runs`);
+    return response;
+  },
+};

--- a/components/browser_use/browser_use.app.mjs
+++ b/components/browser_use/browser_use.app.mjs
@@ -35,6 +35,34 @@ export default {
         };
       },
     },
+    runId: {
+      type: "string",
+      label: "Run ID",
+      description: "Select a Browser Use V4 run or provide a run ID.",
+      async options({ prevContext }) {
+        const cursor = prevContext?.cursor;
+        const response = await this.listRuns({
+          params: {
+            limit: DEFAULT_OPTIONS_PAGE_SIZE,
+            ...(cursor && {
+              cursor,
+            }),
+          },
+        });
+        const runs = response.runs ?? [];
+        return {
+          options: runs.map((run) => ({
+            label: `${run.task || run.id} (${run.status})`,
+            value: run.id,
+          })),
+          context: response.hasMore && response.nextCursor
+            ? {
+              cursor: response.nextCursor,
+            }
+            : {},
+        };
+      },
+    },
     browserSessionId: {
       type: "string",
       label: "Browser Session ID",
@@ -163,6 +191,9 @@ export default {
     _baseUrl() {
       return "https://api.browser-use.com/api/v3";
     },
+    _v4BaseUrl() {
+      return "https://api.browser-use.com/api/v4";
+    },
     _headers(headers = {}) {
       return {
         "X-Browser-Use-API-Key": this.$auth.api_key,
@@ -177,6 +208,45 @@ export default {
         ...opts,
         url: `${this._baseUrl()}${path}`,
         headers: this._headers(headers),
+      });
+    },
+    _makeV4Request({
+      $ = this, path, headers, ...opts
+    } = {}) {
+      return axios($, {
+        ...opts,
+        url: `${this._v4BaseUrl()}${path}`,
+        headers: this._headers(headers),
+      });
+    },
+    createRun(opts = {}) {
+      return this._makeV4Request({
+        method: "POST",
+        path: "/runs",
+        ...opts,
+      });
+    },
+    listRuns(opts = {}) {
+      return this._makeV4Request({
+        path: "/runs",
+        ...opts,
+      });
+    },
+    getRun({
+      runId, ...opts
+    } = {}) {
+      return this._makeV4Request({
+        path: `/runs/${encodeURIComponent(runId)}`,
+        ...opts,
+      });
+    },
+    cancelRun({
+      runId, ...opts
+    } = {}) {
+      return this._makeV4Request({
+        method: "POST",
+        path: `/runs/${encodeURIComponent(runId)}/cancel`,
+        ...opts,
       });
     },
     uploadToPresignedUrl({

--- a/components/browser_use/browser_use.app.mjs
+++ b/components/browser_use/browser_use.app.mjs
@@ -38,7 +38,7 @@ export default {
     runId: {
       type: "string",
       label: "Run ID",
-      description: "Select a Browser Use V4 run, or provide the run UUID returned by Create V4 Run or List V4 Runs. Example: `01234567-89ab-cdef-0123-456789abcdef`.",
+      description: "Select a Browser Use V4 run, or provide the run UUID returned by **Create V4 Run** or **List V4 Runs**. Example: `01234567-89ab-cdef-0123-456789abcdef`.",
       async options({ prevContext }) {
         const cursor = prevContext?.cursor;
         const response = await this.listRuns({
@@ -66,7 +66,7 @@ export default {
     v4SessionId: {
       type: "string",
       label: "V4 Session ID",
-      description: "V4 session UUID returned by Create V4 Run or Get V4 Run. Example: `01234567-89ab-cdef-0123-456789abcdef`.",
+      description: "V4 session UUID returned by **Create V4 Run** or **Get V4 Run**. Example: `01234567-89ab-cdef-0123-456789abcdef`.",
       optional: true,
     },
     browserSessionId: {

--- a/components/browser_use/browser_use.app.mjs
+++ b/components/browser_use/browser_use.app.mjs
@@ -38,7 +38,7 @@ export default {
     runId: {
       type: "string",
       label: "Run ID",
-      description: "Select a Browser Use V4 run or provide a run ID.",
+      description: "Select a Browser Use V4 run, or provide the run UUID returned by Create V4 Run or List V4 Runs. Example: `01234567-89ab-cdef-0123-456789abcdef`.",
       async options({ prevContext }) {
         const cursor = prevContext?.cursor;
         const response = await this.listRuns({
@@ -62,6 +62,12 @@ export default {
             : {},
         };
       },
+    },
+    v4SessionId: {
+      type: "string",
+      label: "V4 Session ID",
+      description: "V4 session UUID returned by Create V4 Run or Get V4 Run. Example: `01234567-89ab-cdef-0123-456789abcdef`.",
+      optional: true,
     },
     browserSessionId: {
       type: "string",

--- a/components/browser_use/browser_use.test.mjs
+++ b/components/browser_use/browser_use.test.mjs
@@ -1,0 +1,253 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import browserUse from "./browser_use.app.mjs";
+import cancelRun from "./actions/cancel-run/cancel-run.mjs";
+import createRun from "./actions/create-run/create-run.mjs";
+import getRun from "./actions/get-run/get-run.mjs";
+import listRuns from "./actions/list-runs/list-runs.mjs";
+
+const summarySink = () => {
+  const summaries = [];
+  return {
+    $: {
+      export: (...args) => summaries.push(args),
+    },
+    summaries,
+  };
+};
+
+test("run picker follows the V4 cursor envelope", async () => {
+  const calls = [];
+  const result = await browserUse.propDefinitions.runId.options.call(
+    {
+      listRuns: async (request) => {
+        calls.push(request);
+        return {
+          runs: [
+            {
+              id: "run-1",
+              task: "Check pricing",
+              status: "completed",
+            },
+          ],
+          hasMore: true,
+          nextCursor: "next-page",
+        };
+      },
+    },
+    {
+      prevContext: {
+        cursor: "current-page",
+      },
+    },
+  );
+
+  assert.deepEqual(calls, [
+    {
+      params: {
+        limit: 50,
+        cursor: "current-page",
+      },
+    },
+  ]);
+  assert.deepEqual(result, {
+    options: [
+      {
+        label: "Check pricing (completed)",
+        value: "run-1",
+      },
+    ],
+    context: {
+      cursor: "next-page",
+    },
+  });
+});
+
+test("create run sends the V4 body without undefined fields", async () => {
+  const requests = [];
+  const {
+    $, summaries,
+  } = summarySink();
+  const result = await createRun.run.call(
+    {
+      browserUse: {
+        createRun: async (request) => {
+          requests.push(request);
+          return {
+            id: "run-1",
+            sessionId: "session-1",
+          };
+        },
+      },
+      task: "Check pricing",
+      browserSettings: {
+        proxyCountryCode: "us",
+      },
+      agentmail: false,
+    },
+    {
+      $,
+    },
+  );
+
+  assert.equal(result.id, "run-1");
+  assert.deepEqual(requests[0].data, {
+    task: "Check pricing",
+    browserSettings: {
+      proxyCountryCode: "us",
+    },
+    agentmail: false,
+  });
+  assert.deepEqual(summaries, [
+    [
+      "$summary",
+      "Created V4 run run-1 in session session-1",
+    ],
+  ]);
+});
+
+test("list run forwards cursor and session filters", async () => {
+  const requests = [];
+  const {
+    $, summaries,
+  } = summarySink();
+  await listRuns.run.call(
+    {
+      browserUse: {
+        listRuns: async (request) => {
+          requests.push(request);
+          return {
+            runs: [
+              {
+                id: "run-2",
+              },
+            ],
+          };
+        },
+      },
+      limit: 25,
+      cursor: "cursor-1",
+      sessionId: "session-1",
+    },
+    {
+      $,
+    },
+  );
+
+  assert.deepEqual(requests[0].params, {
+    limit: 25,
+    cursor: "cursor-1",
+    sessionId: "session-1",
+  });
+  assert.deepEqual(summaries, [
+    [
+      "$summary",
+      "Retrieved 1 V4 runs",
+    ],
+  ]);
+});
+
+test("get and cancel encode the selected run ID", async () => {
+  const seen = [];
+  const getSink = summarySink();
+  const cancelSink = summarySink();
+
+  await getRun.run.call(
+    {
+      browserUse: {
+        getRun: async (request) => {
+          seen.push([
+            "get",
+            request.runId,
+          ]);
+          return {
+            id: request.runId,
+            status: "running",
+          };
+        },
+      },
+      runId: "run/with/slash",
+    },
+    {
+      $: getSink.$,
+    },
+  );
+  await cancelRun.run.call(
+    {
+      browserUse: {
+        cancelRun: async (request) => {
+          seen.push([
+            "cancel",
+            request.runId,
+          ]);
+          return {
+            status: "cancelled",
+          };
+        },
+      },
+      runId: "run-2",
+    },
+    {
+      $: cancelSink.$,
+    },
+  );
+
+  assert.deepEqual(seen, [
+    [
+      "get",
+      "run/with/slash",
+    ],
+    [
+      "cancel",
+      "run-2",
+    ],
+  ]);
+});
+
+test("app methods target only V4 run routes", () => {
+  const calls = [];
+  const app = {
+    _makeV4Request: (request) => calls.push(request),
+  };
+
+  browserUse.methods.createRun.call(app, {
+    data: {
+      task: "Check pricing",
+    },
+  });
+  browserUse.methods.listRuns.call(app, {
+    params: {
+      limit: 10,
+    },
+  });
+  browserUse.methods.getRun.call(app, {
+    runId: "run/1",
+  });
+  browserUse.methods.cancelRun.call(app, {
+    runId: "run/1",
+  });
+
+  assert.deepEqual(calls, [
+    {
+      method: "POST",
+      path: "/runs",
+      data: {
+        task: "Check pricing",
+      },
+    },
+    {
+      path: "/runs",
+      params: {
+        limit: 10,
+      },
+    },
+    {
+      path: "/runs/run%2F1",
+    },
+    {
+      method: "POST",
+      path: "/runs/run%2F1/cancel",
+    },
+  ]);
+});

--- a/components/browser_use/browser_use.test.mjs
+++ b/components/browser_use/browser_use.test.mjs
@@ -182,7 +182,8 @@ test("get and cancel encode the selected run ID", async () => {
             request.runId,
           ]);
           return {
-            status: "cancelled",
+            id: request.runId,
+            status: "completed",
           };
         },
       },
@@ -201,6 +202,12 @@ test("get and cancel encode the selected run ID", async () => {
     [
       "cancel",
       "run-2",
+    ],
+  ]);
+  assert.deepEqual(cancelSink.summaries, [
+    [
+      "$summary",
+      "Run run-2 status: completed",
     ],
   ]);
 });

--- a/components/browser_use/package.json
+++ b/components/browser_use/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/browser_use",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "Pipedream Browser Use Components",
   "main": "browser_use.app.mjs",
   "keywords": [

--- a/components/browser_use/package.json
+++ b/components/browser_use/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/browser_use",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Pipedream Browser Use Components",
   "main": "browser_use.app.mjs",
   "keywords": [


### PR DESCRIPTION
## Summary

The Browser Use component in Pipedream currently exposes only V3 actions. This adds create, list, get, and cancel actions for the current V4 run API while leaving every V3 action unchanged. Five focused tests pass.

## Checklist

### Versioning

- [x] All new actions start at `0.0.1`
- [x] The Browser Use app package is bumped to `0.1.0`

### New app

- [x] Browser Use is already integrated

### CodeRabbit review

- [x] All CodeRabbit comments are addressed or acknowledged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating, listing, viewing, and cancelling Browser Use V4 runs.
  * Added configurable run options, including tasks, models, sessions, workspaces, browser settings, AgentMail, and cost limits.
  * Added cursor-based pagination and session filtering when listing runs.
  * Added selectable run IDs for streamlined run management.
  * Added run status summaries and improved visibility into retrieved run details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->