### PR TITLE
feat(components): backfill AI-optimized `ai` field (batch 1/5)

### DIFF
--- a/components/azure_devops/actions/add-pull-request-reviewer/add-pull-request-reviewer.mjs
+++ b/components/azure_devops/actions/add-pull-request-reviewer/add-pull-request-reviewer.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 import { PULL_REQUEST_VOTE_OPTIONS } from "../../common/constants.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "azure_devops-add-pull-request-reviewer",
   name: "Add Pull Request Reviewer",
   description: "Add a reviewer to a pull request, optionally marking them required or casting their vote. Returns the reviewer entry including their current vote. Use this to route a pull request to the right owner automatically. Example: pull request `12`, reviewer `8ebabf04-0b08-6a43-9bf4-96e1f4aa3682`, vote `Approved`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-request-reviewers/create-pull-request-reviewer?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/add-work-item-comment/add-work-item-comment.mjs
+++ b/components/azure_devops/actions/add-work-item-comment/add-work-item-comment.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-add-work-item-comment",
   name: "Add Work Item Comment",
   description: "Add a comment to a work item's discussion thread. Returns the new comment's id and rendered text. Use this to post automated status back to the item humans are watching, rather than editing its description. Example: work item `299`, comment `Deployed to staging in build 4821`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/wit/comments/add?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/cancel-build/cancel-build.mjs
+++ b/components/azure_devops/actions/cancel-build/cancel-build.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 import { BUILD_CANCELLING_STATUS } from "../../common/constants.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "azure_devops-cancel-build",
   name: "Cancel Build",
   description: "Cancel a build that is still running. Returns the build with its status moved to cancelling. Use this to stop a run that has been superseded or was triggered in error. Example: build `4821`. Run the **List Builds** action first to obtain the build id. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/build/builds/update-build?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/create-branch/create-branch.mjs
+++ b/components/azure_devops/actions/create-branch/create-branch.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import azureDevops from "../../azure_devops.app.mjs";
 import { EMPTY_OBJECT_ID } from "../../common/constants.mjs";
