### PR TITLE
Upgrade monday-sdk-js to 0.5.9 for monday_oauth

### DIFF
--- a/components/monday_oauth/actions/create-board/create-board.mjs
+++ b/components/monday_oauth/actions/create-board/create-board.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "monday_oauth-create-board",
-  version: "0.0.3",
+  version: "0.0.4",
   name,
   description,
   type,

--- a/components/monday_oauth/actions/create-column/create-column.mjs
+++ b/components/monday_oauth/actions/create-column/create-column.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "monday_oauth-create-column",
-  version: "0.1.0",
+  version: "0.1.1",
   name,
   description,
   type,

--- a/components/monday_oauth/actions/create-group/create-group.mjs
+++ b/components/monday_oauth/actions/create-group/create-group.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "monday_oauth-create-group",
-  version: "0.0.3",
+  version: "0.0.4",
   name,
   description,
   type,

--- a/components/monday_oauth/actions/create-item/create-item.mjs
+++ b/components/monday_oauth/actions/create-item/create-item.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "monday_oauth-create-item",
-  version: "0.1.0",
+  version: "0.1.1",
   name,
   description,
   type,

--- a/components/monday_oauth/actions/create-subitem/create-subitem.mjs
+++ b/components/monday_oauth/actions/create-subitem/create-subitem.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "monday_oauth-create-subitem",
-  version: "0.1.0",
+  version: "0.1.1",
   name,
   description,
   type,

--- a/components/monday_oauth/actions/create-update/create-update.mjs
+++ b/components/monday_oauth/actions/create-update/create-update.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "monday_oauth-create-update",
-  version: "0.0.3",
+  version: "0.0.4",
   name,
   description,
   type,

--- a/components/monday_oauth/actions/get-column-values/get-column-values.mjs
+++ b/components/monday_oauth/actions/get-column-values/get-column-values.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "monday_oauth-get-column-values",
-  version: "0.0.3",
+  version: "0.0.4",
   name,
   description,
   type,

--- a/components/monday_oauth/actions/get-items-by-column-value/get-items-by-column-value.mjs
+++ b/components/monday_oauth/actions/get-items-by-column-value/get-items-by-column-value.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "monday_oauth-get-items-by-column-value",
-  version: "0.1.0",
+  version: "0.1.1",
   name,
   description,
   type,

--- a/components/monday_oauth/actions/update-column-values/update-column-values.mjs
+++ b/components/monday_oauth/actions/update-column-values/update-column-values.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "monday_oauth-update-column-values",
-  version: "0.1.0",
+  version: "0.1.1",
   name,
   description,
   type,

--- a/components/monday_oauth/actions/update-item-name/update-item-name.mjs
+++ b/components/monday_oauth/actions/update-item-name/update-item-name.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "monday_oauth-update-item-name",
-  version: "0.0.3",
+  version: "0.0.4",
   name,
   description,
   type,

--- a/components/monday_oauth/monday_oauth.app.mjs
+++ b/components/monday_oauth/monday_oauth.app.mjs
@@ -1,5 +1,5 @@
 import common from "@pipedream/monday";
-import mondaySdk from "monday-sdk-js";
+import mondaySdk from "monday-sdk-js@0.5.9";
 
 export default {
   ...common,

--- a/components/monday_oauth/package.json
+++ b/components/monday_oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/monday_oauth",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Pipedream monday.com (OAuth) Components",
   "main": "monday_oauth.app.mjs",
   "keywords": [
@@ -14,6 +14,6 @@
   },
   "dependencies": {
     "@pipedream/monday": "^0.7.0",
-    "monday-sdk-js": "^0.5.5"
+    "monday-sdk-js": "0.5.9"
   }
 }

--- a/components/monday_oauth/package.json
+++ b/components/monday_oauth/package.json
@@ -13,7 +13,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@pipedream/monday": "^0.7.0",
+    "@pipedream/monday": "^0.12.2",
     "monday-sdk-js": "0.5.9"
   }
 }

--- a/components/monday_oauth/sources/column-value-updated/column-value-updated.mjs
+++ b/components/monday_oauth/sources/column-value-updated/column-value-updated.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "monday_oauth-column-value-updated",
-  version: "0.0.3",
+  version: "0.0.4",
   name,
   description,
   type,

--- a/components/monday_oauth/sources/name-updated/name-updated.mjs
+++ b/components/monday_oauth/sources/name-updated/name-updated.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "monday_oauth-name-updated",
-  version: "0.0.3",
+  version: "0.0.4",
   name,
   description,
   type,

--- a/components/monday_oauth/sources/new-board/new-board.mjs
+++ b/components/monday_oauth/sources/new-board/new-board.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "monday_oauth-new-board",
-  version: "0.0.3",
+  version: "0.0.4",
   name,
   description,
   type,

