### PR TITLE
New Integration: Firma (firma.dev) - E-Signature API

### DIFF
--- a/components/firma/actions/cancel-signing-request/cancel-signing-request.mjs
+++ b/components/firma/actions/cancel-signing-request/cancel-signing-request.mjs
@@ -1,0 +1,43 @@
+import firma from "../../firma.app.mjs";
+
+export default {
+  key: "firma-cancel-signing-request",
+  name: "Cancel Signing Request",
+  description: "Cancels a signing request that has been sent but not yet completed. [See the documentation](https://docs.firma.dev/api-reference/signing-requests/cancel-signing-request)",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    firma,
+    signingRequestId: {
+      propDefinition: [
+        firma,
+        "signingRequestId",
+      ],
+    },
+    reason: {
+      type: "string",
+      label: "Reason",
+      description: "Optional cancellation reason",
+      optional: true,
+    },
+    notifySigners: {
+      type: "boolean",
+      label: "Notify Signers",
+      description: "Whether to notify signers of the cancellation",
+      optional: true,
+      default: true,
+    },
+  },
+  async run({ $ }) {
+    const data = {};
+    if (this.reason) data.reason = this.reason;
+    if (this.notifySigners !== undefined) data.notify_signers = this.notifySigners;
+    const response = await this.firma.cancelSigningRequest({
+      $,
+      signingRequestId: this.signingRequestId,
+      data,
+    });
+    $.export("$summary", `Successfully cancelled signing request "${this.signingRequestId}"`);
+    return response;
+  },
+};

--- a/components/firma/actions/create-and-send-signing-request/create-and-send-signing-request.mjs
+++ b/components/firma/actions/create-and-send-signing-request/create-and-send-signing-request.mjs
@@ -1,0 +1,83 @@
+import firma from "../../firma.app.mjs";
+
+export default {
+  key: "firma-create-and-send-signing-request",
+  name: "Create and Send Signing Request",
+  description: "Creates and immediately sends a signing request in a single atomic operation. [See the documentation](https://docs.firma.dev/api-reference/signing-requests/create-and-send-signing-request)",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    firma,
+    name: {
+      type: "string",
+      label: "Name",
+      description: "The name of the signing request",
+    },
+    templateId: {
+      propDefinition: [
+        firma,
+        "templateId",
+      ],
+      optional: true,
+      description: "The template to use. Mutually exclusive with document.",
+    },
+    document: {
+      type: "string",
+      label: "Document",
+      description: "Base64-encoded PDF or DOCX document. Mutually exclusive with Template ID.",
+      optional: true,
+    },
+    description: {
+      type: "string",
+      label: "Description",
+      description: "Description of the signing request",
+      optional: true,
+    },
+    expirationHours: {
+      type: "integer",
+      label: "Expiration Hours",
+      description: "Hours until the signing request expires. Defaults to 168 (7 days).",
+      optional: true,
+      default: 168,
+    },
+    recipients: {
+      type: "string",
+      label: "Recipients",
+      description: "JSON array of recipient objects. Each recipient needs: `first_name`, `last_name`, `email`, `designation` (\"Signer\" or \"Approver\"), `order`. Example: `[{\"first_name\": \"John\", \"last_name\": \"Doe\", \"email\": \"john@example.com\", \"designation\": \"Signer\", \"order\": 1}]`",
+      optional: true,
+    },
+    useSigningOrder: {
+      type: "boolean",
+      label: "Use Signing Order",
+      description: "Enforce signing order based on recipient order. When false, all signers receive the document simultaneously.",
+      optional: true,
+    },
+    sendSigningEmail: {
+      type: "boolean",
+      label: "Send Signing Email",
+      description: "Send email notification to signers",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const data = {
+      name: this.name,
+    };
+    if (this.templateId) data.template_id = this.templateId;
+    if (this.document) data.document = this.document;
+    if (this.description) data.description = this.description;
+    if (this.expirationHours) data.expiration_hours = this.expirationHours;
+    if (this.recipients) data.recipients = JSON.parse(this.recipients);
+    if (this.useSigningOrder !== undefined || this.sendSigningEmail !== undefined) {
+      data.settings = {};
+      if (this.useSigningOrder !== undefined) data.settings.use_signing_order = this.useSigningOrder;
+      if (this.sendSigningEmail !== undefined) data.settings.send_signing_email = this.sendSigningEmail;
+    }
+    const response = await this.firma.createAndSendSigningRequest({
+      $,
+      data,
+    });
+    $.export("$summary", `Successfully created and sent signing request "${this.name}"`);
+    return response;
+  },
+};