@@ -7,8 +6,9 @@ export default {
   key: "azure_devops-create-branch",
   name: "Create Branch",
   description: "Create a branch pointing at an existing commit. Returns the ref update result. Use this to open a working branch before pushing changes and raising a pull request. Example: new branch `feature/login` at commit `a3fecf65a6766ebc6f2e33b66a1520b827c67ef8`. Run the **List Commits** action first to obtain the commit the branch should point at. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/git/refs/update-refs?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/create-or-update-file/create-or-update-file.mjs
+++ b/components/azure_devops/actions/create-or-update-file/create-or-update-file.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import azureDevops from "../../azure_devops.app.mjs";
 import {
@@ -9,8 +8,9 @@ export default {
   key: "azure_devops-create-or-update-file",
   name: "Create Or Update File",
   description: "Push a single file add, edit or delete to an existing branch, as one commit. Returns the push result including the new commit SHA. The branch must already exist. Use this to commit generated config or docs back to a repository. Example: edit `/docs/README.md` on `main` with commit message `Update setup steps`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pushes/create?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/create-or-update-wiki-page/create-or-update-wiki-page.mjs
+++ b/components/azure_devops/actions/create-or-update-wiki-page/create-or-update-wiki-page.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-create-or-update-wiki-page",
   name: "Create Or Update Wiki Page",
   description: "Create a wiki page, or replace the content of an existing one. Returns the resulting page and its version. This replaces the whole page rather than appending, so read the page first if you need to preserve existing content. Use this to publish generated documentation. Example: page path `/Runbooks/Deploy`, Markdown content. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/wiki/pages/create-or-update?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/create-pipeline/create-pipeline.mjs
+++ b/components/azure_devops/actions/create-pipeline/create-pipeline.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 import {
   PIPELINE_CONFIGURATION_TYPE,
@@ -10,8 +9,9 @@ export default {
   key: "azure_devops-create-pipeline",
   name: "Create Pipeline",
   description: "Create a YAML pipeline from a definition file already committed to a Git repository. Returns the new pipeline's id and name. The YAML file must exist before this call - push it first. Use this to register a new service's CI. Example: name `fabrikam-api-CI` from `/azure-pipelines.yml`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/pipelines/pipelines/create?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/create-project/create-project.mjs
+++ b/components/azure_devops/actions/create-project/create-project.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 import {
   AGILE_PROCESS_TEMPLATE_ID,
@@ -10,8 +9,9 @@ export default {
   key: "azure_devops-create-project",
   name: "Create Project",
   description: "Queue creation of a new project. Project creation is asynchronous, so this returns an operation reference rather than the finished project - poll the project list to see it appear. Use when onboarding a new team or product area. Example: name `Payments Platform`, visibility `private`, Agile process. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/core/projects/create?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/create-pull-request-comment/create-pull-request-comment.mjs
+++ b/components/azure_devops/actions/create-pull-request-comment/create-pull-request-comment.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import azureDevops from "../../azure_devops.app.mjs";
 import { COMMENT_THREAD_STATUS_OPTIONS } from "../../common/constants.mjs";
@@ -7,8 +6,9 @@ export default {
   key: "azure_devops-create-pull-request-comment",
   name: "Create Pull Request Comment",
   description: "Start a new comment thread on a pull request, either on the overview or anchored to a line in a file. Returns the new thread with its id. Use this to post automated review findings where the reviewer will see them. Example: pull request `12`, file `/src/index.js` line `42`, comment `This drops the null check`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-request-threads/create?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/create-pull-request/create-pull-request.mjs
+++ b/components/azure_devops/actions/create-pull-request/create-pull-request.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-create-pull-request",
   name: "Create Pull Request",
   description: "Open a pull request between two branches. Returns the new pull request's id and url. Use this after pushing a working branch, to start review. Example: source `refs/heads/feature/login` into target `refs/heads/main`, title `Add SSO login`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-requests/create?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/create-release/create-release.mjs
+++ b/components/azure_devops/actions/create-release/create-release.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 import { parseObject } from "../../common/utils.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "azure_devops-create-release",
   name: "Create Release",
   description: "Create a classic release from a release definition, optionally as a draft or with specific artifact versions. Returns the new release's id and name. Omit **Artifacts** to take the definition's latest versions. Use this to ship a build through a classic release pipeline. Example: definition `3`, description `Nightly deploy`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/release/releases/create?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/create-repository/create-repository.mjs
+++ b/components/azure_devops/actions/create-repository/create-repository.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-create-repository",
   name: "Create Repository",
   description: "Create an empty Git repository in a project. Returns the new repository's id, name and clone urls. The repository starts with no branches - push an initial commit before the other Git actions can act on it. Use when scaffolding a new service. Example: name `fabrikam-payments` in project `Fabrikam-Fiber-Git`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/git/repositories/create?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/create-wiki/create-wiki.mjs
+++ b/components/azure_devops/actions/create-wiki/create-wiki.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import azureDevops from "../../azure_devops.app.mjs";
 import { WIKI_TYPE_OPTIONS } from "../../common/constants.mjs";
@@ -7,8 +6,9 @@ export default {
   key: "azure_devops-create-wiki",
   name: "Create Wiki",
   description: "Create a project wiki, or publish a folder of an existing Git repository as a code wiki. Returns the new wiki's id, name and backing repository. A project wiki provisions its own repository; a code wiki needs an existing repository, branch and folder. Use this when standing up documentation for a new project. Example: name `payments.wiki`, type `projectWiki`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/wiki/wikis/create?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/create-work-item/create-work-item.mjs
+++ b/components/azure_devops/actions/create-work-item/create-work-item.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 import { PATCH_OP } from "../../common/constants.mjs";
 import {
@@ -9,8 +8,9 @@ export default {
   key: "azure_devops-create-work-item",
   name: "Create Work Item",
   description: "Create a work item of any type - Bug, Task, User Story, Epic. Returns the new work item's id and full field set. Use when turning an alert, form submission or support ticket into tracked work. Example: type `Bug`, title `Checkout returns 500 on empty cart`, assigned to `jamal@fabrikam.com`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/wit/work-items/create?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/delete-repository/delete-repository.mjs
+++ b/components/azure_devops/actions/delete-repository/delete-repository.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-delete-repository",
   name: "Delete Repository",
   description: "Move a Git repository to the project's recycle bin. Requires the repository's GUID - names are not accepted here. Use this to retire a service's repository; recover it from the project settings recycle bin if this was a mistake. Example: repository `2f3d611a-f012-4b39-b157-8db63f380226`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/git/repositories/delete?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/azure_devops/actions/delete-wiki-page/delete-wiki-page.mjs
+++ b/components/azure_devops/actions/delete-wiki-page/delete-wiki-page.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-delete-wiki-page",
   name: "Delete Wiki Page",
   description: "Delete a wiki page. Returns the deleted page's path and the wiki commit the deletion created. Use this to retire documentation that has moved elsewhere. Example: page path `/Guides/Onboarding`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/wiki/pages/delete-page?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/azure_devops/actions/delete-work-item/delete-work-item.mjs
+++ b/components/azure_devops/actions/delete-work-item/delete-work-item.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-delete-work-item",
   name: "Delete Work Item",
   description: "Move a work item to the project's recycle bin, or permanently destroy it when **Destroy** is set. Returns the deleted item's id and code. Use this to clean up items created in error - prefer the recycle bin, which is recoverable. Example: work item `299`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/wit/work-items/delete?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/azure_devops/actions/get-build-definition/get-build-definition.mjs
+++ b/components/azure_devops/actions/get-build-definition/get-build-definition.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-get-build-definition",
   name: "Get Build Definition",
   description: "Retrieve one build definition, including its repository, triggers, variables and process. Use this to inspect what a pipeline will do, or to read its variable names before overriding them at queue time. Example: definition `12`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/build/definitions/get?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/get-build/get-build.mjs
+++ b/components/azure_devops/actions/get-build/get-build.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-get-build",
   name: "Get Build",
   description: "Retrieve one build by id. Returns its status, result, timings, requesting identity and source commit. Use this to poll a build queued earlier until it reaches `completed`. Example: build `4821`. Run the **List Builds** action first to obtain the build id. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/build/builds/get?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/get-commit/get-commit.mjs
+++ b/components/azure_devops/actions/get-commit/get-commit.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-get-commit",
   name: "Get Commit",
   description: "Retrieve one commit by its full 40-character SHA. Returns its author, committer, message, parents and change counts. Use this to inspect what a specific commit did before referencing it in a branch or release. Example: commit `a3fecf65a6766ebc6f2e33b66a1520b827c67ef8`. Run the **List Commits** action first to obtain valid commit SHAs. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/git/commits/get-commit?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/get-file-content/get-file-content.mjs
+++ b/components/azure_devops/actions/get-file-content/get-file-content.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-get-file-content",
   name: "Get File Content",
   description: "Read one file from a Git repository, at the default branch or at a specific branch, tag or commit. Returns the file's content along with its object id and path. Use this to read config or documentation without cloning. This is the single-item mode of the items endpoint: it returns one file object. To list a folder's contents instead, use the **List Repository Items** action, which Azure DevOps requires to be a separate call. Example: path `/README.md` on branch `main`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/git/items/get?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/get-pipeline-run/get-pipeline-run.mjs
+++ b/components/azure_devops/actions/get-pipeline-run/get-pipeline-run.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-get-pipeline-run",
   name: "Get Pipeline Run",
   description: "Retrieve one pipeline run. Returns its state, result, the resources it consumed and the template parameters it ran with. Use this to poll a run started earlier until its state reaches `completed`. Example: pipeline `12`, run `48`. Run the **List Pipelines** action first to obtain the pipeline id, then the **List Pipeline Runs** action for valid run ids. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/pipelines/runs/get?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/get-pipeline/get-pipeline.mjs
+++ b/components/azure_devops/actions/get-pipeline/get-pipeline.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-get-pipeline",
   name: "Get Pipeline",
   description: "Retrieve one pipeline, including the repository and path of the YAML file that defines it. Use this to confirm which definition file a pipeline runs before triggering it. Example: pipeline `12`. Run the **List Pipelines** action first to obtain the pipeline id. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/pipelines/pipelines/get?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/get-project/get-project.mjs
+++ b/components/azure_devops/actions/get-project/get-project.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-get-project",
   name: "Get Project",
   description: "Retrieve one project by id or name. Returns its description, state, visibility, default team and, when **Include Capabilities** is set, its version-control and process-template settings. Use this to confirm a project exists before writing to it. Example: `Fabrikam-Fiber-Git`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/core/projects/get?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/get-pull-request/get-pull-request.mjs
+++ b/components/azure_devops/actions/get-pull-request/get-pull-request.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-get-pull-request",
   name: "Get Pull Request",
   description: "Retrieve one pull request by id. Returns its title, description, status, reviewers, merge status and, optionally, its commits. Use this to check whether a pull request is mergeable before completing it. Example: pull request `12`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-requests/get-pull-request?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/get-release/get-release.mjs
+++ b/components/azure_devops/actions/get-release/get-release.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 import {
   RELEASE_APPROVAL_FILTER_OPTIONS, RELEASE_EXPAND_OPTIONS,
@@ -8,8 +7,9 @@ export default {
   key: "azure_devops-get-release",
   name: "Get Release",
   description: "Retrieve one classic release. Returns its environments, each environment's deployment status, and the artifacts it carries. Use this to check whether a release reached production. Example: release `27`. Run the **List Releases** action first to obtain the release id. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/release/releases/get-release?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/get-repository/get-repository.mjs
+++ b/components/azure_devops/actions/get-repository/get-repository.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-get-repository",
   name: "Get Repository",
   description: "Retrieve one Git repository by id or name. Returns its default branch, size, web url and parent project. Use this to confirm a repository's default branch before opening a pull request against it. Example: `fabrikam-api`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/git/repositories/get-repository?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/get-team-iteration/get-team-iteration.mjs
+++ b/components/azure_devops/actions/get-team-iteration/get-team-iteration.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-get-team-iteration",
   name: "Get Team Iteration",
   description: "Retrieve one of a team's iterations by id. Returns its name, path and the start date, finish date and timeframe recorded against it. Use this to pin down a sprint's window before measuring work item activity against it. Run the **List Teams** action first for the team, then the **List Team Iterations** action for the iteration id. Example: returns `Sprint 3` running `2026-08-17` to `2026-08-28`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/work/iterations/get?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/get-team-settings/get-team-settings.mjs
+++ b/components/azure_devops/actions/get-team-settings/get-team-settings.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-get-team-settings",
   name: "Get Team Settings",
   description: "Retrieve a team's board and backlog configuration. Returns the days of the week the team works, its backlog iteration, its default iteration, how bugs are surfaced and which backlog levels are visible. Use this to learn a team's working week before turning sprint dates into working days. Run the **List Teams** action first to obtain the team. Example: `workingDays` returns Monday through Friday. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/work/teamsettings/get?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/get-team/get-team.mjs
+++ b/components/azure_devops/actions/get-team/get-team.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-get-team",
   name: "Get Team",
   description: "Retrieve one team in a project by id or name. Returns the team's description and identity url. Use this to resolve a team name to its GUID before querying its members. Example: `Fabrikam-Fiber-Git Team`. Run the **List Teams** action first to obtain the team id. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/core/teams/get?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/get-user/get-user.mjs
+++ b/components/azure_devops/actions/get-user/get-user.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-get-user",
   name: "Get User",
   description: "Retrieve one user by their graph descriptor. Returns their display name, principal name, mail address and origin. Use this to confirm an identity before assigning work to them. Example: descriptor `aad.OGViYWJmMDQtMGIwOC03YTQz`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/graph/users/get?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/get-velocity/get-velocity.mjs
+++ b/components/azure_devops/actions/get-velocity/get-velocity.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 import { COMPLETED_STATE_CATEGORY } from "../../common/constants.mjs";
 import { escapeODataString } from "../../common/utils.mjs";
@@ -7,8 +6,9 @@ export default {
   key: "azure_devops-get-velocity",
   name: "Get Velocity",
   description: "Report how much work each iteration actually completed, aggregated from the Analytics service. Returns one row per iteration with its name, start and finish dates and the number of completed work items. Covers the whole project by default; set **Team Name** to narrow it to a single team, which is what you want in a project several teams share. Use this to answer whether delivery is speeding up or slowing down, and to sanity-check whether the current sprint is committed beyond its recent average. Set **Points Field** to also sum an estimate, but only if the project's process defines one - the default Basic process has no estimation field and the query fails if you name one it does not have. Example: `Sprint 3` completed 8 items totalling 21 points. [See the documentation](https://learn.microsoft.com/en-us/azure/devops/report/extend-analytics/aggregated-data-analytics?view=azure-devops)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/get-wiki-page/get-wiki-page.mjs
+++ b/components/azure_devops/actions/get-wiki-page/get-wiki-page.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 import { WIKI_RECURSION_LEVEL_OPTIONS } from "../../common/constants.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "azure_devops-get-wiki-page",
   name: "Get Wiki Page",
   description: "Read a wiki page and its Markdown content, optionally including its sub-pages. Returns the page path, content and order. Use this to read runbook or onboarding content into a workflow. Example: page path `/Guides/Onboarding`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/wiki/pages/get-page?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/get-work-item/get-work-item.mjs
+++ b/components/azure_devops/actions/get-work-item/get-work-item.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-get-work-item",
   name: "Get Work Item",
   description: "Retrieve one work item by id. Returns its fields, and optionally its relations and links via **Expand**. Use this to read the current state of an item before deciding whether to update it. Example: work item `299`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/wit/work-items/get-work-item?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/list-branches/list-branches.mjs
+++ b/components/azure_devops/actions/list-branches/list-branches.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-list-branches",
   name: "List Branches And Tags",
   description: "List the refs - branches and tags - of a Git repository, each with the commit it points at. Use this to obtain the fully qualified branch names the pull request and build actions expect, and to read a branch's head SHA. Example: filter `heads/` returns `refs/heads/main` at `a3fecf65...`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/git/refs/list?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/list-build-artifacts/list-build-artifacts.mjs
+++ b/components/azure_devops/actions/list-build-artifacts/list-build-artifacts.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-list-build-artifacts",
   name: "List Build Artifacts",
   description: "List the artifacts a build published, each with its download url and resource type. Use this to hand a build's output to a downstream deploy step. Example: build `4821` returns `drop`. Run the **List Builds** action first to obtain the build id. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/build/artifacts/list?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/list-build-definitions/list-build-definitions.mjs
+++ b/components/azure_devops/actions/list-build-definitions/list-build-definitions.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-list-build-definitions",
   name: "List Build Definitions",
   description: "List a project's build definitions. Returns each definition's id, name, repository and queue status. Use this to obtain the definition id the **Queue Build** action needs. Example: project `Fabrikam-Fiber-Git` returns `fabrikam-api-CI` with id `12`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/build/definitions/list?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/list-build-logs/list-build-logs.mjs
+++ b/components/azure_devops/actions/list-build-logs/list-build-logs.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-list-build-logs",
   name: "List Build Logs",
   description: "List a build's log files, each with its id, line count and the url to fetch its content. Use this to locate the log for a failing step before fetching it. Example: build `4821` returns 3 logs. Run the **List Builds** action first to obtain the build id. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/build/builds/get-build-logs?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/list-builds/list-builds.mjs
+++ b/components/azure_devops/actions/list-builds/list-builds.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 import {
   BUILD_DELETED_FILTER_OPTIONS,
@@ -10,8 +9,9 @@ export default {
   key: "azure_devops-list-builds",
   name: "List Builds",
   description: "List a project's builds, optionally filtered by definition, status, result, branch or time window. Returns each build's id, number, status, result and triggering commit. Use this to report on CI health or to find the last successful build of a branch. Example: result `failed` on branch `refs/heads/main`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/build/builds/list?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/list-classification-nodes/list-classification-nodes.mjs
+++ b/components/azure_devops/actions/list-classification-nodes/list-classification-nodes.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 import { CLASSIFICATION_STRUCTURE_GROUP_OPTIONS } from "../../common/constants.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "azure_devops-list-classification-nodes",
   name: "List Classification Nodes",
   description: "List a project's area or iteration path tree. Returns the node tree with each node's name and full path. Use this to discover the values the **Area Path** and **Iteration Path** inputs of the work item actions expect - those inputs want the backslash-delimited path, not the node name. Example: structure group `Iterations` returns `Fabrikam-Fiber-Git\\\\Sprint 1`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/wit/classification-nodes/get?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/list-commits/list-commits.mjs
+++ b/components/azure_devops/actions/list-commits/list-commits.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import azureDevops from "../../azure_devops.app.mjs";
 import {
@@ -9,8 +8,9 @@ export default {
   key: "azure_devops-list-commits",
   name: "List Commits",
   description: "List a repository's commits, optionally narrowed by author, date range, branch or file path. Returns each commit's SHA, author, message and change counts. Use this to build a changelog or to find the commit that last touched a file. Example: author `jamal@fabrikam.com` since `2026-01-01T00:00:00Z`. Returns at most **Limit** results per call - if that many come back there may be more, so raise **Skip** by **Limit** and call again to page through the rest. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/git/commits/get-commits?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/list-groups/list-groups.mjs
+++ b/components/azure_devops/actions/list-groups/list-groups.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-list-groups",
   name: "List Groups",
   description: "List the groups in an organization, optionally scoped to one project or collection. Returns each group's display name, descriptor and principal name. Use this to find the group to add as a required pull request reviewer. Example: returns `[Fabrikam-Fiber-Git]\\\\Contributors`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/graph/groups/list?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/list-iteration-work-items/list-iteration-work-items.mjs
+++ b/components/azure_devops/actions/list-iteration-work-items/list-iteration-work-items.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-list-iteration-work-items",
   name: "List Iteration Work Items",
   description: "List the work items assigned to a team's iteration. Returns work item relations carrying each item's id and url rather than its fields, so pass those ids to the **List Work Items** action to read titles, states and assignees. Use this to take the sprint backlog as it currently stands. Run the **List Teams** action first for the team, then the **List Team Iterations** action for the iteration id. Example: returns 14 work item references. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/work/iterations/get-iteration-work-items?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/list-organization-name-options/list-organization-name-options.mjs
+++ b/components/azure_devops/actions/list-organization-name-options/list-organization-name-options.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azure_devops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-list-organization-name-options",
   name: "List Organizations",
   description: "List the Azure DevOps organizations the connected account belongs to. Use this first - every other action needs an organization name, and this is the only action that does not. Returns the organization names as plain strings. Example: returns `contoso` and `fabrikam`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/account/accounts/list?view=azure-devops-rest-7.1)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/list-pipeline-runs/list-pipeline-runs.mjs
+++ b/components/azure_devops/actions/list-pipeline-runs/list-pipeline-runs.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-list-pipeline-runs",
   name: "List Pipeline Runs",
   description: "List the most recent runs of a pipeline, each with its id, state, result and creation time. Use this to check whether a pipeline is currently running before triggering another. Example: pipeline `12`. Run the **List Pipelines** action first to obtain the pipeline id. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/pipelines/runs/list?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/list-pipelines/list-pipelines.mjs
+++ b/components/azure_devops/actions/list-pipelines/list-pipelines.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-list-pipelines",
   name: "List Pipelines",
   description: "List a project's YAML pipelines. Returns each pipeline's id, name, folder and revision. Use this to obtain the pipeline id the **Run Pipeline** action needs. Example: project `Fabrikam-Fiber-Git` returns `fabrikam-api-CI` with id `12`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/pipelines/pipelines/list?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/list-processes/list-processes.mjs
+++ b/components/azure_devops/actions/list-processes/list-processes.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-list-processes",
   name: "List Processes",
   description: "List the process templates (Agile, Scrum, Basic, CMMI and any custom ones) available in an organization. Returns each template's id, name and description. Use this to obtain the process template id required by the **Create Project** action. Example: organization `contoso` returns Agile with id `adcc42ab-9882-485e-a3ed-7678f01f66bc`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/core/processes/list?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/list-projects/list-projects.mjs
+++ b/components/azure_devops/actions/list-projects/list-projects.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 import { PROJECT_STATE_OPTIONS } from "../../common/constants.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "azure_devops-list-projects",
   name: "List Projects",
   description: "List the projects in an organization. Returns each project's id, name, state and visibility. Use this first in almost any Azure DevOps workflow - nearly every other action needs a project id or name. Example: organization `contoso` returns `Fabrikam-Fiber-Git` alongside its GUID. Returns at most **Limit** results per call - if that many come back there may be more, so raise **Skip** by **Limit** and call again to page through the rest. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/core/projects/list?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/list-pull-request-threads/list-pull-request-threads.mjs
+++ b/components/azure_devops/actions/list-pull-request-threads/list-pull-request-threads.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-list-pull-request-threads",
   name: "List Pull Request Comment Threads",
   description: "List the comment threads on a pull request, including threads anchored to a file and line. Returns each thread's comments, author and status. Use this to read review feedback before replying or completing the pull request. Example: pull request `12`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-request-threads/list?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/list-pull-requests/list-pull-requests.mjs
+++ b/components/azure_devops/actions/list-pull-requests/list-pull-requests.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-list-pull-requests",
   name: "List Pull Requests",
   description: "List a repository's pull requests, optionally filtered by status, creator, reviewer or branch. Returns each pull request's id, title, status, source and target branches. Use this to find open review work or to check whether a branch already has a pull request. Example: status `active` targeting `refs/heads/main`. Returns at most **Limit** results per call - if that many come back there may be more, so raise **Skip** by **Limit** and call again to page through the rest. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-requests/get-pull-requests?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/list-release-definitions/list-release-definitions.mjs
+++ b/components/azure_devops/actions/list-release-definitions/list-release-definitions.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-list-release-definitions",
   name: "List Release Definitions",
   description: "List a project's classic release definitions. Returns each definition's id, name and path. Use this to obtain the definition id the **Create Release** action needs. Classic Release is separate from YAML pipelines. Example: project `Fabrikam-Fiber-Git` returns `fabrikam-api-CD` with id `3`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/release/definitions/list?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/list-releases/list-releases.mjs
+++ b/components/azure_devops/actions/list-releases/list-releases.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 import { RELEASE_STATUS_OPTIONS } from "../../common/constants.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "azure_devops-list-releases",
   name: "List Releases",
   description: "List a project's classic releases, optionally filtered by definition or status. Returns each release's id, name, status and the definition it came from. Use this to report on what has shipped. Example: definition `3`, status `active`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/release/releases/list?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/list-repositories/list-repositories.mjs
+++ b/components/azure_devops/actions/list-repositories/list-repositories.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-list-repositories",
   name: "List Repositories",
   description: "List the Git repositories in a project, or across the whole organization when no project is given. Returns each repository's id, name, default branch and size. Use this to obtain the repository id or name every other Git action needs. Example: project `Fabrikam-Fiber-Git` returns `fabrikam-api` and its GUID. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/git/repositories/list?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/list-repository-items/list-repository-items.mjs
+++ b/components/azure_devops/actions/list-repository-items/list-repository-items.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 import { RECURSION_LEVEL_OPTIONS } from "../../common/constants.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "azure_devops-list-repository-items",
   name: "List Repository Items",
   description: "List the files and folders under a path in a Git repository. Returns each entry's path, object id and whether it is a folder. Use this to explore a repository's layout, then read a specific file with the **Get File Content** action. Azure DevOps rejects a recursion level other than `none` when a single file path is given, so listing and reading are separate calls. Example: scope path `/src` with recursion `oneLevel`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/git/items/list?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/list-service-endpoints/list-service-endpoints.mjs
+++ b/components/azure_devops/actions/list-service-endpoints/list-service-endpoints.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 import { SERVICE_ENDPOINT_ACTION_FILTER_OPTIONS } from "../../common/constants.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "azure_devops-list-service-endpoints",
   name: "List Service Endpoints",
   description: "List a project's service connections, optionally filtered by type. Returns each connection's id, name, type and authorization scheme, without its secrets. Use this to audit which external systems a project can reach from its pipelines. Example: type `github` returns the GitHub connection and its id. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/serviceendpoint/endpoints/get-service-endpoints?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/list-team-capacity/list-team-capacity.mjs
+++ b/components/azure_devops/actions/list-team-capacity/list-team-capacity.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-list-team-capacity",
   name: "List Team Capacity",
   description: "Retrieve every team member's capacity for an iteration, with their per-day hours split across activities and their individual days off. Returns the per-member records and the team totals. Use this against the iteration's work item list to judge whether a sprint is overcommitted. Run the **List Teams** action first for the team, then the **List Team Iterations** action for the iteration id. Example: 6 hours per day split across `Development` and `Testing`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/work/capacities/get-capacities-with-identity-ref-and-totals?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/list-team-days-off/list-team-days-off.mjs
+++ b/components/azure_devops/actions/list-team-days-off/list-team-days-off.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-list-team-days-off",
   name: "List Team Days Off",
   description: "List the days the whole team is off during an iteration, such as public holidays or a team offsite. Returns each range's start and end date. Use this to subtract non-working days before reading capacity as available hours. Run the **List Teams** action first for the team, then the **List Team Iterations** action for the iteration id. Example: returns `2026-08-25` to `2026-08-25` for a bank holiday. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/work/teamdaysoff/get?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/list-team-iterations/list-team-iterations.mjs
+++ b/components/azure_devops/actions/list-team-iterations/list-team-iterations.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 import { ITERATION_TIMEFRAME_OPTIONS } from "../../common/constants.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "azure_devops-list-team-iterations",
   name: "List Team Iterations",
   description: "List the iterations a team is subscribed to, each with its name, path and the start date, finish date and timeframe held in its attributes. Set **Timeframe** to `current` to resolve the sprint that is running right now. Use this as the entry point for any sprint question, then pass the iteration id it returns to the work item, capacity and days off actions. Run the **List Teams** action first to obtain the team. Example: returns `Sprint 3` starting `2026-08-17`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/work/iterations/list?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/list-team-members/list-team-members.mjs
+++ b/components/azure_devops/actions/list-team-members/list-team-members.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-list-team-members",
   name: "List Team Members",
   description: "List the members of a team. Returns each member's display name, unique name, identity id and whether they are a team admin. Use this to find the identity GUID that the pull request reviewer actions require. Example: team `Fabrikam-Fiber-Git Team` returns Jamal Hartnett and his identity id. Returns at most **Limit** results per call - if that many come back there may be more, so raise **Skip** by **Limit** and call again to page through the rest. Run the **List Teams** action first to obtain the team id. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/core/teams/get-team-members-with-extended-properties?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/list-teams/list-teams.mjs
+++ b/components/azure_devops/actions/list-teams/list-teams.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-list-teams",
   name: "List Teams",
   description: "List the teams in a project. Returns each team's id, name and description. Use this to obtain the team id or name the other team actions need, or to fan a notification out per team. Example: project `Fabrikam-Fiber-Git` returns `Fabrikam-Fiber-Git Team`. Returns at most **Limit** results per call - if that many come back there may be more, so raise **Skip** by **Limit** and call again to page through the rest. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/core/teams/get-teams?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/list-users/list-users.mjs
+++ b/components/azure_devops/actions/list-users/list-users.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 import { GRAPH_SUBJECT_TYPE_OPTIONS } from "../../common/constants.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "azure_devops-list-users",
   name: "List Users",
   description: "List the users in an organization, optionally narrowed by subject type. Returns each user's display name, principal name, descriptor and origin id. Use this to resolve a person to the identity GUID that the pull request reviewer and creator inputs require. Example: subject type `aad` returns Jamal Hartnett and his descriptor. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/graph/users/list?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/list-wikis/list-wikis.mjs
+++ b/components/azure_devops/actions/list-wikis/list-wikis.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-list-wikis",
   name: "List Wikis",
   description: "List the wikis in a project, or across the organization when no project is given. Returns each wiki's id, name, type and backing repository. Use this to obtain the wiki id or name the wiki page actions need. Example: project `Fabrikam-Fiber-Git` returns `Fabrikam-Fiber-Git.wiki`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/wiki/wikis/list?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/list-work-item-comments/list-work-item-comments.mjs
+++ b/components/azure_devops/actions/list-work-item-comments/list-work-item-comments.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-list-work-item-comments",
   name: "List Work Item Comments",
   description: "List the comments on a work item, newest first. Returns each comment's text, author and creation date. Use this to read the human discussion around an item before acting on it. Example: work item `299`. Returns the newest **Limit** comments, up to the API maximum of 200; the response's `continuationToken` field is present when older comments were not returned. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/wit/comments/get-comments?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/list-work-item-fields/list-work-item-fields.mjs
+++ b/components/azure_devops/actions/list-work-item-fields/list-work-item-fields.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 import { WORK_ITEM_FIELD_EXPAND_OPTIONS } from "../../common/constants.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "azure_devops-list-work-item-fields",
   name: "List Work Item Fields",
   description: "List the work item fields defined in an organization or project, with each field's reference name and data type. Use this to discover the reference names the **Additional Fields** and **Fields** inputs of the other work item actions expect. Example: returns `Microsoft.VSTS.Common.Priority` for the field shown as Priority in the UI. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/wit/fields/list?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/list-work-item-revisions/list-work-item-revisions.mjs
+++ b/components/azure_devops/actions/list-work-item-revisions/list-work-item-revisions.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-list-work-item-revisions",
   name: "List Work Item Revisions",
   description: "List the revision history of a work item, one entry per change. Returns each revision's field values at that point in time. Use this to answer who changed what and when, or to reconstruct how long an item sat in a state. Example: work item `299`. Returns at most **Limit** results per call - if that many come back there may be more, so raise **Skip** by **Limit** and call again to page through the rest. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/wit/revisions/list?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/list-work-item-types/list-work-item-types.mjs
+++ b/components/azure_devops/actions/list-work-item-types/list-work-item-types.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-list-work-item-types",
   name: "List Work Item Types",
   description: "List the work item types available in a project, each with the states and fields it allows. Use this to discover valid values for the **Work Item Type** and **State** inputs before creating or updating an item - the states differ per process, so a Basic project uses `To Do`/`Doing`/`Done` where Agile uses `New`/`Active`/`Closed`. Example: project `Fabrikam-Fiber-Git` returns Bug, Task, Epic and User Story. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/wit/work-item-types/list?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/list-work-items/list-work-items.mjs
+++ b/components/azure_devops/actions/list-work-items/list-work-items.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import azureDevops from "../../azure_devops.app.mjs";
 import {
@@ -9,8 +8,9 @@ export default {
   key: "azure_devops-list-work-items",
   name: "List Work Items",
   description: "Retrieve a batch of work items by id in one call, up to 200 at a time. Returns each item's fields. Use this after a query to turn a list of ids into the actual field values. Example: ids `297,298,299`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/wit/work-items/list?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/query-analytics/query-analytics.mjs
+++ b/components/azure_devops/actions/query-analytics/query-analytics.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-query-analytics",
   name: "Query Analytics (OData)",
   description: "Run an OData query against the Azure DevOps Analytics service, which holds the historical and aggregated data the work item APIs do not expose. Returns the matching rows plus the `@odata.context` describing them. Use this for trend questions - how many bugs were open each day, how much work each iteration completed - and use **Query Work Items (WIQL)** instead for the current state of individual items. Set **Apply** to aggregate rather than pulling raw rows back. Example: entity set `WorkItems`, filter `State eq 'Closed'`. [See the documentation](https://learn.microsoft.com/en-us/azure/devops/report/analytics/analytics-query-parts?view=azure-devops)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/query-work-items/query-work-items.mjs
+++ b/components/azure_devops/actions/query-work-items/query-work-items.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 
 export default {
   key: "azure_devops-query-work-items",
   name: "Query Work Items (WIQL)",
   description: "Run a Work Item Query Language (WIQL) query and return the matching work item references. Returns ids and the queried columns, not full field values - pass the ids to the **List Work Items** action to read those. Use this whenever you need to find work by state, type, assignee or date. Example: `SELECT [System.Id] FROM WorkItems WHERE [System.WorkItemType] = 'Bug' AND [System.State] <> 'Closed'`. WIQL has no offset, so narrow the query itself rather than paging when **Limit** results come back. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/wit/wiql/query-by-wiql?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/queue-build/queue-build.mjs
+++ b/components/azure_devops/actions/queue-build/queue-build.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 import { parseObject } from "../../common/utils.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "azure_devops-queue-build",
   name: "Queue Build",
   description: "Queue a new build for a build definition, optionally on a specific branch and with variable overrides. Returns the queued build's id and status - the build itself runs asynchronously. Use this to trigger CI from an external event. Example: definition `12` on `refs/heads/main` with parameters `{ \\\"environment\\\": \\\"staging\\\" }`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/build/builds/queue?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/run-pipeline/run-pipeline.mjs
+++ b/components/azure_devops/actions/run-pipeline/run-pipeline.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import azureDevops from "../../azure_devops.app.mjs";
 import { parseObject } from "../../common/utils.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "azure_devops-run-pipeline",
   name: "Run Pipeline",
   description: "Trigger a run of a YAML pipeline, optionally on a specific branch and with template parameters or variable overrides. Returns the run's id and state; the run itself proceeds asynchronously. Set **Preview Run** to validate instead: Azure DevOps then starts nothing and returns the final expanded YAML document rather than a run. Use this to deploy or test on demand. Example: pipeline `12` on `refs/heads/main`. Run the **List Pipelines** action first to obtain the pipeline id. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/pipelines/runs/run-pipeline?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/update-pull-request/update-pull-request.mjs
+++ b/components/azure_devops/actions/update-pull-request/update-pull-request.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import azureDevops from "../../azure_devops.app.mjs";
 import { PULL_REQUEST_UPDATE_STATUS_OPTIONS } from "../../common/constants.mjs";
@@ -8,8 +7,9 @@ export default {
   key: "azure_devops-update-pull-request",
   name: "Update Pull Request",
   description: "Update a pull request - retitle it, edit its description, retarget it, publish a draft, or complete or abandon it. At least one field is required. Returns the updated pull request. Use status `completed` to merge and `abandoned` to close without merging. Example: pull request `12`, status `abandoned`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-requests/update?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/actions/update-work-item/update-work-item.mjs
+++ b/components/azure_devops/actions/update-work-item/update-work-item.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import azureDevops from "../../azure_devops.app.mjs";
 import {
@@ -12,8 +11,9 @@ export default {
   key: "azure_devops-update-work-item",
   name: "Update Work Item",
   description: "Update an existing work item - retitle it, move it between states, reassign it, repoint its area and iteration, or link it to another work item. At least one field or a link is required. Returns the updated work item. Use when closing out automated work or reflecting a change from another system. Example: work item `299`, state `Closed`. [See the documentation](https://learn.microsoft.com/en-us/rest/api/azure/devops/wit/work-items/update?view=azure-devops-rest-7.1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/azure_devops/package.json
+++ b/components/azure_devops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/azure_devops",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Pipedream Azure DevOps Components",
   "main": "azure_devops.app.mjs",
   "keywords": [

--- a/components/fireflies/actions/ask-question-about-meeting/ask-question-about-meeting.mjs
+++ b/components/fireflies/actions/ask-question-about-meeting/ask-question-about-meeting.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import fireflies from "../../fireflies.app.mjs";
 import mutations from "../../common/mutations.mjs";
 import constants from "../../common/constants.mjs";
@@ -8,13 +7,14 @@ export default {
   key: "fireflies-ask-question-about-meeting",
   name: "Ask Question About Meeting",
   description: "Ask AskFred, Fireflies' AI assistant, a natural language question about a meeting's content — for example, action items, decisions made, or a summary of a specific topic. Starts a new AskFred conversation thread; use **Continue AskFred Conversation** to ask follow-up questions in the same thread. Requires AI credits on the connected Fireflies account. [See the documentation](https://docs.fireflies.ai/graphql-api/mutation/create-askfred-thread)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     fireflies,
     query: {

--- a/components/fireflies/actions/continue-askfred-conversation/continue-askfred-conversation.mjs
+++ b/components/fireflies/actions/continue-askfred-conversation/continue-askfred-conversation.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import fireflies from "../../fireflies.app.mjs";
 import mutations from "../../common/mutations.mjs";
 import constants from "../../common/constants.mjs";
@@ -8,13 +7,14 @@ export default {
   key: "fireflies-continue-askfred-conversation",
   name: "Continue AskFred Conversation",
   description: "Ask a follow-up question in an existing AskFred conversation thread, continuing the context of a prior question. Use **Ask Question About Meeting** first to start a thread and obtain its `thread_id`. [See the documentation](https://docs.fireflies.ai/graphql-api/mutation/continue-askfred-thread)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     fireflies,
     threadId: {

--- a/components/fireflies/actions/create-live-meeting-soundbite/create-live-meeting-soundbite.mjs
+++ b/components/fireflies/actions/create-live-meeting-soundbite/create-live-meeting-soundbite.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import fireflies from "../../fireflies.app.mjs";
 import mutations from "../../common/mutations.mjs";
 import constants from "../../common/constants.mjs";
@@ -8,13 +7,14 @@ export default {
   key: "fireflies-create-live-meeting-soundbite",
   name: "Create Live Meeting Soundbite",
   description: "Create a soundbite from a meeting that is currently live/in-progress, based on a natural language description of the moment to capture (e.g. `the last 2 minutes` or `when the budget was discussed`). This is documented for use during a live meeting; to clip a meeting that has already ended and been transcribed, use **Create Meeting Clip** instead, which takes an explicit start and end time. Only the meeting organizer or a team admin can run this, and it consumes AI credits and is rate-limited to 10 requests per hour. [See the documentation](https://docs.fireflies.ai/graphql-api/mutation/create-live-soundbite)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     fireflies,
     meetingId: {

--- a/components/fireflies/actions/create-meeting-clip/create-meeting-clip.mjs
+++ b/components/fireflies/actions/create-meeting-clip/create-meeting-clip.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import fireflies from "../../fireflies.app.mjs";
 import mutations from "../../common/mutations.mjs";
 import constants from "../../common/constants.mjs";
@@ -18,13 +17,14 @@ export default {
   key: "fireflies-create-meeting-clip",
   name: "Create Meeting Clip",
   description: "Create a clip (a Fireflies \"bite\") from a completed, already-transcribed meeting by specifying a start and end time in seconds. This is the action to use for past meetings — for a meeting that is still running, use **Create Live Meeting Soundbite** instead. To find the moment to clip, read the `sentences` array returned by **Find Meeting by ID**: each sentence carries its own `start_time` and `end_time` in seconds (e.g. `142.5`), so clipping around a quote means passing that sentence's start and end. Clip generation is asynchronous — this returns immediately with `status: pending` and no media, so `preview`, `thumbnail` and the playable URL are not available yet. Pass the returned `id` to **Find Clip by ID** and poll until `status` reaches a terminal `ready` or `error`. [See the documentation](https://docs.fireflies.ai/graphql-api/mutation/create-bite)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     fireflies,
     meetingId: {

--- a/components/fireflies/actions/find-clip-by-id/find-clip-by-id.mjs
+++ b/components/fireflies/actions/find-clip-by-id/find-clip-by-id.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import fireflies from "../../fireflies.app.mjs";
 import queries from "../../common/queries.mjs";
 import { ConfigurationError } from "@pipedream/platform";
@@ -7,13 +6,14 @@ export default {
   key: "fireflies-find-clip-by-id",
   name: "Find Clip by ID",
   description: "Retrieve a single meeting clip (a Fireflies \"bite\") by its ID, including its render status and media URLs. Use this to follow up on **Create Meeting Clip**, which returns immediately with `status: pending` and no media. Poll until `status` reaches a terminal `ready` or `error`, and stop on either — `pending` and `processing` mean the clip is still rendering. Once `ready`, the playable media is at `sources[].src`, with `preview` and `thumbnail` also populated; all three are `null` beforehand. Note that `summary_status` tracks the AI-generated summary separately and can finish while `status` is still `pending`, so poll `status` rather than `summary_status`. Use **List Clips** to look up a clip ID. [See the documentation](https://docs.fireflies.ai/graphql-api/query/bite)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     fireflies,
     biteId: {

--- a/components/fireflies/actions/find-meeting-by-id/find-meeting-by-id.mjs
+++ b/components/fireflies/actions/find-meeting-by-id/find-meeting-by-id.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import fireflies from "../../fireflies.app.mjs";
 import queries from "../../common/queries.mjs";
 import { ConfigurationError } from "@pipedream/platform";
@@ -7,13 +6,14 @@ export default {
   key: "fireflies-find-meeting-by-id",
   name: "Find Meeting by ID",
   description: "Retrieve a single meeting's full transcript by its ID, including the summary (overview, action items, keywords, outline), sentence-level transcript text, duration, date, and audio/video URLs. Use this when you already have a meeting ID; use **Find Recent Meeting** instead to get a user's latest meeting, or **List Meeting ID Options** to look up an ID by meeting title. [See the documentation](https://docs.fireflies.ai/graphql-api/query/transcript)",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     fireflies,
     meetingId: {

--- a/components/fireflies/actions/find-recent-meeting/find-recent-meeting.mjs
+++ b/components/fireflies/actions/find-recent-meeting/find-recent-meeting.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import fireflies from "../../fireflies.app.mjs";
 import queries from "../../common/queries.mjs";
 import { ConfigurationError } from "@pipedream/platform";
@@ -7,13 +6,14 @@ export default {
   key: "fireflies-find-recent-meeting",
   name: "Find Recent Meeting",
   description: "Retrieve a specific user's most recent meeting, returning the full transcript (summary, sentence-level text, duration, date, audio/video URLs) rather than just the ID. Use this as the starting point when a request refers to \"my last meeting\" or \"their latest call\". Returns no data if the user has no meetings yet. Use **Find Meeting by ID** instead when you already have a meeting ID. [See the documentation](https://docs.fireflies.ai/graphql-api/query/user)",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     fireflies,
     userId: {

--- a/components/fireflies/actions/list-askfred-thread-id-options/list-askfred-thread-id-options.mjs
+++ b/components/fireflies/actions/list-askfred-thread-id-options/list-askfred-thread-id-options.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import fireflies from "../../fireflies.app.mjs";
 import queries from "../../common/queries.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "fireflies-list-askfred-thread-id-options",
   name: "List AskFred Thread ID Options",
   description: "List existing AskFred conversation threads as ID/title pairs, to discover a valid AskFred Thread ID. Call this first when resuming an older conversation with **Continue AskFred Conversation** and you no longer have the `thread_id` that **Ask Question About Meeting** returned. Fireflies returns every thread in a single response, so pagination does not apply. [See the documentation](https://docs.fireflies.ai/graphql-api/query/askfred-threads)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/fireflies/actions/list-channel-id-options/list-channel-id-options.mjs
+++ b/components/fireflies/actions/list-channel-id-options/list-channel-id-options.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import fireflies from "../../fireflies.app.mjs";
 import queries from "../../common/queries.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "fireflies-list-channel-id-options",
   name: "List Channel ID Options",
   description: "List the channels accessible to the authenticated user as ID/title pairs, to discover a valid Channel ID. Call this first when you know a channel by name but need its ID for **Update Meeting**. Includes public channels on the team plus private channels you belong to. Fireflies returns every channel in a single response, so pagination does not apply. [See the documentation](https://docs.fireflies.ai/graphql-api/query/channels)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/fireflies/actions/list-clips/list-clips.mjs
+++ b/components/fireflies/actions/list-clips/list-clips.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import fireflies from "../../fireflies.app.mjs";
 import queries from "../../common/queries.mjs";
 import constants from "../../common/constants.mjs";
@@ -8,13 +7,14 @@ export default {
   key: "fireflies-list-clips",
   name: "List Clips",
   description: "List meeting clips (Fireflies \"bites\"). The API requires at least one filter, so **set at least one of `Meeting ID`, `Mine Only`, or `My Team Only`** — `Mine Only` defaults to `true`, which lists the clips created by the connected account. Use this to look up a clip's `id` for **Find Clip by ID**, or to check which clips already exist for a meeting before creating another with **Create Meeting Clip**. Each result includes the clip's render `status` and, once that status is `ready`, its media URLs in `sources[].src`. [See the documentation](https://docs.fireflies.ai/graphql-api/query/bites)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     fireflies,
     meetingId: {

--- a/components/fireflies/actions/list-meeting-id-options/list-meeting-id-options.mjs
+++ b/components/fireflies/actions/list-meeting-id-options/list-meeting-id-options.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import fireflies from "../../fireflies.app.mjs";
 
 export default {
   key: "fireflies-list-meeting-id-options",
   name: "List Meeting ID Options",
   description: "List recent meetings as ID/title pairs, to discover a valid Meeting ID. Call this first when you know a meeting by name but need its ID for **Find Meeting by ID**, **Update Meeting**, **Share Meeting** or **Ask Question About Meeting**. Results are ordered most-recent-first; increment Page to reach older meetings. [See the documentation](https://docs.fireflies.ai/graphql-api/query/transcripts)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/fireflies/actions/list-user-id-options/list-user-id-options.mjs
+++ b/components/fireflies/actions/list-user-id-options/list-user-id-options.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import fireflies from "../../fireflies.app.mjs";
 
 export default {
   key: "fireflies-list-user-id-options",
   name: "List User ID Options",
   description: "List the team's users as ID/name pairs, to discover a valid User ID. Call this first when you know a person by name but need their ID for **Find Recent Meeting** or **Set User Role**. Fireflies returns every user in a single response, so pagination does not apply. [See the documentation](https://docs.fireflies.ai/graphql-api/query/users)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/fireflies/actions/revoke-meeting-access/revoke-meeting-access.mjs
+++ b/components/fireflies/actions/revoke-meeting-access/revoke-meeting-access.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import fireflies from "../../fireflies.app.mjs";
 import mutations from "../../common/mutations.mjs";
 
@@ -6,13 +5,14 @@ export default {
   key: "fireflies-revoke-meeting-access",
   name: "Revoke Meeting Access",
   description: "Revoke a previously shared meeting's access for a specific email address. Access can be re-granted at any time with **Share Meeting**. [See the documentation](https://docs.fireflies.ai/graphql-api/mutation/revoke-shared-meeting-access)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     fireflies,
     meetingId: {

--- a/components/fireflies/actions/set-user-role/set-user-role.mjs
+++ b/components/fireflies/actions/set-user-role/set-user-role.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import fireflies from "../../fireflies.app.mjs";
 import mutations from "../../common/mutations.mjs";
 
@@ -6,13 +5,14 @@ export default {
   key: "fireflies-set-user-role",
   name: "Set User Role",
   description: "Promote a team member to admin or demote an admin to a regular user. The team must always retain at least one admin — attempting to demote the last remaining admin fails with an `admin_must_exist` error. [See the documentation](https://docs.fireflies.ai/graphql-api/mutation/set-user-role)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     fireflies,
     userId: {

--- a/components/fireflies/actions/share-meeting/share-meeting.mjs
+++ b/components/fireflies/actions/share-meeting/share-meeting.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import fireflies from "../../fireflies.app.mjs";
 import mutations from "../../common/mutations.mjs";
 import constants from "../../common/constants.mjs";
@@ -8,13 +7,14 @@ export default {
   key: "fireflies-share-meeting",
   name: "Share Meeting",
   description: "Share a meeting with up to 50 people by email, optionally expiring their access after a number of days. Only the meeting owner or a team admin (on the owner's team) can share a meeting. Rate-limited to 10 requests per hour per user. Use **Revoke Meeting Access** to remove access later. [See the documentation](https://docs.fireflies.ai/graphql-api/mutation/share-meeting)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     fireflies,
     meetingId: {

--- a/components/fireflies/actions/update-meeting/update-meeting.mjs
+++ b/components/fireflies/actions/update-meeting/update-meeting.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import fireflies from "../../fireflies.app.mjs";
 import mutations from "../../common/mutations.mjs";
 import constants from "../../common/constants.mjs";
@@ -8,13 +7,14 @@ export default {
   key: "fireflies-update-meeting",
   name: "Update Meeting",
   description: "Update a meeting's title, privacy level, and/or channel. Each selected field is applied through a separate, sequential mutation rather than a single atomic call — if a later update fails, earlier successful changes remain applied. Set only the fields you want to change — unset fields are left untouched. Updating the title requires admin privileges on the Fireflies team. See the documentation for [Update Meeting Title](https://docs.fireflies.ai/graphql-api/mutation/update-meeting-title), [Update Meeting Privacy](https://docs.fireflies.ai/graphql-api/mutation/update-meeting-privacy) and [Update Meeting Channel](https://docs.fireflies.ai/graphql-api/mutation/update-meeting-channel)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     fireflies,
     meetingId: {

--- a/components/fireflies/package.json
+++ b/components/fireflies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/fireflies",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Pipedream Fireflies Components",
   "main": "fireflies.app.mjs",
   "keywords": [

--- a/components/salesforce_rest_api/actions/add-contact-to-campaign/add-contact-to-campaign.mjs
+++ b/components/salesforce_rest_api/actions/add-contact-to-campaign/add-contact-to-campaign.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import salesforce from "../../salesforce_rest_api.app.mjs";
 import constants from "../../common/constants.mjs";
 
@@ -10,13 +9,14 @@ export default {
     + " The contact must already exist - use **Create Contact** if it does not."
     + " "
     + "[See the documentation](https://developer.salesforce.com/docs/atlas.en-us.228.0.object_reference.meta/object_reference/sforce_api_objects_campaignmember.htm)",
-  version: "0.1.8",
+  version: "0.1.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     salesforce,
     campaignId: {

--- a/components/salesforce_rest_api/actions/add-lead-to-campaign/add-lead-to-campaign.mjs
+++ b/components/salesforce_rest_api/actions/add-lead-to-campaign/add-lead-to-campaign.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import salesforce from "../../salesforce_rest_api.app.mjs";
 import constants from "../../common/constants.mjs";
 
@@ -10,13 +9,14 @@ export default {
     + " The lead must already exist - use **Create Lead** if it does not."
     + " "
     + "[See the documentation](https://developer.salesforce.com/docs/atlas.en-us.228.0.object_reference.meta/object_reference/sforce_api_objects_campaignmember.htm)",
-  version: "0.1.8",
+  version: "0.1.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     salesforce,
     campaignId: {

--- a/components/salesforce_rest_api/actions/convert-soap-xml-to-json/convert-soap-xml-to-json.mjs
+++ b/components/salesforce_rest_api/actions/convert-soap-xml-to-json/convert-soap-xml-to-json.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import salesforce_rest_api from "../../salesforce_rest_api.app.mjs";
 import converter from "../../../helper_functions/actions/xml-to-json/xml-to-json.mjs";
 
@@ -10,13 +9,14 @@ export default {
     + " Every other Salesforce action already returns JSON, so this is only needed for outbound-message workflows."
     + " "
     + "[See the documentation](https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_om_outboundmessaging.htm)",
-  version: "0.0.12",
+  version: "0.0.13",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     salesforce_rest_api,
     infoBox: {

--- a/components/salesforce_rest_api/actions/create-account/create-account.mjs
+++ b/components/salesforce_rest_api/actions/create-account/create-account.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import common, { getProps } from "../common/base-create-update.mjs";
 import account from "../../common/sobjects/account.mjs";
 
@@ -13,13 +12,14 @@ export default {
     + " For example, `Name` `Acme Corp` creates a minimal account and returns its new record ID."
     + " "
     + `[See the documentation](${docsLink})`,
-  version: "0.4.0",
+  version: "0.4.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   methods: {
     ...common.methods,
   },

--- a/components/salesforce_rest_api/actions/create-accounts-batch/create-accounts-batch.mjs
+++ b/components/salesforce_rest_api/actions/create-accounts-batch/create-accounts-batch.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import common from "../common/batch-operation.mjs";
 
 export default {
@@ -11,13 +10,14 @@ export default {
     + " Input is a CSV file - supply a path under `/tmp` or a URL to download it from, with a header row of Salesforce field API names."
     + " "
     + "[See the documentation](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/datafiles_understanding_bulk2_ingest.htm)",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   methods: {
     ...common.methods,
     getObject() {

--- a/components/salesforce_rest_api/actions/create-attachment/create-attachment.mjs
+++ b/components/salesforce_rest_api/actions/create-attachment/create-attachment.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import common, { getProps } from "../common/base-create-update.mjs";
 import attachment from "../../common/sobjects/attachment.mjs";
 import { getFileStream } from "@pipedream/platform";
@@ -14,13 +13,14 @@ export default {
     + " For newer orgs prefer Salesforce Files - use **Insert Blob Data** with `ContentVersion` instead."
     + " "
     + `[See the documentation](${docsLink})`,
-  version: "0.6.0",
+  version: "0.6.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: getProps({
     objType: attachment,
     docsLink,

--- a/components/salesforce_rest_api/actions/create-campaign/create-campaign.mjs
+++ b/components/salesforce_rest_api/actions/create-campaign/create-campaign.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import common, { getProps } from "../common/base-create-update.mjs";
 import campaign from "../../common/sobjects/campaign.mjs";
 
@@ -13,13 +12,14 @@ export default {
     + " For example, `Name: \"Summer 2026 Webinar\"` creates the campaign and returns its ID."
     + " "
     + `[See the documentation](${docsLink})`,
-  version: "0.3.8",
+  version: "0.3.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   methods: {
     ...common.methods,
   },

--- a/components/salesforce_rest_api/actions/create-case/create-case.mjs
+++ b/components/salesforce_rest_api/actions/create-case/create-case.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import common, { getProps } from "../common/base-create-update.mjs";
 import caseObj from "../../common/sobjects/case.mjs";
 
@@ -13,13 +12,14 @@ export default {
     + " After creating, use **Create Case Comment** to add notes or **List Case Feed Items** to read its activity."
     + " "
     + `[See the documentation](${docsLink})`,
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   methods: {
     ...common.methods,
   },

--- a/components/salesforce_rest_api/actions/create-casecomment/create-casecomment.mjs
+++ b/components/salesforce_rest_api/actions/create-casecomment/create-casecomment.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import common, { getProps } from "../common/base-create-update.mjs";
 import caseComment from "../../common/sobjects/caseComment.mjs";
 
@@ -13,13 +12,14 @@ export default {
     + " Comments are visible in the case feed - **List Case Feed Items** shows them as `CaseCommentPost` entries."
     + " "
     + `[See the documentation](${docsLink})`,
-  version: "0.3.8",
+  version: "0.3.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   methods: {
     ...common.methods,
   },

--- a/components/salesforce_rest_api/actions/create-contact/create-contact.mjs
+++ b/components/salesforce_rest_api/actions/create-contact/create-contact.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import common, { getProps } from "../common/base-create-update.mjs";
 import contact from "../../common/sobjects/contact.mjs";
 
@@ -13,13 +12,14 @@ export default {
     + " Use **Describe Object** on `Contact` to discover which fields your org requires."
     + " "
     + `[See the documentation](${docsLink})`,
-  version: "0.3.8",
+  version: "0.3.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   methods: {
     ...common.methods,
   },

--- a/components/salesforce_rest_api/actions/create-content-note/create-content-note.mjs
+++ b/components/salesforce_rest_api/actions/create-content-note/create-content-note.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import common from "../common/base-create-update.mjs";
 import salesforce from "../../salesforce_rest_api.app.mjs";
 import { NOTE_INFO_PROP } from "../../common/props-info.mjs";
@@ -16,13 +15,14 @@ export default {
     + "Notes must be enabled in the org first - see [Set Up Notes](https://help.salesforce.com/s/articleView?id=sales.notes_admin_setup.htm&type=5)."
     + " "
     + `[See the documentation](${docsLink})`,
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     salesforce,
     noteInfo: NOTE_INFO_PROP,

--- a/components/salesforce_rest_api/actions/create-crm-record/create-crm-record.mjs
+++ b/components/salesforce_rest_api/actions/create-crm-record/create-crm-record.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import salesforce from "../../salesforce_rest_api.app.mjs";
 
 export default {
@@ -22,8 +21,9 @@ export default {
     + " `{\"CampaignId\": \"701xxx\", \"ContactId\": \"003xxx\"}` or `{\"CampaignId\": \"701xxx\", \"LeadId\": \"00Qxxx\"}`."
     + " "
     + "[See the documentation](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_sobject_create.htm)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/salesforce_rest_api/actions/create-event/create-event.mjs
+++ b/components/salesforce_rest_api/actions/create-event/create-event.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import common, { getProps } from "../common/base-create-update.mjs";
 import event from "../../common/sobjects/event.mjs";
 
@@ -23,13 +22,14 @@ export default {
     + " Use **Find Records** to get the `WhoId` (contact or lead) and `WhatId` (related record) you want to link."
     + " "
     + `[See the documentation](${docsLink})`,
-  version: "0.4.0",
+  version: "0.4.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   methods: {
     ...common.methods,
   },

--- a/components/salesforce_rest_api/actions/create-lead/create-lead.mjs
+++ b/components/salesforce_rest_api/actions/create-lead/create-lead.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import common, { getProps } from "../common/base-create-update.mjs";
 import lead from "../../common/sobjects/lead.mjs";
 
@@ -13,13 +12,14 @@ export default {
     + " Use **Add Lead to Campaign** afterwards to attribute the lead to a campaign."
     + " "
     + `[See the documentation](${docsLink})`,
-  version: "0.4.0",
+  version: "0.4.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   methods: {
     ...common.methods,
   },

--- a/components/salesforce_rest_api/actions/create-note/create-note.mjs
+++ b/components/salesforce_rest_api/actions/create-note/create-note.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import common, { getProps } from "../common/base-create-update.mjs";
 import note from "../../common/sobjects/note.mjs";
 import { NOTE_INFO_PROP } from "../../common/props-info.mjs";
@@ -19,13 +18,14 @@ export default {
     + " Use **Find Records** to get the parent record ID first."
     + " "
     + `[See the documentation](${docsLink})`,
-  version: "0.3.9",
+  version: "0.3.10",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   methods: {
     ...common.methods,
   },

--- a/components/salesforce_rest_api/actions/create-opportunities-batch/create-opportunities-batch.mjs
+++ b/components/salesforce_rest_api/actions/create-opportunities-batch/create-opportunities-batch.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import common from "../common/batch-operation.mjs";
 
 export default {
@@ -12,13 +11,14 @@ export default {
     + " Poll the job in Salesforce to confirm completion; a successful response means the job was accepted, not that every row loaded."
     + " "
     + "[See the documentation](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/datafiles_understanding_bulk2_ingest.htm)",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   methods: {
     ...common.methods,
     getObject() {

--- a/components/salesforce_rest_api/actions/create-opportunity/create-opportunity.mjs
+++ b/components/salesforce_rest_api/actions/create-opportunity/create-opportunity.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import common, { getProps } from "../common/base-create-update.mjs";
 import opportunity from "../../common/sobjects/opportunity.mjs";
 
@@ -13,13 +12,14 @@ export default {
     + " Use **Find Records** on `Account` to get the `AccountId` to attach the deal to."
     + " "
     + `[See the documentation](${docsLink})`,
-  version: "0.4.0",
+  version: "0.4.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   methods: {
     ...common.methods,
   },

--- a/components/salesforce_rest_api/actions/create-record/create-record.mjs
+++ b/components/salesforce_rest_api/actions/create-record/create-record.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import salesforce from "../../salesforce_rest_api.app.mjs";
 
 export default {
@@ -8,13 +7,14 @@ export default {
     + " Use **List Objects** to discover object types and **Describe Object** to discover fields."
     + " "
     + "[See the documentation](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_sobject_create.htm)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     salesforce,
     objectType: {

--- a/components/salesforce_rest_api/actions/create-task/create-task.mjs
+++ b/components/salesforce_rest_api/actions/create-task/create-task.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import common, { getProps } from "../common/base-create-update.mjs";
 import task from "../../common/sobjects/task.mjs";
 
@@ -14,13 +13,14 @@ export default {
     + " Use **Find Records** to get the `WhoId` (contact or lead) and `WhatId` (related record) to link the task to."
     + " "
     + `[See the documentation](${docsLink})`,
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   methods: {
     ...common.methods,
   },

--- a/components/salesforce_rest_api/actions/create-user/create-user.mjs
+++ b/components/salesforce_rest_api/actions/create-user/create-user.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import common, { getProps } from "../common/base-create-update.mjs";
 import user from "../../common/sobjects/user.mjs";
 
@@ -14,13 +13,14 @@ export default {
     + " Use **Get User** or **Find Records** on `User` to check whether the person already has an account."
     + " "
     + `[See the documentation](${docsLink})`,
-  version: "0.1.8",
+  version: "0.1.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   methods: {
     ...common.methods,
   },

--- a/components/salesforce_rest_api/actions/delete-crm-record/delete-crm-record.mjs
+++ b/components/salesforce_rest_api/actions/delete-crm-record/delete-crm-record.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import salesforce from "../../salesforce_rest_api.app.mjs";
 
 export default {
@@ -9,8 +8,9 @@ export default {
     + " Use **SOQL Query** to find the record ID if you only have the record name."
     + " "
     + "[See the documentation](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_delete_record.htm)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: true,

--- a/components/salesforce_rest_api/actions/delete-note/delete-note.mjs
+++ b/components/salesforce_rest_api/actions/delete-note/delete-note.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import salesforce from "../../salesforce_rest_api.app.mjs";
 import { ConfigurationError } from "@pipedream/platform";
 
@@ -10,8 +9,9 @@ export default {
     + " Use **Find Records** on `Note` or `ContentNote` to get the ID first."
     + " "
     + "[See the documentation](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_sobject_retrieve_delete.htm)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/salesforce_rest_api/actions/delete-opportunity/delete-opportunity.mjs
+++ b/components/salesforce_rest_api/actions/delete-opportunity/delete-opportunity.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import salesforce from "../../salesforce_rest_api.app.mjs";
 
 export default {
@@ -9,13 +8,14 @@ export default {
     + " Use **Find Records** on `Opportunity` to get the ID first, and prefer **Update Opportunity** to set a Closed Lost stage when you want to keep the history."
     + " "
     + "[See the documentation](https://developer.salesforce.com/docs/atlas.en-us.228.0.api_rest.meta/api_rest/dome_delete_record.htm)",
-  version: "0.3.6",
+  version: "0.3.7",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     salesforce,
     recordId: {

--- a/components/salesforce_rest_api/actions/delete-record/delete-record.mjs
+++ b/components/salesforce_rest_api/actions/delete-record/delete-record.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import salesforce from "../../salesforce_rest_api.app.mjs";
 
 export default {
@@ -10,13 +9,14 @@ export default {
     + " Use **Find Records** or **SOQL Query** to confirm you have the right record ID before deleting."
     + " "
     + "[See the documentation](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_sobject_retrieve_delete.htm)",
-  version: "0.2.6",
+  version: "0.2.7",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     salesforce,
     sobjectType: {

--- a/components/salesforce_rest_api/actions/describe-object/describe-object.mjs
+++ b/components/salesforce_rest_api/actions/describe-object/describe-object.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import salesforce from "../../salesforce_rest_api.app.mjs";
 
 export default {
@@ -13,8 +12,9 @@ export default {
     + " Use **List Objects** if you're unsure of the object's API name."
     + " "
     + "[See the documentation](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_sobject_describe.htm)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/salesforce_rest_api/actions/find-records/find-records.mjs
+++ b/components/salesforce_rest_api/actions/find-records/find-records.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import salesforce from "../../salesforce_rest_api.app.mjs";
 import constants from "../../common/constants.mjs";
 import {
@@ -15,13 +14,14 @@ export default {
     + " Leaving `Record ID(s)` empty returns recent records, not every record - Salesforce sends one batch, so set `Limit` and use **SOQL Query** when you need everything."
     + " Newest-first ordering needs `CreatedDate`, so results are unordered on the few object types that lack it."
     + " [See the documentation](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_query.htm)",
-  version: "0.3.2",
+  version: "0.3.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     salesforce,
     sobjectType: {

--- a/components/salesforce_rest_api/actions/get-case/get-case.mjs
+++ b/components/salesforce_rest_api/actions/get-case/get-case.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import salesforce from "../../salesforce_rest_api.app.mjs";
 
 export default {
@@ -9,13 +8,14 @@ export default {
     + " Use **List Case Feed Items** and **List Case Comments** to read the case's activity and comment thread."
     + " "
     + "[See the documentation](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_get_field_values.htm)",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     salesforce,
     caseId: {

--- a/components/salesforce_rest_api/actions/get-current-user/get-current-user.mjs
+++ b/components/salesforce_rest_api/actions/get-current-user/get-current-user.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import salesforce from "../../salesforce_rest_api.app.mjs";
 
 export default {
   key: "salesforce_rest_api-get-current-user",
   name: "Get Current User",
   description: "Returns the authenticated Salesforce user's ID, name, email, and organization ID. Call this first when the user says 'my leads', 'my opportunities', 'my cases', or any first-person query. Use `user_id` as the OwnerId filter in **SOQL Search** (e.g. `WHERE OwnerId = '{user_id}'`) and `organization_id` to construct Salesforce UI URLs. [See the documentation](https://help.salesforce.com/s/articleView?id=sf.remoteaccess_using_userinfo_endpoint.htm).",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/salesforce_rest_api/actions/get-knowledge-articles/get-knowledge-articles.mjs
+++ b/components/salesforce_rest_api/actions/get-knowledge-articles/get-knowledge-articles.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import common from "../common/knowledge.mjs";
 
 export default {
@@ -10,13 +9,14 @@ export default {
     + " Returns published article content, so responses can be large - narrow by category or search term."
     + " "
     + "[See the documentation](https://developer.salesforce.com/docs/atlas.en-us.knowledge_dev.meta/knowledge_dev/sforce_api_rest_retrieve_article_list.htm)",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     ...common.props,
     q: {

--- a/components/salesforce_rest_api/actions/get-knowledge-data-category-groups/get-knowledge-data-category-groups.mjs
+++ b/components/salesforce_rest_api/actions/get-knowledge-data-category-groups/get-knowledge-data-category-groups.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import common from "../common/knowledge.mjs";
 
 export default {
@@ -10,13 +9,14 @@ export default {
     + " Returns only categories the authenticated user can see, so results vary per user."
     + " "
     + "[See the documentation](https://developer.salesforce.com/docs/atlas.en-us.knowledge_dev.meta/knowledge_dev/resources_knowledge_support_dcgroups.htm)",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     ...common.props,
     topCategoriesOnly: {

--- a/components/salesforce_rest_api/actions/get-record-by-id/get-record-by-id.mjs
+++ b/components/salesforce_rest_api/actions/get-record-by-id/get-record-by-id.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import salesforce from "../../salesforce_rest_api.app.mjs";
 
 export default {
@@ -9,8 +8,9 @@ export default {
     + " Use **List Objects** to discover object types if you are unsure of the type name."
     + " "
     + "[See the documentation](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_get_field_values.htm)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/salesforce_rest_api/actions/get-related-records/get-related-records.mjs
+++ b/components/salesforce_rest_api/actions/get-related-records/get-related-records.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import salesforce from "../../salesforce_rest_api.app.mjs";
 
 export default {
@@ -14,8 +13,9 @@ export default {
     + " (look for `relationshipName` on reference fields)."
     + " "
     + "[See the documentation](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_sobject_relationships.htm)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/salesforce_rest_api/actions/get-user-info/get-user-info.mjs
+++ b/components/salesforce_rest_api/actions/get-user-info/get-user-info.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import salesforce from "../../salesforce_rest_api.app.mjs";
 
 export default {
@@ -12,8 +11,9 @@ export default {
     + " `{instanceUrl}/lightning/r/{objectType}/{recordId}/view`."
     + " "
     + "[See the documentation](https://help.salesforce.com/s/articleView?id=sf.remoteaccess_using_userinfo_endpoint.htm&type=5)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/salesforce_rest_api/actions/get-user/get-user.mjs
+++ b/components/salesforce_rest_api/actions/get-user/get-user.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import salesforce from "../../salesforce_rest_api.app.mjs";
 
 export default {
@@ -9,13 +8,14 @@ export default {
     + " Record owner fields such as `OwnerId` hold user IDs - pass one here to resolve it to a name and email."
     + " "
     + "[See the documentation](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_get_field_values.htm)",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     salesforce,
     userId: {

--- a/components/salesforce_rest_api/actions/insert-blob-data/insert-blob-data.mjs
+++ b/components/salesforce_rest_api/actions/insert-blob-data/insert-blob-data.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import salesforce from "../../salesforce_rest_api.app.mjs";
 
 export default {
@@ -9,13 +8,14 @@ export default {
     + " The file content must be supplied as a file path or URL, not as raw bytes in the request."
     + " "
     + "[See the documentation](https://developer.salesforce.com/docs/atlas.en-us.228.0.api_rest.meta/api_rest/dome_sobject_insert_update_blob.htm)",
-  version: "0.2.14",
+  version: "0.2.15",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     salesforce,
     entiyName: {

--- a/components/salesforce_rest_api/actions/list-case-comments/list-case-comments.mjs
+++ b/components/salesforce_rest_api/actions/list-case-comments/list-case-comments.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import salesforce from "../../salesforce_rest_api.app.mjs";
 import constants from "../../common/constants.mjs";
 import {
@@ -13,13 +12,14 @@ export default {
     + " Find the case ID with **List Cases** first."
     + " For example, case ID `5005g00001ABCDeAAI` with `Limit` `20` returns that case's twenty most recent comments."
     + " [See the documentation](https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/sforce_api_objects_casecomment.htm)",
-  version: "0.1.2",
+  version: "0.1.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     salesforce,
     caseId: {

--- a/components/salesforce_rest_api/actions/list-case-feed-items/list-case-feed-items.mjs
+++ b/components/salesforce_rest_api/actions/list-case-feed-items/list-case-feed-items.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import salesforce from "../../salesforce_rest_api.app.mjs";
 import constants from "../../common/constants.mjs";
 import {
@@ -12,13 +11,14 @@ export default {
     + " Use this to read a case's activity trail - text posts, status changes, logged calls, email events and case comment events - in one call."
     + " The case feed only exists when feed tracking is enabled for Cases in the Salesforce org, so an org without it returns no records."
     + " [See the documentation](https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/sforce_api_associated_objects_feed.htm)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     salesforce,
     caseId: {

--- a/components/salesforce_rest_api/actions/list-cases/list-cases.mjs
+++ b/components/salesforce_rest_api/actions/list-cases/list-cases.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import salesforce from "../../salesforce_rest_api.app.mjs";
 import constants from "../../common/constants.mjs";
 import {
@@ -14,13 +13,14 @@ export default {
     + " For example, `Status` `New` with `Limit` `10` returns the ten newest open cases."
     + " Status values are org-configurable."
     + " [See the documentation](https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/sforce_api_objects_case.htm)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     salesforce,
     caseNumber: {

--- a/components/salesforce_rest_api/actions/list-email-messages/list-email-messages.mjs
+++ b/components/salesforce_rest_api/actions/list-email-messages/list-email-messages.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import salesforce from "../../salesforce_rest_api.app.mjs";
 import constants from "../../common/constants.mjs";
 import {
@@ -13,13 +12,14 @@ export default {
     + " Find the case ID with **List Cases** first."
     + " Omit `Case ID` to list the most recent emails across the org, which can be large - set `Limit`."
     + " [See the documentation](https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/sforce_api_objects_emailmessage.htm)",
-  version: "0.1.2",
+  version: "0.1.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     salesforce,
     caseId: {

--- a/components/salesforce_rest_api/actions/list-email-templates/list-email-templates.mjs
+++ b/components/salesforce_rest_api/actions/list-email-templates/list-email-templates.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import salesforce from "../../salesforce_rest_api.app.mjs";
 import constants from "../../common/constants.mjs";
 import {
@@ -12,13 +11,14 @@ export default {
     + " Use this to find a template and its ID before sending with **Send Email**, or before editing with **Update Email Template**."
     + " For example, run with `Limit` `50`, then pass the `Id` of the template you want to **Send Email**."
     + " [See the documentation](https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/sforce_api_objects_emailtemplate.htm)",
-  version: "0.1.2",
+  version: "0.1.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     salesforce,
     fields: {

--- a/components/salesforce_rest_api/actions/list-knowledge-articles/list-knowledge-articles.mjs
+++ b/components/salesforce_rest_api/actions/list-knowledge-articles/list-knowledge-articles.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import salesforce from "../../salesforce_rest_api.app.mjs";
 import constants from "../../common/constants.mjs";
 import {
@@ -12,13 +11,14 @@ export default {
     + " Returns the article container records (`KnowledgeArticle`), not the published article bodies - use **Get Knowledge Articles** to read article content, and **List Knowledge Data Category Groups** to discover the categories articles are filed under."
     + " This can return a lot of records on a mature org, so set `Limit`."
     + " [See the documentation](https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/sforce_api_objects_knowledgearticle.htm)",
-  version: "0.1.2",
+  version: "0.1.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     salesforce,
     fields: {

--- a/components/salesforce_rest_api/actions/list-object-fields/list-object-fields.mjs
+++ b/components/salesforce_rest_api/actions/list-object-fields/list-object-fields.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import salesforce from "../../salesforce_rest_api.app.mjs";
 
 export default {
@@ -9,8 +8,9 @@ export default {
     + " Use **Describe Object** instead when you also need field types, required flags and picklist values."
     + " "
     + "[See the documentation](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_sobject_describe.htm)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/salesforce_rest_api/actions/list-objects/list-objects.mjs
+++ b/components/salesforce_rest_api/actions/list-objects/list-objects.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import salesforce from "../../salesforce_rest_api.app.mjs";
 
 export default {
@@ -12,8 +11,9 @@ export default {
     + " Use **Describe Object** to get field details for a specific object type."
     + " "
     + "[See the documentation](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_describeGlobal.htm)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/salesforce_rest_api/actions/post-feed-to-chatter/post-feed-to-chatter.mjs
+++ b/components/salesforce_rest_api/actions/post-feed-to-chatter/post-feed-to-chatter.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import salesforce from "../../salesforce_rest_api.app.mjs";
 
 export default {
@@ -10,13 +9,14 @@ export default {
     + " The message is built from segments - a plain string becomes text, and `{ \"type\": \"Mention\", \"username\": \"jsmith\" }` mentions a user."
     + " "
     + "[See the documentation](https://developer.salesforce.com/docs/atlas.en-us.chatterapi.meta/chatterapi/quickreference_post_feed_item.htm)",
-  version: "0.1.6",
+  version: "0.1.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     salesforce,
     sobjectType: {

--- a/components/salesforce_rest_api/actions/search-string/search-string.mjs
+++ b/components/salesforce_rest_api/actions/search-string/search-string.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import salesforce from "../../salesforce_rest_api.app.mjs";
 
 export default {
@@ -9,13 +8,14 @@ export default {
     + " SOSL matches indexed text fields, so it finds partial words but will not filter on numeric or date criteria."
     + " "
     + "[See the documentation](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_search_parameterized_get.htm)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     salesforce,
     infoBox: {

--- a/components/salesforce_rest_api/actions/send-email/send-email.mjs
+++ b/components/salesforce_rest_api/actions/send-email/send-email.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import salesforce from "../../salesforce_rest_api.app.mjs";
 
 export default {
@@ -9,13 +8,14 @@ export default {
     + " Sent mail is logged against the related record - use **List Email Messages** to read it back."
     + " "
     + "[See the documentation](https://developer.salesforce.com/docs/atlas.en-us.api_action.meta/api_action/actions_obj_email_simple.htm)",
-  version: "0.1.2",
+  version: "0.1.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     salesforce,
     emailAddress: {

--- a/components/salesforce_rest_api/actions/soql-query/soql-query.mjs
+++ b/components/salesforce_rest_api/actions/soql-query/soql-query.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import salesforce from "../../salesforce_rest_api.app.mjs";
 
 export default {
@@ -28,8 +27,9 @@ export default {
     + " using the format `{instanceUrl}/lightning/r/{objectType}/{Id}/view` (get `instanceUrl` from **Get User Info**)."
     + " "
     + "[See the documentation](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_query.htm)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/salesforce_rest_api/actions/soql-search/soql-search.mjs
+++ b/components/salesforce_rest_api/actions/soql-search/soql-search.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import salesforce from "../../salesforce_rest_api.app.mjs";
 import { docsInfo } from "../sosl-search/sosl-search.mjs";
 
@@ -12,13 +11,14 @@ export default {
     + " SOQL filters on exact field values; use **Text Search** for keyword search."
     + " "
     + `[See the documentation](${docsLink})`,
-  version: "0.2.15",
+  version: "0.2.16",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     salesforce,
     docsInfo,

--- a/components/salesforce_rest_api/actions/sosl-search/sosl-search.mjs
+++ b/components/salesforce_rest_api/actions/sosl-search/sosl-search.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import salesforce from "../../salesforce_rest_api.app.mjs";
 
 const docsLink = "https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_sosl_examples.htm";
@@ -17,13 +16,14 @@ export default {
     + " SOSL matches indexed text fields, so it finds partial words but will not filter on numeric or date criteria."
     + " "
     + `[See the documentation](${docsLink})`,
-  version: "0.2.14",
+  version: "0.2.15",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     salesforce,
     docsInfo,

--- a/components/salesforce_rest_api/actions/text-search/text-search.mjs
+++ b/components/salesforce_rest_api/actions/text-search/text-search.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import salesforce from "../../salesforce_rest_api.app.mjs";
 
 export default {
@@ -11,8 +10,9 @@ export default {
     + " Results are grouped by object type."
     + " "
     + "[See the documentation](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_search.htm)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/salesforce_rest_api/actions/update-account/update-account.mjs
+++ b/components/salesforce_rest_api/actions/update-account/update-account.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import common, { getProps } from "../common/base-create-update.mjs";
 import account from "../../common/sobjects/account.mjs";
 import salesforce from "../../salesforce_rest_api.app.mjs";
@@ -23,13 +22,14 @@ export default {
     + " Use **Find Records** on `Account` to get the record ID first."
     + " "
     + `[See the documentation](${docsLink})`,
-  version: "0.4.0",
+  version: "0.4.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   methods: {
     ...common.methods,
   },

--- a/components/salesforce_rest_api/actions/update-accounts-batch/update-accounts-batch.mjs
+++ b/components/salesforce_rest_api/actions/update-accounts-batch/update-accounts-batch.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import common from "../common/batch-operation.mjs";
 
 export default {
@@ -12,13 +11,14 @@ export default {
     + " Poll the job in Salesforce to confirm completion; a successful response means the job was accepted, not that every row loaded."
     + " "
     + "[See the documentation](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/datafiles_understanding_bulk2_ingest.htm)",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   methods: {
     ...common.methods,
     getObject() {

--- a/components/salesforce_rest_api/actions/update-contact/update-contact.mjs
+++ b/components/salesforce_rest_api/actions/update-contact/update-contact.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import common, { getProps } from "../common/base-create-update.mjs";
 import contact from "../../common/sobjects/contact.mjs";
 import salesforce from "../../salesforce_rest_api.app.mjs";
@@ -23,13 +22,14 @@ export default {
     + " Use **Find Records** on `Contact` to get the record ID first."
     + " "
     + `[See the documentation](${docsLink})`,
-  version: "0.4.0",
+  version: "0.4.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   methods: {
     ...common.methods,
   },

--- a/components/salesforce_rest_api/actions/update-content-note/update-content-note.mjs
+++ b/components/salesforce_rest_api/actions/update-content-note/update-content-note.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import common, { getProps } from "../common/base-create-update.mjs";
 import contentNote from "../../common/sobjects/content-note.mjs";
 import salesforce from "../../salesforce_rest_api.app.mjs";
@@ -27,8 +26,9 @@ export default {
     + "Notes must be enabled in the org first - see [Set Up Notes](https://help.salesforce.com/s/articleView?id=sales.notes_admin_setup.htm&type=5)."
     + " "
     + `[See the documentation](${docsLink})`,
-  version: "1.0.0",
+  version: "1.0.1",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/salesforce_rest_api/actions/update-crm-record/update-crm-record.mjs
+++ b/components/salesforce_rest_api/actions/update-crm-record/update-crm-record.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import salesforce from "../../salesforce_rest_api.app.mjs";
 
 export default {
@@ -10,8 +9,9 @@ export default {
     + " Use **SOQL Query** to find the record ID if you only have the name."
     + " "
     + "[See the documentation](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_update_fields.htm)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/salesforce_rest_api/actions/update-email-template/update-email-template.mjs
+++ b/components/salesforce_rest_api/actions/update-email-template/update-email-template.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import salesforce from "../../salesforce_rest_api.app.mjs";
 
 export default {
@@ -9,13 +8,14 @@ export default {
     + " Only the fields you supply change; everything else is left as-is."
     + " "
     + "[See the documentation](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_update_fields.htm)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     salesforce,
     recordId: {

--- a/components/salesforce_rest_api/actions/update-note/update-note.mjs
+++ b/components/salesforce_rest_api/actions/update-note/update-note.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import common, { getProps } from "../common/base-create-update.mjs";
 import note from "../../common/sobjects/note.mjs";
 import salesforce from "../../salesforce_rest_api.app.mjs";
@@ -25,8 +24,9 @@ export default {
     + " Supplying `Body` replaces the note text outright rather than appending to it."
     + " "
     + `[See the documentation](${docsLink})`,
-  version: "0.1.0",
+  version: "0.1.1",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/salesforce_rest_api/actions/update-opportunities-batch/update-opportunities-batch.mjs
+++ b/components/salesforce_rest_api/actions/update-opportunities-batch/update-opportunities-batch.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import common from "../common/batch-operation.mjs";
 
 export default {
@@ -12,13 +11,14 @@ export default {
     + " Poll the job in Salesforce to confirm completion; a successful response means the job was accepted, not that every row loaded."
     + " "
     + "[See the documentation](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/datafiles_understanding_bulk2_ingest.htm)",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   methods: {
     ...common.methods,
     getObject() {

--- a/components/salesforce_rest_api/actions/update-opportunity/update-opportunity.mjs
+++ b/components/salesforce_rest_api/actions/update-opportunity/update-opportunity.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import common, { getProps } from "../common/base-create-update.mjs";
 import opportunity from "../../common/sobjects/opportunity.mjs";
 import salesforce from "../../salesforce_rest_api.app.mjs";
@@ -24,13 +23,14 @@ export default {
     + " Only the fields you supply change; everything else is left as-is."
     + " "
     + `[See the documentation](${docsLink})`,
-  version: "0.4.0",
+  version: "0.4.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   methods: {
     ...common.methods,
   },

--- a/components/salesforce_rest_api/actions/update-record/update-record.mjs
+++ b/components/salesforce_rest_api/actions/update-record/update-record.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import salesforce from "../../salesforce_rest_api.app.mjs";
 
 export default {
@@ -8,13 +7,14 @@ export default {
     + " Only the fields you supply change; everything else is left as-is."
     + " "
     + "[See the documentation](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_update_fields.htm)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     salesforce,
     sobjectType: {

--- a/components/salesforce_rest_api/actions/upsert-record/upsert-record.mjs
+++ b/components/salesforce_rest_api/actions/upsert-record/upsert-record.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import salesforce from "../../salesforce_rest_api.app.mjs";
 
 export default {
@@ -9,13 +8,14 @@ export default {
     + " Use **Create CRM Record** or **Update CRM Record** when you already know whether the record exists."
     + " "
     + "[See the documentation](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_upsert.htm)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     salesforce,
     objectType: {

--- a/components/salesforce_rest_api/package.json
+++ b/components/salesforce_rest_api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/salesforce_rest_api",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Pipedream Salesforce (REST API) Components",
   "main": "salesforce_rest_api.app.mjs",
   "keywords": [

--- a/components/slack_v2/actions/add-emoji-reaction/add-emoji-reaction.mjs
+++ b/components/slack_v2/actions/add-emoji-reaction/add-emoji-reaction.mjs
@@ -1,17 +1,17 @@
-// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 
 export default {
   key: "slack_v2-add-emoji-reaction",
   name: "Add Emoji Reaction",
   description: "Add an emoji reaction to a message. [See the documentation](https://api.slack.com/methods/reactions.add)",
-  version: "0.0.25",
+  version: "0.0.26",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     slack,
     conversation: {

--- a/components/slack_v2/actions/add-reaction/add-reaction.mjs
+++ b/components/slack_v2/actions/add-reaction/add-reaction.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 
 export default {
@@ -10,8 +9,9 @@ export default {
     + " Use **Get Channel History** or **Search** to find the message timestamp."
     + " Emoji name should be without colons (e.g. `thumbsup`, `fire`, `heart`)."
     + " [See the documentation](https://api.slack.com/methods/reactions.add)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/archive-channel/archive-channel.mjs
+++ b/components/slack_v2/actions/archive-channel/archive-channel.mjs
@@ -1,17 +1,17 @@
-// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 
 export default {
   key: "slack_v2-archive-channel",
   name: "Archive Channel",
   description: "Archive a public or private channel. Direct messages and group DMs can't be archived — pass a channel ID (e.g. `C1234567890`), not a user or group ID. [See the documentation](https://api.slack.com/methods/conversations.archive)",
-  version: "0.0.33",
+  version: "0.0.34",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     slack,
     conversation: {

--- a/components/slack_v2/actions/browse-files/browse-files.mjs
+++ b/components/slack_v2/actions/browse-files/browse-files.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 
 export default {
@@ -10,8 +9,9 @@ export default {
     + " Filter by file type (e.g. `images`, `pdfs`, `snippets`)."
     + " Returns file metadata including name, type, size, and download URL."
     + " [See the documentation](https://api.slack.com/methods/files.list)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/create-channel/create-channel.mjs
+++ b/components/slack_v2/actions/create-channel/create-channel.mjs
@@ -1,17 +1,17 @@
-// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 
 export default {
   key: "slack_v2-create-channel",
   name: "Create a Channel",
   description: "Create a new channel. [See the documentation](https://api.slack.com/methods/conversations.create)",
-  version: "0.0.33",
+  version: "0.0.34",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     slack,
     channelName: {

--- a/components/slack_v2/actions/create-reminder/create-reminder.mjs
+++ b/components/slack_v2/actions/create-reminder/create-reminder.mjs
@@ -1,17 +1,17 @@
-// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 
 export default {
   key: "slack_v2-create-reminder",
   name: "Create Reminder",
   description: "Create a reminder. [See the documentation](https://api.slack.com/methods/reminders.add)",
-  version: "0.0.34",
+  version: "0.0.35",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     slack,
     text: {

--- a/components/slack_v2/actions/delete-file/delete-file.mjs
+++ b/components/slack_v2/actions/delete-file/delete-file.mjs
@@ -1,17 +1,17 @@
-// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 
 export default {
   key: "slack_v2-delete-file",
   name: "Delete File",
   description: "Delete a file. [See the documentation](https://api.slack.com/methods/files.delete)",
-  version: "0.0.33",
+  version: "0.0.34",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     slack,
     conversation: {

--- a/components/slack_v2/actions/delete-message/delete-message.mjs
+++ b/components/slack_v2/actions/delete-message/delete-message.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 
 export default {
@@ -13,13 +12,14 @@ export default {
     + " lets an identity delete its own messages, so this deletes as whichever identity posted:"
     + " it retries automatically with the other identity if the first attempt returns"
     + " `cant_delete_message`. [See the documentation](https://api.slack.com/methods/chat.delete)",
-  version: "0.2.3",
+  version: "0.2.4",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     slack,
     conversation: {

--- a/components/slack_v2/actions/edit-message/edit-message.mjs
+++ b/components/slack_v2/actions/edit-message/edit-message.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 import { ConfigurationError } from "@pipedream/platform";
 
@@ -11,8 +10,9 @@ export default {
     + " Requires the message timestamp (`ts`) from **Get Channel History** or **Post Message**."
     + " You can only edit messages posted by the same token/user."
     + " [See the documentation](https://api.slack.com/methods/chat.update)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/find-message/find-message.mjs
+++ b/components/slack_v2/actions/find-message/find-message.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import utils from "../../common/utils.mjs";
 import slack from "../../slack_v2.app.mjs";
 
@@ -16,13 +15,14 @@ export default {
     + " omitted when no mention carried a name."
     + " Do NOT splice a name back inline: Slack renders `<@U123|Name>` as literal text, not a mention."
     + " [See the documentation](https://api.slack.com/methods/assistant.search.context)",
-  version: "0.2.0",
+  version: "0.2.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     slack,
     query: {

--- a/components/slack_v2/actions/find-user-by-email/find-user-by-email.mjs
+++ b/components/slack_v2/actions/find-user-by-email/find-user-by-email.mjs
@@ -1,17 +1,17 @@
-// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 
 export default {
   key: "slack_v2-find-user-by-email",
   name: "Find User by Email",
   description: "Find a user by matching against their email. [See the documentation](https://api.slack.com/methods/users.lookupByEmail)",
-  version: "0.0.32",
+  version: "0.0.33",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     slack,
     email: {

--- a/components/slack_v2/actions/find-user-by-id/find-user-by-id.mjs
+++ b/components/slack_v2/actions/find-user-by-id/find-user-by-id.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 
 export default {
   key: "slack_v2-find-user-by-id",
   name: "Find User by ID",
   description: "Find a user by their ID — including a specific user you already have the Slack ID for, whether or not it's your own. Returns user profile information including name, email (requires `users:read.email` scope), timezone, and status. If you only have an email address, use **Find User by Email** instead. [See the documentation](https://api.slack.com/methods/users.info)",
-  version: "0.0.9",
+  version: "0.0.10",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/get-channel-details/get-channel-details.mjs
+++ b/components/slack_v2/actions/get-channel-details/get-channel-details.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 
 export default {
   key: "slack_v2-get-channel-details",
   name: "Get Channel Details",
   description: "Retrieve details for a Slack channel, specified by ID or by name — names are resolved automatically. [See the documentation](https://api.slack.com/methods/conversations.info)",
-  version: "0.1.3",
+  version: "0.1.4",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/get-channel-history/get-channel-history.mjs
+++ b/components/slack_v2/actions/get-channel-history/get-channel-history.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import utils from "../../common/utils.mjs";
 import slack from "../../slack_v2.app.mjs";
 
@@ -16,8 +15,9 @@ export default {
     + " messages carry blocks, attachments and edit metadata, so a busy channel can run to tens"
     + " of thousands of characters and be truncated before you see any of it."
     + " [See the documentation](https://api.slack.com/methods/conversations.history)",
-  version: "0.2.2",
+  version: "0.2.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/get-current-user/get-current-user.mjs
+++ b/components/slack_v2/actions/get-current-user/get-current-user.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 
 export default {
   key: "slack_v2-get-current-user",
   name: "Get Current User",
   description: "Do NOT use for a plain \"who am I\" / \"what's my user ID\" question — call **Get User Details** for that; it answers the same question with a far smaller payload. Do NOT use to look up a DIFFERENT, specifically-identified user (by ID or email) — this only ever describes the authenticated caller; use **Find User by ID** / **Find User by Email** for someone else. Do NOT use to enumerate multiple teams/workspaces (e.g. Enterprise Grid) — use **List Teams** for that; this returns only the caller's own current team. Use this ONLY when you specifically need the full member profile: locale, timezone, presence/status, admin and owner flags, name variants, or workspace domain and enterprise metadata. Combines `auth.test`, `users.info`, `users.profile.get` and `team.info`. [See Slack API docs](https://api.slack.com/methods/auth.test).",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/get-file/get-file.mjs
+++ b/components/slack_v2/actions/get-file/get-file.mjs
@@ -1,17 +1,17 @@
-// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 
 export default {
   key: "slack_v2-get-file",
   name: "Get File",
   description: "Return information about a file. [See the documentation](https://api.slack.com/methods/files.info)",
-  version: "0.1.8",
+  version: "0.1.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     slack,
     conversation: {

--- a/components/slack_v2/actions/get-thread-replies/get-thread-replies.mjs
+++ b/components/slack_v2/actions/get-thread-replies/get-thread-replies.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import utils from "../../common/utils.mjs";
 import slack from "../../slack_v2.app.mjs";
 
@@ -14,8 +13,9 @@ export default {
     + " Slack messages carry blocks, attachments and edit metadata, so a long thread can run"
     + " to tens of thousands of characters and be truncated before you see any of it."
     + " [See the documentation](https://api.slack.com/methods/conversations.replies)",
-  version: "0.1.3",
+  version: "0.1.4",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/get-user-details/get-user-details.mjs
+++ b/components/slack_v2/actions/get-user-details/get-user-details.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 
 export default {
@@ -14,8 +13,9 @@ export default {
     + " Prefer this over **Get Current User**, which returns a much larger payload and is only"
     + " needed for full profile detail (locale, status, admin flags)."
     + " [See the documentation](https://api.slack.com/methods/auth.test)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/invite-user-to-channel/invite-user-to-channel.mjs
+++ b/components/slack_v2/actions/invite-user-to-channel/invite-user-to-channel.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import slack from "../../slack_v2.app.mjs";
 
@@ -6,13 +5,14 @@ export default {
   key: "slack_v2-invite-user-to-channel",
   name: "Invite User to Channel",
   description: "Invite one or more users to an existing channel. Accepts a channel ID or NAME, and a user ID, EMAIL address or display name — all resolved automatically. Pass several users as a comma-separated list. [See the documentation](https://api.slack.com/methods/conversations.invite)",
-  version: "0.1.3",
+  version: "0.1.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     slack,
     conversation: {

--- a/components/slack_v2/actions/kick-user/kick-user.mjs
+++ b/components/slack_v2/actions/kick-user/kick-user.mjs
@@ -1,17 +1,17 @@
-// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 
 export default {
   key: "slack_v2-kick-user",
   name: "Kick User",
   description: "Remove a user from a conversation. [See the documentation](https://api.slack.com/methods/conversations.kick)",
-  version: "0.0.33",
+  version: "0.0.34",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     slack,
     conversation: {

--- a/components/slack_v2/actions/list-channels/list-channels.mjs
+++ b/components/slack_v2/actions/list-channels/list-channels.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import utils from "../../common/utils.mjs";
 import slack from "../../slack_v2.app.mjs";
 
@@ -16,13 +15,14 @@ export default {
     + " fetched — when you see that, raise `numPages` (or pass `cursor`) before answering"
     + " any 'how many' or 'list every' question, otherwise your answer is silently incomplete."
     + " [See the documentation](https://api.slack.com/methods/conversations.list)",
-  version: "0.3.1",
+  version: "0.3.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     slack,
     channelTypes: {

--- a/components/slack_v2/actions/list-emojis/list-emojis.mjs
+++ b/components/slack_v2/actions/list-emojis/list-emojis.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 
 export default {
@@ -6,13 +5,14 @@ export default {
   name: "List Emojis",
   description:
     "List all available emojis in the Slack workspace. Optionally include emoji image URLs. [See the documentation](https://api.slack.com/methods/emoji.list)",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     slack,
     includeEmojiImage: {

--- a/components/slack_v2/actions/list-files/list-files.mjs
+++ b/components/slack_v2/actions/list-files/list-files.mjs
@@ -1,17 +1,17 @@
-// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 
 export default {
   key: "slack_v2-list-files",
   name: "List Files",
   description: "Return a list of files within a team. [See the documentation](https://api.slack.com/methods/files.list)",
-  version: "0.1.8",
+  version: "0.1.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     slack,
     conversation: {

--- a/components/slack_v2/actions/list-group-conversations/list-group-conversations.mjs
+++ b/components/slack_v2/actions/list-group-conversations/list-group-conversations.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 
 export default {
@@ -11,13 +10,14 @@ export default {
     + " Returns `has_more: true` and `next_cursor` when more conversations exist than were"
     + " fetched — raise `numPages` (or pass `cursor`) to see the rest."
     + " [See the documentation](https://api.slack.com/methods/conversations.list)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     slack,
     pageSize: {

--- a/components/slack_v2/actions/list-group-members/list-group-members.mjs
+++ b/components/slack_v2/actions/list-group-members/list-group-members.mjs
@@ -1,17 +1,17 @@
-// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 
 export default {
   key: "slack_v2-list-group-members",
   name: "List Group Members",
   description: "List all users in a User Group. [See the documentation](https://api.slack.com/methods/usergroups.users.list)",
-  version: "0.0.17",
+  version: "0.0.18",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     slack,
     userGroup: {

--- a/components/slack_v2/actions/list-icon-emoji-options/list-icon-emoji-options.mjs
+++ b/components/slack_v2/actions/list-icon-emoji-options/list-icon-emoji-options.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import slack_v2 from "../../slack_v2.app.mjs";
 
 export default {
   key: "slack_v2-list-icon-emoji-options",
   name: "List Icon (emoji) Options",
   description: "Retrieves available options for the Icon (emoji) field. [See the documentation](https://api.slack.com/methods/emoji.list)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/list-members-in-channel/list-members-in-channel.mjs
+++ b/components/slack_v2/actions/list-members-in-channel/list-members-in-channel.mjs
@@ -1,17 +1,17 @@
-// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 
 export default {
   key: "slack_v2-list-members-in-channel",
   name: "List Members in Channel",
   description: "Retrieve members of a channel. Accepts a channel ID or NAME (e.g. general or #general) — names are resolved automatically. [See the documentation](https://api.slack.com/methods/conversations.members)",
-  version: "0.1.3",
+  version: "0.1.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     slack,
     conversation: {

--- a/components/slack_v2/actions/list-messages/list-messages.mjs
+++ b/components/slack_v2/actions/list-messages/list-messages.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 
 export default {
@@ -10,13 +9,14 @@ export default {
     + " selection to keep responses small, and returns the same message data."
     + " This legacy tool remains only for existing workflows: it accepts a raw conversation ID and"
     + " returns full, untrimmed message objects. [See the documentation](https://api.slack.com/methods/conversations.history)",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     slack,
     conversation: {

--- a/components/slack_v2/actions/list-reminder-options/list-reminder-options.mjs
+++ b/components/slack_v2/actions/list-reminder-options/list-reminder-options.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import slack_v2 from "../../slack_v2.app.mjs";
 
 export default {
   key: "slack_v2-list-reminder-options",
   name: "List Reminder Options",
   description: "Retrieves available options for the Reminder field. [See the documentation](https://docs.slack.dev/reference/methods/reminders.list)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/list-replies/list-replies.mjs
+++ b/components/slack_v2/actions/list-replies/list-replies.mjs
@@ -1,17 +1,17 @@
-// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 
 export default {
   key: "slack_v2-list-replies",
   name: "List Replies",
   description: "Retrieve a thread of messages posted to a conversation. [See the documentation](https://api.slack.com/methods/conversations.replies)",
-  version: "0.0.33",
+  version: "0.0.34",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     slack,
     conversation: {

--- a/components/slack_v2/actions/list-teams/list-teams.mjs
+++ b/components/slack_v2/actions/list-teams/list-teams.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 
 export default {
@@ -15,13 +14,14 @@ export default {
     + " Returns `has_more: true` and `next_cursor` when more teams exist than were"
     + " fetched — raise `numPages` (or pass `cursor`) to see the rest."
     + " [See the documentation](https://api.slack.com/methods/auth.teams.list)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     slack,
     pageSize: {

--- a/components/slack_v2/actions/list-user-group-options/list-user-group-options.mjs
+++ b/components/slack_v2/actions/list-user-group-options/list-user-group-options.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import slack_v2 from "../../slack_v2.app.mjs";
 
 export default {
   key: "slack_v2-list-user-group-options",
   name: "List User Group Options",
   description: "Retrieves available options for the User Group field. [See the documentation](https://docs.slack.dev/reference/methods/usergroups.list)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/list-users/list-users.mjs
+++ b/components/slack_v2/actions/list-users/list-users.mjs
@@ -1,17 +1,17 @@
-// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 
 export default {
   key: "slack_v2-list-users",
   name: "List Users",
   description: "Return a list of all users in a workspace. [See the documentation](https://api.slack.com/methods/users.list)",
-  version: "0.0.32",
+  version: "0.0.33",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     slack,
     teamId: {

--- a/components/slack_v2/actions/post-message/post-message.mjs
+++ b/components/slack_v2/actions/post-message/post-message.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 import { ConfigurationError } from "@pipedream/platform";
 
@@ -12,8 +11,9 @@ export default {
     + " To reply to a thread, provide `threadTs` (Slack calls this `thread_ts`) from **Get Channel History**."
     + " Supports plain text with Slack mrkdwn formatting and Block Kit blocks."
     + " [See the documentation](https://api.slack.com/methods/chat.postMessage)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/reply-to-a-message/reply-to-a-message.mjs
+++ b/components/slack_v2/actions/reply-to-a-message/reply-to-a-message.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 import common from "../common/send-message.mjs";
 
@@ -14,13 +13,14 @@ export default {
     + " (e.g. `1403051575.000407`); get it from **Get Channel History** or an incoming event's"
     + " `ts` field. For a plain, non-threaded message use **Post Message** instead."
     + " [See the documentation](https://api.slack.com/methods/chat.postMessage)",
-  version: "0.2.8",
+  version: "0.2.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     slack: common.props.slack,
     conversation: {

--- a/components/slack_v2/actions/search/search.mjs
+++ b/components/slack_v2/actions/search/search.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import utils from "../../common/utils.mjs";
 import slack from "../../slack_v2.app.mjs";
 
@@ -15,8 +14,9 @@ export default {
     + " omitted when no mention carried a name."
     + " Do NOT splice a name back inline: Slack renders `<@U123|Name>` as literal text, not a mention."
     + " [See the documentation](https://api.slack.com/methods/assistant.search.context)",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/slack_v2/actions/send-block-kit-message/send-block-kit-message.mjs
+++ b/components/slack_v2/actions/send-block-kit-message/send-block-kit-message.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import buildBlocks from "../common/build-blocks.mjs";
 import common from "../common/send-message.mjs";
 
@@ -8,13 +7,14 @@ export default {
   key: "slack_v2-send-block-kit-message",
   name: "Build and Send a Block Kit Message",
   description: "Configure custom blocks and send to a channel, group, or user. [See the documentation](https://api.slack.com/tools/block-kit-builder).",
-  version: "0.5.8",
+  version: "0.5.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     slack: common.props.slack,
     conversation: {

--- a/components/slack_v2/actions/send-large-message/send-large-message.mjs
+++ b/components/slack_v2/actions/send-large-message/send-large-message.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import common from "../common/send-message.mjs";
 
 export default {
@@ -6,13 +5,14 @@ export default {
   key: "slack_v2-send-large-message",
   name: "Send a Large Message (3000+ characters)",
   description: "Send a large message (more than 3000 characters) to a channel, group or user. See [postMessage](https://api.slack.com/methods/chat.postMessage) or [scheduleMessage](https://api.slack.com/methods/chat.scheduleMessage) docs here",
-  version: "0.1.8",
+  version: "0.1.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     slack: common.props.slack,
     conversation: {

--- a/components/slack_v2/actions/send-message-advanced/send-message-advanced.mjs
+++ b/components/slack_v2/actions/send-message-advanced/send-message-advanced.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import common from "../common/send-message.mjs";
 import buildBlocks from "../common/build-blocks.mjs";
@@ -9,13 +8,14 @@ export default {
   key: "slack_v2-send-message-advanced",
   name: "Send Message (Advanced)",
   description: "Customize advanced settings and send a message to a channel, group or user. See [postMessage](https://api.slack.com/methods/chat.postMessage) or [scheduleMessage](https://api.slack.com/methods/chat.scheduleMessage) docs here",
-  version: "0.1.8",
+  version: "0.1.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     slack: common.props.slack,
     conversation: {

--- a/components/slack_v2/actions/send-message-to-channel/send-message-to-channel.mjs
+++ b/components/slack_v2/actions/send-message-to-channel/send-message-to-channel.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import common from "../common/send-message.mjs";
 
 export default {
@@ -12,13 +11,14 @@ export default {
     + " replies and unfurl settings. Use this tool only if a workflow specifically needs to"
     + " target a channel exclusively, without the user/group support **Post Message** offers."
     + " [See the documentation](https://api.slack.com/methods/chat.postMessage)",
-  version: "0.2.1",
+  version: "0.2.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     slack: common.props.slack,
     conversation: {

--- a/components/slack_v2/actions/send-message-to-user-or-group/send-message-to-user-or-group.mjs
+++ b/components/slack_v2/actions/send-message-to-user-or-group/send-message-to-user-or-group.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import common from "../common/send-message.mjs";
 import { ConfigurationError } from "@pipedream/platform";
 
@@ -7,13 +6,14 @@ export default {
   key: "slack_v2-send-message-to-user-or-group",
   name: "Send Message to User or Group",
   description: "Send a message to a user or group. [See the documentation](https://api.slack.com/methods/chat.postMessage)",
-  version: "0.2.1",
+  version: "0.2.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     slack: common.props.slack,
     users: {

--- a/components/slack_v2/actions/send-message/send-message.mjs
+++ b/components/slack_v2/actions/send-message/send-message.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import common from "../common/send-message.mjs";
 import constants from "../../common/constants.mjs";
 
@@ -7,13 +6,14 @@ export default {
   key: "slack_v2-send-message",
   name: "Send Message",
   description: "Send a message to a user, group, private channel or public channel. [See the documentation](https://api.slack.com/methods/chat.postMessage)",
-  version: "0.2.1",
+  version: "0.2.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     slack: common.props.slack,
     channelType: {

--- a/components/slack_v2/actions/set-channel-description/set-channel-description.mjs
+++ b/components/slack_v2/actions/set-channel-description/set-channel-description.mjs
@@ -1,17 +1,17 @@
-// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 
 export default {
   key: "slack_v2-set-channel-description",
   name: "Set Channel Description",
   description: "Change the description or purpose of a channel. [See the documentation](https://api.slack.com/methods/conversations.setPurpose)",
-  version: "0.0.18",
+  version: "0.0.19",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     slack,
     conversation: {

--- a/components/slack_v2/actions/set-channel-topic/set-channel-topic.mjs
+++ b/components/slack_v2/actions/set-channel-topic/set-channel-topic.mjs
@@ -1,17 +1,17 @@
-// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 
 export default {
   key: "slack_v2-set-channel-topic",
   name: "Set Channel Topic",
   description: "Set the topic on a channel, specified by ID or by name — names are resolved automatically. [See the documentation](https://api.slack.com/methods/conversations.setTopic)",
-  version: "0.1.3",
+  version: "0.1.4",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     slack,
     conversation: {

--- a/components/slack_v2/actions/set-status/set-status.mjs
+++ b/components/slack_v2/actions/set-status/set-status.mjs
@@ -1,17 +1,17 @@
-// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 
 export default {
   key: "slack_v2-set-status",
   name: "Set Status",
   description: "Set the current status for a user. [See the documentation](https://api.slack.com/methods/users.profile.set)",
-  version: "0.0.17",
+  version: "0.0.18",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     slack,
     statusText: {

--- a/components/slack_v2/actions/update-group-members/update-group-members.mjs
+++ b/components/slack_v2/actions/update-group-members/update-group-members.mjs
@@ -1,17 +1,17 @@
-// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 
 export default {
   key: "slack_v2-update-group-members",
   name: "Update Group Members",
   description: "Update the list of users for a User Group. [See the documentation](https://api.slack.com/methods/usergroups.users.update)",
-  version: "0.0.18",
+  version: "0.0.19",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     slack,
     userGroup: {

--- a/components/slack_v2/actions/update-message/update-message.mjs
+++ b/components/slack_v2/actions/update-message/update-message.mjs
@@ -1,17 +1,17 @@
-// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 
 export default {
   key: "slack_v2-update-message",
   name: "Update Message",
   description: "Update a message. [See the documentation](https://api.slack.com/methods/chat.update)",
-  version: "0.2.8",
+  version: "0.2.9",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     slack,
     conversation: {

--- a/components/slack_v2/actions/update-profile/update-profile.mjs
+++ b/components/slack_v2/actions/update-profile/update-profile.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import slack from "../../slack_v2.app.mjs";
 import { ConfigurationError } from "@pipedream/platform";
 
@@ -6,13 +5,14 @@ export default {
   key: "slack_v2-update-profile",
   name: "Update Profile",
   description: "Update basic profile field such as name or title. [See the documentation](https://api.slack.com/methods/users.profile.set)",
-  version: "0.0.33",
+  version: "0.0.34",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     slack,
     displayName: {

--- a/components/slack_v2/actions/upload-file/upload-file.mjs
+++ b/components/slack_v2/actions/upload-file/upload-file.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import {
   ConfigurationError, axios, getFileStreamAndMetadata,
 } from "@pipedream/platform";
@@ -9,13 +8,14 @@ export default {
   key: "slack_v2-upload-file",
   name: "Upload File",
   description: "Upload a file. [See the documentation](https://api.slack.com/messaging/files#uploading_files)",
-  version: "0.1.12",
+  version: "0.1.13",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     slack,
     conversation: {

--- a/components/slack_v2/actions/verify-slack-signature/verify-slack-signature.mjs
+++ b/components/slack_v2/actions/verify-slack-signature/verify-slack-signature.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import crypto from "crypto";
 import slack from "../../slack_v2.app.mjs";
 
@@ -6,13 +5,14 @@ export default {
   key: "slack_v2-verify-slack-signature",
   name: "Verify Slack Signature",
   description: "Verifying requests from Slack, slack signs its requests using a secret that's unique to your app. `Request Body` must be the raw request body as a string (not a parsed object) — Slack computes its signature over the exact raw bytes it sent, so re-serializing a parsed object will not match. [See the documentation](https://api.slack.com/authentication/verifying-requests-from-slack)",
-  version: "1.0.1",
+  version: "1.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     slack,
     slackSigningSecret: {

--- a/components/slack_v2/package.json
+++ b/components/slack_v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/slack_v2",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Pipedream Slack_v2 Components",
   "main": "slack_v2.app.mjs",
   "keywords": [


### PR DESCRIPTION
DJ-4272 backfill, **batch 1 of 5** (continues canary #21870).

Sets the top-level `ai: "optimized"` field on **200 AI-optimized actions across 4 apps**, replaces any legacy `// x-pd-ai: optimized` marker comment with the real field, and patch-bumps each touched component + app `package.json` (required by `check_version`).

Batched at ≤200 components per the deployment publish cap. The 5 batches cover **disjoint apps**, so they can merge independently in any order.

Apps: azure_devops,fireflies salesforce_rest_api,slack_v2