### PR TITLE
[21812] fix(slack_v2): fix user-id/user-name encoding consistency across actions

### DIFF
--- a/components/slack_v2/actions/add-emoji-reaction/add-emoji-reaction.mjs
+++ b/components/slack_v2/actions/add-emoji-reaction/add-emoji-reaction.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-add-emoji-reaction",
   name: "Add Emoji Reaction",
   description: "Add an emoji reaction to a message. [See the documentation](https://api.slack.com/methods/reactions.add)",
-  version: "0.0.24",
+  version: "0.0.25",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/add-reaction/add-reaction.mjs
+++ b/components/slack_v2/actions/add-reaction/add-reaction.mjs
@@ -10,7 +10,7 @@ export default {
     + " Use **Get Channel History** or **Search** to find the message timestamp."
     + " Emoji name should be without colons (e.g. `thumbsup`, `fire`, `heart`)."
     + " [See the documentation](https://api.slack.com/methods/reactions.add)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/archive-channel/archive-channel.mjs
+++ b/components/slack_v2/actions/archive-channel/archive-channel.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-archive-channel",
   name: "Archive Channel",
   description: "Archive a public or private channel. Direct messages and group DMs can't be archived — pass a channel ID (e.g. `C1234567890`), not a user or group ID. [See the documentation](https://api.slack.com/methods/conversations.archive)",
-  version: "0.0.32",
+  version: "0.0.33",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/slack_v2/actions/browse-files/browse-files.mjs
+++ b/components/slack_v2/actions/browse-files/browse-files.mjs
@@ -10,7 +10,7 @@ export default {
     + " Filter by file type (e.g. `images`, `pdfs`, `snippets`)."
     + " Returns file metadata including name, type, size, and download URL."
     + " [See the documentation](https://api.slack.com/methods/files.list)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/create-channel/create-channel.mjs
+++ b/components/slack_v2/actions/create-channel/create-channel.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-create-channel",
   name: "Create a Channel",
   description: "Create a new channel. [See the documentation](https://api.slack.com/methods/conversations.create)",
-  version: "0.0.32",
+  version: "0.0.33",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/create-reminder/create-reminder.mjs
+++ b/components/slack_v2/actions/create-reminder/create-reminder.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-create-reminder",
   name: "Create Reminder",
   description: "Create a reminder. [See the documentation](https://api.slack.com/methods/reminders.add)",
-  version: "0.0.33",
+  version: "0.0.34",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/delete-file/delete-file.mjs
+++ b/components/slack_v2/actions/delete-file/delete-file.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-delete-file",
   name: "Delete File",
   description: "Delete a file. [See the documentation](https://api.slack.com/methods/files.delete)",
-  version: "0.0.32",
+  version: "0.0.33",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/slack_v2/actions/delete-message/delete-message.mjs
+++ b/components/slack_v2/actions/delete-message/delete-message.mjs
@@ -13,7 +13,7 @@ export default {
     + " lets an identity delete its own messages, so this deletes as whichever identity posted:"
     + " it retries automatically with the other identity if the first attempt returns"
     + " `cant_delete_message`. [See the documentation](https://api.slack.com/methods/chat.delete)",
-  version: "0.2.2",
+  version: "0.2.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/slack_v2/actions/edit-message/edit-message.mjs
+++ b/components/slack_v2/actions/edit-message/edit-message.mjs
@@ -11,7 +11,7 @@ export default {
     + " Requires the message timestamp (`ts`) from **Get Channel History** or **Post Message**."
     + " You can only edit messages posted by the same token/user."
     + " [See the documentation](https://api.slack.com/methods/chat.update)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/find-message/find-message.mjs
+++ b/components/slack_v2/actions/find-message/find-message.mjs
@@ -5,7 +5,12 @@ import slack from "../../slack_v2.app.mjs";
 export default {
   key: "slack_v2-find-message",
   name: "Find Message",
-  description: "Find a Slack message."
+  description: "Find a Slack message by keyword or natural-language query across public and private channels."
+    + " Returns matching messages with channel context, timestamps, and permalinks."
+    + " Pass the returned `message_ts` to **Reply to a Message** to answer in thread,"
+    + " or to **Get Thread Replies** to read the rest of that conversation."
+    + " Use **Search** instead when you need file results or want to restrict `channelTypes`;"
+    + " use this action when you want to order results with `sort` / `sortDirection`."
     + " User mentions come back in the canonical `<@U123>` form; echo it verbatim to post a real mention."
     + " Display names are returned separately as `mentions`, an array of `{ id, name }` objects,"
     + " omitted when no mention carried a name."

--- a/components/slack_v2/actions/find-message/find-message.mjs
+++ b/components/slack_v2/actions/find-message/find-message.mjs
@@ -6,8 +6,10 @@ export default {
   key: "slack_v2-find-message",
   name: "Find Message",
   description: "Find a Slack message."
-    + " User mentions come back as `<@U123>`,"
-    + " any display names Slack supplied are returned separately in each result's `mentions`."
+    + " User mentions come back in the canonical `<@U123>` form; echo it verbatim to post a real mention."
+    + " Display names are returned separately as `mentions`, an array of `{ id, name }` objects,"
+    + " omitted when no mention carried a name."
+    + " Do NOT splice a name back inline: Slack renders `<@U123|Name>` as literal text, not a mention."
     + " [See the documentation](https://api.slack.com/methods/assistant.search.context)",
   version: "0.2.0",
   annotations: {

--- a/components/slack_v2/actions/find-message/find-message.mjs
+++ b/components/slack_v2/actions/find-message/find-message.mjs
@@ -1,11 +1,15 @@
 // x-pd-ai: optimized
+import utils from "../../common/utils.mjs";
 import slack from "../../slack_v2.app.mjs";
 
 export default {
   key: "slack_v2-find-message",
   name: "Find Message",
-  description: "Find a Slack message. [See the documentation](https://api.slack.com/methods/assistant.search.context)",
-  version: "0.1.6",
+  description: "Find a Slack message."
+    + " User mentions come back as `<@U123>`,"
+    + " any display names Slack supplied are returned separately in each result's `mentions`."
+    + " [See the documentation](https://api.slack.com/methods/assistant.search.context)",
+  version: "0.2.0",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -63,7 +67,7 @@ export default {
         cursor = response.response_metadata?.next_cursor;
       } while (cursor && matches.length < maxResults);
 
-      return matches.slice(0, maxResults);
+      return utils.normalizeSearchMessages(matches.slice(0, maxResults));
     },
   },
   async run({ $ }) {

--- a/components/slack_v2/actions/find-user-by-email/find-user-by-email.mjs
+++ b/components/slack_v2/actions/find-user-by-email/find-user-by-email.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-find-user-by-email",
   name: "Find User by Email",
   description: "Find a user by matching against their email. [See the documentation](https://api.slack.com/methods/users.lookupByEmail)",
-  version: "0.0.31",
+  version: "0.0.32",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/find-user-by-id/find-user-by-id.mjs
+++ b/components/slack_v2/actions/find-user-by-id/find-user-by-id.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-find-user-by-id",
   name: "Find User by ID",
   description: "Find a user by their ID — including a specific user you already have the Slack ID for, whether or not it's your own. Returns user profile information including name, email (requires `users:read.email` scope), timezone, and status. If you only have an email address, use **Find User by Email** instead. [See the documentation](https://api.slack.com/methods/users.info)",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/get-channel-details/get-channel-details.mjs
+++ b/components/slack_v2/actions/get-channel-details/get-channel-details.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-get-channel-details",
   name: "Get Channel Details",
   description: "Retrieve details for a Slack channel, specified by ID or by name — names are resolved automatically. [See the documentation](https://api.slack.com/methods/conversations.info)",
-  version: "0.1.2",
+  version: "0.1.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/get-channel-history/get-channel-history.mjs
+++ b/components/slack_v2/actions/get-channel-history/get-channel-history.mjs
@@ -16,7 +16,7 @@ export default {
     + " messages carry blocks, attachments and edit metadata, so a busy channel can run to tens"
     + " of thousands of characters and be truncated before you see any of it."
     + " [See the documentation](https://api.slack.com/methods/conversations.history)",
-  version: "0.2.1",
+  version: "0.2.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/get-current-user/get-current-user.mjs
+++ b/components/slack_v2/actions/get-current-user/get-current-user.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-get-current-user",
   name: "Get Current User",
   description: "Do NOT use for a plain \"who am I\" / \"what's my user ID\" question — call **Get User Details** for that; it answers the same question with a far smaller payload. Do NOT use to look up a DIFFERENT, specifically-identified user (by ID or email) — this only ever describes the authenticated caller; use **Find User by ID** / **Find User by Email** for someone else. Do NOT use to enumerate multiple teams/workspaces (e.g. Enterprise Grid) — use **List Teams** for that; this returns only the caller's own current team. Use this ONLY when you specifically need the full member profile: locale, timezone, presence/status, admin and owner flags, name variants, or workspace domain and enterprise metadata. Combines `auth.test`, `users.info`, `users.profile.get` and `team.info`. [See Slack API docs](https://api.slack.com/methods/auth.test).",
-  version: "0.0.7",
+  version: "0.0.8",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/get-file/get-file.mjs
+++ b/components/slack_v2/actions/get-file/get-file.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-get-file",
   name: "Get File",
   description: "Return information about a file. [See the documentation](https://api.slack.com/methods/files.info)",
-  version: "0.1.7",
+  version: "0.1.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/get-thread-replies/get-thread-replies.mjs
+++ b/components/slack_v2/actions/get-thread-replies/get-thread-replies.mjs
@@ -14,7 +14,7 @@ export default {
     + " Slack messages carry blocks, attachments and edit metadata, so a long thread can run"
     + " to tens of thousands of characters and be truncated before you see any of it."
     + " [See the documentation](https://api.slack.com/methods/conversations.replies)",
-  version: "0.1.2",
+  version: "0.1.3",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/get-user-details/get-user-details.mjs
+++ b/components/slack_v2/actions/get-user-details/get-user-details.mjs
@@ -14,7 +14,7 @@ export default {
     + " Prefer this over **Get Current User**, which returns a much larger payload and is only"
     + " needed for full profile detail (locale, status, admin flags)."
     + " [See the documentation](https://api.slack.com/methods/auth.test)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/invite-user-to-channel/invite-user-to-channel.mjs
+++ b/components/slack_v2/actions/invite-user-to-channel/invite-user-to-channel.mjs
@@ -6,7 +6,7 @@ export default {
   key: "slack_v2-invite-user-to-channel",
   name: "Invite User to Channel",
   description: "Invite one or more users to an existing channel. Accepts a channel ID or NAME, and a user ID, EMAIL address or display name — all resolved automatically. Pass several users as a comma-separated list. [See the documentation](https://api.slack.com/methods/conversations.invite)",
-  version: "0.1.2",
+  version: "0.1.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/kick-user/kick-user.mjs
+++ b/components/slack_v2/actions/kick-user/kick-user.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-kick-user",
   name: "Kick User",
   description: "Remove a user from a conversation. [See the documentation](https://api.slack.com/methods/conversations.kick)",
-  version: "0.0.32",
+  version: "0.0.33",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/slack_v2/actions/list-channels/list-channels.mjs
+++ b/components/slack_v2/actions/list-channels/list-channels.mjs
@@ -16,7 +16,7 @@ export default {
     + " fetched — when you see that, raise `numPages` (or pass `cursor`) before answering"
     + " any 'how many' or 'list every' question, otherwise your answer is silently incomplete."
     + " [See the documentation](https://api.slack.com/methods/conversations.list)",
-  version: "0.3.0",
+  version: "0.3.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/list-emojis/list-emojis.mjs
+++ b/components/slack_v2/actions/list-emojis/list-emojis.mjs
@@ -6,7 +6,7 @@ export default {
   name: "List Emojis",
   description:
     "List all available emojis in the Slack workspace. Optionally include emoji image URLs. [See the documentation](https://api.slack.com/methods/emoji.list)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/list-files/list-files.mjs
+++ b/components/slack_v2/actions/list-files/list-files.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-list-files",
   name: "List Files",
   description: "Return a list of files within a team. [See the documentation](https://api.slack.com/methods/files.list)",
-  version: "0.1.7",
+  version: "0.1.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/list-group-conversations/list-group-conversations.mjs
+++ b/components/slack_v2/actions/list-group-conversations/list-group-conversations.mjs
@@ -11,7 +11,7 @@ export default {
     + " Returns `has_more: true` and `next_cursor` when more conversations exist than were"
     + " fetched — raise `numPages` (or pass `cursor`) to see the rest."
     + " [See the documentation](https://api.slack.com/methods/conversations.list)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/list-group-members/list-group-members.mjs
+++ b/components/slack_v2/actions/list-group-members/list-group-members.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-list-group-members",
   name: "List Group Members",
   description: "List all users in a User Group. [See the documentation](https://api.slack.com/methods/usergroups.users.list)",
-  version: "0.0.16",
+  version: "0.0.17",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/list-icon-emoji-options/list-icon-emoji-options.mjs
+++ b/components/slack_v2/actions/list-icon-emoji-options/list-icon-emoji-options.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-list-icon-emoji-options",
   name: "List Icon (emoji) Options",
   description: "Retrieves available options for the Icon (emoji) field. [See the documentation](https://api.slack.com/methods/emoji.list)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/list-members-in-channel/list-members-in-channel.mjs
+++ b/components/slack_v2/actions/list-members-in-channel/list-members-in-channel.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-list-members-in-channel",
   name: "List Members in Channel",
   description: "Retrieve members of a channel. Accepts a channel ID or NAME (e.g. general or #general) — names are resolved automatically. [See the documentation](https://api.slack.com/methods/conversations.members)",
-  version: "0.1.2",
+  version: "0.1.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/list-messages/list-messages.mjs
+++ b/components/slack_v2/actions/list-messages/list-messages.mjs
@@ -10,7 +10,7 @@ export default {
     + " selection to keep responses small, and returns the same message data."
     + " This legacy tool remains only for existing workflows: it accepts a raw conversation ID and"
     + " returns full, untrimmed message objects. [See the documentation](https://api.slack.com/methods/conversations.history)",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/list-reminder-options/list-reminder-options.mjs
+++ b/components/slack_v2/actions/list-reminder-options/list-reminder-options.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-list-reminder-options",
   name: "List Reminder Options",
   description: "Retrieves available options for the Reminder field. [See the documentation](https://docs.slack.dev/reference/methods/reminders.list)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/list-replies/list-replies.mjs
+++ b/components/slack_v2/actions/list-replies/list-replies.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-list-replies",
   name: "List Replies",
   description: "Retrieve a thread of messages posted to a conversation. [See the documentation](https://api.slack.com/methods/conversations.replies)",
-  version: "0.0.32",
+  version: "0.0.33",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/list-teams/list-teams.mjs
+++ b/components/slack_v2/actions/list-teams/list-teams.mjs
@@ -15,7 +15,7 @@ export default {
     + " Returns `has_more: true` and `next_cursor` when more teams exist than were"
     + " fetched — raise `numPages` (or pass `cursor`) to see the rest."
     + " [See the documentation](https://api.slack.com/methods/auth.teams.list)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/list-user-group-options/list-user-group-options.mjs
+++ b/components/slack_v2/actions/list-user-group-options/list-user-group-options.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-list-user-group-options",
   name: "List User Group Options",
   description: "Retrieves available options for the User Group field. [See the documentation](https://docs.slack.dev/reference/methods/usergroups.list)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/slack_v2/actions/list-users/list-users.mjs
+++ b/components/slack_v2/actions/list-users/list-users.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-list-users",
   name: "List Users",
   description: "Return a list of all users in a workspace. [See the documentation](https://api.slack.com/methods/users.list)",
-  version: "0.0.31",
+  version: "0.0.32",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/post-message/post-message.mjs
+++ b/components/slack_v2/actions/post-message/post-message.mjs
@@ -12,7 +12,7 @@ export default {
     + " To reply to a thread, provide `threadTs` (Slack calls this `thread_ts`) from **Get Channel History**."
     + " Supports plain text with Slack mrkdwn formatting and Block Kit blocks."
     + " [See the documentation](https://api.slack.com/methods/chat.postMessage)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -29,7 +29,7 @@ export default {
     text: {
       type: "string",
       label: "Text",
-      description: "The message text. Supports Slack mrkdwn formatting (e.g. `*bold*`, `_italic_`, `<https://example.com|link>`).",
+      description: "The message text. Supports Slack mrkdwn formatting (e.g. `*bold*`, `_italic_`, `<https://example.com|link>`). To mention a user, use `<@U123>` with their user ID. Do NOT append a display name after a pipe: Slack renders `<@U123|Name>` as literal text, not a mention.",
     },
     blocks: {
       type: "string",

--- a/components/slack_v2/actions/reply-to-a-message/reply-to-a-message.mjs
+++ b/components/slack_v2/actions/reply-to-a-message/reply-to-a-message.mjs
@@ -14,7 +14,7 @@ export default {
     + " (e.g. `1403051575.000407`); get it from **Get Channel History** or an incoming event's"
     + " `ts` field. For a plain, non-threaded message use **Post Message** instead."
     + " [See the documentation](https://api.slack.com/methods/chat.postMessage)",
-  version: "0.2.7",
+  version: "0.2.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/search/search.mjs
+++ b/components/slack_v2/actions/search/search.mjs
@@ -1,4 +1,5 @@
 // x-pd-ai: optimized
+import utils from "../../common/utils.mjs";
 import slack from "../../slack_v2.app.mjs";
 
 export default {
@@ -9,8 +10,10 @@ export default {
     + " Supports keyword and semantic search across public and private channels."
     + " Use **Get User Details** first to find your user ID for filtering by 'my' messages."
     + " Returns matching messages with channel context, timestamps, and permalinks."
+    + " User mentions come back as `<@U123>`,"
+    + " any display names Slack supplied are returned separately in each result's `mentions`."
     + " [See the documentation](https://api.slack.com/methods/assistant.search.context)",
-  version: "0.0.4",
+  version: "0.1.0",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -54,7 +57,7 @@ export default {
       cursor = response.response_metadata?.next_cursor;
     } while (cursor && matches.length < maxResults);
 
-    const results = matches.slice(0, maxResults);
+    const results = utils.normalizeSearchMessages(matches.slice(0, maxResults));
 
     $.export("$summary", `Found ${results.length} result${results.length === 1
       ? ""

--- a/components/slack_v2/actions/search/search.mjs
+++ b/components/slack_v2/actions/search/search.mjs
@@ -10,8 +10,10 @@ export default {
     + " Supports keyword and semantic search across public and private channels."
     + " Use **Get User Details** first to find your user ID for filtering by 'my' messages."
     + " Returns matching messages with channel context, timestamps, and permalinks."
-    + " User mentions come back as `<@U123>`,"
-    + " any display names Slack supplied are returned separately in each result's `mentions`."
+    + " User mentions come back in the canonical `<@U123>` form; echo it verbatim to post a real mention."
+    + " Display names are returned separately as `mentions`, an array of `{ id, name }` objects,"
+    + " omitted when no mention carried a name."
+    + " Do NOT splice a name back inline: Slack renders `<@U123|Name>` as literal text, not a mention."
     + " [See the documentation](https://api.slack.com/methods/assistant.search.context)",
   version: "0.1.0",
   type: "action",

--- a/components/slack_v2/actions/send-block-kit-message/send-block-kit-message.mjs
+++ b/components/slack_v2/actions/send-block-kit-message/send-block-kit-message.mjs
@@ -8,7 +8,7 @@ export default {
   key: "slack_v2-send-block-kit-message",
   name: "Build and Send a Block Kit Message",
   description: "Configure custom blocks and send to a channel, group, or user. [See the documentation](https://api.slack.com/tools/block-kit-builder).",
-  version: "0.5.7",
+  version: "0.5.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/send-large-message/send-large-message.mjs
+++ b/components/slack_v2/actions/send-large-message/send-large-message.mjs
@@ -6,7 +6,7 @@ export default {
   key: "slack_v2-send-large-message",
   name: "Send a Large Message (3000+ characters)",
   description: "Send a large message (more than 3000 characters) to a channel, group or user. See [postMessage](https://api.slack.com/methods/chat.postMessage) or [scheduleMessage](https://api.slack.com/methods/chat.scheduleMessage) docs here",
-  version: "0.1.7",
+  version: "0.1.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/send-message-advanced/send-message-advanced.mjs
+++ b/components/slack_v2/actions/send-message-advanced/send-message-advanced.mjs
@@ -9,7 +9,7 @@ export default {
   key: "slack_v2-send-message-advanced",
   name: "Send Message (Advanced)",
   description: "Customize advanced settings and send a message to a channel, group or user. See [postMessage](https://api.slack.com/methods/chat.postMessage) or [scheduleMessage](https://api.slack.com/methods/chat.scheduleMessage) docs here",
-  version: "0.1.7",
+  version: "0.1.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/send-message-to-channel/send-message-to-channel.mjs
+++ b/components/slack_v2/actions/send-message-to-channel/send-message-to-channel.mjs
@@ -12,7 +12,7 @@ export default {
     + " replies and unfurl settings. Use this tool only if a workflow specifically needs to"
     + " target a channel exclusively, without the user/group support **Post Message** offers."
     + " [See the documentation](https://api.slack.com/methods/chat.postMessage)",
-  version: "0.2.0",
+  version: "0.2.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/send-message-to-user-or-group/send-message-to-user-or-group.mjs
+++ b/components/slack_v2/actions/send-message-to-user-or-group/send-message-to-user-or-group.mjs
@@ -7,7 +7,7 @@ export default {
   key: "slack_v2-send-message-to-user-or-group",
   name: "Send Message to User or Group",
   description: "Send a message to a user or group. [See the documentation](https://api.slack.com/methods/chat.postMessage)",
-  version: "0.2.0",
+  version: "0.2.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/send-message/send-message.mjs
+++ b/components/slack_v2/actions/send-message/send-message.mjs
@@ -7,7 +7,7 @@ export default {
   key: "slack_v2-send-message",
   name: "Send Message",
   description: "Send a message to a user, group, private channel or public channel. [See the documentation](https://api.slack.com/methods/chat.postMessage)",
-  version: "0.2.0",
+  version: "0.2.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/set-channel-description/set-channel-description.mjs
+++ b/components/slack_v2/actions/set-channel-description/set-channel-description.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-set-channel-description",
   name: "Set Channel Description",
   description: "Change the description or purpose of a channel. [See the documentation](https://api.slack.com/methods/conversations.setPurpose)",
-  version: "0.0.17",
+  version: "0.0.18",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/set-channel-topic/set-channel-topic.mjs
+++ b/components/slack_v2/actions/set-channel-topic/set-channel-topic.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-set-channel-topic",
   name: "Set Channel Topic",
   description: "Set the topic on a channel, specified by ID or by name — names are resolved automatically. [See the documentation](https://api.slack.com/methods/conversations.setTopic)",
-  version: "0.1.2",
+  version: "0.1.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/slack_v2/actions/set-status/set-status.mjs
+++ b/components/slack_v2/actions/set-status/set-status.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-set-status",
   name: "Set Status",
   description: "Set the current status for a user. [See the documentation](https://api.slack.com/methods/users.profile.set)",
-  version: "0.0.16",
+  version: "0.0.17",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/slack_v2/actions/update-group-members/update-group-members.mjs
+++ b/components/slack_v2/actions/update-group-members/update-group-members.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-update-group-members",
   name: "Update Group Members",
   description: "Update the list of users for a User Group. [See the documentation](https://api.slack.com/methods/usergroups.users.update)",
-  version: "0.0.17",
+  version: "0.0.18",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/slack_v2/actions/update-message/update-message.mjs
+++ b/components/slack_v2/actions/update-message/update-message.mjs
@@ -5,7 +5,7 @@ export default {
   key: "slack_v2-update-message",
   name: "Update Message",
   description: "Update a message. [See the documentation](https://api.slack.com/methods/chat.update)",
-  version: "0.2.7",
+  version: "0.2.8",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/slack_v2/actions/update-profile/update-profile.mjs
+++ b/components/slack_v2/actions/update-profile/update-profile.mjs
@@ -6,7 +6,7 @@ export default {
   key: "slack_v2-update-profile",
   name: "Update Profile",
   description: "Update basic profile field such as name or title. [See the documentation](https://api.slack.com/methods/users.profile.set)",
-  version: "0.0.32",
+  version: "0.0.33",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/slack_v2/actions/upload-file/upload-file.mjs
+++ b/components/slack_v2/actions/upload-file/upload-file.mjs
@@ -9,7 +9,7 @@ export default {
   key: "slack_v2-upload-file",
   name: "Upload File",
   description: "Upload a file. [See the documentation](https://api.slack.com/messaging/files#uploading_files)",
-  version: "0.1.11",
+  version: "0.1.12",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/verify-slack-signature/verify-slack-signature.mjs
+++ b/components/slack_v2/actions/verify-slack-signature/verify-slack-signature.mjs
@@ -6,7 +6,7 @@ export default {
   key: "slack_v2-verify-slack-signature",
   name: "Verify Slack Signature",
   description: "Verifying requests from Slack, slack signs its requests using a secret that's unique to your app. `Request Body` must be the raw request body as a string (not a parsed object) — Slack computes its signature over the exact raw bytes it sent, so re-serializing a parsed object will not match. [See the documentation](https://api.slack.com/authentication/verifying-requests-from-slack)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/common/utils.mjs
+++ b/components/slack_v2/common/utils.mjs
@@ -64,21 +64,14 @@ export function projectFields(records, value) {
 }
 
 /**
- * A user mention as Slack encodes it in message text, in BOTH encodings the API emits.
+ * A user mention as Slack encodes it in message text.
  * `[UW]` because Enterprise Grid mints both prefixes and they coexist in one message:
  * `W`-prefixed ids are the older grid format, `U`-prefixed the current one.
  */
 const USER_MENTION = /<@([UW][A-Z0-9]{8,})(?:\|([^>]*))?>/g;
 
 /**
- * Rewrite `<@U123|Display Name>` to `<@U123>`, and report the names that were dropped.
- *
- * Slack's read APIs disagree on how they encode a mention. `conversations.history` and
- * `conversations.replies` return the modern `<@U123>`; `assistant.search.context` returns
- * the legacy `<@U123|Display Name>`. An agent that reads a channel through both — search
- * to find the thread, history to read it — ends up holding both encodings at once, and
- * echoes whichever it happened to copy into the message it posts. Slack does NOT render
- * the pipe form on the write path: `chat.postMessage` prints it as literal text, so the
+ * Slack does not render the pipe form on the write path: `chat.postMessage` prints it as literal text, so the
  * reader sees a raw `<@U123|Display Name>` where a mention belonged.
  *
  * Normalizing on the read side means every read tool hands the agent the one encoding
@@ -99,8 +92,6 @@ export function normalizeUserMentions(text) {
     };
   }
 
-  // Keyed by id so a user mentioned three times yields one entry, and so a later bare
-  // `<@U123>` cannot overwrite a name captured from an earlier labelled span.
   const named = new Map();
 
   const normalized = text.replace(USER_MENTION, (match, id, label) => {

--- a/components/slack_v2/common/utils.mjs
+++ b/components/slack_v2/common/utils.mjs
@@ -1,5 +1,6 @@
 /**
- * Shared helpers for the `fields` projection offered by the list/history actions.
+ * Shared helpers for the `fields` projection offered by the list/history actions, and for
+ * normalizing the user-mention encoding that `assistant.search.context` returns.
  *
  * Three actions (Get Channel History, Get Thread Replies, List Channels) let the caller
  * name the properties they want back. Both halves of that feature — normalizing the prop
@@ -62,8 +63,96 @@ export function projectFields(records, value) {
     : records;
 }
 
+/**
+ * A user mention as Slack encodes it in message text, in BOTH encodings the API emits.
+ * `[UW]` because Enterprise Grid mints both prefixes and they coexist in one message:
+ * `W`-prefixed ids are the older grid format, `U`-prefixed the current one.
+ */
+const USER_MENTION = /<@([UW][A-Z0-9]{8,})(?:\|([^>]*))?>/g;
+
+/**
+ * Rewrite `<@U123|Display Name>` to `<@U123>`, and report the names that were dropped.
+ *
+ * Slack's read APIs disagree on how they encode a mention. `conversations.history` and
+ * `conversations.replies` return the modern `<@U123>`; `assistant.search.context` returns
+ * the legacy `<@U123|Display Name>`. An agent that reads a channel through both — search
+ * to find the thread, history to read it — ends up holding both encodings at once, and
+ * echoes whichever it happened to copy into the message it posts. Slack does NOT render
+ * the pipe form on the write path: `chat.postMessage` prints it as literal text, so the
+ * reader sees a raw `<@U123|Display Name>` where a mention belonged.
+ *
+ * Normalizing on the read side means every read tool hands the agent the one encoding
+ * that is safe to echo back.
+ *
+ * The display name is NOT simply discarded. The
+ * names travel alongside the text as a compact `{id, name}` list instead of inline.
+ *
+ * @param {string} text - message text as Slack returned it
+ * @returns {{text: string, mentions: {id: string, name: string}[]}} normalized text, plus
+ *   one entry per distinct mentioned user that carried a display name
+ */
+export function normalizeUserMentions(text) {
+  if (typeof text !== "string" || !text.includes("<@")) {
+    return {
+      text,
+      mentions: [],
+    };
+  }
+
+  // Keyed by id so a user mentioned three times yields one entry, and so a later bare
+  // `<@U123>` cannot overwrite a name captured from an earlier labelled span.
+  const named = new Map();
+
+  const normalized = text.replace(USER_MENTION, (match, id, label) => {
+    const name = label?.trim();
+    if (name && !named.has(id)) {
+      named.set(id, name);
+    }
+    return `<@${id}>`;
+  });
+
+  return {
+    text: normalized,
+    mentions: [
+      ...named,
+    ].map(([
+      id,
+      name,
+    ]) => ({
+      id,
+      name,
+    })),
+  };
+}
+
+/**
+ * @param {object[]} messages - search result messages
+ * @returns {object[]} messages with normalized `content`, plus `mentions` where present
+ */
+export function normalizeSearchMessages(messages) {
+  return messages.map((message) => {
+    if (typeof message?.content !== "string") {
+      return message;
+    }
+    const {
+      text, mentions,
+    } = normalizeUserMentions(message.content);
+    return {
+      ...message,
+      content: text,
+      ...(mentions.length
+        ? {
+          mentions,
+        }
+        : {}),
+    };
+  });
+}
+
 export default {
   parseFields,
   pickFields,
   projectFields,
+  normalizeUserMentions,
+  normalizeSearchMessages,
 };

--- a/components/slack_v2/common/utils.mjs
+++ b/components/slack_v2/common/utils.mjs
@@ -71,14 +71,14 @@ export function projectFields(records, value) {
 const USER_MENTION = /<@([UW][A-Z0-9]{8,})(?:\|([^>]*))?>/g;
 
 /**
- * Slack does not render the pipe form on the write path: `chat.postMessage` prints it as literal text, so the
- * reader sees a raw `<@U123|Display Name>` where a mention belonged.
+ * Slack does not render the pipe form on the write path: `chat.postMessage` prints it
+ * as literal text, so the reader sees a raw `<@U123|Display Name>` where a mention belonged.
  *
  * Normalizing on the read side means every read tool hands the agent the one encoding
  * that is safe to echo back.
  *
- * The display name is NOT simply discarded. The
- * names travel alongside the text as a compact `{id, name}` list instead of inline.
+ * The display name is not discarded: the names travel alongside the text as a compact
+ * `{id, name}` list instead of inline.
  *
  * @param {string} text - message text as Slack returned it
  * @returns {{text: string, mentions: {id: string, name: string}[]}} normalized text, plus

--- a/components/slack_v2/package.json
+++ b/components/slack_v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/slack_v2",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Pipedream Slack_v2 Components",
   "main": "slack_v2.app.mjs",
   "keywords": [

--- a/components/slack_v2/slack_v2.app.mjs
+++ b/components/slack_v2/slack_v2.app.mjs
@@ -52,7 +52,7 @@ export default {
     text: {
       type: "string",
       label: "Text",
-      description: "Text of the message to send (see Slack's [formatting docs](https://api.slack.com/reference/surfaces/formatting)). This field is usually necessary, unless you're providing only attachments instead.",
+      description: "Text of the message to send (see Slack's [formatting docs](https://api.slack.com/reference/surfaces/formatting)). This field is usually necessary, unless you're providing only attachments instead. To mention a user, use `<@U123>` with their user ID. Do NOT append a display name after a pipe: Slack renders `<@U123|Name>` as literal text, not a mention.",
     },
     topic: {
       type: "string",

--- a/components/slack_v2/sources/new-channel-created/new-channel-created.mjs
+++ b/components/slack_v2/sources/new-channel-created/new-channel-created.mjs
@@ -5,7 +5,7 @@ export default {
   ...common,
   key: "slack_v2-new-channel-created",
   name: "New Channel Created (Instant)",
-  version: "0.0.17",
+  version: "0.0.18",
   description: "Emit new event when a new channel is created.",
   type: "source",
   dedupe: "unique",

--- a/components/slack_v2/sources/new-interaction-event-received/new-interaction-event-received.mjs
+++ b/components/slack_v2/sources/new-interaction-event-received/new-interaction-event-received.mjs
@@ -3,7 +3,7 @@ import sampleEmit from "./test-event.mjs";
 
 export default {
   name: "New Interaction Events (Instant)",
-  version: "0.0.28",
+  version: "0.0.29",
   key: "slack_v2-new-interaction-event-received",
   description: "Emit new events on new Slack [interactivity events](https://api.slack.com/interactivity) sourced from [Block Kit interactive elements](https://api.slack.com/interactivity/components), [Slash commands](https://api.slack.com/interactivity/slash-commands), or [Shortcuts](https://api.slack.com/interactivity/shortcuts).",
   type: "source",

--- a/components/slack_v2/sources/new-keyword-mention/new-keyword-mention.mjs
+++ b/components/slack_v2/sources/new-keyword-mention/new-keyword-mention.mjs
@@ -7,7 +7,7 @@ export default {
   ...common,
   key: "slack_v2-new-keyword-mention",
   name: "New Keyword Mention (Instant)",
-  version: "0.1.7",
+  version: "0.1.8",
   description: "Emit new event when a specific keyword is mentioned in a channel",
   type: "source",
   dedupe: "unique",

--- a/components/slack_v2/sources/new-message-in-channels/new-message-in-channels.mjs
+++ b/components/slack_v2/sources/new-message-in-channels/new-message-in-channels.mjs
@@ -7,7 +7,7 @@ export default {
   ...common,
   key: "slack_v2-new-message-in-channels",
   name: "New Message In Channels (Instant)",
-  version: "1.1.7",
+  version: "1.1.8",
   description: "Emit new event when a new message is posted to one or more channels",
   type: "source",
   dedupe: "unique",

--- a/components/slack_v2/sources/new-private-channel-created/new-private-channel-created.mjs
+++ b/components/slack_v2/sources/new-private-channel-created/new-private-channel-created.mjs
@@ -4,7 +4,7 @@ export default {
   ...common,
   key: "slack_v2-new-private-channel-created",
   name: "New Private Channel Created",
-  version: "0.0.7",
+  version: "0.0.8",
   description: "Emit new event when a new private channel is created. [See the documentation](https://api.slack.com/methods/conversations.list)",
   type: "source",
   dedupe: "unique",

--- a/components/slack_v2/sources/new-reaction-added/new-reaction-added.mjs
+++ b/components/slack_v2/sources/new-reaction-added/new-reaction-added.mjs
@@ -5,7 +5,7 @@ export default {
   ...common,
   key: "slack_v2-new-reaction-added",
   name: "New Reaction Added (Instant)",
-  version: "1.2.7",
+  version: "1.2.8",
   description: "Emit new event when a member has added an emoji reaction to a message",
   type: "source",
   dedupe: "unique",

--- a/components/slack_v2/sources/new-saved-message/new-saved-message.mjs
+++ b/components/slack_v2/sources/new-saved-message/new-saved-message.mjs
@@ -5,7 +5,7 @@ export default {
   ...common,
   key: "slack_v2-new-saved-message",
   name: "New Saved Message (Instant)",
-  version: "0.0.13",
+  version: "0.0.14",
   description: "Emit new event when a message is saved. Note: The endpoint is marked as deprecated, and Slack might shut this off at some point down the line.",
   type: "source",
   dedupe: "unique",

--- a/components/slack_v2/sources/new-user-added/new-user-added.mjs
+++ b/components/slack_v2/sources/new-user-added/new-user-added.mjs
@@ -5,7 +5,7 @@ export default {
   ...common,
   key: "slack_v2-new-user-added",
   name: "New User Added (Instant)",
-  version: "0.0.11",
+  version: "0.0.12",
   description: "Emit new event when a new member joins a workspace.",
   type: "source",
   dedupe: "unique",

--- a/components/slack_v2/sources/new-user-mention/new-user-mention.mjs
+++ b/components/slack_v2/sources/new-user-mention/new-user-mention.mjs
@@ -7,7 +7,7 @@ export default {
   ...common,
   key: "slack_v2-new-user-mention",
   name: "New User Mention (Instant)",
-  version: "0.1.7",
+  version: "0.1.8",
   description: "Emit new event when a username or specific keyword is mentioned in a channel",
   type: "source",
   dedupe: "unique",


### PR DESCRIPTION
## Summary

<!-- Add your PR description here -->
Closes #21812 
Two different slack tools were returning different encodings, `<@U123>` & `<@U123|Jer>` which caused the agent to use one of the two encodings when posting a message. Modified the descriptions regarding encoding to keep it consistent across tools.

## Checklist
Please check the following items before your PR can be reviewed:

### Versioning
- [x] All components updated in this PR had their version updated (`0.0.1` for new ones)
- [x] The app updated in this PR had its `package.json`'s version updated

### New app
If this is a new app, please submit [an app integration request](https://github.com/PipedreamHQ/pipedream/issues/new?template=app---service-integration.md) - the PR will only be reviewed after the app is integrated.
- [x] The app updated in this PR is already integrated

### CodeRabbit review
After the PR is opened, and if new changes are pushed, CodeRabbit will automatically review it. Do not 'mark as resolved' CodeRabbit's comments, but reply to them instead, whether you agree (and update the PR accordingly) or disagree.
- [ ] I have addressed or acknowledged all of CodeRabbit's review comments



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search and message-finding results now consistently represent user mentions with canonical IDs and provide display names separately in a mentions list.

* **Documentation**
  * Added guidance for formatting user mentions in Slack messages and search results.
  * Clarified that including a display name within mention syntax renders as literal text.

* **Chores**
  * Updated component and package versions across Slack actions and event sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->