--- a/components/monday_oauth/sources/new-item/new-item.mjs
+++ b/components/monday_oauth/sources/new-item/new-item.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "monday_oauth-new-item",
-  version: "0.0.3",
+  version: "0.0.4",
   name,
   description,
   type,

--- a/components/monday_oauth/sources/new-subitem-update/new-subitem-update.mjs
+++ b/components/monday_oauth/sources/new-subitem-update/new-subitem-update.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "monday_oauth-new-subitem-update",
-  version: "0.0.3",
+  version: "0.0.4",
   name,
   description,
   type,

--- a/components/monday_oauth/sources/new-subitem/new-subitem.mjs
+++ b/components/monday_oauth/sources/new-subitem/new-subitem.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "monday_oauth-new-subitem",
-  version: "0.0.3",
+  version: "0.0.4",
   name,
   description,
   type,

--- a/components/monday_oauth/sources/subitem-column-value-updated/subitem-column-value-updated.mjs
+++ b/components/monday_oauth/sources/subitem-column-value-updated/subitem-column-value-updated.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "monday_oauth-subitem-column-value-updated",
-  version: "0.0.3",
+  version: "0.0.4",
   name,
   description,
   type,

--- a/components/monday_oauth/sources/subitem-name-updated/subitem-name-updated.mjs
+++ b/components/monday_oauth/sources/subitem-name-updated/subitem-name-updated.mjs
@@ -11,7 +11,7 @@ const props = adjustPropDefinitions(others.props, app);
 export default {
   ...others,
   key: "monday_oauth-subitem-name-updated",
-  version: "0.0.3",
+  version: "0.0.4",
   name,
   description,
   type,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10305,8 +10305,8 @@ importers:
   components/monday_oauth:
     dependencies:
       '@pipedream/monday':
-        specifier: ^0.7.0
-        version: 0.7.0(encoding@0.1.13)
+        specifier: ^0.12.2
+        version: 0.12.2(encoding@0.1.13)
       monday-sdk-js:
         specifier: 0.5.9
         version: 0.5.9(encoding@0.1.13)
@@ -22354,8 +22354,8 @@ packages:
   '@pipedream/microsoft_outlook@1.7.5':
     resolution: {integrity: sha512-fokEnKwVvV9cWxZQClPuYCu56ryoWZu1/LPT+WHsvaR/sJbUkhH94bG/nyQynsDlborglVbT4N+CzfY8w1FpqA==}
 
-  '@pipedream/monday@0.7.0':
-    resolution: {integrity: sha512-ovVtLhKMJpOTSoc7JcVLrbVrJxW4BT96eW79TiiPc+DgMSM7ouRmCk5lHL2xCAtrqDForXSrXXGjHOAzhJsytA==}
+  '@pipedream/monday@0.12.2':
+    resolution: {integrity: sha512-PMDJk3QdniuzucPcC+0v94Sx20q9nng2zsa+35gULocD4nRgt9kUnVuGE38D8D8lQjYvc680UwO03DpaUhnOTA==}
 
   '@pipedream/notiff_io@0.1.0':
     resolution: {integrity: sha512-jgt5JJGxI9SM6chDeQpxbaS/NSuUUxhe/PeAXRdZKx28Gp0QCxW7egIImC3pqQ9aMSubaeygRyR0ELhKhmbtPg==}
@@ -25002,10 +25002,6 @@ packages:
 
   '@types/serve-static@1.15.10':
     resolution: {integrity: sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==}
-
-  '@types/source-map@0.5.7':
-    resolution: {integrity: sha512-LrnsgZIfJaysFkv9rRJp4/uAyqw87oVed3s1hhF83nwbo9c7MG9g5DqR0seHP+lkX4ldmMrVolPjQSe2ZfD0yA==}
-    deprecated: This is a stub types definition for source-map (https://github.com/mozilla/source-map). source-map provides its own type definitions, so you don't need @types/source-map installed!
 
   '@types/sshpk@1.10.3':
     resolution: {integrity: sha512-cru1waDhHZnZuB18E6Dgf2UXf8U93mdOEDcKYe5jTri+fpucidSs7DLmGICpLxN+95aYkwtgeyny9fBFzQVdmA==}
@@ -31076,9 +31072,6 @@ packages:
 
   moment@2.30.1:
     resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
-
-  monday-sdk-js@0.1.6:
-    resolution: {integrity: sha512-OfkICgBQRI8N4dmSLqR2k8tpIIogpfLQCksuV3E/TLayyJzinuN6KOp1Mk/qdG1lilA9AArQO11UvZnQ4ZRXDQ==}
 
   monday-sdk-js@0.5.9:
     resolution: {integrity: sha512-r42aX2RfcAJN1VZLCmDUCBPC0RE6lJvo78DcKH2yH1y4NRjdGd++gGeuMRZg/xTru6Xl3sjOAdLRcvklfkLcPQ==}
@@ -41441,14 +41434,14 @@ snapshots:
       - debug
       - supports-color
 
-  '@pipedream/monday@0.7.0(encoding@0.1.13)':
+  '@pipedream/monday@0.12.2(encoding@0.1.13)':
     dependencies:
       '@pipedream/platform': 3.4.0
       form-data: 4.0.4
       lodash.flatmap: 4.5.0
       lodash.map: 4.6.0
       lodash.uniqby: 4.7.0
-      monday-sdk-js: 0.1.6(encoding@0.1.13)
+      monday-sdk-js: 0.5.9(encoding@0.1.13)
     transitivePeerDependencies:
       - debug
       - encoding
@@ -44815,10 +44808,6 @@ snapshots:
       '@types/http-errors': 2.0.5
       '@types/node': 20.19.43
       '@types/send': 0.17.6
-
-  '@types/source-map@0.5.7':
-    dependencies:
-      source-map: 0.7.6
 
   '@types/sshpk@1.10.3':
     dependencies:
@@ -52856,13 +52845,6 @@ snapshots:
   moment@2.29.4: {}
 
   moment@2.30.1: {}
-
-  monday-sdk-js@0.1.6(encoding@0.1.13):
-    dependencies:
-      '@types/source-map': 0.5.7
-      node-fetch: 2.7.0(encoding@0.1.13)
-    transitivePeerDependencies:
-      - encoding
 
   monday-sdk-js@0.5.9(encoding@0.1.13):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10308,8 +10308,8 @@ importers:
         specifier: ^0.7.0
         version: 0.7.0(encoding@0.1.13)
       monday-sdk-js:
-        specifier: ^0.5.5
-        version: 0.5.6(encoding@0.1.13)
+        specifier: 0.5.9
+        version: 0.5.9(encoding@0.1.13)
 
   components/moneybird:
     dependencies:
@@ -31079,9 +31079,6 @@ packages:
 
   monday-sdk-js@0.1.6:
     resolution: {integrity: sha512-OfkICgBQRI8N4dmSLqR2k8tpIIogpfLQCksuV3E/TLayyJzinuN6KOp1Mk/qdG1lilA9AArQO11UvZnQ4ZRXDQ==}
-
-  monday-sdk-js@0.5.6:
-    resolution: {integrity: sha512-+jxffW5tgXuFilfJVZL4VMLv7H0PJgV3R9qfKDb4gnCPVZXLPVAUT8vwljlv7D8ozPuoHm8xJ4vofg+1t2ggmg==}
 
   monday-sdk-js@0.5.9:
     resolution: {integrity: sha512-r42aX2RfcAJN1VZLCmDUCBPC0RE6lJvo78DcKH2yH1y4NRjdGd++gGeuMRZg/xTru6Xl3sjOAdLRcvklfkLcPQ==}
@@ -52863,12 +52860,6 @@ snapshots:
   monday-sdk-js@0.1.6(encoding@0.1.13):
     dependencies:
       '@types/source-map': 0.5.7
-      node-fetch: 2.7.0(encoding@0.1.13)
-    transitivePeerDependencies:
-      - encoding
-
-  monday-sdk-js@0.5.6(encoding@0.1.13):
-    dependencies:
       node-fetch: 2.7.0(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding


### PR DESCRIPTION
## Summary

- Pinned Monday SDK version to 0.5.9 for monday_oauth
- Updated the Monday package version to 0.12.2

<!-- Add your PR description here -->



## Checklist
Please check the following items before your PR can be reviewed:

### Versioning
- [x] All components updated in this PR had their version updated (`0.0.1` for new ones)
- [x] The app updated in this PR had its `package.json`'s version updated

### New app
If this is a new app, please submit [an app integration request](https://github.com/PipedreamHQ/pipedream/issues/new?template=app---service-integration.md) - the PR will only be reviewed after the app is integrated.
- [x] The app updated in this PR is already integrated

### CodeRabbit review
After the PR is opened, and if new changes are pushed, CodeRabbit will automatically review it. Do not 'mark as resolved' CodeRabbit's comments, but reply to them instead, whether you agree (and update the PR accordingly) or disagree.
- [ ] I have addressed or acknowledged all of CodeRabbit's review comments



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated the Monday.com OAuth integration and its actions and event sources to newer component releases.
  * Improved package consistency by aligning the integration with updated Monday.com libraries.
  * Pinned the Monday.com SDK to a specific version for more predictable behavior.
* **Bug Fixes**
  * No functional logic or workflow changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->