### PR TITLE
Google Health: adjusting dailyRollUp method

### DIFF
--- a/components/google_health/actions/get-daily-activity-summary/get-daily-activity-summary.mjs
+++ b/components/google_health/actions/get-daily-activity-summary/get-daily-activity-summary.mjs
@@ -30,7 +30,7 @@ export default {
   key: "google_health-get-daily-activity-summary",
   name: "Get Daily Activity Summary",
   description: "Get a full day of activity at once: steps, distance, calories, active minutes by intensity, active zone minutes by heart rate zone, and floors. The right tool when the user wants an overall picture of a day rather than one metric — use **Get Daily Step Count** for steps alone or **Get Heart Rate** for heart rate detail. The range is inclusive and capped at **14 days** (calories and active minutes impose that limit on the aggregation). Example: startDate=\"2026-08-24\" → `days: [{ date, steps: 8432, distanceKm: 6.1, totalCalories: 2380, activeCalories: 620, activeMinutes: { light, moderate, vigorous, total }, activeZoneMinutes: { fatBurn, cardio, peak, total }, floors: 12 }]`. Set dataSourceFamily=\"google-wearables\" to exclude manually logged activity. A `null` metric means that one metric did not sync for that day and says nothing about the rest of the day — a day can carry real steps alongside a `null` `distanceKm`, so do not report the whole day as empty. An empty `days` array is the separate case where no activity data synced at all for the range. Never report either as zero. The API has no concept of daily goals, so no targets are returned. [See the documentation](https://developers.google.com/health/reference/rest/v4/users.dataTypes.dataPoints/dailyRollUp)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/google_health/actions/get-daily-steps/get-daily-steps.mjs
+++ b/components/google_health/actions/get-daily-steps/get-daily-steps.mjs
@@ -11,7 +11,7 @@ export default {
   key: "google_health-get-daily-steps",
   name: "Get Daily Step Count",
   description: "Get the user's total step count per day — the tool for any \"how many steps\" question. Returns one pre-aggregated total per day, not raw samples. Use **Get Daily Activity Summary** instead when distance, calories, active minutes, or floors are wanted alongside steps. The range is inclusive and capped at 90 days, because these totals are server-aggregated. Example: startDate=\"2026-08-17\", endDate=\"2026-08-23\" → `days: [{ date, steps: 8432 }, ...]` plus `totalSteps`, `averageSteps`, `daysRequested` and `daysWithData`. Set dataSourceFamily=\"google-wearables\" to count only tracker-recorded steps, excluding manual entries. Days the tracker never reported are omitted from `days` entirely, so `daysWithData` can be lower than `daysRequested` and `averageSteps` is the mean over `daysWithData`. An empty `days` array means nothing synced, not zero steps — `totalSteps` and `averageSteps` are `null` in that case rather than 0. [See the documentation](https://developers.google.com/health/reference/rest/v4/users.dataTypes.dataPoints/dailyRollUp)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/google_health/actions/get-nutrition-and-hydration/get-nutrition-and-hydration.mjs
+++ b/components/google_health/actions/get-nutrition-and-hydration/get-nutrition-and-hydration.mjs
@@ -28,7 +28,7 @@ export default {
   key: "google_health-get-nutrition-and-hydration",
   name: "Get Nutrition and Hydration Logs",
   description: "Get the user's logged food and water intake, with aggregate calorie, macro and water totals. Example: startDate=\"2026-08-24\" → `entries: [{ time, foodDisplayName: \"Greek yogurt\", mealType: \"BREAKFAST\", calories: 180, totalFatG: 4.5, totalCarbohydrateG: 9 }]`, `hydration: [{ time, milliliters: 500, liters: 0.5, flOz: 16.9 }]`, and `totals`. `totals` is **one object covering the whole requested range, not per-day figures** — call a single day at a time if daily breakdowns are wanted. Entries have no date-range limit, but `totals` are server-aggregated and cap the range at 90 days — set includeTotals=false to read entries over a longer span, which makes `totals` `null`. At most **1000 food entries and 1000 hydration entries** come back per call (five pages of 200); `truncated: true` means there were more, so check it before treating the entry list as complete and narrow the range if it is set. Only food the user **logged manually** appears here; nothing is inferred from activity, so an empty result means nothing was logged, not that nothing was eaten. [See the documentation](https://developers.google.com/health/data-types/nutrition)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
   annotations: {
     destructiveHint: false,

--- a/components/google_health/google_health.app.mjs
+++ b/components/google_health/google_health.app.mjs
@@ -11,6 +11,7 @@ import {
   buildTimeFilter,
   civilInterval,
   dataSourceFamilyPath,
+  daysBetween,
   durationToSeconds,
 } from "./common/utils.mjs";
 
@@ -210,10 +211,14 @@ export default {
      * boundaries are the user's own local midnights, so no timezone lookup is
      * needed anywhere in this path.
      *
-     * `pageSize` is pinned to the API maximum because `DailyRollUpDataPointsResponse`
-     * carries no `nextPageToken`: if the server ever returned a partial set
-     * there would be no way to detect it. One window per day against a 90-day
-     * ceiling means the real ask never approaches the cap.
+     * `pageSize` must cover the requested range exactly. `DailyRollUpDataPointsResponse`
+     * carries no `nextPageToken`, so a page smaller than the range would be
+     * silently truncated with no way to detect it — but a page larger than the
+     * range is rejected outright: the server validates `windowSizeDays * pageSize`
+     * as a *duration* against the data type's range cap (90 days, 14 for the
+     * heart-rate family), so an oversized page 400s even for a single day.
+     * `resolveRange` has already refused anything over that cap, so sizing the
+     * page to the range keeps it under the ceiling by construction.
      */
     async dailyRollUp({
       $,
@@ -224,13 +229,16 @@ export default {
       windowSizeDays = 1,
     } = {}) {
       const familyPath = dataSourceFamilyPath(dataSourceFamily);
+      const pageSize = Math.ceil(
+        daysBetween(startDate, endExclusive) / windowSizeDays,
+      );
       const response = await this.dailyRollUpDataPoints({
         $,
         dataType,
         data: {
           range: civilInterval(startDate, endExclusive),
           windowSizeDays,
-          pageSize: 10000,
+          pageSize,
           ...familyPath
             ? {
               dataSourceFamily: familyPath,

--- a/components/google_health/package.json
+++ b/components/google_health/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_health",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Google Health Components",
   "main": "google_health.app.mjs",
   "keywords": [


### PR DESCRIPTION
This fixes a specific bug in the `dailyRollUp` app file method that was used by three components:
- `get-daily-steps`;
- `get-daily-activity-summary`;
- `get-nutrition-and-hydration`;

Only the versions of these components were bumped since others are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daily health data retrieval by adjusting request sizes to match the selected date range and API limits.
  * Updated health data actions to their latest versions.

* **Chores**
  * Updated the Google Health component package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->