--- a/components/firma/actions/download-signing-request/download-signing-request.mjs
+++ b/components/firma/actions/download-signing-request/download-signing-request.mjs
@@ -1,0 +1,26 @@
+import firma from "../../firma.app.mjs";
+
+export default {
+  key: "firma-download-signing-request",
+  name: "Download Signing Request Document",
+  description: "Retrieves a download URL for a signing request's signed document. [See the documentation](https://docs.firma.dev/api-reference/signing-requests/download-signing-request-document)",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    firma,
+    signingRequestId: {
+      propDefinition: [
+        firma,
+        "signingRequestId",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.firma.downloadSigningRequest({
+      $,
+      signingRequestId: this.signingRequestId,
+    });
+    $.export("$summary", `Successfully retrieved download URL for signing request "${this.signingRequestId}"`);
+    return response;
+  },
+};

--- a/components/firma/actions/get-signing-request/get-signing-request.mjs
+++ b/components/firma/actions/get-signing-request/get-signing-request.mjs
@@ -1,0 +1,26 @@
+import firma from "../../firma.app.mjs";
+
+export default {
+  key: "firma-get-signing-request",
+  name: "Get Signing Request",
+  description: "Retrieves details of a specific signing request. [See the documentation](https://docs.firma.dev/api-reference/signing-requests/get-signing-request)",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    firma,
+    signingRequestId: {
+      propDefinition: [
+        firma,
+        "signingRequestId",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.firma.getSigningRequest({
+      $,
+      signingRequestId: this.signingRequestId,
+    });
+    $.export("$summary", `Successfully retrieved signing request "${response.name || this.signingRequestId}"`);
+    return response;
+  },
+};

--- a/components/firma/actions/get-template/get-template.mjs
+++ b/components/firma/actions/get-template/get-template.mjs
@@ -1,0 +1,26 @@
+import firma from "../../firma.app.mjs";
+
+export default {
+  key: "firma-get-template",
+  name: "Get Template",
+  description: "Retrieves details of a specific template. [See the documentation](https://docs.firma.dev/api-reference/templates/get-template)",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    firma,
+    templateId: {
+      propDefinition: [
+        firma,
+        "templateId",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.firma.getTemplate({
+      $,
+      templateId: this.templateId,
+    });
+    $.export("$summary", `Successfully retrieved template "${response.name || this.templateId}"`);
+    return response;
+  },
+};

--- a/components/firma/actions/list-signing-requests/list-signing-requests.mjs
+++ b/components/firma/actions/list-signing-requests/list-signing-requests.mjs
@@ -1,0 +1,80 @@
+import firma from "../../firma.app.mjs";
+import {
+  SIGNING_REQUEST_STATUSES,
+  SIGNING_REQUEST_SORT_FIELDS,
+  SORT_ORDERS,
+} from "../../common/constants.mjs";
+
+export default {
+  key: "firma-list-signing-requests",
+  name: "List Signing Requests",
+  description: "Retrieves a paginated list of signing requests. [See the documentation](https://docs.firma.dev/api-reference/signing-requests/list-signing-requests)",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    firma,
+    status: {
+      type: "string",
+      label: "Status",
+      description: "Filter by signing request status",
+      optional: true,
+      options: SIGNING_REQUEST_STATUSES,
+    },
+    name: {
+      type: "string",
+      label: "Name",
+      description: "Filter by name (partial match, case-insensitive)",
+      optional: true,
+    },
+    signerEmail: {
+      type: "string",
+      label: "Signer Email",
+      description: "Filter by signer email address (exact match)",
+      optional: true,
+    },
+    sortBy: {
+      type: "string",
+      label: "Sort By",
+      description: "Field to sort by",
+      optional: true,
+      options: SIGNING_REQUEST_SORT_FIELDS,
+    },
+    sortOrder: {
+      type: "string",
+      label: "Sort Order",
+      description: "Sort order",
+      optional: true,
+      options: SORT_ORDERS,
+    },
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "Page number",
+      optional: true,
+      default: 1,
+    },
+    pageSize: {
+      type: "integer",
+      label: "Page Size",
+      description: "Items per page (max 200)",
+      optional: true,
+      default: 50,
+    },
+  },
+  async run({ $ }) {
+    const params = {};
+    if (this.status) params.status = this.status;
+    if (this.name) params.name = this.name;
+    if (this.signerEmail) params.signer_email = this.signerEmail;
+    if (this.sortBy) params.sort_by = this.sortBy;
+    if (this.sortOrder) params.sort_order = this.sortOrder;
+    if (this.page) params.page = this.page;
+    if (this.pageSize) params.page_size = this.pageSize;
+    const response = await this.firma.listSigningRequests({
+      $,
+      params,
+    });
+    $.export("$summary", `Successfully retrieved ${response.results?.length || 0} signing request(s)`);
+    return response;
+  },
+};

--- a/components/firma/actions/list-templates/list-templates.mjs
+++ b/components/firma/actions/list-templates/list-templates.mjs
@@ -1,0 +1,64 @@
+import firma from "../../firma.app.mjs";
+import {
+  TEMPLATE_SORT_FIELDS,
+  SORT_ORDERS,
+} from "../../common/constants.mjs";
+
+export default {
+  key: "firma-list-templates",
+  name: "List Templates",
+  description: "Retrieves a paginated list of templates. [See the documentation](https://docs.firma.dev/api-reference/templates/list-templates)",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    firma,
+    name: {
+      type: "string",
+      label: "Name",
+      description: "Filter by template name (partial match, case-insensitive)",
+      optional: true,
+    },
+    sortBy: {
+      type: "string",
+      label: "Sort By",
+      description: "Field to sort by",
+      optional: true,
+      options: TEMPLATE_SORT_FIELDS,
+    },
+    sortOrder: {
+      type: "string",
+      label: "Sort Order",
+      description: "Sort order",
+      optional: true,
+      options: SORT_ORDERS,
+    },
+    page: {
+      type: "integer",
+      label: "Page",
+      description: "Page number",
+      optional: true,
+      default: 1,
+    },
+    pageSize: {
+      type: "integer",
+      label: "Page Size",
+      description: "Items per page (max 200)",
+      optional: true,
+      default: 50,
+    },
+  },
+  async run({ $ }) {
+    const params = {};
+    if (this.name) params.name = this.name;
+    if (this.sortBy) params.sort_by = this.sortBy;
+    if (this.sortOrder) params.sort_order = this.sortOrder;
+    if (this.page) params.page = this.page;
+    if (this.pageSize) params.page_size = this.pageSize;
+    const response = await this.firma.listTemplates({
+      $,
+      params,
+    });
+    $.export("$summary", `Successfully retrieved ${response.results?.length || 0} template(s)`);
+    return response;
+  },
+};

