### PR TITLE
Sentry - New Issue Event (Instant): add optional project filter

### DIFF
--- a/components/sentry/actions/list-issue-events/list-issue-events.mjs
+++ b/components/sentry/actions/list-issue-events/list-issue-events.mjs
@@ -4,7 +4,7 @@ export default {
   key: "sentry-list-issue-events",
   name: "List Issue Events",
   description: "Return a list of events bound to an issue. [See the docs here](https://docs.sentry.io/api/events/list-an-issues-events/)",
-  version: "0.1.3",
+  version: "0.1.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/sentry/actions/list-project-events/list-project-events.mjs
+++ b/components/sentry/actions/list-project-events/list-project-events.mjs
@@ -2,7 +2,7 @@ import app from "../../sentry.app.mjs";
 
 export default {
   key: "sentry-list-project-events",
-  version: "0.1.2",
+  version: "0.1.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/sentry/actions/list-project-issues/list-project-issues.mjs
+++ b/components/sentry/actions/list-project-issues/list-project-issues.mjs
@@ -2,7 +2,7 @@ import app from "../../sentry.app.mjs";
 
 export default {
   key: "sentry-list-project-issues",
-  version: "0.1.2",
+  version: "0.1.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/sentry/actions/update-issue/update-issue.mjs
+++ b/components/sentry/actions/update-issue/update-issue.mjs
@@ -3,7 +3,7 @@ import options from  "../../options.mjs";
 
 export default {
   key: "sentry-update-issue",
-  version: "0.1.2",
+  version: "0.1.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/sentry/package.json
+++ b/components/sentry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/sentry",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "description": "Pipedream Sentry Components",
   "main": "sentry.app.mjs",
   "keywords": [

--- a/components/sentry/sentry.app.mjs
+++ b/components/sentry/sentry.app.mjs
@@ -27,6 +27,27 @@ export default {
         };
       },
     },
+    projectSlugs: {
+      type: "string[]",
+      label: "Projects",
+      description: "Only consider issue events from these projects, matched by project slug (e.g. `my-backend`). Leave empty to consider every project in the organization.",
+      optional: true,
+      async options(context) {
+        const { organizationSlug } = context;
+        const url = this._organizationProjectsEndpoint(organizationSlug);
+        const {
+          data,
+          next,
+        } = await this._propDefinitionsOptions(url, {}, context);
+        const options = data.map(this._projectObjectToOption);
+        return {
+          options,
+          context: {
+            nextPage: next,
+          },
+        };
+      },
+    },
     projectId: {
       type: "string",
       label: "Project",
@@ -101,6 +122,10 @@ export default {
       const baseUrl = this._apiUrl();
       return `${baseUrl}/organizations/`;
     },
+    _organizationProjectsEndpoint(organizationSlug) {
+      const baseUrl = this._organizationsEndpoint();
+      return `${baseUrl}${organizationSlug}/projects/`;
+    },
     _integrationsEndpoint(integrationSlug) {
       const baseUrl = this._apiUrl();
       const url = `${baseUrl}/sentry-apps`;
@@ -150,6 +175,17 @@ export default {
         name,
         slug,
       } = organization;
+      const label = `${name} (${slug})`;
+      return {
+        label,
+        value: slug,
+      };
+    },
+    _projectObjectToOption(project) {
+      const {
+        name,
+        slug,
+      } = project;
       const label = `${name} (${slug})`;
       return {
         label,

--- a/components/sentry/sources/issue-event/issue-event.mjs
+++ b/components/sentry/sources/issue-event/issue-event.mjs
@@ -2,9 +2,9 @@ import sentry from "../../sentry.app.mjs";
 
 export default {
   key: "sentry-issue-event",
-  version: "0.1.2",
+  version: "0.2.0",
   name: "New Issue Event (Instant)",
-  description: "Emit new events for issues that have been created or updated.",
+  description: "Emit new events for issues that have been created or updated. Optionally filter the events by project. [See the documentation](https://docs.sentry.io/organization/integrations/integration-platform/webhooks/issues/)",
   type: "source",
   props: {
     db: "$.service.db",
@@ -17,6 +17,15 @@ export default {
       propDefinition: [
         sentry,
         "organizationSlug",
+      ],
+    },
+    projectSlugs: {
+      propDefinition: [
+        sentry,
+        "projectSlugs",
+        ({ organizationSlug }) => ({
+          organizationSlug,
+        }),
       ],
     },
   },
@@ -53,6 +62,13 @@ export default {
     getEventSourceName() {
       return "Issue Event (Instant)";
     },
+    isProjectSelected(issue) {
+      const projectSlugs = [].concat(this.projectSlugs ?? []);
+      if (!projectSlugs.length) {
+        return true;
+      }
+      return projectSlugs.includes(issue?.project?.slug);
+    },
   },
   async run(event) {
     const clientSecret = this._getClientSecret();
@@ -70,6 +86,11 @@ export default {
     const {
       body, body: { data: { issue } },
     } = event;
+
+    if (!this.isProjectSelected(issue)) {
+      console.log(`Issue ${issue?.id} belongs to project "${issue?.project?.slug}", which is not selected. Skipping.`);
+      return;
+    }
 
     this.$emit(body, {
       id: issue.id,


### PR DESCRIPTION
## Summary

Sentry App (internal integration) webhooks are organization-wide: the `issue` event subscription created by this source has no documented way to be scoped to a project, so the **New Issue Event (Instant)** source currently emits every issue event in the organization. Users who only care about one or two projects have no way to narrow it down.

This PR adds an optional **Projects** multi-select to the source. When set, events for issues in other projects are still acknowledged (HTTP 200 back to Sentry) but not emitted. Left empty, behaviour is unchanged. Same pattern as the `projectId` filter in the Linear sources and the webinar filter in `zoom_admin-webinar-ended`.

### Changes

- `sentry.app.mjs`: new `projectSlugs` (`string[]`, optional) propDefinition with paginated async options from `GET /organizations/{organization_slug}/projects/`, reusing the existing `_propDefinitionsOptions` Link-header pagination. Small helpers `_organizationProjectsEndpoint` and `_projectObjectToOption`.
- `sources/issue-event/issue-event.mjs`: `projectSlugs` prop whose options are scoped to the selected **Organization**, `isProjectSelected()` check before `$emit` (normalizes the value with `[].concat` so a single string never falls into substring matching), description updated with the documentation link. `0.1.2` -> `0.2.0` (new optional prop = minor, per `.github/pipedream-component-guidelines.md`).
- `package.json` `0.4.4` -> `0.5.0` (same segment as the source bump). Patch bumps for the four actions that import the changed app file.

### Testing

- `pnpm exec eslint components/sentry` is clean.
- Local harness against the component module: signature validation unchanged (404 on a bad signature), no filter, `null` and `[]` emit exactly as before, matching slug emits, non-matching slug is skipped with a 200, a bare-string value does not substring-match, payload without `issue.project` handled. `options()` verified end to end through `_propDefinitionsOptions` against a stub HTTP server returning Sentry-style `Link` headers across three pages (`results="true"` follows the cursor, `results="false"` stops).
- Not run against a live Sentry organization (no test account available). The payload path `data.issue.project.slug` and the organization projects endpoint were checked against Sentry's API and webhook docs.

## Checklist
Please check the following items before your PR can be reviewed:

### Versioning
- [x] All components updated in this PR had their version updated (`0.0.1` for new ones)
- [x] The app updated in this PR had its `package.json`'s version updated

### New app
If this is a new app, please submit [an app integration request](https://github.com/PipedreamHQ/pipedream/issues/new?template=app---service-integration.md) - the PR will only be reviewed after the app is integrated.
- [x] The app updated in this PR is already integrated

### CodeRabbit review
After the PR is opened, and if new changes are pushed, CodeRabbit will automatically review it. Do not 'mark as resolved' CodeRabbit's comments, but reply to them instead, whether you agree (and update the PR accordingly) or disagree.
- [x] I have addressed or acknowledged all of CodeRabbit's review comments (no actionable comments were generated)
