### PR TITLE
feat(components): backfill AI-optimized `ai` field (batch 2/5)

### DIFF
--- a/components/clockify/actions/add-members-to-project/add-members-to-project.mjs
+++ b/components/clockify/actions/add-members-to-project/add-members-to-project.mjs
@@ -1,17 +1,17 @@
-// x-pd-ai: optimized
 import clockify from "../../clockify.app.mjs";
 
 export default {
   key: "clockify-add-members-to-project",
   name: "Add Members To Project",
   description: "Adds member(s) to a project in Clockify. [See the documentation](https://docs.clockify.me/#tag/Project/operation/updateMemberships)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     clockify,
     workspaceId: {

--- a/components/clockify/actions/add-task-to-project/add-task-to-project.mjs
+++ b/components/clockify/actions/add-task-to-project/add-task-to-project.mjs
@@ -1,17 +1,17 @@
-// x-pd-ai: optimized
 import clockify from "../../clockify.app.mjs";
 
 export default {
   key: "clockify-add-task-to-project",
   name: "Add Task To Project",
   description: "Adds a task to an existing project in a Clockify workspace. Tasks are the units of work that time entries are logged against, so create the task before calling **Log Time Entry** or **Start Timer** with a task. Optionally assign workspace members to it. Use **List Projects** to find the project ID. [See the documentation](https://docs.clockify.me/#tag/Task/operation/createTask)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     clockify,
     workspaceId: {

--- a/components/clockify/actions/create-client/create-client.mjs
+++ b/components/clockify/actions/create-client/create-client.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import clockify from "../../clockify.app.mjs";
 
 export default {
   key: "clockify-create-client",
   name: "Create Client",
   description: "Creates a new client in a Clockify workspace. Requires a client name; address and note are optional. [See the documentation](https://docs.clockify.me/#tag/Client/operation/createClient)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/clockify/actions/create-invoice/create-invoice.mjs
+++ b/components/clockify/actions/create-invoice/create-invoice.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import clockify from "../../clockify.app.mjs";
 import constants from "../../common/constants.mjs";
@@ -8,8 +7,9 @@ export default {
   key: "clockify-create-invoice",
   name: "Create Invoice",
   description: "Creates a new invoice for a client in a Clockify workspace. Set **Import From** and **Import To** to bill tracked time: the invoice is created and the time entries logged in that period are imported as line items. Leave both blank to create an empty invoice. The invoice is created first and the tracked time is imported in a second request, so if the import fails the invoice still exists and can be removed with **Delete Invoice** or retried. Chain **Update Invoice** afterwards to set the subject, note or status. [See the documentation](https://docs.clockify.me/#tag/Invoice/operation/createInvoice)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/clockify/actions/create-project/create-project.mjs
+++ b/components/clockify/actions/create-project/create-project.mjs
@@ -1,17 +1,17 @@
-// x-pd-ai: optimized
 import clockify from "../../clockify.app.mjs";
 
 export default {
   key: "clockify-create-project",
   name: "Create Project",
   description: "Creates a new project in a Clockify workspace. Only the name is required; link the project to a client so its time can be invoiced, and set an hourly rate to make tracked time billable at that rate. Use **Add Task To Project** afterwards to add the tasks that time entries are logged against. [See the documentation](https://docs.clockify.me/#tag/Project/operation/createNewProject)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     clockify,
     workspaceId: {

--- a/components/clockify/actions/create-tag/create-tag.mjs
+++ b/components/clockify/actions/create-tag/create-tag.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import clockify from "../../clockify.app.mjs";
 
 export default {
   key: "clockify-create-tag",
   name: "Create Tag",
   description: "Creates a new tag in a Clockify workspace. Requires the tag name. [See the documentation](https://docs.clockify.me/#tag/Tag/operation/createNewTag)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/clockify/actions/delete-client/delete-client.mjs
+++ b/components/clockify/actions/delete-client/delete-client.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import clockify from "../../clockify.app.mjs";
 import utils from "../../common/utils.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "clockify-delete-client",
   name: "Delete Client",
   description: "Deletes a client from a Clockify workspace. This cannot be undone. Clockify only allows deleting archived clients, so this action archives the client first if it isn't already. Use **List Clients** to find the ID of the client to delete. [See the documentation](https://docs.clockify.me/#tag/Client/operation/deleteClient) and the [update endpoint](https://docs.clockify.me/#tag/Client/operation/updateClient) used for the archive step",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/clockify/actions/delete-invoice/delete-invoice.mjs
+++ b/components/clockify/actions/delete-invoice/delete-invoice.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import clockify from "../../clockify.app.mjs";
 
 export default {
   key: "clockify-delete-invoice",
   name: "Delete Invoice",
   description: "Deletes an invoice from a Clockify workspace. This cannot be undone. Use **List Invoices** to find the ID of the invoice to delete. [See the documentation](https://docs.clockify.me/#tag/Invoice/operation/deleteInvoice)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/clockify/actions/delete-tag/delete-tag.mjs
+++ b/components/clockify/actions/delete-tag/delete-tag.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import clockify from "../../clockify.app.mjs";
 
 export default {
   key: "clockify-delete-tag",
   name: "Delete Tag",
   description: "Deletes a tag from a Clockify workspace. This cannot be undone. Use **List Tags** to find the ID of the tag to delete. [See the documentation](https://docs.clockify.me/#tag/Tag/operation/deleteTag)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/clockify/actions/get-time-entry-report/get-time-entry-report.mjs
+++ b/components/clockify/actions/get-time-entry-report/get-time-entry-report.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import clockify from "../../clockify.app.mjs";
 
 export default {
   name: "Get Time Entry Report",
   description: "Get a time entry report. [See the documentation](https://docs.clockify.me/#tag/Time-Entry-Report/operation/generateDetailedReport)",
   key: "clockify-get-time-entry-report",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/clockify/actions/list-clients/list-clients.mjs
+++ b/components/clockify/actions/list-clients/list-clients.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import clockify from "../../clockify.app.mjs";
 
 export default {
   key: "clockify-list-clients",
   name: "List Clients",
   description: "List all clients in a Clockify workspace. Optionally filter by a substring of the client name or by archived status, and page through results with the page and page size inputs. [See the documentation](https://docs.clockify.me/#tag/Client/operation/getClients)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/clockify/actions/list-invoices/list-invoices.mjs
+++ b/components/clockify/actions/list-invoices/list-invoices.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import clockify from "../../clockify.app.mjs";
 
 export default {
   key: "clockify-list-invoices",
   name: "List Invoices",
   description: "Returns a single page of invoices in a Clockify workspace. Use the `page` and `pageSize` inputs to page through results. [See the documentation](https://docs.clockify.me/#tag/Invoice/operation/getInvoices)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/clockify/actions/list-projects/list-projects.mjs
+++ b/components/clockify/actions/list-projects/list-projects.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import clockify from "../../clockify.app.mjs";
 import constants from "../../common/constants.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "clockify-list-projects",
   name: "List Projects",
   description: "List all projects in a Clockify workspace. [See the documentation](https://docs.clockify.me/#tag/Project/operation/getProjects)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/clockify/actions/list-tags/list-tags.mjs
+++ b/components/clockify/actions/list-tags/list-tags.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import clockify from "../../clockify.app.mjs";
 
 export default {
   key: "clockify-list-tags",
   name: "List Tags",
   description: "List all tags in a Clockify workspace. Optionally filter by a substring of the tag name, and page through results with the page and page size inputs. [See the documentation](https://docs.clockify.me/#tag/Tag/operation/getTags)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/clockify/actions/list-tasks/list-tasks.mjs
+++ b/components/clockify/actions/list-tasks/list-tasks.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import clockify from "../../clockify.app.mjs";
 import constants from "../../common/constants.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "clockify-list-tasks",
   name: "List Tasks",
   description: "Returns a single page of tasks in a Clockify project, optionally filtered by a substring of the task name or by active status. Tasks belong to a project, so set both Workspace and Project — use **List Projects** to find the project ID. Use the `Page` and `Page Size` inputs to page through results. [See the documentation](https://docs.clockify.me/#tag/Task/operation/getTasks)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/clockify/actions/list-time-entries/list-time-entries.mjs
+++ b/components/clockify/actions/list-time-entries/list-time-entries.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import clockify from "../../clockify.app.mjs";
 
 export default {
   key: "clockify-list-time-entries",
   name: "List Time Entries",
   description: "List all time entries in a Clockify workspace. [See the documentation](https://docs.clockify.me/#tag/Time-entry/operation/getTimeEntries)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/clockify/actions/list-workspace-id-options/list-workspace-id-options.mjs
+++ b/components/clockify/actions/list-workspace-id-options/list-workspace-id-options.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import clockify from "../../clockify.app.mjs";
 
 export default {
   key: "clockify-list-workspace-id-options",
   name: "List Workspace Options",
   description: "Lists the workspaces the authenticated user belongs to, as `{ label, value }` pairs where `value` is the workspace ID that every other Clockify action requires. Call this first when you don't already know which workspace to operate on. [See the documentation](https://docs.clockify.me/#tag/Workspace/operation/getWorkspacesOfUser)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/clockify/actions/log-time-entry/log-time-entry.mjs
+++ b/components/clockify/actions/log-time-entry/log-time-entry.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import clockify from "../../clockify.app.mjs";
 
 export default {
   key: "clockify-log-time-entry",
   name: "Log Time Entry",
   description: "Logs a completed time entry with an explicit start and end time in Clockify — use this to backfill time already tracked elsewhere. Use **Start Timer** instead if you want to start a running timer with no end time yet. [See the documentation](https://docs.clockify.me/#tag/Time-entry/operation/createTimeEntry), or [logging for another member](https://docs.clockify.me/#tag/Time-entry/operation/createForOthers) when `User` is set",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/clockify/actions/start-timer/start-timer.mjs
+++ b/components/clockify/actions/start-timer/start-timer.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import clockify from "../../clockify.app.mjs";
 
 export default {
   key: "clockify-start-timer",
   name: "Start Timer",
   description: "Starts a running timer for a new time entry in Clockify — no end time is set. Use **Stop Timer** to stop it, or **Update Time Entry** to set an end time later. Use **Log Time Entry** instead if you already know both the start and end time. [See the documentation](https://docs.clockify.me/#tag/Time-entry/operation/createTimeEntry), or [starting for another member](https://docs.clockify.me/#tag/Time-entry/operation/createForOthers) when `User` is set",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/clockify/actions/stop-timer/stop-timer.mjs
+++ b/components/clockify/actions/stop-timer/stop-timer.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import clockify from "../../clockify.app.mjs";
 
 export default {
   key: "clockify-stop-timer",
   name: "Stop Timer",
   description: "Stops the currently running timer for a workspace member in Clockify, setting its end time. [See the documentation](https://docs.clockify.me/#tag/Time-entry/operation/stopRunningTimeEntry)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/clockify/actions/update-client/update-client.mjs
+++ b/components/clockify/actions/update-client/update-client.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import clockify from "../../clockify.app.mjs";
 import utils from "../../common/utils.mjs";
@@ -7,8 +6,9 @@ export default {
   key: "clockify-update-client",
   name: "Update Client",
   description: "Updates an existing client in a Clockify workspace. Set only the fields you want to change — Clockify's update endpoint replaces the whole client, so this action fetches the current record first and merges your changes into it. Use **List Clients** to find the ID of the client to update. [See the documentation](https://docs.clockify.me/#tag/Client/operation/updateClient)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/clockify/actions/update-invoice/update-invoice.mjs
+++ b/components/clockify/actions/update-invoice/update-invoice.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import clockify from "../../clockify.app.mjs";
 import constants from "../../common/constants.mjs";
@@ -8,8 +7,9 @@ export default {
   key: "clockify-update-invoice",
   name: "Update Invoice",
   description: "Updates an existing invoice in a Clockify workspace. Clockify's update endpoint replaces the entire invoice, so this action first fetches the current invoice and merges your changes into it — fields you don't set are left unchanged, including the invoice's tax and discount percentages, which this action preserves but cannot edit. `Status` is applied through a separate endpoint, so it is sent as a second request after the field changes are saved, and setting it alone skips the replace entirely. Clockify offers no transaction across the two endpoints: if the status request fails, the field changes have already been applied. Line items and imported time cannot be set through Clockify's public API. Use **List Invoices** to find the ID of the invoice to update. [See the documentation](https://docs.clockify.me/#tag/Invoice/operation/updateInvoice) and the [status endpoint](https://docs.clockify.me/#tag/Invoice/operation/changeInvoiceStatus)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/clockify/actions/update-tag/update-tag.mjs
+++ b/components/clockify/actions/update-tag/update-tag.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import clockify from "../../clockify.app.mjs";
 
 export default {
   key: "clockify-update-tag",
   name: "Update Tag",
   description: "Updates the name of an existing tag in a Clockify workspace. Use **List Tags** to find the ID of the tag to update. [See the documentation](https://docs.clockify.me/#tag/Tag/operation/updateTag)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/clockify/actions/update-time-entry/update-time-entry.mjs
+++ b/components/clockify/actions/update-time-entry/update-time-entry.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import clockify from "../../clockify.app.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "clockify-update-time-entry",
   name: "Update Time Entry",
   description: "Updates an existing time entry in Clockify — change its start/end time, project, task, description, billable status, or tags. Clockify's update endpoint replaces the entire entry, so this action first fetches the current entry and merges your changes into it before saving — fields you don't set are left unchanged. Use **List Time Entries** to find the ID of the entry to update. [See the documentation](https://docs.clockify.me/#tag/Time-entry/operation/updateTimeEntry)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/clockify/package.json
+++ b/components/clockify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/clockify",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Pipedream Clockify Components",
   "main": "clockify.app.mjs",
   "keywords": [

--- a/components/github/actions/create-branch/create-branch.mjs
+++ b/components/github/actions/create-branch/create-branch.mjs
@@ -4,13 +4,14 @@ export default {
   key: "github-create-branch",
   name: "Create Branch",
   description: "Create a new branch in a repository, pointing at the tip of a source branch. Provide the repository as an `owner/repo` string, the new `branchName`, and optionally the `sourceBranch` to branch from (defaults to the repository's default branch). Use **Create or Update File Contents** to add commits to the new branch, then **Create Pull Request** to open a PR. [See the documentation](https://docs.github.com/en/rest/git/refs#create-a-reference)",
-  version: "1.0.1",
+  version: "1.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     github,
     repoFullname: {

--- a/components/github/actions/create-issue-comment/create-issue-comment.mjs
+++ b/components/github/actions/create-issue-comment/create-issue-comment.mjs
@@ -4,13 +4,14 @@ export default {
   key: "github-create-issue-comment",
   name: "Create Issue Comment",
   description: "Add a comment to an existing issue **or pull request** (GitHub treats PRs as issues for comments, so the same `number` works for both). Provide the repository as an `owner/repo` string, the issue/PR number, and the comment body. If you only know the issue/PR by title, call **Search Issues and Pull Requests** first to resolve its number. [See the documentation](https://docs.github.com/en/rest/issues/comments#create-an-issue-comment)",
-  version: "0.1.2",
+  version: "0.1.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     github,
     repoFullname: {

--- a/components/github/actions/create-issue/create-issue.mjs
+++ b/components/github/actions/create-issue/create-issue.mjs
@@ -4,13 +4,14 @@ export default {
   key: "github-create-issue",
   name: "Create Issue",
   description: "Create a new issue in a repository, optionally with labels, assignees, and a milestone. Provide the repository as an `owner/repo` string. Labels and assignees are passed by name/login (e.g. `bug`, `octocat`) — setting them requires push access to the repo. To comment on an existing issue instead, use **Create Issue Comment**; to change an existing issue, use **Update Issue**. [See the documentation](https://docs.github.com/en/rest/issues/issues#create-an-issue)",
-  version: "0.4.2",
+  version: "0.4.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     github,
     repoFullname: {

--- a/components/github/actions/create-or-update-file-contents/create-or-update-file-contents.mjs
+++ b/components/github/actions/create-or-update-file-contents/create-or-update-file-contents.mjs
@@ -4,13 +4,14 @@ export default {
   key: "github-create-or-update-file-contents",
   name: "Create or Update File Contents",
   description: "Create a new file or overwrite an existing one in a repository with a single commit. Provide the repository as an `owner/repo` string, the file `path`, the raw text `content` (passed as-is — do not base64-encode it yourself), and a commit message. If the file already exists on the target branch it is overwritten; the required blob SHA is resolved for you automatically. Defaults to the repository's default branch unless `branch` is set. [See the documentation](https://docs.github.com/en/rest/repos/contents#create-or-update-file-contents)",
-  version: "1.0.2",
+  version: "1.0.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     github,
     repoFullname: {

--- a/components/github/actions/create-pull-request-review/create-pull-request-review.mjs
+++ b/components/github/actions/create-pull-request-review/create-pull-request-review.mjs
@@ -5,13 +5,14 @@ export default {
   key: "github-create-pull-request-review",
   name: "Create Pull Request Review",
   description: "Submit a review on a pull request: approve it, request changes, or leave a general comment. Set `event` to `APPROVE`, `REQUEST_CHANGES`, or `COMMENT` — a `body` is required for `REQUEST_CHANGES` and `COMMENT`. Optionally attach inline `comments` tied to specific lines of the diff. GitHub forbids approving your own pull request, so use `COMMENT` to leave feedback on PRs you authored. Provide the repository as an `owner/repo` string and the PR number. Use **Get Pull Request Files** to find the file paths and lines to comment on, and **Search Issues and Pull Requests** with `is:pr` to resolve the PR number from a title. [See the documentation](https://docs.github.com/en/rest/pulls/reviews#create-a-review-for-a-pull-request)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     github,
     repoFullname: {

--- a/components/github/actions/create-pull-request/create-pull-request.mjs
+++ b/components/github/actions/create-pull-request/create-pull-request.mjs
@@ -4,13 +4,14 @@ export default {
   key: "github-create-pull-request",
   name: "Create Pull Request",
   description: "Open a pull request proposing to merge one branch into another within a repository. Provide the repository as an `owner/repo` string, the `head` branch (the source containing your changes) and the `base` branch (the target, e.g. `main`), plus a title. The head and base branches must already exist and differ. For a cross-fork PR, set `head` to `username:branch`. Use **Create or Update File Contents** to push changes to a branch before opening the PR. [See the documentation](https://docs.github.com/en/rest/pulls/pulls#create-a-pull-request)",
-  version: "1.0.2",
+  version: "1.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     github,
     repoFullname: {

--- a/components/github/actions/get-commit/get-commit.mjs
+++ b/components/github/actions/get-commit/get-commit.mjs
@@ -4,13 +4,14 @@ export default {
   key: "github-get-commit",
   name: "Get Commit",
   description: "Get the details of a single commit, including the list of files it changed (with per-file additions/deletions and patches) and aggregate stats. Provide the repository as an `owner/repo` string and a `ref` — a commit SHA, branch name, or tag. Use **List Commits** to find a commit SHA, or pass a branch name like `main` to get its latest commit. [See the documentation](https://docs.github.com/en/rest/commits/commits#get-a-commit)",
-  version: "1.0.1",
+  version: "1.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     github,
     repoFullname: {

--- a/components/github/actions/get-current-user/get-current-user.mjs
+++ b/components/github/actions/get-current-user/get-current-user.mjs
@@ -7,8 +7,9 @@ export default {
   key: "github-get-current-user",
   name: "Get Current User",
   description: "Gather a full snapshot of the authenticated GitHub actor, combining `/user`, `/user/orgs`, and `/user/teams`. Returns profile metadata (login, name, email, company, plan, creation timestamps) and trimmed lists of organizations and teams for quick role awareness. Helpful when you need to validate which user is calling the API, adapt behavior based on their org/team memberships, or provide LLMs with grounding before repository operations. [See the documentation](https://docs.github.com/en/rest/users/users?apiVersion=2022-11-28#get-the-authenticated-user).",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/github/actions/get-issue/get-issue.mjs
+++ b/components/github/actions/get-issue/get-issue.mjs
@@ -4,13 +4,14 @@ export default {
   key: "github-get-issue",
   name: "Get Issue",
   description: "Get the full details of a single issue: title, body, state, labels, assignees, milestone, comment count, and timestamps. Provide the repository as an `owner/repo` string and the issue number. If you only know the issue by title or topic, call **Search Issues and Pull Requests** first to resolve its number. [See the documentation](https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#get-an-issue)",
-  version: "0.1.2",
+  version: "0.1.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     github,
     repoFullname: {

--- a/components/github/actions/get-pull-request-files/get-pull-request-files.mjs
+++ b/components/github/actions/get-pull-request-files/get-pull-request-files.mjs
@@ -4,13 +4,14 @@ export default {
   key: "github-get-pull-request-files",
   name: "Get Pull Request Files",
   description: "List the files changed in a pull request (the PR diff at the file level). Returns each file's `filename`, `status` (added/modified/removed/renamed), additions/deletions/changes counts, and the unified `patch` when available — use this to review what a PR changes before approving or merging it. Provide the repository as an `owner/repo` string and the PR number. If you only know the PR by title, call **Get Pull Request** or **Search Issues and Pull Requests** with `is:pr` first to resolve its number. [See the documentation](https://docs.github.com/en/rest/pulls/pulls#list-pull-requests-files)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     github,
     repoFullname: {

--- a/components/github/actions/get-pull-request/get-pull-request.mjs
+++ b/components/github/actions/get-pull-request/get-pull-request.mjs
@@ -4,13 +4,14 @@ export default {
   key: "github-get-pull-request",
   name: "Get Pull Request",
   description: "Get the full details of a single pull request along with its reviews and a CI/merge readiness summary. Returns PR metadata (title, body, state, head/base branches, draft flag, timestamps), the `mergeable`/`mergeable_state` flags, a `checksSummary` rollup of CI status for the head commit (combined commit status + check runs, summarized to an overall state and pass/fail counts), the list of reviews, and a deduplicated list of reviewers with their review states (e.g. `APPROVED`, `CHANGES_REQUESTED`). Use this to answer \"can I merge this?\" and \"is CI green?\" before calling **Merge Pull Request**. Provide the repository as an `owner/repo` string and the PR number. If you only know the PR by title, call **Search Issues and Pull Requests** with `is:pr` first to resolve its number. [See the documentation](https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request)",
-  version: "0.1.1",
+  version: "0.1.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     github,
     repoFullname: {

--- a/components/github/actions/get-repository-content/get-repository-content.mjs
+++ b/components/github/actions/get-repository-content/get-repository-content.mjs
@@ -4,13 +4,14 @@ export default {
   key: "github-get-repository-content",
   name: "Get Repository Content",
   description: "Read a file's contents or list a directory in a repository. For a file, the base64 payload is decoded for you and returned as plain text in the `content` field. For a directory, returns the list of entries (name, path, type). Provide the repository as an `owner/repo` string and the `path` to the file or directory (omit `path` for the repo root). Use **Get Repository** first if you need to know the default branch. [See the documentation](https://docs.github.com/en/rest/repos/contents#get-repository-content)",
-  version: "1.0.2",
+  version: "1.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     github,
     repoFullname: {

--- a/components/github/actions/get-repository/get-repository.mjs
+++ b/components/github/actions/get-repository/get-repository.mjs
@@ -4,13 +4,14 @@ export default {
   key: "github-get-repository",
   name: "Get Repository Info",
   description: "Get metadata for a single repository: description, default branch, visibility, topics, star/fork/open-issue counts, your permission level, and timestamps. Use this to discover a repo's default branch before reading files with **Get Repository Content** or listing history with **List Commits**. Provide the repository as an `owner/repo` string (e.g. `PipedreamHQ/pipedream`). [See the documentation](https://docs.github.com/en/rest/repos/repos#get-a-repository)",
-  version: "0.1.2",
+  version: "0.1.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     github,
     repoFullname: {

--- a/components/github/actions/get-workflow-run/get-workflow-run.mjs
+++ b/components/github/actions/get-workflow-run/get-workflow-run.mjs
@@ -4,13 +4,14 @@ export default {
   key: "github-get-workflow-run",
   name: "Get Workflow Run",
   description: "Get the details of a single GitHub Actions workflow run, including its per-job conclusions and a link to the run's logs. Returns the run's `status`/`conclusion` and timestamps plus a `jobs` array (each job's name, status, conclusion, and `logsUrl`) so you can see exactly which job failed. Provide the repository as an `owner/repo` string and the run ID. Use **List Workflow Runs** to find a run ID, then **Run Workflow** to re-run the failed jobs. [See the documentation](https://docs.github.com/en/rest/actions/workflow-runs#get-a-workflow-run)",
-  version: "1.0.1",
+  version: "1.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     github,
     repoFullname: {

--- a/components/github/actions/list-branches/list-branches.mjs
+++ b/components/github/actions/list-branches/list-branches.mjs
@@ -4,13 +4,14 @@ export default {
   key: "github-list-branches",
   name: "List Branches",
   description: "List the branches in a repository. Provide the repository as an `owner/repo` string. Optionally filter to only protected (or only unprotected) branches. If you need to discover repository names first, use **List Repositories**. [See the documentation](https://docs.github.com/en/rest/branches/branches#list-branches)",
-  version: "1.0.1",
+  version: "1.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     github,
     repoFullname: {

--- a/components/github/actions/list-commits/list-commits.mjs
+++ b/components/github/actions/list-commits/list-commits.mjs
@@ -4,13 +4,14 @@ export default {
   key: "github-list-commits",
   name: "List Commits",
   description: "List commits in a repository, most recent first. Optionally scope to a branch or starting SHA, a file path, an author, or a date range. Provide the repository as an `owner/repo` string. Use **Get Repository** to find the default branch name if needed. [See the documentation](https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#list-commits)",
-  version: "0.1.2",
+  version: "0.1.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     github,
     repoFullname: {

--- a/components/github/actions/list-repositories/list-repositories.mjs
+++ b/components/github/actions/list-repositories/list-repositories.mjs
@@ -5,13 +5,14 @@ export default {
   key: "github-list-repositories",
   name: "List Repositories",
   description: "List repositories the authenticated user can access, or — when `org` is provided — the repositories of a specific organization. Use this to discover a repo's `owner/repo` name before calling **Get Repository**, **Get Repository Content**, or **List Commits**. To find repos by name, set the `name` substring filter. [See the documentation](https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-repositories-for-the-authenticated-user)",
-  version: "1.0.2",
+  version: "1.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     github,
     org: {

--- a/components/github/actions/list-workflow-runs/list-workflow-runs.mjs
+++ b/components/github/actions/list-workflow-runs/list-workflow-runs.mjs
@@ -4,13 +4,14 @@ export default {
   key: "github-list-workflow-runs",
   name: "List Workflow Runs",
   description: "List GitHub Actions workflow runs for a repository, most recent first. Optionally filter by `branch` or `status` (e.g. `completed`, `in_progress`, `failure`, `success`). Returns each run's `id`, workflow name, `status`, `conclusion`, branch, and timestamps. Use this to triage CI — find a failing run, then pass its `id` to **Get Workflow Run** for job details or to **Run Workflow** to re-run its failed jobs. Provide the repository as an `owner/repo` string. [See the documentation](https://docs.github.com/en/rest/actions/workflow-runs#list-workflow-runs-for-a-repository)",
-  version: "1.0.1",
+  version: "1.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     github,
     repoFullname: {

--- a/components/github/actions/list-workflows/list-workflows.mjs
+++ b/components/github/actions/list-workflows/list-workflows.mjs
@@ -4,13 +4,14 @@ export default {
   key: "github-list-workflows",
   name: "List Workflows",
   description: "List the GitHub Actions workflows defined in a repository. Returns each workflow's `id`, `name`, `path` (e.g. `.github/workflows/ci.yml`), and `state`. Use this to discover the workflow file name or ID needed by **Run Workflow**. Provide the repository as an `owner/repo` string. [See the documentation](https://docs.github.com/en/rest/actions/workflows#list-repository-workflows)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     github,
     repoFullname: {

--- a/components/github/actions/merge-pull-request/merge-pull-request.mjs
+++ b/components/github/actions/merge-pull-request/merge-pull-request.mjs
@@ -4,13 +4,14 @@ export default {
   key: "github-merge-pull-request",
   name: "Merge Pull Request",
   description: "Merge an open pull request into its base branch. Choose the `mergeMethod`: `merge` (a merge commit, the default), `squash` (combine all commits into one), or `rebase`. The merge fails if the PR is not mergeable (conflicts, failing required checks, or required reviews missing) — check mergeable state and CI with **Get Pull Request** first. Provide the repository as an `owner/repo` string and the PR number. To create the PR first, use **Create Pull Request**. [See the documentation](https://docs.github.com/en/rest/pulls/pulls#merge-a-pull-request)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     github,
     repoFullname: {

--- a/components/github/actions/run-workflow/run-workflow.mjs
+++ b/components/github/actions/run-workflow/run-workflow.mjs
@@ -5,13 +5,14 @@ export default {
   key: "github-run-workflow",
   name: "Run Workflow",
   description: "Trigger a GitHub Actions workflow run, or re-run the failed jobs of a previous run. To start a new run, provide `workflow` (the workflow file name, e.g. `ci.yml`, its display name, or its numeric ID) and optionally `ref` (the branch or tag to run on — defaults to the repository's default branch) and `inputs` (for `workflow_dispatch` workflows). To re-run only the failed jobs of an existing run instead, provide `rerunFailedRunId`. The workflow must already have a `workflow_dispatch` trigger to be dispatchable. Use **List Workflows** to find the workflow file name and **List Workflow Runs** to find a run ID. Provide the repository as an `owner/repo` string. [See the documentation](https://docs.github.com/en/rest/actions/workflows#create-a-workflow-dispatch-event)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     github,
     repoFullname: {

--- a/components/github/actions/search-issues-and-pull-requests/search-issues-and-pull-requests.mjs
+++ b/components/github/actions/search-issues-and-pull-requests/search-issues-and-pull-requests.mjs
@@ -7,13 +7,14 @@ export default {
     + "Build the `query` from space-separated qualifiers: `repo:owner/name` to scope to one repo (a bare `repo:name` with no owner is auto-resolved to your own account), `is:issue`/`is:pr`, `is:open`/`is:closed`, `label:bug`, `author:octocat`, `assignee:octocat`, `in:title`/`in:body`, and free-text keywords. "
     + "Example: `repo:PipedreamHQ/pipedream is:issue is:open label:bug raptor`. "
     + "Returns matching items (each with `number`, `title`, `state`, `labels`, `html_url`); feed a result's `number` into **Get Issue**, **Get Pull Request**, or **Create Issue Comment**. [See the query syntax](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests)",
-  version: "0.3.2",
+  version: "0.3.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     github,
     query: {

--- a/components/github/actions/update-issue/update-issue.mjs
+++ b/components/github/actions/update-issue/update-issue.mjs
@@ -4,13 +4,14 @@ export default {
   key: "github-update-issue",
   name: "Update Issue",
   description: "Update an existing issue: change its title, body, state (open/closed), labels, assignees, or milestone. Provide the repository as an `owner/repo` string and the issue number. Setting `labels` **replaces** the full label set (it does not append), so include any existing labels you want to keep. Closing an issue is done here by setting `state` to `closed`. Use **Get Issue** first if you need the current values. [See the documentation](https://docs.github.com/en/rest/issues/issues#update-an-issue)",
-  version: "0.3.2",
+  version: "0.3.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     github,
     repoFullname: {

--- a/components/github/actions/update-pull-request/update-pull-request.mjs
+++ b/components/github/actions/update-pull-request/update-pull-request.mjs
@@ -4,8 +4,9 @@ export default {
   key: "github-update-pull-request",
   name: "Update Pull Request",
   description: "Update an existing pull request's title, body, state (`open`/`closed`), or base branch. Only the fields you provide are changed. Provide the repository as an `owner/repo` string and the PR number. If you only know the PR by title, call **Get Pull Request** or **Search Issues and Pull Requests** with `is:pr` first to resolve its number. To merge a PR, use **Merge Pull Request**; to comment on it, use **Create Issue Comment**. [See the documentation](https://docs.github.com/en/rest/pulls/pulls#update-a-pull-request)",
-  version: "1.0.1",
+  version: "1.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/github/package.json
+++ b/components/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/github",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Pipedream GitHub Components",
   "main": "github.app.mjs",
   "keywords": [

--- a/components/google_drive/actions/add-comment/add-comment.mjs
+++ b/components/google_drive/actions/add-comment/add-comment.mjs
@@ -4,13 +4,14 @@ export default {
   key: "google_drive-add-comment",
   name: "Add Comment",
   description: "Add an unanchored comment to a Google Doc (general feedback, no text highlighting). [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/comments/create)",
-  version: "0.1.9",
+  version: "0.1.10",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     googleDrive,
     drive: {

--- a/components/google_drive/actions/copy-file/copy-file.mjs
+++ b/components/google_drive/actions/copy-file/copy-file.mjs
@@ -4,13 +4,14 @@ export default {
   key: "google_drive-copy-file",
   name: "Copy File",
   description: "Create a copy of the specified file. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/copy) for more information",
-  version: "0.1.24",
+  version: "0.1.25",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     googleDrive,
     drive: {

--- a/components/google_drive/actions/create-file-from-template/create-file-from-template.mjs
+++ b/components/google_drive/actions/create-file-from-template/create-file-from-template.mjs
@@ -9,13 +9,14 @@ export default {
   key: "google_drive-create-file-from-template",
   name: "Create New File From Template",
   description: "Create a new Google Docs file from a template. Optionally include placeholders in the template document that will get replaced from this action. [See documentation](https://www.npmjs.com/package/google-docs-mustaches)",
-  version: "0.1.27",
+  version: "0.1.28",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     googleDrive,
     drive: {

--- a/components/google_drive/actions/create-file-from-text/create-file-from-text.mjs
+++ b/components/google_drive/actions/create-file-from-text/create-file-from-text.mjs
@@ -5,13 +5,14 @@ export default {
   key: "google_drive-create-file-from-text",
   name: "Create New File From Text",
   description: "Create a new file from plain text. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/create) for more information",
-  version: "0.2.17",
+  version: "0.2.18",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     googleDrive,
     drive: {

--- a/components/google_drive/actions/create-folder/create-folder.mjs
+++ b/components/google_drive/actions/create-folder/create-folder.mjs
@@ -13,13 +13,14 @@ export default {
   key: "google_drive-create-folder",
   name: "Create Folder",
   description: "Create a new empty folder. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/create) for more information",
-  version: "0.1.25",
+  version: "0.1.26",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     googleDrive,
     drive: {

--- a/components/google_drive/actions/create-shared-drive/create-shared-drive.mjs
+++ b/components/google_drive/actions/create-shared-drive/create-shared-drive.mjs
@@ -4,13 +4,14 @@ export default {
   key: "google_drive-create-shared-drive",
   name: "Create Shared Drive",
   description: "Create a new shared drive. [See the documentation](https://developers.google.com/drive/api/v3/reference/drives/create) for more information",
-  version: "0.1.25",
+  version: "0.1.26",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     googleDrive,
     name: {

--- a/components/google_drive/actions/create-text-file/create-text-file.mjs
+++ b/components/google_drive/actions/create-text-file/create-text-file.mjs
@@ -12,8 +12,9 @@ export default {
     + " `mimeType = 'application/vnd.google-apps.folder'` to find the folder ID first."
     + " Supported content formats: plain text, Markdown, HTML, Rich Text, CSV."
     + " [See the documentation](https://developers.google.com/drive/api/v3/reference/files/create)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/delete-comment/delete-comment.mjs
+++ b/components/google_drive/actions/delete-comment/delete-comment.mjs
@@ -4,13 +4,14 @@ export default {
   key: "google_drive-delete-comment",
   name: "Delete Comment",
   description: "Delete a specific comment (Requires ownership or permissions). [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/comments/delete)",
-  version: "0.0.13",
+  version: "0.0.14",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     googleDrive,
     drive: {

--- a/components/google_drive/actions/delete-file/delete-file.mjs
+++ b/components/google_drive/actions/delete-file/delete-file.mjs
@@ -5,13 +5,14 @@ export default {
   name: "Delete File",
   description:
     "Permanently delete a file or folder without moving it to the trash. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/delete) for more information",
-  version: "0.1.25",
+  version: "0.1.26",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     googleDrive,
     infoAlert: {

--- a/components/google_drive/actions/delete-reply/delete-reply.mjs
+++ b/components/google_drive/actions/delete-reply/delete-reply.mjs
@@ -4,13 +4,14 @@ export default {
   key: "google_drive-delete-reply",
   name: "Delete Reply",
   description: "Delete a reply on a specific comment. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/replies/delete) for more information",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     googleDrive,
     drive: {

--- a/components/google_drive/actions/delete-shared-drive/delete-shared-drive.mjs
+++ b/components/google_drive/actions/delete-shared-drive/delete-shared-drive.mjs
@@ -4,13 +4,14 @@ export default {
   key: "google_drive-delete-shared-drive",
   name: "Delete Shared Drive",
   description: "Delete a shared drive without any content. [See the documentation](https://developers.google.com/drive/api/v3/reference/drives/delete) for more information",
-  version: "0.1.24",
+  version: "0.1.25",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     googleDrive,
     drive: {

--- a/components/google_drive/actions/download-file/download-file.mjs
+++ b/components/google_drive/actions/download-file/download-file.mjs
@@ -33,13 +33,14 @@ export default {
     + " Pass `mimeType` to force a specific format. Shortcuts are resolved to their target automatically."
     + " Folders, Forms, and My Maps cannot be downloaded via this action."
     + " [See the documentation](https://developers.google.com/drive/api/v3/manage-downloads)",
-  version: "0.2.1",
+  version: "0.2.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     googleDrive,
     drive: {

--- a/components/google_drive/actions/find-file/find-file.mjs
+++ b/components/google_drive/actions/find-file/find-file.mjs
@@ -6,13 +6,14 @@ export default {
   key: "google_drive-find-file",
   name: "Find File",
   description: "Search for a specific file by name. The `Search Name` field uses Google Drive's tokenized full-text matching — pass a distinctive word or short phrase rather than the full title when the name contains special characters like `&` or `'`. [See the documentation](https://developers.google.com/drive/api/v3/search-files) for more information",
-  version: "0.1.25",
+  version: "0.1.26",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     googleDrive,
     drive: {

--- a/components/google_drive/actions/find-folder/find-folder.mjs
+++ b/components/google_drive/actions/find-folder/find-folder.mjs
@@ -7,13 +7,14 @@ export default {
   key: "google_drive-find-folder",
   name: "Find Folder",
   description: "Search for a specific folder by name. The `Search Name` field uses Google Drive's tokenized full-text matching — pass a distinctive word or short phrase rather than the full title when the name contains special characters like `&` or `'`. [See the documentation](https://developers.google.com/drive/api/v3/search-files) for more information",
-  version: "0.1.25",
+  version: "0.1.26",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     googleDrive,
     drive: {

--- a/components/google_drive/actions/find-forms/find-forms.mjs
+++ b/components/google_drive/actions/find-forms/find-forms.mjs
@@ -6,13 +6,14 @@ export default {
   key: "google_drive-find-forms",
   name: "Find Forms",
   description: "List Google Form documents or search for a Form by name. The `Search Name` field uses Google Drive's tokenized full-text matching — pass a distinctive word or short phrase rather than the full title when the name contains special characters like `&` or `'`. [See the documentation](https://developers.google.com/drive/api/v3/search-files) for more information",
-  version: "0.0.26",
+  version: "0.0.27",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     googleDrive,
     drive: {

--- a/components/google_drive/actions/find-spreadsheets/find-spreadsheets.mjs
+++ b/components/google_drive/actions/find-spreadsheets/find-spreadsheets.mjs
@@ -6,13 +6,14 @@ export default {
   key: "google_drive-find-spreadsheets",
   name: "Find Spreadsheets",
   description: "Search for a specific spreadsheet by name. The `Search Name` field uses Google Drive's tokenized full-text matching — pass a distinctive word or short phrase rather than the full title when the name contains special characters like `&` or `'`. [See the documentation](https://developers.google.com/drive/api/v3/search-files) for more information",
-  version: "0.1.25",
+  version: "0.1.26",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     googleDrive,
     drive: {

--- a/components/google_drive/actions/get-comment/get-comment.mjs
+++ b/components/google_drive/actions/get-comment/get-comment.mjs
@@ -4,13 +4,14 @@ export default {
   key: "google_drive-get-comment",
   name: "Get Comment By ID",
   description: "Get comment by ID on a specific file. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/comments/get) for more information",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     googleDrive,
     drive: {

--- a/components/google_drive/actions/get-current-user/get-current-user.mjs
+++ b/components/google_drive/actions/get-current-user/get-current-user.mjs
@@ -6,8 +6,9 @@ export default {
   key: "google_drive-get-current-user",
   name: "Get Current User",
   description: "Retrieve Google Drive account metadata for the authenticated user via `about.get`, including display name, email, permission ID, and storage quota. Useful when flows or agents need to confirm the active Google identity or understand available storage. [See the documentation](https://developers.google.com/drive/api/v3/reference/about/get).",
-  version: "0.0.11",
+  version: "0.0.12",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/get-file-by-id/get-file-by-id.mjs
+++ b/components/google_drive/actions/get-file-by-id/get-file-by-id.mjs
@@ -5,13 +5,14 @@ export default {
   key: "google_drive-get-file-by-id",
   name: "Get File By ID",
   description: "Get info on a specific file. [See the documentation](https://developers.google.com/drive/api/reference/rest/v3/files/get) for more information",
-  version: "0.0.21",
+  version: "0.0.22",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     googleDrive,
     drive: {

--- a/components/google_drive/actions/get-file/get-file.mjs
+++ b/components/google_drive/actions/get-file/get-file.mjs
@@ -11,8 +11,9 @@ export default {
     + "\n\nCommon fields: `id`, `name`, `mimeType`, `size`, `parents`, `webViewLink`, `webContentLink`,"
     + " `createdTime`, `modifiedTime`, `owners`, `permissions`, `description`, `trashed`."
     + " [See the documentation](https://developers.google.com/drive/api/v3/reference/files/get)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/get-folder-id-for-path/get-folder-id-for-path.mjs
+++ b/components/google_drive/actions/get-folder-id-for-path/get-folder-id-for-path.mjs
@@ -12,13 +12,14 @@ export default {
   key: "google_drive-get-folder-id-for-path",
   name: "Get Folder ID for a Path",
   description: "Retrieve a folderId for a path. [See the documentation](https://developers.google.com/drive/api/v3/search-files) for more information",
-  version: "0.1.26",
+  version: "0.1.27",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     googleDrive,
     drive: {

--- a/components/google_drive/actions/get-reply/get-reply.mjs
+++ b/components/google_drive/actions/get-reply/get-reply.mjs
@@ -4,13 +4,14 @@ export default {
   key: "google_drive-get-reply",
   name: "Get Reply By ID",
   description: "Get reply by ID on a specific comment. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/replies/get) for more information",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     googleDrive,
     drive: {

--- a/components/google_drive/actions/get-shared-drive/get-shared-drive.mjs
+++ b/components/google_drive/actions/get-shared-drive/get-shared-drive.mjs
@@ -4,13 +4,14 @@ export default {
   key: "google_drive-get-shared-drive",
   name: "Get Shared Drive",
   description: "Get metadata for one or all shared drives. [See the documentation](https://developers.google.com/drive/api/v3/reference/drives/get) for more information",
-  version: "0.1.24",
+  version: "0.1.25",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     googleDrive,
     drive: {

--- a/components/google_drive/actions/get-user-details/get-user-details.mjs
+++ b/components/google_drive/actions/get-user-details/get-user-details.mjs
@@ -10,8 +10,9 @@ export default {
     + " When the user says 'my files' or 'my documents', call this first to get the owner email,"
     + " then pass it to **Search Files** with a query like `'user@example.com' in owners`."
     + " [See the documentation](https://developers.google.com/drive/api/v3/reference/about/get)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/is-folder-ancestor/is-folder-ancestor.mjs
+++ b/components/google_drive/actions/is-folder-ancestor/is-folder-ancestor.mjs
@@ -4,8 +4,9 @@ export default {
   key: "google_drive-is-folder-ancestor",
   name: "Is Folder Ancestor",
   description: "Check if a specific folder is anywhere in the parent hierarchy of a file or folder. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/files/get)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/list-access-proposals/list-access-proposals.mjs
+++ b/components/google_drive/actions/list-access-proposals/list-access-proposals.mjs
@@ -4,13 +4,14 @@ export default {
   key: "google_drive-list-access-proposals",
   name: "List Access Proposals",
   description: "List access proposals for a file or folder. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/accessproposals/list)",
-  version: "0.0.17",
+  version: "0.0.18",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     googleDrive,
     drive: {

--- a/components/google_drive/actions/list-comments/list-comments.mjs
+++ b/components/google_drive/actions/list-comments/list-comments.mjs
@@ -8,13 +8,14 @@ export default {
   key: "google_drive-list-comments",
   name: "List Comments",
   description: "List the comments on a file, including each comment's author, plain text and HTML content, the file text it is anchored to, whether it is resolved, and its full reply thread. Use **Find File** first to resolve a file's name to its ID. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/comments/list)",
-  version: "0.1.0",
+  version: "0.1.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     googleDrive,
     drive: {

--- a/components/google_drive/actions/list-files/list-files.mjs
+++ b/components/google_drive/actions/list-files/list-files.mjs
@@ -9,13 +9,14 @@ export default {
   key: "google_drive-list-files",
   name: "List Files",
   description: "List files from a specific folder. Set `Max Results` to cap how many files are returned per run, then pass the returned `nextPageToken` back in as `Page Token` on the next run to page through a large folder in fixed-size batches. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/list) for more information",
-  version: "1.0.1",
+  version: "1.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     googleDrive,
     limitToMyDrive: {

--- a/components/google_drive/actions/list-mime-type-options/list-mime-type-options.mjs
+++ b/components/google_drive/actions/list-mime-type-options/list-mime-type-options.mjs
@@ -4,8 +4,9 @@ export default {
   key: "google_drive-list-mime-type-options",
   name: "List Mime Type Options",
   description: "Retrieves available options for the Mime Type field.",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/list-permissions/list-permissions.mjs
+++ b/components/google_drive/actions/list-permissions/list-permissions.mjs
@@ -10,8 +10,9 @@ export default {
     + " Use this tool when the user asks 'who has access to this file?' or needs to audit sharing."
     + " Pass permission IDs from this response to **Remove Sharing** to revoke access."
     + " [See the documentation](https://developers.google.com/drive/api/v3/reference/permissions/list)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/list-replies/list-replies.mjs
+++ b/components/google_drive/actions/list-replies/list-replies.mjs
@@ -4,13 +4,14 @@ export default {
   key: "google_drive-list-replies",
   name: "List Replies",
   description: "List replies to a specific comment. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/replies/list) for more information",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     googleDrive,
     drive: {

--- a/components/google_drive/actions/list-shared-drives/list-shared-drives.mjs
+++ b/components/google_drive/actions/list-shared-drives/list-shared-drives.mjs
@@ -10,8 +10,9 @@ export default {
     + " Pass a drive ID to **Search Files** `driveId` parameter to search within a specific shared drive."
     + " Optionally filter by name using the `query` parameter (e.g., `name contains 'Engineering'`)."
     + " [See the documentation](https://developers.google.com/drive/api/v3/reference/drives/list)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/list-theme-id-options/list-theme-id-options.mjs
+++ b/components/google_drive/actions/list-theme-id-options/list-theme-id-options.mjs
@@ -4,8 +4,9 @@ export default {
   key: "google_drive-list-theme-id-options",
   name: "List Theme ID Options",
   description: "Retrieves available options for the Theme ID field.",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/move-file-to-trash/move-file-to-trash.mjs
+++ b/components/google_drive/actions/move-file-to-trash/move-file-to-trash.mjs
@@ -5,13 +5,14 @@ export default {
   key: "google_drive-move-file-to-trash",
   name: "Move File to Trash",
   description: "Move a file or folder to trash. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/update) for more information",
-  version: "0.1.24",
+  version: "0.1.25",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     googleDrive,
     infoAlert: {

--- a/components/google_drive/actions/move-file/move-file.mjs
+++ b/components/google_drive/actions/move-file/move-file.mjs
@@ -4,13 +4,14 @@ export default {
   key: "google_drive-move-file",
   name: "Move File",
   description: "Move a file from one folder to another. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/update) for more information",
-  version: "0.1.24",
+  version: "0.1.25",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     googleDrive,
     drive: {

--- a/components/google_drive/actions/remove-sharing/remove-sharing.mjs
+++ b/components/google_drive/actions/remove-sharing/remove-sharing.mjs
@@ -10,8 +10,9 @@ export default {
     + " The owner permission cannot be removed."
     + " Use **Search Files** to find the file ID by name if needed."
     + " [See the documentation](https://developers.google.com/drive/api/v3/reference/permissions/delete)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_drive/actions/reply-to-comment/reply-to-comment.mjs
+++ b/components/google_drive/actions/reply-to-comment/reply-to-comment.mjs
@@ -4,13 +4,14 @@ export default {
   key: "google_drive-reply-to-comment",
   name: "Reply to Comment",
   description: "Add a reply to an existing comment. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/replies/create)",
-  version: "0.0.13",
+  version: "0.0.14",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     googleDrive,
     drive: {

--- a/components/google_drive/actions/resolve-access-proposal/resolve-access-proposal.mjs
+++ b/components/google_drive/actions/resolve-access-proposal/resolve-access-proposal.mjs
@@ -5,13 +5,14 @@ export default {
   key: "google_drive-resolve-access-proposal",
   name: "Resolve Access Proposals",
   description: "Accept or deny a request for access to a file or folder in Google Drive. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/accessproposals/resolve)",
-  version: "0.0.17",
+  version: "0.0.18",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     googleDrive,
     drive: {

--- a/components/google_drive/actions/resolve-comment/resolve-comment.mjs
+++ b/components/google_drive/actions/resolve-comment/resolve-comment.mjs
@@ -4,13 +4,14 @@ export default {
   key: "google_drive-resolve-comment",
   name: "Resolve Comment",
   description: "Mark a comment as resolved. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/comments/update)",
-  version: "0.0.13",
+  version: "0.0.14",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     googleDrive,
     drive: {

--- a/components/google_drive/actions/search-files/search-files.mjs
+++ b/components/google_drive/actions/search-files/search-files.mjs
@@ -22,8 +22,9 @@ export default {
     + "\n\nWhen the user says 'my files', use **Get User Details** first to get the owner email."
     + " To scope to a shared drive, pass the `driveId` from **List Shared Drives**."
     + " [See the documentation](https://developers.google.com/drive/api/v3/search-files)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/search-shared-drives/search-shared-drives.mjs
+++ b/components/google_drive/actions/search-shared-drives/search-shared-drives.mjs
@@ -4,13 +4,14 @@ export default {
   key: "google_drive-search-shared-drives",
   name: "Search for Shared Drives",
   description: "Search for shared drives with query options. [See the documentation](https://developers.google.com/drive/api/v3/search-shareddrives) for more information",
-  version: "0.1.25",
+  version: "0.1.26",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     googleDrive,
     q: {

--- a/components/google_drive/actions/share-file/share-file.mjs
+++ b/components/google_drive/actions/share-file/share-file.mjs
@@ -15,8 +15,9 @@ export default {
     + "\n\n**Roles:** `reader` (view only), `commenter` (can comment), `writer` (can edit)."
     + " Use **List Permissions** to see existing sharing on a file."
     + " [See the documentation](https://developers.google.com/drive/api/v3/reference/permissions/create)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_drive/actions/trash-file/trash-file.mjs
+++ b/components/google_drive/actions/trash-file/trash-file.mjs
@@ -10,8 +10,9 @@ export default {
     + " Use this instead of permanent deletion as the safer default."
     + " To find trashed files, use **Search Files** with `trashed = true`."
     + " [See the documentation](https://developers.google.com/drive/api/v3/reference/files/update)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/google_drive/actions/update-comment/update-comment.mjs
+++ b/components/google_drive/actions/update-comment/update-comment.mjs
@@ -4,13 +4,14 @@ export default {
   key: "google_drive-update-comment",
   name: "Update Comment",
   description: "Update the content of a specific comment. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/comments/update) for more information",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     googleDrive,
     drive: {

--- a/components/google_drive/actions/update-file/update-file.mjs
+++ b/components/google_drive/actions/update-file/update-file.mjs
@@ -6,13 +6,14 @@ export default {
   key: "google_drive-update-file",
   name: "Update File",
   description: "Update a file's metadata and/or content. [See the documentation](https://developers.google.com/drive/api/v3/reference/files/update) for more information",
-  version: "2.0.16",
+  version: "2.0.17",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     googleDrive,
     drive: {

--- a/components/google_drive/actions/update-reply/update-reply.mjs
+++ b/components/google_drive/actions/update-reply/update-reply.mjs
@@ -4,13 +4,14 @@ export default {
   key: "google_drive-update-reply",
   name: "Update Reply",
   description: "Update a reply on a specific comment. [See the documentation](https://developers.google.com/workspace/drive/api/reference/rest/v3/replies/update) for more information",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     googleDrive,
     drive: {

--- a/components/google_drive/actions/update-shared-drive/update-shared-drive.mjs
+++ b/components/google_drive/actions/update-shared-drive/update-shared-drive.mjs
@@ -4,13 +4,14 @@ export default {
   key: "google_drive-update-shared-drive",
   name: "Update Shared Drive",
   description: "Update an existing shared drive. [See the documentation](https://developers.google.com/drive/api/v3/reference/drives/update) for more information",
-  version: "0.1.24",
+  version: "0.1.25",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     googleDrive,
     drive: {

--- a/components/google_drive/package.json
+++ b/components/google_drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_drive",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Pipedream Google_drive Components",
   "main": "google_drive.app.mjs",
   "keywords": [

--- a/components/hubspot/actions/create-association/create-association.mjs
+++ b/components/hubspot/actions/create-association/create-association.mjs
@@ -12,13 +12,14 @@ export default {
     + " deal→contact (3), contact→deal (4), deal→company (5), company→deal (6),"
     + " ticket→contact (15), contact→ticket (16), ticket→company (26), company→ticket (25)."
     + " [See the documentation](https://developers.hubspot.com/docs/api/crm/associations)",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     hubspot,
     fromObjectType: {

--- a/components/hubspot/actions/create-communication/create-communication.mjs
+++ b/components/hubspot/actions/create-communication/create-communication.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import { ASSOCIATION_CATEGORY } from "../../common/constants.mjs";
 import appProp from "../common/common-app-prop.mjs";
@@ -11,13 +10,14 @@ export default {
   name: "Create Communication",
   description:
     "Log a WhatsApp, LinkedIn, or SMS communication in HubSpot. Put the message fields in **Object Properties** (`hs_communication_channel_type` = `SMS` | `WHATS_APP` | `LINKEDIN_MESSAGE`, `hs_communication_body`); `hs_communication_logged_from` and `hs_timestamp` are set for you. Optionally associate it with a record via **Associated Object Type/ID** + **Association Type**. Example: Object Properties `{ \"hs_communication_channel_type\": \"SMS\", \"hs_communication_body\": \"Reminder: call at 9am\" }`. Returns the created communication with its id. [See the documentation](https://developers.hubspot.com/beta-docs/reference/api/crm/engagements/communications/v3#post-%2Fcrm%2Fv3%2Fobjects%2Fcommunications)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     ...appProp.props,
     toObjectType: {

--- a/components/hubspot/actions/create-company/create-company.mjs
+++ b/components/hubspot/actions/create-company/create-company.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { OBJECT_TYPE } from "../../common/constants.mjs";
 import common from "../common/common-create-object.mjs";
 
@@ -8,13 +7,14 @@ export default {
   name: "Create Company",
   description:
     "Create a company in HubSpot. Put the company fields in **Object Properties** as a JSON object of HubSpot internal property names (use **Get Properties** for `companies` to discover them). Example: `{ \"name\": \"InGen\", \"domain\": \"ingen.com\", \"industry\": \"BIOTECHNOLOGY\" }`. Returns the created company with its id. [See the documentation](https://developers.hubspot.com/docs/api/crm/companies#endpoint?spec=POST-/crm/v3/objects/companies)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   methods: {
     ...common.methods,
     getObjectType() {

--- a/components/hubspot/actions/create-crm-object/create-crm-object.mjs
+++ b/components/hubspot/actions/create-crm-object/create-crm-object.mjs
@@ -14,13 +14,14 @@ export default {
     + " and **List Pipelines and Stages** to find valid pipeline/stage IDs for deals and tickets."
     + " Use **List Owners** to find valid `hubspot_owner_id` values."
     + " [See the documentation](https://developers.hubspot.com/docs/api/crm/objects)",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     hubspot,
     objectType: {

--- a/components/hubspot/actions/create-custom-object/create-custom-object.mjs
+++ b/components/hubspot/actions/create-custom-object/create-custom-object.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import common from "../common/common-create-object.mjs";
 
 const {
@@ -11,13 +10,14 @@ export default {
   name: "Create Custom Object",
   description:
     "Create a custom object record in HubSpot. Set **Custom Object Type** to the object's `fullyQualifiedName` (e.g. `p_pets`; use **List Custom Object Schemas** to find it) and put fields in **Object Properties**. Example: Custom Object Type `p_pets`, Object Properties `{ \"pet_name\": \"Rexy\" }`. Returns the created record with its id. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/custom-objects#create-a-custom-object)",
-  version: "2.0.0",
+  version: "2.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     hubspot,
     customObjectType: {

--- a/components/hubspot/actions/create-deal/create-deal.mjs
+++ b/components/hubspot/actions/create-deal/create-deal.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { OBJECT_TYPE } from "../../common/constants.mjs";
 import common from "../common/common-create-object.mjs";
 
@@ -8,13 +7,14 @@ export default {
   name: "Create Deal",
   description:
     "Create a deal in HubSpot. Set **Deal Name**, **Pipeline**, and **Stage**, and put any extra fields in **Object Properties** as HubSpot internal names. Example: Deal Name `InGen Annual Contract`, Pipeline `default`, Stage `appointmentscheduled`, Object Properties `{ \"amount\": \"250000\", \"closedate\": \"2026-09-23\" }`. Returns the created deal with its id. [See the documentation](https://developers.hubspot.com/docs/api/crm/deals#endpoint?spec=POST-/crm/v3/objects/deals)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     ...common.props,
     dealname: {

--- a/components/hubspot/actions/create-engagement/create-engagement.mjs
+++ b/components/hubspot/actions/create-engagement/create-engagement.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import { ENGAGEMENT_TYPE_OPTIONS } from "../../common/constants.mjs";
 import common from "../common/common-create.mjs";
@@ -92,13 +91,14 @@ export default {
     + "No `reloadProps` step and no **CONFIGURE_COMPONENT** requirement: association fields accept raw HubSpot IDs (use **Search CRM** or the Associations API to resolve `associationType` when needed). "
     + "For **only** a note on a contact by ID, **Add Note to Contact** (`hubspot-add-note-to-contact`) is still simpler. "
     + "[See the documentation](https://developers.hubspot.com/docs/api/crm/engagements)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     ...common.props,
     engagementType: {

--- a/components/hubspot/actions/create-lead/create-lead.mjs
+++ b/components/hubspot/actions/create-lead/create-lead.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import {
   ASSOCIATION_CATEGORY, OBJECT_TYPE,
 } from "../../common/constants.mjs";
@@ -14,13 +13,14 @@ export default {
   name: "Create Lead",
   description:
     "Create a lead in HubSpot associated with an existing contact. Set **Contact ID** (the contact to link) and put lead fields in **Object Properties** as HubSpot internal names. Example: Contact ID `12345`, Object Properties `{ \"hs_lead_name\": \"Isla Nublar Opportunity\" }`. Returns the created lead with its id. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/leads#create-leads)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     hubspot,
     contactId: {

--- a/components/hubspot/actions/create-meeting/create-meeting.mjs
+++ b/components/hubspot/actions/create-meeting/create-meeting.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 /* eslint-disable no-unused-vars */
 import { ConfigurationError } from "@pipedream/platform";
 import {
@@ -13,13 +12,14 @@ export default {
   name: "Create Meeting",
   description:
     "Create a meeting engagement in HubSpot. Put meeting fields in **Object Properties** (`hs_meeting_title`, `hs_meeting_body`, `hs_meeting_start_time`, `hs_meeting_end_time` as ISO-8601); `hs_timestamp` defaults to the start time. Set **Associated Object Type** and optionally link a record via **Associated Object ID** + **Association Type**. Example: Object Properties `{ \"hs_meeting_title\": \"Kickoff\", \"hs_meeting_start_time\": \"2026-08-27T14:00:00Z\", \"hs_meeting_end_time\": \"2026-08-27T15:00:00Z\" }`. Returns the created meeting with its id. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/engagements/meetings#post-%2Fcrm%2Fv3%2Fobjects%2Fmeetings)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     ...common.props,
     toObjectType: {

--- a/components/hubspot/actions/create-note/create-note.mjs
+++ b/components/hubspot/actions/create-note/create-note.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import { ASSOCIATION_CATEGORY } from "../../common/constants.mjs";
 import common from "../common/common-create.mjs";
@@ -13,13 +12,14 @@ export default {
     + "For **only** a contact ID + note body, **Add Note to Contact** is simpler. "
     + "To associate the note with another record, supply `toObjectType`, `toObjectId`, and `associationType` together. "
     + "[See the documentation](https://developers.hubspot.com/docs/api/crm/objects/notes)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     ...common.props,
     toObjectType: {

--- a/components/hubspot/actions/create-or-update-contact/create-or-update-contact.mjs
+++ b/components/hubspot/actions/create-or-update-contact/create-or-update-contact.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { OBJECT_TYPE } from "../../common/constants.mjs";
 import common from "../common/common-create-object.mjs";
 
@@ -8,13 +7,14 @@ export default {
   name: "Create or Update Contact",
   description:
     "Create a contact in HubSpot, or update it when one with the same email already exists (enable **Update If Exists**). Put contact fields in **Object Properties** as HubSpot internal names. Example: Object Properties `{ \"email\": \"ada@example.com\", \"firstname\": \"Ada\", \"jobtitle\": \"CTO\" }`. Returns the created or updated contact with its id. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts#endpoint?spec=POST-/crm/v3/objects/contacts)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     ...common.props,
     updateIfExists: {

--- a/components/hubspot/actions/create-task/create-task.mjs
+++ b/components/hubspot/actions/create-task/create-task.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import { ASSOCIATION_CATEGORY } from "../../common/constants.mjs";
 import common from "../common/common-create.mjs";
@@ -10,13 +9,14 @@ export default {
   name: "Create Task",
   description:
     "Create a task engagement in HubSpot. Put task fields in **Object Properties** as HubSpot internal names (`hs_task_subject`, `hs_task_body`, `hs_task_status`, `hs_task_priority`); `hs_timestamp` is defaulted for you. Optionally associate it with a record via **Associated Object Type/ID** + **Association Type**. Example: Object Properties `{ \"hs_task_subject\": \"Call Art Vandelay\", \"hs_task_status\": \"NOT_STARTED\", \"hs_task_priority\": \"HIGH\" }`. Returns the created task with its id. [See the documentation](https://developers.hubspot.com/docs/api/crm/engagements)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     ...common.props,
     toObjectType: {

--- a/components/hubspot/actions/create-ticket/create-ticket.mjs
+++ b/components/hubspot/actions/create-ticket/create-ticket.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { OBJECT_TYPE } from "../../common/constants.mjs";
 import common from "../common/common-create-object.mjs";
 
@@ -8,13 +7,14 @@ export default {
   name: "Create Ticket",
   description:
     "Create a support ticket in HubSpot. Set **Ticket Name**, **Pipeline**, and **Pipeline Stage** (use **List Pipelines and Stages** for `tickets` to get valid ids), and put extra fields in **Object Properties**. Example: subject `Login broken`, hs_pipeline `0`, hs_pipeline_stage `1`, Object Properties `{ \"hs_ticket_priority\": \"HIGH\" }`. Returns the created ticket with its id. [See the documentation](https://developers.hubspot.com/docs/api/crm/tickets)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     ...common.props,
     subject: {

--- a/components/hubspot/actions/get-associated-meetings/get-associated-meetings.mjs
+++ b/components/hubspot/actions/get-associated-meetings/get-associated-meetings.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import { DEFAULT_MEETING_PROPERTIES } from "../../common/constants.mjs";
 import { OBJECT_TYPE } from "../../common/object-types.mjs";
@@ -15,13 +14,14 @@ export default {
   name: "Get Associated Meetings",
   description:
     "List meetings associated with a contact, company, or deal in HubSpot. Set **From Object Type** and **Object ID** (for contacts you may pass an email instead of the numeric id). Optionally narrow with **Timeframe** (today, this_week, this_month, last_month, or custom with **Start/End Date**), or set **Most Recent** to return only the latest meeting. Returns up to 100 meetings with default meeting properties. Example: From Object Type `contacts`, Object ID `ada@example.com`, Timeframe `this_month`. [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/associations/association-details)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     hubspot,
     objectType: {

--- a/components/hubspot/actions/get-company/get-company.mjs
+++ b/components/hubspot/actions/get-company/get-company.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { OBJECT_TYPE } from "../../common/constants.mjs";
 import common from "../common/common-get-object.mjs";
 
@@ -8,13 +7,14 @@ export default {
   name: "Get Company",
   description:
     "Get a single company from HubSpot by its id, with a default set of company properties. Add **Additional properties to retrieve** (internal names; use **Get Properties** for `companies`) to include more. Example: Object ID `123`, Additional properties `[\"industry\", \"numberofemployees\"]`. Returns the company record. [See the documentation](https://developers.hubspot.com/docs/api/crm/companies#endpoint?spec=GET-/crm/v3/objects/companies/{companyId})",
-  version: "0.1.0",
+  version: "0.1.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     ...common.props,
     objectId: {

--- a/components/hubspot/actions/get-contact/get-contact.mjs
+++ b/components/hubspot/actions/get-contact/get-contact.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { OBJECT_TYPE } from "../../common/constants.mjs";
 import common from "../common/common-get-object.mjs";
 
@@ -8,13 +7,14 @@ export default {
   name: "Get Contact",
   description:
     "Get a single contact from HubSpot by its id, with a default set of contact properties. Add **Additional properties to retrieve** to include more (use **Get Properties** for `contacts`). Look up the id with **Search CRM** by email if you only have an address. Example: Object ID `123`, Additional properties `[\"jobtitle\"]`. Returns the contact record. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts#endpoint?spec=GET-/crm/v3/objects/contacts/{contactId})",
-  version: "0.1.0",
+  version: "0.1.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     ...common.props,
     objectId: {

--- a/components/hubspot/actions/get-crm-objects/get-crm-objects.mjs
+++ b/components/hubspot/actions/get-crm-objects/get-crm-objects.mjs
@@ -13,13 +13,14 @@ export default {
     + " Supports standard object types only."
     + " For custom objects, use **Get Custom Object** instead."
     + " [See the documentation](https://developers.hubspot.com/docs/api/crm/objects)",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     hubspot,
     objectType: {

--- a/components/hubspot/actions/get-deal/get-deal.mjs
+++ b/components/hubspot/actions/get-deal/get-deal.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { OBJECT_TYPE } from "../../common/constants.mjs";
 import common from "../common/common-get-object.mjs";
 
@@ -8,13 +7,14 @@ export default {
   name: "Get Deal",
   description:
     "Get a single deal from HubSpot by its id, with a default set of deal properties. Add **Additional properties to retrieve** to include more (use **Get Properties** for `deals`). Example: Object ID `123`, Additional properties `[\"amount\", \"dealstage\"]`. Returns the deal record. [See the documentation](https://developers.hubspot.com/docs/api/crm/deals#endpoint?spec=GET-/crm/v3/objects/deals/{dealId})",
-  version: "0.1.0",
+  version: "0.1.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     ...common.props,
     objectId: {

--- a/components/hubspot/actions/get-meeting/get-meeting.mjs
+++ b/components/hubspot/actions/get-meeting/get-meeting.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { OBJECT_TYPE } from "../../common/constants.mjs";
 import common from "../common/common-get-object.mjs";
 
@@ -8,13 +7,14 @@ export default {
   name: "Get Meeting",
   description:
     "Get a single meeting engagement from HubSpot by its id, with a default set of meeting properties. Add **Additional properties to retrieve** to include more. Example: Object ID `123`. Returns the meeting record (title, body, start/end time). [See the documentation](https://developers.hubspot.com/docs/reference/api/crm/engagements/meetings#get-%2Fcrm%2Fv3%2Fobjects%2Fmeetings%2F%7Bmeetingid%7D)",
-  version: "0.1.0",
+  version: "0.1.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     ...common.props,
     objectId: {

--- a/components/hubspot/actions/get-properties/get-properties.mjs
+++ b/components/hubspot/actions/get-properties/get-properties.mjs
@@ -7,13 +7,14 @@ export default {
   name: "Get Properties",
   description:
     "Get detailed property definitions for specific properties on a CRM object type. Returns full metadata including data types, enum options with valid values, referenced object types, and read-only status. Use this after **Search Properties** to get valid values for specific fields (e.g. enum options for `dealstage` or `hs_pipeline`). Property details can be large — fetch only the properties you need rather than all of them. For custom object properties, use **List Custom Object Properties** instead (custom object types are not in the standard type list). [See the documentation](https://developers.hubspot.com/docs/api/crm/properties)",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     hubspot,
     objectType: {

--- a/components/hubspot/actions/get-user-details/get-user-details.mjs
+++ b/components/hubspot/actions/get-user-details/get-user-details.mjs
@@ -10,13 +10,14 @@ export default {
     + " (e.g. 'my deals' requires filtering by `hubspot_owner_id`)."
     + " Also returns available CRM object types for the account."
     + " [See the documentation](https://developers.hubspot.com/docs/api/oauth/tokens)",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     hubspot,
   },

--- a/components/hubspot/actions/list-owners/list-owners.mjs
+++ b/components/hubspot/actions/list-owners/list-owners.mjs
@@ -6,13 +6,14 @@ export default {
   name: "List Owners",
   description:
     "List owners (users) in the HubSpot account. Returns owner IDs, names, and emails. Use this to discover valid values for the `hubspot_owner_id` property when creating or updating any CRM object (contacts, companies, deals, tickets, etc.). [See the documentation](https://developers.hubspot.com/docs/api/crm/owners)",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     hubspot,
     email: {

--- a/components/hubspot/actions/list-pipelines-and-stages/list-pipelines-and-stages.mjs
+++ b/components/hubspot/actions/list-pipelines-and-stages/list-pipelines-and-stages.mjs
@@ -6,13 +6,14 @@ export default {
   name: "List Pipelines and Stages",
   description:
     "List all pipelines and their stages for deals or tickets. Returns pipeline IDs, labels, and each pipeline's ordered stages with stage IDs and labels. Use this to discover valid `pipeline` and `dealstage` / `hs_pipeline_stage` values before creating or updating deals and tickets. [See the documentation](https://developers.hubspot.com/docs/api/crm/pipelines)",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     hubspot,
     objectType: {

--- a/components/hubspot/actions/search-crm-objects/search-crm-objects.mjs
+++ b/components/hubspot/actions/search-crm-objects/search-crm-objects.mjs
@@ -38,13 +38,14 @@ export default {
     + " For custom objects, use **List Custom Object Schemas** to discover available types,"
     + " then **List Custom Objects** to list records."
     + " [See the documentation](https://developers.hubspot.com/docs/api/crm/search)",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     hubspot,
     objectType: {

--- a/components/hubspot/actions/search-crm/search-crm.mjs
+++ b/components/hubspot/actions/search-crm/search-crm.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import {
   DEFAULT_COMPANY_PROPERTIES,
@@ -19,13 +18,14 @@ export default {
   name: "Search CRM",
   description:
     "Search a CRM object type by a single property. Set **Object Type**, **Search Property** (internal name, e.g. `email` or `dealname`; use **Get Properties** / **Search Properties** to find valid names), and **Search Value**. With **Exact Match** off, partial (substring) matches are returned. Results are capped per call — if `paging.next` is present in the response, call again with **Offset** advanced to fetch the next page. Example: Object Type `deal`, Search Property `dealname`, Search Value `InGen Annual Contract`. Returns matching records plus paging. For lookups, keep results small with **Limit** and **Fields** (return only the properties you need). [See the documentation](https://developers.hubspot.com/docs/api/crm/search)",
-  version: "2.0.0",
+  version: "2.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     hubspot,
     objectType: {

--- a/components/hubspot/actions/search-properties/search-properties.mjs
+++ b/components/hubspot/actions/search-properties/search-properties.mjs
@@ -7,13 +7,14 @@ export default {
   name: "Search Properties",
   description:
     "Search for property definitions (field names) on a CRM object type. Returns lightweight results: property names, labels, descriptions, and types — without enum options. Use this to discover what fields exist before creating or updating records. To get full details including valid enum values for a specific property, use **Get Properties**. To search for actual CRM data/records, use **Search CRM Objects**. For custom object properties, use **List Custom Object Properties** instead (custom object types are not in the standard type list). [See the documentation](https://developers.hubspot.com/docs/api/crm/properties)",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     hubspot,
     objectType: {

--- a/components/hubspot/actions/update-company/update-company.mjs
+++ b/components/hubspot/actions/update-company/update-company.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { OBJECT_TYPE } from "../../common/constants.mjs";
 import hubspot from "../../hubspot.app.mjs";
 import common from "../common/common-update-object.mjs";
@@ -9,13 +8,14 @@ export default {
   name: "Update Company",
   description:
     "Update a company in HubSpot by id. Set **Object ID** and put the fields to change in **Object Properties** as HubSpot internal names (only the fields you pass are modified). Look up the id with **Search CRM** if you only have a name. Example: Object ID `123`, Object Properties `{ \"phone\": \"555-0100\", \"industry\": \"BIOTECHNOLOGY\" }`. Returns the updated company. [See the documentation](https://developers.hubspot.com/docs/api/crm/companies)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   methods: {
     ...common.methods,
     getObjectType() {

--- a/components/hubspot/actions/update-contact/update-contact.mjs
+++ b/components/hubspot/actions/update-contact/update-contact.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { OBJECT_TYPE } from "../../common/constants.mjs";
 import hubspot from "../../hubspot.app.mjs";
 import common from "../common/common-update-object.mjs";
@@ -9,13 +8,14 @@ export default {
   name: "Update Contact",
   description:
     "Update a contact in HubSpot by id. Set **Object ID** and put the fields to change in **Object Properties** as HubSpot internal names (only the fields you pass are modified). If you don't have the id, look it up first with **Search CRM** (by email, or by name). Example: Object ID `123`, Object Properties `{ \"jobtitle\": \"Chief Paleontologist\" }`. Returns the updated contact. [See the documentation](https://developers.hubspot.com/docs/api/crm/contacts#endpoint?spec=PATCH-/crm/v3/objects/contacts/{contactId})",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   methods: {
     ...common.methods,
     getObjectType() {

--- a/components/hubspot/actions/update-crm-object/update-crm-object.mjs
+++ b/components/hubspot/actions/update-crm-object/update-crm-object.mjs
@@ -13,13 +13,14 @@ export default {
     + " **Search Properties** to discover available fields,"
     + " and **Get Properties** to find valid enum values."
     + " [See the documentation](https://developers.hubspot.com/docs/api/crm/objects)",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     hubspot,
     objectType: {

--- a/components/hubspot/actions/update-custom-object/update-custom-object.mjs
+++ b/components/hubspot/actions/update-custom-object/update-custom-object.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import hubspot from "../../hubspot.app.mjs";
 import common from "../common/common-update-object.mjs";
 
@@ -8,13 +7,14 @@ export default {
   name: "Update Custom Object",
   description:
     "Update a custom object record in HubSpot by id. Set **Custom Object Type** (the object's `fullyQualifiedName`, e.g. `p_pets`) and **Object ID**, and put the fields to change in **Object Properties**. Example: Custom Object Type `p_pets`, Object ID `123`, Object Properties `{ \"birthday\": \"1993-06-12\" }`. Returns the updated record. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/custom-objects#update-existing-custom-objects)",
-  version: "2.0.0",
+  version: "2.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   methods: {
     ...common.methods,
     getObjectType() {

--- a/components/hubspot/actions/update-deal/update-deal.mjs
+++ b/components/hubspot/actions/update-deal/update-deal.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { OBJECT_TYPE } from "../../common/constants.mjs";
 import hubspot from "../../hubspot.app.mjs";
 import common from "../common/common-update-object.mjs";
@@ -9,13 +8,14 @@ export default {
   name: "Update Deal",
   description:
     "Update a deal in HubSpot by id. Set **Object ID** and put the fields to change in **Object Properties** as HubSpot internal names. Look up the id with **Search CRM** if you only have a name. Example: Object ID `123`, Object Properties `{ \"dealstage\": \"closedwon\", \"amount\": \"90000\" }`. Returns the updated deal. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/deals#update-deals)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   methods: {
     ...common.methods,
     getObjectType() {

--- a/components/hubspot/actions/update-lead/update-lead.mjs
+++ b/components/hubspot/actions/update-lead/update-lead.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { OBJECT_TYPE } from "../../common/constants.mjs";
 import hubspot from "../../hubspot.app.mjs";
 import common from "../common/common-update-object.mjs";
@@ -9,13 +8,14 @@ export default {
   name: "Update Lead",
   description:
     "Update a lead in HubSpot by id. Set **Object ID** and put the fields to change in **Object Properties** as HubSpot internal names. Look up the id with **Search CRM** if you only have a name. Example: Object ID `123`, Object Properties `{ \"hs_lead_name\": \"Site B Expansion - Priority\" }`. Returns the updated lead. [See the documentation](https://developers.hubspot.com/beta-docs/guides/api/crm/objects/leads#update-leads)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   methods: {
     ...common.methods,
     getObjectType() {

--- a/components/hubspot/package.json
+++ b/components/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/hubspot",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Pipedream Hubspot Components",
   "main": "hubspot.app.mjs",
   "keywords": [

--- a/components/monta/actions/add-order-colli/add-order-colli.mjs
+++ b/components/monta/actions/add-order-colli/add-order-colli.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import monta from "../../monta.app.mjs";
 
 export default {
   key: "monta-add-order-colli",
   name: "Add Order Colli",
   description: "Register a collo (parcel) on an order, including its dimensions and tracking details. Use this to record how an order was packed; inspect the result with **List Order Colli**. [See the documentation](https://api-v6.monta.nl/index.html#tag/Order/paths/~1order~1%7Bwebshoporderid%7D~1colli/post)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monta/actions/approve-inbound-forecasts/approve-inbound-forecasts.mjs
+++ b/components/monta/actions/approve-inbound-forecasts/approve-inbound-forecasts.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import monta from "../../monta.app.mjs";
 
 export default {
   key: "monta-approve-inbound-forecasts",
   name: "Approve Inbound Forecasts",
   description: "Approve multiple inbound forecasts at once by their IDs. [See the documentation](https://api-v6.monta.nl/index.html#tag/InboundForecast/paths/~1inboundforecast~1approve/post)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monta/actions/cancel-order/cancel-order.mjs
+++ b/components/monta/actions/cancel-order/cancel-order.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import monta from "../../monta.app.mjs";
 
 export default {
   key: "monta-cancel-order",
   name: "Cancel Order",
   description: "Cancel (delete) an order. Monta rejects this once picking has started (error 18), after the order has shipped (error 19), or when returns exist (error 25). [See the documentation](https://api-v6.monta.nl/index.html#tag/Order/paths/~1order~1%7Bwebshoporderid%7D/delete)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/monta/actions/create-inbound-forecast-group/create-inbound-forecast-group.mjs
+++ b/components/monta/actions/create-inbound-forecast-group/create-inbound-forecast-group.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import monta from "../../monta.app.mjs";
 import { parseJsonObjects } from "../../common/utils.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "monta-create-inbound-forecast-group",
   name: "Create Inbound Forecast Group",
   description: "Create a new inbound forecast group describing stock expected at the warehouse. Manage the group afterwards with **Update Inbound Forecast Group**, **Get Inbound Forecast Group**, or **Delete Inbound Forecast Group**. [See the documentation](https://api-v6.monta.nl/index.html#tag/InboundForecast/paths/~1inboundforecast~1group/post)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monta/actions/create-order/create-order.mjs
+++ b/components/monta/actions/create-order/create-order.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import monta from "../../monta.app.mjs";
 import { parseJsonObjects } from "../../common/utils.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "monta-create-order",
   name: "Create Order",
   description: "Create a new order in Monta for fulfillment. Provide the recipient's delivery address (which needs a Company or Last Name) and at least one order line; validate the address first with **Validate Address** if needed. [See the documentation](https://api-v6.monta.nl/index.html#tag/Order/paths/~1order/post)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monta/actions/create-rma-link/create-rma-link.mjs
+++ b/components/monta/actions/create-rma-link/create-rma-link.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import monta from "../../monta.app.mjs";
 
 export default {
   key: "monta-create-rma-link",
   name: "Create RMA Link",
   description: "Create an RMA (return merchandise authorization) link for an order, so a customer can start a return. Review existing returns for the order with **List Order Returns**. [See the documentation](https://api-v6.monta.nl/index.html#tag/Order/paths/~1order~1%7Bwebshoporderid%7D~1rmalinks/post)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monta/actions/create-shipping-label/create-shipping-label.mjs
+++ b/components/monta/actions/create-shipping-label/create-shipping-label.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import monta from "../../monta.app.mjs";
 import constants from "../../common/constants.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "monta-create-shipping-label",
   name: "Create Shipping Label",
   description: "Generate a shipping label for an order in a supported output format (`pdf` or `zpl`). Use this when an order is ready to ship and needs a carrier label. [See the documentation](https://api-v6.monta.nl/index.html#tag/Order/paths/~1order~1%7Bwebshoporderid%7D~1shippinglabels/post)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monta/actions/delete-inbound-forecast-group/delete-inbound-forecast-group.mjs
+++ b/components/monta/actions/delete-inbound-forecast-group/delete-inbound-forecast-group.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import monta from "../../monta.app.mjs";
 
 export default {
   key: "monta-delete-inbound-forecast-group",
   name: "Delete Inbound Forecast Group",
   description: "Delete an inbound forecast group, or a single SKU within it when a SKU is provided. [See the documentation](https://api-v6.monta.nl/index.html#tag/InboundForecast/paths/~1inboundforecast~1group~1%7Breference%7D/delete)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/monta/actions/download-shipping-label/download-shipping-label.mjs
+++ b/components/monta/actions/download-shipping-label/download-shipping-label.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import fs from "fs";
 import monta from "../../monta.app.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "monta-download-shipping-label",
   name: "Download Shipping Label",
   description: "Download a single shipping label file for an order and save it to the `/tmp` directory. [See the documentation](https://api-v6.monta.nl/index.html#tag/Order/paths/~1order~1%7Bwebshoporderid%7D~1shippinglabels~1%7Bfilename%7D/get)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monta/actions/forget-order/forget-order.mjs
+++ b/components/monta/actions/forget-order/forget-order.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import monta from "../../monta.app.mjs";
 
 export default {
   key: "monta-forget-order",
   name: "Forget Order",
   description: "Anonymize an order for GDPR erasure. This permanently removes personal data and cannot be undone. [See the documentation](https://api-v6.monta.nl/index.html#tag/Order/paths/~1order~1%7Bwebshoporderid%7D~1forget/post)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/monta/actions/get-inbound-forecast-group/get-inbound-forecast-group.mjs
+++ b/components/monta/actions/get-inbound-forecast-group/get-inbound-forecast-group.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import monta from "../../monta.app.mjs";
 
 export default {
   key: "monta-get-inbound-forecast-group",
   name: "Get Inbound Forecast Group",
   description: "Retrieve an inbound forecast group and its forecasts by reference. [See the documentation](https://api-v6.monta.nl/index.html#tag/InboundForecast/paths/~1inboundforecast~1group~1%7Breference%7D/get)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monta/actions/get-inbound-forecast/get-inbound-forecast.mjs
+++ b/components/monta/actions/get-inbound-forecast/get-inbound-forecast.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import monta from "../../monta.app.mjs";
 
 export default {
   key: "monta-get-inbound-forecast",
   name: "Get Inbound Forecast",
   description: "Retrieve a single inbound forecast from a group by reference and SKU. [See the documentation](https://api-v6.monta.nl/index.html#tag/InboundForecast/paths/~1inboundforecast~1group~1%7Breference%7D~1%7Bsku%7D/get)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monta/actions/get-order/get-order.mjs
+++ b/components/monta/actions/get-order/get-order.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import monta from "../../monta.app.mjs";
 
 export default {
   key: "monta-get-order",
   name: "Get Order",
   description: "Get an order by ID. [See the documentation](https://api-v6.monta.nl/index.html#tag/Order/paths/~1order~1%7Bwebshoporderid%7D/get)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monta/actions/get-return/get-return.mjs
+++ b/components/monta/actions/get-return/get-return.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import monta from "../../monta.app.mjs";
 
 export default {
   key: "monta-get-return",
   name: "Get Return",
   description: "Get a return by ID. [See the documentation](https://api-v6.monta.nl/index.html#tag/Return/paths/~1return~1%7Bid%7D/get)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monta/actions/list-inbound-forecast-events/list-inbound-forecast-events.mjs
+++ b/components/monta/actions/list-inbound-forecast-events/list-inbound-forecast-events.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import monta from "../../monta.app.mjs";
 
 export default {
   key: "monta-list-inbound-forecast-events",
   name: "List Inbound Forecast Events",
   description: "List inbound forecast change events created after the provided cursor ID. Use this for reliable incremental syncing of inbound forecast changes by repeatedly polling with the last event ID. [See the documentation](https://api-v6.monta.nl/index.html#tag/InboundForecast/paths/~1inboundforecast~1events~1since_id~1%7Bid%7D/get)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monta/actions/list-inbound-forecast-groups/list-inbound-forecast-groups.mjs
+++ b/components/monta/actions/list-inbound-forecast-groups/list-inbound-forecast-groups.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import monta from "../../monta.app.mjs";
 import constants from "../../common/constants.mjs";
@@ -7,8 +6,9 @@ export default {
   key: "monta-list-inbound-forecast-groups",
   name: "List Inbound Forecast Groups",
   description: "List inbound forecast groups matching the provided filters. You must supply at least one filter (Created Since, Created Until, Approved, SKU, or Reference). Use this to find group references for **Get Inbound Forecast Group**, **Update Inbound Forecast Group**, or **Delete Inbound Forecast Group**. [See the documentation](https://api-v6.monta.nl/index.html#tag/InboundForecast/paths/~1inboundforecast~1group/get)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monta/actions/list-inbound-forecasts-by-product-sku/list-inbound-forecasts-by-product-sku.mjs
+++ b/components/monta/actions/list-inbound-forecasts-by-product-sku/list-inbound-forecasts-by-product-sku.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import monta from "../../monta.app.mjs";
 
 export default {
   key: "monta-list-inbound-forecasts-by-product-sku",
   name: "List Inbound Forecasts by Product SKU",
   description: "List all inbound forecasts for a given product SKU across groups. Use this to check expected incoming stock for a SKU. [See the documentation](https://api-v6.monta.nl/index.html#tag/InboundForecast/paths/~1inboundforecast~1group~1byproductsku~1%7Bproductsku%7D/get)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monta/actions/list-inbounds/list-inbounds.mjs
+++ b/components/monta/actions/list-inbounds/list-inbounds.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import monta from "../../monta.app.mjs";
 
 export default {
   key: "monta-list-inbounds",
   name: "List Inbounds",
   description: "List inbound shipments expected at the warehouse. Use this to review incoming stock, paging forward with the Since ID cursor to walk through large result sets; relate to **List Inbound Forecast Groups** for grouped forecast data. [See the documentation](https://api-v6.monta.nl/index.html#tag/Inbounds/paths/~1inbounds/get)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monta/actions/list-order-batches/list-order-batches.mjs
+++ b/components/monta/actions/list-order-batches/list-order-batches.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import monta from "../../monta.app.mjs";
 
 export default {
   key: "monta-list-order-batches",
   name: "List Order Batches",
   description: "List the batch (lot) lines shipped for an order. Use this for batch traceability when you need to know which lots were used to fulfill an order. [See the documentation](https://api-v6.monta.nl/index.html#tag/Order/paths/~1order~1%7Bwebshoporderid%7D~1batches/get)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monta/actions/list-order-colli/list-order-colli.mjs
+++ b/components/monta/actions/list-order-colli/list-order-colli.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import monta from "../../monta.app.mjs";
 
 export default {
   key: "monta-list-order-colli",
   name: "List Order Colli",
   description: "List the colli (parcels) that make up an order. Use this to inspect the parcel and tracking breakdown for a shipment, for example after registering parcels with the **Add Order Colli** action. [See the documentation](https://api-v6.monta.nl/index.html#tag/Order/paths/~1order~1%7Bwebshoporderid%7D~1colli/get)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monta/actions/list-order-events-since-id/list-order-events-since-id.mjs
+++ b/components/monta/actions/list-order-events-since-id/list-order-events-since-id.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import monta from "../../monta.app.mjs";
 
 export default {
   key: "monta-list-order-events-since-id",
   name: "List Order Events Since ID",
   description: "List order change events created after the provided cursor ID, which is Monta's recommended method for reliable status-change polling. Use this for incremental syncing across all orders; see **List Order Events** for a single order's history or **List Updated Orders** for datetime-based bulk syncing. [See the documentation](https://api-v6.monta.nl/index.html#tag/OrderEvent/paths/~1orderevents~1since_id~1%7Bid%7D/get)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monta/actions/list-order-events/list-order-events.mjs
+++ b/components/monta/actions/list-order-events/list-order-events.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import monta from "../../monta.app.mjs";
 
 export default {
   key: "monta-list-order-events",
   name: "List Order Events",
   description: "List order events for an order. [See the documentation](https://api-v6.monta.nl/index.html#tag/Order/paths/~1order~1%7Bwebshoporderid%7D~1events/get)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monta/actions/list-order-id-options/list-order-id-options.mjs
+++ b/components/monta/actions/list-order-id-options/list-order-id-options.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import monta from "../../monta.app.mjs";
 
 export default {
   key: "monta-list-order-id-options",
   name: "List Order ID Options",
   description: "Retrieves available options for the Order ID field.",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monta/actions/list-order-returns/list-order-returns.mjs
+++ b/components/monta/actions/list-order-returns/list-order-returns.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import monta from "../../monta.app.mjs";
 
 export default {
   key: "monta-list-order-returns",
   name: "List Order Returns",
   description: "List the return records for an order. Use this to see all returns registered against an order. [See the documentation](https://api-v6.monta.nl/index.html#tag/Order/paths/~1order~1%7Bwebshoporderid%7D~1return/get)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monta/actions/list-product-stock-changes/list-product-stock-changes.mjs
+++ b/components/monta/actions/list-product-stock-changes/list-product-stock-changes.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import monta from "../../monta.app.mjs";
 
 export default {
@@ -6,8 +5,9 @@ export default {
   name: "List Product Stock Changes",
   description:
     "List products whose stock changed since a specified date and time. [See the documentation](https://api-v6.monta.nl/index.html#tag/Product/paths/~1product~1updated_since~1%7BupdatedSince%7D/get)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monta/actions/list-return-forecasts/list-return-forecasts.mjs
+++ b/components/monta/actions/list-return-forecasts/list-return-forecasts.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import monta from "../../monta.app.mjs";
 
 export default {
   key: "monta-list-return-forecasts",
   name: "List Return Forecasts",
   description: "List the expected (forecasted) returns for an order, as opposed to the actual return records from **List Order Returns**. Use this to anticipate inbound returns before they physically arrive. [See the documentation](https://api-v6.monta.nl/index.html#tag/Order/paths/~1order~1%7Bwebshoporderid%7D~1returnforecasts/get)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monta/actions/list-return-labels/list-return-labels.mjs
+++ b/components/monta/actions/list-return-labels/list-return-labels.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import monta from "../../monta.app.mjs";
 
 export default {
   key: "monta-list-return-labels",
   name: "List Return Labels",
   description: "List the return labels for an order (labels for inbound returns), as opposed to outbound shipping labels. Use this when handling a customer return that needs a prepaid inbound label; see **List Order Returns** for the associated return records. [See the documentation](https://api-v6.monta.nl/index.html#tag/Order/paths/~1order~1%7Bwebshoporderid%7D~1returnlabels/get)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monta/actions/list-shipping-labels/list-shipping-labels.mjs
+++ b/components/monta/actions/list-shipping-labels/list-shipping-labels.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import monta from "../../monta.app.mjs";
 
 export default {
   key: "monta-list-shipping-labels",
   name: "List Shipping Labels",
   description: "List the shipping labels of an order. Use this to retrieve the label file names, typically after generating labels with **Create Shipping Label**. [See the documentation](https://api-v6.monta.nl/index.html#tag/Order/paths/~1order~1%7Bwebshoporderid%7D~1shippinglabels/get)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monta/actions/list-updated-orders/list-updated-orders.mjs
+++ b/components/monta/actions/list-updated-orders/list-updated-orders.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import monta from "../../monta.app.mjs";
 import constants from "../../common/constants.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "monta-list-updated-orders",
   name: "List Updated Orders",
   description: "List orders whose status changed since a specified date and time, including orders deleted since then. Use this for reliable bulk order syncing; for cursor-based incremental polling of individual change events, use **List Order Events Since ID** instead. [See the documentation](https://api-v6.monta.nl/index.html#tag/Order/paths/~1order~1updated_since~1%7BupdatedSince%7D/get)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monta/actions/update-inbound-forecast-group/update-inbound-forecast-group.mjs
+++ b/components/monta/actions/update-inbound-forecast-group/update-inbound-forecast-group.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import monta from "../../monta.app.mjs";
 
 export default {
   key: "monta-update-inbound-forecast-group",
   name: "Update Inbound Forecast Group",
   description: "Update an existing inbound forecast group's details by its reference: its comment, warehouse, or expected delivery date. The forecasts, supplier, and stock-allocation flag are set at creation and cannot be changed here. [See the documentation](https://api-v6.monta.nl/index.html#tag/InboundForecast/paths/~1inboundforecast~1group~1%7Breference%7D/put)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monta/actions/update-order/update-order.mjs
+++ b/components/monta/actions/update-order/update-order.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import monta from "../../monta.app.mjs";
 
@@ -15,8 +14,9 @@ export default {
   key: "monta-update-order",
   name: "Update Order",
   description: "Change an existing order by its ID, for example to correct a customer's delivery address before it is picked. Call this directly with the order ID and the fields to change. When changing the delivery address, first read the current address with **Get Order**, then call this with the full address plus your change, since Monta replaces the entire address (it needs at least Street, City, and Country Code). Monta rejects address changes once picking has started (error 17) or after the order has shipped (error 19). [See the documentation](https://api-v6.monta.nl/index.html#tag/Order/paths/~1order~1%7Bwebshoporderid%7D/put)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monta/actions/validate-address/validate-address.mjs
+++ b/components/monta/actions/validate-address/validate-address.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import monta from "../../monta.app.mjs";
 
 export default {
   key: "monta-validate-address",
   name: "Validate Address",
   description: "Validate a delivery address before submitting it, for example ahead of **Create Order** or **Update Order**. Monta returns structured error codes when the address is invalid; a complete address also needs a recipient (Company or Last Name), Postal Code, and House Number. [See the documentation](https://api-v6.monta.nl/index.html#tag/Address/paths/~1address/post)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/monta/package.json
+++ b/components/monta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/monta",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Pipedream Monta Components",
   "main": "monta.app.mjs",
   "keywords": [

--- a/components/pagerduty/actions/acknowledge-incident/acknowledge-incident.mjs
+++ b/components/pagerduty/actions/acknowledge-incident/acknowledge-incident.mjs
@@ -6,7 +6,8 @@ export default {
   name: "Acknowledge Incident",
   description: "**Deprecated** — use **Update Incident** instead. Acknowledge an incident. [See the documentation](https://developer.pagerduty.com/api-reference/8a0e1aa2ec666-update-an-incident)",
   type: "action",
-  version: "0.0.4",
+  ai: "optimized",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/pagerduty/actions/add-note-to-incident/add-note-to-incident.mjs
+++ b/components/pagerduty/actions/add-note-to-incident/add-note-to-incident.mjs
@@ -7,8 +7,9 @@ export default {
     "Add a text note to an incident. Notes are visible in the incident timeline and useful for documenting investigation steps, resolution details, or handoff notes."
     + " Use **List Incidents** or **Get Incident** to find the incident ID."
     + " [See the documentation](https://developer.pagerduty.com/api-reference/9529ec706026d-create-a-note-on-an-incident)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/pagerduty/actions/create-incident/create-incident.mjs
+++ b/components/pagerduty/actions/create-incident/create-incident.mjs
@@ -9,8 +9,9 @@ export default {
     + " Use **List Priorities** to find priority IDs."
     + " Set `incidentKey` to a stable value derived from the alert source (e.g. a hash of title + service ID) to prevent duplicate incidents on retry — PagerDuty deduplicates open incidents with the same key on the same service."
     + " [See the documentation](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODE0MA-create-an-incident)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/pagerduty/actions/create-schedule-override/create-schedule-override.mjs
+++ b/components/pagerduty/actions/create-schedule-override/create-schedule-override.mjs
@@ -9,8 +9,9 @@ export default {
     + " Time params use ISO 8601 with explicit UTC offset, e.g. `2026-06-02T15:00:00-07:00`."
     + " Always include the UTC offset — do not assume UTC; using the wrong offset will place the override in the wrong time slot."
     + " [See the documentation](https://developer.pagerduty.com/api-reference/41d0a7c3c3a01-create-one-or-more-overrides)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/pagerduty/actions/create-service/create-service.mjs
+++ b/components/pagerduty/actions/create-service/create-service.mjs
@@ -9,8 +9,9 @@ export default {
     + " Use **List Escalation Policies** to find a valid escalation policy ID (required)."
     + " Set `autoResolveTimeout` to `0` to disable auto-resolve. Set `acknowledgementTimeout` to `0` to disable re-triggering after acknowledgment."
     + " [See the documentation](https://developer.pagerduty.com/api-reference/7062f2631b397-create-a-service)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/pagerduty/actions/find-oncall-user/find-oncall-user.mjs
+++ b/components/pagerduty/actions/find-oncall-user/find-oncall-user.mjs
@@ -5,7 +5,8 @@ export default {
   name: "Find Oncall User",
   description: "Find the user on call for a specific schedule. [See the documentation](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODE5MA-list-users-on-call)",
   type: "action",
-  version: "0.0.4",
+  ai: "optimized",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/pagerduty/actions/get-event-orchestration-service/get-event-orchestration-service.mjs
+++ b/components/pagerduty/actions/get-event-orchestration-service/get-event-orchestration-service.mjs
@@ -8,8 +8,9 @@ export default {
     + " Event orchestration routes incoming events to the right responders based on conditions."
     + " Use **List Services** to discover service IDs."
     + " [See the documentation](https://developer.pagerduty.com/api-reference/179537b835e2d-get-the-service-orchestration-for-a-service)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/pagerduty/actions/get-incident/get-incident.mjs
+++ b/components/pagerduty/actions/get-incident/get-incident.mjs
@@ -7,8 +7,9 @@ export default {
     "Get full details for a single incident by ID, including its current status, urgency, assignments, and `html_url`."
     + " Use **List Incidents** to find the incident ID."
     + " [See the documentation](https://developer.pagerduty.com/api-reference/005299ed43553-get-an-incident)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/pagerduty/actions/get-service-analytics/get-service-analytics.mjs
+++ b/components/pagerduty/actions/get-service-analytics/get-service-analytics.mjs
@@ -8,8 +8,9 @@ export default {
     + " Use **List Services** to discover service IDs."
     + " Time params use ISO 8601 with explicit UTC offset, e.g. `2026-06-02T15:00:00-07:00`."
     + " [See the documentation](https://developer.pagerduty.com/api-reference/694e92fe4f943-get-aggregated-service-data)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/pagerduty/actions/list-escalation-policies/list-escalation-policies.mjs
+++ b/components/pagerduty/actions/list-escalation-policies/list-escalation-policies.mjs
@@ -8,8 +8,9 @@ export default {
     + " Supports both exact name match (`name`) and substring search (`query`), plus team filtering."
     + " Use policy IDs with **Create Incident**, **Create Service**, and **Update Escalation Policy**."
     + " [See the documentation](https://developer.pagerduty.com/api-reference/51b21014a4f5a-list-escalation-policies)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/pagerduty/actions/list-incident-change-events/list-incident-change-events.mjs
+++ b/components/pagerduty/actions/list-incident-change-events/list-incident-change-events.mjs
@@ -8,8 +8,9 @@ export default {
     + " Change events show what changed in your systems around the time the incident was triggered."
     + " Use **List Incidents** or **Get Incident** to find the incident ID."
     + " [See the documentation](https://developer.pagerduty.com/api-reference/c7afb7de35741-list-related-change-events-for-an-incident)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/pagerduty/actions/list-incident-workflows/list-incident-workflows.mjs
+++ b/components/pagerduty/actions/list-incident-workflows/list-incident-workflows.mjs
@@ -8,8 +8,9 @@ export default {
     + " Use workflow IDs with **Start Incident Workflow** to run automation on an active incident."
     + " Requires Business+ plan — accounts without this plan will receive empty results or a 402 error."
     + " [See the documentation](https://developer.pagerduty.com/api-reference/d54514b5b003f-list-incident-workflows)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/pagerduty/actions/list-incidents/list-incidents.mjs
+++ b/components/pagerduty/actions/list-incidents/list-incidents.mjs
@@ -9,8 +9,9 @@ export default {
     + " Use **List Services** to discover service IDs and **List Teams** for team IDs."
     + " Time params use ISO 8601 with explicit UTC offset, e.g. `2026-06-02T15:00:00-07:00`."
     + " [See the documentation](https://developer.pagerduty.com/api-reference/9d0b4b12e36f9-list-incidents)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/pagerduty/actions/list-log-entries/list-log-entries.mjs
+++ b/components/pagerduty/actions/list-log-entries/list-log-entries.mjs
@@ -11,8 +11,9 @@ export default {
     + " Time params use ISO 8601 with explicit UTC offset, e.g. `2026-06-02T15:00:00-07:00`."
     + " Set `isOverview: true` to get only the most recent action per incident."
     + " [See the documentation](https://developer.pagerduty.com/api-reference/c661e065403b5-list-log-entries)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/pagerduty/actions/list-oncalls/list-oncalls.mjs
+++ b/components/pagerduty/actions/list-oncalls/list-oncalls.mjs
@@ -10,8 +10,9 @@ export default {
     + " Time params use ISO 8601 with explicit UTC offset, e.g. `2026-06-02T15:00:00-07:00`."
     + " Set `earliest: true` to get one on-call entry per unique (schedule, escalation policy, escalation level) combination."
     + " [See the documentation](https://developer.pagerduty.com/api-reference/3a6b910f11050-list-all-of-the-on-calls)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/pagerduty/actions/list-priorities/list-priorities.mjs
+++ b/components/pagerduty/actions/list-priorities/list-priorities.mjs
@@ -7,8 +7,9 @@ export default {
     "List the priority levels configured for this PagerDuty account."
     + " Returns priority IDs and names (e.g. P1, P2, critical) useful for **Create Incident** and **Update Incident**."
     + " [See the documentation](https://developer.pagerduty.com/api-reference/0fa9ad52bf2d2-list-priorities)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/pagerduty/actions/list-schedules/list-schedules.mjs
+++ b/components/pagerduty/actions/list-schedules/list-schedules.mjs
@@ -7,8 +7,9 @@ export default {
     "List on-call schedules in the PagerDuty account, optionally filtered by name."
     + " Returns schedule IDs and names useful for **List On-Calls** and **Create Schedule Override**."
     + " [See the documentation](https://developer.pagerduty.com/api-reference/846ecf84402bb-list-schedules)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/pagerduty/actions/list-services/list-services.mjs
+++ b/components/pagerduty/actions/list-services/list-services.mjs
@@ -8,8 +8,9 @@ export default {
     + " Returns service IDs, names, status, and `html_url`."
     + " Use **List Teams** to discover team IDs for filtering."
     + " [See the documentation](https://developer.pagerduty.com/api-reference/e960cca205c0f-list-services)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/pagerduty/actions/list-status-page-posts/list-status-page-posts.mjs
+++ b/components/pagerduty/actions/list-status-page-posts/list-status-page-posts.mjs
@@ -9,8 +9,9 @@ export default {
     + " Set `activeOnly: true` to filter to currently active posts (client-side filter)."
     + " Requires Business+ plan — accounts without this plan will receive empty results or a 402 error."
     + " [See the documentation](https://developer.pagerduty.com/api-reference/a2b54c12938bd-list-posts-for-a-status-page)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/pagerduty/actions/list-status-pages/list-status-pages.mjs
+++ b/components/pagerduty/actions/list-status-pages/list-status-pages.mjs
@@ -8,8 +8,9 @@ export default {
     + " Use status page IDs with **List Status Page Posts** to retrieve posts on a specific page."
     + " Requires Business+ plan — accounts without this plan will receive empty results or a 402 error."
     + " [See the documentation](https://developer.pagerduty.com/api-reference/cc01037564658-list-status-pages)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/pagerduty/actions/list-teams/list-teams.mjs
+++ b/components/pagerduty/actions/list-teams/list-teams.mjs
@@ -7,8 +7,9 @@ export default {
     "List teams in the PagerDuty account, optionally filtered by name."
     + " Returns team IDs and names useful for filtering incidents, users, and services."
     + " [See the documentation](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODIyMw-list-teams)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/pagerduty/actions/list-users/list-users.mjs
+++ b/components/pagerduty/actions/list-users/list-users.mjs
@@ -8,8 +8,9 @@ export default {
     + " Returns user IDs, names, emails, and roles."
     + " Optionally filter by team membership using team IDs from **List Teams**."
     + " [See the documentation](https://developer.pagerduty.com/api-reference/c96e889522dd6-list-users)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/pagerduty/actions/resolve-incident/resolve-incident.mjs
+++ b/components/pagerduty/actions/resolve-incident/resolve-incident.mjs
@@ -6,7 +6,8 @@ export default {
   name: "Resolve Incident",
   description: "**Deprecated** — use **Update Incident** instead. Resolve an incident. [See the documentation](https://developer.pagerduty.com/api-reference/8a0e1aa2ec666-update-an-incident)",
   type: "action",
-  version: "0.0.4",
+  ai: "optimized",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/pagerduty/actions/start-incident-workflow/start-incident-workflow.mjs
+++ b/components/pagerduty/actions/start-incident-workflow/start-incident-workflow.mjs
@@ -9,8 +9,9 @@ export default {
     + " Use **List Incidents** or **Get Incident** to find the incident ID."
     + " Requires Business+ plan — accounts without this plan will receive a 402 error."
     + " [See the documentation](https://developer.pagerduty.com/api-reference/02bb39b038412-start-an-incident-workflow-instance)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/pagerduty/actions/trigger-incident/trigger-incident.mjs
+++ b/components/pagerduty/actions/trigger-incident/trigger-incident.mjs
@@ -13,7 +13,8 @@ export default {
   name: "Trigger Incident",
   description: "**Deprecated** — use **Create Incident** instead. Trigger an incident. [See the documentation](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODE0MA-create-an-incident)",
   type: "action",
-  version: "0.0.5",
+  ai: "optimized",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/pagerduty/actions/update-escalation-policy/update-escalation-policy.mjs
+++ b/components/pagerduty/actions/update-escalation-policy/update-escalation-policy.mjs
@@ -10,8 +10,9 @@ export default {
     + " Use **List Escalation Policies** to find the policy ID."
     + " Each escalation rule targets one or more users or schedules: provide `targets` as an array of objects with `id` and `type` (`user_reference` or `schedule_reference`)."
     + " [See the documentation](https://developer.pagerduty.com/api-reference/f9b1e15e70a0c-update-an-escalation-policy)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/pagerduty/actions/update-incident/update-incident.mjs
+++ b/components/pagerduty/actions/update-incident/update-incident.mjs
@@ -9,8 +9,9 @@ export default {
     + " To acknowledge: set `status` to `acknowledged`. To resolve: set `status` to `resolved`."
     + " Use **List Users** to find user IDs for assignments and **List Priorities** for priority IDs."
     + " [See the documentation](https://developer.pagerduty.com/api-reference/8a0e1aa2ec666-update-an-incident)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/pagerduty/package.json
+++ b/components/pagerduty/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/pagerduty",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Pipedream Pagerduty Components",
   "main": "pagerduty.app.mjs",
   "keywords": [

--- a/components/wealthbox/actions/add-member-to-household/add-member-to-household.mjs
+++ b/components/wealthbox/actions/add-member-to-household/add-member-to-household.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import wealthbox from "../../wealthbox.app.mjs";
 import { HOUSEHOLD_MEMBER_TITLES } from "../../common/constants.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "wealthbox-add-member-to-household",
   name: "Add Member To Household",
   description: "Add an existing contact as a member of an existing household via POST /households/{household_id}/members. Run **List Households** to find household ids and **List Contact Options** to find contact ids. Example: add contact `67890` as `Spouse` to household `12345`; returns the household object including `id` and a `members` array, each member with `id`, `first_name`, `last_name`, `title`, and `type`. [See the documentation](https://dev.wealthbox.com/#household-members-create-post)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/wealthbox/actions/create-contact/create-contact.mjs
+++ b/components/wealthbox/actions/create-contact/create-contact.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import wealthbox from "../../wealthbox.app.mjs";
 import { CONTACT_TYPES } from "../../common/constants.mjs";
@@ -9,13 +8,14 @@ export default {
   key: "wealthbox-create-contact",
   name: "Create Contact",
   description: "Create a new contact in Wealthbox. For `Person` type, provide First Name and Last Name (both required). For `Household`, `Organization`, or `Trust` types, the Name field is used as the entity name (the API accepts a top-level `name` field for non-Person types). Example: create a `Person` contact with first name `Jane`, last name `Smith`, email `jane@acme.com`; returns the contact object including `id`, `first_name`, `last_name`, `email_addresses`, `type`, and `contact_type`. [See the documentation](https://dev.wealthbox.com/#contacts-create-a-new-contact-post)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     wealthbox,
     firstName: {

--- a/components/wealthbox/actions/create-event/create-event.mjs
+++ b/components/wealthbox/actions/create-event/create-event.mjs
@@ -1,17 +1,17 @@
-// x-pd-ai: optimized
 import wealthbox from "../../wealthbox.app.mjs";
 
 export default {
   key: "wealthbox-create-event",
   name: "Create Event",
   description: "Create a new calendar event in Wealthbox. Supply a title, start/end timestamps (`YYYY-MM-DD HH:MM AM/PM ±HHMM`), and an optional state. Valid `state` values are `unconfirmed`, `confirmed`, `tentative`, `completed`, and `cancelled`. Example: create an event titled `Q4 Portfolio Review` starting `2026-12-15 10:00 AM -0500` ending `2026-12-15 11:00 AM -0500` with state `confirmed`; returns the event object including `id`, `title`, `starts_at`, `ends_at`, and `state`. [See the documentation](https://dev.wealthbox.com/#events-retrieve-all-events-post)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     wealthbox,
     title: {

--- a/components/wealthbox/actions/create-note/create-note.mjs
+++ b/components/wealthbox/actions/create-note/create-note.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import wealthbox from "../../wealthbox.app.mjs";
 import {
   DEFAULT_LINKED_TO_TYPE,
@@ -9,8 +8,9 @@ export default {
   key: "wealthbox-create-note",
   name: "Create Note",
   description: "Create a note linked to a contact via POST /notes. Run **List Contact Options** to find the id of the contact to link the note to. Example: create a note with body `Called client to discuss Q3 portfolio review` linked to contact id `67890`; returns the note object including `id`, `content`, `linked_to`, `visible_to`, and `created_at`. [See the documentation](https://dev.wealthbox.com/#notes-retrieve-all-notes-post)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/wealthbox/actions/create-opportunity/create-opportunity.mjs
+++ b/components/wealthbox/actions/create-opportunity/create-opportunity.mjs
@@ -1,17 +1,17 @@
-// x-pd-ai: optimized
 import wealthbox from "../../wealthbox.app.mjs";
 
 export default {
   key: "wealthbox-create-opportunity",
   name: "Create Opportunity",
   description: "Create a new opportunity in Wealthbox. Supply an opportunity name, target close date, probability (integer 0–100), amount type and value, and stage ID. Use **List Stage Options** to find valid stage IDs and **List Contact Options** to find the contact ID to link. Example: create opportunity `Q4 AUM Expansion` with probability `75`, amount `50000` of type `AUM`, target close `2026-12-31 10:00 AM -0500`; returns the opportunity object including `id`, `name`, `stage`, `probability`, `target_close`, and `amounts`. [See the documentation](https://dev.wealthbox.com/#opportunities-retrieve-all-opportunities-post)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     wealthbox,
     name: {

--- a/components/wealthbox/actions/create-task/create-task.mjs
+++ b/components/wealthbox/actions/create-task/create-task.mjs
@@ -1,17 +1,17 @@
-// x-pd-ai: optimized
 import wealthbox from "../../wealthbox.app.mjs";
 
 export default {
   key: "wealthbox-create-task",
   name: "Create Task",
   description: "Create a new task in Wealthbox. Supply a task name, due date (`YYYY-MM-DD HH:MM AM/PM ±HHMM`), and optional category and priority. Use **List Category Options** to find valid category IDs. Example: create a task named `Send Q4 Report` due `2026-12-31 5:00 PM -0500` with priority `High`; returns the task object including `id`, `name`, `due_date`, `category`, and `priority`. [See the documentation](https://dev.wealthbox.com/#tasks-retrieve-all-tasks-post)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     wealthbox,
     name: {

--- a/components/wealthbox/actions/find-contact/find-contact.mjs
+++ b/components/wealthbox/actions/find-contact/find-contact.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import wealthbox from "../../wealthbox.app.mjs";
 
@@ -9,8 +8,9 @@ export default {
   key: "wealthbox-find-contact",
   name: "Find Contact",
   description: "Search Wealthbox contacts by name, email, and/or phone. Automatically paginates through all result pages (capped at 1,000 contacts total). At least one search parameter is required. Example: search `name='Jane Smith'`; returns contact objects each including `id`, `first_name`, `last_name`, `email_addresses`, `phone_numbers`, `type`, and `contact_type`. Supply the optional Fields parameter (e.g. `[\"id\",\"first_name\",\"last_name\"]`) to receive a trimmed response. [See the documentation](https://dev.wealthbox.com/#contacts-retrieve-all-contacts-get)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/wealthbox/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/wealthbox/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import wealthbox from "../../wealthbox.app.mjs";
 
 export default {
   key: "wealthbox-list-contact-id-options",
   name: "List Contact Options",
   description: "List Wealthbox contacts (paginated, 25 per page) so agents and users can discover valid contact IDs to supply to other actions. Use this before any action that requires a Contact ID — for example **Create Opportunity**, **Create Note**, **Add Member To Household**, or **Start Workflow**. Returns objects with `label` (full name) and `value` (numeric contact ID, e.g. `67890`). Increment Page to load the next batch. [See the documentation](https://dev.wealthbox.com/#contacts-retrieve-all-contacts-get)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/wealthbox/actions/list-contact-type-options/list-contact-type-options.mjs
+++ b/components/wealthbox/actions/list-contact-type-options/list-contact-type-options.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import wealthbox from "../../wealthbox.app.mjs";
 
 export default {
   key: "wealthbox-list-contact-type-options",
   name: "List Type Options",
   description: "List the user-defined contact type categories configured in Wealthbox (e.g. `Client`, `Prospect`, `Vendor`) so agents and users can discover valid values to pass to the Contact Type prop in **Create Contact**. Returns an array of type name strings. [See the documentation](https://dev.wealthbox.com/#customizable-categories-list-all-members-of-a-customizable-category-get)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/wealthbox/actions/list-households/list-households.mjs
+++ b/components/wealthbox/actions/list-households/list-households.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import wealthbox from "../../wealthbox.app.mjs";
 import {
   DEFAULT_LIST_LIMIT,
@@ -12,8 +11,9 @@ export default {
   key: "wealthbox-list-households",
   name: "List Households",
   description: "Companion list action for the free-form Household id prop. Returns household-type contacts via GET /contacts so agents/users can discover valid household ids for **Add Member To Household**. Paginates automatically up to the requested Limit. Example: returns household objects each including `id`, `name`, `type`, `email_addresses`, and `phone_numbers`. Supply the optional Fields parameter (e.g. `[\"id\",\"name\"]`) to receive a trimmed response. [See the documentation](https://dev.wealthbox.com/#contacts-retrieve-all-contacts-get)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/wealthbox/actions/list-opportunity-stage-options/list-opportunity-stage-options.mjs
+++ b/components/wealthbox/actions/list-opportunity-stage-options/list-opportunity-stage-options.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import wealthbox from "../../wealthbox.app.mjs";
 
 export default {
   key: "wealthbox-list-opportunity-stage-options",
   name: "List Stage Options",
   description: "List the opportunity stages configured in Wealthbox (e.g. `Prospect`, `Proposal`, `Closed Won`) so agents and users can discover valid stage IDs to pass to the Stage prop in **Create Opportunity**. Returns objects with `label` (stage name) and `value` (numeric stage ID). [See the documentation](https://dev.wealthbox.com/#customizable-categories-list-all-members-of-a-customizable-category-get)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/wealthbox/actions/list-task-category-options/list-task-category-options.mjs
+++ b/components/wealthbox/actions/list-task-category-options/list-task-category-options.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import wealthbox from "../../wealthbox.app.mjs";
 
 export default {
   key: "wealthbox-list-task-category-options",
   name: "List Category Options",
   description: "List the task categories configured in Wealthbox (e.g. `Follow Up`, `Meeting`, `Review`) so agents and users can discover valid category IDs to pass to the Category prop in **Create Task**. Returns objects with `label` (category name) and `value` (numeric category ID). [See the documentation](https://dev.wealthbox.com/#customizable-categories-list-all-members-of-a-customizable-category-get)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/wealthbox/actions/list-workflow-templates/list-workflow-templates.mjs
+++ b/components/wealthbox/actions/list-workflow-templates/list-workflow-templates.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import wealthbox from "../../wealthbox.app.mjs";
 import {
   DEFAULT_LIST_LIMIT,
@@ -12,8 +11,9 @@ export default {
   key: "wealthbox-list-workflow-templates",
   name: "List Workflow Templates",
   description: "Companion list action for the free-form Workflow id prop. Returns available workflow templates via GET /workflow_templates so agents/users can discover valid template ids for **Start Workflow**. Paginates up to the requested Limit. Example: returns template objects each including `id`, `name`, and workflow step configuration. Supply the optional Fields parameter (e.g. `[\"id\",\"name\"]`) to receive a trimmed response. [See the documentation](https://dev.wealthbox.com/#workflow-templates-retrieve-all-workflow-templates-get)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/wealthbox/actions/start-workflow/start-workflow.mjs
+++ b/components/wealthbox/actions/start-workflow/start-workflow.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import wealthbox from "../../wealthbox.app.mjs";
 import { DEFAULT_LINKED_TO_TYPE } from "../../common/constants.mjs";
@@ -7,8 +6,9 @@ export default {
   key: "wealthbox-start-workflow",
   name: "Start Workflow",
   description: "Enroll a contact in a workflow template via POST /workflows. Run **List Workflow Templates** to find the template id and **List Contact Options** to find the contact id to enroll. Example: enroll contact `67890` in template `999` starting `2026-09-01T09:00:00Z`; returns the workflow enrollment object including `id`, `workflow_template`, `linked_to`, and `starts_at`. [See the documentation](https://dev.wealthbox.com/#workflows-retrieve-all-workflows-post)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/wealthbox/package.json
+++ b/components/wealthbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/wealthbox",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Pipedream Wealthbox Components",
   "main": "wealthbox.app.mjs",
   "keywords": [


### PR DESCRIPTION
DJ-4272 backfill, **batch 2 of 5** (continues canary #21870).

Sets the top-level `ai: "optimized"` field on **200 AI-optimized actions across 7 apps**, replaces any legacy `// x-pd-ai: optimized` marker comment with the real field, and patch-bumps each touched component + app `package.json` (required by `check_version`).

Batched at ≤200 components per the deployment publish cap. The 5 batches cover **disjoint apps**, so they can merge independently in any order.

Apps: clockify,github google_drive,hubspot monta,pagerduty wealthbox