--- a/components/firma/common/constants.mjs
+++ b/components/firma/common/constants.mjs
@@ -1,0 +1,40 @@
+export const BASE_URL = "https://api.firma.dev/functions/v1/signing-request-api";
+
+export const WEBHOOK_EVENTS = [
+  "signing_request.created",
+  "signing_request.sent",
+  "signing_request.viewed",
+  "signing_request.completed",
+  "signing_request.cancelled",
+  "signing_request.deleted",
+  "signing_request.expired",
+  "signing_request.updated",
+];
+
+export const SIGNING_REQUEST_STATUSES = [
+  "not_sent",
+  "in_progress",
+  "finished",
+  "cancelled",
+  "declined",
+  "expired",
+];
+
+export const SORT_ORDERS = [
+  "asc",
+  "desc",
+];
+
+export const SIGNING_REQUEST_SORT_FIELDS = [
+  "name",
+  "created_on",
+  "expiration_hours",
+  "sent_on",
+  "finished_on",
+];
+
+export const TEMPLATE_SORT_FIELDS = [
+  "name",
+  "created_on",
+  "last_changed_on",
+];

--- a/components/firma/firma.app.mjs
+++ b/components/firma/firma.app.mjs
@@ -1,0 +1,144 @@
+import { axios } from "@pipedream/platform";
+import {
+  BASE_URL,
+  WEBHOOK_EVENTS,
+} from "./common/constants.mjs";
+
+export default {
+  type: "app",
+  app: "firma",
+  propDefinitions: {
+    signingRequestId: {
+      type: "string",
+      label: "Signing Request ID",
+      description: "The ID of the signing request",
+      async options({ page }) {
+        const { results } = await this.listSigningRequests({
+          params: {
+            page: page + 1,
+            page_size: 50,
+          },
+        });
+        return results?.map(({
+          id, name,
+        }) => ({
+          label: name || id,
+          value: id,
+        })) || [];
+      },
+    },
+    templateId: {
+      type: "string",
+      label: "Template ID",
+      description: "The ID of the template to use",
+      async options({ page }) {
+        const { results } = await this.listTemplates({
+          params: {
+            page: page + 1,
+            page_size: 50,
+          },
+        });
+        return results?.map(({
+          id, name,
+        }) => ({
+          label: name || id,
+          value: id,
+        })) || [];
+      },
+    },
+    webhookEvents: {
+      type: "string[]",
+      label: "Webhook Events",
+      description: "The events to subscribe to",
+      options: WEBHOOK_EVENTS,
+    },
+  },
+  methods: {
+    _baseUrl() {
+      return BASE_URL;
+    },
+    _headers() {
+      return {
+        "Authorization": this.$auth.api_key,
+        "Content-Type": "application/json",
+      };
+    },
+    async _makeRequest({
+      $ = this, path, ...opts
+    }) {
+      return axios($, {
+        ...opts,
+        url: `${this._baseUrl()}${path}`,
+        headers: this._headers(),
+      });
+    },
+    listSigningRequests(opts = {}) {
+      return this._makeRequest({
+        path: "/signing-requests",
+        ...opts,
+      });
+    },
+    getSigningRequest({
+      signingRequestId, ...opts
+    }) {
+      return this._makeRequest({
+        path: `/signing-requests/${signingRequestId}`,
+        ...opts,
+      });
+    },
+    createAndSendSigningRequest(opts = {}) {
+      return this._makeRequest({
+        method: "POST",
+        path: "/signing-requests/create-and-send",
+        ...opts,
+      });
+    },
+    cancelSigningRequest({
+      signingRequestId, ...opts
+    }) {
+      return this._makeRequest({
+        method: "POST",
+        path: `/signing-requests/${signingRequestId}/cancel`,
+        ...opts,
+      });
+    },
+    downloadSigningRequest({
+      signingRequestId, ...opts
+    }) {
+      return this._makeRequest({
+        path: `/signing-requests/${signingRequestId}/download`,
+        ...opts,
+      });
+    },
+    listTemplates(opts = {}) {
+      return this._makeRequest({
+        path: "/templates",
+        ...opts,
+      });
+    },
+    getTemplate({
+      templateId, ...opts
+    }) {
+      return this._makeRequest({
+        path: `/templates/${templateId}`,
+        ...opts,
+      });
+    },
+    createWebhook(opts = {}) {
+      return this._makeRequest({
+        method: "POST",
+        path: "/webhooks",
+        ...opts,
+      });
+    },
+    deleteWebhook({
+      webhookId, ...opts
+    }) {
+      return this._makeRequest({
+        method: "DELETE",
+        path: `/webhooks/${webhookId}`,
+        ...opts,
+      });
+    },
+  },
+};

