### PR TITLE
[bug-fix] post-message unexpectedly changed message sender identity

### DIFF
--- a/components/slack_v2/actions/edit-message/edit-message.mjs
+++ b/components/slack_v2/actions/edit-message/edit-message.mjs
@@ -11,7 +11,7 @@ export default {
     + " Requires the message timestamp (`ts`) from **Get Channel History** or **Post Message**."
     + " You can only edit messages posted by the same token/user."
     + " [See the documentation](https://api.slack.com/methods/chat.update)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -57,25 +57,7 @@ export default {
         throw new ConfigurationError("Invalid JSON string: " + error.message);
       }
     }
-    // Slack refuses chat.update unless the calling identity authored the message, and
-    // post-message tries the bot identity first, falling back to the user identity when
-    // the bot can't deliver — so the message being edited may have been posted as
-    // either one. Try both here too, mirroring the fallback already used in
-    // delete-message, rather than guessing which identity posted it.
-    const attempt = (asUser) => this.slack.updateMessage({
-      ...args,
-      as_user: asUser,
-    });
-    const hasBotToken = Boolean(this.slack.getBotToken());
-
-    let response;
-    try {
-      response = await attempt(false);
-    } catch (error) {
-      if (!hasBotToken || !`${error}`.includes("cant_update_message")) throw error;
-      response = await attempt(true);
-    }
-
+    const response = await this.slack.updateMessage(args);
     $.export("$summary", `Message updated in ${channelId}`);
     return response;
   },

--- a/components/slack_v2/actions/post-message/post-message.mjs
+++ b/components/slack_v2/actions/post-message/post-message.mjs
@@ -12,7 +12,7 @@ export default {
     + " To reply to a thread, provide `threadTs` (Slack calls this `thread_ts`) from **Get Channel History**."
     + " Supports plain text with Slack mrkdwn formatting and Block Kit blocks."
     + " [See the documentation](https://api.slack.com/methods/chat.postMessage)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   annotations: {
     destructiveHint: false,
@@ -93,32 +93,7 @@ export default {
       args.thread_ts = this.threadTs;
       args.reply_broadcast = this.replyBroadcast;
     }
-
-    // Prefer the bot token (as_user: false) — it works for channels the bot has joined
-    // and needs no extra scope. But a bot can't message a user unless that user has
-    // enabled its Messages tab, and can't post in a channel it hasn't joined, so those
-    // specific failures fall back to the authenticated user's token instead of failing
-    // the whole call. Mirrors the identity fallback already used in delete-message.
-    const hasBotToken = Boolean(this.slack.getBotToken());
-    let response;
-    try {
-      response = await this.slack.postChatMessage({
-        ...args,
-        as_user: false,
-      });
-    } catch (error) {
-      const botCannotDeliver = hasBotToken
-        && [
-          "messages_tab_disabled",
-          "channel_not_found",
-          "not_in_channel",
-        ].some((code) => `${error}`.includes(code));
-      if (!botCannotDeliver) throw error;
-      response = await this.slack.postChatMessage({
-        ...args,
-        as_user: true,
-      });
-    }
+    const response = await this.slack.postChatMessage(args);
     let permalink;
     try {
       const permalinkResponse = await this.slack.makeRequest({

--- a/components/slack_v2/package.json
+++ b/components/slack_v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/slack_v2",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Pipedream Slack_v2 Components",
   "main": "slack_v2.app.mjs",
   "keywords": [


### PR DESCRIPTION
Summary:
The post-message action changed its default message identity from the authenticated user to the Pipedream bot starting in v0.0.4.

Details:

In v0.0.3 and earlier, postChatMessage(args) did not pass as_user, so the message was posted using the authenticated user's token and appeared under the user's name/avatar. From v0.0.4 (14c6b461, 2026-08-27), as_user: false was explicitly added, causing messages to be posted as the Pipedream bot. The change was introduced as part of PR #21786, whose primary scope was removing reloadProps/additionalProps for MCP v3 compatibility. The sender-identity behavior change was not explicitly called out. post-message currently does not expose an as_user option, so users cannot choose to retain the previous behavior. The behavior is still present in v0.0.5 / master (a2033dcf).

**The fix is done in both post-message and edit-message.mjs file.**

**Before fix:**
In the component as_user is sent as false always so the bot token is used for all the user conversation.

<img width="727" height="827" alt="Screenshot 2026-09-01 at 10 27 31 AM" src="https://github.com/user-attachments/assets/56ccea07-45f4-45e0-90ec-62deab17fc16" />

<img width="1188" height="75" alt="Screenshot 2026-09-01 at 10 27 21 AM" src="https://github.com/user-attachments/assets/dac4d225-d226-4966-9b7b-7564b10ac940" />


**After fix:**
Reverted the changes by removing as_user passed in the api call and maintained the default behaviour.
<img width="724" height="842" alt="Screenshot 2026-09-01 at 10 28 13 AM" src="https://github.com/user-attachments/assets/19136707-7a5f-49ea-bae3-4c97cb85adb9" />

<img width="1202" height="148" alt="Screenshot 2026-09-01 at 10 28 23 AM" src="https://github.com/user-attachments/assets/72da4f95-8b18-43de-87f5-784c359fb65c" />



Expected:
Changing the props/schema for MCP v3 compatibility should not unintentionally change the sender identity of existing post-message calls.

Proposed Fix:
 Preserve the previous default behavior, while clearly documenting the sender identity and fallback behavior.

Impact:
Existing workflows that previously posted messages under the authenticated user's identity now post as the Pipedream bot, resulting in a visible behavioral change for users.

## Checklist
Please check the following items before your PR can be reviewed:

### Versioning
- [ ] All components updated in this PR had their version updated (`0.0.1` for new ones)
- [ ] The app updated in this PR had its `package.json`'s version updated

### New app
If this is a new app, please submit [an app integration request](https://github.com/PipedreamHQ/pipedream/issues/new?template=app---service-integration.md) - the PR will only be reviewed after the app is integrated.
- [ ] The app updated in this PR is already integrated

### CodeRabbit review
After the PR is opened, and if new changes are pushed, CodeRabbit will automatically review it. Do not 'mark as resolved' CodeRabbit's comments, but reply to them instead, whether you agree (and update the PR accordingly) or disagree.
- [ ] I have addressed or acknowledged all of CodeRabbit's review comments



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Updates**
  - Improved Slack message posting and editing by automatically using the app’s resolved identity.
  - Removed fallback retries that could send or update messages using a different sender identity.
  - Updated the Slack message posting and editing actions and package version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<img width="1188" height="75" alt="Screenshot 2026-09-01 at 10 27 21 AM" src="https://github.com/user-attachments/assets/cc5046be-d73b-4ca4-9d22-173dbd83defd" />
