### PR TITLE
New Components - gandr

### DIFF
--- a/components/gandr/actions/convert-text-to-speech/convert-text-to-speech.mjs
+++ b/components/gandr/actions/convert-text-to-speech/convert-text-to-speech.mjs
@@ -1,0 +1,80 @@
+import fs from "fs";
+import stream from "stream";
+import { promisify } from "util";
+import { ConfigurationError } from "@pipedream/platform";
+import gandr from "../../gandr.app.mjs";
+
+const MAX_INPUT_LENGTH = 2000;
+
+export default {
+  key: "gandr-convert-text-to-speech",
+  name: "Convert Text to Speech",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  description: "Converts text into speech audio and saves the result to a file in the `/tmp` directory. Supports 23 languages, and every render is watermarked. [See the documentation](https://gandr.ai)",
+  type: "action",
+  props: {
+    gandr,
+    text: {
+      type: "string",
+      label: "Text",
+      description: `The text that will get converted into speech. Maximum ${MAX_INPUT_LENGTH} characters per request.`,
+    },
+    voice: {
+      propDefinition: [
+        gandr,
+        "voice",
+      ],
+      default: "gandr-mia",
+    },
+    responseFormat: {
+      propDefinition: [
+        gandr,
+        "responseFormat",
+      ],
+      optional: true,
+    },
+    syncDir: {
+      type: "dir",
+      accessMode: "write",
+      sync: true,
+    },
+  },
+  async run({ $ }) {
+    const {
+      gandr,
+      text,
+      voice,
+    } = this;
+
+    if (text.length > MAX_INPUT_LENGTH) {
+      throw new ConfigurationError(`Text is ${text.length} characters. The maximum is ${MAX_INPUT_LENGTH} characters per request. Split longer text into multiple requests.`);
+    }
+
+    const responseFormat = this.responseFormat || "mp3";
+
+    const { data: response } = await gandr.createSpeech({
+      $,
+      data: {
+        model: "tts-1",
+        input: text,
+        voice,
+        response_format: responseFormat,
+      },
+    });
+
+    const filePath = `/tmp/gandr-speech-${Date.now()}.${responseFormat}`;
+
+    const pipeline = promisify(stream.pipeline);
+    await pipeline(response, fs.createWriteStream(filePath));
+
+    $.export("$summary", `Generated speech audio with voice ${voice} and saved it to ${filePath}`);
+    return {
+      filePath,
+    };
+  },
+};

--- a/components/gandr/gandr.app.mjs
+++ b/components/gandr/gandr.app.mjs
@@ -1,0 +1,63 @@
+import { axios } from "@pipedream/platform";
+
+export default {
+  type: "app",
+  app: "gandr",
+  propDefinitions: {
+    voice: {
+      type: "string",
+      label: "Voice",
+      description: "The voice that will be used for the generated speech.",
+      options: [
+        "gandr-mia",
+        "gandr-ava",
+        "gandr-jenny",
+        "gandr-dane",
+        "gandr-leo",
+        "gandr-lewis",
+      ],
+    },
+    responseFormat: {
+      type: "string",
+      label: "Response Format",
+      description: "The audio format of the response. `pcm` is headerless signed 16-bit little-endian mono audio at 24000 Hz. Default: `mp3`",
+      options: [
+        "mp3",
+        "wav",
+        "pcm",
+      ],
+      default: "mp3",
+    },
+  },
+  methods: {
+    _apiUrl() {
+      return "https://tts.gandr.ai/v1";
+    },
+    _getHeaders(args = {}) {
+      return {
+        "Authorization": `Bearer ${this.$auth.api_key}`,
+        ...args,
+      };
+    },
+    async _makeRequest({
+      $ = this, path, headers, ...opts
+    }) {
+      const config = {
+        url: `${this._apiUrl()}/${path}`,
+        headers: this._getHeaders(headers),
+        ...opts,
+      };
+
+      return axios($, config);
+    },
+    createSpeech(args = {}) {
+      return this._makeRequest({
+        method: "POST",
+        path: "audio/speech",
+        returnFullResponse: true,
+        responseType: "stream",
+        ...args,
+      });
+    },
+  },
+};

--- a/components/gandr/package.json
+++ b/components/gandr/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@pipedream/gandr",
+  "version": "0.1.0",
+  "description": "Pipedream Gandr Components",
+  "main": "gandr.app.mjs",
+  "keywords": [
+    "pipedream",
+    "gandr"
+  ],
+  "homepage": "https://pipedream.com/apps/gandr",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^3.4.0"
+  }
+}


### PR DESCRIPTION

## WHY

Adds a Gandr app file and a first action so Pipedream workflows can call the Gandr text to speech API.

Gandr is a text to speech API. It exposes an OpenAI style endpoint at `POST https://tts.gandr.ai/v1/audio/speech` with bearer key auth, six stock voices, and mp3, wav, and pcm output. It supports 23 languages, every render is watermarked, input is capped at 2000 characters per request, and the free tier is 50,000 tokens. API keys are available at https://gandr.ai.

## What changed

- `components/gandr/gandr.app.mjs`: app file with `voice` and `responseFormat` prop definitions (static option lists), a `_makeRequest` helper on base URL `https://tts.gandr.ai/v1` with `Authorization: Bearer` auth from `this.$auth.api_key`, and a `createSpeech` method that streams the response.
- `components/gandr/actions/convert-text-to-speech/convert-text-to-speech.mjs`: new action, key `gandr-convert-text-to-speech`, version 0.0.1. Validates the 2000 character input cap client side with a `ConfigurationError`, posts `{ model, input, voice, response_format }`, pipes the streamed audio to a file under `/tmp`, exports a `$summary`, and returns `{ filePath }`.
- `components/gandr/package.json`: new package `@pipedream/gandr` at 0.1.0.

## How it mirrors the existing provider pattern

The structure follows `components/elevenlabs`: the same `_apiUrl` / `_getHeaders` / `_makeRequest` app method shape, the same streaming download pattern (`returnFullResponse: true`, `responseType: "stream"`, `promisify(stream.pipeline)` into `/tmp`, `syncDir` dir prop), the app prop first, an annotations block, and a documentation link at the end of the action description. Component key format and the 0.0.1 starting version follow the component guidelines; the package fields follow the shape of recently added apps such as `components/google_health`.

## How to verify

1. `npx eslint components/gandr` from the repo root after `pnpm install`.
2. With a key in `GANDR_API_KEY`, confirm the request shape the action sends:

```
curl -sS -X POST https://tts.gandr.ai/v1/audio/speech \
  -H "Authorization: Bearer $GANDR_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"model":"tts-1","input":"Hello from Pipedream.","voice":"gandr-mia","response_format":"mp3"}' \
  -o /tmp/gandr-verify.mp3 && file /tmp/gandr-verify.mp3
```

3. Deploy the action to a test workflow, run it with text under 2000 characters, and confirm the returned `filePath` exists and plays; run it with text over 2000 characters and confirm the configuration error.

The `gandr` app registration (slug and api key auth field) is handled on the Pipedream platform side and is a prerequisite for deploying these components.

Disclosure: I work on Gandr.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gandr text-to-speech support.
  * Convert text into audio using selectable voices and MP3, WAV, or PCM formats.
  * Generated audio files are saved for use in workflows.
  * Added validation to prevent text inputs exceeding 2,000 characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->