--- a/components/firma/package.json
+++ b/components/firma/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@pipedream/firma",
+  "version": "0.1.0",
+  "description": "Pipedream Firma Components",
+  "main": "firma.app.mjs",
+  "keywords": [
+    "pipedream",
+    "firma"
+  ],
+  "homepage": "https://pipedream.com/apps/firma",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^3.2.5"
+  }
+}

--- a/components/firma/sources/common/webhook.mjs
+++ b/components/firma/sources/common/webhook.mjs
@@ -1,0 +1,80 @@
+import firma from "../../firma.app.mjs";
+
+export default {
+  props: {
+    firma,
+    db: "$.service.db",
+    http: {
+      type: "$.interface.http",
+      customResponse: true,
+    },
+  },
+  methods: {
+    getEventTypes() {
+      throw new Error("getEventTypes not implemented");
+    },
+    generateMeta() {
+      throw new Error("generateMeta not implemented");
+    },
+    _getWebhookId() {
+      return this.db.get("webhookId");
+    },
+    _setWebhookId(id) {
+      this.db.set("webhookId", id);
+    },
+  },
+  hooks: {
+    async activate() {
+      const response = await this.firma.createWebhook({
+        data: {
+          url: this.http.endpoint,
+          events: this.getEventTypes(),
+        },
+      });
+      this._setWebhookId(response.id);
+    },
+    async deactivate() {
+      const webhookId = this._getWebhookId();
+      if (webhookId) {
+        await this.firma.deleteWebhook({
+          webhookId,
+        });
+      }
+    },
+    async deploy() {
+      const eventTypes = this.getEventTypes();
+      const isCompleted = eventTypes.includes("signing_request.completed");
+      const { results } = await this.firma.listSigningRequests({
+        params: {
+          page: 1,
+          page_size: 25,
+          sort_by: "created_on",
+          sort_order: "desc",
+          ...(isCompleted && {
+            status: "finished",
+          }),
+        },
+      });
+      if (results?.length) {
+        for (const item of results.slice(0, 25)) {
+          const meta = this.generateMeta(item);
+          this.$emit(item, meta);
+        }
+      }
+    },
+  },
+  async run({
+    body, headers,
+  }) {
+    this.http.respond({
+      status: 200,
+    });
+    const eventTypes = this.getEventTypes();
+    const eventType = body?.type || headers?.["x-firma-event"];
+    if (eventType && !eventTypes.includes(eventType)) {
+      return;
+    }
+    const meta = this.generateMeta(body);
+    this.$emit(body, meta);
+  },
+};

