### PR TITLE
feat(components): backfill AI-optimized `ai` field (batch 4/5)

### DIFF
--- a/components/amplitude/actions/create-cohort/create-cohort.mjs
+++ b/components/amplitude/actions/create-cohort/create-cohort.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import app from "../../amplitude.app.mjs";
 import { COHORT_ID_TYPES } from "../../common/constants.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "amplitude-create-cohort",
   name: "Create Cohort",
   description: "Create a static cohort in Amplitude from an explicit list of user or Amplitude IDs via `POST /api/3/cohorts/upload` (the only REST-documented cohort creation endpoint; behavioral/dynamic cohorts cannot be created via REST). Use **List Cohorts** to find an existing cohort ID if updating. Example: call with `cohortName=\"Power Users Q3\"`, `appId=849238`, `idType=\"BY_USER_ID\"`, `ids=[\"user@example.com\"]`, `owner=\"admin@example.com\"` -> returns `{cohortId: \"abc123\"}`. [See the documentation](https://amplitude.com/docs/apis/analytics/behavioral-cohorts#upload-cohort).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: true,

--- a/components/amplitude/actions/download-cohort-file/download-cohort-file.mjs
+++ b/components/amplitude/actions/download-cohort-file/download-cohort-file.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import app from "../../amplitude.app.mjs";
 import { COHORT_DOWNLOAD_MAX_MEMBERS } from "../../common/constants.mjs";
 import { parseCohortDownload } from "../../common/utils.mjs";
