### PR TITLE
Pinning Monday SDK version to previous version 0.5.9

### DIFF
--- a/components/monday/actions/create-board/create-board.mjs
+++ b/components/monday/actions/create-board/create-board.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Create Board",
   description: "Creates a new board. [See the documentation](https://developer.monday.com/api-reference/reference/boards#create-a-board)",
   type: "action",
-  version: "0.0.13",
+  version: "0.0.14",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monday/actions/create-column/create-column.mjs
+++ b/components/monday/actions/create-column/create-column.mjs
@@ -7,7 +7,7 @@ export default {
   name: "Create Column",
   description: "Creates a column. [See the documentation](https://developer.monday.com/api-reference/reference/columns#create-a-column)",
   type: "action",
-  version: "0.1.5",
+  version: "0.1.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monday/actions/create-group/create-group.mjs
+++ b/components/monday/actions/create-group/create-group.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Create Group",
   description: "Creates a new group in a specific board. [See the documentation](https://developer.monday.com/api-reference/reference/groups#create-a-group)",
   type: "action",
-  version: "0.0.14",
+  version: "0.0.15",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monday/actions/create-item/create-item.mjs
+++ b/components/monday/actions/create-item/create-item.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Create Item",
   description: "Creates an item. [See the documentation](https://developer.monday.com/api-reference/reference/items#create-an-item)",
   type: "action",
-  version: "0.1.6",
+  version: "0.1.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monday/actions/create-subitem/create-subitem.mjs
+++ b/components/monday/actions/create-subitem/create-subitem.mjs
@@ -8,7 +8,7 @@ export default {
   name: "Create Subitem",
   description: "Creates a subitem. [See the documentation](https://developer.monday.com/api-reference/reference/subitems#create-a-subitem)",
   type: "action",
-  version: "0.1.6",
+  version: "0.1.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monday/actions/create-update/create-update.mjs
+++ b/components/monday/actions/create-update/create-update.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Create an Update",
   description: "Creates a new update. [See the documentation](https://developer.monday.com/api-reference/reference/updates#create-an-update)",
   type: "action",
-  version: "0.0.16",
+  version: "0.0.17",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/monday/actions/get-board-items-page/get-board-items-page.mjs
+++ b/components/monday/actions/get-board-items-page/get-board-items-page.mjs
@@ -6,7 +6,7 @@ export default {
   key: "monday-get-board-items-page",
   name: "Get Board Items Page",
   description: "Retrieves all items from a board. [See the documentation](https://developer.monday.com/api-reference/reference/items-page)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monday/actions/get-column-values/get-column-values.mjs
+++ b/components/monday/actions/get-column-values/get-column-values.mjs
@@ -5,7 +5,7 @@ export default {
   key: "monday-get-column-values",
   name: "Get Column Values",
   description: "Return values of specific column(s) for a board item. [See the documentation](https://developer.monday.com/api-reference/reference/column-values-v2)",
-  version: "0.0.11",
+  version: "0.0.12",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monday/actions/get-items-by-column-value/get-items-by-column-value.mjs
+++ b/components/monday/actions/get-items-by-column-value/get-items-by-column-value.mjs
@@ -6,7 +6,7 @@ export default {
   key: "monday-get-items-by-column-value",
   name: "Get Items By Column Value",
   description: "Searches a column for items matching a value. [See the documentation](https://developer.monday.com/api-reference/reference/items-page-by-column-values)",
-  version: "0.1.5",
+  version: "0.1.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monday/actions/list-board-id-options/list-board-id-options.mjs
+++ b/components/monday/actions/list-board-id-options/list-board-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "monday-list-board-id-options",
   name: "List Board ID Options",
   description: "Retrieves available options for the Board ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/monday/actions/list-board-ids-options/list-board-ids-options.mjs
+++ b/components/monday/actions/list-board-ids-options/list-board-ids-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "monday-list-board-ids-options",
   name: "List Board IDs Options",
   description: "Retrieves available options for the Board IDs field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/monday/actions/list-boards/list-boards.mjs
+++ b/components/monday/actions/list-boards/list-boards.mjs
@@ -5,7 +5,7 @@ export default {
   key: "monday-list-boards",
   name: "List Boards",
   description: "List all boards. [See the documentation](https://developer.monday.com/api-reference/reference/boards)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/monday/actions/list-workspace-id-options/list-workspace-id-options.mjs
+++ b/components/monday/actions/list-workspace-id-options/list-workspace-id-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "monday-list-workspace-id-options",
   name: "List Workspace ID Options",
   description: "Retrieves available options for the Workspace ID field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/monday/actions/list-workspace-ids-options/list-workspace-ids-options.mjs
+++ b/components/monday/actions/list-workspace-ids-options/list-workspace-ids-options.mjs
@@ -4,7 +4,7 @@ export default {
   key: "monday-list-workspace-ids-options",
   name: "List Workspace IDs Options",
   description: "Retrieves available options for the Workspace IDs field.",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/monday/actions/update-column-values/update-column-values.mjs
+++ b/components/monday/actions/update-column-values/update-column-values.mjs
@@ -4,6 +4,7 @@ import {
   getFileStreamAndMetadata,
 } from "@pipedream/platform";
 import FormData from "form-data";
+import constants from "../../common/constants.mjs";
 import { getColumnOptions } from "../../common/utils.mjs";
 import common from "../common/column-values.mjs";
 
@@ -12,7 +13,7 @@ export default {
   key: "monday-update-column-values",
   name: "Update Column Values",
   description: "Update multiple column values of an item. [See the documentation](https://developer.monday.com/api-reference/reference/columns#change-multiple-column-values)",
-  version: "0.2.7",
+  version: "0.2.8",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
@@ -95,6 +96,7 @@ export default {
         headers: {
           "Content-Type": `multipart/form-data; boundary=${formData._boundary}`,
           "Authorization": this.monday.$auth.api_key,
+          "API-Version": constants.API_VERSION,
         },
         data: formData,
       });

--- a/components/monday/actions/update-column-values/update-column-values.mjs
+++ b/components/monday/actions/update-column-values/update-column-values.mjs
@@ -4,7 +4,6 @@ import {
   getFileStreamAndMetadata,
 } from "@pipedream/platform";
 import FormData from "form-data";
-import constants from "../../common/constants.mjs";
 import { getColumnOptions } from "../../common/utils.mjs";
 import common from "../common/column-values.mjs";
 
@@ -96,7 +95,6 @@ export default {
         headers: {
           "Content-Type": `multipart/form-data; boundary=${formData._boundary}`,
           "Authorization": this.monday.$auth.api_key,
-          "API-Version": constants.API_VERSION,
         },
         data: formData,
       });

--- a/components/monday/actions/update-item-name/update-item-name.mjs
+++ b/components/monday/actions/update-item-name/update-item-name.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Update Item Name",
   description: "Update an item's name. [See the documentation](https://developer.monday.com/api-reference/reference/columns#change-multiple-column-values)",
   type: "action",
-  version: "0.0.15",
+  version: "0.0.16",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/monday/common/constants.mjs
+++ b/components/monday/common/constants.mjs
@@ -171,10 +171,7 @@ const BOARD_TYPE = {
   SUB_ITEMS_BOARD: "sub_items_board",
 };
 
-const API_VERSION = "2026-07";
-
 export default {
-  API_VERSION,
   BOARD_KIND_OPTIONS,
   BOARDS_ORDER_BY_OPTIONS,
   COLUMN_TYPE_OPTIONS,

--- a/components/monday/common/constants.mjs
+++ b/components/monday/common/constants.mjs
@@ -171,7 +171,10 @@ const BOARD_TYPE = {
   SUB_ITEMS_BOARD: "sub_items_board",
 };
 
+const API_VERSION = "2026-07";
+
 export default {
+  API_VERSION,
   BOARD_KIND_OPTIONS,
   BOARDS_ORDER_BY_OPTIONS,
   COLUMN_TYPE_OPTIONS,

--- a/components/monday/monday.app.mjs
+++ b/components/monday/monday.app.mjs
@@ -166,6 +166,7 @@ export default {
     }) {
       const monday = mondaySdk();
       monday.setToken(this.$auth.api_key);
+      monday.setApiVersion(constants.API_VERSION);
       return monday.api(query, options);
     },
     async createWebhook(variables) {

--- a/components/monday/monday.app.mjs
+++ b/components/monday/monday.app.mjs
@@ -1,7 +1,7 @@
 import flatMap from "lodash.flatmap";
 import map from "lodash.map";
 import uniqBy from "lodash.uniqby";
-import mondaySdk from "monday-sdk-js";
+import mondaySdk from "monday-sdk-js@0.5.9";
 import constants from "./common/constants.mjs";
 import mutations from "./common/mutations.mjs";
 import queries from "./common/queries.mjs";
@@ -166,7 +166,6 @@ export default {
     }) {
       const monday = mondaySdk();
       monday.setToken(this.$auth.api_key);
-      monday.setApiVersion(constants.API_VERSION);
       return monday.api(query, options);
     },
     async createWebhook(variables) {

--- a/components/monday/package.json
+++ b/components/monday/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/monday",
-  "version": "0.13.0",
+  "version": "0.12.2",
   "description": "Pipedream Monday Components",
   "main": "monday.app.mjs",
   "keywords": [
@@ -19,6 +19,6 @@
     "lodash.flatmap": "^4.5.0",
     "lodash.map": "^4.6.0",
     "lodash.uniqby": "^4.7.0",
-    "monday-sdk-js": "^0.5.5"
+    "monday-sdk-js": "0.5.9"
   }
 }

--- a/components/monday/package.json
+++ b/components/monday/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/monday",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Pipedream Monday Components",
   "main": "monday.app.mjs",
   "keywords": [
@@ -19,6 +19,6 @@
     "lodash.flatmap": "^4.5.0",
     "lodash.map": "^4.6.0",
     "lodash.uniqby": "^4.7.0",
-    "monday-sdk-js": "^0.1.3"
+    "monday-sdk-js": "^0.5.5"
   }
 }

--- a/components/monday/sources/column-value-updated/column-value-updated.mjs
+++ b/components/monday/sources/column-value-updated/column-value-updated.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Column Value Updated (Instant)",
   description: "Emit new event when a column value is updated on a board. [See the documentation](https://developer.monday.com/api-reference/reference/webhooks#sample-payload-for-webhook-events)",
   type: "source",
-  version: "0.0.12",
+  version: "0.0.13",
   dedupe: "unique",
   hooks: {
     ...common.hooks,

--- a/components/monday/sources/name-updated/name-updated.mjs
+++ b/components/monday/sources/name-updated/name-updated.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Name Updated (Instant)",
   description: "Emit new event when an item's name is updated. [See the documentation](https://developer.monday.com/api-reference/reference/webhooks#sample-payload-for-webhook-events)",
   type: "source",
-  version: "0.0.12",
+  version: "0.0.13",
   dedupe: "unique",
   hooks: {
     ...common.hooks,

--- a/components/monday/sources/new-board/new-board.mjs
+++ b/components/monday/sources/new-board/new-board.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Board Created",
   description: "Emit new event when a board is created in Monday. [See the documentation](https://developer.monday.com/api-reference/reference/webhooks#sample-payload-for-webhook-events)",
   type: "source",
-  version: "0.0.13",
+  version: "0.0.14",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/monday/sources/new-item/new-item.mjs
+++ b/components/monday/sources/new-item/new-item.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Item Created (Instant)",
   description: "Emit new event when a new item is added to a board. [See the documentation](https://developer.monday.com/api-reference/reference/webhooks#sample-payload-for-webhook-events)",
   type: "source",
-  version: "0.0.12",
+  version: "0.0.13",
   dedupe: "unique",
   hooks: {
     ...common.hooks,

--- a/components/monday/sources/new-subitem-update/new-subitem-update.mjs
+++ b/components/monday/sources/new-subitem-update/new-subitem-update.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Sub-Item Update (Instant)",
   description: "Emit new event when an update is posted in sub-items. [See the documentation](https://developer.monday.com/api-reference/reference/webhooks#sample-payload-for-webhook-events)",
   type: "source",
-  version: "0.0.11",
+  version: "0.0.12",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/monday/sources/new-subitem/new-subitem.mjs
+++ b/components/monday/sources/new-subitem/new-subitem.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New Sub-Item Created (Instant)",
   description: "Emit new event when a sub-item is created. [See the documentation](https://developer.monday.com/api-reference/reference/webhooks#sample-payload-for-webhook-events)",
   type: "source",
-  version: "0.0.11",
+  version: "0.0.12",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/monday/sources/new-user/new-user.mjs
+++ b/components/monday/sources/new-user/new-user.mjs
@@ -6,7 +6,7 @@ export default {
   name: "New User Created",
   description: "Emit new event when a new user is created in Monday. [See the documentation](https://developer.monday.com/api-reference/reference/webhooks#sample-payload-for-webhook-events)",
   type: "source",
-  version: "0.0.13",
+  version: "0.0.14",
   dedupe: "unique",
   methods: {
     ...common.methods,

--- a/components/monday/sources/specific-column-updated/specific-column-updated.mjs
+++ b/components/monday/sources/specific-column-updated/specific-column-updated.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Specific Column Updated (Instant)",
   description: "Emit new event when a value in the specified column is updated. [See the documentation](https://developer.monday.com/api-reference/reference/webhooks#sample-payload-for-webhook-events)",
   type: "source",
-  version: "0.0.12",
+  version: "0.0.13",
   dedupe: "unique",
   hooks: {
     ...common.hooks,

--- a/components/monday/sources/subitem-column-value-updated/subitem-column-value-updated.mjs
+++ b/components/monday/sources/subitem-column-value-updated/subitem-column-value-updated.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Sub-Item Column Value Updated (Instant)",
   description: "Emit new event when any sub-item column changes. [See the documentation](https://developer.monday.com/api-reference/reference/webhooks#sample-payload-for-webhook-events)",
   type: "source",
-  version: "0.0.12",
+  version: "0.0.13",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/components/monday/sources/subitem-name-updated/subitem-name-updated.mjs
+++ b/components/monday/sources/subitem-name-updated/subitem-name-updated.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Sub-Item Name Updated (Instant)",
   description: "Emit new event when a sub-item name changes. [See the documentation](https://developer.monday.com/api-reference/reference/webhooks#sample-payload-for-webhook-events)",
   type: "source",
-  version: "0.0.11",
+  version: "0.0.12",
   dedupe: "unique",
   props: {
     ...common.props,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10299,8 +10299,8 @@ importers:
         specifier: ^4.7.0
         version: 4.7.0
       monday-sdk-js:
-        specifier: ^0.1.3
-        version: 0.1.6(encoding@0.1.13)
+        specifier: ^0.5.5
+        version: 0.5.6(encoding@0.1.13)
 
   components/monday_oauth:
     dependencies:
@@ -42247,6 +42247,7 @@ snapshots:
     transitivePeerDependencies:
       - rolldown
       - rollup
+      - supports-color
 
   '@putout/operator-parens@2.0.0(rolldown@1.0.0-beta.60(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2))(rollup@4.62.0)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10299,8 +10299,8 @@ importers:
         specifier: ^4.7.0
         version: 4.7.0
       monday-sdk-js:
-        specifier: ^0.5.5
-        version: 0.5.6(encoding@0.1.13)
+        specifier: 0.5.9
+        version: 0.5.9(encoding@0.1.13)
 
   components/monday_oauth:
     dependencies:
@@ -31082,6 +31082,9 @@ packages:
 
   monday-sdk-js@0.5.6:
     resolution: {integrity: sha512-+jxffW5tgXuFilfJVZL4VMLv7H0PJgV3R9qfKDb4gnCPVZXLPVAUT8vwljlv7D8ozPuoHm8xJ4vofg+1t2ggmg==}
+
+  monday-sdk-js@0.5.9:
+    resolution: {integrity: sha512-r42aX2RfcAJN1VZLCmDUCBPC0RE6lJvo78DcKH2yH1y4NRjdGd++gGeuMRZg/xTru6Xl3sjOAdLRcvklfkLcPQ==}
 
   mongodb-connection-string-url@2.6.0:
     resolution: {integrity: sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==}
@@ -52865,6 +52868,12 @@ snapshots:
       - encoding
 
   monday-sdk-js@0.5.6(encoding@0.1.13):
+    dependencies:
+      node-fetch: 2.7.0(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
+
+  monday-sdk-js@0.5.9(encoding@0.1.13):
     dependencies:
       node-fetch: 2.7.0(encoding@0.1.13)
     transitivePeerDependencies:


### PR DESCRIPTION
- Pinned Monday SDKs version to 0.5.9
- Bump component and source versions.

## Summary

<!-- Add your PR description here -->



## Checklist
Please check the following items before your PR can be reviewed:

### Versioning
- [ ] All components updated in this PR had their version updated (`0.0.1` for new ones)
- [ ] The app updated in this PR had its `package.json`'s version updated

### New app
If this is a new app, please submit [an app integration request](https://github.com/PipedreamHQ/pipedream/issues/new?template=app---service-integration.md) - the PR will only be reviewed after the app is integrated.
- [ ] The app updated in this PR is already integrated

### CodeRabbit review
After the PR is opened, and if new changes are pushed, CodeRabbit will automatically review it. Do not 'mark as resolved' CodeRabbit's comments, but reply to them instead, whether you agree (and update the PR accordingly) or disagree.
- [ ] I have addressed or acknowledged all of CodeRabbit's review comments



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Monday.com integration and its actions and event sources to new component versions.
  * Standardized the Monday SDK on version 0.5.9 for improved consistency and compatibility.
  * No user-facing behavior or functionality changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->