--- a/components/firma/sources/new-signing-request-completed/new-signing-request-completed.mjs
+++ b/components/firma/sources/new-signing-request-completed/new-signing-request-completed.mjs
@@ -1,0 +1,29 @@
+import common from "../common/webhook.mjs";
+
+export default {
+  ...common,
+  key: "firma-new-signing-request-completed",
+  name: "New Signing Request Completed (Instant)",
+  description: "Triggers when a signing request is completed by all signers. [See the documentation](https://docs.firma.dev/api-reference/webhooks/overview)",
+  version: "0.0.1",
+  type: "source",
+  dedupe: "unique",
+  methods: {
+    ...common.methods,
+    getEventTypes() {
+      return [
+        "signing_request.completed",
+      ];
+    },
+    generateMeta(event) {
+      const sr = event?.data || event;
+      const id = event?.id || sr?.id;
+      const name = sr?.name || id;
+      return {
+        id,
+        summary: `Signing Request Completed: ${name}`,
+        ts: Date.parse(event?.created_at || sr?.created_on) || Date.now(),
+      };
+    },
+  },
+};

--- a/components/firma/sources/new-signing-request-created/new-signing-request-created.mjs
+++ b/components/firma/sources/new-signing-request-created/new-signing-request-created.mjs
@@ -1,0 +1,29 @@
+import common from "../common/webhook.mjs";
+
+export default {
+  ...common,
+  key: "firma-new-signing-request-created",
+  name: "New Signing Request Created (Instant)",
+  description: "Triggers when a new signing request is created. [See the documentation](https://docs.firma.dev/api-reference/webhooks/overview)",
+  version: "0.0.1",
+  type: "source",
+  dedupe: "unique",
+  methods: {
+    ...common.methods,
+    getEventTypes() {
+      return [
+        "signing_request.created",
+      ];
+    },
+    generateMeta(event) {
+      const sr = event?.data || event;
+      const id = event?.id || sr?.id;
+      const name = sr?.name || id;
+      return {
+        id,
+        summary: `Signing Request Created: ${name}`,
+        ts: Date.parse(event?.created_at || sr?.created_on) || Date.now(),
+      };
+    },
+  },
+};


### PR DESCRIPTION
## Summary

- Adds [Firma](https://firma.dev) integration - an electronic signature and document signing API
- App file with API key authentication, reusable propDefinitions with dynamic options, and convenience methods
- 7 actions covering signing request and template operations
- 2 instant webhook-based sources for real-time event triggers

## Components

### App (`firma.app.mjs`)
- Auth: API key via `Authorization` header
- PropDefinitions: `signingRequestId`, `templateId`, `webhookEvents` (all with dynamic `options()`)
- Methods: `_makeRequest`, plus per-resource methods for signing requests, templates, and webhooks

### Actions
| Action | Endpoint | Description |
|---|---|---|
| Create and Send Signing Request | `POST /signing-requests/create-and-send` | Atomic create + send in one call |
| List Signing Requests | `GET /signing-requests` | Paginated list with status/name/email filters |
| Get Signing Request | `GET /signing-requests/{id}` | Full details of a signing request |
| Download Signing Request | `GET /signing-requests/{id}/download` | Pre-signed download URL for signed document |
| Cancel Signing Request | `POST /signing-requests/{id}/cancel` | Cancel with optional reason and signer notification |
| List Templates | `GET /templates` | Paginated list with name filter |
| Get Template | `GET /templates/{id}` | Full template details |

### Sources (Instant, Webhook-based)
| Source | Event | Description |
|---|---|---|
| New Signing Request Completed | `signing_request.completed` | Triggers when all signers complete |
| New Signing Request Created | `signing_request.created` | Triggers when a new request is created |

Both sources auto-register webhooks via Firma's webhook API on activate, clean up on deactivate, and backfill recent items on initial deploy.

## Test plan
- [ ] Verify app authentication with Firma API key
- [ ] Test each action with valid inputs
- [ ] Test source webhook registration/cleanup lifecycle
- [ ] Test source event emission with sample webhook payloads

## Links
- [Firma API Docs](https://docs.firma.dev)
- [Firma Website](https://firma.dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Firma integration support for creating, sending, cancelling, downloading, and retrieving signing requests.
  - Added actions for listing and retrieving signing templates, with filtering, sorting, and pagination options.
  - Added webhook triggers for newly created and completed signing requests.
  - Added configurable webhook event handling and signer notification options.
  - Added support for signing request templates, recipient details, expiration settings, and signing-order preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->