### PR TITLE
feat(ai): mark AI-optimized components with `ai` field (batch 1/7)

### DIFF
--- a/components/_2markdown/actions/url-to-markdown/url-to-markdown.mjs
+++ b/components/_2markdown/actions/url-to-markdown/url-to-markdown.mjs
@@ -4,13 +4,14 @@ export default {
   key: "_2markdown-url-to-markdown",
   name: "URL to Markdown",
   description: "Extract the essential content of a website as plaintext. [See the documentation](https://2markdown.com/docs#url2md)",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     _2markdown,
     url: {

--- a/components/_2markdown/package.json
+++ b/components/_2markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/_2markdown",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Pipedream 2markdown Components",
   "main": "_2markdown.app.mjs",
   "keywords": [

--- a/components/deel/actions/amend-eor-contract/amend-eor-contract.mjs
+++ b/components/deel/actions/amend-eor-contract/amend-eor-contract.mjs
@@ -10,8 +10,9 @@ export default {
     + " `effective_date` and `start_date` must be in ISO 8601 format (e.g., `2026-09-01`)."
     + " Use **List Contracts** to find the contract ID."
     + " [See the documentation](https://developer.deel.com/api/reference/endpoints/eor-amendments/create-contract-amendment)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/deel/actions/amend-ic-contract/amend-ic-contract.mjs
+++ b/components/deel/actions/amend-ic-contract/amend-ic-contract.mjs
@@ -11,8 +11,9 @@ export default {
     + " The amendment takes effect immediately but is recorded with the given date."
     + " Use **List Contracts** to find the contract ID."
     + " [See the documentation](https://developer.deel.com/api/reference/endpoints/eor-amendments/create-contract-amendment)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/deel/actions/create-adjustment/create-adjustment.mjs
+++ b/components/deel/actions/create-adjustment/create-adjustment.mjs
@@ -13,8 +13,9 @@ export default {
     + " or ask your Deel administrator."
     + " Use **List Contracts** to find the contract ID."
     + " [See the documentation](https://developer.deel.com/api/reference/endpoints/adjustments/create-contract-adjustment)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/deel/actions/create-contract-task/create-contract-task.mjs
+++ b/components/deel/actions/create-contract-task/create-contract-task.mjs
@@ -11,8 +11,9 @@ export default {
     + " otherwise the task will require review via **Review Contract Task**."
     + " Use **List Contracts** to find the contract ID."
     + " [See the documentation](https://developer.deel.com/api/reference/endpoints/tasks/create-contract-task)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/deel/actions/create-eor-contract/create-eor-contract.mjs
+++ b/components/deel/actions/create-eor-contract/create-eor-contract.mjs
@@ -15,8 +15,9 @@ export default {
     + " `5`=Principal/Staff, `6`=Director, `7`=Head of Dept, `8`=VP, `9`=SVP, `34`=Not applicable."
     + " `scope_of_work` must be at least 100 characters long."
     + " [See the documentation](https://developer.deel.com/api/reference/endpoints/eor-contract/create-eor-contract)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/deel/actions/create-gp-contract/create-gp-contract.mjs
+++ b/components/deel/actions/create-gp-contract/create-gp-contract.mjs
@@ -13,8 +13,9 @@ export default {
     + " `client_team_id` and `client_legal_entity_id` are required — retrieve from your Deel organization settings."
     + " For US-based employees: `work_location_state` (2-letter state code, e.g., `OR`), `work_location_is_wfh`, and (if not WFH) `work_location_name` (office name) are required."
     + " [See the documentation](https://developer.deel.com/api/reference/endpoints/gp-hiring/create-gp-contract)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/deel/actions/create-ic-contract/create-ic-contract.mjs
+++ b/components/deel/actions/create-ic-contract/create-ic-contract.mjs
@@ -13,8 +13,9 @@ export default {
     + " `clientTeamId` and `clientLegalEntityId` are required — ask the user to provide these from"
     + " their Deel organization settings."
     + " [See the documentation](https://developer.deel.com/api/reference/endpoints/contracts/create-ic-contract)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/deel/actions/create-invoice-adjustment/create-invoice-adjustment.mjs
+++ b/components/deel/actions/create-invoice-adjustment/create-invoice-adjustment.mjs
@@ -11,8 +11,9 @@ export default {
     + " Set `is_auto_approved` to `true` to auto-approve without manual review."
     + " Use **List Contracts** to find the contract ID."
     + " [See the documentation](https://developer.deel.com/api/reference/endpoints/invoice-adjustments/create-invoice-adjustment)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/deel/actions/create-shift-rate/create-shift-rate.mjs
+++ b/components/deel/actions/create-shift-rate/create-shift-rate.mjs
@@ -14,8 +14,9 @@ export default {
     + " `type` must be one of: `MULTIPLIER_PERCENTAGE` (e.g., 150 = 1.5x pay),"
     + " `PER_HOUR_FLAT_RATE` (fixed hourly amount), `PER_UNIT_FLAT_RATE` (fixed per-unit amount)."
     + " [See the documentation](https://developer.deel.com/api/reference/endpoints/time-tracking/create-time-tracking-shift-rate)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/deel/actions/create-shifts/create-shifts.mjs
+++ b/components/deel/actions/create-shifts/create-shifts.mjs
@@ -17,8 +17,9 @@ export default {
     + " \"summary\": {\"time_unit\": \"HOUR\", \"time_amount\": 8, \"shift_rate_external_id\": \"rate-overtime-001\"}}]`"
     + " Use **List Contracts** to find the contract ID."
     + " [See the documentation](https://developer.deel.com/api/reference/endpoints/time-tracking-shifts/create-time-tracking-shifts)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/deel/actions/get-contract-preview/get-contract-preview.mjs
+++ b/components/deel/actions/get-contract-preview/get-contract-preview.mjs
@@ -9,8 +9,9 @@ export default {
     + " Works for IC and EOR contracts."
     + " Use **List Contracts** to find contract IDs."
     + " [See the documentation](https://developer.deel.com/api/reference/endpoints/contracts/get-contract)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/deel/actions/get-contract/get-contract.mjs
+++ b/components/deel/actions/get-contract/get-contract.mjs
@@ -8,8 +8,9 @@ export default {
     + " status, and timeline. Works for IC, EOR, and GP contract types."
     + " Use **List Contracts** to find contract IDs."
     + " [See the documentation](https://developer.deel.com/api/reference/endpoints/contracts/get-contract)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/deel/actions/get-eor-benefits/get-eor-benefits.mjs
+++ b/components/deel/actions/get-eor-benefits/get-eor-benefits.mjs
@@ -13,8 +13,9 @@ export default {
     + " `work_visa` is `true` if the employee requires a work visa."
     + " `team_id` and `legal_entity_id` are required — retrieve from your Deel organization settings."
     + " [See the documentation](https://developer.deel.com/api/reference/endpoints/eor-hiring/get-benefits)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/deel/actions/get-eor-contract-form/get-eor-contract-form.mjs
+++ b/components/deel/actions/get-eor-contract-form/get-eor-contract-form.mjs
@@ -9,8 +9,9 @@ export default {
     + " Use this to understand exactly what data is needed before creating an EOR contract."
     + " `country_code` must be an ISO 3166-1 alpha-2 code (e.g., `DE` for Germany, `GB` for UK)."
     + " [See the documentation](https://developer.deel.com/api/reference/endpoints/eor-hiring/get-create-contract-form)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/deel/actions/get-eor-hiring-guide/get-eor-hiring-guide.mjs
+++ b/components/deel/actions/get-eor-hiring-guide/get-eor-hiring-guide.mjs
@@ -10,8 +10,9 @@ export default {
     + " restrictions apply (e.g., minimum salary, mandatory benefits, work visa rules)."
     + " `country_code` must be an ISO 3166-1 alpha-2 code (e.g., `DE` for Germany, `GB` for UK, `US` for United States)."
     + " [See the documentation](https://developer.deel.com/api/reference/endpoints/eor-hiring/get-eor-hiring-guide-by-country)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/deel/actions/list-contract-adjustments/list-contract-adjustments.mjs
+++ b/components/deel/actions/list-contract-adjustments/list-contract-adjustments.mjs
@@ -9,8 +9,9 @@ export default {
     + " Optionally filter by date range."
     + " Use **List Contracts** to find the contract ID."
     + " [See the documentation](https://developer.deel.com/api/reference/endpoints/adjustments/get-contract-adjustments)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/deel/actions/list-contract-tasks/list-contract-tasks.mjs
+++ b/components/deel/actions/list-contract-tasks/list-contract-tasks.mjs
@@ -9,8 +9,9 @@ export default {
     + " Use task IDs with **Review Contract Task** to approve or decline pending tasks."
     + " Use **List Contracts** to find the contract ID."
     + " [See the documentation](https://developer.deel.com/api/reference/endpoints/tasks/get-contract-tasks)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/deel/actions/list-contracts/list-contracts.mjs
+++ b/components/deel/actions/list-contracts/list-contracts.mjs
@@ -9,8 +9,9 @@ export default {
     + " contractor/employee roster. Supports filtering by search term, status, contract type, team, and"
     + " country. Returns contract ID, title, type, status, worker name, and start date."
     + " [See the documentation](https://developer.deel.com/api/reference/endpoints/contracts/get-contracts)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/deel/actions/list-eor-payslips/list-eor-payslips.mjs
+++ b/components/deel/actions/list-eor-payslips/list-eor-payslips.mjs
@@ -8,8 +8,9 @@ export default {
     + " Returns payslip IDs, pay periods, gross/net amounts, and download links."
     + " Use **Get Contract** to find the worker ID from a contract's worker details."
     + " [See the documentation](https://developer.deel.com/api/reference/endpoints/eor-payslips/get-worker-payslips)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/deel/actions/list-gp-payslips/list-gp-payslips.mjs
+++ b/components/deel/actions/list-gp-payslips/list-gp-payslips.mjs
@@ -8,8 +8,9 @@ export default {
     + " Returns payslip IDs, pay periods, gross/net amounts, and download links."
     + " Use **Get Contract** to find the worker ID from a contract's worker details."
     + " [See the documentation](https://developer.deel.com/api/reference/endpoints/payslips/get-gp-worker-payslips)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/deel/actions/list-timesheets/list-timesheets.mjs
+++ b/components/deel/actions/list-timesheets/list-timesheets.mjs
@@ -9,8 +9,9 @@ export default {
     + " Returns timesheet IDs, contract info, hours worked, status, and pay period."
     + " Use **List Contracts** to find contract IDs for filtering."
     + " [See the documentation](https://developer.deel.com/api/reference/endpoints/timesheets/get-timesheets)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/deel/actions/review-contract-task/review-contract-task.mjs
+++ b/components/deel/actions/review-contract-task/review-contract-task.mjs
@@ -11,8 +11,9 @@ export default {
     + " Use **List Contract Tasks** to find task IDs."
     + " Use **List Contracts** to find the contract ID."
     + " [See the documentation](https://developer.deel.com/api/reference/endpoints/tasks/review-multiple-tasks)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/deel/actions/send-contract-invitation/send-contract-invitation.mjs
+++ b/components/deel/actions/send-contract-invitation/send-contract-invitation.mjs
@@ -8,8 +8,9 @@ export default {
     + " Use this after creating a contract to notify the worker and prompt them to sign."
     + " Use **List Contracts** to find the contract ID."
     + " [See the documentation](https://developer.deel.com/api/reference/endpoints/contractor-hiring/create-contract-invitation)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/deel/actions/sign-contract/sign-contract.mjs
+++ b/components/deel/actions/sign-contract/sign-contract.mjs
@@ -9,8 +9,9 @@ export default {
     + " `client_signature` is typically the full legal name of the signing party."
     + " Use **List Contracts** to find the contract ID."
     + " [See the documentation](https://developer.deel.com/api/reference/endpoints/contracts/sign-worker-contract)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/deel/package.json
+++ b/components/deel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/deel",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Deel Components",
   "main": "deel.app.mjs",
   "keywords": [

--- a/components/enrich_layer/actions/check-disposable-email/check-disposable-email.mjs
+++ b/components/enrich_layer/actions/check-disposable-email/check-disposable-email.mjs
@@ -4,8 +4,9 @@ export default {
   key: "enrich_layer-check-disposable-email",
   name: "Check Disposable Email",
   description: "Check if an email address belongs to a disposable email service. Cost: 0 credits. [See the documentation](https://enrichlayer.com/docs/api/v2/contact-api/disposable-email-address-check).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/enrich_layer/actions/get-company-id-lookup/get-company-id-lookup.mjs
+++ b/components/enrich_layer/actions/get-company-id-lookup/get-company-id-lookup.mjs
@@ -4,8 +4,9 @@ export default {
   key: "enrich_layer-get-company-id-lookup",
   name: "Get Company ID Lookup",
   description: "Look up the vanity ID of a company by its numeric ID. Cost: 0 credits. [See the documentation](https://enrichlayer.com/docs/api/v2/company-api/company-id-lookup).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/enrich_layer/actions/get-company-lookup/get-company-lookup.mjs
+++ b/components/enrich_layer/actions/get-company-lookup/get-company-lookup.mjs
@@ -4,8 +4,9 @@ export default {
   key: "enrich_layer-get-company-lookup",
   name: "Get Company Lookup",
   description: "Resolve a company profile from company name, domain name, and/or location. Cost: 2 credits per successful request. [See the documentation](https://enrichlayer.com/docs/api/v2/company-api/company-lookup).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/enrich_layer/actions/get-company-profile-picture/get-company-profile-picture.mjs
+++ b/components/enrich_layer/actions/get-company-profile-picture/get-company-profile-picture.mjs
@@ -4,8 +4,9 @@ export default {
   key: "enrich_layer-get-company-profile-picture",
   name: "Get Company Profile Picture",
   description: "Get the profile picture of a company from cached profiles. Cost: 0 credits. [See the documentation](https://enrichlayer.com/docs/api/v2/company-api/company-profile-picture).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/enrich_layer/actions/get-company-profile/get-company-profile.mjs
+++ b/components/enrich_layer/actions/get-company-profile/get-company-profile.mjs
@@ -4,8 +4,9 @@ export default {
   key: "enrich_layer-get-company-profile",
   name: "Get Company Profile",
   description: "Get structured data of a Company Profile from a professional network URL. Cost: 1 credit per successful request. [See the documentation](https://enrichlayer.com/docs/api/v2/company-api/company-profile).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/enrich_layer/actions/get-employee-count/get-employee-count.mjs
+++ b/components/enrich_layer/actions/get-employee-count/get-employee-count.mjs
@@ -4,8 +4,9 @@ export default {
   key: "enrich_layer-get-employee-count",
   name: "Get Employee Count",
   description: "Get the total number of employees of a company from various sources. Cost: 1 credit per successful request. [See the documentation](https://enrichlayer.com/docs/api/v2/company-api/employee-count).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/enrich_layer/actions/get-employee-listing/get-employee-listing.mjs
+++ b/components/enrich_layer/actions/get-employee-listing/get-employee-listing.mjs
@@ -4,8 +4,9 @@ export default {
   key: "enrich_layer-get-employee-listing",
   name: "Get Employee Listing",
   description: "Get a list of employees of a company. Cost: 3 credits per employee returned. [See the documentation](https://enrichlayer.com/docs/api/v2/company-api/employee-listing).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/enrich_layer/actions/get-employee-search/get-employee-search.mjs
+++ b/components/enrich_layer/actions/get-employee-search/get-employee-search.mjs
@@ -4,8 +4,9 @@ export default {
   key: "enrich_layer-get-employee-search",
   name: "Get Employee Search",
   description: "Search employees of a target company by their job title. Cost: 10 credits per successful request + 3 credits per employee returned. [See the documentation](https://enrichlayer.com/docs/api/v2/company-api/employee-search).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/enrich_layer/actions/get-job-listing-count/get-job-listing-count.mjs
+++ b/components/enrich_layer/actions/get-job-listing-count/get-job-listing-count.mjs
@@ -4,8 +4,9 @@ export default {
   key: "enrich_layer-get-job-listing-count",
   name: "Get Job Listing Count",
   description: "Count the number of jobs posted by a company on professional networks. Cost: 2 credits per successful request. [See the documentation](https://enrichlayer.com/docs/api/v2/jobs-api/jobs-listing-count).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/enrich_layer/actions/get-job-profile/get-job-profile.mjs
+++ b/components/enrich_layer/actions/get-job-profile/get-job-profile.mjs
@@ -4,8 +4,9 @@ export default {
   key: "enrich_layer-get-job-profile",
   name: "Get Job Profile",
   description: "Get structured data of a Job Profile from a professional network job URL. Cost: 2 credits per successful request. [See the documentation](https://enrichlayer.com/docs/api/v2/jobs-api/job-profile).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/enrich_layer/actions/get-job-search/get-job-search.mjs
+++ b/components/enrich_layer/actions/get-job-search/get-job-search.mjs
@@ -4,8 +4,9 @@ export default {
   key: "enrich_layer-get-job-search",
   name: "Get Job Search",
   description: "List jobs posted by a company on professional networks. Cost: 2 credits per successful request. [See the documentation](https://enrichlayer.com/docs/api/v2/jobs-api/job-search).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/enrich_layer/actions/get-person-lookup/get-person-lookup.mjs
+++ b/components/enrich_layer/actions/get-person-lookup/get-person-lookup.mjs
@@ -4,8 +4,9 @@ export default {
   key: "enrich_layer-get-person-lookup",
   name: "Get Person Lookup",
   description: "Look up a person with a name and company information to find their professional network profile. Cost: 2 credits per successful request. [See the documentation](https://enrichlayer.com/docs/api/v2/people-api/person-lookup).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/enrich_layer/actions/get-person-profile-picture/get-person-profile-picture.mjs
+++ b/components/enrich_layer/actions/get-person-profile-picture/get-person-profile-picture.mjs
@@ -4,8 +4,9 @@ export default {
   key: "enrich_layer-get-person-profile-picture",
   name: "Get Person Profile Picture",
   description: "Get the profile picture of a person from cached profiles. Cost: 0 credits. [See the documentation](https://enrichlayer.com/docs/api/v2/people-api/person-profile-picture).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/enrich_layer/actions/get-person-profile/get-person-profile.mjs
+++ b/components/enrich_layer/actions/get-person-profile/get-person-profile.mjs
@@ -4,8 +4,9 @@ export default {
   key: "enrich_layer-get-person-profile",
   name: "Get Person Profile",
   description: "Get structured data of a Person Profile from a professional network URL. Cost: 1 credit per successful request. [See the documentation](https://enrichlayer.com/docs/api/v2/people-api/person-profile).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/enrich_layer/actions/get-personal-contact-number/get-personal-contact-number.mjs
+++ b/components/enrich_layer/actions/get-personal-contact-number/get-personal-contact-number.mjs
@@ -4,8 +4,9 @@ export default {
   key: "enrich_layer-get-personal-contact-number",
   name: "Get Personal Contact Number",
   description: "Find personal phone numbers associated with a given social media profile. Cost: 1 credit per contact number returned. [See the documentation](https://enrichlayer.com/docs/api/v2/contact-api/personal-contact-number-lookup).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/enrich_layer/actions/get-personal-email/get-personal-email.mjs
+++ b/components/enrich_layer/actions/get-personal-email/get-personal-email.mjs
@@ -4,8 +4,9 @@ export default {
   key: "enrich_layer-get-personal-email",
   name: "Get Personal Email",
   description: "Find personal email addresses associated with a given social media profile. Cost: 1 credit per email returned. [See the documentation](https://enrichlayer.com/docs/api/v2/contact-api/personal-email-lookup).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/enrich_layer/actions/get-reverse-contact-number-lookup/get-reverse-contact-number-lookup.mjs
+++ b/components/enrich_layer/actions/get-reverse-contact-number-lookup/get-reverse-contact-number-lookup.mjs
@@ -4,8 +4,9 @@ export default {
   key: "enrich_layer-get-reverse-contact-number-lookup",
   name: "Get Reverse Contact Number Lookup",
   description: "Find social media profiles from a contact phone number. Cost: 3 credits per successful request. [See the documentation](https://enrichlayer.com/docs/api/v2/contact-api/reverse-contact-number-lookup).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/enrich_layer/actions/get-reverse-email-lookup/get-reverse-email-lookup.mjs
+++ b/components/enrich_layer/actions/get-reverse-email-lookup/get-reverse-email-lookup.mjs
@@ -4,8 +4,9 @@ export default {
   key: "enrich_layer-get-reverse-email-lookup",
   name: "Get Reverse Email Lookup",
   description: "Resolve social media profiles correlated from an email address. Works with both personal and work emails. Cost: 3 credits per successful request. [See the documentation](https://enrichlayer.com/docs/api/v2/contact-api/reverse-email-lookup).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/enrich_layer/actions/get-role-lookup/get-role-lookup.mjs
+++ b/components/enrich_layer/actions/get-role-lookup/get-role-lookup.mjs
@@ -4,8 +4,9 @@ export default {
   key: "enrich_layer-get-role-lookup",
   name: "Get Role Lookup",
   description: "Find the person who most closely matches a specified role in a company (e.g., the CTO of Apple). Cost: 3 credits per successful request. [See the documentation](https://enrichlayer.com/docs/api/v2/people-api/role-lookup).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/enrich_layer/actions/get-school-profile/get-school-profile.mjs
+++ b/components/enrich_layer/actions/get-school-profile/get-school-profile.mjs
@@ -4,8 +4,9 @@ export default {
   key: "enrich_layer-get-school-profile",
   name: "Get School Profile",
   description: "Get structured data of a School Profile from a professional network URL. Cost: 1 credit per successful request. [See the documentation](https://enrichlayer.com/docs/api/v2/school-api/school-profile).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/enrich_layer/actions/get-student-listing/get-student-listing.mjs
+++ b/components/enrich_layer/actions/get-student-listing/get-student-listing.mjs
@@ -4,8 +4,9 @@ export default {
   key: "enrich_layer-get-student-listing",
   name: "Get Student Listing",
   description: "Get a list of students of a school. Cost: 3 credits per student returned. [See the documentation](https://enrichlayer.com/docs/api/v2/school-api/student-listing).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/enrich_layer/actions/get-work-email-lookup/get-work-email-lookup.mjs
+++ b/components/enrich_layer/actions/get-work-email-lookup/get-work-email-lookup.mjs
@@ -4,8 +4,9 @@ export default {
   key: "enrich_layer-get-work-email-lookup",
   name: "Get Work Email Lookup",
   description: "Look up the work email address of a person from their professional network profile URL. Emails are verified with 95%+ deliverability guarantee. Cost: 3 credits per successful request. [See the documentation](https://enrichlayer.com/docs/api/v2/contact-api/work-email-lookup).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/enrich_layer/actions/search-companies/search-companies.mjs
+++ b/components/enrich_layer/actions/search-companies/search-companies.mjs
@@ -4,8 +4,9 @@ export default {
   key: "enrich_layer-search-companies",
   name: "Search Companies",
   description: "Search for companies that meet a set of criteria. Returns up to 10,000,000 results. Cost: 3 credits per company URL returned. [See the documentation](https://enrichlayer.com/docs/api/v2/search-api/company-search).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/enrich_layer/actions/search-people/search-people.mjs
+++ b/components/enrich_layer/actions/search-people/search-people.mjs
@@ -4,8 +4,9 @@ export default {
   key: "enrich_layer-search-people",
   name: "Search People",
   description: "Search for people who meet a set of criteria. Returns a single page of results per call — use the `next_page` URL from the response to retrieve subsequent pages. Cost: 3 credits per profile URL returned. [See the documentation](https://enrichlayer.com/docs/api/v2/search-api/person-search).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/enrich_layer/package.json
+++ b/components/enrich_layer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/enrich_layer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Enrich Layer Components",
   "main": "enrich_layer.app.mjs",
   "keywords": [

--- a/components/hedy/actions/create-session-context/create-session-context.mjs
+++ b/components/hedy/actions/create-session-context/create-session-context.mjs
@@ -8,8 +8,9 @@ export default {
     + " Set `isDefault` to `true` to make this context automatically applied to new sessions."
     + " Use **Update Session Context** to modify an existing context, or **Delete Session Context** to remove one."
     + " [See the documentation](https://app.swaggerhub.com/apis-docs/HedyAI/hedy-api/1.5.2#/Session%20Contexts/post_contexts)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hedy/actions/create-topic/create-topic.mjs
+++ b/components/hedy/actions/create-topic/create-topic.mjs
@@ -7,8 +7,9 @@ export default {
     + " Topics can include a custom AI analysis context (`topicContext`) — up to 20,000 characters of instructions that guide Hedy's AI when analyzing meetings in this topic."
     + " Use **Update Topic** to modify an existing topic, or **Delete Topic** to remove one."
     + " [See the documentation](https://app.swaggerhub.com/apis-docs/HedyAI/hedy-api/1.5.2#/Topics/post_topics)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hedy/actions/delete-session-context/delete-session-context.mjs
+++ b/components/hedy/actions/delete-session-context/delete-session-context.mjs
@@ -7,8 +7,9 @@ export default {
     + " If you delete the current default context, the most recently created remaining context is automatically promoted to default."
     + " Use **Get Many Session Contexts** to find the context ID before deleting."
     + " [See the documentation](https://app.swaggerhub.com/apis-docs/HedyAI/hedy-api/1.5.2#/Session%20Contexts/delete_contexts__contextId_)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/hedy/actions/delete-topic/delete-topic.mjs
+++ b/components/hedy/actions/delete-topic/delete-topic.mjs
@@ -6,8 +6,9 @@ export default {
   description: "Deletes a Hedy topic. Sessions that were linked to the topic are NOT deleted — they are unlinked and remain in your account."
     + " This action is irreversible. Use **Get Many Topics** to find the topic ID before deleting."
     + " [See the documentation](https://app.swaggerhub.com/apis-docs/HedyAI/hedy-api/1.5.2#/Topics/delete_topics__topicId_)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/hedy/actions/get-highlight/get-highlight.mjs
+++ b/components/hedy/actions/get-highlight/get-highlight.mjs
@@ -6,8 +6,9 @@ export default {
   description: "Retrieves full details for a single AI-generated highlight by ID, including the raw quote, cleaned quote, main idea, and AI insight."
     + " Use **Get Many Highlights** or **Get Highlights By Session** first to find a highlight ID."
     + " [See the documentation](https://app.swaggerhub.com/apis-docs/HedyAI/hedy-api/1.5.2#/Highlights/get_highlights__highlightId_)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hedy/actions/get-highlights-by-session/get-highlights-by-session.mjs
+++ b/components/hedy/actions/get-highlights-by-session/get-highlights-by-session.mjs
@@ -8,8 +8,9 @@ export default {
     + " Each result includes a highlight ID, title, and timestamp within the session."
     + " Use **Get Highlight** with the highlight ID to fetch the full detail including raw quote, cleaned quote, main idea, and AI insight."
     + " [See the documentation](https://app.swaggerhub.com/apis-docs/HedyAI/hedy-api/1.5.2#/Highlights/get_sessions__sessionId__highlights)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hedy/actions/get-many-highlights/get-many-highlights.mjs
+++ b/components/hedy/actions/get-many-highlights/get-many-highlights.mjs
@@ -8,8 +8,9 @@ export default {
     + " Use **Get Highlight** with a specific highlight ID to fetch the full detail including raw quote, cleaned quote, main idea, and AI insight."
     + " To list highlights for a specific session only, use **Get Highlights By Session**."
     + " [See the documentation](https://app.swaggerhub.com/apis-docs/HedyAI/hedy-api/1.5.2#/Highlights/get_highlights)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hedy/actions/get-many-session-contexts/get-many-session-contexts.mjs
+++ b/components/hedy/actions/get-many-session-contexts/get-many-session-contexts.mjs
@@ -7,8 +7,9 @@ export default {
     + " Session contexts are custom AI instruction sets that guide Hedy's analysis of meeting recordings."
     + " Use this tool to browse available contexts or to find a context ID to pass to **Get Session Context**, **Update Session Context**, or **Delete Session Context**."
     + " [See the documentation](https://app.swaggerhub.com/apis-docs/HedyAI/hedy-api/1.5.2#/Session%20Contexts/get_contexts)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hedy/actions/get-many-sessions/get-many-sessions.mjs
+++ b/components/hedy/actions/get-many-sessions/get-many-sessions.mjs
@@ -9,8 +9,9 @@ export default {
     + " To list sessions within a specific topic, use **Get Topic Sessions** instead."
     + " Paginate using the `after` cursor from the response's `pagination` field."
     + " [See the documentation](https://app.swaggerhub.com/apis-docs/HedyAI/hedy-api/1.5.2#/Sessions/get_sessions)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hedy/actions/get-many-todos/get-many-todos.mjs
+++ b/components/hedy/actions/get-many-todos/get-many-todos.mjs
@@ -8,8 +8,9 @@ export default {
     + " To get todos for a specific session only, use **Get Todos By Session**."
     + " Use **Get Todo** with a specific todo ID to fetch a single item's full detail."
     + " [See the documentation](https://app.swaggerhub.com/apis-docs/HedyAI/hedy-api/1.5.2#/Todos/get_todos)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hedy/actions/get-many-topics/get-many-topics.mjs
+++ b/components/hedy/actions/get-many-topics/get-many-topics.mjs
@@ -6,8 +6,9 @@ export default {
   description: "Retrieves all Hedy meeting topics with their session counts, last session date, dominant session type, and cached AI overview."
     + " Use this tool to browse available topics or to find a topic ID to pass to **Get Topic**, **Get Topic Sessions**, **Update Topic**, or **Delete Topic**."
     + " [See the documentation](https://app.swaggerhub.com/apis-docs/HedyAI/hedy-api/1.5.2#/Topics/get_topics)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hedy/actions/get-session-context/get-session-context.mjs
+++ b/components/hedy/actions/get-session-context/get-session-context.mjs
@@ -7,8 +7,9 @@ export default {
     + " Session contexts are reusable custom AI instruction sets that guide Hedy's analysis across multiple meetings."
     + " Use **Get Many Session Contexts** first to list available contexts and obtain a context ID."
     + " [See the documentation](https://app.swaggerhub.com/apis-docs/HedyAI/hedy-api/1.5.2#/Session%20Contexts/get_contexts__contextId_)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hedy/actions/get-session/get-session.mjs
+++ b/components/hedy/actions/get-session/get-session.mjs
@@ -6,8 +6,9 @@ export default {
   description: "Retrieves full details for a single Hedy meeting session by ID, including the complete transcript, meeting minutes, recap, session notes, highlights array, and action items (todos)."
     + " Use **Get Many Sessions** first to list sessions and obtain a session ID."
     + " [See the documentation](https://app.swaggerhub.com/apis-docs/HedyAI/hedy-api/1.5.2#/Sessions/get_sessions__sessionId_)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hedy/actions/get-todo/get-todo.mjs
+++ b/components/hedy/actions/get-todo/get-todo.mjs
@@ -7,8 +7,9 @@ export default {
     + " Both the session ID and todo ID are required."
     + " Use **Get Todos By Session** first to list todos for a session and obtain todo IDs."
     + " [See the documentation](https://app.swaggerhub.com/apis-docs/HedyAI/hedy-api/1.5.2#/Todos/get_sessions__sessionId__todos__todoId_)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hedy/actions/get-todos-by-session/get-todos-by-session.mjs
+++ b/components/hedy/actions/get-todos-by-session/get-todos-by-session.mjs
@@ -8,8 +8,9 @@ export default {
     + " Each result includes the todo text, completion status, and optional due date."
     + " Use **Get Todo** with the session ID and todo ID for single-item detail."
     + " [See the documentation](https://app.swaggerhub.com/apis-docs/HedyAI/hedy-api/1.5.2#/Todos/get_sessions__sessionId__todos)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hedy/actions/get-topic-sessions/get-topic-sessions.mjs
+++ b/components/hedy/actions/get-topic-sessions/get-topic-sessions.mjs
@@ -7,8 +7,9 @@ export default {
     + " Use **Get Many Topics** first to find the topic ID."
     + " Paginate using the `startAfter` cursor (a session ID from the last item in the previous page)."
     + " [See the documentation](https://app.swaggerhub.com/apis-docs/HedyAI/hedy-api/1.5.2#/Topics/get_topics__topicId__sessions)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hedy/actions/get-topic/get-topic.mjs
+++ b/components/hedy/actions/get-topic/get-topic.mjs
@@ -7,8 +7,9 @@ export default {
     + " The `topicContext` field (up to 20,000 characters) contains custom instructions that guide Hedy's AI analysis for sessions in this topic."
     + " Use **Get Many Topics** first to list topics and obtain a topic ID."
     + " [See the documentation](https://app.swaggerhub.com/apis-docs/HedyAI/hedy-api/1.5.2#/Topics/get_topics__topicId_)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hedy/actions/update-session-context/update-session-context.mjs
+++ b/components/hedy/actions/update-session-context/update-session-context.mjs
@@ -7,8 +7,9 @@ export default {
     + " If you set `isDefault` to `true`, this context becomes the default and the previous default is demoted."
     + " Use **Get Many Session Contexts** to find the context ID."
     + " [See the documentation](https://app.swaggerhub.com/apis-docs/HedyAI/hedy-api/1.5.2#/Session%20Contexts/patch_contexts__contextId_)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hedy/actions/update-topic/update-topic.mjs
+++ b/components/hedy/actions/update-topic/update-topic.mjs
@@ -7,8 +7,9 @@ export default {
     + " To clear the custom AI context, pass an empty string or `null` for `topicContext`."
     + " Use **Get Many Topics** to find the topic ID."
     + " [See the documentation](https://app.swaggerhub.com/apis-docs/HedyAI/hedy-api/1.5.2#/Topics/patch_topics__topicId_)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hedy/package.json
+++ b/components/hedy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/hedy",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Hedy Components",
   "main": "hedy.app.mjs",
   "keywords": [

--- a/components/hubspot/actions/add-note-to-contact/add-note-to-contact.mjs
+++ b/components/hubspot/actions/add-note-to-contact/add-note-to-contact.mjs
@@ -31,13 +31,14 @@ export default {
     + "Do **not** use **Create Engagement** for this workflow. "
     + "For every writable note property or non-contact associations, use **Create Note** instead. "
     + "[See the documentation](https://developers.hubspot.com/docs/api/crm/objects/notes)",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     hubspot,
     contactId: {

--- a/components/hubspot/actions/archive-thread/archive-thread.mjs
+++ b/components/hubspot/actions/archive-thread/archive-thread.mjs
@@ -4,8 +4,9 @@ export default {
   key: "hubspot-archive-thread",
   name: "Archive Thread",
   description: "Archives a thread (soft delete). The thread is hidden from active views but can be restored via the HubSpot UI or by listing archived threads. [See the documentation](https://developers.hubspot.com/docs/reference/api/conversations/inbox-and-messages#archive-threads)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/book-meeting-link/book-meeting-link.mjs
+++ b/components/hubspot/actions/book-meeting-link/book-meeting-link.mjs
@@ -7,13 +7,14 @@ export default {
   key: "hubspot-book-meeting-link",
   name: "Book Meeting on Meeting Link",
   description: "Book a meeting on a HubSpot meeting scheduling page. Creates a calendar event for the organizer and registers the booker as a contact. [See the documentation](https://developers.hubspot.com/docs/api-reference/legacy/scheduler/guide#book-a-meeting)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     hubspot,
     slug: {

--- a/components/hubspot/actions/enroll-contact-into-workflow/enroll-contact-into-workflow.mjs
+++ b/components/hubspot/actions/enroll-contact-into-workflow/enroll-contact-into-workflow.mjs
@@ -5,13 +5,14 @@ export default {
   name: "Enroll Contact Into Workflow",
   description:
     "Add a contact to a workflow. Note: The Workflows API currently only supports contact-based workflows and is only available for Marketing Hub Enterprise accounts. [See the documentation](https://legacydocs.hubspot.com/docs/methods/workflows/add_contact)",
-  version: "0.0.35",
+  version: "0.0.36",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     hubspot,
     workflow: {

--- a/components/hubspot/actions/get-actor/get-actor.mjs
+++ b/components/hubspot/actions/get-actor/get-actor.mjs
@@ -4,8 +4,9 @@ export default {
   key: "hubspot-get-actor",
   name: "Get Actor",
   description: "Resolves an actor ID (e.g. the value returned by a message's `senders[].actorId` field) to its name, email, and type. [See the documentation](https://developers.hubspot.com/docs/reference/api/conversations/inbox-and-messages#get-actors)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/get-custom-object/get-custom-object.mjs
+++ b/components/hubspot/actions/get-custom-object/get-custom-object.mjs
@@ -10,8 +10,9 @@ export default {
     + " Use **List Custom Object Schemas** to get the correct `objectType` identifier."
     + " Max 100 IDs per request."
     + " [See the documentation](https://developers.hubspot.com/docs/api-reference/latest/crm/objects/objects/batch/get-objects)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/get-engagements/get-engagements.mjs
+++ b/components/hubspot/actions/get-engagements/get-engagements.mjs
@@ -5,13 +5,14 @@ export default {
   key: "hubspot-get-engagements",
   name: "Get Engagements",
   description: "Retrieves one or more engagements by their IDs. Use this action to fetch details about multiple engagements, such as their types, timestamps, and associated CRM objects. Requires engagement IDs, which you can obtain from the **List CRM Objects** action. [See the documentation](https://developers.hubspot.com/docs/api-reference/legacy/crm/objects/objects/batch/get-objects)",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     hubspot,
     engagementType: {

--- a/components/hubspot/actions/get-file-public-url/get-file-public-url.mjs
+++ b/components/hubspot/actions/get-file-public-url/get-file-public-url.mjs
@@ -5,13 +5,14 @@ export default {
   name: "Get File Public URL",
   description:
     "Get a publicly available URL for a file that was uploaded using a Hubspot form. [See the documentation](https://developers.hubspot.com/docs/api/files/files#endpoint?spec=GET-/files/v3/files/{fileId}/signed-url)",
-  version: "0.0.35",
+  version: "0.0.36",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     hubspot,
     fileUrl: {

--- a/components/hubspot/actions/get-meeting-link-availability/get-meeting-link-availability.mjs
+++ b/components/hubspot/actions/get-meeting-link-availability/get-meeting-link-availability.mjs
@@ -4,13 +4,14 @@ export default {
   key: "hubspot-get-meeting-link-availability",
   name: "Get Meeting Link Availability",
   description: "Fetch the upcoming availability windows (and busy times) for a meeting scheduling page. Use this when you only need the open slots; use **Get Meeting Link Booking Info** for the full booking configuration. [See the documentation](https://developers.hubspot.com/docs/api-reference/legacy/scheduler/guide#list-availability)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     hubspot,
     slug: {

--- a/components/hubspot/actions/get-meeting-link-booking-info/get-meeting-link-booking-info.mjs
+++ b/components/hubspot/actions/get-meeting-link-booking-info/get-meeting-link-booking-info.mjs
@@ -4,13 +4,14 @@ export default {
   key: "hubspot-get-meeting-link-booking-info",
   name: "Get Meeting Link Booking Info",
   description: "Retrieve the booking configuration and availability for a meeting scheduling page. Returns link metadata, availability windows by duration, busy times, branding, and organizer details. [See the documentation](https://developers.hubspot.com/docs/api-reference/legacy/scheduler/guide#list-booking-information)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     hubspot,
     slug: {

--- a/components/hubspot/actions/get-owner/get-owner.mjs
+++ b/components/hubspot/actions/get-owner/get-owner.mjs
@@ -6,13 +6,14 @@ export default {
   description:
     "Get a single HubSpot owner (user) by ID. Provide an owner ID or use **List Owners** to fetch IDs."
     + " [See the documentation](https://developers.hubspot.com/docs/api-reference/crm-owners-v3/owners/get-crm-v3-owners-ownerId)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     hubspot,
     ownerId: {

--- a/components/hubspot/actions/get-thread/get-thread.mjs
+++ b/components/hubspot/actions/get-thread/get-thread.mjs
@@ -4,8 +4,9 @@ export default {
   key: "hubspot-get-thread",
   name: "Get Thread",
   description: "Retrieves a single thread's metadata, including status, assignee, associations, and latest-message info. [See the documentation](https://developers.hubspot.com/docs/reference/api/conversations/inbox-and-messages#retrieve-threads)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/list-associated-engagements/list-associated-engagements.mjs
+++ b/components/hubspot/actions/list-associated-engagements/list-associated-engagements.mjs
@@ -9,13 +9,14 @@ export default {
     + " Use **Offset** for pagination when `hasMore` is true."
     + " For newer CRM v3 engagement objects, prefer v4 **List CRM Associations** from the record to `notes`, `tasks`, `calls`, etc."
     + " [See the documentation](https://developers.hubspot.com/docs/api-reference/legacy/engagements-v1/engagements/get-engagements-v1-engagements-associated-crm-object-id-paged)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     hubspot,
     objectType: {

--- a/components/hubspot/actions/list-association-labels/list-association-labels.mjs
+++ b/components/hubspot/actions/list-association-labels/list-association-labels.mjs
@@ -8,13 +8,14 @@ export default {
     + " Use the returned `typeId` values when creating associations with **Create Association** or **Create CRM Object** (associations JSON)."
     + " Order matters: from/to defines the direction of the relationship."
     + " [See the documentation](https://developers.hubspot.com/docs/api-reference/crm/associations-v4/definitions/get-crm-v4-associations-fromToObjectType-toToObjectType-labels)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     hubspot,
     fromObjectType: {

--- a/components/hubspot/actions/list-crm-associations/list-crm-associations.mjs
+++ b/components/hubspot/actions/list-crm-associations/list-crm-associations.mjs
@@ -8,13 +8,14 @@ export default {
     + " Returns associated record IDs and association types for each link."
     + " Direction matters: `from` is the record you are querying from; swap from/to to traverse the relationship the other way."
     + " [See the documentation](https://developers.hubspot.com/docs/api-reference/crm/associations-v4/basic/get-crm-v4-objects-objectType-objectId-associations-toObjectType)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     hubspot,
     fromObjectType: {

--- a/components/hubspot/actions/list-custom-object-properties/list-custom-object-properties.mjs
+++ b/components/hubspot/actions/list-custom-object-properties/list-custom-object-properties.mjs
@@ -11,8 +11,9 @@ export default {
     + " Standard object types (contacts, companies, deals, tickets) are not supported here —"
     + " use **Get Properties** or **Search Properties** for those."
     + " [See the documentation](https://developers.hubspot.com/docs/api-reference/latest/crm/properties/get-properties)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/list-custom-object-schemas/list-custom-object-schemas.mjs
+++ b/components/hubspot/actions/list-custom-object-schemas/list-custom-object-schemas.mjs
@@ -10,8 +10,9 @@ export default {
     + " Call this first before any other custom object operation to obtain the correct objectType identifier."
     + " Standard object types (contacts, companies, deals, tickets) do NOT appear here."
     + " [See the documentation](https://developers.hubspot.com/docs/api-reference/latest/crm/objects/schemas/get-schemas)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/list-custom-objects/list-custom-objects.mjs
+++ b/components/hubspot/actions/list-custom-objects/list-custom-objects.mjs
@@ -11,8 +11,9 @@ export default {
     + " (fullyQualifiedName or objectTypeId)."
     + " Use **List Custom Object Properties** to discover which properties are available to request."
     + " [See the documentation](https://developers.hubspot.com/docs/api-reference/latest/crm/objects/objects/get-objects)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/list-meeting-links/list-meeting-links.mjs
+++ b/components/hubspot/actions/list-meeting-links/list-meeting-links.mjs
@@ -5,13 +5,14 @@ export default {
   key: "hubspot-list-meeting-links",
   name: "List Meeting Links",
   description: "List meeting scheduling pages for a HubSpot organizer. Returns a single page of results; use **Limit** to control the page size and check the `(of N total)` summary to see if more results exist beyond the page returned. [See the documentation](https://developers.hubspot.com/docs/api-reference/legacy/scheduler/guide#list-meeting-scheduling-pages)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     hubspot,
     organizerUserId: {

--- a/components/hubspot/actions/retrieve-quotes/retrieve-quotes.mjs
+++ b/components/hubspot/actions/retrieve-quotes/retrieve-quotes.mjs
@@ -10,13 +10,14 @@ export default {
     "Fetch one quote by ID or list quotes with CRM v3 pagination (`after`, `limit`)."
     + " Complements **Create CRM Object** for quotes when you need read access outside **Search CRM**."
     + " [See the documentation](https://developers.hubspot.com/docs/api-reference/crm-quotes-v3/basic/get-crm-v3-objects-quotes)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     hubspot,
     quoteId: {

--- a/components/hubspot/actions/unarchive-thread/unarchive-thread.mjs
+++ b/components/hubspot/actions/unarchive-thread/unarchive-thread.mjs
@@ -4,8 +4,9 @@ export default {
   key: "hubspot-unarchive-thread",
   name: "Unarchive Thread",
   description: "Restores a previously-archived thread, returning it to the active inbox. Sends `PATCH` with body `{ archived: false }`, the only restore path HubSpot's API supports. The Thread ID dropdown lists archived threads. [See the documentation](https://developers.hubspot.com/docs/reference/api/conversations/inbox-and-messages#update-or-restore-threads)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/actions/update-thread/update-thread.mjs
+++ b/components/hubspot/actions/update-thread/update-thread.mjs
@@ -4,8 +4,9 @@ export default {
   key: "hubspot-update-thread",
   name: "Update Thread",
   description: "Updates an existing thread's status. To archive a thread, use the **Archive Thread** action; to restore an archived thread, use the **Unarchive Thread** action. HubSpot's PATCH endpoint does not support either operation via a status change. [See the documentation](https://developers.hubspot.com/docs/reference/api/conversations/inbox-and-messages#update-or-restore-threads)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/package.json
+++ b/components/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/hubspot",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Pipedream Hubspot Components",
   "main": "hubspot.app.mjs",
   "keywords": [

--- a/components/ipgeolocation/actions/convert-timezone/convert-timezone.mjs
+++ b/components/ipgeolocation/actions/convert-timezone/convert-timezone.mjs
@@ -5,8 +5,9 @@ export default {
   name: "Convert Timezone",
   description:
     "Convert a time between two timezones using timezone names, coordinates, city, IATA, ICAO, or UN/LOCODE. [See the documentation](https://ipgeolocation.io/documentation/timezone-api.html)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/ipgeolocation/actions/get-abuse-contact/get-abuse-contact.mjs
+++ b/components/ipgeolocation/actions/get-abuse-contact/get-abuse-contact.mjs
@@ -5,8 +5,9 @@ export default {
   name: "Get Abuse Contact",
   description:
     "Retrieve abuse contact information for an IPv4 or IPv6 address, including abuse emails, phone numbers, organization, and network route. Only available on paid plans. [See the documentation](https://ipgeolocation.io/documentation/ip-abuse-contact-api.html)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/ipgeolocation/actions/get-asn/get-asn.mjs
+++ b/components/ipgeolocation/actions/get-asn/get-asn.mjs
@@ -5,8 +5,9 @@ export default {
   name: "Get ASN Details",
   description:
     "Retrieve detailed ASN information including peers, upstreams, downstreams, routes, and WHOIS data for an ASN number or IP address. Only available on paid plans. [See the documentation](https://ipgeolocation.io/documentation/asn-api.html)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/ipgeolocation/actions/get-astronomy-time-series/get-astronomy-time-series.mjs
+++ b/components/ipgeolocation/actions/get-astronomy-time-series/get-astronomy-time-series.mjs
@@ -5,8 +5,9 @@ export default {
   name: "Get Astronomy Time Series",
   description:
     "Retrieve astronomical data (sunrise, sunset, moonrise, moonset, moon phase, and more) for a date range up to 90 days for a location by IP address, coordinates, or address. [See the documentation](https://ipgeolocation.io/documentation/astronomy-api.html#time-series-lookup)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/ipgeolocation/actions/get-astronomy/get-astronomy.mjs
+++ b/components/ipgeolocation/actions/get-astronomy/get-astronomy.mjs
@@ -5,8 +5,9 @@ export default {
   name: "Get Astronomy Data",
   description:
     "Retrieve sunrise, sunset, moonrise, moonset, moon phase, and sun/moon position data for a location by IP address, coordinates, or location string. [See the documentation](https://ipgeolocation.io/documentation/astronomy-api.html)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/ipgeolocation/actions/get-bulk-geolocation/get-bulk-geolocation.mjs
+++ b/components/ipgeolocation/actions/get-bulk-geolocation/get-bulk-geolocation.mjs
@@ -5,8 +5,9 @@ export default {
   name: "Get Bulk IP Geolocation",
   description:
     "Retrieve geolocation data for multiple IPv4/IPv6 addresses or domain names in a single request. Maximum 50,000 IPs per request. Only available on paid plans. [See the documentation](https://ipgeolocation.io/documentation/ip-location-api.html#bulk-ip-geolocation-lookup-api)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/ipgeolocation/actions/get-bulk-ip-security/get-bulk-ip-security.mjs
+++ b/components/ipgeolocation/actions/get-bulk-ip-security/get-bulk-ip-security.mjs
@@ -5,8 +5,9 @@ export default {
   name: "Get Bulk IP Security",
   description:
     "Retrieve real-time threat intelligence for multiple IPv4 or IPv6 addresses in a single request, including VPN, proxy, Tor, bot, spam detection, and threat scores. Maximum 50,000 IPs per request. Only available on paid plans. [See the documentation](https://ipgeolocation.io/documentation/ip-security-api.html#bulk-ip-security-lookup-endpoint)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/ipgeolocation/actions/get-geolocation/get-geolocation.mjs
+++ b/components/ipgeolocation/actions/get-geolocation/get-geolocation.mjs
@@ -5,8 +5,9 @@ export default {
   name: "Get IP Geolocation",
   description:
     "Retrieve geolocation data for an IPv4/IPv6 address or domain name, including location, country metadata, timezone, currency, ASN, security insights and more. [See the documentation](https://ipgeolocation.io/documentation/ip-location-api.html)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/ipgeolocation/actions/get-ip-security/get-ip-security.mjs
+++ b/components/ipgeolocation/actions/get-ip-security/get-ip-security.mjs
@@ -5,8 +5,9 @@ export default {
   name: "Get IP Security",
   description:
     "Retrieve real-time threat intelligence for an IPv4 or IPv6 address, including VPN, proxy, Tor, bot, spam detection, and a threat score. Only available on paid plans. [See the documentation](https://ipgeolocation.io/documentation/ip-security-api.html)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/ipgeolocation/actions/get-timezone/get-timezone.mjs
+++ b/components/ipgeolocation/actions/get-timezone/get-timezone.mjs
@@ -5,8 +5,9 @@ export default {
   name: "Get Timezone",
   description:
     "Retrieve timezone information using a timezone name, IP address, coordinates, city, IATA code, ICAO code, or UN/LOCODE. [See the documentation](https://ipgeolocation.io/documentation/timezone-api.html)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/ipgeolocation/actions/parse-bulk-user-agents/parse-bulk-user-agents.mjs
+++ b/components/ipgeolocation/actions/parse-bulk-user-agents/parse-bulk-user-agents.mjs
@@ -5,8 +5,9 @@ export default {
   name: "Parse Bulk User Agents",
   description:
     "Extract browser, device, operating system, and engine details from multiple user agent strings in a single request. Maximum 50,000 strings per request. Only available on paid plans. [See the documentation](https://ipgeolocation.io/documentation/user-agent-api.html#parse-bulk-user-agent-strings)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/ipgeolocation/actions/parse-user-agent/parse-user-agent.mjs
+++ b/components/ipgeolocation/actions/parse-user-agent/parse-user-agent.mjs
@@ -5,8 +5,9 @@ export default {
   name: "Parse User Agent",
   description:
     "Extract browser, device, operating system, and engine details from a user agent string. Only available on paid plans. [See the documentation](https://ipgeolocation.io/documentation/user-agent-api.html)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/ipgeolocation/package.json
+++ b/components/ipgeolocation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/ipgeolocation",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream IPGeolocation Components",
   "main": "ipgeolocation.app.mjs",
   "keywords": [

--- a/components/lever/actions/add-note/add-note.mjs
+++ b/components/lever/actions/add-note/add-note.mjs
@@ -10,8 +10,9 @@ export default {
     + " Set Secret to true to make the note visible only to admins and super admins."
     + " Example: call with opportunityId=\"<id>\", note=\"Strong communicator; advancing to onsite.\", performAs=\"<userId>\" → adds the note and returns it."
     + " [See the documentation](https://hire.lever.co/developer/documentation#create-a-note)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/lever/actions/archive-opportunity/archive-opportunity.mjs
+++ b/components/lever/actions/archive-opportunity/archive-opportunity.mjs
@@ -11,8 +11,9 @@ export default {
     + " Archiving is reversible — candidates can be unarchived in the Lever UI."
     + " Example: call with opportunityId=\"<id>\", reasonId=\"<reasonId>\", performAs=\"<userId>\" → archives the candidate (reversible in the Lever UI) and returns the updated opportunity."
     + " [See the documentation](https://hire.lever.co/developer/documentation#update-opportunity-archived-state)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/lever/actions/create-interview/create-interview.mjs
+++ b/components/lever/actions/create-interview/create-interview.mjs
@@ -15,8 +15,9 @@ export default {
     + " Use **Search Opportunities** to find the opportunity ID."
     + " Example: call with opportunityId=\"<id>\", panelId=\"<panelId>\" (from **List Opportunity Items** (resource=interviews)), interviewers=\"<userId>\", date=1700000000000, duration=60, performAs=\"<userId>\" → adds an interview to the panel and returns it."
     + " [See the documentation](https://hire.lever.co/developer/documentation#create-an-interview)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/lever/actions/create-opportunity/create-opportunity.mjs
+++ b/components/lever/actions/create-opportunity/create-opportunity.mjs
@@ -12,8 +12,9 @@ export default {
     + " WARNING: only one posting UID may be specified per request."
     + " Example: to add Jane Doe as a referred candidate on a posting, call with performAs=\"<userId>\", candidateName=\"Jane Doe\", email=\"jane@example.com\", postingId=\"<postingId>\", origin=\"referred\" → returns the created opportunity with its `id`."
     + " [See the documentation](https://hire.lever.co/developer/documentation#create-an-opportunity)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/lever/actions/download-opportunity-files/download-opportunity-files.mjs
+++ b/components/lever/actions/download-opportunity-files/download-opportunity-files.mjs
@@ -13,8 +13,9 @@ export default {
     + " Each file is saved to the temporary directory; the action exports `file_paths` and returns a `files` array (each with `resource`, `id`, `name`, `file_path`). Documents that fail to download are reported in `errors` rather than aborting the batch."
     + " Example: to get a candidate's CV and any other documents, call with opportunityId=\"<id>\", resources=[\"resumes\",\"files\"] → downloads every résumé and file and exports their paths. Add fileNameContains=\".pdf\" to limit to PDFs."
     + " [See the documentation](https://hire.lever.co/developer/documentation#download-a-resume-file)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/lever/actions/get-opportunity/get-opportunity.mjs
+++ b/components/lever/actions/get-opportunity/get-opportunity.mjs
@@ -10,8 +10,9 @@ export default {
     + " The opportunity ID comes from search results or from a webhook payload."
     + " Example: call with opportunityId=\"<id>\", expand=[\"applications\",\"stage\"] → returns the full opportunity with the application and stage objects inlined."
     + " [See the documentation](https://hire.lever.co/developer/documentation#retrieve-a-single-opportunity)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/lever/actions/get-posting/get-posting.mjs
+++ b/components/lever/actions/get-posting/get-posting.mjs
@@ -9,8 +9,9 @@ export default {
     + " Use **List Postings** to find posting IDs."
     + " Example: call with postingId=\"<id>\" → returns the posting with its full job description under `content.description`."
     + " [See the documentation](https://hire.lever.co/developer/documentation#retrieve-a-single-posting)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/lever/actions/list-archive-reasons/list-archive-reasons.mjs
+++ b/components/lever/actions/list-archive-reasons/list-archive-reasons.mjs
@@ -11,8 +11,9 @@ export default {
     + " Returns one page (up to `limit`); if the response's `hasNext` is true, pass its `next` value to `offset` to fetch the following page."
     + " Example: call with type=\"non-hired\" → returns rejection reasons each with id, text, and type; pass an id as the reason for **Archive Opportunity**."
     + " [See the documentation](https://hire.lever.co/developer/documentation#list-all-archive-reasons)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/lever/actions/list-feedback-templates/list-feedback-templates.mjs
+++ b/components/lever/actions/list-feedback-templates/list-feedback-templates.mjs
@@ -10,8 +10,9 @@ export default {
     + " Returns one page (up to `limit`); if the response's `hasNext` is true, pass its `next` value to `offset` to fetch the following page."
     + " Example: call with no arguments → returns templates like `{ id: \"<templateId>\", text: \"Onsite Interview\", fields: [{ id: \"<fieldId>\", type: \"score-system\", text: \"Overall\" }] }`; pass that template id as `baseTemplateId` and the field ids inside `fieldValues` when calling **Submit Feedback**."
     + " [See the documentation](https://hire.lever.co/developer/documentation#feedback-templates)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/lever/actions/list-opportunity-items/list-opportunity-items.mjs
+++ b/components/lever/actions/list-opportunity-items/list-opportunity-items.mjs
@@ -13,8 +13,9 @@ export default {
     + " Gotcha: `resumes` and `files` are **not** paginated — Lever returns the full set in a single payload with no `hasNext`/`next` cursor, and `limit`/`offset` are ignored, so do not expect cursor metadata for them."
     + " Example: to read a candidate's interview feedback, call with opportunityId=\"<id>\", resource=\"feedback\" → returns feedback records each with panel id, interviewer, score, and completed form fields."
     + " [See the documentation](https://hire.lever.co/developer/documentation#opportunities)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/lever/actions/list-postings/list-postings.mjs
+++ b/components/lever/actions/list-postings/list-postings.mjs
@@ -10,8 +10,9 @@ export default {
     + " Returns one page (up to `limit`); if the response's `hasNext` is true, pass its `next` value to `offset` to fetch the following page."
     + " Example: to find published engineering roles, call with team=\"Engineering\", state=\"published\" → returns postings each with id, name, state, team, and location."
     + " [See the documentation](https://hire.lever.co/developer/documentation#list-all-postings)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/lever/actions/list-stages/list-stages.mjs
+++ b/components/lever/actions/list-stages/list-stages.mjs
@@ -10,8 +10,9 @@ export default {
     + " Returns one page (up to `limit`); if the response's `hasNext` is true, pass its `next` value to `offset` to fetch the following page."
     + " Example: call with no arguments → returns stages like `{ id: \"lead-new\", text: \"New lead\" }`; pass a stage id to **Update Opportunity Stage**."
     + " [See the documentation](https://hire.lever.co/developer/documentation#list-all-stages)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/lever/actions/list-users/list-users.mjs
+++ b/components/lever/actions/list-users/list-users.mjs
@@ -10,8 +10,9 @@ export default {
     + " Returns one page (up to `limit`); if the response's `hasNext` is true, pass its `next` value to `offset` to fetch the following page."
     + " Example: call with no arguments → returns users each with id, name, email, and access role; pass a user's id as Perform As on write actions."
     + " [See the documentation](https://hire.lever.co/developer/documentation#list-all-users)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/lever/actions/search-opportunities/search-opportunities.mjs
+++ b/components/lever/actions/search-opportunities/search-opportunities.mjs
@@ -14,8 +14,9 @@ export default {
     + " Returns cursor-paginated results; use the `next` field in the response to fetch subsequent pages."
     + " Example: to find a candidate by email, call with email=\"jane@example.com\" → exact match; to find by name, call with email=\"Jane Doe\" → local name match."
     + " [See the documentation](https://hire.lever.co/developer/documentation#list-all-opportunities)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/lever/actions/submit-feedback/submit-feedback.mjs
+++ b/components/lever/actions/submit-feedback/submit-feedback.mjs
@@ -14,8 +14,9 @@ export default {
     + " Perform As is required — feedback is attributed to this user. Use **List Users** to find user IDs."
     + " Example: call with opportunityId=\"<id>\", performAs=\"<userId>\", baseTemplateId=\"<templateId>\", fieldValues=`[{\"id\": \"<fieldId>\", \"value\": \"strong_yes\"}]` → submits the scorecard and returns the created feedback record."
     + " [See the documentation](https://hire.lever.co/developer/documentation#create-a-feedback-form)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/lever/actions/update-opportunity-stage/update-opportunity-stage.mjs
+++ b/components/lever/actions/update-opportunity-stage/update-opportunity-stage.mjs
@@ -10,8 +10,9 @@ export default {
     + " Every stage change is logged in Lever's audit trail under the Perform As user."
     + " Example: call with opportunityId=\"<id>\", stageId=\"<stageId>\", performAs=\"<userId>\" → moves the candidate to that stage and returns the updated opportunity."
     + " [See the documentation](https://hire.lever.co/developer/documentation#update-stage-on-an-opportunity)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/lever/package.json
+++ b/components/lever/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/lever",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Lever Components",
   "main": "lever.app.mjs",
   "keywords": [

--- a/components/servicenow/actions/add-item-to-cart/add-item-to-cart.mjs
+++ b/components/servicenow/actions/add-item-to-cart/add-item-to-cart.mjs
@@ -5,8 +5,9 @@ export default {
   key: "servicenow-add-item-to-cart",
   name: "Add Item to Cart",
   description: "Add a ServiceNow catalog item to the current user's cart. Run **Search Catalog Items** to find the item `sys_id` and **Get Catalog Item Variables** to learn which variable names to supply. After adding items, use **View Cart**, then **Checkout Cart** or **Submit Cart Order** to submit. [See the documentation](https://www.servicenow.com/docs/r/zurich/api-reference/rest-apis/c_ServiceCatalogAPI.html)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/servicenow/actions/check-order-status/check-order-status.mjs
+++ b/components/servicenow/actions/check-order-status/check-order-status.mjs
@@ -5,8 +5,9 @@ export default {
   key: "servicenow-check-order-status",
   name: "Check Order Status",
   description: "Retrieve the status of a ServiceNow catalog request (REQ) from the `sc_request` table, including request state, approval, and stage. Provide the request number returned by **Checkout Cart**, **Submit Cart Order**, or **Order Catalog Item**. [See the documentation](https://www.servicenow.com/docs/r/zurich/api-reference/rest-apis/c_TableAPI.html)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/servicenow/actions/checkout-cart/checkout-cart.mjs
+++ b/components/servicenow/actions/checkout-cart/checkout-cart.mjs
@@ -4,8 +4,9 @@ export default {
   key: "servicenow-checkout-cart",
   name: "Checkout Cart",
   description: "Submit the current user's ServiceNow cart via the standard `/cart/checkout` endpoint, generating a request (REQ). The result depends on the instance's one-step vs two-step checkout configuration (in two-step mode it returns the order summary/status to confirm rather than finalizing). Add items first with **Add Item to Cart** and inspect with **View Cart**. Use **Check Order Status** afterward to track the resulting request. [See the documentation](https://www.servicenow.com/docs/r/zurich/api-reference/rest-apis/c_ServiceCatalogAPI.html)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/servicenow/actions/delete-cart-item/delete-cart-item.mjs
+++ b/components/servicenow/actions/delete-cart-item/delete-cart-item.mjs
@@ -4,8 +4,9 @@ export default {
   key: "servicenow-delete-cart-item",
   name: "Delete Cart Item",
   description: "Remove an item from the current user's ServiceNow cart. Run **View Cart** first to obtain the `cart_item` id to delete. This permanently removes the line item from the cart. [See the documentation](https://www.servicenow.com/docs/r/zurich/api-reference/rest-apis/c_ServiceCatalogAPI.html)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: true,

--- a/components/servicenow/actions/empty-cart/empty-cart.mjs
+++ b/components/servicenow/actions/empty-cart/empty-cart.mjs
@@ -4,8 +4,9 @@ export default {
   key: "servicenow-empty-cart",
   name: "Empty Cart",
   description: "Empty and delete the current user's ServiceNow cart, removing all of its items. The action resolves the active cart automatically, so no cart ID is required. Emptying a cart that still has items requires the `catalog_admin` role (a plain `admin` can only delete an already-empty cart). [See the documentation](https://www.servicenow.com/docs/r/zurich/api-reference/rest-apis/c_ServiceCatalogAPI.html)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: true,

--- a/components/servicenow/actions/find-users/find-users.mjs
+++ b/components/servicenow/actions/find-users/find-users.mjs
@@ -5,8 +5,9 @@ export default {
   key: "servicenow-find-users",
   name: "Find Users",
   description: "Search ServiceNow `sys_user` records to find a user's `sys_id` (used by props like the requested-for field on **Add Item to Cart**). Choose whether to match on name (partial) or email (exact). [See the documentation](https://www.servicenow.com/docs/r/zurich/api-reference/rest-apis/c_TableAPI.html)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/servicenow/actions/get-article-attachment/get-article-attachment.mjs
+++ b/components/servicenow/actions/get-article-attachment/get-article-attachment.mjs
@@ -6,8 +6,9 @@ export default {
   key: "servicenow-get-article-attachment",
   name: "Get Article Attachment",
   description: "Download an attachment from a knowledge article to the `/tmp` directory. Run **Get Article** first: its `attachments` array holds each attachment's `sys_id` and `file_name`, but only when the article record has `display_attachments` enabled. [See the documentation](https://www.servicenow.com/docs/r/zurich/api-reference/rest-apis/knowledge-api.html)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/servicenow/actions/get-article/get-article.mjs
+++ b/components/servicenow/actions/get-article/get-article.mjs
@@ -4,8 +4,9 @@ export default {
   key: "servicenow-get-article",
   name: "Get Article",
   description: "Retrieve a single knowledge article, including its entire HTML body (`content`). Run **Search Knowledge Base** first to find an article, then pass its `number` or `sys_id` here. The `attachments` array is only returned when the article record has `display_attachments` enabled. [See the documentation](https://www.servicenow.com/docs/r/zurich/api-reference/rest-apis/knowledge-api.html)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/servicenow/actions/get-catalog-item-variables/get-catalog-item-variables.mjs
+++ b/components/servicenow/actions/get-catalog-item-variables/get-catalog-item-variables.mjs
@@ -4,8 +4,9 @@ export default {
   key: "servicenow-get-catalog-item-variables",
   name: "Get Catalog Item Variables",
   description: "Retrieve the ordered variables (form fields) for a ServiceNow catalog item. Run **Search Catalog Items** first to obtain the item `sys_id`, then use the returned variable names to build the `variables` payload for **Add Item to Cart**, **Order Catalog Item**, or **Submit Record Producer**. [See the documentation](https://www.servicenow.com/docs/r/zurich/api-reference/rest-apis/c_ServiceCatalogAPI.html)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/servicenow/actions/get-current-user/get-current-user.mjs
+++ b/components/servicenow/actions/get-current-user/get-current-user.mjs
@@ -4,8 +4,9 @@ export default {
   key: "servicenow-get-current-user",
   name: "Get Current User",
   description: "Returns the authenticated ServiceNow user's sys_id, name, email, username, and instance URL. Call this first when the user says 'my incidents', 'my cases', 'assigned to me', or needs their ServiceNow identity. Use `sys_id` to filter records in **Get Table Records** (e.g. `assigned_to={sys_id}`) or **Create Table Record**. [See the documentation](https://docs.servicenow.com/bundle/vancouver-api-reference/page/integrate/inbound-rest/concept/c_TableAPI.html).",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/servicenow/actions/list-knowledge-bases/list-knowledge-bases.mjs
+++ b/components/servicenow/actions/list-knowledge-bases/list-knowledge-bases.mjs
@@ -4,8 +4,9 @@ export default {
   key: "servicenow-list-knowledge-bases",
   name: "List Knowledge Bases",
   description: "List the knowledge bases in the instance, to find the `sys_id`s that scope a search on **Search Knowledge Base**. [See the documentation](https://www.servicenow.com/docs/r/zurich/api-reference/rest-apis/c_TableAPI.html)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/servicenow/actions/order-catalog-item/order-catalog-item.mjs
+++ b/components/servicenow/actions/order-catalog-item/order-catalog-item.mjs
@@ -5,8 +5,9 @@ export default {
   key: "servicenow-order-catalog-item",
   name: "Order Catalog Item",
   description: "Place a one-step Order Now request for a single ServiceNow catalog item, bypassing the cart. Run **Search Catalog Items** to find the item `sys_id` and **Get Catalog Item Variables** to learn which variable names to supply. Use **Check Order Status** afterward to track the resulting request. [See the documentation](https://www.servicenow.com/docs/r/zurich/api-reference/rest-apis/c_ServiceCatalogAPI.html)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/servicenow/actions/search-catalog-items/search-catalog-items.mjs
+++ b/components/servicenow/actions/search-catalog-items/search-catalog-items.mjs
@@ -4,8 +4,9 @@ export default {
   key: "servicenow-search-catalog-items",
   name: "Search Catalog Items",
   description: "Search the ServiceNow Service Catalog for orderable items. Use this first to discover catalog item `sys_id` values needed by **Get Catalog Item Variables**, **Add Item to Cart**, **Order Catalog Item**, and **Submit Record Producer**. [See the documentation](https://www.servicenow.com/docs/r/zurich/api-reference/rest-apis/c_ServiceCatalogAPI.html)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/servicenow/actions/search-knowledge-base/search-knowledge-base.mjs
+++ b/components/servicenow/actions/search-knowledge-base/search-knowledge-base.mjs
@@ -4,8 +4,9 @@ export default {
   key: "servicenow-search-knowledge-base",
   name: "Search Knowledge Base",
   description: "Search ServiceNow knowledge base articles via the Knowledge Management API. Returns matching articles with snippets only; use **Get Article** to fetch an article's full HTML body. Optionally restrict the search to specific knowledge bases (run **List Knowledge Bases** to find their `sys_id`s). Requires the Knowledge API (`sn_km_api`) plugin, which is not active by default. [See the documentation](https://www.servicenow.com/docs/r/zurich/api-reference/rest-apis/knowledge-api.html)",
-  version: "0.1.0",
+  version: "0.1.1",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/servicenow/actions/submit-cart-order/submit-cart-order.mjs
+++ b/components/servicenow/actions/submit-cart-order/submit-cart-order.mjs
@@ -4,8 +4,9 @@ export default {
   key: "servicenow-submit-cart-order",
   name: "Submit Cart Order",
   description: "Submit the current user's ServiceNow cart via the `/cart/submit_order` endpoint, generating a request (REQ). Like **Checkout Cart**, the result depends on the instance's one-step vs two-step checkout configuration. Add items first with **Add Item to Cart** and inspect with **View Cart**. Use **Check Order Status** afterward to track the resulting request. [See the documentation](https://www.servicenow.com/docs/r/zurich/api-reference/rest-apis/c_ServiceCatalogAPI.html)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/servicenow/actions/submit-record-producer/submit-record-producer.mjs
+++ b/components/servicenow/actions/submit-record-producer/submit-record-producer.mjs
@@ -5,8 +5,9 @@ export default {
   key: "servicenow-submit-record-producer",
   name: "Submit Record Producer",
   description: "Submit a ServiceNow record producer to create the target record (e.g. an incident or RITM) from catalog variables. Run **Search Catalog Items** to find the record producer `sys_id` and **Get Catalog Item Variables** to learn which variable names to supply. [See the documentation](https://www.servicenow.com/docs/r/zurich/api-reference/rest-apis/c_ServiceCatalogAPI.html)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/servicenow/actions/update-table-record/update-table-record.mjs
+++ b/components/servicenow/actions/update-table-record/update-table-record.mjs
@@ -5,13 +5,14 @@ export default {
   key: "servicenow-update-table-record",
   name: "Update Table Record",
   description: "Updates the specified record with the name-value pairs included in the request body. [See the documentation](https://www.servicenow.com/docs/bundle/zurich-api-reference/page/integrate/inbound-rest/concept/c_TableAPI.html#title_table-PATCH)",
-  version: "1.0.5",
+  version: "1.0.6",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     servicenow,
     table: {

--- a/components/servicenow/actions/view-cart/view-cart.mjs
+++ b/components/servicenow/actions/view-cart/view-cart.mjs
@@ -23,8 +23,9 @@ export default {
   key: "servicenow-view-cart",
   name: "View Cart",
   description: "Retrieve the current user's ServiceNow cart contents, including the `cart_item` ids needed by **Delete Cart Item**. Use before **Checkout Cart** or **Submit Cart Order** to confirm what will be ordered. [See the documentation](https://www.servicenow.com/docs/r/zurich/api-reference/rest-apis/c_ServiceCatalogAPI.html)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/servicenow/package.json
+++ b/components/servicenow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/servicenow",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Pipedream ServiceNow Components",
   "main": "servicenow.app.mjs",
   "keywords": [

--- a/components/shopify/actions/bulk-import/bulk-import.mjs
+++ b/components/shopify/actions/bulk-import/bulk-import.mjs
@@ -8,13 +8,14 @@ export default {
   key: "shopify-bulk-import",
   name: "Run Bulk Mutation",
   description: "Runs a bulk mutation (Shopify's `bulkOperationRunMutation`) by uploading a JSONL file of per-line mutation variables, so a mutation (e.g. product/variant/metafield create or update) runs once per line across thousands of records in a single Admin GraphQL bulk operation instead of one API call per record. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/bulkoperationrunmutation)",
-  version: "0.1.0",
+  version: "0.1.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     shopify,
     alert: {

--- a/components/shopify/actions/cancel-fulfillment-order/cancel-fulfillment-order.mjs
+++ b/components/shopify/actions/cancel-fulfillment-order/cancel-fulfillment-order.mjs
@@ -4,8 +4,9 @@ export default {
   key: "shopify-cancel-fulfillment-order",
   name: "Cancel Fulfillment Order",
   description: "Cancels a fulfillment order. Run **Search for Orders** and inspect the order's fulfillment orders to obtain the fulfillment order GID. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/fulfillmentOrderCancel).",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: true,

--- a/components/shopify/actions/cancel-fulfillment/cancel-fulfillment.mjs
+++ b/components/shopify/actions/cancel-fulfillment/cancel-fulfillment.mjs
@@ -4,8 +4,9 @@ export default {
   key: "shopify-cancel-fulfillment",
   name: "Cancel Fulfillment",
   description: "Cancels a fulfillment. Run the **Search for Orders** action and inspect the order's fulfillments to obtain the fulfillment GID. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/fulfillmentCancel).",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: true,

--- a/components/shopify/actions/cancel-order/cancel-order.mjs
+++ b/components/shopify/actions/cancel-order/cancel-order.mjs
@@ -6,8 +6,9 @@ export default {
   key: "shopify-cancel-order",
   name: "Cancel Order",
   description: "Cancel an existing order. Run **Search for Orders** first to obtain the order GID. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/orderCancel)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/shopify/actions/create-discount-codes-batch/create-discount-codes-batch.mjs
+++ b/components/shopify/actions/create-discount-codes-batch/create-discount-codes-batch.mjs
@@ -5,8 +5,9 @@ export default {
   key: "shopify-create-discount-codes-batch",
   name: "Create Discount Codes in Bulk",
   description: "Adds multiple discount codes to a price rule in Shopify (up to 100 codes per request). [See the documentation](https://shopify.dev/docs/api/admin-rest/2026-07/resources/discountcode#post-price-rules-price-rule-id-batch).",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/shopify/actions/create-gift-card/create-gift-card.mjs
+++ b/components/shopify/actions/create-gift-card/create-gift-card.mjs
@@ -4,8 +4,9 @@ export default {
   key: "shopify-create-gift-card",
   name: "Create Gift Card",
   description: "Creates a new gift card. To supply an optional customer, run **Get Customers** first to retrieve the customer GID. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/giftCardCreate).",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/shopify/actions/create-order/create-order.mjs
+++ b/components/shopify/actions/create-order/create-order.mjs
@@ -6,8 +6,9 @@ export default {
   key: "shopify-create-order",
   name: "Create Order",
   description: "Creates a new order. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/orderCreate).",
-  version: "0.0.12",
+  version: "0.0.13",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/shopify/actions/create-product/create-product.mjs
+++ b/components/shopify/actions/create-product/create-product.mjs
@@ -5,13 +5,14 @@ export default {
   key: "shopify-create-product",
   name: "Create Product",
   description: "Create a new product. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/productCreate)",
-  version: "0.0.23",
+  version: "0.0.24",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     shopify,
     title: {

--- a/components/shopify/actions/create-refund/create-refund.mjs
+++ b/components/shopify/actions/create-refund/create-refund.mjs
@@ -5,8 +5,9 @@ export default {
   key: "shopify-create-refund",
   name: "Create Refund",
   description: "Create a refund on an existing order. Run **Search for Orders** first to obtain the order GID and the line item GIDs to refund. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/refundCreate)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify/actions/create-return/create-return.mjs
+++ b/components/shopify/actions/create-return/create-return.mjs
@@ -5,8 +5,9 @@ export default {
   key: "shopify-create-return",
   name: "Create Return",
   description: "Creates a return for an order. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/returnCreate).",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/shopify/actions/get-customers/get-customers.mjs
+++ b/components/shopify/actions/get-customers/get-customers.mjs
@@ -4,13 +4,14 @@ export default {
   key: "shopify-get-customers",
   name: "Get Customers",
   description: "Retrieve a list of customers. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/queries/customers)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     shopify,
     // This app is not approved to access the Customer object. See https://shopify.dev/docs/apps/launch/protected-customer-data for more details."

--- a/components/shopify/actions/get-discount-code/get-discount-code.mjs
+++ b/components/shopify/actions/get-discount-code/get-discount-code.mjs
@@ -4,8 +4,9 @@ export default {
   key: "shopify-get-discount-code",
   name: "Get Discount Code",
   description: "Retrieves a single discount code that belongs to a price rule in Shopify. Run **List Price Rules** to find a valid price rule ID and **List Discount Codes** to find a valid discount code ID. [See the documentation](https://shopify.dev/docs/api/admin-rest/2026-07/resources/discountcode#get-price-rules-price-rule-id-discount-codes-discount-code-id).",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/shopify/actions/get-draft-orders/get-draft-orders.mjs
+++ b/components/shopify/actions/get-draft-orders/get-draft-orders.mjs
@@ -4,13 +4,14 @@ export default {
   key: "shopify-get-draft-orders",
   name: "Get Draft Orders",
   description: "Retrieve a list of draft orders. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/queries/draftorders)",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     shopify,
     // eslint-disable-next-line pipedream/props-label, pipedream/props-description

--- a/components/shopify/actions/get-fulfillment-orders/get-fulfillment-orders.mjs
+++ b/components/shopify/actions/get-fulfillment-orders/get-fulfillment-orders.mjs
@@ -4,13 +4,14 @@ export default {
   key: "shopify-get-fulfillment-orders",
   name: "Get Fulfillment Orders",
   description: "Retrieve a list of fulfillment orders. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/queries/fulfillmentorders)",
-  version: "0.0.13",
+  version: "0.0.14",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     shopify,
     // eslint-disable-next-line pipedream/props-label, pipedream/props-description

--- a/components/shopify/actions/hold-fulfillment-order/hold-fulfillment-order.mjs
+++ b/components/shopify/actions/hold-fulfillment-order/hold-fulfillment-order.mjs
@@ -5,8 +5,9 @@ export default {
   key: "shopify-hold-fulfillment-order",
   name: "Hold Fulfillment Order",
   description: "Places a fulfillment order on hold. Run **Search for Orders** and inspect the order's fulfillment orders to obtain the fulfillment order GID. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/fulfillmentOrderHold).",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/shopify/actions/list-discount-codes/list-discount-codes.mjs
+++ b/components/shopify/actions/list-discount-codes/list-discount-codes.mjs
@@ -4,8 +4,9 @@ export default {
   key: "shopify-list-discount-codes",
   name: "List Discount Codes",
   description: "Lists all discount codes for a given price rule in Shopify so you can obtain a valid discount code ID. [See the documentation](https://shopify.dev/docs/api/admin-rest/2026-07/resources/discountcode#get-price-rules-price-rule-id-discount-codes).",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/shopify/actions/refund-return/refund-return.mjs
+++ b/components/shopify/actions/refund-return/refund-return.mjs
@@ -5,8 +5,9 @@ export default {
   key: "shopify-refund-return",
   name: "Refund Return",
   description: "Processes an existing return in Shopify via the `returnProcess` mutation, marking the specified return line items as processed. By default no refund is issued — to also issue a refund, include a `financialTransfer` object with an `issueRefund` operation (and its required `orderTransactions`) in **Additional Fields**. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/returnProcess).",
-  version: "0.1.1",
+  version: "0.1.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/shopify/actions/search-products/search-products.mjs
+++ b/components/shopify/actions/search-products/search-products.mjs
@@ -6,13 +6,14 @@ export default {
   key: "shopify-search-products",
   name: "Search for Products",
   description: "Search for products. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/queries/products)",
-  version: "0.0.23",
+  version: "0.0.24",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     shopify,
     title: {

--- a/components/shopify/actions/send-order-invoice/send-order-invoice.mjs
+++ b/components/shopify/actions/send-order-invoice/send-order-invoice.mjs
@@ -4,8 +4,9 @@ export default {
   key: "shopify-send-order-invoice",
   name: "Send Order Invoice",
   description: "Sends an invoice email for an existing order. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/orderInvoiceSend).",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/shopify/actions/submit-cancellation-request/submit-cancellation-request.mjs
+++ b/components/shopify/actions/submit-cancellation-request/submit-cancellation-request.mjs
@@ -4,8 +4,9 @@ export default {
   key: "shopify-submit-cancellation-request",
   name: "Submit Cancellation Request",
   description: "Request cancellation of a fulfillment order. This is a fulfillment-service workflow distinct from cancelling the order itself. Run **Get Fulfillment Orders** first to obtain the fulfillment order GID. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/fulfillmentOrderSubmitCancellationRequest)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/shopify/actions/update-discount-code/update-discount-code.mjs
+++ b/components/shopify/actions/update-discount-code/update-discount-code.mjs
@@ -5,8 +5,9 @@ export default {
   key: "shopify-update-discount-code",
   name: "Update Discount Code",
   description: "Updates the value of an existing discount code belonging to a price rule in Shopify. Run **List Price Rules** and **List Discount Codes** to find valid IDs. [See the documentation](https://shopify.dev/docs/api/admin-rest/2026-07/resources/discountcode#put-price-rules-price-rule-id-discount-codes-discount-code-id).",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/shopify/package.json
+++ b/components/shopify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/shopify",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Pipedream Shopify Components",
   "main": "shopify.app.mjs",
   "keywords": [

--- a/components/smartsheet/actions/add-column/add-column.mjs
+++ b/components/smartsheet/actions/add-column/add-column.mjs
@@ -10,8 +10,9 @@ export default {
     + " For PICKLIST columns, provide the `options` array with valid values."
     + " Use **List Columns** to see existing columns before adding."
     + " [See the documentation](https://developers.smartsheet.com/api/smartsheet/openapi/columns/columns-addtosheet)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/smartsheet/actions/add-row-to-sheet/add-row-to-sheet.mjs
+++ b/components/smartsheet/actions/add-row-to-sheet/add-row-to-sheet.mjs
@@ -11,8 +11,9 @@ export default {
     + " `[{\"Task\": \"Review doc\", \"Status\": \"Open\"}]`."
     + " For a single row, pass a one-element array."
     + " [See the documentation](https://developers.smartsheet.com/api/smartsheet/openapi/rows/rows-addtosheet)",
-  version: "1.0.0",
+  version: "1.0.1",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/smartsheet/actions/copy-rows/copy-rows.mjs
+++ b/components/smartsheet/actions/copy-rows/copy-rows.mjs
@@ -13,8 +13,9 @@ export default {
     + " Use **Get Sheet** to find row IDs in the source sheet."
     + " To move rows instead (removing them from the source), use **Move Rows**."
     + " [See the documentation](https://developers.smartsheet.com/api/smartsheet/openapi/rows/copy-rows)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/smartsheet/actions/copy-sheet/copy-sheet.mjs
+++ b/components/smartsheet/actions/copy-sheet/copy-sheet.mjs
@@ -12,8 +12,9 @@ export default {
     + " Use **List Sheets** to find the source sheet ID."
     + " To move a sheet instead (removing it from the original location), use **Move Sheet**."
     + " [See the documentation](https://developers.smartsheet.com/api/smartsheet/openapi/sheets/copy-sheet)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/smartsheet/actions/create-sheet/create-sheet.mjs
+++ b/components/smartsheet/actions/create-sheet/create-sheet.mjs
@@ -12,8 +12,9 @@ export default {
     + " You must provide either a Workspace ID or Folder ID — the home-level create endpoint is deprecated."
     + " Use **List Sheets** to verify the sheet was created."
     + " [See the documentation](https://developers.smartsheet.com/api/smartsheet/openapi/sheets/create-sheet-in-workspace)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/smartsheet/actions/delete-column/delete-column.mjs
+++ b/components/smartsheet/actions/delete-column/delete-column.mjs
@@ -8,8 +8,9 @@ export default {
     + " Use **List Columns** to find the column ID before deleting."
     + " Consider using **Get Sheet** to review the column's data before deletion."
     + " [See the documentation](https://developers.smartsheet.com/api/smartsheet/openapi/columns/column-delete)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/smartsheet/actions/delete-rows/delete-rows.mjs
+++ b/components/smartsheet/actions/delete-rows/delete-rows.mjs
@@ -8,8 +8,9 @@ export default {
     "Delete one or more rows from a sheet by row ID. This is permanent and cannot be undone."
     + " Use **Get Sheet** or **Search** to find row IDs first."
     + " [See the documentation](https://developers.smartsheet.com/api/smartsheet/openapi/rows/delete-rows)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/smartsheet/actions/delete-sheet/delete-sheet.mjs
+++ b/components/smartsheet/actions/delete-sheet/delete-sheet.mjs
@@ -7,8 +7,9 @@ export default {
     "Permanently delete a sheet. This is irreversible — all data, rows, and columns are destroyed."
     + " Use **List Sheets** to find the sheet ID first."
     + " [See the documentation](https://developers.smartsheet.com/api/smartsheet/openapi/sheets/deletesheet)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/smartsheet/actions/email-sheet/email-sheet.mjs
+++ b/components/smartsheet/actions/email-sheet/email-sheet.mjs
@@ -9,8 +9,9 @@ export default {
     "Send a sheet as an email attachment to one or more recipients. The sheet can be sent as PDF, Excel, or PDF Gantt format."
     + " Use **List Sheets** to find the sheet ID."
     + " [See the documentation](https://developers.smartsheet.com/api/smartsheet/openapi/sheets/sheet-send)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/smartsheet/actions/get-current-user/get-current-user.mjs
+++ b/components/smartsheet/actions/get-current-user/get-current-user.mjs
@@ -7,8 +7,9 @@ export default {
     "Get the authenticated user's identity — returns user ID, email, first/last name, and account details."
     + " Use this when the user says 'my sheets' or 'my account' to identify the owner."
     + " [See the documentation](https://developers.smartsheet.com/api/smartsheet/openapi/users/get-current-user)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/smartsheet/actions/get-row/get-row.mjs
+++ b/components/smartsheet/actions/get-row/get-row.mjs
@@ -10,8 +10,9 @@ export default {
     + " Use **Get Sheet** or **Search** to find row IDs."
     + " To update a row after reading it, use **Update Row**."
     + " [See the documentation](https://developers.smartsheet.com/api/smartsheet/openapi/rows/row-get)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/smartsheet/actions/get-sheet/get-sheet.mjs
+++ b/components/smartsheet/actions/get-sheet/get-sheet.mjs
@@ -9,8 +9,9 @@ export default {
     + " Returns rows with cell values keyed by column name for readability."
     + " For a lightweight column-only view, use **List Columns** instead."
     + " [See the documentation](https://developers.smartsheet.com/api/smartsheet/openapi/sheets/getsheet)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/smartsheet/actions/import-sheet/import-sheet.mjs
+++ b/components/smartsheet/actions/import-sheet/import-sheet.mjs
@@ -13,8 +13,9 @@ export default {
     + " Supported formats: CSV (.csv) and Excel XLSX (.xlsx)."
     + " Use **List Sheets** to verify the sheet was created after import."
     + " [See the documentation](https://developers.smartsheet.com/api/smartsheet/openapi/imports/import-sheet-into-workspace)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/smartsheet/actions/list-columns/list-columns.mjs
+++ b/components/smartsheet/actions/list-columns/list-columns.mjs
@@ -9,8 +9,9 @@ export default {
     + " Use this before **Add Row to Sheet** or **Update Row** to discover column names and types."
     + " For full sheet data including rows, use **Get Sheet** instead."
     + " [See the documentation](https://developers.smartsheet.com/api/smartsheet/openapi/columns/columns-listonsheet)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/smartsheet/actions/list-sheets/list-sheets.mjs
+++ b/components/smartsheet/actions/list-sheets/list-sheets.mjs
@@ -8,8 +8,9 @@ export default {
     + " Use this to find sheet IDs before calling **Get Sheet**, **Add Row to Sheet**, **Update Row**, **Delete Rows**, **Copy Sheet**, or **Move Sheet**."
     + " To search sheets by content rather than listing them, use **Search** instead."
     + " [See the documentation](https://developers.smartsheet.com/api/smartsheet/openapi/sheets/list-sheets)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/smartsheet/actions/list-workspace-templates/list-workspace-templates.mjs
+++ b/components/smartsheet/actions/list-workspace-templates/list-workspace-templates.mjs
@@ -7,8 +7,9 @@ export default {
     "Lists templates available in your workspaces."
     + " Use this to find template IDs for **New Sheet From Template**."
     + " [See the documentation](https://developers.smartsheet.com/api/smartsheet/openapi/workspaces/get-workspace-children)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/smartsheet/actions/move-rows/move-rows.mjs
+++ b/components/smartsheet/actions/move-rows/move-rows.mjs
@@ -13,8 +13,9 @@ export default {
     + " Use **Get Sheet** to find row IDs in the source sheet."
     + " To copy rows instead (keeping them in the source), use **Copy Rows**."
     + " [See the documentation](https://developers.smartsheet.com/api/smartsheet/openapi/rows/move-rows)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/smartsheet/actions/move-sheet/move-sheet.mjs
+++ b/components/smartsheet/actions/move-sheet/move-sheet.mjs
@@ -11,8 +11,9 @@ export default {
     + " Use **List Sheets** to find the sheet ID."
     + " To copy a sheet instead (keeping the original), use **Copy Sheet**."
     + " [See the documentation](https://developers.smartsheet.com/api/smartsheet/openapi/sheets/move-sheet)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/smartsheet/actions/new-sheet-from-template/new-sheet-from-template.mjs
+++ b/components/smartsheet/actions/new-sheet-from-template/new-sheet-from-template.mjs
@@ -10,13 +10,14 @@ export default {
     + " Use **List Workspace Options** to find workspace IDs."
     + " Use **List Folder Options** to find folder IDs."
     + " See the documentation: [Create in folder](https://developers.smartsheet.com/api/smartsheet/openapi/sheets/create-sheet-in-folder), [Create in workspace](https://developers.smartsheet.com/api/smartsheet/openapi/sheets/create-sheet-in-workspace)",
-  version: "1.0.1",
+  version: "1.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     smartsheet,
     name: {

--- a/components/smartsheet/actions/search/search.mjs
+++ b/components/smartsheet/actions/search/search.mjs
@@ -9,8 +9,9 @@ export default {
     + " To find a sheet by name, use **List Sheets** instead — this tool searches content within sheets."
     + " Provide a `sheetId` to scope the search to a single sheet, or omit it to search globally."
     + " [See the documentation](https://developers.smartsheet.com/api/smartsheet/openapi/search/list-search)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/smartsheet/actions/update-column/update-column.mjs
+++ b/components/smartsheet/actions/update-column/update-column.mjs
@@ -10,8 +10,9 @@ export default {
     + " Use **List Columns** to find the column ID and current properties before updating."
     + " Note: some type conversions may cause data loss."
     + " [See the documentation](https://developers.smartsheet.com/api/smartsheet/openapi/columns/column-updatecolumn)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/smartsheet/actions/update-row/update-row.mjs
+++ b/components/smartsheet/actions/update-row/update-row.mjs
@@ -11,8 +11,9 @@ export default {
     + " Each object needs a `rowId` plus column name/value pairs:"
     + " `[{\"rowId\": 123456, \"Status\": \"Done\", \"Priority\": \"High\"}]`."
     + " [See the documentation](https://developers.smartsheet.com/api/smartsheet/openapi/rows/update-rows)",
-  version: "1.0.0",
+  version: "1.0.1",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/smartsheet/actions/update-sheet/update-sheet.mjs
+++ b/components/smartsheet/actions/update-sheet/update-sheet.mjs
@@ -8,8 +8,9 @@ export default {
     "Update a sheet's properties such as its name."
     + " Use **List Sheets** to find the sheet ID first."
     + " [See the documentation](https://developers.smartsheet.com/api/smartsheet/openapi/sheets/updatesheet)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/smartsheet/package.json
+++ b/components/smartsheet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/smartsheet",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Pipedream Smartsheet Components",
   "main": "smartsheet.app.mjs",
   "keywords": [

--- a/components/universal_api/actions/create-distributor-order/create-distributor-order.mjs
+++ b/components/universal_api/actions/create-distributor-order/create-distributor-order.mjs
@@ -5,8 +5,9 @@ export default {
   name: "Create Distributor Order",
   description:
     "Create a new order via the Distributors API on Universal API. Use **List Distributor Products** to discover valid product identifiers for the order items. [See the documentation](https://docs.universalapi.io/reference/create-order).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/universal_api/actions/delete-connection/delete-connection.mjs
+++ b/components/universal_api/actions/delete-connection/delete-connection.mjs
@@ -6,8 +6,9 @@ export default {
   name: "Delete Connection",
   description:
     "Permanently delete a connection identified by `universalApi` and `serviceId` via the Platform API on Universal API. This is irreversible. Run **List Connections** first to find the correct `serviceId`. [See the documentation](https://docs.universalapi.io/reference/revoke-connection).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: true,

--- a/components/universal_api/actions/delete-consumer/delete-consumer.mjs
+++ b/components/universal_api/actions/delete-consumer/delete-consumer.mjs
@@ -5,8 +5,9 @@ export default {
   name: "Delete Consumer",
   description:
     "Permanently delete a consumer via the Platform API on Universal API. This is irreversible. Run **List Consumers** first to find the consumer ID. [See the documentation](https://docs.universalapi.io/reference/delete-consumer).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: true,

--- a/components/universal_api/actions/get-connection/get-connection.mjs
+++ b/components/universal_api/actions/get-connection/get-connection.mjs
@@ -6,8 +6,9 @@ export default {
   name: "Get Connection",
   description:
     "Retrieve a single connection identified by `universalApi` and `serviceId` from the Platform API on Universal API. Run **List Connections** first to find the correct `serviceId`. [See the documentation](https://docs.universalapi.io/reference/get-connection).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/universal_api/actions/get-distributor-order/get-distributor-order.mjs
+++ b/components/universal_api/actions/get-distributor-order/get-distributor-order.mjs
@@ -5,8 +5,9 @@ export default {
   name: "Get Distributor Order",
   description:
     "Retrieve a single distributor order by ID from Universal API. Run **List Distributor Orders** first to discover valid IDs. [See the documentation](https://docs.universalapi.io/reference/get-order).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/universal_api/actions/get-distributor-product/get-distributor-product.mjs
+++ b/components/universal_api/actions/get-distributor-product/get-distributor-product.mjs
@@ -5,8 +5,9 @@ export default {
   name: "Get Distributor Product",
   description:
     "Retrieve a single distributor product by ID from Universal API. Run **List Distributor Products** first to discover valid IDs. [See the documentation](https://docs.universalapi.io/reference/get-product).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/universal_api/actions/get-hris-employee/get-hris-employee.mjs
+++ b/components/universal_api/actions/get-hris-employee/get-hris-employee.mjs
@@ -5,8 +5,9 @@ export default {
   name: "Get HRIS Employee",
   description:
     "Retrieve a single HRIS employee by ID from Universal API. Run **List HRIS Employees** first to discover valid employee IDs. [See the documentation](https://docs.universalapi.io/reference/get-employee).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/universal_api/actions/get-mdm-dep-token/get-mdm-dep-token.mjs
+++ b/components/universal_api/actions/get-mdm-dep-token/get-mdm-dep-token.mjs
@@ -5,8 +5,9 @@ export default {
   name: "Get MDM DEP Token",
   description:
     "Retrieve a single DEP token by ID from the MDM API on Universal API. Run **List MDM DEP Tokens** first to discover valid IDs. [See the documentation](https://docs.universalapi.io/reference/get-dep-tokens).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/universal_api/actions/get-mdm-vpp-token/get-mdm-vpp-token.mjs
+++ b/components/universal_api/actions/get-mdm-vpp-token/get-mdm-vpp-token.mjs
@@ -5,8 +5,9 @@ export default {
   name: "Get MDM VPP Token",
   description:
     "Retrieve a single VPP token by ID from the MDM API on Universal API. Run **List MDM VPP Tokens** first to discover valid IDs. [See the documentation](https://docs.universalapi.io/reference/get-vpp-token).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/universal_api/actions/list-am-employees/list-am-employees.mjs
+++ b/components/universal_api/actions/list-am-employees/list-am-employees.mjs
@@ -5,8 +5,9 @@ export default {
   name: "List Asset Management Employees",
   description:
     "List employees from the Asset Management (AM) API on Universal API. Returns an array of AM employee objects (paginated internally, up to `maxResults`). This hits a different endpoint than **List HRIS Employees**. [See the documentation](https://docs.universalapi.io/reference/list-employees-1).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/universal_api/actions/list-am-orders/list-am-orders.mjs
+++ b/components/universal_api/actions/list-am-orders/list-am-orders.mjs
@@ -5,8 +5,9 @@ export default {
   name: "List Asset Management Orders",
   description:
     "List orders from the Asset Management (AM) API on Universal API. Returns an array of AM order objects. This hits a different endpoint than **List Distributor Orders**. [See the documentation](https://docs.universalapi.io/reference/list-orders)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/universal_api/actions/list-connections/list-connections.mjs
+++ b/components/universal_api/actions/list-connections/list-connections.mjs
@@ -8,8 +8,9 @@ export default {
   name: "List Connections",
   description:
     "List connections from the Platform API on Universal API. Returns an array; use the returned IDs with **Get Connection**, **Update Connection**, or **Delete Connection**. [See the documentation](https://docs.universalapi.io/reference/list-connections).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/universal_api/actions/list-consumers/list-consumers.mjs
+++ b/components/universal_api/actions/list-consumers/list-consumers.mjs
@@ -5,8 +5,9 @@ export default {
   name: "List Consumers",
   description:
     "List consumers from the Platform API on Universal API. Returns an array (paginated internally, up to `maxResults`); use the returned IDs with **Delete Consumer**. [See the documentation](https://docs.universalapi.io/reference/get-consumer).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/universal_api/actions/list-distributor-orders/list-distributor-orders.mjs
+++ b/components/universal_api/actions/list-distributor-orders/list-distributor-orders.mjs
@@ -5,8 +5,9 @@ export default {
   name: "List Distributor Orders",
   description:
     "List orders from the Distributors API on Universal API. Returns an array; use the returned IDs with **Get Distributor Order**. This hits a different endpoint than **List Asset Management Orders**. [See the documentation](https://docs.universalapi.io/reference/list-orders-1).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/universal_api/actions/list-hris-employees/list-hris-employees.mjs
+++ b/components/universal_api/actions/list-hris-employees/list-hris-employees.mjs
@@ -5,8 +5,9 @@ export default {
   name: "List HRIS Employees",
   description:
     "List employees from the connected HRIS integration on Universal API. Returns an array of employee objects (paginated internally, up to `maxResults`); use the returned IDs with **Get HRIS Employee**. Provide `serviceId` only when the consumer has multiple active HRIS integrations. [See the documentation](https://docs.universalapi.io/reference/list-employees).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/universal_api/actions/list-mdm-dep-tokens/list-mdm-dep-tokens.mjs
+++ b/components/universal_api/actions/list-mdm-dep-tokens/list-mdm-dep-tokens.mjs
@@ -5,8 +5,9 @@ export default {
   name: "List MDM DEP Tokens",
   description:
     "List DEP (Device Enrollment Program) tokens from the MDM API on Universal API. Returns an array; use the returned IDs with **Get MDM DEP Token**. [See the documentation](https://docs.universalapi.io/reference/list-dep-tokens).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/universal_api/actions/list-mdm-device-apps/list-mdm-device-apps.mjs
+++ b/components/universal_api/actions/list-mdm-device-apps/list-mdm-device-apps.mjs
@@ -5,8 +5,9 @@ export default {
   name: "List MDM Device Apps",
   description:
     "List device apps from the MDM API on Universal API. Returns an array of device-app objects. [See the documentation](https://docs.universalapi.io/reference/list-device-apps).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/universal_api/actions/list-mdm-vpp-tokens/list-mdm-vpp-tokens.mjs
+++ b/components/universal_api/actions/list-mdm-vpp-tokens/list-mdm-vpp-tokens.mjs
@@ -5,8 +5,9 @@ export default {
   name: "List MDM VPP Tokens",
   description:
     "List VPP (Volume Purchase Program) tokens from the MDM API on Universal API. Returns an array; use the returned IDs with **Get MDM VPP Token**. [See the documentation](https://docs.universalapi.io/reference/list-vpp-tokens).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/universal_api/actions/track-shipment/track-shipment.mjs
+++ b/components/universal_api/actions/track-shipment/track-shipment.mjs
@@ -6,8 +6,9 @@ export default {
   name: "Track Shipment",
   description:
     "Retrieve tracking statuses for a shipment by tracking ID from the Shipment API on Universal API. Provide `serviceId` to pick the carrier when a consumer has multiple active shipment integrations. [See the documentation](https://docs.universalapi.io/reference/track-shipment).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/universal_api/actions/update-connection/update-connection.mjs
+++ b/components/universal_api/actions/update-connection/update-connection.mjs
@@ -6,8 +6,9 @@ export default {
   name: "Update Connection",
   description:
     "Update a connection identified by `universalApi` and `serviceId` via the Platform API on Universal API (PATCH; only supplied fields are changed). Run **List Connections** first to find the correct `serviceId`. [See the documentation](https://docs.universalapi.io/reference/update-connection).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/universal_api/package.json
+++ b/components/universal_api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/universal_api",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Universal API Components",
   "main": "universal_api.app.mjs",
   "keywords": [


### PR DESCRIPTION
Continuation of the DJ-4272 AI-optimized backfill, sourced from the product team's AI-optimized actions list (Aug 11 2026). Sets the top-level `ai: "optimized"` field on AI-optimized action components not covered by the earlier allowlist∪marker backfill.

**Batch 1 of 7** — 200 components across 11 apps. Each component gets the `ai` field plus a patch version bump; each app's `package.json` is bumped (`check_version` gate). Batches cover disjoint apps and can merge independently in any order.

Apps: _2markdown,deel enrich_layer,hedy hubspot,ipgeolocation lever,servicenow shopify,smartsheet universal_api