@@ -7,8 +6,9 @@ export default {
   key: "amplitude-download-cohort-file",
   name: "Download Cohort File",
   description: "Download a completed cohort export's member list (step 3 of 3: request -> status -> download). Call **Request Cohort Download** then **Get Cohort Download Status** first, and only call this once status is `JOB COMPLETED` — calling it earlier will fail. Returns one record per member (`amplitude_id`/`user_id`, plus any requested user properties) — not the cohort's own metadata (name, size, definition); use **List Cohorts** for that. Example: call with `requestId=\"req_456\"` -> returns `{requestId: \"req_456\", memberCount: 4200, returnedCount: 4200, truncated: false, members: [{amplitude_id: \"123456789\", user_id: \"user@example.com\"}, ...]}`. [See the documentation](https://amplitude.com/docs/apis/analytics/behavioral-cohorts#download-cohort).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/amplitude/actions/get-cohort-download-status/get-cohort-download-status.mjs
+++ b/components/amplitude/actions/get-cohort-download-status/get-cohort-download-status.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import app from "../../amplitude.app.mjs";
 
 export default {
   key: "amplitude-get-cohort-download-status",
   name: "Get Cohort Download Status",
   description: "Check whether a cohort download job has finished (step 2 of 3: request -> status -> download). Call **Request Cohort Download** first to get a `requestId`. This action polls internally for up to ~35 seconds before returning, since Amplitude's export jobs commonly take 30-60+ seconds regardless of cohort size. If the returned `async_status` is still `JOB INPROGRESS`, call this action again with the same request ID (it may take a few calls) — do not call **Download Cohort File** until `async_status` is `JOB COMPLETED`. Example: call with `requestId=\"req_456\"` -> returns `{request_id: \"req_456\", cohort_id: \"abc123\", async_status: \"JOB COMPLETED\"}`. [See the documentation](https://amplitude.com/docs/apis/analytics/behavioral-cohorts#get-request-status).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/amplitude/actions/get-event-segmentation/get-event-segmentation.mjs
+++ b/components/amplitude/actions/get-event-segmentation/get-event-segmentation.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import app from "../../amplitude.app.mjs";
 import {
@@ -10,8 +9,9 @@ export default {
   key: "amplitude-get-event-segmentation",
   name: "Get Event Segmentation",
   description: "Query event segmentation data (counts, uniques, and other metrics) for one or more events over a date range from the Amplitude Dashboard REST API. Use this to analyze how an event trends over time, optionally broken down by user properties. Example: call with `event={\"event_type\":\"Purchase\"}`, `startDate=\"20240706\"`, `endDate=\"20240805\"`, `metric=\"uniques\"` -> returns `{data: {xValues: [\"2024-07-06\", ...], series: [[42, 51, ...]]}}` (one value per day per requested series). [See the documentation](https://amplitude.com/docs/apis/analytics/dashboard-rest#event-segmentation).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/amplitude/actions/get-funnel-analysis/get-funnel-analysis.mjs
+++ b/components/amplitude/actions/get-funnel-analysis/get-funnel-analysis.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import app from "../../amplitude.app.mjs";
 import {
   FUNNEL_MODES,
@@ -10,8 +9,9 @@ export default {
   key: "amplitude-get-funnel-analysis",
   name: "Get Funnel Analysis",
   description: "Compute conversion rates across an ordered (or unordered/sequential) set of funnel steps over a date range from the Amplitude Dashboard REST API. Provide one event definition per funnel step. Example: call with `events=[\"{\\\"event_type\\\":\\\"Sign Up\\\"}\",\"{\\\"event_type\\\":\\\"Purchase\\\"}\"]`, `startDate=\"20240706\"`, `endDate=\"20240805\"` -> returns `{data: [{stepByStep: [...], cumulative: [...], eventCount: 4200}, ...]}` (one entry per step). [See the documentation](https://amplitude.com/docs/apis/analytics/dashboard-rest#funnel-analysis).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/amplitude/actions/get-retention-analysis/get-retention-analysis.mjs
+++ b/components/amplitude/actions/get-retention-analysis/get-retention-analysis.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import app from "../../amplitude.app.mjs";
 import { RETENTION_MODES } from "../../common/constants.mjs";
@@ -7,8 +6,9 @@ export default {
   key: "amplitude-get-retention-analysis",
   name: "Get Retention Analysis",
   description: "Compute retention (return rate) between a start event and a return event over a date range from the Amplitude Dashboard REST API. Example: call with `startEvent={\"event_type\":\"_new\"}`, `returnEvent={\"event_type\":\"_active\"}`, `startDate=\"20240706\"`, `endDate=\"20240805\"` -> returns `{data: {series: [[...retention counts per interval...]], seriesLabels: [...]}}`. [See the documentation](https://amplitude.com/docs/apis/analytics/dashboard-rest#retention-analysis).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/amplitude/actions/get-user-activity/get-user-activity.mjs
+++ b/components/amplitude/actions/get-user-activity/get-user-activity.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import app from "../../amplitude.app.mjs";
 import {
   USER_ACTIVITY_DIRECTIONS,
@@ -13,8 +12,9 @@ export default {
   key: "amplitude-get-user-activity",
   name: "Get User Activity",
   description: `Fetch the event stream for a single user by their numeric Amplitude ID from the Amplitude Dashboard REST API. Each returned event defaults to just ${USER_ACTIVITY_ALWAYS_FIELDS.join(" and ")}; pass \`fields\` to also get e.g. \`event_properties\`, \`user_properties\`, \`uuid\`, \`session_id\`, \`amplitude_id\`, \`device_id\` (event objects can carry many properties, so these stay opt-in). Amplitude's API caps each request at ${LIMIT_MAX} events with no cursor; this tool pages \`offset\` forward automatically to collect up to \`limit\` events (set it above ${LIMIT_MAX}, up to ${USER_ACTIVITY_MAX_RESULTS}, to fetch more than one page). Use **Search Users** first to resolve the Amplitude ID. Example: call with \`user=12345678\`, \`limit=50\` -> returns \`{events: [{event_type: "Purchase", event_time: "2024-08-05 14:22:10"}, ...], userData: {...}, truncated: false}\` (\`truncated: true\` means more events likely exist beyond what was returned — raise \`limit\`/\`offset\` to fetch further). [See the documentation](https://amplitude.com/docs/apis/analytics/dashboard-rest#user-activity).`,
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/amplitude/actions/list-cohorts/list-cohorts.mjs
+++ b/components/amplitude/actions/list-cohorts/list-cohorts.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import app from "../../amplitude.app.mjs";
 import { COHORT_DEFAULT_FIELDS } from "../../common/constants.mjs";
 import { pluck } from "../../common/utils.mjs";
@@ -7,8 +6,9 @@ export default {
   key: "amplitude-list-cohorts",
   name: "List Cohorts",
   description: `List all behavioral cohorts in the Amplitude project. Returns a \`cohorts\` array; each entry defaults to ${COHORT_DEFAULT_FIELDS.join(", ")}. Pass \`fields\` to get more, e.g. \`description\`, \`published\`, \`archived\`, or the large \`definition\` (the cohort's filter logic) / \`owners\`/\`viewers\` (email arrays). Use this to discover valid cohort IDs for **Request Cohort Download** (step 1 of 3, followed by **Get Cohort Download Status** and **Download Cohort File**, to fetch a cohort's member list). Example: call with no parameters -> returns \`{cohorts: [{id: "abc123", name: "Power Users Q3", size: 4200, lastMod: 1722873600000, appId: 849238}, ...]}\`. [See the documentation](https://amplitude.com/docs/apis/analytics/behavioral-cohorts#get-all-cohorts).`,
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/amplitude/actions/request-cohort-download/request-cohort-download.mjs
+++ b/components/amplitude/actions/request-cohort-download/request-cohort-download.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import app from "../../amplitude.app.mjs";
 
 export default {
   key: "amplitude-request-cohort-download",
   name: "Request Cohort Download",
   description: "Start a behavioral cohort download job (step 1 of 3: request -> status -> download, per Amplitude's Behavioral Cohorts Download API). Returns a `request_id` — pass it to **Get Cohort Download Status** to poll until the job completes, then to **Download Cohort File** to fetch the member list. Use **List Cohorts** first to discover valid cohort IDs. Example: call with `cohortId=\"abc123\"` -> returns `{request_id: \"req_456\", cohort_id: \"abc123\"}`. [See the documentation](https://amplitude.com/docs/apis/analytics/behavioral-cohorts#get-one-cohort).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/amplitude/actions/search-users/search-users.mjs
+++ b/components/amplitude/actions/search-users/search-users.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import app from "../../amplitude.app.mjs";
 
 export default {
   key: "amplitude-search-users",
   name: "Search Users",
   description: "Look up Amplitude users by Amplitude ID, Device ID, User ID, or a User ID prefix. Use this before **Get User Activity** to resolve a user's `amplitude_id`. Example: call with `user=\"user@example.com\"` -> returns `{matches: [{amplitude_id: 12345678, user_id: \"user@example.com\"}], type: \"user_id\"}`. [See the documentation](https://amplitude.com/docs/apis/analytics/dashboard-rest#user-search).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/amplitude/actions/send-event-data/send-event-data.mjs
+++ b/components/amplitude/actions/send-event-data/send-event-data.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import app from "../../amplitude.app.mjs";
 
@@ -6,13 +5,14 @@ export default {
   key: "amplitude-send-event-data",
   name: "Send Event Data",
   description: "Record a single analytics event for a user or device via Amplitude's HTTP V2 API. Use this to send product-usage events (page views, feature use, purchases) as they happen, rather than the read-only Dashboard REST actions in this app (e.g. **Get Event Segmentation**, **Get Retention Analysis**), which only read existing data back. Identify the user with `userId` and/or `deviceId` — Amplitude requires at least one. Example: call with `userId=\"user_123\"`, `eventType=\"Purchase\"`, `eventProperties={\"item\":\"Pro Plan\",\"price\":29.99}` -> returns `{code: 200, events_ingested: 1, payload_size_bytes: 148, server_upload_time: 1722873600000}`. [See the documentation](https://www.docs.developers.amplitude.com/analytics/apis/http-v2-api/#keys-for-the-event-argument)",
-  version: "0.1.0",
+  version: "0.1.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     userId: {

--- a/components/amplitude/package.json
+++ b/components/amplitude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/amplitude",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Amplitude Components",
   "main": "amplitude.app.mjs",
   "keywords": [

--- a/components/apollo_io_oauth/actions/add-contacts-to-sequence/add-contacts-to-sequence.mjs
+++ b/components/apollo_io_oauth/actions/add-contacts-to-sequence/add-contacts-to-sequence.mjs
@@ -15,8 +15,9 @@ export default {
     + " enroll contacts already active in other sequences."
     + " [See the documentation](https://docs.apollo.io/reference"
     + "/add-contacts-to-sequence)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/apollo_io_oauth/actions/create-or-update-account/create-or-update-account.mjs
+++ b/components/apollo_io_oauth/actions/create-or-update-account/create-or-update-account.mjs
@@ -14,8 +14,9 @@ export default {
     + " discover valid stage IDs."
     + " [See the documentation](https://docs.apollo.io/reference"
     + "/create-an-account)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/apollo_io_oauth/actions/create-or-update-contact/create-or-update-contact.mjs
+++ b/components/apollo_io_oauth/actions/create-or-update-contact/create-or-update-contact.mjs
@@ -16,8 +16,9 @@ export default {
     + " **Search Accounts** to find the account ID."
     + " [See the documentation](https://docs.apollo.io/reference"
     + "/create-a-contact)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/apollo_io_oauth/actions/create-or-update-opportunity/create-or-update-opportunity.mjs
+++ b/components/apollo_io_oauth/actions/create-or-update-opportunity/create-or-update-opportunity.mjs
@@ -17,8 +17,9 @@ export default {
     + " Use **Get Current User** to find owner IDs."
     + " [See the documentation](https://docs.apollo.io/reference"
     + "/create-opportunity)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/apollo_io_oauth/actions/enrich-person/enrich-person.mjs
+++ b/components/apollo_io_oauth/actions/enrich-person/enrich-person.mjs
@@ -18,8 +18,9 @@ export default {
     + " asynchronously."
     + " [See the documentation](https://docs.apollo.io/reference"
     + "/people-enrichment)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/apollo_io_oauth/actions/get-current-user/get-current-user.mjs
+++ b/components/apollo_io_oauth/actions/get-current-user/get-current-user.mjs
@@ -11,8 +11,9 @@ export default {
     + " **Search Accounts**."
     + " [See the documentation](https://docs.apollo.io/reference"
     + "/get-authenticated-user)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/apollo_io_oauth/actions/get-opportunity/get-opportunity.mjs
+++ b/components/apollo_io_oauth/actions/get-opportunity/get-opportunity.mjs
@@ -11,8 +11,9 @@ export default {
     + " retrieval."
     + " [See the documentation](https://docs.apollo.io/reference"
     + "/get-opportunity)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/apollo_io_oauth/actions/list-metadata/list-metadata.mjs
+++ b/components/apollo_io_oauth/actions/list-metadata/list-metadata.mjs
@@ -13,8 +13,9 @@ export default {
     + " for **Create or Update Opportunity**."
     + " [See the documentation](https://docs.apollo.io/reference"
     + "/get-contact-stages)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/apollo_io_oauth/actions/search-accounts/search-accounts.mjs
+++ b/components/apollo_io_oauth/actions/search-accounts/search-accounts.mjs
@@ -13,8 +13,9 @@ export default {
     + " contacts or opportunities."
     + " [See the documentation](https://docs.apollo.io/reference"
     + "/search-for-accounts)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/apollo_io_oauth/actions/search-contacts/search-contacts.mjs
+++ b/components/apollo_io_oauth/actions/search-contacts/search-contacts.mjs
@@ -15,8 +15,9 @@ export default {
     + " company, and email."
     + " [See the documentation](https://docs.apollo.io/reference"
     + "/search-for-contacts)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/apollo_io_oauth/package.json
+++ b/components/apollo_io_oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/apollo_io_oauth",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Apollo.io (OAuth) Components",
   "main": "apollo_io_oauth.app.mjs",
   "keywords": [

--- a/components/arlo/actions/create-event/create-event.mjs
+++ b/components/arlo/actions/create-event/create-event.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import arlo from "../../arlo.app.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "arlo-create-event",
   name: "Create Event",
   description: "Create a new scheduled Arlo Event by submitting an event import request. Provide the parent template `Code` (not its numeric ID) and one or more sessions. The Arlo API processes this asynchronously and returns an `AsyncTaskID`; the created event starts in `Draft` status. Run **List Event Templates** to find the template `Code`. Example: call with `templateCode: \"SP1\"`, `sessions: '[{\"Name\":\"Day 1\",\"StartDateTime\":\"2026-09-15T09:00:00+12:00\",\"EndDateTime\":\"2026-09-15T17:00:00+12:00\"}]'` to schedule one session under that template. [See the documentation](https://developer.arlo.co/doc/api/2012-02-01/auth/resources/eventimportrequests#submitting).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/arlo/actions/create-presenter/create-presenter.mjs
+++ b/components/arlo/actions/create-presenter/create-presenter.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import arlo from "../../arlo.app.mjs";
 
 export default {
   key: "arlo-create-presenter",
   name: "Create Presenter",
   description: "Create a new Arlo contact record to be used as a presenter. FirstName, LastName, and Email are required. Returns the created contact including its ID. Example: call with `firstName: \"Kevin\"`, `lastName: \"Malone\"`, `email: \"kevin.malone@example.com\"` to create a new active contact and get back its `ContactID`. [See the documentation](https://developer.arlo.co/doc/api/2012-02-01/auth/resources/contacts#collection-httppost).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/arlo/actions/get-event/get-event.mjs
+++ b/components/arlo/actions/get-event/get-event.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import arlo from "../../arlo.app.mjs";
 
 export default {
   key: "arlo-get-event",
   name: "Get Event",
   description: "Retrieve the full detail for a single Arlo Event by its ID. Run **List Events** first to find a valid `eventId`. Example: call with `eventId: \"4\"` to get that event's full `Name`, `Code`, `StartDateTime`, `FinishDateTime`, `Status`, and venue/presenter links. [See the documentation](https://developer.arlo.co/doc/api/2012-02-01/auth/resources/events#instance-httpget).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/arlo/actions/get-registration/get-registration.mjs
+++ b/components/arlo/actions/get-registration/get-registration.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import arlo from "../../arlo.app.mjs";
 
 export default {
   key: "arlo-get-registration",
   name: "Get Registration",
   description: "Retrieve full registration plus attendee/contact detail for a single registration by its ID. Run **List Registrations** first to find a valid `registrationId`. Example: call with `registrationId: \"3\"` to get that registration's `Status`, `CreatedDateTime`, and attendee `Contact` (name, email). [See the documentation](https://developer.arlo.co/doc/api/2012-02-01/auth/resources/registrations#instance-httpget).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/arlo/actions/list-event-templates/list-event-templates.mjs
+++ b/components/arlo/actions/list-event-templates/list-event-templates.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import arlo from "../../arlo.app.mjs";
 import {
   DEFAULT_LIMIT,
@@ -9,8 +8,9 @@ export default {
   key: "arlo-list-event-templates",
   name: "List Event Templates",
   description: "List Arlo EventTemplate (course) records. Use this first to discover the template `Code` and `TemplateID` values needed by **Create Event** and **List Events**. Optionally filter by status. Results are paged (see `limit`/`skip`); if the page comes back full, call again with a higher `skip` for more. Use `fields` to shrink the response for large template lists. Example: call with `status: \"Active\"` to get up to 100 active templates with `TemplateID`, `Code`, `Name`. [See the documentation](https://developer.arlo.co/doc/api/2012-02-01/auth/resources/eventtemplates#collection-httpget).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/arlo/actions/list-events/list-events.mjs
+++ b/components/arlo/actions/list-events/list-events.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import arlo from "../../arlo.app.mjs";
 import {
   DEFAULT_LIMIT,
@@ -9,8 +8,9 @@ export default {
   key: "arlo-list-events",
   name: "List Events",
   description: "List Arlo Event (scheduled session) records, optionally filtered by status (the Arlo API does not support filtering this collection by parent event template). Results are paged (see `limit`/`skip`); if the page comes back full, call again with a higher `skip` for more. Use `fields` to shrink the response for large event lists. Example: call with `status: \"Active\"`, `limit: 50` to get up to 50 active events with `EventID`, `Name`, `Code`, `StartDateTime`. [See the documentation](https://developer.arlo.co/doc/api/2012-02-01/auth/resources/events#collection-httpget).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/arlo/actions/list-presenters/list-presenters.mjs
+++ b/components/arlo/actions/list-presenters/list-presenters.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import arlo from "../../arlo.app.mjs";
 import {
   CONTACT_STATUSES,
@@ -9,8 +8,9 @@ export default {
   key: "arlo-list-presenters",
   name: "List Presenters",
   description: "List Arlo contact records that serve as presenters. NOTE: the Arlo Contacts collection has no dedicated 'is presenter' filter, so this returns contact records and callers should filter by tag/code externally. Results are paged (see `limit`/`skip`); if the page comes back full, call again with a higher `skip` for more. Use `fields` to shrink the response for large contact lists. Example: call with `status: \"Active\"`, `limit: 50` to get up to 50 active contacts with `ContactID`, `FirstName`, `LastName`, `Email`. [See the documentation](https://developer.arlo.co/doc/api/2012-02-01/auth/resources/contacts#collection-httpget).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/arlo/actions/list-registrations/list-registrations.mjs
+++ b/components/arlo/actions/list-registrations/list-registrations.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import arlo from "../../arlo.app.mjs";
 import {
   DEFAULT_LIMIT,
@@ -9,8 +8,9 @@ export default {
   key: "arlo-list-registrations",
   name: "List Registrations",
   description: "List Arlo registration records with embedded attendee/contact detail, optionally filtered by event. Run **List Events** first to obtain an `eventId`. Results are paged (see `limit`/`skip`); if the page comes back full, call again with a higher `skip` for more. Use `fields` to shrink the response — registration lists can be very large (thousands of records) and each record is verbose. Example: call with `eventId: \"4\"`, `limit: 50` to get up to 50 registrations for event 4 with `RegistrationID`, `Status`, `Contact`. [See the documentation](https://developer.arlo.co/doc/api/2012-02-01/auth/resources/registrations#collection-httpget).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/arlo/actions/list-venues/list-venues.mjs
+++ b/components/arlo/actions/list-venues/list-venues.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import arlo from "../../arlo.app.mjs";
 import {
   DEFAULT_LIMIT,
@@ -9,8 +8,9 @@ export default {
   key: "arlo-list-venues",
   name: "List Venues",
   description: "List Arlo venue records. Use the returned `VenueID` values when specifying `VenueDetails` in **Create Event** sessions. Optionally filter by status. Results are paged (see `limit`/`skip`); if the page comes back full, call again with a higher `skip` for more. Use `fields` to shrink the response for large venue lists. Example: call with `status: \"Active\"` to get up to 100 active venues with `VenueID`, `Name`, `Status`. [See the documentation](https://developer.arlo.co/doc/api/2012-02-01/auth/resources/venues#collection-httpget).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/arlo/actions/update-presenter/update-presenter.mjs
+++ b/components/arlo/actions/update-presenter/update-presenter.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import arlo from "../../arlo.app.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "arlo-update-presenter",
   name: "Update Presenter",
   description: "Update an existing Arlo presenter (contact) record. Only the fields you provide are changed (applied as a partial PATCH diff). Run **List Presenters** first to find a valid `presenterId`. Example: call with `presenterId: \"102\"`, `email: \"jim.halpert@athlead.com\"` to change just that contact's email and leave all other fields untouched. [See the documentation](https://developer.arlo.co/doc/api/2012-02-01/auth/resources/contacts#instance-httppatch).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/arlo/package.json
+++ b/components/arlo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/arlo",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Arlo Components",
   "main": "arlo.app.mjs",
   "keywords": [

--- a/components/attio/actions/create-note/create-note.mjs
+++ b/components/attio/actions/create-note/create-note.mjs
@@ -1,17 +1,17 @@
-// x-pd-ai: optimized
 import attio from "../../attio.app.mjs";
 
 export default {
   key: "attio-create-note",
   name: "Create Note",
   description: "Create a plaintext note attached to a record (person, company, deal, or any object). Use when you want to log context on a record. Set **Parent Object**, **Parent Record ID**, **Title**, and **Content**. Example: Parent Object `people`, Parent Record ID `891dcbfc-9141-415d-9b2a-2238a6cc012d`, Title `Intro call`, Content `Discussed the Q3 rollout timeline`. Returns the created note with its id. [See the documentation](https://developers.attio.com/reference/post_v2-notes)",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     attio,
     parentObject: {

--- a/components/attio/actions/create-person/create-person.mjs
+++ b/components/attio/actions/create-person/create-person.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import attio from "../../attio.app.mjs";
 import constants from "../../common/constants.mjs";
 
@@ -6,13 +5,14 @@ export default {
   key: "attio-create-person",
   name: "Create Person",
   description: "Create a new person record in Attio. Use when adding a contact. Set any of the person fields (name, email, job title, phone, socials) and optionally link a company by its record id. Example: First Name `Ada`, Last Name `Lovelace`, Email `ada@example.com`, Job Title `Analyst`. Returns the created person record with its id. [See the documentation](https://developers.attio.com/reference/post_v2-objects-people-records).",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     attio,
     firstName: {

--- a/components/attio/actions/create-task/create-task.mjs
+++ b/components/attio/actions/create-task/create-task.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import attio from "../../attio.app.mjs";
 
@@ -6,13 +5,14 @@ export default {
   key: "attio-create-task",
   name: "Create Task",
   description: "Create a task in Attio with content, a deadline, completion state, optional assignees, and optional linked records. Use when you need a follow-up or to-do. Example: Content `Email the signed contract to Ada`, Deadline `2026-09-01T17:00:00Z`, Is Completed `false`. Returns the created task with its id. [See the documentation](https://docs.attio.com/rest-api/endpoint-reference/tasks/create-a-task)",
-  version: "0.1.0",
+  version: "0.1.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     attio,
     content: {

--- a/components/attio/actions/create-update-record/create-update-record.mjs
+++ b/components/attio/actions/create-update-record/create-update-record.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import attio from "../../attio.app.mjs";
 import constants from "../../common/constants.mjs";
@@ -7,13 +6,14 @@ export default {
   key: "attio-create-update-record",
   name: "Create or Update Record",
   description: "Creates or updates a specific record such as a person or a company. If a record with the same matching attribute already exists, it's updated; otherwise a new record is created. Objects without a unique attribute to match on (e.g. deals) are not available here. Example: Object `companies`, Matching Attribute `domains`, Values `{ \"domains\": [\"acme.com\"], \"name\": \"Acme\" }`. Returns the created or updated record with its id. [See the documentation](https://developers.attio.com/reference/put_v2-objects-object-records)",
-  version: "0.1.0",
+  version: "0.1.1",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     attio,
     objectId: {

--- a/components/attio/actions/delete-list-entry/delete-list-entry.mjs
+++ b/components/attio/actions/delete-list-entry/delete-list-entry.mjs
@@ -1,17 +1,17 @@
-// x-pd-ai: optimized
 import attio from "../../attio.app.mjs";
 
 export default {
   key: "attio-delete-list-entry",
   name: "Delete List Entry",
   description: "Delete an entry from a list (this removes the record from the list, not the underlying record itself). Destructive — confirm the entry before deleting. Use **List List ID Options** to find a **List ID**, then choose the **Entry ID** to remove. Example: List ID `33ebdbe9-e529-47c9-b894-0ba25e9c15c0`, Entry ID `2e6e29ea-c4e9-4f4b-9b1e-7f2c1a0d9c11`. Returns the API confirmation. [See the documentation](https://developers.attio.com/reference/delete_v2-lists-list-entries-entry-id)",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     attio,
     listId: {

--- a/components/attio/actions/get-record/get-record.mjs
+++ b/components/attio/actions/get-record/get-record.mjs
@@ -1,17 +1,17 @@
-// x-pd-ai: optimized
 import attio from "../../attio.app.mjs";
 
 export default {
   key: "attio-get-record",
   name: "Get Record",
   description: "Retrieve a single record by its ID from a given object (people, companies, deals, or a custom object). Use when you have a record's id and need its attribute values. Example: Object `people`, Record ID `891dcbfc-9141-415d-9b2a-2238a6cc012d`. Returns the record with its attribute values. [See the documentation](https://docs.attio.com/rest-api/endpoint-reference/records/get-a-record)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     attio,
     objectId: {

--- a/components/attio/actions/list-list-id-options/list-list-id-options.mjs
+++ b/components/attio/actions/list-list-id-options/list-list-id-options.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import attio from "../../attio.app.mjs";
 
 export default {
   key: "attio-list-list-id-options",
   name: "List List ID Options",
   description: "List the workspace's lists as {value, label} options, to discover a **List ID** to pass to other actions (e.g. Delete List Entry). Use when you need a list's id and don't have it. Takes no input. Example: call with no arguments; returns e.g. `[{ \"value\": \"33ebdbe9-e529-47c9-b894-0ba25e9c15c0\", \"label\": \"Hot Leads\" }]`. [See the documentation](https://developers.attio.com/reference/get_v2-lists)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/attio/actions/list-records/list-records.mjs
+++ b/components/attio/actions/list-records/list-records.mjs
@@ -1,17 +1,17 @@
-// x-pd-ai: optimized
 import attio from "../../attio.app.mjs";
 
 export default {
   key: "attio-list-records",
   name: "List Records",
   description: "List records for an object (people, companies, deals, or a custom object), most recent first. Use when you need to find or enumerate records and don't have a specific id. Set **Object** and optionally a **Limit** and **Fields**. Example: Object `companies`, Limit `20`. Returns an array of records with their attribute values. If the number of records returned equals the **Limit**, call again with **Offset** advanced by the limit to fetch the next page. [See the documentation](https://docs.attio.com/rest-api/endpoint-reference/records/list-records)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     attio,
     objectId: {

--- a/components/attio/actions/update-person/update-person.mjs
+++ b/components/attio/actions/update-person/update-person.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import attio from "../../attio.app.mjs";
 import constants from "../../common/constants.mjs";
 
@@ -6,13 +5,14 @@ export default {
   key: "attio-update-person",
   name: "Update Person",
   description: "Update an existing person record by its ID; only the fields you set are changed. Use **Get Record** (object `people`) or the Person ID lookup to find the **Person ID** first. Example: Person ID `891dcbfc-9141-415d-9b2a-2238a6cc012d`, Job Title `VP Sales`, Email `ada@example.com`. Returns the updated person record. [See the documentation](https://developers.attio.com/reference/patch_v2-objects-people-records-record-id).",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     attio,
     recordId: {

--- a/components/attio/package.json
+++ b/components/attio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/attio",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Pipedream Attio Components",
   "main": "attio.app.mjs",
   "keywords": [

--- a/components/bonusly/actions/get-company-participation-report/get-company-participation-report.mjs
+++ b/components/bonusly/actions/get-company-participation-report/get-company-participation-report.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import bonusly from "../../bonusly.app.mjs";
 
 export default {
   key: "bonusly-get-company-participation-report",
   name: "Get Company Participation Report",
   description: "Return company-level recognition participation analytics - giving/receiving rates by group (department, location, etc.) or by manager and team, for a given date range. [See the documentation](https://docs.bonus.ly/reference/adminparticipationreport-1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/bonusly/actions/give-bonus/give-bonus.mjs
+++ b/components/bonusly/actions/give-bonus/give-bonus.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import bonusly from "../../bonusly.app.mjs";
 
 export default {
   key: "bonusly-give-bonus",
   name: "Give Bonus",
   description: "Send recognition (a bonus) to one or more colleagues on behalf of the authenticated caller. Do not include `@mentions` or the point amount in the `reason` yourself - Bonusly synthesizes those from `recipients` and `amount` automatically. [See the documentation](https://docs.bonus.ly/reference/giverecognition-1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/bonusly/actions/list-departments/list-departments.mjs
+++ b/components/bonusly/actions/list-departments/list-departments.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import bonusly from "../../bonusly.app.mjs";
 
 export default {
   key: "bonusly-list-departments",
   name: "List Departments",
   description: "List the distinct departments configured for users in the authenticated caller's company, with a user count for each. Call this first to discover the exact department names accepted by **List Users In Department**, which matches exactly and returns nothing for a misspelled or differently-cased name. [See the documentation](https://docs.bonus.ly/reference/listdepartments)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/bonusly/actions/list-locations/list-locations.mjs
+++ b/components/bonusly/actions/list-locations/list-locations.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import bonusly from "../../bonusly.app.mjs";
 
 export default {
   key: "bonusly-list-locations",
   name: "List Locations",
   description: "List the distinct locations configured for users in the authenticated caller's company, with a user count for each. Call this first to discover the exact location names accepted by **List Users In Location**, which matches exactly and returns nothing for a misspelled or differently-cased name. [See the documentation](https://docs.bonus.ly/reference/listlocations)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/bonusly/actions/list-reward-redemptions/list-reward-redemptions.mjs
+++ b/components/bonusly/actions/list-reward-redemptions/list-reward-redemptions.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import bonusly from "../../bonusly.app.mjs";
 
 export default {
   key: "bonusly-list-reward-redemptions",
   name: "List Reward Redemptions",
   description: "Return paginated reward redemption records for the caller's company, with optional filtering by user email, date range, and fulfillment status. This is a company-wide admin report, not just the caller's own redemptions. [See the documentation](https://docs.bonus.ly/reference/adminrewardsredemptionsreport-1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/bonusly/actions/list-top-level-users/list-top-level-users.mjs
+++ b/components/bonusly/actions/list-top-level-users/list-top-level-users.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import bonusly from "../../bonusly.app.mjs";
 
 export default {
   key: "bonusly-list-top-level-users",
   name: "List Top-Level Users",
   description: "List the users in the authenticated caller's company who have no manager - the roots of the org chart, typically executives. Use this to answer who sits at the top of the company, or as a starting point when you have no other identifier to work from. Takes no required input. [See the documentation](https://docs.bonus.ly/reference/listtoplevelusers)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/bonusly/actions/list-users-in-department/list-users-in-department.mjs
+++ b/components/bonusly/actions/list-users-in-department/list-users-in-department.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import bonusly from "../../bonusly.app.mjs";
 
 export default {
   key: "bonusly-list-users-in-department",
   name: "List Users In Department",
   description: "List the users in the authenticated caller's company who belong to a specific department. Use this to enumerate a department's roster - unlike **Search Users**, no search term is required, so it returns every member of the department. [See the documentation](https://docs.bonus.ly/reference/listusersindepartment)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/bonusly/actions/list-users-in-location/list-users-in-location.mjs
+++ b/components/bonusly/actions/list-users-in-location/list-users-in-location.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import bonusly from "../../bonusly.app.mjs";
 
 export default {
   key: "bonusly-list-users-in-location",
   name: "List Users In Location",
   description: "List the users in the authenticated caller's company who belong to a specific location. Use this to enumerate a location's roster - unlike **Search Users**, no search term is required, so it returns everyone based at the location. [See the documentation](https://docs.bonus.ly/reference/listusersinlocation)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/bonusly/actions/search-users/search-users.mjs
+++ b/components/bonusly/actions/search-users/search-users.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import bonusly from "../../bonusly.app.mjs";
 
 export default {
   key: "bonusly-search-users",
   name: "Search Users",
   description: "Search users in the authenticated caller's company by name or email. This is a search, not a full company directory dump - a `Search Term` is required and matches on name or email. To list users without a search term, use **List Users In Department**, **List Users In Location**, or **List Top-Level Users** instead. [See the documentation](https://docs.bonus.ly/reference/searchusers)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/bonusly/package.json
+++ b/components/bonusly/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/bonusly",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Bonusly Components",
   "main": "bonusly.app.mjs",
   "keywords": [

--- a/components/calendly_v2/actions/cancel-event/cancel-event.mjs
+++ b/components/calendly_v2/actions/cancel-event/cancel-event.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { MAX_CANCELLATION_REASON_LENGTH } from "../../common/constants.mjs";
 import calendly from "../../calendly_v2.app.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "calendly_v2-cancel-event",
   name: "Cancel Event",
   description: "Cancel a scheduled Calendly event. Posts to `POST /scheduled_events/{uuid}/cancellation`. Run **List Events** first to obtain the event UUID. Example: with `eventUuid` set to `a1b2c3d4-e5f6-7890-abcd-ef1234567890` and `reason` set to `Schedule conflict - rescheduling needed`, the event is canceled and all invitees are notified. [See the documentation](https://developer.calendly.com/api-docs/afb2e9fe3a0a0-cancel-event).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/calendly_v2/actions/create-invitee-no-show/create-invitee-no-show.mjs
+++ b/components/calendly_v2/actions/create-invitee-no-show/create-invitee-no-show.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { axios } from "@pipedream/platform";
 import calendly from "../../calendly_v2.app.mjs";
 
@@ -6,13 +5,14 @@ export default {
   key: "calendly_v2-create-invitee-no-show",
   name: "Create Invitee No Show",
   description: "Marks an invitee as a no-show via `POST /invitee_no_shows`. Use when an invitee didn't attend a scheduled event and you want to flag it in Calendly. Run **List Events** first to obtain the event UUID, then select the invitee from the dropdown (populated from **List Event Invitees**). Example: with `eventId` set to `a1b2c3d4-e5f6-7890-abcd-ef1234567890`, selecting invitee \"Jane Doe\" marks her as a no-show for that event. [See the documentation](https://calendly.stoplight.io/docs/api-docs/cebd8c3170790-create-invitee-no-show).",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     calendly,
     eventId: {

--- a/components/calendly_v2/actions/create-scheduling-link/create-scheduling-link.mjs
+++ b/components/calendly_v2/actions/create-scheduling-link/create-scheduling-link.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import calendly from "../../calendly_v2.app.mjs";
 import { ConfigurationError } from "@pipedream/platform";
 
@@ -6,13 +5,14 @@ export default {
   key: "calendly_v2-create-scheduling-link",
   name: "Create a Scheduling Link",
   description: "Creates a single-use scheduling link for an event type via `POST /scheduling_links`. Run **List Event Types** first to obtain the event type UUID. Example: with `owner` set to `https://api.calendly.com/event_types/AAAAAAAAAAAAAAAA`'s UUID and `maxEventCount` set to `1`, returns a booking URL like `https://calendly.com/d/ABC-123/30-minute-meeting` that can be scheduled once before expiring. [See the documentation](https://calendly.stoplight.io/docs/api-docs/b3A6MzQyNTM0OQ-create-single-use-scheduling-link)",
-  version: "0.1.0",
+  version: "0.1.1",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     calendly,
     owner: {

--- a/components/calendly_v2/actions/get-event/get-event.mjs
+++ b/components/calendly_v2/actions/get-event/get-event.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import { URL } from "url";
 import calendly from "../../calendly_v2.app.mjs";
@@ -7,13 +6,14 @@ export default {
   key: "calendly_v2-get-event",
   name: "Get Event",
   description: "Gets information about a scheduled event via `GET /scheduled_events/{uuid}`. Provide either the Event UUID (from **List Events**) or the full Event URL. Example: with `eventId` set to `a1b2c3d4-e5f6-7890-abcd-ef1234567890`, returns the event's name, start/end times, status, and location. [See the documentation](https://developer.calendly.com/api-docs/e2f95ebd44914-get-event).",
-  version: "0.1.8",
+  version: "0.1.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     calendly,
     eventId: {

--- a/components/calendly_v2/actions/get-invitee/get-invitee.mjs
+++ b/components/calendly_v2/actions/get-invitee/get-invitee.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import calendly from "../../calendly_v2.app.mjs";
 
 export default {
   key: "calendly_v2-get-invitee",
   name: "Get Event Invitee",
   description: "Retrieve the full invitee resource (including `email`, `name`, `status`, `reschedule_url`, and `no_show`) via `GET /scheduled_events/{event_uuid}/invitees/{invitee_uuid}`. Use the returned `reschedule_url` to direct an invitee to self-reschedule. Run **List Events** to find event UUIDs, then **List Event Invitees** to find invitee UUIDs. Example: with `eventUuid` set to `a1b2c3d4-e5f6-7890-abcd-ef1234567890` and `inviteeUuid` set to `f7e6d5c4-b3a2-1098-fedc-ba9876543210`, returns that invitee's `email`, `name`, and `status: \"active\"`. [See the documentation](https://developer.calendly.com/api-docs/8305c0ccfac70-get-event-invitee).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/calendly_v2/actions/list-event-invitees/list-event-invitees.mjs
+++ b/components/calendly_v2/actions/list-event-invitees/list-event-invitees.mjs
@@ -1,17 +1,17 @@
-// x-pd-ai: optimized
 import calendly from "../../calendly_v2.app.mjs";
 
 export default {
   key: "calendly_v2-list-event-invitees",
   name: "List Event Invitees",
   description: "List the invitees for a scheduled event via `GET /scheduled_events/{uuid}/invitees`. Run **List Events** first to obtain the event UUID. Example: call with `eventId` set to `a1b2c3d4-e5f6-7890-abcd-ef1234567890` and `status` set to `active` to return only that event's non-canceled invitees, each with a `uri` whose trailing segment is the invitee UUID used by **Get Event Invitee** and **Create Invitee No Show**. [See the documentation](https://calendly.stoplight.io/docs/api-docs/b3A6NTkxNDEx-list-event-invitees)",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     calendly,
     eventId: {

--- a/components/calendly_v2/actions/list-event-types/list-event-types.mjs
+++ b/components/calendly_v2/actions/list-event-types/list-event-types.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import calendly from "../../calendly_v2.app.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "calendly_v2-list-event-types",
   name: "List Event Types",
   description: "Retrieve the event types available to a user or organization via `GET /event_types`. Use this to discover valid event type URIs and UUIDs for scheduling flows. Provide either an Organization URI or a User URI; if neither is provided the authenticated user is used. Use **List Organization Memberships** to find user and organization URIs. Example: called with no props, returns the authenticated user's event types such as `{ name: \"30 Minute Meeting\", uuid: \"AAAAAAAAAAAAAAAA\" }` — pass that `uuid` as the `owner` prop in **Create a Scheduling Link**. [See the documentation](https://developer.calendly.com/api-docs/25a4ece03c1bc-list-user-s-event-types).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/calendly_v2/actions/list-events/list-events.mjs
+++ b/components/calendly_v2/actions/list-events/list-events.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import calendly from "../../calendly_v2.app.mjs";
 
@@ -6,13 +5,14 @@ export default {
   key: "calendly_v2-list-events",
   name: "List Events",
   description: "List scheduled Calendly events. Scope the results by providing at most one of Organization URI, User URI, or Group UUID; if none is provided, events for the authenticated user are returned (supplying more than one raises a configuration error). Narrow the results further with an invitee email to return only events scheduled with that invitee. Filter by date range using `Min Start Time` and/or `Max Start Time`, both ISO 8601 datetimes in UTC (e.g. `2026-08-01T00:00:00Z`). Each returned event includes a `uri`; the trailing UUID segment is the event UUID used by downstream actions such as **Get Event**, **List Event Invitees**, **Get Event Invitee**, and **Cancel Event**. Example: called with no props, returns the authenticated user's upcoming events, each like `{ name: \"30 Minute Meeting\", uri: \"https://api.calendly.com/scheduled_events/a1b2c3d4-e5f6-7890-abcd-ef1234567890\", status: \"active\" }`. [See the documentation](https://calendly.stoplight.io/docs/api-docs/b3A6NTkxNDEy-list-events)",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     calendly,
     organization: {

--- a/components/calendly_v2/actions/list-groups/list-groups.mjs
+++ b/components/calendly_v2/actions/list-groups/list-groups.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import calendly from "../../calendly_v2.app.mjs";
 
 export default {
   key: "calendly_v2-list-groups",
   name: "List Groups",
   description: "List the groups within a Calendly organization via `GET /groups` (requires organization admin/owner privilege). Use this to discover valid Group UUIDs for scoping **List Events** to a specific group. Run **List Organization Memberships** first to obtain an organization URI. Example: call with `organization` set to `https://api.calendly.com/organizations/AAAAAAAAAAAAAAAA` to get groups such as `{ name: \"Sales Team\", uri: \"https://api.calendly.com/groups/BBBBBBBBBBBBBBBB\" }`; pass the trailing `BBBBBBBBBBBBBBBB` segment as the Group UUID to **List Events**. [See the documentation](https://calendly.stoplight.io/docs/api-docs/6rb6dtdln74sy-list-groups)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/calendly_v2/actions/list-organization-members/list-organization-members.mjs
+++ b/components/calendly_v2/actions/list-organization-members/list-organization-members.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { MEMBERSHIP_ROLE_OPTIONS } from "../../common/constants.mjs";
 import calendly from "../../calendly_v2.app.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "calendly_v2-list-organization-members",
   name: "List Organization Memberships",
   description: "List the members of a Calendly organization via `GET /organization_memberships`, returning each membership's user URI, role, and email. Use this as the companion lookup action for user and organization URIs consumed by other tools. Supports optional `role` and `email` filters plus pagination. Example: called with no props, returns the authenticated user's memberships such as `{ user: { name: \"Jane Doe\", uri: \"https://api.calendly.com/users/AAAAAAAAAAAAAAAA\" }, organization: \"https://api.calendly.com/organizations/BBBBBBBBBBBBBBBB\", role: \"owner\" }` — pass those URIs as the `user`/`organization` props in other actions. [See the documentation](https://developer.calendly.com/api-docs/eaed2e61a6bc3-list-organization-memberships).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/calendly_v2/actions/list-user-availability-schedules/list-user-availability-schedules.mjs
+++ b/components/calendly_v2/actions/list-user-availability-schedules/list-user-availability-schedules.mjs
@@ -1,17 +1,17 @@
-// x-pd-ai: optimized
 import calendly from "../../calendly_v2.app.mjs";
 
 export default {
   key: "calendly_v2-list-user-availability-schedules",
   name: "List User Availability Schedules",
   description: "List the availability schedules of the given user via `GET /user_availability_schedules`. Run **List Organization Memberships** first to obtain a user URI. Example: call with `user` set to `https://api.calendly.com/users/AAAAAAAAAAAAAAAA` to return that user's named availability schedules (e.g. `Working Hours`) with their weekly rules. [See the documentation](https://developer.calendly.com/api-docs/8098de44af94c-list-user-availability-schedules)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     calendly,
     organization: {

--- a/components/calendly_v2/actions/list-webhook-subscriptions/list-webhook-subscriptions.mjs
+++ b/components/calendly_v2/actions/list-webhook-subscriptions/list-webhook-subscriptions.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import calendly from "../../calendly_v2.app.mjs";
 import { ConfigurationError } from "@pipedream/platform";
 
@@ -6,13 +5,14 @@ export default {
   key: "calendly_v2-list-webhook-subscriptions",
   name: "List Webhook Subscriptions",
   description: "Get a list of Webhook Subscriptions for an Organization or User via `GET /webhook_subscriptions`. Requires `organizationUri` when `scope` is `organization`, or `userUri` when `scope` is `user`. Run **List Organization Memberships** first to obtain an organization or user URI. Example: call with `scope` set to `organization` and `organizationUri` set to `https://api.calendly.com/organizations/AAAAAAAAAAAAAAAA` to return that organization's webhook subscriptions. [See the documentation](https://calendly.stoplight.io/docs/api-docs/faac832d7c57d-list-webhook-subscriptions)",
-  version: "0.1.7",
+  version: "0.1.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     calendly,
     scope: {

--- a/components/calendly_v2/package.json
+++ b/components/calendly_v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/calendly_v2",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Pipedream Calendly V2 Components",
   "main": "calendly_v2.app.mjs",
   "keywords": [

--- a/components/datadog/actions/get-account-info/get-account-info.mjs
+++ b/components/datadog/actions/get-account-info/get-account-info.mjs
@@ -15,8 +15,9 @@ export default {
     + " **Get Metric Data**, and all other Datadog tools."
     + " [See the docs](https://docs.datadoghq.com/api/"
     + "latest/authentication/#validate-api-key)",
-  version: "1.0.1",
+  version: "1.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: false,

--- a/components/datadog/actions/get-metric-data/get-metric-data.mjs
+++ b/components/datadog/actions/get-metric-data/get-metric-data.mjs
@@ -17,8 +17,9 @@ export default {
     + " [See the docs](https://docs.datadoghq.com/api/"
     + "latest/metrics/#query-timeseries-data-across"
     + "-multiple-products)",
-  version: "1.0.1",
+  version: "1.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/datadog/actions/post-metric-data/post-metric-data.mjs
+++ b/components/datadog/actions/post-metric-data/post-metric-data.mjs
@@ -16,13 +16,14 @@ export default {
     + " appends data to a metric time series."
     + " [See the docs](https://docs.datadoghq.com/"
     + "metrics)",
-  version: "1.0.1",
+  version: "1.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     datadog,
     region: {

--- a/components/datadog/actions/search-dashboards/search-dashboards.mjs
+++ b/components/datadog/actions/search-dashboards/search-dashboards.mjs
@@ -13,8 +13,9 @@ export default {
     + " dashboards related to a specific service."
     + " [See the docs](https://docs.datadoghq.com/api/"
     + "latest/dashboards/#get-all-dashboards)",
-  version: "1.0.1",
+  version: "1.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/datadog/actions/search-events/search-events.mjs
+++ b/components/datadog/actions/search-events/search-events.mjs
@@ -17,8 +17,9 @@ export default {
     + " **Search Logs** for deeper investigation."
     + " [See the docs](https://docs.datadoghq.com/api/"
     + "latest/events/#get-a-list-of-events)",
-  version: "1.0.1",
+  version: "1.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/datadog/actions/search-hosts/search-hosts.mjs
+++ b/components/datadog/actions/search-hosts/search-hosts.mjs
@@ -17,8 +17,9 @@ export default {
     + " [See the docs](https://docs.datadoghq.com/api/"
     + "latest/hosts/"
     + "#get-all-hosts-for-your-organization)",
-  version: "1.0.1",
+  version: "1.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/datadog/actions/search-incidents/search-incidents.mjs
+++ b/components/datadog/actions/search-incidents/search-incidents.mjs
@@ -14,8 +14,9 @@ export default {
     + " and **Search Services** for ownership info."
     + " [See the docs](https://docs.datadoghq.com/api/"
     + "latest/incidents/#get-a-list-of-incidents)",
-  version: "1.0.1",
+  version: "1.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/datadog/actions/search-logs/search-logs.mjs
+++ b/components/datadog/actions/search-logs/search-logs.mjs
@@ -16,8 +16,9 @@ export default {
     + " search logs for that time window and service."
     + " [See the docs](https://docs.datadoghq.com/api/"
     + "latest/logs/#search-logs)",
-  version: "1.0.1",
+  version: "1.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/datadog/actions/search-metrics/search-metrics.mjs
+++ b/components/datadog/actions/search-metrics/search-metrics.mjs
@@ -14,8 +14,9 @@ export default {
     + " the `host` filter."
     + " [See the docs](https://docs.datadoghq.com/api/"
     + "latest/metrics/#get-active-metrics-list)",
-  version: "1.0.1",
+  version: "1.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/datadog/actions/search-monitors/search-monitors.mjs
+++ b/components/datadog/actions/search-monitors/search-monitors.mjs
@@ -15,8 +15,9 @@ export default {
     + " ID, name, type, query, status, and tags."
     + " [See the docs](https://docs.datadoghq.com/api/"
     + "latest/monitors/#get-all-monitor-details)",
-  version: "1.0.1",
+  version: "1.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/datadog/actions/search-services/search-services.mjs
+++ b/components/datadog/actions/search-services/search-services.mjs
@@ -14,8 +14,9 @@ export default {
     + " [See the docs](https://docs.datadoghq.com/api/"
     + "latest/service-definition/"
     + "#get-all-service-definitions)",
-  version: "1.0.1",
+  version: "1.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/datadog/package.json
+++ b/components/datadog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/datadog",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Pipedream Datadog Components",
   "main": "datadog.app.mjs",
   "keywords": [

--- a/components/dataiku/actions/build-dataset/build-dataset.mjs
+++ b/components/dataiku/actions/build-dataset/build-dataset.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import dataiku from "../../dataiku.app.mjs";
 import { BUILD_TYPES } from "../../common/constants.mjs";
@@ -7,8 +6,9 @@ export default {
   key: "dataiku-build-dataset",
   name: "Build Dataset",
   description: "Start a job that builds one or more outputs (typically datasets) in a DSS project. Use this to rebuild specific outputs directly; use **Run Scenario** instead when the pipeline is already orchestrated as a scenario. Use **List Datasets** to find valid output names. A successful call only means the job was accepted — the response's `id` is the job ID, which you pass to **Get Job Status** to follow it to completion. Requires the `RUN_JOBS` privilege on the project. [See the documentation](https://doc.dataiku.com/dss/api/15/rest/#jobs-jobs-post)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/dataiku/actions/get-job-status/get-job-status.mjs
+++ b/components/dataiku/actions/get-job-status/get-job-status.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import dataiku from "../../dataiku.app.mjs";
 
 export default {
   key: "dataiku-get-job-status",
   name: "Get Job Status",
   description: "Check the status of a DSS build job, returned as `baseStatus.status`. Poll this after **Build Dataset** using the `id` it returned. `NOT_STARTED` and `RUNNING` mean the job is still in flight; `DONE`, `FAILED` and `ABORTED` are terminal, so stop polling on any of them and treat `FAILED`/`ABORTED` as an unsuccessful build. Use **List Jobs** to recover a job ID you no longer have. Requires the `MONITOR_JOBS` privilege on the project. [See the documentation](https://doc.dataiku.com/dss/api/15/rest/#jobs-job-get)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/dataiku/actions/list-datasets/list-datasets.mjs
+++ b/components/dataiku/actions/list-datasets/list-datasets.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import dataiku from "../../dataiku.app.mjs";
 
 export default {
   key: "dataiku-list-datasets",
   name: "List Datasets",
   description: "List the datasets of a DSS project. Use this to discover a dataset's `name` — the identifier **Build Dataset** needs to build it — along with its `type` (e.g. `Filesystem`) and connection parameters. Use **List Projects** first if you do not know the project key. Requires the `READ_CONF` privilege on the project. [See the documentation](https://doc.dataiku.com/dss/api/15/rest/#datasets-datasets-get)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/dataiku/actions/list-jobs/list-jobs.mjs
+++ b/components/dataiku/actions/list-jobs/list-jobs.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import dataiku from "../../dataiku.app.mjs";
 
 export default {
   key: "dataiku-list-jobs",
   name: "List Jobs",
   description: "Retrieve the latest build jobs of a DSS project, each with its `jobId` and `state`. Use this to check what a project has been building recently, or to recover a `jobId` you no longer have before calling **Get Job Status**. Requires the `READ_CONF` privilege on the project. [See the documentation](https://doc.dataiku.com/dss/api/15/rest/#jobs-jobs-get)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/dataiku/actions/list-projects/list-projects.mjs
+++ b/components/dataiku/actions/list-projects/list-projects.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import dataiku from "../../dataiku.app.mjs";
 
 export default {
   key: "dataiku-list-projects",
   name: "List Projects",
   description: "List the projects on the DSS instance. Start here when you only know a project by its display name: every other Dataiku tool is addressed by `projectKey` (e.g. `MYPROJECT`), which this tool returns. Only projects the connected API key holds the `READ_CONF` privilege on are listed, so an empty result usually means a permissions gap rather than an empty instance. Note that the free edition of DSS does not include Public API access — the API key must come from a trial or licensed instance. [See the documentation](https://doc.dataiku.com/dss/api/15/rest/#projects-projects-get)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/dataiku/actions/list-scenario-runs/list-scenario-runs.mjs
+++ b/components/dataiku/actions/list-scenario-runs/list-scenario-runs.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import dataiku from "../../dataiku.app.mjs";
 
 export default {
   key: "dataiku-list-scenario-runs",
   name: "List Scenario Runs",
   description: "Retrieve the last runs of a DSS scenario. Use this after **Run Scenario**, which returns no run identifier of its own, to follow the outcome: each entry carries a `runId`, `start`/`end` timestamps and a `result` object reporting `outcome` (e.g. `SUCCESS`) and `type` (e.g. `SCENARIO_DONE`). This tool cannot tell you which entry corresponds to a run you started: the response is just the scenario's recent runs, so a concurrent run, or one already in progress before you called **Run Scenario**, looks no different. Correlate deliberately — match on the `start` timestamp (the `runId`, e.g. `2016-04-15-16-57-37-759`, is derived from it) against the moment you triggered the run, rather than assuming any particular entry is yours. Stop polling once the run you are tracking reports a `result`, whatever its outcome. Requires the `RUN_JOBS` privilege on the project. [See the documentation](https://doc.dataiku.com/dss/api/15/rest/#scenarios-scenario-get-3)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/dataiku/actions/list-scenarios/list-scenarios.mjs
+++ b/components/dataiku/actions/list-scenarios/list-scenarios.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import dataiku from "../../dataiku.app.mjs";
 
 export default {
   key: "dataiku-list-scenarios",
   name: "List Scenarios",
   description: "List the scenarios of a DSS project, with each scenario's `id`, whether it is currently `running`, and whether it is `active` (i.e. responding to its own triggers). Call this before **Run Scenario** to find a valid scenario ID, or to check whether a scenario is already in flight before starting another run. Requires the `MONITOR_JOBS` privilege on the project. [See the documentation](https://doc.dataiku.com/dss/api/15/rest/#scenarios-scenarios-get)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/dataiku/actions/run-scenario/run-scenario.mjs
+++ b/components/dataiku/actions/run-scenario/run-scenario.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import dataiku from "../../dataiku.app.mjs";
 
 export default {
   key: "dataiku-run-scenario",
   name: "Run Scenario",
   description: "Start a run of a DSS scenario — the usual way to kick off an orchestrated pipeline (a sequence of builds, checks and reporters) as opposed to building a single dataset, which **Build Dataset** does. Use **List Scenarios** to find a valid scenario ID. A successful call only means the run was accepted, and the response carries no run identifier, so poll **List Scenario Runs** to follow the outcome. Requires the `RUN_JOBS` privilege on the project. [See the documentation](https://doc.dataiku.com/dss/api/15/rest/#scenarios-scenario-post)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/dataiku/package.json
+++ b/components/dataiku/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/dataiku",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Dataiku Components",
   "main": "dataiku.app.mjs",
   "keywords": [

--- a/components/elastic_cloud/actions/create-deployment/create-deployment.mjs
+++ b/components/elastic_cloud/actions/create-deployment/create-deployment.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import elasticCloud from "../../elastic_cloud.app.mjs";
 
 export default {
   key: "elastic_cloud-create-deployment",
   name: "Create Deployment",
   description: "Create a new Elastic Cloud deployment. Requires a name, region, and version at minimum. Provide the `resources` JSON object to configure Elasticsearch/Kibana/APM topology; omit it to accept region defaults. [See the documentation](https://www.elastic.co/docs/api/doc/cloud/operation/operation-create-deployment)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   props: {
     elasticCloud,
     name: {

--- a/components/elastic_cloud/actions/create-traffic-filter/create-traffic-filter.mjs
+++ b/components/elastic_cloud/actions/create-traffic-filter/create-traffic-filter.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import elasticCloud from "../../elastic_cloud.app.mjs";
 import { TRAFFIC_FILTER_TYPES } from "../../common/constants.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "elastic_cloud-create-traffic-filter",
   name: "Create Traffic Filter Ruleset",
   description: "Create a new traffic filter ruleset in Elastic Cloud. The API requires a name, type, region, rules, and include-by-default flag. Note that `type` and `region` cannot be changed after the ruleset is created. [See the documentation](https://www.elastic.co/docs/api/doc/cloud/operation/operation-create-traffic-filter-ruleset)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   props: {
     elasticCloud,
     name: {

--- a/components/elastic_cloud/actions/delete-traffic-filter/delete-traffic-filter.mjs
+++ b/components/elastic_cloud/actions/delete-traffic-filter/delete-traffic-filter.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import elasticCloud from "../../elastic_cloud.app.mjs";
 
 export default {
   key: "elastic_cloud-delete-traffic-filter",
   name: "Delete Traffic Filter Ruleset",
   description: "Permanently delete a traffic filter ruleset from Elastic Cloud. This is irreversible. Run **List Traffic Filter Rulesets** first to find the ruleset ID. [See the documentation](https://www.elastic.co/docs/api/doc/cloud/operation/operation-delete-traffic-filter-ruleset)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   props: {
     elasticCloud,
     rulesetId: {

--- a/components/elastic_cloud/actions/get-deployment/get-deployment.mjs
+++ b/components/elastic_cloud/actions/get-deployment/get-deployment.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import elasticCloud from "../../elastic_cloud.app.mjs";
 
 export default {
   key: "elastic_cloud-get-deployment",
   name: "Get Deployment",
   description: "Retrieve a single Elastic Cloud deployment by ID. Run **List Deployments** first to find a valid deployment ID. [See the documentation](https://www.elastic.co/docs/api/doc/cloud/operation/operation-get-deployment)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   props: {
     elasticCloud,
     deploymentId: {

--- a/components/elastic_cloud/actions/list-deployments/list-deployments.mjs
+++ b/components/elastic_cloud/actions/list-deployments/list-deployments.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import elasticCloud from "../../elastic_cloud.app.mjs";
 
 export default {
   key: "elastic_cloud-list-deployments",
   name: "List Deployments",
   description: "List all deployments in your Elastic Cloud organization. Use this first to discover deployment IDs before calling **Get Deployment** or **Update Deployment**. [See the documentation](https://www.elastic.co/docs/api/doc/cloud/operation/operation-list-deployments)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   props: {
     elasticCloud,
   },

--- a/components/elastic_cloud/actions/list-traffic-filters/list-traffic-filters.mjs
+++ b/components/elastic_cloud/actions/list-traffic-filters/list-traffic-filters.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import elasticCloud from "../../elastic_cloud.app.mjs";
 
 export default {
   key: "elastic_cloud-list-traffic-filters",
   name: "List Traffic Filter Rulesets",
   description: "List all traffic filter rulesets in your Elastic Cloud organization. Use this first to discover ruleset IDs before calling **Update Traffic Filter Ruleset** or **Delete Traffic Filter Ruleset**. [See the documentation](https://www.elastic.co/docs/api/doc/cloud/operation/operation-get-traffic-filter-rulesets)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   props: {
     elasticCloud,
   },

--- a/components/elastic_cloud/actions/update-deployment/update-deployment.mjs
+++ b/components/elastic_cloud/actions/update-deployment/update-deployment.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import elasticCloud from "../../elastic_cloud.app.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "elastic_cloud-update-deployment",
   name: "Update Deployment",
   description: "Update an existing Elastic Cloud deployment, including resizing cluster capacity. Cluster resize is performed here by supplying updated `resources` sizing (no separate resize action exists). Run **List Deployments** first to find the deployment ID. [See the documentation](https://www.elastic.co/docs/api/doc/cloud/operation/operation-update-deployment)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   props: {
     elasticCloud,
     deploymentId: {

--- a/components/elastic_cloud/actions/update-traffic-filter/update-traffic-filter.mjs
+++ b/components/elastic_cloud/actions/update-traffic-filter/update-traffic-filter.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import elasticCloud from "../../elastic_cloud.app.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "elastic_cloud-update-traffic-filter",
   name: "Update Traffic Filter Ruleset",
   description: "Update an existing traffic filter ruleset in Elastic Cloud. The underlying API replaces the whole ruleset, so this action first reads the current ruleset and merges your changes over it — supply only the fields you want to change. The ruleset's `type` and `region` are immutable after creation and are carried over automatically. Run **List Traffic Filter Rulesets** first to find the ruleset ID. [See the documentation](https://www.elastic.co/docs/api/doc/cloud/operation/operation-update-traffic-filter-ruleset)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   props: {
     elasticCloud,
     rulesetId: {

--- a/components/elastic_cloud/package.json
+++ b/components/elastic_cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/elastic_cloud",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Elastic Cloud Components",
   "main": "elastic_cloud.app.mjs",
   "keywords": [

--- a/components/element/actions/ban-user/ban-user.mjs
+++ b/components/element/actions/ban-user/ban-user.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import element from "../../element.app.mjs";
 
 export default {
   key: "element-ban-user",
   name: "Ban User",
   description: "Ban a user from a room, also kicking them if they are currently joined. A banned user cannot rejoin or be invited back until the ban is lifted with **Unban User** — use **Kick User** instead to remove someone without blocking their return. The connected account must be in the room with a power level high enough to ban, otherwise the API returns `M_FORBIDDEN`. Use **List Rooms** to find the room ID. [See the documentation](https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidban)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/element/actions/create-room/create-room.mjs
+++ b/components/element/actions/create-room/create-room.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import element from "../../element.app.mjs";
 
 export default {
   key: "element-create-room",
   name: "Create Room",
   description: "Create a new room, optionally inviting other users to it right away. Returns the new room's ID, which can be passed into **Send Message** or **Invite User**. Set `Room Alias Name` to give the room a memorable local alias (e.g. `thepub` becomes `#thepub:matrix.org` on matrix.org). If you omit `Preset`, `Visibility` also picks join rules — `public` creates an openly-joinable room. [See the documentation](https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3createroom)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/element/actions/invite-user/invite-user.mjs
+++ b/components/element/actions/invite-user/invite-user.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import element from "../../element.app.mjs";
 
 export default {
   key: "element-invite-user",
   name: "Invite User",
   description: "Invite a user to an existing room. The connected account must already be joined to the room and have permission to invite. Optionally include a `Reason`, which is stored on the membership event. [See the documentation](https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidinvite)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/element/actions/kick-user/kick-user.mjs
+++ b/components/element/actions/kick-user/kick-user.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import element from "../../element.app.mjs";
 
 export default {
   key: "element-kick-user",
   name: "Kick User",
   description: "Remove a user from a room without banning them. A kicked user can be invited back with **Invite User**, and can rejoin on their own if the room's join rules allow it — use **Ban User** instead to also block their return. The connected account must be in the room with a power level high enough to kick, otherwise the API returns `M_FORBIDDEN`; the same error is returned if the target user is not currently in the room. Use **List Rooms** to find the room ID. [See the documentation](https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidkick)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/element/actions/leave-room/leave-room.mjs
+++ b/components/element/actions/leave-room/leave-room.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import element from "../../element.app.mjs";
 
 export default {
   key: "element-leave-room",
   name: "Leave Room",
   description: "Leave a room the connected account has joined, or reject a pending invite to it. After leaving, the account stops receiving new events in the room; rejoining an invite-only room requires a fresh invite, so treat this as hard to undo. Use **List Rooms** to find the room ID. [See the documentation](https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidleave)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/element/actions/list-rooms/list-rooms.mjs
+++ b/components/element/actions/list-rooms/list-rooms.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import element from "../../element.app.mjs";
 
 export default {
   key: "element-list-rooms",
   name: "List Rooms",
   description: "List the Matrix rooms the connected account has joined. The Matrix API only returns room IDs from this endpoint (no name or topic) — pass a returned ID directly into **Send Message** or **Invite User**. Because the IDs are opaque, prefer **Resolve Room Alias** when you know the room by an alias such as `#engineering:matrix.org`. [See the documentation](https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3joined_rooms)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/element/actions/resolve-room-alias/resolve-room-alias.mjs
+++ b/components/element/actions/resolve-room-alias/resolve-room-alias.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import element from "../../element.app.mjs";
 
 export default {
   key: "element-resolve-room-alias",
   name: "Resolve Room Alias",
   description: "Look up the room ID that a human-readable room alias points to, e.g. `#engineering:matrix.org`. Every other action in this app takes a room ID (`!OGEhHVWSdvArJzumhm:matrix.org`) and rejects aliases, so use this first whenever you only know the alias. Aliases can be re-pointed to a different room over time, so always trust the returned `room_id` rather than assuming an alias still maps to the room you expect. Returns the room ID and the servers that know the alias. [See the documentation](https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3directoryroomroomalias)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/element/actions/send-message/send-message.mjs
+++ b/components/element/actions/send-message/send-message.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import element from "../../element.app.mjs";
 
 export default {
   key: "element-send-message",
   name: "Send Message",
   description: "Send a text message to a room. The room must be one the connected account has already joined, and must be identified by room ID rather than alias — use **List Rooms** to find it. Returns the `event_id` of the sent message. [See the documentation](https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3roomsroomidsendeventtypetxnid)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/element/actions/unban-user/unban-user.mjs
+++ b/components/element/actions/unban-user/unban-user.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import element from "../../element.app.mjs";
 
 export default {
   key: "element-unban-user",
   name: "Unban User",
   description: "Lift a ban on a user in a room, reversing **Ban User**. Unbanning does not put the user back in the room — it only allows them to be invited again, and to rejoin if the room's join rules would otherwise let them. The connected account must have a power level high enough to unban, otherwise the API returns `M_FORBIDDEN`. Use **List Rooms** to find the room ID. [See the documentation](https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidunban)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/element/package.json
+++ b/components/element/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/element",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Element Components",
   "main": "element.app.mjs",
   "keywords": [

--- a/components/expensify/actions/create-expense/create-expense.ts
+++ b/components/expensify/actions/create-expense/create-expense.ts
@@ -1,10 +1,9 @@
-// x-pd-ai: optimized
 import { defineAction } from "@pipedream/types";
 import expensify from "../../app/expensify.app";
 
 export default defineAction({
   key: "expensify-create-expense",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -13,6 +12,7 @@ export default defineAction({
   name: "Create Expense",
   description: "Creates a new expense. [See docs here](https://integrations.expensify.com/Integration-Server/doc/#expense-creator)",
   type: "action",
+  ai: "optimized",
   props: {
     expensify,
     employeeEmail: {

--- a/components/expensify/actions/create-report/create-report.ts
+++ b/components/expensify/actions/create-report/create-report.ts
@@ -1,11 +1,10 @@
-// x-pd-ai: optimized
 import { defineAction } from "@pipedream/types";
 import app from "../../app/expensify.app";
 import utils from "../../common/utils";
 
 export default defineAction({
   key: "expensify-create-report",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -14,6 +13,7 @@ export default defineAction({
   name: "Create Report",
   description: "Creates a new report with transactions in a user's account. [See docs here](https://integrations.expensify.com/Integration-Server/doc/#report-creator)",
   type: "action",
+  ai: "optimized",
   props: {
     app,
     employeeEmail: {

--- a/components/expensify/actions/export-report-to-pdf/export-report-to-pdf.ts
+++ b/components/expensify/actions/export-report-to-pdf/export-report-to-pdf.ts
@@ -1,11 +1,10 @@
-// x-pd-ai: optimized
 import { defineAction } from "@pipedream/types";
 import expensify from "../../app/expensify.app";
 import fs from "fs";
 
 export default defineAction({
   key: "expensify-export-report-to-pdf",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -14,6 +13,7 @@ export default defineAction({
   name: "Export Report To PDF",
   description: "Export a report to PDF. [See docs here](https://integrations.expensify.com/Integration-Server/doc/#report-exporter)",
   type: "action",
+  ai: "optimized",
   props: {
     expensify,
     reportId: {

--- a/components/expensify/actions/export-report/export-report.ts
+++ b/components/expensify/actions/export-report/export-report.ts
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { defineAction } from "@pipedream/types";
 import expensify from "../../app/expensify.app";
 import fs from "fs";
@@ -12,13 +11,14 @@ export default defineAction({
   key: "expensify-export-report",
   name: "Export Report",
   description: "Export Expensify reports to a file (csv, xls, xlsx, txt, pdf, json, xml). [See the documentation](https://integrations.expensify.com/Integration-Server/doc/#report-exporter)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     expensify,
     reportIds: {

--- a/components/expensify/actions/get-report/get-report.ts
+++ b/components/expensify/actions/get-report/get-report.ts
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { defineAction } from "@pipedream/types";
 import expensify from "../../app/expensify.app";
 import { REPORT_DETAIL_FTL_TEMPLATE } from "../../common/constants";
@@ -7,8 +6,9 @@ export default defineAction({
   key: "expensify-get-report",
   name: "Get Report",
   description: "Retrieve a single Expensify report by ID, returning a structured object with the report metadata plus its complete expense line-item list (per-expense amount, currency, merchant, date, category, receiptURL, etc.). NOT a file. Implemented via the Report Exporter with reportIDList set to the given ID and an embedded Freemarker JSON template read in memory. Use **List Reports** to discover report IDs. This action also covers per-expense reads: the returned transactionList contains full expense details, so a separate expense-by-ID lookup is unnecessary. [See the documentation](https://integrations.expensify.com/Integration-Server/doc/#report-exporter)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/expensify/actions/list-expenses/list-expenses.ts
+++ b/components/expensify/actions/list-expenses/list-expenses.ts
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { defineAction } from "@pipedream/types";
 import expensify from "../../app/expensify.app";
 import { EXPENSE_LIST_FTL_TEMPLATE } from "../../common/constants";
@@ -7,8 +6,9 @@ export default defineAction({
   key: "expensify-list-expenses",
   name: "List Expenses",
   description: "List individual expenses (transactions) for an employee within a date range, returning a structured JSON array (each with amount, currency, merchant, created date, category, receiptURL, reportID). NOT a file. Implemented via the Report Exporter with an embedded Freemarker JSON template that flattens transactionList, read in memory. Use **List Policies** to discover valid IDs for the optional policyId filter. To read all expenses on one specific report, use **Get Report** instead. [See the documentation](https://integrations.expensify.com/Integration-Server/doc/#report-exporter)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/expensify/actions/list-policies/list-policies.ts
+++ b/components/expensify/actions/list-policies/list-policies.ts
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { defineAction } from "@pipedream/types";
 import expensify from "../../app/expensify.app";
 
@@ -6,13 +5,14 @@ export default defineAction({
   key: "expensify-list-policies",
   name: "List Policies",
   description: "Retrieves a list of policies. [See the documentation](https://integrations.expensify.com/Integration-Server/doc/#policy-list-getter)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     expensify,
     adminOnly: {

--- a/components/expensify/actions/list-reports/list-reports.ts
+++ b/components/expensify/actions/list-reports/list-reports.ts
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { defineAction } from "@pipedream/types";
 import { ConfigurationError } from "@pipedream/platform";
 import expensify from "../../app/expensify.app";
@@ -12,8 +11,9 @@ export default defineAction({
   key: "expensify-list-reports",
   name: "List Reports",
   description: "Search Expensify reports by state and/or date range and return a structured JSON array of report summaries (reportID, reportName, total, status, submitterEmail, etc.), NOT a file. Use this to find reports before acting on them. Under the hood this calls the Report Exporter with an embedded Freemarker JSON template and reads the result in memory (no /tmp file written). You must provide either a reportState or a startDate/endDate range. Note: OPEN reports cannot be returned when an employeeEmail filter is set (API restriction). Use **List Policies** to discover valid policy IDs for the optional policyId filter. Use **Get Report** to retrieve a single report's full expense line items. [See the documentation](https://integrations.expensify.com/Integration-Server/doc/#report-exporter)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/expensify/actions/reimburse-report/reimburse-report.ts
+++ b/components/expensify/actions/reimburse-report/reimburse-report.ts
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import { defineAction } from "@pipedream/types";
 import expensify from "../../app/expensify.app";
@@ -8,8 +7,9 @@ export default defineAction({
   key: "expensify-reimburse-report",
   name: "Reimburse Report",
   description: "Mark an APPROVED Expensify report as `REIMBURSED` via the Integration Server `reportStatus` updater. This is the only report-status transition the API supports — Approve and Reject are not available (attempting `APPROVED` returns responseCode 410). Use **List Reports** with reportState=APPROVED to find reports eligible for reimbursement. [See the documentation](https://integrations.expensify.com/Integration-Server/doc/#report-status-updater)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/expensify/package.json
+++ b/components/expensify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/expensify",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Pipedream Expensify Components",
   "main": "dist/app/expensify.app.mjs",
   "keywords": [

--- a/components/gmail/actions/create-draft/create-draft.mjs
+++ b/components/gmail/actions/create-draft/create-draft.mjs
@@ -11,13 +11,14 @@ export default {
     + " To draft to yourself, pass `\"me\"` in `to` — the action resolves it to the authenticated user's email address. No pre-call to **Get Current User** required."
     + " Attachments use `file-ref` inputs and require matching `attachmentFilenames[]` entries."
     + " [See the documentation](https://developers.google.com/gmail/api/reference/rest/v1/users.drafts/create).",
-  version: "0.2.2",
+  version: "0.2.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     gmail,
     to: {

--- a/components/gmail/actions/create-label/create-label.mjs
+++ b/components/gmail/actions/create-label/create-label.mjs
@@ -13,13 +13,14 @@ export default {
     + " Nested labels are expressed with `/` — e.g. `Clients/Acme` creates or targets a sub-label under `Clients`."
     + " `color` is optional; when provided, both `textColor` and `backgroundColor` must be supplied together and must come from Gmail's fixed palette."
     + " [See the documentation](https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.labels/create).",
-  version: "0.1.2",
+  version: "0.1.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     gmail,
     name: {

--- a/components/gmail/actions/download-attachment/download-attachment.mjs
+++ b/components/gmail/actions/download-attachment/download-attachment.mjs
@@ -17,13 +17,14 @@ export default {
     + " If `filename` is omitted, the action looks up the attachment's filename from the message payload."
     + " Set `convertToPdf: true` to convert image / HTML / plain-text / DOCX attachments to PDF during download; other MIME types are rejected."
     + " [See the documentation](https://developers.google.com/gmail/api/reference/rest/v1/users.messages.attachments/get).",
-  version: "0.1.2",
+  version: "0.1.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     gmail,
     messageId: {

--- a/components/gmail/actions/find-email/find-email.mjs
+++ b/components/gmail/actions/find-email/find-email.mjs
@@ -46,13 +46,14 @@ export default {
     + " `format` stays `metadata` unless you need the raw MIME tree for **Download Attachment**, in which case pass `format: \"full\"` and request `payload`."
     + " Responses are capped. Over the cap: if you named `fields`, whole messages are dropped rather than your chosen fields being removed, and the note says how many of how many are shown — narrow `q` and retry. If you named none, messages are compacted instead so counts stay accurate. `bodyText` shrinks toward a floor before anything is dropped, flagging each cut message with `bodyTruncated: true`."
     + " [See the documentation](https://developers.google.com/gmail/api/reference/rest/v1/users.messages/list) and [Gmail search operators](https://support.google.com/mail/answer/7190).",
-  version: "0.3.0",
+  version: "0.3.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     gmail,
     q: {

--- a/components/gmail/actions/get-current-user/get-current-user.mjs
+++ b/components/gmail/actions/get-current-user/get-current-user.mjs
@@ -4,8 +4,9 @@ export default {
   key: "gmail-get-current-user",
   name: "Get Current User",
   description: "Returns the authenticated Gmail user's name, email address, and mailbox stats (total messages and threads). Call this first when the user says 'my emails', 'my inbox', or needs identity context. Use the returned `emailAddress` to identify the user's own messages in **Find Emails** results. [See the documentation](https://developers.google.com/gmail/api/reference/rest/v1/users/getProfile).",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/gmail/actions/list-labels/list-labels.mjs
+++ b/components/gmail/actions/list-labels/list-labels.mjs
@@ -8,13 +8,14 @@ export default {
     + " Call this before **Modify Labels** or **Find Emails** when you need to target a label that the user named rather than an obvious system label — it resolves a name like `Clients/Acme` to its opaque label ID."
     + " User labels are returned first, then system labels."
     + " [See the documentation](https://developers.google.com/gmail/api/reference/rest/v1/users.labels/list).",
-  version: "0.1.2",
+  version: "0.1.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     gmail,
   },

--- a/components/gmail/actions/list-thread-messages/list-thread-messages.mjs
+++ b/components/gmail/actions/list-thread-messages/list-thread-messages.mjs
@@ -14,13 +14,14 @@ export default {
     + " With `format: full` (default) each message includes decoded `text`/`html` bodies and attachment metadata. Use `format: metadata` to skip bodies and get only headers + labelIds — useful for large threads."
     + " Responses are capped — oversized threads fall back to `metadata`-level detail (or are further truncated from the tail) with a `[truncated]` marker so the caller knows to narrow the request."
     + " [See the documentation](https://developers.google.com/gmail/api/reference/rest/v1/users.threads/get).",
-  version: "0.2.0",
+  version: "0.2.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     gmail,
     threadId: {

--- a/components/gmail/actions/modify-labels/modify-labels.mjs
+++ b/components/gmail/actions/modify-labels/modify-labels.mjs
@@ -24,13 +24,14 @@ export default {
     + "\n\n`addLabels` and `removeLabels` accept either raw label IDs (system labels like `INBOX`, `STARRED`, `UNREAD`, `TRASH`) or user-visible label names — names are resolved via **List Labels** before the API call."
     + " Use **Create Label** first if you need to apply a brand-new label that doesn't yet exist."
     + " [See the documentation](https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.messages/batchModify).",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     gmail,
     messageIds: {

--- a/components/gmail/actions/send-email/send-email.mjs
+++ b/components/gmail/actions/send-email/send-email.mjs
@@ -13,13 +13,14 @@ export default {
     + " To send to yourself, pass `\"me\"` in `to` — the action resolves it to the authenticated user's email address. No pre-call to **Get Current User** required."
     + " Attachments: for small inline content (the common case in MCP / cloud runs), set `attachmentContent` to the file's text contents and `attachmentFilename` to its name. For files already on disk (Pipedream workflows, File Stash), use `attachments[]` + `attachmentFilenames[]` instead."
     + " [See the documentation](https://developers.google.com/gmail/api/reference/rest/v1/users.messages/send).",
-  version: "0.3.2",
+  version: "0.3.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     gmail,
     to: {

--- a/components/gmail/package.json
+++ b/components/gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/gmail",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Pipedream Gmail Components",
   "main": "gmail.app.mjs",
   "keywords": [

--- a/components/google_health/actions/get-body-measurements/get-body-measurements.mjs
+++ b/components/google_health/actions/get-body-measurements/get-body-measurements.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import app from "../../google_health.app.mjs";
 import {
   addDays,
@@ -25,8 +24,9 @@ export default {
   key: "google_health-get-body-measurements",
   name: "Get Body Measurements",
   description: "Get the user's weight logs with **computed BMI**, their body-fat percentage logs, and their current height. Raw logs, so there is no date cap; at most 1000 weigh-ins per call, with `truncated` set when there were more. Example: startDate=\"2026-08-01\", endDate=\"2026-08-25\" → `weightLogs: [{ time, weightKg: 74.2, weightLb: 163.6, bmi: 22.9, notes }]`, `bodyFatLogs: [{ time, percentage }]`, and `height: { heightCm, heightIn, measuredAt }`. `weightLogs` and `bodyFatLogs` are newest first. Two things to tell the user rather than guess: the API has **no BMI field**, so BMI is computed here as kg ÷ height in m² and is `null` when no height is on record. `height` is not measured over the requested range at all — it is the most recent height found in a ten-year lookback, capped at one page, so check `measuredAt` before calling it current: it can be years old, and when nothing turns up `bmiComputable` is `false` and every `bmi` is `null`. Body fat is measured separately from weight, so a weigh-in on a scale without body composition appears in `weightLogs` with no matching `bodyFatLogs` entry. Set includeBodyFat=false to skip the body-fat request entirely — `bodyFatLogs` then comes back empty because it was never asked for, which is not the same as the user having no body-fat data. [See the documentation](https://developers.google.com/health/reference/rest/v4/users.dataTypes.dataPoints/list)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_health/actions/get-daily-activity-summary/get-daily-activity-summary.mjs
+++ b/components/google_health/actions/get-daily-activity-summary/get-daily-activity-summary.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import app from "../../google_health.app.mjs";
 import {
   civilDateToString,
@@ -30,8 +29,9 @@ export default {
   key: "google_health-get-daily-activity-summary",
   name: "Get Daily Activity Summary",
   description: "Get a full day of activity at once: steps, distance, calories, active minutes by intensity, active zone minutes by heart rate zone, and floors. The right tool when the user wants an overall picture of a day rather than one metric — use **Get Daily Step Count** for steps alone or **Get Heart Rate** for heart rate detail. The range is inclusive and capped at **14 days** (calories and active minutes impose that limit on the aggregation). Example: startDate=\"2026-08-24\" → `days: [{ date, steps: 8432, distanceKm: 6.1, totalCalories: 2380, activeCalories: 620, activeMinutes: { light, moderate, vigorous, total }, activeZoneMinutes: { fatBurn, cardio, peak, total }, floors: 12 }]`. Set dataSourceFamily=\"google-wearables\" to exclude manually logged activity. A `null` metric means that one metric did not sync for that day and says nothing about the rest of the day — a day can carry real steps alongside a `null` `distanceKm`, so do not report the whole day as empty. An empty `days` array is the separate case where no activity data synced at all for the range. Never report either as zero. The API has no concept of daily goals, so no targets are returned. [See the documentation](https://developers.google.com/health/reference/rest/v4/users.dataTypes.dataPoints/dailyRollUp)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_health/actions/get-daily-steps/get-daily-steps.mjs
+++ b/components/google_health/actions/get-daily-steps/get-daily-steps.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import app from "../../google_health.app.mjs";
 import {
   civilDateToString,
@@ -11,8 +10,9 @@ export default {
   key: "google_health-get-daily-steps",
   name: "Get Daily Step Count",
   description: "Get the user's total step count per day — the tool for any \"how many steps\" question. Returns one pre-aggregated total per day, not raw samples. Use **Get Daily Activity Summary** instead when distance, calories, active minutes, or floors are wanted alongside steps. The range is inclusive and capped at 90 days, because these totals are server-aggregated. Example: startDate=\"2026-08-17\", endDate=\"2026-08-23\" → `days: [{ date, steps: 8432 }, ...]` plus `totalSteps`, `averageSteps`, `daysRequested` and `daysWithData`. Set dataSourceFamily=\"google-wearables\" to count only tracker-recorded steps, excluding manual entries. Days the tracker never reported are omitted from `days` entirely, so `daysWithData` can be lower than `daysRequested` and `averageSteps` is the mean over `daysWithData`. An empty `days` array means nothing synced, not zero steps — `totalSteps` and `averageSteps` are `null` in that case rather than 0. [See the documentation](https://developers.google.com/health/reference/rest/v4/users.dataTypes.dataPoints/dailyRollUp)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_health/actions/get-heart-rate/get-heart-rate.mjs
+++ b/components/google_health/actions/get-heart-rate/get-heart-rate.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import app from "../../google_health.app.mjs";
 import { ROLLUP_WINDOWS } from "../../common/constants.mjs";
@@ -23,8 +22,9 @@ export default {
   key: "google_health-get-heart-rate",
   name: "Get Heart Rate",
   description: "Get the user's heart rate aggregated into time windows, plus their daily resting heart rate. Each window reports average, minimum, and maximum BPM; pick the window size with `granularity`. The range is inclusive and capped at **14 days**, because the windows are server-aggregated. Example: startDate=\"2026-08-24\", granularity=\"900s\" → 96 fifteen-minute windows as `{ startTime, endTime, avgBpm, minBpm, maxBpm }`, plus `restingHeartRate: [{ date, bpm }]` and an overall `summary`. Use granularity=\"86400s\" for one figure per day. Resting heart rate comes back from this tool too — there is no separate resting-HR tool. For active zone minutes, which are heart-rate derived but reported as activity, use **Get Daily Activity Summary**. [See the documentation](https://developers.google.com/health/reference/rest/v4/users.dataTypes.dataPoints/rollUp)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_health/actions/get-identity/get-identity.mjs
+++ b/components/google_health/actions/get-identity/get-identity.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import app from "../../google_health.app.mjs";
 
 export default {
   key: "google_health-get-identity",
   name: "Get Identity",
   description: "Get the connected user's Google Health identifiers: `healthUserId` and `legacyUserId`, the ID the same user had on the legacy Fitbit Web APIs. Use it to correlate records between a system that stored Fitbit IDs and one now on Google Health. Also the cheapest way to confirm the connection works, since it needs no synced data. Example: call with no parameters → returns `{ healthUserId: \"NGL8Q2...\", legacyUserId: \"2E4RVC\" }`. `legacyUserId` is 1-63 characters of letters, numbers and hyphens — treat it as an opaque string and do not assume a fixed length or format. It is empty for users who never had a Fitbit account. [See the documentation](https://developers.google.com/health/reference/rest/v4/users/getIdentity)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_health/actions/get-nutrition-and-hydration/get-nutrition-and-hydration.mjs
+++ b/components/google_health/actions/get-nutrition-and-hydration/get-nutrition-and-hydration.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import app from "../../google_health.app.mjs";
 import { DEFAULT_MAX_RANGE_DAYS } from "../../common/constants.mjs";
@@ -28,8 +27,9 @@ export default {
   key: "google_health-get-nutrition-and-hydration",
   name: "Get Nutrition and Hydration Logs",
   description: "Get the user's logged food and water intake, with aggregate calorie, macro and water totals. Example: startDate=\"2026-08-24\" → `entries: [{ time, foodDisplayName: \"Greek yogurt\", mealType: \"BREAKFAST\", calories: 180, totalFatG: 4.5, totalCarbohydrateG: 9 }]`, `hydration: [{ time, milliliters: 500, liters: 0.5, flOz: 16.9 }]`, and `totals`. `totals` is **one object covering the whole requested range, not per-day figures** — call a single day at a time if daily breakdowns are wanted. Entries have no date-range limit, but `totals` are server-aggregated and cap the range at 90 days — set includeTotals=false to read entries over a longer span, which makes `totals` `null`. At most **1000 food entries and 1000 hydration entries** come back per call (five pages of 200); `truncated: true` means there were more, so check it before treating the entry list as complete and narrow the range if it is set. Only food the user **logged manually** appears here; nothing is inferred from activity, so an empty result means nothing was logged, not that nothing was eaten. [See the documentation](https://developers.google.com/health/data-types/nutrition)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_health/actions/get-sleep-data/get-sleep-data.mjs
+++ b/components/google_health/actions/get-sleep-data/get-sleep-data.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import app from "../../google_health.app.mjs";
 import {
   buildTimeFilter,
@@ -27,8 +26,9 @@ export default {
   key: "google_health-get-sleep-data",
   name: "Get Sleep Data",
   description: "Get the user's sleep sessions with per-stage totals, time asleep and awake, and a derived efficiency figure. A session is attributed to the date the user **woke up**, matching Fitbit — asking for 2026-08-24 returns the night of the 23rd into the 24th. Example: startDate=\"2026-08-24\" → `sessions: [{ startTime, endTime, type: \"STAGES\", isMainSleep: true, minutesAsleep: 431, minutesAwake: 48, efficiency: 0.9, stageTotals: { LIGHT: 240, DEEP: 71, REM: 120, AWAKE: 48 } }]`, plus `mainSleep` and `totalMinutesAsleep`. Three things to tell the user rather than invent: this API has **no sleep score**, so none is returned, and `efficiency` is computed here as time asleep over time in bed — not the figure Fitbit showed. Stage names depend on `type`, so read `stageTotals` rather than assuming a fixed set: `STAGES` sessions report LIGHT/DEEP/REM/AWAKE, older `CLASSIC` ones only ASLEEP/AWAKE/RESTLESS. Naps are separate sessions with `isNap: true`. At most 125 sessions per call; `truncated: true` means narrow the range. [See the documentation](https://developers.google.com/health/reference/rest/v4/users.dataTypes.dataPoints/list)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_health/actions/list-data-points/list-data-points.mjs
+++ b/components/google_health/actions/list-data-points/list-data-points.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import app from "../../google_health.app.mjs";
 import {
@@ -36,8 +35,9 @@ export default {
   key: "google_health-list-data-points",
   name: "List Data Points",
   description: "Read raw data points for any Google Health data type the dedicated tools do not cover — blood oxygen (`oxygen-saturation`), heart rate variability, respiratory rate, VO2 max, body temperature, exercise sessions, sedentary periods, altitude, swim lengths and more; see the `dataType` options for the full list. **Prefer a dedicated tool where one exists**, since those return compact pre-aggregated results while this returns raw records and can be large: **Get Daily Step Count** (steps), **Get Daily Activity Summary** (calories, distance, active minutes, floors), **Get Heart Rate**, **Get Sleep Data**, **Get Body Measurements** (weight, body fat), **Get Nutrition and Hydration Logs** (food, water). Example: dataType=\"oxygen-saturation\", startDate=\"2026-08-24\" → `dataPoints` with each reading's value and timestamp, newest first. Two pages of `pageSize` come back (default 50 → 100 records) and `pageSize` is capped at 500, so **one call returns at most 1000 records**; `truncated: true` means there were more — narrow the date range or raise `pageSize` up to that cap. `food` and `food-measurement-unit` are reference catalogues, not time series — the date range does not apply, the response sets `dateFilterApplied: false`, and you must not describe those results as belonging to a particular day. Not available here: `total-calories`, `floors`, and `calories-in-heart-rate-zone` are aggregate-only (use **Get Daily Activity Summary**); ECG and irregular-rhythm data need OAuth scopes this app does not request. [See the documentation](https://developers.google.com/health/data-types)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/google_health/package.json
+++ b/components/google_health/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_health",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream Google Health Components",
   "main": "google_health.app.mjs",
   "keywords": [

--- a/components/grafana/actions/create-annotation/create-annotation.mjs
+++ b/components/grafana/actions/create-annotation/create-annotation.mjs
@@ -13,8 +13,9 @@ export default {
     + " all dashboards."
     + " Use `time` and `timeEnd` for range annotations (e.g.,"
     + " deployment window).",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/grafana/actions/delete-dashboard/delete-dashboard.mjs
+++ b/components/grafana/actions/delete-dashboard/delete-dashboard.mjs
@@ -8,8 +8,9 @@ export default {
     "Permanently delete a Grafana dashboard by UID."
     + " This cannot be undone."
     + " Use **Search Dashboards** to find the dashboard UID.",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/grafana/actions/get-current-user/get-current-user.mjs
+++ b/components/grafana/actions/get-current-user/get-current-user.mjs
@@ -11,8 +11,9 @@ export default {
     + " organizational context."
     + " The user ID and org context may be needed when creating"
     + " dashboards or filtering resources.",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: false,

--- a/components/grafana/actions/get-dashboard/get-dashboard.mjs
+++ b/components/grafana/actions/get-dashboard/get-dashboard.mjs
@@ -11,8 +11,9 @@ export default {
     + " UID."
     + " The returned model can be modified and saved back with"
     + " **Save Dashboard**.",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/grafana/actions/list-alert-rules/list-alert-rules.mjs
+++ b/components/grafana/actions/list-alert-rules/list-alert-rules.mjs
@@ -11,8 +11,9 @@ export default {
     + " and annotations."
     + " Use this to answer questions like 'what alerts are"
     + " firing?' or 'what alerts exist for service X?'",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: false,

--- a/components/grafana/actions/list-data-sources/list-data-sources.mjs
+++ b/components/grafana/actions/list-data-sources/list-data-sources.mjs
@@ -12,8 +12,9 @@ export default {
     + " The `type` field indicates what query language to use"
     + " (e.g., `prometheus` → PromQL, `loki` → LogQL,"
     + " `mysql` → SQL).",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: false,

--- a/components/grafana/actions/list-folders/list-folders.mjs
+++ b/components/grafana/actions/list-folders/list-folders.mjs
@@ -10,8 +10,9 @@ export default {
     + " Use folder UIDs with **Search Dashboards** to filter by"
     + " folder, or with **Save Dashboard** to place a dashboard"
     + " in a specific folder.",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: false,

--- a/components/grafana/actions/query-data-source/query-data-source.mjs
+++ b/components/grafana/actions/query-data-source/query-data-source.mjs
@@ -27,8 +27,9 @@ export default {
     + "Time range defaults to last 1 hour. Use `from` and `to`"
     + " for custom ranges (supports relative: `now-24h`,"
     + " `now-7d`, or epoch milliseconds).",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/grafana/actions/save-dashboard/save-dashboard.mjs
+++ b/components/grafana/actions/save-dashboard/save-dashboard.mjs
@@ -15,8 +15,9 @@ export default {
     + " conflicts."
     + " [See the documentation](https://grafana.com/docs/"
     + "grafana/latest/developers/http_api/dashboard/)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/grafana/actions/search-dashboards/search-dashboards.mjs
+++ b/components/grafana/actions/search-dashboards/search-dashboards.mjs
@@ -12,8 +12,9 @@ export default {
     + " dashboard model."
     + " Use **List Folders** to discover folder UIDs for"
     + " filtering.",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/grafana/package.json
+++ b/components/grafana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/grafana",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream Grafana Components",
   "main": "grafana.app.mjs",
   "keywords": [

--- a/components/ionos_hosting_services/actions/create-dns-records/create-dns-records.mjs
+++ b/components/ionos_hosting_services/actions/create-dns-records/create-dns-records.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import ionosHostingServices from "../../ionos_hosting_services.app.mjs";
 import { parseRecords } from "../../common/utils.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "ionos_hosting_services-create-dns-records",
   name: "Create DNS Records",
   description: "Create one or more DNS records in a zone. Accepts a JSON array of record objects and returns the created records (each with a new `id`). The `name` field in each record must be the fully-qualified domain name (FQDN) including the zone domain — use `newman.example.com`, not just `newman`. Run **List DNS Zones** first to get the zone ID and zone domain name, then construct the full FQDN for each record. [See the documentation](https://developer.hosting.ionos.com/docs/dns).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/ionos_hosting_services/actions/delete-dns-record/delete-dns-record.mjs
+++ b/components/ionos_hosting_services/actions/delete-dns-record/delete-dns-record.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import ionosHostingServices from "../../ionos_hosting_services.app.mjs";
 
 export default {
   key: "ionos_hosting_services-delete-dns-record",
   name: "Delete DNS Record",
   description: "Permanently delete a single DNS record from a zone by its record ID. This cannot be undone. Run **Get DNS Zone** to find the record ID. [See the documentation](https://developer.hosting.ionos.com/docs/dns).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: true,

--- a/components/ionos_hosting_services/actions/get-dns-record/get-dns-record.mjs
+++ b/components/ionos_hosting_services/actions/get-dns-record/get-dns-record.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import ionosHostingServices from "../../ionos_hosting_services.app.mjs";
 
 export default {
   key: "ionos_hosting_services-get-dns-record",
   name: "Get DNS Record",
   description: "Get a single DNS record from a zone by its record ID. Returns the record object, for example `{\"id\":\"rec-uuid\",\"name\":\"www.example.com\",\"type\":\"A\",\"content\":\"5.6.7.8\",\"ttl\":3600}` (full fields include `rootName`, `prio`, `disabled`, `changeDate`). Run **List DNS Zones** to find the zone ID and **Get DNS Zone** to find the record ID. [See the documentation](https://developer.hosting.ionos.com/docs/dns).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/ionos_hosting_services/actions/get-dns-zone/get-dns-zone.mjs
+++ b/components/ionos_hosting_services/actions/get-dns-zone/get-dns-zone.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import ionosHostingServices from "../../ionos_hosting_services.app.mjs";
 import { DNS_RECORD_TYPES } from "../../common/constants.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "ionos_hosting_services-get-dns-zone",
   name: "Get DNS Zone",
   description: "Get a single DNS zone including its `records` array. This is also the only way to list a zone's DNS records (there is no dedicated list-records endpoint) - use the optional `nameFilter` and `recordType` filters to narrow the returned records, and read each record's `id` for use in the record-level actions. Returns an object like `{\"id\":\"4ab3a7e2-1234-5678-abcd-ef0123456789\",\"name\":\"example.com\",\"type\":\"NATIVE\",\"records\":[{\"id\":\"90d81ac0-3a30-44d4-95a5-12959effa6ee\",\"name\":\"www.example.com\",\"type\":\"A\",\"content\":\"5.6.7.8\",\"ttl\":3600}]}`. Run **List DNS Zones** first to obtain a zone ID. [See the documentation](https://developer.hosting.ionos.com/docs/dns).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/ionos_hosting_services/actions/list-dns-zones/list-dns-zones.mjs
+++ b/components/ionos_hosting_services/actions/list-dns-zones/list-dns-zones.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import ionosHostingServices from "../../ionos_hosting_services.app.mjs";
 
 export default {
   key: "ionos_hosting_services-list-dns-zones",
   name: "List DNS Zones",
   description: "List all DNS zones for the authenticated IONOS Hosting Services account. Returns an array of zone objects, for example `[{\"id\":\"4ab3a7e2-1234-5678-abcd-ef0123456789\",\"name\":\"example.com\",\"type\":\"NATIVE\"}]`. Use the `id` field (not the `name` field) as the zone ID in other DNS actions. [See the documentation](https://developer.hosting.ionos.com/docs/dns).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/ionos_hosting_services/actions/patch-dns-zone/patch-dns-zone.mjs
+++ b/components/ionos_hosting_services/actions/patch-dns-zone/patch-dns-zone.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import ionosHostingServices from "../../ionos_hosting_services.app.mjs";
 import { parseRecords } from "../../common/utils.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "ionos_hosting_services-patch-dns-zone",
   name: "Patch DNS Zone",
   description: "Partially update a DNS zone (HTTP PATCH): for each provided record, all existing records sharing the same name and type are replaced with the provided ones. Records with other name/type combinations are left untouched. For a full zone overwrite use **Update DNS Zone (Full Replace)** instead. Run **List DNS Zones** to find the zone ID. [See the documentation](https://developer.hosting.ionos.com/docs/dns).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: true,

--- a/components/ionos_hosting_services/actions/update-dns-record/update-dns-record.mjs
+++ b/components/ionos_hosting_services/actions/update-dns-record/update-dns-record.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import ionosHostingServices from "../../ionos_hosting_services.app.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "ionos_hosting_services-update-dns-record",
   name: "Update DNS Record",
   description: "Update an existing DNS record (HTTP PUT on a single record). Only `content`, `ttl`, `prio`, and `disabled` can be changed - the record's `name` and `type` are immutable via this endpoint (delete and recreate to change them). Run **Get DNS Zone** to find the record ID. [See the documentation](https://developer.hosting.ionos.com/docs/dns).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/ionos_hosting_services/actions/update-dns-zone/update-dns-zone.mjs
+++ b/components/ionos_hosting_services/actions/update-dns-zone/update-dns-zone.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import ionosHostingServices from "../../ionos_hosting_services.app.mjs";
 import { parseRecords } from "../../common/utils.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "ionos_hosting_services-update-dns-zone",
   name: "Update DNS Zone (Full Replace)",
   description: "Replace ALL records in a DNS zone with the provided record set (HTTP PUT / full zone overwrite). Any existing record not present in the payload is permanently removed. For a partial update that only replaces records sharing the same name and type, use **Patch DNS Zone** instead. Run **List DNS Zones** to find the zone ID and **Get DNS Zone** to inspect current records first. [See the documentation](https://developer.hosting.ionos.com/docs/dns).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: true,

--- a/components/ionos_hosting_services/package.json
+++ b/components/ionos_hosting_services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/ionos_hosting_services",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream IONOS Hosting Services Components",
   "main": "ionos_hosting_services.app.mjs",
   "keywords": [

--- a/components/mercury/actions/add-recipient/add-recipient.mjs
+++ b/components/mercury/actions/add-recipient/add-recipient.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import mercury from "../../mercury.app.mjs";
 import {
@@ -10,8 +9,9 @@ export default {
   key: "mercury-add-recipient",
   name: "Add Recipient",
   description: "Create a new Mercury payment recipient. Provide **Recipient Name** and **Emails** for a basic contact. To attach bank details, set **Payment Method** and the matching fields: `ach` needs Account Number, Routing Number, Electronic Account Type, and the address fields; `domesticWire` needs Account Number, Routing Number, and the address fields; `check` needs only the address fields. All numeric-looking values (account number, routing number, postal code) are sent to Mercury as strings (individual string props, so leading zeros are preserved). Example: `recipientName=\"Art Vandelay\"`, `emails=[\"art@vandelayindustries.com\"]`, `paymentMethod=\"ach\"`, `accountNumber=\"123456789\"`, `routingNumber=\"021000021\"`, `electronicAccountType=\"businessChecking\"`, `addressLine1=\"100 Federal Street\"`, `city=\"Boston\"`, `region=\"MA\"`, `postalCode=\"02101\"`, `country=\"US\"` -> returns the created recipient `{ id: \"b56db170-927b-11f1-a805-27c2879b4c72\", name: \"Art Vandelay\", ... }` (the `id` is a UUID, not a prefixed string). [See the documentation](https://docs.mercury.com/reference/createrecipient)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/mercury/actions/get-account-info/get-account-info.mjs
+++ b/components/mercury/actions/get-account-info/get-account-info.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import mercury from "../../mercury.app.mjs";
 import { MAX_LIMIT } from "../../common/constants.mjs";
@@ -7,13 +6,14 @@ export default {
   key: "mercury-get-account-info",
   name: "Get Account Information",
   description: "Retrieve information (including balances) about a specific Mercury account by its ID. Mercury has no get-account-by-ID endpoint, so this pages through **List Accounts** and returns the account whose `id` matches. Run **List Accounts** first to obtain a valid account ID. The account ID is a UUID, not a prefixed string. Example: call with `account=\"69c8b0ee-8b87-11f1-a9e5-e7cd8f0e3f51\"` -> returns that account's full record `{ id, name, currentBalance, availableBalance, type, ... }`. [See the documentation](https://docs.mercury.com/reference/getaccounts)",
-  version: "0.1.0",
+  version: "0.1.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     mercury,
     account: {

--- a/components/mercury/actions/get-transaction/get-transaction.mjs
+++ b/components/mercury/actions/get-transaction/get-transaction.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import mercury from "../../mercury.app.mjs";
 
 export default {
   key: "mercury-get-transaction",
   name: "Get Transaction",
   description: "Retrieve the full detail of a single Mercury transaction by its account and transaction IDs. Run **List Accounts** to obtain the account ID and **List Transactions** to obtain the transaction ID. Both IDs are UUIDs, not prefixed strings. Example: call with `accountId=\"69c8b0ee-8b87-11f1-a9e5-e7cd8f0e3f51\"` and `transactionId=\"9a3f2c14-4d21-11f1-8c7e-1b2d3e4f5a6b\"` -> returns the transaction `{ id, amount, counterpartyName, status, postedAt, ... }`. [See the documentation](https://docs.mercury.com/reference/gettransaction)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/mercury/actions/list-accounts/list-accounts.mjs
+++ b/components/mercury/actions/list-accounts/list-accounts.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import mercury from "../../mercury.app.mjs";
 import {
@@ -12,8 +11,9 @@ export default {
   key: "mercury-list-accounts",
   name: "List Accounts",
   description: "Retrieve a page of Mercury bank accounts for the connected profile (up to **Limit** per call, default 1000; pass the last account's ID as **Start After** to fetch later pages), including current and available balance fields (returned as numbers, not strings). Use this first to discover account IDs (each a UUID) needed by **List Transactions**, **Get Transaction**, and **Send Payment**. Serves the 'check balances across accounts' need since the accounts response already includes balance data. Example: call with no parameters -> returns `{ accounts: [{ id: \"69c8b0ee-8b87-11f1-a9e5-e7cd8f0e3f51\", name: \"Mercury Checking ••1234\", currentBalance: 5000, availableBalance: 4800.55 }] }`. [See the documentation](https://docs.mercury.com/reference/getaccounts)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/mercury/actions/list-categories/list-categories.mjs
+++ b/components/mercury/actions/list-categories/list-categories.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import mercury from "../../mercury.app.mjs";
 import {
@@ -12,8 +11,9 @@ export default {
   key: "mercury-list-categories",
   name: "List Categories",
   description: "List all custom expense categories for the organization. Use this to discover category IDs and names used to classify transactions. Example: call with no parameters -> returns `{ categories: [{ id: \"a1b2...\", name: \"Software\", visibleForCardSpend: true, visibleForOther: true, visibleForReimbursements: false }], page: { nextPage: null, previousPage: null } }`. [See the documentation](https://docs.mercury.com/reference/listcategories)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/mercury/actions/list-recipients/list-recipients.mjs
+++ b/components/mercury/actions/list-recipients/list-recipients.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import mercury from "../../mercury.app.mjs";
 import {
@@ -12,8 +11,9 @@ export default {
   key: "mercury-list-recipients",
   name: "List Recipients",
   description: "List a page of payment recipients configured on the connected Mercury profile (up to **Limit** per call, default 1000; pass the last recipient's ID as **Start After** to fetch later pages). Use this to discover recipient IDs needed by **Send Payment**. Recipient IDs are UUIDs, not prefixed strings. Example: call with no parameters -> returns `{ recipients: [{ id: \"b56db170-927b-11f1-a805-27c2879b4c72\", name: \"Acme Corp\", emails: [\"billing@acme.com\"] }] }`. [See the documentation](https://docs.mercury.com/reference/getrecipients)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/mercury/actions/list-send-money-requests/list-send-money-requests.mjs
+++ b/components/mercury/actions/list-send-money-requests/list-send-money-requests.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import mercury from "../../mercury.app.mjs";
 import {
@@ -12,8 +11,9 @@ export default {
   key: "mercury-list-send-money-requests",
   name: "List Send Money Requests",
   description: "List send money approval requests for the organization. Optionally filter by account and status. Use this to discover pending approvals and their `requestId`. Example: call with `status: \"pendingApproval\"` -> returns `{ requests: [{ requestId: \"3f1a9c22-8b87-11f1-a9e5-6b3dd34242f2\", accountId: \"69c8b0ee-8b87-11f1-a9e5-e7cd8f0e3f51\", amount: 100.5, paymentMethod: \"ach\", status: \"pendingApproval\" }], page: { nextPage: null, previousPage: null } }`. [See the documentation](https://docs.mercury.com/reference/listsendmoneyapprovalrequests)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/mercury/actions/list-transactions/list-transactions.mjs
+++ b/components/mercury/actions/list-transactions/list-transactions.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import mercury from "../../mercury.app.mjs";
 import {
   DEFAULT_LIMIT,
@@ -12,8 +11,9 @@ export default {
   key: "mercury-list-transactions",
   name: "List Transactions",
   description: "List transactions for a Mercury account, with optional date-range, search, status, and pagination filters. Run **List Accounts** first to obtain a valid account ID. All IDs are UUIDs, not prefixed strings. Example: call with `accountId=\"69c8b0ee-8b87-11f1-a9e5-e7cd8f0e3f51\"`, `status=\"sent\"`, and `limit=10` -> returns `{ transactions: [{ id: \"9a3f2c14-4d21-11f1-8c7e-1b2d3e4f5a6b\", amount: \"-42.00\", counterpartyName: \"AWS\", status: \"sent\", createdAt: \"2026-01-15T...\" }] }`. [See the documentation](https://docs.mercury.com/reference/listaccounttransactions)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/mercury/actions/send-payment/send-payment.mjs
+++ b/components/mercury/actions/send-payment/send-payment.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { randomUUID } from "crypto";
 import { ConfigurationError } from "@pipedream/platform";
 import mercury from "../../mercury.app.mjs";
@@ -13,8 +12,9 @@ export default {
   key: "mercury-send-payment",
   name: "Send Payment",
   description: "Create a payment transaction from a Mercury account to an existing recipient via ACH, check, or domestic wire. This endpoint requires the connected account's IP to be whitelisted; the transaction is submitted immediately (there is no scheduling parameter), but is returned in a `pending` state when the account's policy requires approval (otherwise `sent`) — check the returned `status`. Run **List Accounts** for the account ID and **List Recipients** for the recipient ID. NOTE: this only submits the payment; submitting a separate approval request is a different Mercury operation (`requestSendMoney`). Duplicate payments (same recipient, account, and amount within 24h) are rejected with HTTP 400. All IDs (`accountId`, `recipientId`, and the returned transaction `id`) are UUIDs, not prefixed strings. Example: call with `accountId=\"69c8b0ee-8b87-11f1-a9e5-e7cd8f0e3f51\"`, `recipientId=\"b56db170-927b-11f1-a805-27c2879b4c72\"`, `amount=\"10.00\"`, and `paymentMethod=\"ach\"` -> returns the created transaction `{ id: \"9a3f2c14-4d21-11f1-8c7e-1b2d3e4f5a6b\", status: \"pending\" }`. [See the documentation](https://docs.mercury.com/reference/createtransaction)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/mercury/package.json
+++ b/components/mercury/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/mercury",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Mercury Components",
   "main": "mercury.app.mjs",
   "keywords": [

--- a/components/microsoft_power_bi/actions/add-rows-to-push-dataset/add-rows-to-push-dataset.mjs
+++ b/components/microsoft_power_bi/actions/add-rows-to-push-dataset/add-rows-to-push-dataset.mjs
@@ -12,8 +12,9 @@ export default {
     + " Common mistakes: (1) case mismatch on `tableName` returns 404 — copy the exact string from the dataset's `tables` array. (2) Sending values that don't match the declared column data type returns `RequestedResourceNotFound` or `DMTS_DatasourceHasNoCredentialsError`."
     + " Push-dataset rows have no individual IDs and cannot be updated or deleted — only appended or bulk-cleared."
     + " [See the documentation](https://learn.microsoft.com/en-us/rest/api/power-bi/push-datasets/datasets-post-rows-in-group)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/microsoft_power_bi/actions/execute-dax-query/execute-dax-query.mjs
+++ b/components/microsoft_power_bi/actions/execute-dax-query/execute-dax-query.mjs
@@ -21,8 +21,9 @@ export default {
     + " The tenant must have 'Dataset Execute Queries REST API' enabled (admin setting) or the call returns 401/403."
     + " Pass `workspaceId` (from **List Workspaces**) or `workspaceName` to target a specific workspace, or omit both for My workspace."
     + " [See the documentation](https://learn.microsoft.com/en-us/rest/api/power-bi/datasets/execute-queries-in-group)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/microsoft_power_bi/actions/export-report/export-report.mjs
+++ b/components/microsoft_power_bi/actions/export-report/export-report.mjs
@@ -18,8 +18,9 @@ export default {
     + " The export is asynchronous — this tool starts the export, then polls until the job reaches `Succeeded` or `Failed` (or `pollTimeoutSeconds` elapses), then downloads the file and returns it as base64 along with the job metadata."
     + " PNG exports only work for single-page reports. For PPTX/PDF, pass `pages` (array of page names, e.g., `[\"ReportSection\", \"ReportSection1\"]`) to limit the export."
     + " [See the documentation](https://learn.microsoft.com/en-us/rest/api/power-bi/reports/export-to-file-in-group)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/microsoft_power_bi/actions/get-refresh-history/get-refresh-history.mjs
+++ b/components/microsoft_power_bi/actions/get-refresh-history/get-refresh-history.mjs
@@ -8,8 +8,9 @@ export default {
     + " Pass `workspaceId` (from **List Workspaces**) or `workspaceName` to scope to a specific workspace, or omit both for My workspace."
     + " Each entry includes `requestId`, `refreshType` (`OnDemand`, `Scheduled`, `ViaApi`, etc.), `startTime`, `endTime`, `status` (`Completed`, `Failed`, `Disabled`, `Cancelled`, `Unknown` — `Unknown` means still in progress), and `serviceExceptionJson` on failures."
     + " [See the documentation](https://learn.microsoft.com/en-us/rest/api/power-bi/datasets/get-refresh-history-in-group)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/microsoft_power_bi/actions/get-reports-by-id/get-reports-by-id.mjs
+++ b/components/microsoft_power_bi/actions/get-reports-by-id/get-reports-by-id.mjs
@@ -4,13 +4,14 @@ export default {
   key: "microsoft_power_bi-get-reports-by-id",
   name: "Get Report by id",
   description: "Retrieve metadata for a single Power BI report by ID. Uses My workspace by default; set Workspace (Group) ID for a specific workspace. [See the documentation](https://learn.microsoft.com/en-us/rest/api/power-bi/reports/get-report)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     microsoftPowerBi,
     groupId: {

--- a/components/microsoft_power_bi/actions/get-reports/get-reports.mjs
+++ b/components/microsoft_power_bi/actions/get-reports/get-reports.mjs
@@ -4,13 +4,14 @@ export default {
   key: "microsoft_power_bi-get-reports",
   name: "Get Reports",
   description: "Get reports from a Power BI workspace. [See the documentation](https://learn.microsoft.com/en-us/rest/api/power-bi/reports/get-reports)",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     microsoftPowerBi,
   },

--- a/components/microsoft_power_bi/actions/list-dashboards/list-dashboards.mjs
+++ b/components/microsoft_power_bi/actions/list-dashboards/list-dashboards.mjs
@@ -9,8 +9,9 @@ export default {
     + " Each dashboard includes `id`, `displayName`, `isReadOnly`, `webUrl`, and `embedUrl`."
     + " Note: dashboards cannot be created via the REST API — they are built interactively in the Power BI service."
     + " [See the documentation](https://learn.microsoft.com/en-us/rest/api/power-bi/dashboards/get-dashboards-in-group)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/microsoft_power_bi/actions/list-datasets/list-datasets.mjs
+++ b/components/microsoft_power_bi/actions/list-datasets/list-datasets.mjs
@@ -10,8 +10,9 @@ export default {
     + " Use this tool to resolve a dataset name → ID before calling **Refresh Dataset**, **Execute DAX Query**, **Get Refresh History**, or **Add Rows To Push Dataset**."
     + " For push-dataset row inserts, call the dataset's `GET tables` endpoint (not exposed as a separate tool) by inspecting the dataset's `name` → tables are defined at dataset creation; the table name is the string configured at creation time (e.g., `Species`)."
     + " [See the documentation](https://learn.microsoft.com/en-us/rest/api/power-bi/datasets/get-datasets-in-group)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/microsoft_power_bi/actions/list-reports/list-reports.mjs
+++ b/components/microsoft_power_bi/actions/list-reports/list-reports.mjs
@@ -9,8 +9,9 @@ export default {
     + " Each report includes `id`, `name`, `webUrl`, `embedUrl`, `datasetId`, and `reportType` (`PowerBIReport` or `PaginatedReport`)."
     + " Note: reports cannot be created via the REST API — they are published from Power BI Desktop."
     + " [See the documentation](https://learn.microsoft.com/en-us/rest/api/power-bi/reports/get-reports)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/microsoft_power_bi/actions/list-workspaces/list-workspaces.mjs
+++ b/components/microsoft_power_bi/actions/list-workspaces/list-workspaces.mjs
@@ -9,8 +9,9 @@ export default {
     + " Every item in the response includes `id`, `name`, `isReadOnly`, `isOnDedicatedCapacity`, and `type`."
     + " Note: when a user says 'my workspace' without a name, they may mean personal My workspace (implicit — pass no `workspaceId` to other tools) OR a specific named workspace — ask only if ambiguous."
     + " [See the documentation](https://learn.microsoft.com/en-us/rest/api/power-bi/groups/get-groups)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/microsoft_power_bi/actions/refresh-dataset/refresh-dataset.mjs
+++ b/components/microsoft_power_bi/actions/refresh-dataset/refresh-dataset.mjs
@@ -10,8 +10,9 @@ export default {
     + " Power BI Pro licenses allow up to 8 scheduled refreshes per day; Premium allows 48."
     + " Note: Push datasets accept this endpoint but the refresh is metadata-only (tile refresh), not a data refresh — no cancellable history entry is produced."
     + " [See the documentation](https://learn.microsoft.com/en-us/rest/api/power-bi/datasets/refresh-dataset-in-group)",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/microsoft_power_bi/package.json
+++ b/components/microsoft_power_bi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/microsoft_power_bi",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Pipedream Microsoft Power BI Components",
   "main": "microsoft_power_bi.app.mjs",
   "keywords": [

--- a/components/notion/actions/append-block/append-block.mjs
+++ b/components/notion/actions/append-block/append-block.mjs
@@ -14,13 +14,14 @@ export default {
     + " Provide the page ID or URL (use **Search** to resolve a page name into an ID)."
     + " To change a database row's property values instead, use **Update Page**."
     + " [See the documentation](https://developers.notion.com/reference/patch-block-children)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     notion,
     pageId: {

--- a/components/notion/actions/create-comment/create-comment.mjs
+++ b/components/notion/actions/create-comment/create-comment.mjs
@@ -9,13 +9,14 @@ export default {
     "Add a comment to a Notion page, or reply to an existing discussion thread."
     + " Provide **either** a page ID/URL (use **Search** to resolve a page name) **or** a discussion ID — not both."
     + " [See the documentation](https://developers.notion.com/reference/create-a-comment)",
-  version: "0.1.0",
+  version: "0.1.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     notion,
     pageId: {

--- a/components/notion/actions/create-database/create-database.mjs
+++ b/components/notion/actions/create-database/create-database.mjs
@@ -11,13 +11,14 @@ export default {
     + " `{ \"Name\": \"title\", \"Quantity\": \"number\", \"Category\": { \"select\": { \"options\": [ { \"name\": \"A\" }, { \"name\": \"B\" } ] } } }`."
     + " Exactly one column must be the `title` type."
     + " [See the documentation](https://developers.notion.com/reference/database-create)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     notion,
     parent: {

--- a/components/notion/actions/create-page/create-page.mjs
+++ b/components/notion/actions/create-page/create-page.mjs
@@ -14,13 +14,14 @@ export default {
     + " When the parent is a database, set `properties` to a flat JSON object of column-name → value (e.g. `{ \"Status\": \"Active\", \"ThreatLevel\": 9 }`); call **Retrieve Database Schema** first to learn the exact column names and valid select options."
     + " `content` is the page body as Markdown (headings, bullet lists, paragraphs, etc.)."
     + " [See the documentation](https://developers.notion.com/reference/post-page)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     notion,
     parent: {

--- a/components/notion/actions/get-current-user/get-current-user.mjs
+++ b/components/notion/actions/get-current-user/get-current-user.mjs
@@ -4,8 +4,9 @@ export default {
   key: "notion-get-current-user",
   name: "Get Current User",
   description: "Retrieve the Notion identity tied to the current OAuth token, returning the full `users.retrieve` payload for `me` (person or bot). Includes the user ID, name, avatar URL, type (`person` vs `bot`), and workspace ownership metadata—useful for confirming which workspace is connected, adapting downstream queries, or giving an LLM the context it needs about who is operating inside Notion. [See the documentation](https://developers.notion.com/reference/get-user).",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/notion/actions/query-database/query-database.mjs
+++ b/components/notion/actions/query-database/query-database.mjs
@@ -12,13 +12,14 @@ export default {
     + " Omit `filter` to return all rows."
     + " Provide the **data source ID** (use **Search** with `filter: data_source` to resolve a database name)."
     + " [See the documentation](https://developers.notion.com/reference/filter-data-source-entries)",
-  version: "1.1.0",
+  version: "1.1.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     notion,
     dataSourceId: {

--- a/components/notion/actions/retrieve-database-schema/retrieve-database-schema.mjs
+++ b/components/notion/actions/retrieve-database-schema/retrieve-database-schema.mjs
@@ -9,13 +9,14 @@ export default {
     + " **Call this before Query Data Source, Create Page, or Update Page on a database** so you use exact property names and valid option values."
     + " Provide the **data source ID** (use **Search** with `filter: data_source` to resolve a database name into its ID)."
     + " [See the documentation](https://developers.notion.com/reference/retrieve-a-data-source)",
-  version: "1.1.0",
+  version: "1.1.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     notion,
     dataSourceId: {

--- a/components/notion/actions/retrieve-page/retrieve-page.mjs
+++ b/components/notion/actions/retrieve-page/retrieve-page.mjs
@@ -9,13 +9,14 @@ export default {
     + " Use this to read what a page says or to inspect a database row's fields."
     + " Provide a page ID or a Notion page URL (use **Search** to resolve a page name into an ID)."
     + " [See the documentation](https://developers.notion.com/reference/retrieve-a-page)",
-  version: "0.1.0",
+  version: "0.1.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     notion,
     pageId: {

--- a/components/notion/actions/search/search.mjs
+++ b/components/notion/actions/search/search.mjs
@@ -9,8 +9,9 @@ export default {
     + " Leave `query` blank to list everything the integration can access."
     + " Set `filter` to `data_source` to find databases or `page` to find pages — on the current Notion API a database is returned as a `data_source` object, and its `id` is the **data source ID** you pass to the database tools."
     + " [See the documentation](https://developers.notion.com/reference/post-search)",
-  version: "1.0.0",
+  version: "1.0.1",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/notion/actions/update-database/update-database.mjs
+++ b/components/notion/actions/update-database/update-database.mjs
@@ -10,13 +10,14 @@ export default {
     + " `properties` is a JSON object of changes: to **add** a column, use a new name → type (e.g. `{ \"Location\": \"rich_text\" }`); to **rename/retype** an existing column, key it by its current name/ID."
     + " Each value is a [property schema object](https://developers.notion.com/reference/property-schema-object) or a shorthand type name."
     + " [See the documentation](https://developers.notion.com/reference/update-a-data-source)",
-  version: "2.0.0",
+  version: "2.0.1",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     notion,
     dataSourceId: {

--- a/components/notion/actions/update-page/update-page.mjs
+++ b/components/notion/actions/update-page/update-page.mjs
@@ -12,13 +12,14 @@ export default {
     + " Set `properties` to a flat JSON object of column-name → value, e.g. `{ \"Status\": \"Contained\" }`; call **Retrieve Database Schema** first to learn the exact column names and valid select options."
     + " To add body content instead of changing properties, use **Append Block to Parent**."
     + " [See the documentation](https://developers.notion.com/reference/patch-page)",
-  version: "3.0.0",
+  version: "3.0.1",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     notion,
     pageId: {

--- a/components/notion/package.json
+++ b/components/notion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/notion",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Pipedream Notion Components",
   "main": "notion.app.mjs",
   "keywords": [

--- a/components/super_carl/actions/cancel-communication/cancel-communication.mjs
+++ b/components/super_carl/actions/cancel-communication/cancel-communication.mjs
@@ -1,17 +1,17 @@
-// x-pd-ai: optimized
 import superCarl from "../../super_carl.app.mjs";
 
 export default {
   key: "super_carl-cancel-communication",
   name: "Cancel Communication",
   description: "Cancel a queued or in-progress Super Carl communication. Use this when a workflow needs to stop delivery before the communication reaches a terminal status. [See the documentation](https://supercarl.ai/docs#endpoints-communications)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     superCarl,
     communicationId: {

--- a/components/super_carl/actions/check-communication-capabilities/check-communication-capabilities.mjs
+++ b/components/super_carl/actions/check-communication-capabilities/check-communication-capabilities.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import superCarl from "../../super_carl.app.mjs";
 import {
   applyFieldSelection,
@@ -10,13 +9,14 @@ export default {
   key: "super_carl-check-communication-capabilities",
   name: "Check Communication Capabilities",
   description: "Check which Super Carl communication channels are available for a target before sending a message. Returns the list of channels with their `can_send` status, recipient email, and connector user IDs. Each channel entry carries verbose reason/relationship metadata — pass Fields (e.g. `channel`, `can_send`, `reason`) to keep the result small when you only need the essentials. [See the documentation](https://supercarl.ai/docs#endpoints-communications)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     superCarl,
     targetUserId: {

--- a/components/super_carl/actions/get-communication-history/get-communication-history.mjs
+++ b/components/super_carl/actions/get-communication-history/get-communication-history.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import superCarl from "../../super_carl.app.mjs";
 import { requireCommunicationTarget } from "../../common/utils.mjs";
 
@@ -6,13 +5,14 @@ export default {
   key: "super_carl-get-communication-history",
   name: "Get Communication History",
   description: "Fetch prior Super Carl communication history for a target before drafting or sending. Use this to avoid duplicate outreach and to inspect recent Gmail, LinkedIn, X, Instagram, and Super Carl sends. [See the documentation](https://supercarl.ai/docs#endpoints-communications)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     superCarl,
     targetUserId: {

--- a/components/super_carl/actions/get-communication/get-communication.mjs
+++ b/components/super_carl/actions/get-communication/get-communication.mjs
@@ -1,17 +1,17 @@
-// x-pd-ai: optimized
 import superCarl from "../../super_carl.app.mjs";
 
 export default {
   key: "super_carl-get-communication",
   name: "Get Communication",
   description: "Fetch a Super Carl communication record, normalized status, recent events, task metadata, and artifact URLs after **Send Communication**. Use Wait Milliseconds when a workflow should pause for delivery progress. [See the documentation](https://supercarl.ai/docs#endpoints-communications)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     superCarl,
     communicationId: {

--- a/components/super_carl/actions/get-network-summary/get-network-summary.mjs
+++ b/components/super_carl/actions/get-network-summary/get-network-summary.mjs
@@ -1,17 +1,17 @@
-// x-pd-ai: optimized
 import superCarl from "../../super_carl.app.mjs";
 
 export default {
   key: "super_carl-get-network-summary",
   name: "Get Network Summary",
   description: "Check Super Carl network readiness before running **Search People**, **Search Jobs**, or **Search Companies**. Use this to inspect LinkedIn/Gmail/Super Carl graph sync status for the API key owner or a delegated team-seat user via Delegate User ID; low or unsynced counts can explain weak network-aware results. [See the documentation](https://supercarl.ai/docs/endpoints)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     superCarl,
     delegateUserId: {

--- a/components/super_carl/actions/search-companies/search-companies.mjs
+++ b/components/super_carl/actions/search-companies/search-companies.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import superCarl from "../../super_carl.app.mjs";
 import {
   applyFieldSelection,
@@ -11,13 +10,14 @@ export default {
   key: "super_carl-search-companies",
   name: "Search Companies",
   description: "Search companies by name, domain, funding, size, industry, location, growth, or technology. Use this to qualify a target company or find companies matching structured Filters before reaching out. Use **Search People** afterward to find people at a matched company; enable Resolve Only to just disambiguate a single company name, domain, or LinkedIn URL without running a full search — Resolve Only returns identity metadata ONLY (name, domain, a coarse `employee_count`, `industries`), never a company's real size or description. When the task needs to know a company's actual size or what it does, leave Resolve Only off (or set it false) and set Result Mode to `detailed`; don't fill gaps from outside knowledge when Resolve Only comes back thin — re-call with `detailed` instead. Company rows in `detailed` mode can be large — pass Fields (e.g. `name`, `domain`, `employee_count`) to keep the result small. [See the documentation](https://supercarl.ai/docs#endpoints-companies)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     superCarl,
     query: {

--- a/components/super_carl/actions/search-jobs/search-jobs.mjs
+++ b/components/super_carl/actions/search-jobs/search-jobs.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import superCarl from "../../super_carl.app.mjs";
 import {
   applyFieldSelection,
@@ -11,13 +10,14 @@ export default {
   key: "super_carl-search-jobs",
   name: "Search Jobs",
   description: "Search jobs when the workflow needs hiring-company opportunities, role fit, or warm paths into employers. Use **Search People** for candidate/advisor discovery, and enable With People when the workflow should return 1st/2nd-degree contacts at each hiring company. `filters.locations` scopes the hiring company/people, not the job posting itself — check `applied_filter_summary.people_company_scope` in the response to see how a location filter was actually applied, and don't retry the same query with reworded locations if it comes back `applied_as_job_posting_filters: false`, since that's a scope limitation, not a bad query. Job rows can be large — pass Fields (flat field names only, e.g. `title`, `company_name`, `location`, `primary_source_url`; there is no nested `company.name` path) to keep the result small. [See the documentation](https://supercarl.ai/docs#endpoints-jobs)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     superCarl,
     query: {

--- a/components/super_carl/actions/search-people/search-people.mjs
+++ b/components/super_carl/actions/search-people/search-people.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import superCarl from "../../super_carl.app.mjs";
 import {
   applyFieldSelection,
@@ -13,13 +12,14 @@ export default {
   key: "super_carl-search-people",
   name: "Search People",
   description: "Search people by role, company history, expertise, location, network relationship, or recent activity. Keep Preview enabled for fast counts and lightweight rows; disable Preview when you need full rows and Evidence Format, since Evidence Format is ignored during preview. Use **Search Companies** first when a named employer is ambiguous. Person rows carry deep connection/evidence metadata and can be large — pass Fields (e.g. `name`, `linkedin_profile_url`, `headline`) to keep the result small when you only need a few values. Always pass Fields when Preview is off and you set Relationship Detail to `intro_paths` or Evidence Format to anything other than `none`: that combination alone can exceed the response size limit even with a handful of rows, so don't wait for a truncated first call to add Fields. Read-only against Super Carl's shared external people database: there is no way to edit, hide, or delete a person's profile through this or any other Super Carl tool. [See the documentation](https://supercarl.ai/docs#endpoints-people-search)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     superCarl,
     query: {

--- a/components/super_carl/actions/search-posts/search-posts.mjs
+++ b/components/super_carl/actions/search-posts/search-posts.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import superCarl from "../../super_carl.app.mjs";
 import {
   applyFieldSelection,
@@ -11,13 +10,14 @@ export default {
   key: "super_carl-search-posts",
   name: "Search Posts",
   description: "Search Super Carl post and activity signals, including authored posts, comments, likes, reactions, company mentions, and engagement. Use this before **Search People** when the workflow is anchored on someone posting or engaging with content; enable With People to return deduped actors from matching activity. Post rows can be large — pass Fields (flat field names only, e.g. `author_name`, `text`, `url`; there is no nested `author.name` path) to keep the result small; With People's deduped rows are already trimmed and don't need Fields. [See the documentation](https://supercarl.ai/docs#endpoints-posts)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     superCarl,
     query: {

--- a/components/super_carl/actions/send-communication/send-communication.mjs
+++ b/components/super_carl/actions/send-communication/send-communication.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import superCarl from "../../super_carl.app.mjs";
 import {
@@ -10,13 +9,14 @@ export default {
   key: "super_carl-send-communication",
   name: "Send Communication",
   description: "Create a Super Carl outbound communication and optionally send it through Gmail, LinkedIn, X, Instagram, or Super Carl channels. Dry Run defaults to true; set it to false only after **Check Communication Capabilities** passes and the user approves live delivery. [See the documentation](https://supercarl.ai/docs#endpoints-communications)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     superCarl,
     channel: {

--- a/components/super_carl/package.json
+++ b/components/super_carl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/super_carl",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Super Carl Components",
   "main": "super_carl.app.mjs",
   "keywords": [

--- a/components/wrike/actions/create-comment/create-comment.mjs
+++ b/components/wrike/actions/create-comment/create-comment.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import wrike from "../../wrike.app.mjs";
 
 export default {
   key: "wrike-create-comment",
   name: "Create Comment",
   description: "Post a comment on a Wrike task via POST /tasks/{taskId}/comments. Use **Find Tasks** or **Get Task** to obtain the taskId. [See the documentation](https://developers.wrike.com/reference/posttaskssinglecomments)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/wrike/actions/create-folder/create-folder.mjs
+++ b/components/wrike/actions/create-folder/create-folder.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import wrike from "../../wrike.app.mjs";
 import { parseJson } from "../../common/utils.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "wrike-create-folder",
   name: "Create Folder",
   description: "Create a folder (or a project, by supplying the optional project object) under a parent folder via POST /folders/{folderId}/folders. Supplying the 'project' prop switches creation into project mode; there is no separate create-project action. Use **List Folder ID Options** or **List Space ID Options** to obtain a parent folder ID. [See the documentation](https://developers.wrike.com/reference/postfolderssinglefolders)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/wrike/actions/find-tasks/find-tasks.mjs
+++ b/components/wrike/actions/find-tasks/find-tasks.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import wrike from "../../wrike.app.mjs";
 import {
   TASK_STATUS_OPTIONS, TASK_IMPORTANCE_OPTIONS, DEFAULT_LIMIT, MAX_LIMIT,
@@ -9,8 +8,9 @@ export default {
   key: "wrike-find-tasks",
   name: "Find Tasks",
   description: "Query tasks within a Wrike folder or project via GET /folders/{folderId}/tasks, with optional status, due-date, importance, and assignee filters. Answers questions like 'what's overdue in the Marketing project?'. Use **List Folder ID Options** to obtain a folderId. Use the returned task IDs with **Get Task** or **Update Task**. [See the documentation](https://developers.wrike.com/reference/getfolderssingletasks)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/wrike/actions/get-task/get-task.mjs
+++ b/components/wrike/actions/get-task/get-task.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import { ConfigurationError } from "@pipedream/platform";
 import wrike from "../../wrike.app.mjs";
 import { MAX_LIMIT } from "../../common/constants.mjs";
@@ -7,8 +6,9 @@ export default {
   key: "wrike-get-task",
   name: "Get Task",
   description: "Retrieve the full details of one or more Wrike tasks (title, status, importance, dates, responsibles, custom fields) via GET /tasks/{taskIds}. Use this when you already know a task ID and need its complete record. Use **Find Tasks** to discover task IDs within a folder first. Provide the taskId as returned by **Find Tasks**. [See the documentation](https://developers.wrike.com/reference/gettasksmulti)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/wrike/actions/list-contact-id-options/list-contact-id-options.mjs
+++ b/components/wrike/actions/list-contact-id-options/list-contact-id-options.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import wrike from "../../wrike.app.mjs";
 import {
   CONTACT_TYPE_OPTIONS, CONTACT_FIELD_OPTIONS,
@@ -9,8 +8,9 @@ export default {
   key: "wrike-list-contact-id-options",
   name: "List Contact ID Options",
   description: "Retrieves available contacts so callers can copy an ID into free-form responsibles or contactId props in other actions. [See the documentation](https://developers.wrike.com/reference/getcontactsempty)",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/wrike/actions/list-custom-fields-keys-options/list-custom-fields-keys-options.mjs
+++ b/components/wrike/actions/list-custom-fields-keys-options/list-custom-fields-keys-options.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import wrike from "../../wrike.app.mjs";
 import {
   CUSTOM_FIELD_APPLICABLE_ENTITY_TYPE_OPTIONS,
@@ -12,8 +11,9 @@ export default {
   key: "wrike-list-custom-fields-keys-options",
   name: "List Custom Fields Keys Options",
   description: "Retrieves available custom fields so callers can copy field IDs into free-form customFields props in other actions. [See the documentation](https://developers.wrike.com/reference/getcustomfieldsempty)",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/wrike/actions/list-folder-id-options/list-folder-id-options.mjs
+++ b/components/wrike/actions/list-folder-id-options/list-folder-id-options.mjs
@@ -1,12 +1,12 @@
-// x-pd-ai: optimized
 import wrike from "../../wrike.app.mjs";
 
 export default {
   key: "wrike-list-folder-id-options",
   name: "List Folder ID Options",
   description: "Retrieves available folders so callers can copy an ID into another action's free-form folderId prop. [See the documentation](https://developers.wrike.com/reference/getfoldersempty)",
-  version: "1.0.0",
+  version: "1.0.1",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/wrike/actions/list-space-id-options/list-space-id-options.mjs
+++ b/components/wrike/actions/list-space-id-options/list-space-id-options.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import wrike from "../../wrike.app.mjs";
 import {
   SPACE_ACCESS_TYPE_OPTIONS, SPACE_FIELD_OPTIONS,
@@ -9,8 +8,9 @@ export default {
   key: "wrike-list-space-id-options",
   name: "List Space ID Options",
   description: "Retrieves available spaces so callers can copy an ID into another action's free-form spaceId or folderId prop. [See the documentation](https://developers.wrike.com/reference/getspacesempty)",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/wrike/actions/new-task/new-task.mjs
+++ b/components/wrike/actions/new-task/new-task.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import wrike from "../../wrike.app.mjs";
 import {
   TASK_STATUS_OPTIONS, TASK_IMPORTANCE_OPTIONS,
@@ -9,13 +8,14 @@ export default {
   key: "wrike-new-task",
   name: "New Task",
   description: "Create a Wrike task under a specified folder ID. [See the documentation](https://developers.wrike.com/api/v4/tasks/#create-task)",
-  version: "0.3.3",
+  version: "0.3.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     wrike,
     folderId: {

--- a/components/wrike/actions/update-folder/update-folder.mjs
+++ b/components/wrike/actions/update-folder/update-folder.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import wrike from "../../wrike.app.mjs";
 import { parseJson } from "../../common/utils.mjs";
 
@@ -6,8 +5,9 @@ export default {
   key: "wrike-update-folder",
   name: "Update Folder",
   description: "Update a folder or project's metadata via PUT /folders/{folderId}. Supply the optional 'project' prop to set project attributes (or null to convert a project back to a folder); there is no separate update-project action. Use **List Folder ID Options** to obtain the folderId. [See the documentation](https://developers.wrike.com/reference/putfolderssingle)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/wrike/actions/update-task/update-task.mjs
+++ b/components/wrike/actions/update-task/update-task.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import wrike from "../../wrike.app.mjs";
 import {
   TASK_STATUS_OPTIONS, TASK_IMPORTANCE_OPTIONS,
@@ -9,8 +8,9 @@ export default {
   key: "wrike-update-task",
   name: "Update Task",
   description: "Update any combination of a Wrike task's fields (title, description, status, importance, assignees, dates, custom fields) in a single call via PUT /tasks/{taskId}. Supersedes the former Update Task Custom Fields action. Use **Find Tasks** or **Get Task** to obtain the taskId; use **List Contact ID Options** for assignee IDs and **List Custom Fields Keys Options** for custom field IDs. [See the documentation](https://developers.wrike.com/reference/puttaskssingle)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/wrike/package.json
+++ b/components/wrike/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/wrike",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Pipedream Wrike Components",
   "main": "wrike.app.mjs",
   "keywords": [

--- a/components/writer/actions/ask-knowledge-graph/ask-knowledge-graph.mjs
+++ b/components/writer/actions/ask-knowledge-graph/ask-knowledge-graph.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import app from "../../writer.app.mjs";
 
 export default {
@@ -10,8 +9,9 @@ export default {
     + "Example: call with `graphIds=[\"a1b2...\"]` and `question=\"What are the park hours?\"` -> returns `{ question, answer, sources, references }`. "
     + "If a graph has no relevant content it returns a graceful 'no relevant information' answer rather than an error. "
     + "[See the documentation](https://dev.writer.com/api-reference/kg-api/question)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/writer/actions/get-application/get-application.mjs
+++ b/components/writer/actions/get-application/get-application.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import app from "../../writer.app.mjs";
 
 export default {
@@ -8,8 +7,9 @@ export default {
     + "Use **List Applications** first to find the application's `id`, then call this before **Run Application** so you know the input field `id`s (names) the agent expects. "
     + "Example: call with `applicationId=\"3f9c...\"` -> returns `{ id, name, type, status, inputs: [{ id, name, ... }], created_at, updated_at }`, where each `inputs[].id` is an input field name such as `\"topic\"`. "
     + "[See the documentation](https://dev.writer.com/api-reference/application-api/application-details)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/writer/actions/list-applications/list-applications.mjs
+++ b/components/writer/actions/list-applications/list-applications.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import app from "../../writer.app.mjs";
 import {
   APPLICATION_DEFAULT_FIELDS,
@@ -15,8 +14,9 @@ export default {
     + `Auto-paginates up to ${MAX_RESULTS} applications. `
     + "Example: to list the content-generation agents and see just their names, call with `type=\"generation\"` and `fields=[\"name\"]` -> returns records like `{ id: \"...\", name: \"Blog Writer\" }`. "
     + "[See the documentation](https://dev.writer.com/api-reference/application-api/list-applications)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/writer/actions/list-knowledge-graphs/list-knowledge-graphs.mjs
+++ b/components/writer/actions/list-knowledge-graphs/list-knowledge-graphs.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import app from "../../writer.app.mjs";
 import {
   GRAPH_DEFAULT_FIELDS,
@@ -14,8 +13,9 @@ export default {
     + `Auto-paginates up to ${MAX_RESULTS} graphs. `
     + "Example: to get just the names of your graphs, call with `fields=[\"name\"]` -> returns records like `{ id: \"...\", name: \"Isla Nublar Field Guide\" }`. "
     + "[See the documentation](https://dev.writer.com/api-reference/kg-api/list-graphs)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/writer/actions/list-models/list-models.mjs
+++ b/components/writer/actions/list-models/list-models.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import app from "../../writer.app.mjs";
 
 export default {
@@ -9,8 +8,9 @@ export default {
     + "Example: call with no parameters -> returns models such as `{ id: \"palmyra-x5\", name: \"Palmyra X5\" }`, `{ id: \"palmyra-x4\", name: \"Palmyra X4\" }`, and any others enabled for the account. "
     + "`palmyra-x5` is the recommended general-purpose model (creative writing included); pick a different id from the returned list only for a specialized need. "
     + "[See the documentation](https://dev.writer.com/api-reference/completion-api/list-models)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/writer/actions/run-application/run-application.mjs
+++ b/components/writer/actions/run-application/run-application.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import app from "../../writer.app.mjs";
 
 export default {
@@ -9,8 +8,9 @@ export default {
     + "Provide `inputs` as a JSON array of `{ id, value }` objects, where each `id` is an **input field name** from the application's schema (not the application id) and `value` is an array of strings (one entry per value for that field). "
     + "Example: call with `applicationId=\"3f9c...\"` and `inputs=[{ \"id\": \"topic\", \"value\": [\"Velociraptor exhibit\"] }, { \"id\": \"tone\", \"value\": [\"exciting\"] }]` (here `\"topic\"` and `\"tone\"` are input field names) -> returns the agent's generated content. "
     + "[See the documentation](https://dev.writer.com/api-reference/application-api/applications)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/writer/actions/send-prompt/send-prompt.mjs
+++ b/components/writer/actions/send-prompt/send-prompt.mjs
@@ -1,4 +1,3 @@
-// x-pd-ai: optimized
 import app from "../../writer.app.mjs";
 import { parseFloatProp } from "../../common/utils.mjs";
 
@@ -11,13 +10,14 @@ export default {
     + "For questions grounded in your team's own documents, use **Ask Knowledge Graph** instead. "
     + "Example: to draft a welcome message, call with `messages=[{ \"role\": \"user\", \"content\": \"Draft a 2-sentence welcome message for new visitors.\" }]` and `model=\"palmyra-x5\"` -> returns an OpenAI-shaped response whose `choices[0].message.content` holds the generated text. "
     + "[See the documentation](https://dev.writer.com/api-reference/completion-api/chat-completion)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     messages: {

--- a/components/writer/package.json
+++ b/components/writer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/writer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Pipedream Writer Components",
   "main": "writer.app.mjs",
   "keywords": [


### PR DESCRIPTION
DJ-4272 backfill, **batch 4 of 5** (continues canary #21870).

Sets the top-level `ai: "optimized"` field on **200 AI-optimized actions across 21 apps**, replaces any legacy `// x-pd-ai: optimized` marker comment with the real field, and patch-bumps each touched component + app `package.json` (required by `check_version`).

Batched at ≤200 components per the deployment publish cap. The 5 batches cover **disjoint apps**, so they can merge independently in any order.

Apps: amplitude,apollo_io_oauth arlo,attio bonusly,calendly_v2 datadog,dataiku elastic_cloud,element expensify,gmail google_health,grafana ionos_hosting_services,mercury microsoft_power_bi,notion super_carl,wrike writer