### PR TITLE
feat(ai): mark AI-optimized components with `ai` field (batch 2/7)

### DIFF
--- a/components/_302_ai/actions/create-embeddings/create-embeddings.mjs
+++ b/components/_302_ai/actions/create-embeddings/create-embeddings.mjs
@@ -3,7 +3,7 @@ import _302_ai from "../../_302_ai.app.mjs";
 
 export default {
   name: "Create Embeddings",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -12,6 +12,7 @@ export default {
   key: "_302_ai-create-embeddings",
   description: "Generate vector embeddings from text using the 302.AI Embeddings API. Useful for semantic search, clustering, and vector store indexing. [See documentation](https://doc.302.ai/147522048e0)",
   type: "action",
+  ai: "optimized",
   props: {
     _302_ai,
     modelId: {

--- a/components/_302_ai/package.json
+++ b/components/_302_ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/_302_ai",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream 302.ai Components",
   "main": "_302_ai.app.mjs",
   "keywords": [

--- a/components/asana/actions/add-task-to-section/add-task-to-section.mjs
+++ b/components/asana/actions/add-task-to-section/add-task-to-section.mjs
@@ -5,13 +5,14 @@ export default {
   name: "Add Task To Section",
   description: "Add a task to a specific, existing section. This will remove the task from other sections of the project. [See the documentation](https://developers.asana.com/docs/add-task-to-section)",
   key: "asana-add-task-to-section",
-  version: "0.2.15",
+  version: "0.2.16",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     ...common.props,
     task: {

--- a/components/asana/actions/get-portfolio/get-portfolio.mjs
+++ b/components/asana/actions/get-portfolio/get-portfolio.mjs
@@ -4,13 +4,14 @@ export default {
   key: "asana-get-portfolio",
   name: "Get Portfolio",
   description: "Returns the complete portfolio record for a single portfolio. Use this after **List Portfolios** to retrieve full portfolio details including custom fields, members, and owner; the `optFields` prop requests specific properties (e.g. `custom_field_settings`, `members`, `start_on`, `due_on`). [See the documentation](https://developers.asana.com/reference/getportfolio)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     asana,
     portfolioId: {

--- a/components/asana/actions/get-tasks-from-task-list/get-tasks-from-task-list.mjs
+++ b/components/asana/actions/get-tasks-from-task-list/get-tasks-from-task-list.mjs
@@ -4,13 +4,14 @@ export default {
   key: "asana-get-tasks-from-task-list",
   name: "Get Tasks From Task List",
   description: "Returns tasks from the user's personal **My Tasks** inbox — NOT a project task list. Use this when the user asks for 'my tasks', 'my task list', or 'My Tasks'. Only a workspace GID is needed; no project GID required. [See the documentation](https://developers.asana.com/reference/gettasksforusertasklist)",
-  version: "1.1.0",
+  version: "1.1.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     asana,
     workspace: {

--- a/components/asana/actions/list-portfolio-items/list-portfolio-items.mjs
+++ b/components/asana/actions/list-portfolio-items/list-portfolio-items.mjs
@@ -5,13 +5,14 @@ export default {
   key: "asana-list-portfolio-items",
   name: "List Portfolio Items",
   description: "Returns a list of the items (projects) in the given portfolio. Use this after **List Portfolios** to answer count, timing, and spend questions; the default Opt Fields include `created_at`, `start_on`, `due_on`, and `custom_fields`. Archived filtering happens client-side because Asana has no server-side filter on this endpoint. [See the documentation](https://developers.asana.com/reference/getitemsforportfolio)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     asana,
     portfolioId: {

--- a/components/asana/actions/list-portfolios/list-portfolios.mjs
+++ b/components/asana/actions/list-portfolios/list-portfolios.mjs
@@ -4,13 +4,14 @@ export default {
   key: "asana-list-portfolios",
   name: "List Portfolios",
   description: "Returns a list of portfolios in the given workspace owned by the given user. Use this to discover portfolio GIDs before calling **Get Portfolio** or **List Portfolio Items**. Owner defaults to the authenticated user; regular API users can only list portfolios they own. [See the documentation](https://developers.asana.com/reference/getportfolios)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     asana,
     workspace: {

--- a/components/asana/actions/list-teams/list-teams.mjs
+++ b/components/asana/actions/list-teams/list-teams.mjs
@@ -4,13 +4,14 @@ export default {
   key: "asana-list-teams",
   name: "List Teams",
   description: "Retrieves all teams in a specified Asana workspace. Use this action to discover available teams for creating projects, adding team members, or organizing work by department. Requires a workspace GID, which you can obtain from the **List Workspaces** action. The authenticated user must have access to the workspace; only teams visible to the user are returned. Results are paginated (default 25, max 100 per page); use the returned offset token to fetch additional pages. To include optional fields like description, visibility, or access levels, specify them in Opt Fields. Consider following up with **Create Project** to create a project under a team, or **List Users** to find team members. [See the documentation](https://developers.asana.com/reference/getteamsforworkspace)",
-  version: "1.0.1",
+  version: "1.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     asana,
     workspace: {

--- a/components/asana/actions/list-users/list-users.mjs
+++ b/components/asana/actions/list-users/list-users.mjs
@@ -4,13 +4,14 @@ export default {
   key: "asana-list-users",
   name: "List Users",
   description: "Retrieves all users in a specified Asana workspace. Use this action to populate assignee choices for tasks, verify workspace membership, or audit user access. Requires a workspace GID, which you can obtain from the **List Workspaces** action. The authenticated user must have access to the workspace. Results are paginated; use the returned offset token to fetch additional pages. To include optional fields like email or photo, specify them in Opt Fields. Consider following up with **Create Task** or **Update Task** to assign work to the retrieved users. [See the documentation](https://developers.asana.com/reference/getusersforworkspace)",
-  version: "1.0.1",
+  version: "1.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     asana,
     workspace: {

--- a/components/asana/actions/list-workspaces/list-workspaces.mjs
+++ b/components/asana/actions/list-workspaces/list-workspaces.mjs
@@ -4,8 +4,9 @@ export default {
   key: "asana-list-workspaces",
   name: "List Workspaces",
   description: "List workspaces available to the authenticated Asana account. Use this when you need a workspace GID before running **List Teams** or other workspace-scoped actions. `optFields` can include optional workspace properties such as `email_domains` and `is_organization`; leave `offset` empty for the first page and pass a returned offset token (for example, `3:0:abcdef123456`) to fetch the next page. [See the documentation](https://developers.asana.com/reference/getworkspaces)",
-  version: "1.0.1",
+  version: "1.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/asana/actions/search-tasks-premium/search-tasks-premium.mjs
+++ b/components/asana/actions/search-tasks-premium/search-tasks-premium.mjs
@@ -5,13 +5,14 @@ export default {
   key: "asana-search-tasks-premium",
   name: "Search Tasks Premium",
   description: "Searches for a task by name, assignee, section, project, completed since, and modified since. Requires a Premium Asana account. [See the documentation](https://developers.asana.com/reference/searchtasksforworkspace)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     asana,
     info: {

--- a/components/asana/package.json
+++ b/components/asana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/asana",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Pipedream Asana Components",
   "main": "asana.app.mjs",
   "keywords": [

--- a/components/codex/actions/filter-tokens/filter-tokens.mjs
+++ b/components/codex/actions/filter-tokens/filter-tokens.mjs
@@ -11,8 +11,9 @@ export default {
     + " Filter to a specific network by passing a numeric `networkId` (e.g., `1` for Ethereum, `137` for Polygon)."
     + " Use **Get Networks** to find numeric network IDs."
     + " [See the documentation](https://docs.codex.io/api-reference/queries/filtertokens)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/codex/actions/get-networks/get-networks.mjs
+++ b/components/codex/actions/get-networks/get-networks.mjs
@@ -8,8 +8,9 @@ export default {
     + " Call this first to resolve `networkId` values required by every other Codex tool."
     + " Example: Ethereum = 1, Polygon = 137, BNB Chain = 56, Arbitrum = 42161."
     + " [See the documentation](https://docs.codex.io/api-reference/queries/getnetworks)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/codex/actions/get-pair-stats/get-pair-stats.mjs
+++ b/components/codex/actions/get-pair-stats/get-pair-stats.mjs
@@ -9,8 +9,9 @@ export default {
     + " `statsType` `FILTERED` removes wash trades for cleaner signal; `UNFILTERED` includes all activity."
     + " Use **Get Networks** to resolve the numeric `networkId` if needed."
     + " [See the documentation](https://docs.codex.io/api-reference/queries/getdetailedpairstats)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/codex/actions/get-prediction-market-data/get-prediction-market-data.mjs
+++ b/components/codex/actions/get-prediction-market-data/get-prediction-market-data.mjs
@@ -9,8 +9,9 @@ export default {
     + " **Requires a Codex Growth or Enterprise plan** — returns an error on free/Starter plans."
     + " Supports offset-based pagination — pass `offset` (and optional `limit`) to fetch subsequent pages (e.g., `offset: 20` with `limit: 20` fetches the second page)."
     + " [See the documentation](https://docs.codex.io/api-reference/queries/filterpredictionmarkets)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/codex/actions/get-token-chart/get-token-chart.mjs
+++ b/components/codex/actions/get-token-chart/get-token-chart.mjs
@@ -10,8 +10,9 @@ export default {
     + " `from` and `to` are Unix timestamps in seconds (e.g., current time = `Math.floor(Date.now() / 1000)`)."
     + " Valid resolutions: `1` (1 min), `5`, `15`, `30`, `60` (1 hr), `240` (4 hr), `720` (12 hr), `1D`, `7D`."
     + " [See the documentation](https://docs.codex.io/api-reference/queries/gettokenbars)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/codex/actions/get-token-details/get-token-details.mjs
+++ b/components/codex/actions/get-token-details/get-token-details.mjs
@@ -10,8 +10,9 @@ export default {
     + " Use **Get Networks** first to resolve the numeric `networkId` if needed."
     + " Accepts a JSON array of `{address, networkId}` objects — example: `[{\"address\": \"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2\", \"networkId\": 1}]`."
     + " [See the documentation](https://docs.codex.io/api-reference/queries/tokens)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/codex/actions/get-token-events/get-token-events.mjs
+++ b/components/codex/actions/get-token-events/get-token-events.mjs
@@ -10,8 +10,9 @@ export default {
     + " Use **Get Networks** to resolve the numeric `networkId` if needed."
     + " Supports cursor-based pagination — pass the `cursor` from the previous response to fetch the next page."
     + " [See the documentation](https://docs.codex.io/api-reference/queries/gettokenevents)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/codex/actions/get-token-holders/get-token-holders.mjs
+++ b/components/codex/actions/get-token-holders/get-token-holders.mjs
@@ -9,8 +9,9 @@ export default {
     + " Use **Get Networks** to resolve the numeric `networkId` if needed."
     + " Supports cursor-based pagination — pass `cursor` from the previous response to fetch the next page."
     + " [See the documentation](https://docs.codex.io/reference/holders)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/codex/actions/get-wallet-balances/get-wallet-balances.mjs
+++ b/components/codex/actions/get-wallet-balances/get-wallet-balances.mjs
@@ -8,8 +8,9 @@ export default {
     + " Use this to inspect what tokens a wallet holds."
     + " Use **Get Networks** to resolve the numeric `networkId` if needed (e.g., 1 = Ethereum, 137 = Polygon)."
     + " [See the documentation](https://docs.codex.io/reference/balances)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/codex/actions/get-wallet-transactions/get-wallet-transactions.mjs
+++ b/components/codex/actions/get-wallet-transactions/get-wallet-transactions.mjs
@@ -10,8 +10,9 @@ export default {
     + " Use **Get Networks** to resolve the numeric `networkId` if needed."
     + " Supports offset-based pagination — pass `offset` (and optional `limit`) to fetch subsequent pages."
     + " [See the documentation](https://docs.codex.io/api-reference/queries/filtertokenwallets)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/codex/package.json
+++ b/components/codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/codex",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Codex Components",
   "main": "codex.app.mjs",
   "keywords": [

--- a/components/databricks/actions/cancel-all-runs/cancel-all-runs.mjs
+++ b/components/databricks/actions/cancel-all-runs/cancel-all-runs.mjs
@@ -4,13 +4,14 @@ export default {
   key: "databricks-cancel-all-runs",
   name: "Cancel All Runs",
   description: "Cancel all active runs for a job. The runs are canceled asynchronously, so it doesn't prevent new runs from being started. [See the documentation](https://docs.databricks.com/api/workspace/jobs/cancelallruns)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     // eslint-disable-next-line pipedream/props-label, pipedream/props-description

--- a/components/databricks/actions/cancel-run/cancel-run.mjs
+++ b/components/databricks/actions/cancel-run/cancel-run.mjs
@@ -4,13 +4,14 @@ export default {
   key: "databricks-cancel-run",
   name: "Cancel Run",
   description: "Cancel a job run. The run is canceled asynchronously, so it may still be running when this request completes. [See the documentation](https://docs.databricks.com/api/workspace/jobs/cancelrun)",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     runId: {

--- a/components/databricks/actions/delete-run/delete-run.mjs
+++ b/components/databricks/actions/delete-run/delete-run.mjs
@@ -4,13 +4,14 @@ export default {
   key: "databricks-delete-run",
   name: "Delete Run",
   description: "Delete a non-active run. Returns an error if the run is active. [See the documentation](https://docs.databricks.com/api/workspace/jobs/deleterun)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     runId: {

--- a/components/databricks/actions/delete-vector-search-index-data/delete-vector-search-index-data.mjs
+++ b/components/databricks/actions/delete-vector-search-index-data/delete-vector-search-index-data.mjs
@@ -7,13 +7,14 @@ export default {
   name: "Delete Data from Vector Search Index",
   description:
     "Deletes rows from a Direct Access vector index by primary-key values. [See the documentation](https://docs.databricks.com/api/workspace/vectorsearchindexes/deletedatavectorindex)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     databricks,
     endpointName: {

--- a/components/databricks/actions/query-vector-search-index-next-page/query-vector-search-index-next-page.mjs
+++ b/components/databricks/actions/query-vector-search-index-next-page/query-vector-search-index-next-page.mjs
@@ -4,8 +4,9 @@ export default {
   key: "databricks-query-vector-search-index-next-page",
   name: "Query Vector Search Index Next Page",
   description: "Fetch the next page of results from a previously executed Databricks Vector Search query, using the `next_page_token` returned by a prior call. Run **Query Vector Search Index** first to get an initial page and its `next_page_token`, then pass that token here (and again on each subsequent call) to walk through all pages. Results are returned in groups of up to 1000, with a maximum of 10,000 total; an empty `next_page_token` in the response means there are no more pages. [See the documentation](https://docs.databricks.com/api/workspace/vectorsearchindexes/querynextpage).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/databricks/actions/query-vector-search-index/query-vector-search-index.mjs
+++ b/components/databricks/actions/query-vector-search-index/query-vector-search-index.mjs
@@ -7,13 +7,14 @@ export default {
   key: "databricks-query-vector-search-index",
   name: "Query Vector Search Index",
   description: "Query a specific vector search index in Databricks. Returns up to **Max Results** items; when the result set spans more than one 1000-item page, the action automatically follows `next_page_token` to collect the rest. [See the documentation](https://docs.databricks.com/api/workspace/vectorsearchindexes/queryindex)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     databricks,
     endpointName: {

--- a/components/databricks/actions/reset-job/reset-job.mjs
+++ b/components/databricks/actions/reset-job/reset-job.mjs
@@ -5,13 +5,14 @@ export default {
   key: "databricks-reset-job",
   name: "Reset Job",
   description: "Overwrite all settings for the given job. [See the documentation](https://docs.databricks.com/api/workspace/jobs/reset)",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     jobId: {

--- a/components/databricks/actions/run-job-now/run-job-now.mjs
+++ b/components/databricks/actions/run-job-now/run-job-now.mjs
@@ -4,13 +4,14 @@ export default {
   key: "databricks-run-job-now",
   name: "Run Job Now",
   description: "Run a job now and return the id of the triggered run. [See the documentation](https://docs.databricks.com/api/workspace/jobs/runnow)",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     databricks,
     jobId: {

--- a/components/databricks/actions/scan-vector-search-index/scan-vector-search-index.mjs
+++ b/components/databricks/actions/scan-vector-search-index/scan-vector-search-index.mjs
@@ -5,13 +5,14 @@ export default {
   name: "Scan Vector Search Index",
   description:
     "Scans a vector search index and returns entries after the given primary key. [See the documentation](https://docs.databricks.com/api/workspace/vectorsearchindexes/scanindex)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     databricks,
     endpointName: {

--- a/components/databricks/actions/update-job/update-job.mjs
+++ b/components/databricks/actions/update-job/update-job.mjs
@@ -5,13 +5,14 @@ export default {
   key: "databricks-update-job",
   name: "Update Job",
   description: "Update an existing job. Only the fields that are provided will be updated. [See the documentation](https://docs.databricks.com/api/workspace/jobs/update)",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     jobId: {

--- a/components/databricks/package.json
+++ b/components/databricks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/databricks",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Pipedream Databricks Components",
   "main": "databricks.app.mjs",
   "keywords": [

--- a/components/dataforseo/actions/get-app-intersection/get-app-intersection.mjs
+++ b/components/dataforseo/actions/get-app-intersection/get-app-intersection.mjs
@@ -6,13 +6,14 @@ export default {
   key: "dataforseo-get-app-intersection",
   name: "Get App Intersection",
   description: "Compare keyword overlap between mobile apps to find shared ranking opportunities. [See the documentation](https://docs.dataforseo.com/v3/dataforseo_labs/google/app_intersection/live/?bash)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     dataforseo,
     appIds: {

--- a/components/dataforseo/actions/get-app-reviews-summary/get-app-reviews-summary.mjs
+++ b/components/dataforseo/actions/get-app-reviews-summary/get-app-reviews-summary.mjs
@@ -5,13 +5,14 @@ export default {
   key: "dataforseo-get-app-reviews-summary",
   name: "Get App Reviews Summary",
   description: "Get app reviews and ratings summary for mobile app reputation analysis. [See the documentation](https://docs.dataforseo.com/v3/app_data/apple/app_reviews/task_post/?bash)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     dataforseo,
     appId: {

--- a/components/dataforseo/actions/get-backlinks-history/get-backlinks-history.mjs
+++ b/components/dataforseo/actions/get-backlinks-history/get-backlinks-history.mjs
@@ -5,13 +5,14 @@ export default {
   name: "Get Backlinks History",
   description:
     "Get historical backlinks data back to the beginning of 2019. [See the documentation](https://docs.dataforseo.com/v3/backlinks/history/live/)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   methods: {
     getBacklinksHistory(args = {}) {
       return this.dataforseo._makeRequest({

--- a/components/dataforseo/actions/get-crawled-pages/get-crawled-pages.mjs
+++ b/components/dataforseo/actions/get-crawled-pages/get-crawled-pages.mjs
@@ -5,8 +5,9 @@ export default {
   key: "dataforseo-get-crawled-pages",
   name: "Get Crawled Pages with OnPage",
   description: "Get page-specific data with detailed information on how well your pages are optimized for search. [See the documentation](https://docs.dataforseo.com/v3/on_page/pages/)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/dataforseo/actions/get-domain-intersection/get-domain-intersection.mjs
+++ b/components/dataforseo/actions/get-domain-intersection/get-domain-intersection.mjs
@@ -5,13 +5,14 @@ export default {
   key: "dataforseo-get-domain-intersection",
   name: "Get Domain Intersection",
   description: "Compare keyword overlap between multiple domains to find shared ranking opportunities. [See the documentation](https://docs.dataforseo.com/v3/dataforseo_labs/google/domain_intersection/live/?bash)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     dataforseo,
     target1: {

--- a/components/dataforseo/actions/get-keyword-data-errors/get-keyword-data-errors.mjs
+++ b/components/dataforseo/actions/get-keyword-data-errors/get-keyword-data-errors.mjs
@@ -5,13 +5,14 @@ export default {
   key: "dataforseo-get-keyword-data-errors",
   name: "Get Keyword Data Errors",
   description: "Retrieve information about the Keywords Data API tasks that returned an error within the past 7 days [See the documentation](https://docs.dataforseo.com/v3/keywords_data/errors/?bash)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     dataforseo,
     dateTimeFrom: {

--- a/components/dataforseo/actions/get-keyword-data-id-list/get-keyword-data-id-list.mjs
+++ b/components/dataforseo/actions/get-keyword-data-id-list/get-keyword-data-id-list.mjs
@@ -5,13 +5,14 @@ export default {
   key: "dataforseo-get-keyword-data-id-list",
   name: "Get Keyword Data ID List",
   description: "Retrieve the list of IDs and metadata of the completed Keywords Data tasks during the specified period. [See the documentation](https://docs.dataforseo.com/v3/keywords_data/id_list/?bash)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     dataforseo,
     dateTimeFrom: {

--- a/components/dataforseo/actions/parse-page-content/parse-page-content.mjs
+++ b/components/dataforseo/actions/parse-page-content/parse-page-content.mjs
@@ -6,13 +6,14 @@ export default {
   name: "Parse Page Content with OnPage",
   description:
     "Parse the content on any page and return its structured content. [See the documentation](https://docs.dataforseo.com/v3/on_page/content_parsing/live/)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   methods: {
     parsePageContent(args = {}) {
       return this.dataforseo._makeRequest({

--- a/components/dataforseo/package.json
+++ b/components/dataforseo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/dataforseo",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Pipedream DataForSEO Components",
   "main": "dataforseo.app.mjs",
   "keywords": [

--- a/components/docusign/actions/create-envelope-from-file/create-envelope-from-file.mjs
+++ b/components/docusign/actions/create-envelope-from-file/create-envelope-from-file.mjs
@@ -11,13 +11,14 @@ export default {
   key: "docusign-create-envelope-from-file",
   name: "Create Envelope From File",
   description: "Create and optionally send a single-document DocuSign envelope from a file path or URL. This action places a SignHere tab by anchor text, such as `/sn1/`, in the uploaded document. Set Client User ID when you need embedded signing, then use **Create Recipient View** with the same value. [See the documentation](https://developers.docusign.com/docs/esign-rest-api/reference/envelopes/envelopes/create/)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     docusign,
     account: {

--- a/components/docusign/actions/create-envelope/create-envelope.mjs
+++ b/components/docusign/actions/create-envelope/create-envelope.mjs
@@ -8,13 +8,14 @@ export default {
   key: "docusign-create-envelope",
   name: "Create Envelope",
   description: "Create a DocuSign envelope from a full envelope definition JSON payload. Use this for advanced cases such as multiple documents, multiple recipients, composite templates, custom tabs, or eventNotification webhooks. For a simpler single-document flow, use **Create Envelope From File**. [See the documentation](https://developers.docusign.com/docs/esign-rest-api/reference/envelopes/envelopes/create/)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     docusign,
     account: {

--- a/components/docusign/actions/create-recipient-view/create-recipient-view.mjs
+++ b/components/docusign/actions/create-recipient-view/create-recipient-view.mjs
@@ -5,13 +5,14 @@ export default {
   key: "docusign-create-recipient-view",
   name: "Create Recipient View",
   description: "Create an embedded signing URL for a selected envelope recipient. The recipient must have been created with a `clientUserId`. [See the documentation](https://developers.docusign.com/docs/esign-rest-api/reference/envelopes/envelopeviews/createrecipient/)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     docusign,
     account: {

--- a/components/docusign/actions/get-envelope/get-envelope.mjs
+++ b/components/docusign/actions/get-envelope/get-envelope.mjs
@@ -4,13 +4,14 @@ export default {
   key: "docusign-get-envelope",
   name: "Get Envelope",
   description: "Get details for a DocuSign envelope by ID. Use **List Envelopes** first if you need to find an envelope ID. [See the documentation](https://developers.docusign.com/docs/esign-rest-api/reference/envelopes/envelopes/get/)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     docusign,
     account: {

--- a/components/docusign/actions/list-accounts/list-accounts.mjs
+++ b/components/docusign/actions/list-accounts/list-accounts.mjs
@@ -4,13 +4,14 @@ export default {
   key: "docusign-list-accounts",
   name: "List Accounts",
   description: "List the DocuSign accounts available to the connected user. Use this to find the **Account** ID required by other actions when the connected user belongs to more than one account. [See the documentation](https://developers.docusign.com/platform/auth/reference/user-info/)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     docusign,
   },

--- a/components/docusign/actions/list-documents/list-documents.mjs
+++ b/components/docusign/actions/list-documents/list-documents.mjs
@@ -4,13 +4,14 @@ export default {
   key: "docusign-list-documents",
   name: "List Documents",
   description: "List documents in a DocuSign envelope. Use this to find document IDs before downloading a specific document. [See the documentation](https://developers.docusign.com/docs/esign-rest-api/reference/envelopes/envelopedocuments/list/)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     docusign,
     account: {

--- a/components/docusign/actions/list-envelopes/list-envelopes.mjs
+++ b/components/docusign/actions/list-envelopes/list-envelopes.mjs
@@ -8,13 +8,14 @@ export default {
   key: "docusign-list-envelopes",
   name: "List Envelopes",
   description: "Search for DocuSign envelopes by date, status, email, text, or folder filters. Use this to find envelope IDs for **Get Envelope**, **List Recipients**, **List Documents**, **Send Envelope**, **Void Envelope**, or **Create Recipient View**. [See the documentation](https://developers.docusign.com/docs/esign-rest-api/reference/envelopes/envelopes/liststatuschanges/)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     docusign,
     account: {

--- a/components/docusign/actions/send-envelope/send-envelope.mjs
+++ b/components/docusign/actions/send-envelope/send-envelope.mjs
@@ -4,13 +4,14 @@ export default {
   key: "docusign-send-envelope",
   name: "Send Envelope",
   description: "Send an existing draft DocuSign envelope by updating its status to `sent`. Use this after **Create Envelope** or **Create Envelope From File**, or any workflow that creates an envelope with status `created`. [See the documentation](https://developers.docusign.com/docs/esign-rest-api/reference/envelopes/envelopes/update/)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     docusign,
     account: {

--- a/components/docusign/actions/void-envelope/void-envelope.mjs
+++ b/components/docusign/actions/void-envelope/void-envelope.mjs
@@ -4,13 +4,14 @@ export default {
   key: "docusign-void-envelope",
   name: "Void Envelope",
   description: "Void a DocuSign envelope that is still in process. Voiding cancels the envelope and prevents recipients from completing it. [See the documentation](https://developers.docusign.com/docs/esign-rest-api/reference/envelopes/envelopes/update/)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     docusign,
     account: {

--- a/components/docusign/package.json
+++ b/components/docusign/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/docusign",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Pipedream Docusign Components",
   "main": "docusign.app.mjs",
   "keywords": [

--- a/components/eppo/actions/create-experiment/create-experiment.mjs
+++ b/components/eppo/actions/create-experiment/create-experiment.mjs
@@ -13,8 +13,9 @@ export default {
     + " Example metrics: `[{\"metric_id\": 333870, \"is_primary\": true}]`."
     + " Dates must be ISO 8601 format: `2024-01-01T00:00:00Z`."
     + " [See the documentation](https://eppo.cloud/api/docs#/Experiments/createExperiment)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/eppo/actions/create-feature-flag/create-feature-flag.mjs
+++ b/components/eppo/actions/create-feature-flag/create-feature-flag.mjs
@@ -11,8 +11,9 @@ export default {
     + " Example: `[{\"variant_key\": \"on\", \"type\": \"STRING\", \"name\": \"On\"}, {\"variant_key\": \"off\", \"type\": \"STRING\", \"name\": \"Off\"}]`."
     + " Use **List Feature Flags** to verify the flag was created."
     + " [See the documentation](https://eppo.cloud/api/docs#/FeatureFlags/createFeatureFlag)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/eppo/actions/get-experiment-results/get-experiment-results.mjs
+++ b/components/eppo/actions/get-experiment-results/get-experiment-results.mjs
@@ -9,8 +9,9 @@ export default {
     + " Use **List Experiments** first to find the numeric `experimentId` — Eppo uses integer IDs for experiment lookups."
     + " Set `allowDeleted` to `true` to include soft-deleted experiments in the response."
     + " [See the documentation](https://eppo.cloud/api/docs#/Experiments/getExperiment)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/eppo/actions/get-feature-flag/get-feature-flag.mjs
+++ b/components/eppo/actions/get-feature-flag/get-feature-flag.mjs
@@ -8,8 +8,9 @@ export default {
     + " Use this tool when the user asks about a specific flag's configuration or assignment logic."
     + " Use **List Feature Flags** first to find the numeric `flagId` — Eppo uses integer IDs, not string keys, for flag lookups."
     + " [See the documentation](https://eppo.cloud/api/docs#/FeatureFlags/getFeatureFlag)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/eppo/actions/list-experiments/list-experiments.mjs
+++ b/components/eppo/actions/list-experiments/list-experiments.mjs
@@ -9,8 +9,9 @@ export default {
     + " Filter by `type` (`all`, `experiments`, or `holdouts`), `experimentKey`, `entityId`, `tagNames`, `isDeleted`, `updatedSince`, or `createdSince` to narrow results."
     + " Set `withCalculatedMetrics` or `withFullCupedData` to include additional metric data in the response."
     + " [See the documentation](https://eppo.cloud/api/docs#/Experiments/getExperiments)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/eppo/actions/list-feature-flags/list-feature-flags.mjs
+++ b/components/eppo/actions/list-feature-flags/list-feature-flags.mjs
@@ -8,8 +8,9 @@ export default {
     + " Use this tool when a user wants to see all flags, find a specific flag by name, or discover flag IDs needed by **Get Feature Flag** or **Toggle Feature Flag**."
     + " Set `includeArchived` to also return archived flags."
     + " [See the documentation](https://eppo.cloud/api/docs#/FeatureFlags/getFeatureFlags)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/eppo/actions/list-metrics/list-metrics.mjs
+++ b/components/eppo/actions/list-metrics/list-metrics.mjs
@@ -10,8 +10,9 @@ export default {
     + " Set `includeExperiments` to `true` to include associated experiments in the response (requires `limit` ≤ 10)."
     + " Supports pagination via `limit` and `offset`."
     + " [See the documentation](https://eppo.cloud/api/docs#/Metrics/getMetrics)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/eppo/actions/toggle-feature-flag/toggle-feature-flag.mjs
+++ b/components/eppo/actions/toggle-feature-flag/toggle-feature-flag.mjs
@@ -8,8 +8,9 @@ export default {
     + " Use this when the user wants to turn a flag on or off in Production, Test, or another environment."
     + " Use **List Feature Flags** or **Get Feature Flag** first to find the numeric `flagId` and to discover valid `environmentId` values from the flag's `environments` array."
     + " [See the documentation](https://eppo.cloud/api/docs#/FeatureFlags/updateEnvironmentStatus)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/eppo/actions/upsert-metric/upsert-metric.mjs
+++ b/components/eppo/actions/upsert-metric/upsert-metric.mjs
@@ -22,8 +22,9 @@ export default {
     + " For ratio metrics, also provide `denominator`. Set `denominator` to the JSON literal `null` for non-ratio metrics."
     + " IMPORTANT: `metric_event_measure_id` is a data-source ID from your Eppo data pipeline configuration — obtain it from your Eppo workspace's data integration settings. It is NOT the same as a metric ID or aggregation ID. The Eppo API requires the full numerator/percentile/funnel definition even for metadata-only updates."
     + " [See the documentation - Create Metric](https://eppo.cloud/api/docs#/Metrics/createMetric) and [See the documentation - Update Metric](https://eppo.cloud/api/docs#/Metrics/updateMetric)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/eppo/package.json
+++ b/components/eppo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/eppo",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Eppo Components",
   "main": "eppo.app.mjs",
   "keywords": [

--- a/components/linkupapi/actions/connect-account/connect-account.mjs
+++ b/components/linkupapi/actions/connect-account/connect-account.mjs
@@ -6,8 +6,9 @@ export default {
   key: "linkupapi-connect-account",
   name: "Connect Account",
   description: "Authenticate a LinkedIn account and obtain a persistent `account_id` to reuse across all other actions. Connect with either a login token or email + password. If a checkpoint/challenge is required, follow up with **Verify Code**. [See the documentation](https://docs.linkupapi.com/api-reference/v2/accounts/login)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/linkupapi/actions/connect-to-profile/connect-to-profile.mjs
+++ b/components/linkupapi/actions/connect-to-profile/connect-to-profile.mjs
@@ -3,10 +3,11 @@ import app from "../../linkupapi.app.mjs";
 
 export default {
   type: "action",
+  ai: "optimized",
   key: "linkupapi-connect-to-profile",
   name: "Connect To Profile",
   description: "Send a connection invitation to a LinkedIn profile. [See the documentation](https://docs.linkupapi.com/api-reference/v2/network/invite)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/linkupapi/actions/create-comment/create-comment.mjs
+++ b/components/linkupapi/actions/create-comment/create-comment.mjs
@@ -4,8 +4,9 @@ export default {
   key: "linkupapi-create-comment",
   name: "Create Comment",
   description: "Post a comment on LinkedIn content. [See the documentation](https://docs.linkupapi.com/api-reference/v2/content/comment)",
-  version: "1.0.0",
+  version: "1.0.1",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/linkupapi/actions/get-conversation-messages/get-conversation-messages.mjs
+++ b/components/linkupapi/actions/get-conversation-messages/get-conversation-messages.mjs
@@ -3,10 +3,11 @@ import app from "../../linkupapi.app.mjs";
 
 export default {
   type: "action",
+  ai: "optimized",
   key: "linkupapi-get-conversation-messages",
   name: "Get Conversation Messages",
   description: "Retrieve messages from a LinkedIn conversation. Identify the conversation by its ID or by the recipient's profile URL. [See the documentation](https://docs.linkupapi.com/api-reference/v2/messages/get-conversation)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/linkupapi/actions/get-invitations-status/get-invitations-status.mjs
+++ b/components/linkupapi/actions/get-invitations-status/get-invitations-status.mjs
@@ -2,10 +2,11 @@ import app from "../../linkupapi.app.mjs";
 
 export default {
   type: "action",
+  ai: "optimized",
   key: "linkupapi-get-invitations-status",
   name: "Get Invitations Status",
   description: "List pending connection invitations **received** by the connected account. Note: this returns invitations received, not ones you have sent. [See the documentation](https://docs.linkupapi.com/api-reference/v2/network/list-invitations)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/linkupapi/actions/get-profile-info/get-profile-info.mjs
+++ b/components/linkupapi/actions/get-profile-info/get-profile-info.mjs
@@ -3,10 +3,11 @@ import app from "../../linkupapi.app.mjs";
 
 export default {
   type: "action",
+  ai: "optimized",
   key: "linkupapi-get-profile-info",
   name: "Get Profile Info",
   description: "Fetch details for a LinkedIn profile. Identify the target by profile URL, public identifier, or profile URN. [See the documentation](https://docs.linkupapi.com/api-reference/v2/profiles/get-profile)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/linkupapi/actions/list-inbox/list-inbox.mjs
+++ b/components/linkupapi/actions/list-inbox/list-inbox.mjs
@@ -4,8 +4,9 @@ export default {
   key: "linkupapi-list-inbox",
   name: "List Inbox",
   description: "List conversations from the LinkedIn inbox, each with its `conversation_id` to use with **Get Conversation Messages**. [See the documentation](https://docs.linkupapi.com/api-reference/v2/messages/list-inbox)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/linkupapi/actions/send-message/send-message.mjs
+++ b/components/linkupapi/actions/send-message/send-message.mjs
@@ -2,10 +2,11 @@ import app from "../../linkupapi.app.mjs";
 
 export default {
   type: "action",
+  ai: "optimized",
   key: "linkupapi-send-message",
   name: "Send Message",
   description: "Send a message to a LinkedIn profile. Make sure you are already connected to the recipient. [See the documentation](https://docs.linkupapi.com/api-reference/v2/messages/send)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/linkupapi/actions/verify-code/verify-code.mjs
+++ b/components/linkupapi/actions/verify-code/verify-code.mjs
@@ -2,10 +2,11 @@ import app from "../../linkupapi.app.mjs";
 
 export default {
   type: "action",
+  ai: "optimized",
   key: "linkupapi-verify-code",
   name: "Verify Code",
   description: "Submit a checkpoint/challenge verification code to complete authentication for a connected account. [See the documentation](https://docs.linkupapi.com/api-reference/v2/accounts/checkpoint)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/linkupapi/package.json
+++ b/components/linkupapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/linkupapi",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Pipedream LinkupAPI Components",
   "main": "linkupapi.app.mjs",
   "keywords": [

--- a/components/luma/actions/add-guests/add-guests.mjs
+++ b/components/luma/actions/add-guests/add-guests.mjs
@@ -10,8 +10,9 @@ export default {
   key: "luma-add-guests",
   name: "Add Guests",
   description: "Add guests to a Luma event with status `Going`. Guests receive the default ticket type unless Ticket JSON or Tickets JSON is provided. Use **List Events** first if you need to find the event ID, and **List Ticket Types** if assigning custom tickets. [See the documentation](https://docs.luma.com/reference/post_v1-event-add-guests)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/luma/actions/create-event/create-event.mjs
+++ b/components/luma/actions/create-event/create-event.mjs
@@ -8,8 +8,9 @@ export default {
   key: "luma-create-event",
   name: "Create Event",
   description: "Create an event on the connected Luma calendar. Required datetime fields must be ISO 8601 strings and Timezone must be an IANA timezone like `America/New_York`. [See the documentation](https://docs.luma.com/reference/post_v1-event-create)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/luma/actions/get-event/get-event.mjs
+++ b/components/luma/actions/get-event/get-event.mjs
@@ -4,8 +4,9 @@ export default {
   key: "luma-get-event",
   name: "Get Event",
   description: "Get admin details for a Luma event the connected calendar can manage. Use **List Events** first if you need to find the event ID. [See the documentation](https://docs.luma.com/reference/get_v1-event-get)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/luma/actions/get-guest/get-guest.mjs
+++ b/components/luma/actions/get-guest/get-guest.mjs
@@ -4,8 +4,9 @@ export default {
   key: "luma-get-guest",
   name: "Get Guest",
   description: "Get detailed information for a Luma event guest by guest ID, ticket key, guest key, or email. Use **Get Guests** first if you need to find a guest identifier. [See the documentation](https://docs.luma.com/reference/get_v1-event-get-guest)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/luma/actions/get-guests/get-guests.mjs
+++ b/components/luma/actions/get-guests/get-guests.mjs
@@ -8,8 +8,9 @@ export default {
   key: "luma-get-guests",
   name: "Get Guests",
   description: "List guests who registered for, were invited to, or are waitlisted for a Luma event. Omit Approval Status to include all guest statuses. Use **List Events** first if you need to find the event ID. [See the documentation](https://docs.luma.com/reference/get_v1-event-get-guests)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/luma/actions/list-events/list-events.mjs
+++ b/components/luma/actions/list-events/list-events.mjs
@@ -8,8 +8,9 @@ export default {
   key: "luma-list-events",
   name: "List Events",
   description: "List events managed by the connected Luma calendar. Use this to find event IDs for **Get Event**, **Get Guests**, **Add Guests**, or **Send Invites**. This only returns events managed by the calendar, not external events merely listed on it. [See the documentation](https://docs.luma.com/reference/get_v1-calendar-list-events)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/luma/actions/list-ticket-types/list-ticket-types.mjs
+++ b/components/luma/actions/list-ticket-types/list-ticket-types.mjs
@@ -5,8 +5,9 @@ export default {
   key: "luma-list-ticket-types",
   name: "List Ticket Types",
   description: "List ticket types for a Luma event. Use this before assigning custom tickets through Luma's guest-management APIs. [See the documentation](https://docs.luma.com/reference/get_v1-event-ticket-types-list)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/luma/actions/send-invites/send-invites.mjs
+++ b/components/luma/actions/send-invites/send-invites.mjs
@@ -5,8 +5,9 @@ export default {
   key: "luma-send-invites",
   name: "Send Invites",
   description: "Send email invitations for a Luma event. Guests are invited but not automatically marked as going. Use **Add Guests** when guests should be added with status `Going`. [See the documentation](https://docs.luma.com/reference/post_v1-event-send-invites)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/luma/package.json
+++ b/components/luma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/luma",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Luma Components",
   "main": "luma.app.mjs",
   "keywords": [

--- a/components/microsoft_outlook/actions/download-attachment/download-attachment.mjs
+++ b/components/microsoft_outlook/actions/download-attachment/download-attachment.mjs
@@ -22,8 +22,9 @@ export default {
     + " Set `convertToPdf: true` to convert images, HTML, plain text, or DOCX files to PDF."
     + " For text attachments (text/*, JSON), the response includes `fileContent` with the decoded text (truncated at 100 KB, flagged by `contentTruncated`), so the content can be read directly without fetching the file."
     + " [See the documentation](https://learn.microsoft.com/en-us/graph/api/attachment-get)",
-  version: "0.1.4",
+  version: "0.1.5",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/microsoft_outlook/actions/find-contacts/find-contacts.mjs
+++ b/components/microsoft_outlook/actions/find-contacts/find-contacts.mjs
@@ -14,8 +14,9 @@ export default {
     + " Example: `find-contacts(searchString=\"george@vandelay.com\")` → matches by email address."
     + " Use the returned contact `id` with **Save Contact** to update the contact."
     + " [See the documentation](https://docs.microsoft.com/en-us/graph/api/user-list-contacts)",
-  version: "1.0.1",
+  version: "1.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/microsoft_outlook/actions/find-email/find-email.mjs
+++ b/components/microsoft_outlook/actions/find-email/find-email.mjs
@@ -15,8 +15,9 @@ export default {
     + " Set `folderScope` explicitly to override this behavior for either mode."
     + " To search a shared mailbox, set `userId` (the mailbox owner's UPN or ID); add `sharedFolderId` to target a specific folder within it."
     + " [See the documentation](https://learn.microsoft.com/en-us/graph/api/user-list-messages?view=graph-rest-1.0)",
-  version: "1.1.0",
+  version: "1.1.1",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/microsoft_outlook/actions/get-current-user/get-current-user.mjs
+++ b/components/microsoft_outlook/actions/get-current-user/get-current-user.mjs
@@ -4,8 +4,9 @@ export default {
   key: "microsoft_outlook-get-current-user",
   name: "Get Current User",
   description: "Returns the authenticated Microsoft user's ID, display name, email, and principal name via Microsoft Graph. Call this first when the user says 'my emails', 'my inbox', or needs identity context. Use the returned `id` to scope queries in **Find Email** or identify the sender in email results. [See the documentation](https://learn.microsoft.com/en-us/graph/api/user-get).",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/microsoft_outlook/actions/get-folder/get-folder.mjs
+++ b/components/microsoft_outlook/actions/get-folder/get-folder.mjs
@@ -4,8 +4,9 @@ export default {
   key: "microsoft_outlook-get-folder",
   name: "Get Folder",
   description: "Retrieve a single mail folder by its ID. Returns the folder's `id`, `displayName`, `parentFolderId`, `childFolderCount`, `totalItemCount`, and `unreadItemCount`. If you only have a display name and need the ID, use **List Folders** first. [See the documentation](https://learn.microsoft.com/en-us/graph/api/mailfolder-get?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/microsoft_outlook/actions/get-message/get-message.mjs
+++ b/components/microsoft_outlook/actions/get-message/get-message.mjs
@@ -9,8 +9,9 @@ export default {
     + " Set `includeAttachments: true` to expand attachment metadata — the `id` field of each attachment is required by **Download Attachment**."
     + " Example: after `find-email(search=\"Eval-Festivus\")` returns a message with `id: \"AAMk...\"`, call `get-message(messageId=\"AAMk...\", includeAttachments=true)` to get the body text and attachment list."
     + " [See the documentation](https://learn.microsoft.com/en-us/graph/api/message-get)",
-  version: "0.0.6",
+  version: "0.0.7",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/microsoft_outlook/actions/get-shared-folder/get-shared-folder.mjs
+++ b/components/microsoft_outlook/actions/get-shared-folder/get-shared-folder.mjs
@@ -4,8 +4,9 @@ export default {
   key: "microsoft_outlook-get-shared-folder",
   name: "Get Shared Folder",
   description: "Retrieve a single folder from a shared mailbox by its ID. Returns the folder's `id`, `displayName`, `parentFolderId`, `childFolderCount`, `totalItemCount`, and `unreadItemCount`. If you only have a display name and need the ID, use **List Shared Folders** first. [See the documentation](https://learn.microsoft.com/en-us/graph/api/mailfolder-get?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.4",
+  version: "0.0.5",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/microsoft_outlook/actions/list-contacts/list-contacts.mjs
+++ b/components/microsoft_outlook/actions/list-contacts/list-contacts.mjs
@@ -3,8 +3,9 @@ import { COUNT_QUERY_PARAM } from "../../common/constants.mjs";
 
 export default {
   type: "action",
+  ai: "optimized",
   key: "microsoft_outlook-list-contacts",
-  version: "1.0.1",
+  version: "1.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/microsoft_outlook/actions/list-folders/list-folders.mjs
+++ b/components/microsoft_outlook/actions/list-folders/list-folders.mjs
@@ -5,13 +5,14 @@ export default {
   key: "microsoft_outlook-list-folders",
   name: "List Folders",
   description: "Retrieves mail folders for the authenticated user. Returns `{ count, folders }` where `folders` contains each folder's `id`, `displayName`, `parentFolderId`, `childFolderCount`, `totalItemCount`, and `unreadItemCount`. The `count` field reflects the true API total when Microsoft Graph returns `@odata.count` (supported for top-level mailFolders queries); when `Include Subfolders` is `true` or Graph does not return `@odata.count` for the requested filter, `count` equals the number of folders actually retrieved. **Use this action to resolve a folder display name to its ID** — set `Display Name` to filter by exact name. Use **Get Folder** instead when you already have the folder ID. [See the documentation](https://learn.microsoft.com/en-us/graph/api/user-list-mailfolders?view=graph-rest-1.0&tabs=http)",
-  version: "1.0.1",
+  version: "1.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     microsoftOutlook,
     displayName: {

--- a/components/microsoft_outlook/actions/list-important-mail/list-important-mail.mjs
+++ b/components/microsoft_outlook/actions/list-important-mail/list-important-mail.mjs
@@ -7,13 +7,14 @@ export default {
   key: "microsoft_outlook-list-important-mail",
   name: "List Important Mail",
   description: "Get the most important mail from the user's Inbox (messages with high importance or flagged status). Returns `{ count, data }` where `count` is the true total matching message count reported by Microsoft Graph (`@odata.count` for the applied filter) and `data` is the array of retrieved messages (up to `maxResults`). [See the documentation](https://learn.microsoft.com/en-us/graph/api/user-list-messages?view=graph-rest-1.0&tabs=http)",
-  version: "0.1.1",
+  version: "0.1.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     microsoftOutlook,
     userId: {

--- a/components/microsoft_outlook/actions/list-shared-folders/list-shared-folders.mjs
+++ b/components/microsoft_outlook/actions/list-shared-folders/list-shared-folders.mjs
@@ -5,8 +5,9 @@ export default {
   key: "microsoft_outlook-list-shared-folders",
   name: "List Shared Folders",
   description: "Retrieves mail folders from a shared or delegated mailbox (routes to `/users/{userId}/mailFolders`). Returns `{ count, folders }` where `folders` contains each folder's `id`, `displayName`, `parentFolderId`, `childFolderCount`, `totalItemCount`, and `unreadItemCount`. The `count` field reflects the true API total when Microsoft Graph returns `@odata.count`; when `Include Subfolders` is `true` or Graph does not return `@odata.count` for the requested filter, `count` equals the number of folders actually retrieved. **Use this action to resolve a shared mailbox folder display name to its ID** — set `Display Name` to filter by exact name. Use **Get Shared Folder** instead when you already have the folder ID. [See the documentation](https://learn.microsoft.com/en-us/graph/api/user-list-mailfolders?view=graph-rest-1.0&tabs=http)",
-  version: "1.0.1",
+  version: "1.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/microsoft_outlook/actions/modify-email/modify-email.mjs
+++ b/components/microsoft_outlook/actions/modify-email/modify-email.mjs
@@ -15,8 +15,9 @@ export default {
     + " Example: `modify-email(messageId=\"AAMk...\", isRead=true)` → marks the message as read."
     + " Example: `modify-email(messageId=\"AAMk...\", addCategories=[\"Eval-Seinfeld\"], destinationFolderId=\"archive\")` → adds a category AND moves to archive in a single call."
     + " [See the documentation](https://learn.microsoft.com/en-us/graph/api/message-update)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/microsoft_outlook/actions/save-contact/save-contact.mjs
+++ b/components/microsoft_outlook/actions/save-contact/save-contact.mjs
@@ -11,8 +11,9 @@ export default {
     + " Example (update): `save-contact(contactId=\"AQMk...\", businessPhones=[\"+1-555-0100\"])` → patches the existing contact."
     + " [See the create documentation](https://docs.microsoft.com/en-us/graph/api/user-post-contacts)"
     + " [See the update documentation](https://docs.microsoft.com/en-us/graph/api/contact-update)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/microsoft_outlook/actions/send-email/send-email.mjs
+++ b/components/microsoft_outlook/actions/send-email/send-email.mjs
@@ -14,8 +14,9 @@ export default {
     + " Example (draft): `send-email(recipients=[\"boss@example.com\"], subject=\"Weekly report\", content=\"...\", isDraft=true)`"
     + " Use **Find Email** to locate a message `id` before replying."
     + " [See the documentation](https://learn.microsoft.com/en-us/graph/api/user-sendmail)",
-  version: "0.1.4",
+  version: "0.1.5",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/microsoft_outlook/package.json
+++ b/components/microsoft_outlook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/microsoft_outlook",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "description": "Pipedream Microsoft Outlook Components",
   "main": "microsoft_outlook.app.mjs",
   "keywords": [

--- a/components/mindbody/actions/book-appointment/book-appointment.mjs
+++ b/components/mindbody/actions/book-appointment/book-appointment.mjs
@@ -10,8 +10,9 @@ export default {
     + " `startDateTime` format: ISO 8601 `YYYY-MM-DDTHH:MM:SS` (e.g., `2026-07-15T10:00:00`)."
     + " Location IDs are returned by **Get Site Info**."
     + " [See the documentation](https://developers.mindbodyonline.com/ui/documentation/public-api#/http/api-endpoints/appointment/add-appointment)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/mindbody/actions/cancel-appointment/cancel-appointment.mjs
+++ b/components/mindbody/actions/cancel-appointment/cancel-appointment.mjs
@@ -7,8 +7,9 @@ export default {
     "Cancels an existing appointment by setting its status to Cancelled."
     + " Requires the appointment ID — use **Get Appointments** to find the ID by client, date, or staff."
     + " [See the documentation](https://developers.mindbodyonline.com/ui/documentation/public-api#/http/api-endpoints/appointment/update-appointment)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/mindbody/actions/get-appointments/get-appointments.mjs
+++ b/components/mindbody/actions/get-appointments/get-appointments.mjs
@@ -10,8 +10,9 @@ export default {
     + " Date formats: `YYYY-MM-DD` (e.g., `2026-07-01`)."
     + " Without date filters, returns appointments from the current date forward (up to `limit`)."
     + " [See the documentation](https://developers.mindbodyonline.com/ui/documentation/public-api#/http/api-endpoints/appointment/get-staff-appointments)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/mindbody/actions/get-classes/get-classes.mjs
+++ b/components/mindbody/actions/get-classes/get-classes.mjs
@@ -9,8 +9,9 @@ export default {
     + " Use `staffId` to find classes taught by a specific instructor — see **List Staff** for IDs."
     + " Use `locationId` to filter by studio location — see **Get Site Info** for location IDs."
     + " [See the documentation](https://developers.mindbodyonline.com/ui/documentation/public-api#/http/api-endpoints/class/get-classes)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/mindbody/actions/get-client-details/get-client-details.mjs
+++ b/components/mindbody/actions/get-client-details/get-client-details.mjs
@@ -7,8 +7,9 @@ export default {
     "Returns the complete profile for a client (member), including contact info, active memberships, purchased services, account balance, and visit history."
     + " Requires the client's numeric ID — use **Search Clients** first to look up the ID by name or email."
     + " [See the documentation](https://developers.mindbodyonline.com/ui/documentation/public-api#/http/api-endpoints/client/get-client-complete-info)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/mindbody/actions/get-client-purchases/get-client-purchases.mjs
+++ b/components/mindbody/actions/get-client-purchases/get-client-purchases.mjs
@@ -9,8 +9,9 @@ export default {
     + " Requires the client's numeric ID - use **Search Clients** first to look up the ID by name or email."
     + " IMPORTANT: the API defaults `startDate` to today and `endDate` to end of today, so for true lifetime spend you MUST set `startDate` to an early date (e.g. `2000-01-01`) and page through all results via `offset`."
     + " [See the documentation](https://developers.mindbodyonline.com/ui/documentation/public-api#/http/api-endpoints/client/get-client-purchases)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/mindbody/actions/get-client-visits/get-client-visits.mjs
+++ b/components/mindbody/actions/get-client-visits/get-client-visits.mjs
@@ -11,8 +11,9 @@ export default {
     + " Iterate `offset` to page through the full history."
     + " IMPORTANT: the API defaults `startDate` to today and `endDate` to end of today, so for true lifetime spend you MUST set `startDate` to an early date (e.g. `2000-01-01`) and page through all results via `offset`."
     + " [See the documentation](https://developers.mindbodyonline.com/ui/documentation/public-api#/http/api-endpoints/client/get-client-visits)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/mindbody/actions/get-site-info/get-site-info.mjs
+++ b/components/mindbody/actions/get-site-info/get-site-info.mjs
@@ -8,8 +8,9 @@ export default {
     + " Use this as the identity anchor — call it first to discover the site name, ID, and timezone before querying other resources."
     + " Also provides location IDs needed by **List Staff**, **Get Classes**, and **Book Appointment**."
     + " [See the documentation](https://developers.mindbodyonline.com/ui/documentation/public-api#/http/api-endpoints/site/get-sites)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/mindbody/actions/list-session-types/list-session-types.mjs
+++ b/components/mindbody/actions/list-session-types/list-session-types.mjs
@@ -8,8 +8,9 @@ export default {
     + " Use this to discover the `sessionTypeId` values needed by **Book Appointment**."
     + " Optionally filter by `programIds` to narrow results to a specific program category."
     + " [See the documentation](https://developers.mindbodyonline.com/ui/documentation/public-api#/http/api-endpoints/site/get-session-types)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/mindbody/actions/list-staff/list-staff.mjs
+++ b/components/mindbody/actions/list-staff/list-staff.mjs
@@ -8,8 +8,9 @@ export default {
     + " Use this to discover `staffId` values needed by **Book Appointment** and **Get Classes**."
     + " Filter by `filters` to find staff with a specific role (e.g., `AppointmentInstructor`)."
     + " [See the documentation](https://developers.mindbodyonline.com/ui/documentation/public-api#/http/api-endpoints/staff/get-staff)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/mindbody/actions/search-clients/search-clients.mjs
+++ b/components/mindbody/actions/search-clients/search-clients.mjs
@@ -9,8 +9,9 @@ export default {
     + " Use this to find a client's ID before calling **Get Client Details**, **Get Appointments**, or **Book Appointment**."
     + " The `searchText` matches against first name, last name, email, and phone — partial matches are supported."
     + " [See the documentation](https://developers.mindbodyonline.com/ui/documentation/public-api#/http/api-endpoints/client/get-clients)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/mindbody/actions/upsert-client/upsert-client.mjs
+++ b/components/mindbody/actions/upsert-client/upsert-client.mjs
@@ -11,8 +11,9 @@ export default {
     + " BirthDate format: ISO datetime string `YYYY-MM-DDTHH:MM:SS` (e.g., `1990-05-15T00:00:00`)."
     + " Use **Search Clients** to find an existing client's ID before updating."
     + " [See the documentation](https://developers.mindbodyonline.com/ui/documentation/public-api#/http/api-endpoints/client/update-client)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/mindbody/package.json
+++ b/components/mindbody/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/mindbody",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Mindbody Components",
   "main": "mindbody.app.mjs",
   "keywords": [

--- a/components/pipedream_utils/actions/add-subtract-time/add-subtract-time.mjs
+++ b/components/pipedream_utils/actions/add-subtract-time/add-subtract-time.mjs
@@ -15,13 +15,14 @@ export default {
   name: "Formatting - [Date/Time] Add/Subtract Time",
   description: "Add or subtract time from a given input",
   key: "pipedream_utils-add-subtract-time",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     ...commonDateTime.props,
     operation: {

--- a/components/pipedream_utils/actions/compare-arrays/compare-arrays.mjs
+++ b/components/pipedream_utils/actions/compare-arrays/compare-arrays.mjs
@@ -4,13 +4,14 @@ export default {
   key: "pipedream_utils-compare-arrays",
   name: "Helper Functions - Compare Arrays",
   description: "Get the difference, intersection, union, or symetric difference of two arrays/sets.",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     pipedream_utils,
     array1: {

--- a/components/pipedream_utils/actions/compare-dates/compare-dates.mjs
+++ b/components/pipedream_utils/actions/compare-dates/compare-dates.mjs
@@ -6,13 +6,14 @@ export default {
   name: "Formatting - [Date/Time] Compare Dates",
   description: "Get the duration between two dates in days, hours, minutes, and seconds along with checking if they are the same.",
   key: "pipedream_utils-compare-dates",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     ...commonDateTime.props,
     inputDate: {

--- a/components/pipedream_utils/actions/csv-file-to-objects/csv-file-to-objects.mjs
+++ b/components/pipedream_utils/actions/csv-file-to-objects/csv-file-to-objects.mjs
@@ -7,13 +7,14 @@ export default {
   key: "pipedream_utils-csv-file-to-objects",
   name: "Helper Functions - CSV File To Objects",
   description: "Convert a CSV file to an array of objects.",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: false,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     pipedream_utils,
     filePath: {

--- a/components/pipedream_utils/actions/get-current-time-in-specific-timezone/get-current-time-in-specific-timezone.mjs
+++ b/components/pipedream_utils/actions/get-current-time-in-specific-timezone/get-current-time-in-specific-timezone.mjs
@@ -6,13 +6,14 @@ export default {
   key: "pipedream_utils-get-current-time-in-specific-timezone",
   name: "Helper Functions - Get Current Time in Timezone",
   description: "Returns the current time, tied to this workflow invocation, in the target timezone",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     pipedream_utils,
     timezone: {

--- a/components/pipedream_utils/actions/get-time-in-specific-timezone/get-time-in-specific-timezone.mjs
+++ b/components/pipedream_utils/actions/get-time-in-specific-timezone/get-time-in-specific-timezone.mjs
@@ -6,13 +6,14 @@ export default {
   key: "pipedream_utils-get-time-in-specific-timezone",
   name: "Helper Functions - Get Time in Timezone",
   description: "Given an ISO 8601 timestamp, and a timezone, convert the time to the target timezone.",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     pipedream_utils,
     time: {

--- a/components/pipedream_utils/actions/send-email-with-nodemailer/send-email-with-nodemailer.mjs
+++ b/components/pipedream_utils/actions/send-email-with-nodemailer/send-email-with-nodemailer.mjs
@@ -6,13 +6,14 @@ export default {
   key: "pipedream_utils-send-email-with-nodemailer",
   name: "Helper Functions - Send email with Nodemailer",
   description: "Sends an email using the nodemailer package",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     pipedream_utils,
     host: {

--- a/components/pipedream_utils/actions/send-to-s3/send-to-s3.mjs
+++ b/components/pipedream_utils/actions/send-to-s3/send-to-s3.mjs
@@ -5,13 +5,14 @@ export default {
   key: "pipedream_utils-send-to-s3",
   name: "Helper Functions - Send to Amazon S3",
   description: "Send data to Amazon S3 using Pipedream's destination integration. See https://docs.pipedream.com/destinations/s3/",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     pipedream_utils,
     bucket: {

--- a/components/pipedream_utils/package.json
+++ b/components/pipedream_utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/pipedream_utils",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Pipedream Utils Components",
   "main": "pipedream_utils.app.mjs",
   "keywords": [

--- a/components/pipedrive/actions/add-activity/add-activity.mjs
+++ b/components/pipedrive/actions/add-activity/add-activity.mjs
@@ -7,13 +7,14 @@ export default {
   key: "pipedrive-add-activity",
   name: "Add Activity",
   description: "Adds a new activity. Includes `more_activities_scheduled_in_context` property in response's `additional_data` which indicates whether there are more undone activities scheduled with the same deal, person or organization (depending on the supplied data). See the Pipedrive API docs for Activities [here](https://developers.pipedrive.com/docs/api/v1/#!/Activities). For info on [adding an activity in Pipedrive](https://developers.pipedrive.com/docs/api/v1/Activities#addActivity)",
-  version: "0.1.25",
+  version: "0.1.26",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     pipedriveApp,
     subject: {

--- a/components/pipedrive/actions/add-lead/add-lead.mjs
+++ b/components/pipedrive/actions/add-lead/add-lead.mjs
@@ -6,13 +6,14 @@ export default {
   key: "pipedrive-add-lead",
   name: "Add Lead",
   description: "Create a new lead in Pipedrive. [See the documentation](https://developers.pipedrive.com/docs/api/v1/Leads#addLead)",
-  version: "0.0.19",
+  version: "0.0.20",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     pipedrive,
     title: {

--- a/components/pipedrive/actions/add-note/add-note.mjs
+++ b/components/pipedrive/actions/add-note/add-note.mjs
@@ -5,13 +5,14 @@ export default {
   key: "pipedrive-add-note",
   name: "Add Note",
   description: "Adds a new note. For info on [adding an note in Pipedrive](https://developers.pipedrive.com/docs/api/v1/Notes#addNote)",
-  version: "0.0.20",
+  version: "0.0.21",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     pipedriveApp,
     content: {

--- a/components/pipedrive/actions/get-all-leads/get-all-leads.mjs
+++ b/components/pipedrive/actions/get-all-leads/get-all-leads.mjs
@@ -4,8 +4,9 @@ export default {
   key: "pipedrive-get-all-leads",
   name: "Get All Leads",
   description: "Get all leads from Pipedrive. [See the documentation](https://developers.pipedrive.com/docs/api/v1/Leads#getLeads)",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/pipedrive/actions/list-deals/list-deals.mjs
+++ b/components/pipedrive/actions/list-deals/list-deals.mjs
@@ -5,8 +5,9 @@ export default {
   key: "pipedrive-list-deals",
   name: "List Deals",
   description: "List deals in your Pipedrive account. [See the documentation](https://developers.pipedrive.com/docs/api/v1/Deals#listDeals)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/pipedrive/actions/search-leads/search-leads.mjs
+++ b/components/pipedrive/actions/search-leads/search-leads.mjs
@@ -5,13 +5,14 @@ export default {
   key: "pipedrive-search-leads",
   name: "Search Leads",
   description: "Search for leads by name or email. [See the documentation](https://developers.pipedrive.com/docs/api/v1/Leads#searchLeads)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     pipedriveApp,
     term: {

--- a/components/pipedrive/actions/search-persons/search-persons.mjs
+++ b/components/pipedrive/actions/search-persons/search-persons.mjs
@@ -8,13 +8,14 @@ export default {
   key: "pipedrive-search-persons",
   name: "Search persons",
   description: "Searches all Persons by `name`, `email`, `phone`, `notes` and/or custom fields. This endpoint is a wrapper of `/v1/itemSearch` with a narrower OAuth scope. Found Persons can be filtered by Organization ID. See the Pipedrive API docs [here](https://developers.pipedrive.com/docs/api/v1/Persons#searchPersons)",
-  version: "0.1.25",
+  version: "0.1.26",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     pipedriveApp,
     term: {

--- a/components/pipedrive/actions/update-lead/update-lead.mjs
+++ b/components/pipedrive/actions/update-lead/update-lead.mjs
@@ -5,13 +5,14 @@ export default {
   key: "pipedrive-update-lead",
   name: "Update Lead",
   description: "Updates a lead in Pipedrive. [See the documentation](https://developers.pipedrive.com/docs/api/v1/Leads#updateLead)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     pipedriveApp,
     leadId: {

--- a/components/pipedrive/package.json
+++ b/components/pipedrive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/pipedrive",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Pipedream Pipedrive Components",
   "main": "pipedrive.app.mjs",
   "keywords": [

--- a/components/renderio/actions/delete-stored-file/delete-stored-file.mjs
+++ b/components/renderio/actions/delete-stored-file/delete-stored-file.mjs
@@ -4,13 +4,14 @@ export default {
   key: "renderio-delete-stored-file",
   name: "Delete Stored File",
   description: "Delete a stored file by ID. [See the documentation](https://renderio.dev/docs/api-reference/files/delete-file)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     renderio,
     fileId: {

--- a/components/renderio/actions/download-and-process-video-with-ytdlp/download-and-process-video-with-ytdlp.mjs
+++ b/components/renderio/actions/download-and-process-video-with-ytdlp/download-and-process-video-with-ytdlp.mjs
@@ -10,13 +10,14 @@ export default {
   key: "renderio-download-and-process-video-with-ytdlp",
   name: "Download and Process Video with yt-dlp",
   description: "Download publicly accessible videos with yt-dlp and optionally process them with FFmpeg. Use this to fetch videos from supported platforms and transform them, for example extract audio, resize, trim, or convert formats. Provide input URLs as a dictionary with `in_` prefixed keys; when processing with FFmpeg, provide output aliases with `out_` prefixes. [See the documentation](https://renderio.dev/docs/api-reference/commands/run-ytdlp-command)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     renderio,
     inputUrls: {

--- a/components/renderio/actions/download-video-with-ytdlp/download-video-with-ytdlp.mjs
+++ b/components/renderio/actions/download-video-with-ytdlp/download-video-with-ytdlp.mjs
@@ -10,13 +10,14 @@ export default {
   key: "renderio-download-video-with-ytdlp",
   name: "Download Video with yt-dlp",
   description: "Download publicly accessible videos from yt-dlp-supported platforms like YouTube, TikTok, Instagram, Vimeo, and Twitch without additional processing. Provide input URLs as a dictionary with `in_` prefixed keys, for example `{ \"in_video\": \"https://www.youtube.com/watch?v=dQw4w9WgXcQ\" }`. For download plus FFmpeg processing, use **Download and Process Video with yt-dlp** instead. [See the documentation](https://renderio.dev/docs/api-reference/commands/ytdlp-download)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     renderio,
     inputUrls: {

--- a/components/renderio/actions/execute-preset/execute-preset.mjs
+++ b/components/renderio/actions/execute-preset/execute-preset.mjs
@@ -8,13 +8,14 @@ export default {
   key: "renderio-execute-preset",
   name: "Execute Preset",
   description: "Execute a RenderIO preset with input files. [See the documentation](https://renderio.dev/docs/api-reference/presets/execute-preset)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     renderio,
     presetId: {

--- a/components/renderio/actions/get-ffmpeg-command-status/get-ffmpeg-command-status.mjs
+++ b/components/renderio/actions/get-ffmpeg-command-status/get-ffmpeg-command-status.mjs
@@ -4,13 +4,14 @@ export default {
   key: "renderio-get-ffmpeg-command-status",
   name: "Get FFmpeg Command Status",
   description: "Get the status and results of a previously submitted FFmpeg command. [See the documentation](https://renderio.dev/docs/api-reference/commands/get-command)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     renderio,
     commandId: {

--- a/components/renderio/actions/get-preset/get-preset.mjs
+++ b/components/renderio/actions/get-preset/get-preset.mjs
@@ -4,13 +4,14 @@ export default {
   key: "renderio-get-preset",
   name: "Get Preset",
   description: "Retrieve a preset by ID. [See the documentation](https://renderio.dev/docs/api-reference/presets/get-preset)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     renderio,
     presetId: {

--- a/components/renderio/actions/get-stored-file/get-stored-file.mjs
+++ b/components/renderio/actions/get-stored-file/get-stored-file.mjs
@@ -4,13 +4,14 @@ export default {
   key: "renderio-get-stored-file",
   name: "Get Stored File",
   description: "Retrieve a stored file by ID. [See the documentation](https://renderio.dev/docs/api-reference/files/get-file)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     renderio,
     fileId: {

--- a/components/renderio/actions/run-chained-ffmpeg-commands/run-chained-ffmpeg-commands.mjs
+++ b/components/renderio/actions/run-chained-ffmpeg-commands/run-chained-ffmpeg-commands.mjs
@@ -10,13 +10,14 @@ export default {
   key: "renderio-run-chained-ffmpeg-commands",
   name: "Run Chained FFmpeg Commands",
   description: "Execute multiple chained FFmpeg commands sequentially with shared input and output file specifications. [See the documentation](https://renderio.dev/docs/api-reference/commands/run-chained-commands)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     renderio,
     inputFiles: {

--- a/components/renderio/actions/run-ffmpeg-command/run-ffmpeg-command.mjs
+++ b/components/renderio/actions/run-ffmpeg-command/run-ffmpeg-command.mjs
@@ -16,13 +16,14 @@ export default {
   key: "renderio-run-ffmpeg-command",
   name: "Run FFmpeg Command",
   description: "Submit an FFmpeg command for processing with input and output file specifications. [See the documentation](https://renderio.dev/docs/api-reference/commands/run-ffmpeg-command)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     renderio,
     inputFiles: {

--- a/components/renderio/actions/run-multiple-ffmpeg-commands/run-multiple-ffmpeg-commands.mjs
+++ b/components/renderio/actions/run-multiple-ffmpeg-commands/run-multiple-ffmpeg-commands.mjs
@@ -9,13 +9,14 @@ export default {
   key: "renderio-run-multiple-ffmpeg-commands",
   name: "Run Multiple FFmpeg Commands",
   description: "Execute multiple independent FFmpeg commands in one request. [See the documentation](https://renderio.dev/docs/api-reference/commands/run-multiple-commands)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     renderio,
     commands: {

--- a/components/renderio/package.json
+++ b/components/renderio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/renderio",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream RenderIO Components",
   "main": "renderio.app.mjs",
   "keywords": [

--- a/components/returnista/actions/create-draft-return-order/create-draft-return-order.mjs
+++ b/components/returnista/actions/create-draft-return-order/create-draft-return-order.mjs
@@ -8,8 +8,9 @@ export default {
     + " Draft return orders are pending merchant review before being accepted or rejected."
     + " Use **Process Draft Return Order** to accept or reject the created draft."
     + " [See the documentation](https://platform.returnista.com/reference/rest-api/#post-/consumer/-consumerId-/draft-return-order)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/returnista/actions/create-return-location/create-return-location.mjs
+++ b/components/returnista/actions/create-return-location/create-return-location.mjs
@@ -9,8 +9,9 @@ export default {
     + " Optional: `suffix`, `stateProvinceCode`, `attention`, `contactName`."
     + " To update a location after creation, use **Update Return Location** with the returned ID."
     + " [See the documentation](https://platform.returnista.com/reference/rest-api/#post-/account/-accountId/return-location)",
-  version: "1.0.0",
+  version: "1.0.1",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/returnista/actions/get-consumer-purchases/get-consumer-purchases.mjs
+++ b/components/returnista/actions/get-consumer-purchases/get-consumer-purchases.mjs
@@ -7,8 +7,9 @@ export default {
     + " Useful for support workflows to understand what a consumer has purchased before they initiated a return."
     + " To find a consumer ID, use **Get Return Orders** with `expand: [\"consumer\"]` on a related return order — the consumer object will include the ID."
     + " [See the documentation](https://platform.returnista.com/reference/rest-api/#get-/consumer/-consumerId/purchases)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/returnista/actions/get-return-order-emails/get-return-order-emails.mjs
+++ b/components/returnista/actions/get-return-order-emails/get-return-order-emails.mjs
@@ -7,8 +7,9 @@ export default {
     + " Useful for support and audit workflows to see what emails were sent to the consumer during the return process."
     + " To find a return order ID, use **Get Return Orders** first."
     + " [See the documentation](https://platform.returnista.com/reference/rest-api/#get-/account/-accountId/return-order/-id/emails)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/returnista/actions/get-return-order/get-return-order.mjs
+++ b/components/returnista/actions/get-return-order/get-return-order.mjs
@@ -8,8 +8,9 @@ export default {
     + " To find a return order ID, use **Get Return Orders** first."
     + " To view the email communications for a return order, use **Get Return Order Emails**."
     + " [See the documentation](https://platform.returnista.com/reference/rest-api/#get-/account/-accountId/return-order/-id)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/returnista/actions/get-return-request/get-return-request.mjs
+++ b/components/returnista/actions/get-return-request/get-return-request.mjs
@@ -7,8 +7,9 @@ export default {
     + " Return requests contain item-level information: purchase order number, return reason, requested resolution (refund, exchange, etc.)."
     + " To find a return request ID, use **Get Return Requests** first."
     + " [See the documentation](https://platform.returnista.com/reference/rest-api/#get-/account/-accountId-/return-request/-id-)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/returnista/actions/process-draft-return-order/process-draft-return-order.mjs
+++ b/components/returnista/actions/process-draft-return-order/process-draft-return-order.mjs
@@ -8,8 +8,9 @@ export default {
     + " Set `action` to `accept` to approve the return (this triggers shipment label creation) or `reject` to decline it."
     + " Use **Get Return Orders** with `filter: \"status:draft\"` to find draft order IDs."
     + " [See the documentation](https://platform.returnista.com/reference/rest-api/#put-/account/-accountId/draft-return-order/-id/accept)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/returnista/actions/resend-confirmation-email/resend-confirmation-email.mjs
+++ b/components/returnista/actions/resend-confirmation-email/resend-confirmation-email.mjs
@@ -10,8 +10,9 @@ export default {
     + " Requires both an Account ID (from your Returnista dashboard settings) and a Return Order ID."
     + " Note: this triggers an immediate send — there is no scheduling or preview step."
     + " [See the documentation](https://platform.returnista.com/reference/rest-api/#get-/account/-accountId/return-order/-id/resend-confirmation-email)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/returnista/actions/update-return-location/update-return-location.mjs
+++ b/components/returnista/actions/update-return-location/update-return-location.mjs
@@ -10,8 +10,9 @@ export default {
     + " To find the return location ID, use **Get Return Locations**."
     + " Use a two-letter ISO 3166-1 alpha-2 country code for `countryCode` (e.g., `NL`, `DE`, `GB`, `US`)."
     + " [See the documentation](https://platform.returnista.com/reference/rest-api/#patch-/account/-accountId/return-location/-returnLocationId)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/returnista/package.json
+++ b/components/returnista/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/returnista",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Pipedream Returnista Components",
   "main": "returnista.app.mjs",
   "keywords": [

--- a/components/rydoo/actions/add-new-user/add-new-user.mjs
+++ b/components/rydoo/actions/add-new-user/add-new-user.mjs
@@ -4,8 +4,9 @@ export default {
   key: "rydoo-add-new-user",
   name: "Add New User",
   description: "Creates a new employee record in the company directory. [See the documentation](https://developers.rydoo.com/reference/v2useradduser)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/rydoo/actions/create-bank-transaction/create-bank-transaction.mjs
+++ b/components/rydoo/actions/create-bank-transaction/create-bank-transaction.mjs
@@ -5,8 +5,9 @@ export default {
   key: "rydoo-create-bank-transaction",
   name: "Create Bank Transaction",
   description: "Manually pushes a bank transaction record for a specific user. [See the documentation](https://developers.rydoo.com/reference/v2transactionsaddtransaction)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/rydoo/actions/create-project/create-project.mjs
+++ b/components/rydoo/actions/create-project/create-project.mjs
@@ -4,8 +4,9 @@ export default {
   key: "rydoo-create-project",
   name: "Create Project",
   description: "Sets up a new company project for expense allocation. [See the documentation](https://developers.rydoo.com/reference/v2projectsaddproject)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/rydoo/actions/create-trip/create-trip.mjs
+++ b/components/rydoo/actions/create-trip/create-trip.mjs
@@ -5,8 +5,9 @@ export default {
   key: "rydoo-create-trip",
   name: "Create Trip",
   description: "Registers a new business trip for a specific user. [See the documentation](https://developers.rydoo.com/reference/v2tripsaddtrip)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/rydoo/actions/export-expenses/export-expenses.mjs
+++ b/components/rydoo/actions/export-expenses/export-expenses.mjs
@@ -4,8 +4,9 @@ export default {
   key: "rydoo-export-expenses",
   name: "Export Expenses",
   description: "Retrieves a list of expenses that have been exported, with optional filtering by date range, user, group, trip, or branch. [See the documentation](https://developers.rydoo.com/reference/v2expensesgetexportedexpenses)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/rydoo/actions/find-group/find-group.mjs
+++ b/components/rydoo/actions/find-group/find-group.mjs
@@ -4,8 +4,9 @@ export default {
   key: "rydoo-find-group",
   name: "Find Group",
   description: "Searches for organizational groups by name to find their UUIDs. [See the documentation](https://developers.rydoo.com/reference/v2groupsgetgroups)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/rydoo/actions/search-branches/search-branches.mjs
+++ b/components/rydoo/actions/search-branches/search-branches.mjs
@@ -4,8 +4,9 @@ export default {
   key: "rydoo-search-branches",
   name: "Search Branches",
   description: "Finds branches by name, ID, or active status. [See the documentation](https://developers.rydoo.com/reference/v2branchgetbranches)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/rydoo/actions/search-payment-methods/search-payment-methods.mjs
+++ b/components/rydoo/actions/search-payment-methods/search-payment-methods.mjs
@@ -4,8 +4,9 @@ export default {
   key: "rydoo-search-payment-methods",
   name: "Search Payment Methods",
   description: "Finds payment methods by type, branch, card type, status, and more. [See the documentation](https://web-services.rydoo.com/index.html)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/rydoo/actions/search-projects/search-projects.mjs
+++ b/components/rydoo/actions/search-projects/search-projects.mjs
@@ -4,8 +4,9 @@ export default {
   key: "rydoo-search-projects",
   name: "Search Projects",
   description: "Finds active projects by name or reference ID. [See the documentation](https://developers.rydoo.com/reference/v2projectsgetprojects)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/rydoo/actions/search-trips/search-trips.mjs
+++ b/components/rydoo/actions/search-trips/search-trips.mjs
@@ -4,8 +4,9 @@ export default {
   key: "rydoo-search-trips",
   name: "Search Trips",
   description: "Finds trips by user, status, or name. [See the documentation](https://developers.rydoo.com/reference/v2tripsgettrips)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/rydoo/actions/search-user/search-user.mjs
+++ b/components/rydoo/actions/search-user/search-user.mjs
@@ -4,8 +4,9 @@ export default {
   key: "rydoo-search-user",
   name: "Search User",
   description: "Searches for users by email, first name, last name, free-text, card status, or external ID. [See the documentation](https://developers.rydoo.com/reference/v2usersearchuser)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/rydoo/actions/update-user-profile/update-user-profile.mjs
+++ b/components/rydoo/actions/update-user-profile/update-user-profile.mjs
@@ -4,8 +4,9 @@ export default {
   key: "rydoo-update-user-profile",
   name: "Update User Profile",
   description: "Modifies existing user details like names, nationality, or status. [See the documentation](https://developers.rydoo.com/reference/v2userupdateuser)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/rydoo/package.json
+++ b/components/rydoo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/rydoo",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Rydoo Components",
   "main": "rydoo.app.mjs",
   "keywords": [

--- a/components/servicem8/actions/create-badge/create-badge.mjs
+++ b/components/servicem8/actions/create-badge/create-badge.mjs
@@ -4,13 +4,14 @@ export default {
   key: "servicem8-create-badge",
   name: "Create Badge",
   description: "Create a badge. [See the documentation](https://developer.servicem8.com/reference/createbadges)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     servicem8,
     name: {

--- a/components/servicem8/actions/create-company-contact/create-company-contact.mjs
+++ b/components/servicem8/actions/create-company-contact/create-company-contact.mjs
@@ -5,13 +5,14 @@ export default {
   key: "servicem8-create-company-contact",
   name: "Create Company Contact",
   description: "Create a company contact. [See the documentation](https://developer.servicem8.com/reference/createcompanycontacts)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     servicem8,
     companyUuid: {

--- a/components/servicem8/actions/create-job-material/create-job-material.mjs
+++ b/components/servicem8/actions/create-job-material/create-job-material.mjs
@@ -5,13 +5,14 @@ export default {
   key: "servicem8-create-job-material",
   name: "Create Job Material",
   description: "Create a job material line. [See the documentation](https://developer.servicem8.com/reference/createjobmaterials)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     servicem8,
     jobUuid: {

--- a/components/servicem8/actions/create-queue/create-queue.mjs
+++ b/components/servicem8/actions/create-queue/create-queue.mjs
@@ -9,13 +9,14 @@ export default {
   key: "servicem8-create-queue",
   name: "Create Job Queue",
   description: "Create a job queue. [See the documentation](https://developer.servicem8.com/reference/createjobqueues)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     servicem8,
     name: {

--- a/components/servicem8/actions/create-webhook-subscription/create-webhook-subscription.mjs
+++ b/components/servicem8/actions/create-webhook-subscription/create-webhook-subscription.mjs
@@ -4,13 +4,14 @@ export default {
   key: "servicem8-create-webhook-subscription",
   name: "Create Webhook Subscription",
   description: "Create or update an object webhook subscription. [See the documentation](https://developer.servicem8.com/reference/post_object_webhook_subscription)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     servicem8: app,
     callbackUrl: {

--- a/components/servicem8/actions/make-api-request/make-api-request.mjs
+++ b/components/servicem8/actions/make-api-request/make-api-request.mjs
@@ -7,13 +7,14 @@ export default {
   key: "servicem8-make-api-request",
   name: "Make API Request",
   description: `Send an authenticated ServiceM8 API request. [See the documentation](${DOCS})`,
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     servicem8: app,
     method: {

--- a/components/servicem8/actions/produce-invoice/produce-invoice.mjs
+++ b/components/servicem8/actions/produce-invoice/produce-invoice.mjs
@@ -11,13 +11,14 @@ export default {
   key: "servicem8-produce-invoice",
   name: "Produce Invoice",
   description: `Generate a job invoice (PDF, DOCX, or JPG). [See the documentation](${DOCS})`,
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     servicem8,
     jobUuid: {

--- a/components/servicem8/actions/produce-quote/produce-quote.mjs
+++ b/components/servicem8/actions/produce-quote/produce-quote.mjs
@@ -11,13 +11,14 @@ export default {
   key: "servicem8-produce-quote",
   name: "Produce Quote",
   description: `Generate a job quote (PDF, DOCX, or JPG). [See the documentation](${DOCS})`,
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     servicem8,
     jobUuid: {

--- a/components/servicem8/actions/send-email/send-email.mjs
+++ b/components/servicem8/actions/send-email/send-email.mjs
@@ -5,13 +5,14 @@ export default {
   key: "servicem8-send-email",
   name: "Send Email",
   description: "Send an email via the Messaging API. [See the documentation](https://developer.servicem8.com/reference/send_email)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     servicem8: app,
     to: {

--- a/components/servicem8/actions/send-sms/send-sms.mjs
+++ b/components/servicem8/actions/send-sms/send-sms.mjs
@@ -4,13 +4,14 @@ export default {
   key: "servicem8-send-sms",
   name: "Send SMS",
   description: "Send an SMS via the Messaging API (charges may apply). [See the documentation](https://developer.servicem8.com/reference/send_sms)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     servicem8: app,
     to: {

--- a/components/servicem8/actions/update-badge/update-badge.mjs
+++ b/components/servicem8/actions/update-badge/update-badge.mjs
@@ -5,13 +5,14 @@ export default {
   key: "servicem8-update-badge",
   name: "Update Badge",
   description: "Update a badge (loads the record, merges your fields, then POSTs). [See the documentation](https://developer.servicem8.com/reference/updatebadges)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     servicem8,
     uuid: {

--- a/components/servicem8/actions/update-company-contact/update-company-contact.mjs
+++ b/components/servicem8/actions/update-company-contact/update-company-contact.mjs
@@ -5,13 +5,14 @@ export default {
   key: "servicem8-update-company-contact",
   name: "Update Company Contact",
   description: "Update a company contact (loads the record, merges your fields, then POSTs). [See the documentation](https://developer.servicem8.com/reference/updatecompanycontacts)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     servicem8,
     uuid: {

--- a/components/servicem8/actions/update-job-material/update-job-material.mjs
+++ b/components/servicem8/actions/update-job-material/update-job-material.mjs
@@ -5,13 +5,14 @@ export default {
   key: "servicem8-update-job-material",
   name: "Update Job Material",
   description: "Update a job material line (loads the record, merges your fields, then POSTs). [See the documentation](https://developer.servicem8.com/reference/updatejobmaterials)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     servicem8,
     uuid: {

--- a/components/servicem8/actions/update-queue/update-queue.mjs
+++ b/components/servicem8/actions/update-queue/update-queue.mjs
@@ -9,13 +9,14 @@ export default {
   key: "servicem8-update-queue",
   name: "Update Job Queue",
   description: "Update a job queue (loads the record, merges your fields, then POSTs). [See the documentation](https://developer.servicem8.com/reference/updatejobqueues)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     servicem8,
     uuid: {

--- a/components/servicem8/package.json
+++ b/components/servicem8/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/servicem8",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream ServiceM8 Components",
   "main": "servicem8.app.mjs",
   "keywords": [

--- a/components/strava/actions/create-activity/create-activity.mjs
+++ b/components/strava/actions/create-activity/create-activity.mjs
@@ -9,8 +9,9 @@ export default {
     + " Pass `sportType` from Strava's documented `sport_type` enum (modern field, replaces legacy `type`). Common values: Run, Ride, Hike, Swim, Walk, Workout, Yoga."
     + " `startDateLocal` must be ISO 8601 in the athlete's local time with timezone offset or `Z` for UTC. Example: `2026-05-15T07:00:00Z`."
     + " [See the documentation](https://developers.strava.com/docs/reference/#api-Activities-createActivity)",
-  version: "1.0.0",
+  version: "1.0.1",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/strava/actions/get-activity-comments/get-activity-comments.mjs
+++ b/components/strava/actions/get-activity-comments/get-activity-comments.mjs
@@ -8,8 +8,9 @@ export default {
     + " Use `pageSize` to control the per-page result count (Strava default and max apply). Empty array if no one has commented."
     + " Returns `{ comments, _rateLimitUsage }` — `_rateLimitUsage` exposes Strava's rate-limit headers for observability."
     + " [See the documentation](https://developers.strava.com/docs/reference/#api-Activities-getCommentsByActivityId)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/strava/actions/get-activity-kudoers/get-activity-kudoers.mjs
+++ b/components/strava/actions/get-activity-kudoers/get-activity-kudoers.mjs
@@ -8,8 +8,9 @@ export default {
     + " Empty array if no one has kudosed the activity."
     + " Returns `{ kudoers, _rateLimitUsage }` — `_rateLimitUsage` exposes Strava's rate-limit headers for observability."
     + " [See the documentation](https://developers.strava.com/docs/reference/#api-Activities-getKudoersByActivityId)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/strava/actions/get-activity-laps/get-activity-laps.mjs
+++ b/components/strava/actions/get-activity-laps/get-activity-laps.mjs
@@ -8,8 +8,9 @@ export default {
     + " Note: manually-created activities and some sport types may have no laps; the response will be an empty array in that case (not an error)."
     + " Returns `{ laps, _rateLimitUsage }` — `_rateLimitUsage` includes Strava's `X-RateLimit-Usage` and `X-ReadRateLimit-Usage` so flows can observe approach to the rate-limit cap."
     + " [See the documentation](https://developers.strava.com/docs/reference/#api-Activities-getLapsByActivityId)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/strava/actions/get-activity/get-activity.mjs
+++ b/components/strava/actions/get-activity/get-activity.mjs
@@ -8,8 +8,9 @@ export default {
     + " Set `includeAllEfforts` to `true` to include all segment efforts (slower, larger response — leave false for most reads)."
     + " For sub-resources (comments, kudos, laps), use the dedicated tools: **Get Activity Comments**, **Get Activity Kudoers**, **Get Activity Laps**."
     + " [See the documentation](https://developers.strava.com/docs/reference/#api-Activities-getActivityById)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/strava/actions/get-athlete-stats/get-athlete-stats.mjs
+++ b/components/strava/actions/get-athlete-stats/get-athlete-stats.mjs
@@ -7,8 +7,9 @@ export default {
     + " By default, resolves the authenticated athlete's ID automatically (no input needed). Pass `athleteId` to look up another athlete's publicly-visible stats instead."
     + " Stats only include activities the requesting user has permission to view. For private activities of another athlete, results will be limited."
     + " [See the documentation](https://developers.strava.com/docs/reference/#api-Athletes-getStats)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/strava/actions/get-authenticated-athlete/get-authenticated-athlete.mjs
+++ b/components/strava/actions/get-authenticated-athlete/get-authenticated-athlete.mjs
@@ -7,8 +7,9 @@ export default {
     + " Use this whenever you need to know who the connected user is, or to surface the athlete ID for downstream tools."
     + " Note: a detailed athlete representation requires the `profile:read_all` scope, which is not configured for this connector. This tool returns the summary representation."
     + " [See the documentation](https://developers.strava.com/docs/reference/#api-Athletes-getLoggedInAthlete)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/strava/actions/get-stats/get-stats.mjs
+++ b/components/strava/actions/get-stats/get-stats.mjs
@@ -4,13 +4,14 @@ export default {
   name: "Get Stats",
   description: "Returns the activity stats of an athlete. Only includes data from activities set to Everyone visibilty. [See the docs](https://developers.strava.com/docs/reference/#api-Athletes-getStats)",
   key: "strava-get-stats",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     strava,
   },

--- a/components/strava/actions/search-activities/search-activities.mjs
+++ b/components/strava/actions/search-activities/search-activities.mjs
@@ -11,8 +11,9 @@ export default {
     + " Cross-references: use **Get Activity** to fetch a single activity's full details, **Get Activity Laps** for lap breakdowns, **Get Activity Comments** for comments, **Get Activity Kudoers** for kudos."
     + " Strava read rate limits: 600 / 15 min and 30,000 / day per application. Large unfiltered fetches consume quota — prefer `after` for incremental work."
     + " [See the documentation](https://developers.strava.com/docs/reference/#api-Activities-getLoggedInAthleteActivities)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/strava/actions/update-activity/update-activity.mjs
+++ b/components/strava/actions/update-activity/update-activity.mjs
@@ -9,8 +9,9 @@ export default {
     + " Only fields you provide are updated; omitted fields are left unchanged."
     + " `sportType` uses Strava's modern `sport_type` enum (not the legacy `type` field)."
     + " [See the documentation](https://developers.strava.com/docs/reference/#api-Activities-updateActivityById)",
-  version: "1.0.0",
+  version: "1.0.1",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/strava/package.json
+++ b/components/strava/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/strava",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Pipedream Strava Components",
   "main": "strava.app.mjs",
   "keywords": [

--- a/components/tiktok_ads_manager/actions/create-audience/create-audience.mjs
+++ b/components/tiktok_ads_manager/actions/create-audience/create-audience.mjs
@@ -16,8 +16,9 @@ export default {
     + " `identifier_type` controls the hash format: `EMAIL_SHA256` for hashed emails, `PHONE_SHA256` for hashed phone numbers, `IDFA_SHA256` or `GAID_SHA256` for device IDs."
     + " To add members to an existing audience, use **Update Audience** instead."
     + " [See the documentation](https://business-api.tiktok.com/portal/docs/create-an-audience-by-file/v1.3)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/tiktok_ads_manager/actions/create-lookalike-audience/create-lookalike-audience.mjs
+++ b/components/tiktok_ads_manager/actions/create-lookalike-audience/create-lookalike-audience.mjs
@@ -11,8 +11,9 @@ export default {
     + " Location IDs: `6252001` = United States, `6269131` = United Kingdom."
     + " Newly created audiences require up to 48 hours to be analyzed before they become active."
     + " [See the documentation](https://business-api.tiktok.com/portal/docs/create-a-lookalike-audience/v1.3)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/tiktok_ads_manager/actions/create-or-update-ad-group/create-or-update-ad-group.mjs
+++ b/components/tiktok_ads_manager/actions/create-or-update-ad-group/create-or-update-ad-group.mjs
@@ -11,8 +11,9 @@ export default {
     + " Use campaign IDs from **Create or Update Campaign** or **List Campaigns**."
     + " For create, see [documentation](https://business-api.tiktok.com/portal/docs/create-an-ad-group-reference/v1.3)."
     + " For update, see [documentation](https://business-api.tiktok.com/portal/docs/update-an-ad-group/v1.3).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/tiktok_ads_manager/actions/create-or-update-ad/create-or-update-ad.mjs
+++ b/components/tiktok_ads_manager/actions/create-or-update-ad/create-or-update-ad.mjs
@@ -10,8 +10,9 @@ export default {
     + " `identity_type` and `identity_id` are required in v1.3; use `CUSTOMIZED_USER` for non-Spark Ads."
     + " For create, see [documentation](https://business-api.tiktok.com/portal/docs/create-ads/v1.3)."
     + " For update, see [documentation](https://business-api.tiktok.com/portal/docs/update-ads/v1.3).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/tiktok_ads_manager/actions/create-or-update-campaign/create-or-update-campaign.mjs
+++ b/components/tiktok_ads_manager/actions/create-or-update-campaign/create-or-update-campaign.mjs
@@ -11,8 +11,9 @@ export default {
     + " After creating a campaign, use **Create or Update Ad Group** to add targeting and budget."
     + " For create, see [documentation](https://business-api.tiktok.com/portal/docs/create-a-campaign/v1.3)."
     + " For update, see [documentation](https://business-api.tiktok.com/portal/docs/update-a-campaign/v1.3).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/tiktok_ads_manager/actions/get-advertiser-info/get-advertiser-info.mjs
+++ b/components/tiktok_ads_manager/actions/get-advertiser-info/get-advertiser-info.mjs
@@ -8,8 +8,9 @@ export default {
     + " Returns account details (name, currency, timezone, status) for the given advertiser ID."
     + " Find your advertiser ID in the TikTok Ads Manager URL after `aadvid=`."
     + " [See the documentation](https://business-api.tiktok.com/portal/docs/get-authorized-ad-accounts/v1.3).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/tiktok_ads_manager/actions/get-report/get-report.mjs
+++ b/components/tiktok_ads_manager/actions/get-report/get-report.mjs
@@ -11,8 +11,9 @@ export default {
     + " `dimensions` must include an entity ID dimension for the chosen level (`campaign_id`, `adgroup_id`, or `ad_id`) plus a time dimension (`stat_time_day` or `stat_time_hour`)."
     + " Common metrics: `impressions`, `clicks`, `spend`, `cpc`, `cpm`, `ctr`, `reach`, `conversion`, `cost_per_conversion`."
     + " [See the documentation](https://business-api.tiktok.com/portal/docs/run-a-synchronous-report/v1.3)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/tiktok_ads_manager/actions/list-ad-groups/list-ad-groups.mjs
+++ b/components/tiktok_ads_manager/actions/list-ad-groups/list-ad-groups.mjs
@@ -8,8 +8,9 @@ export default {
     + " Returns ad group IDs, names, status, budget, schedule, and targeting."
     + " Use campaign IDs from **List Campaigns** to filter. Use ad group IDs returned here as input to **List Ads** or **Create or Update Ad**."
     + " [See the documentation](https://business-api.tiktok.com/portal/docs/get-ad-groups/v1.3)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/tiktok_ads_manager/actions/list-ads/list-ads.mjs
+++ b/components/tiktok_ads_manager/actions/list-ads/list-ads.mjs
@@ -8,8 +8,9 @@ export default {
     + " Returns ad IDs, names, status, and creative details."
     + " Use campaign or ad group IDs from **List Campaigns** / **List Ad Groups** to narrow results."
     + " [See the documentation](https://business-api.tiktok.com/portal/docs/get-ads/v1.3)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/tiktok_ads_manager/actions/list-audiences/list-audiences.mjs
+++ b/components/tiktok_ads_manager/actions/list-audiences/list-audiences.mjs
@@ -9,8 +9,9 @@ export default {
     + " Returns both owned and shared audiences — use `is_creator` in the response to check ownership."
     + " Use audience IDs returned here as input to **Update Audience** or **Create Lookalike Audience**."
     + " [See the documentation](https://business-api.tiktok.com/portal/docs/get-all-audiences/v1.3)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/tiktok_ads_manager/actions/list-campaigns/list-campaigns.mjs
+++ b/components/tiktok_ads_manager/actions/list-campaigns/list-campaigns.mjs
@@ -8,8 +8,9 @@ export default {
     + " Returns campaign IDs, names, status, objective, and budget."
     + " Use campaign IDs returned here as input to **List Ad Groups** or **Get Report**."
     + " [See the documentation](https://business-api.tiktok.com/portal/docs/get-campaigns/v1.3)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/tiktok_ads_manager/actions/manage-spark-ad/manage-spark-ad.mjs
+++ b/components/tiktok_ads_manager/actions/manage-spark-ad/manage-spark-ad.mjs
@@ -10,8 +10,9 @@ export default {
     + " Pass either `item_id` (single post) or `item_ids` (up to 20 posts)."
     + " Pass the returned `item_id` to **Create or Update Ad** as `tiktok_item_id` to create a Spark Ad."
     + " [See the documentation](https://business-api.tiktok.com/portal/docs/get-info-about-tiktok-posts/v1.3)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/tiktok_ads_manager/actions/send-conversion-event/send-conversion-event.mjs
+++ b/components/tiktok_ads_manager/actions/send-conversion-event/send-conversion-event.mjs
@@ -11,8 +11,9 @@ export default {
     + " User identifiers (`email`, `phone_number`, `external_id`) must be SHA256-hashed before passing."
     + " `timestamp` uses ISO 8601 format (e.g., `2024-01-15T19:49:27Z`). Defaults to current time if omitted."
     + " [See the documentation](https://business-api.tiktok.com/portal/docs/report-web-events-in-bulk/v1.3)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/tiktok_ads_manager/actions/update-audience/update-audience.mjs
+++ b/components/tiktok_ads_manager/actions/update-audience/update-audience.mjs
@@ -15,8 +15,9 @@ export default {
     + " Audience size must remain ≥ 1,000 after the operation."
     + " Use **List Audiences** to find the `audience_id`."
     + " [See the documentation](https://business-api.tiktok.com/portal/docs/update-an-audience/v1.3)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/tiktok_ads_manager/actions/upload-creative/upload-creative.mjs
+++ b/components/tiktok_ads_manager/actions/upload-creative/upload-creative.mjs
@@ -15,8 +15,9 @@ export default {
     + " Supported image formats: JPG, JPEG, PNG. Supported video formats: MP4, MOV, MPEG, AVI."
     + " For images, see [See the documentation](https://business-api.tiktok.com/portal/docs/upload-an-image-reference/v1.3)."
     + " For videos, see [See the documentation](https://business-api.tiktok.com/portal/docs/upload-a-video/v1.3).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/tiktok_ads_manager/package.json
+++ b/components/tiktok_ads_manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/tiktok_ads_manager",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream TikTok Ads Manager Components",
   "main": "tiktok_ads_manager.app.mjs",
   "keywords": [

--- a/components/zendesk/actions/create-side-conversation/create-side-conversation.mjs
+++ b/components/zendesk/actions/create-side-conversation/create-side-conversation.mjs
@@ -4,8 +4,9 @@ export default {
   key: "zendesk-create-side-conversation",
   name: "Create Side Conversation",
   description: "Create a side conversation on a Zendesk ticket using email, Zendesk agent, Slack, Microsoft Teams, or child-ticket participants. Requires the Zendesk Collaboration add-on. Use **List Side Conversations** to inspect existing conversations. [See the documentation](https://developer.zendesk.com/api-reference/ticketing/side_conversation/side_conversation/#create-side-conversation)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/zendesk/actions/get-dynamic-content-item/get-dynamic-content-item.mjs
+++ b/components/zendesk/actions/get-dynamic-content-item/get-dynamic-content-item.mjs
@@ -4,13 +4,14 @@ export default {
   key: "zendesk-get-dynamic-content-item",
   name: "Get Dynamic Content Item",
   description: "Retrieves a dynamic content item. Note: Dynamic content is available only on the Professional plan and above. [See the documentation](https://developer.zendesk.com/api-reference/ticketing/ticket-management/dynamic_content/#show-item).",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     zendesk,
     itemId: {

--- a/components/zendesk/actions/get-dynamic-content-items-by-name/get-dynamic-content-items-by-name.mjs
+++ b/components/zendesk/actions/get-dynamic-content-items-by-name/get-dynamic-content-items-by-name.mjs
@@ -4,13 +4,14 @@ export default {
   key: "zendesk-get-dynamic-content-items-by-name",
   name: "Get Dynamic Content Items by Name",
   description: "Retrieves multiple dynamic content items by their names. Note: Dynamic content is available only on the Professional plan and above. [See the documentation](https://developer.zendesk.com/api-reference/ticketing/ticket-management/dynamic_content/#show-many-items).",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     zendesk,
     itemNames: {

--- a/components/zendesk/actions/get-side-conversation/get-side-conversation.mjs
+++ b/components/zendesk/actions/get-side-conversation/get-side-conversation.mjs
@@ -4,13 +4,14 @@ export default {
   key: "zendesk-get-side-conversation",
   name: "Get Side Conversation",
   description: "Retrieve a single Zendesk side conversation by ID (UUID, e.g. `8566255a-ece5-11e8-857d-493066fa7b17`). Use **List Side Conversations** to discover IDs for a given ticket. Set `includeEvents` to `true` to sideload the conversation's events (creation, replies, state changes). [See the documentation](https://developer.zendesk.com/api-reference/ticketing/side_conversation/side_conversation/#show-side-conversation).",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     zendesk,
     ticketId: {

--- a/components/zendesk/actions/list-active-macros/list-active-macros.mjs
+++ b/components/zendesk/actions/list-active-macros/list-active-macros.mjs
@@ -6,7 +6,8 @@ export default {
   name: "List Active Macros",
   description: "Lists all active shared and personal macros available to the current user. [See the documentation](https://developer.zendesk.com/api-reference/ticketing/business-rules/macros/#list-active-macros).",
   type: "action",
-  version: "0.0.10",
+  ai: "optimized",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zendesk/actions/list-dynamic-content-items/list-dynamic-content-items.mjs
+++ b/components/zendesk/actions/list-dynamic-content-items/list-dynamic-content-items.mjs
@@ -5,13 +5,14 @@ export default {
   key: "zendesk-list-dynamic-content-items",
   name: "List Dynamic Content Items",
   description: "Retrieves a list of dynamic content items. Note: Dynamic content is available only on the Professional plan and above. [See the documentation](https://developer.zendesk.com/api-reference/ticketing/ticket-management/dynamic_content/#list-items).",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     zendesk,
     pageSize: {

--- a/components/zendesk/actions/list-side-conversations/list-side-conversations.mjs
+++ b/components/zendesk/actions/list-side-conversations/list-side-conversations.mjs
@@ -4,13 +4,14 @@ export default {
   key: "zendesk-list-side-conversations",
   name: "List Side Conversations",
   description: "Retrieve all side conversations on a Zendesk ticket. Side conversations are collaboration threads attached to a ticket (email, Slack, Microsoft Teams, or linked child tickets). Use **Get Side Conversation** to fetch a single side conversation by ID. Set `includeEvents` to `true` to sideload each conversation's events (creation, replies, state changes). [See the documentation](https://developer.zendesk.com/api-reference/ticketing/side_conversation/side_conversation/#list-side-conversations).",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     zendesk,
     ticketId: {

--- a/components/zendesk/actions/reply-to-side-conversation/reply-to-side-conversation.mjs
+++ b/components/zendesk/actions/reply-to-side-conversation/reply-to-side-conversation.mjs
@@ -4,8 +4,9 @@ export default {
   key: "zendesk-reply-to-side-conversation",
   name: "Reply to Side Conversation",
   description: "Reply to an existing Zendesk side conversation. Zendesk requires recipients on every reply, so pass the participants the reply should go to. [See the documentation](https://developer.zendesk.com/api-reference/ticketing/side_conversation/side_conversation/#reply-to-side-conversation)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/zendesk/actions/search-articles/search-articles.mjs
+++ b/components/zendesk/actions/search-articles/search-articles.mjs
@@ -6,7 +6,8 @@ export default {
   name: "Search Articles",
   description: "Searches Help Center articles. [See the documentation](https://developer.zendesk.com/api-reference/help_center/help-center-api/search/).",
   type: "action",
-  version: "0.0.8",
+  ai: "optimized",
+  version: "0.0.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zendesk/actions/search-community-posts/search-community-posts.mjs
+++ b/components/zendesk/actions/search-community-posts/search-community-posts.mjs
@@ -5,7 +5,8 @@ export default {
   name: "Search Community Posts",
   description: "Searches Help Center community posts. [See the documentation](https://developer.zendesk.com/api-reference/help_center/help-center-api/search/).",
   type: "action",
-  version: "0.0.8",
+  ai: "optimized",
+  version: "0.0.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zendesk/actions/search-help-center/search-help-center.mjs
+++ b/components/zendesk/actions/search-help-center/search-help-center.mjs
@@ -6,7 +6,8 @@ export default {
   name: "Search Help Center",
   description: "Searches across knowledge base articles, community posts, and external records using the Zendesk unified Guide search. [See the documentation](https://developer.zendesk.com/api-reference/help_center/help-center-api/search/).",
   type: "action",
-  version: "0.0.8",
+  ai: "optimized",
+  version: "0.0.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zendesk/actions/search-tickets/search-tickets.mjs
+++ b/components/zendesk/actions/search-tickets/search-tickets.mjs
@@ -5,7 +5,8 @@ export default {
   name: "Search Tickets",
   description: "Searches for tickets using Zendesk's search API. [See the documentation](https://developer.zendesk.com/api-reference/ticketing/ticket-management/search/#search-tickets).",
   type: "action",
-  version: "0.0.19",
+  ai: "optimized",
+  version: "0.0.20",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zendesk/actions/set-custom-ticket-fields/set-custom-ticket-fields.mjs
+++ b/components/zendesk/actions/set-custom-ticket-fields/set-custom-ticket-fields.mjs
@@ -7,7 +7,8 @@ export default {
   name: "Set Custom Ticket Fields",
   description: "Sets one or more custom field values on a ticket. [See the documentation](https://developer.zendesk.com/api-reference/ticketing/tickets/tickets/#update-ticket).",
   type: "action",
-  version: "0.0.13",
+  ai: "optimized",
+  version: "0.0.14",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zendesk/actions/update-side-conversation/update-side-conversation.mjs
+++ b/components/zendesk/actions/update-side-conversation/update-side-conversation.mjs
@@ -6,8 +6,9 @@ export default {
   key: "zendesk-update-side-conversation",
   name: "Update Side Conversation",
   description: "Update the state or subject of a Zendesk side conversation. [See the documentation](https://developer.zendesk.com/api-reference/ticketing/side_conversation/side_conversation/#update-side-conversation)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/zendesk/actions/upload-ticket-attachments/upload-ticket-attachments.mjs
+++ b/components/zendesk/actions/upload-ticket-attachments/upload-ticket-attachments.mjs
@@ -6,7 +6,8 @@ export default {
   description:
     "Upload one or more files as ticket attachments via the Zendesk Uploads API. Returns upload tokens that can be used when creating or updating tickets. [See the documentation](https://developer.zendesk.com/api-reference/ticketing/tickets/ticket-attachments/#upload-files).",
   type: "action",
-  version: "0.0.5",
+  ai: "optimized",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zendesk/package.json
+++ b/components/zendesk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/zendesk",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "Pipedream Zendesk Components",
   "main": "zendesk.app.mjs",
   "keywords": [


### PR DESCRIPTION
Continuation of the DJ-4272 AI-optimized backfill, sourced from the product team's AI-optimized actions list (Aug 11 2026). Sets the top-level `ai: "optimized"` field on AI-optimized action components not covered by the earlier allowlist∪marker backfill.

**Batch 2 of 7** — 200 components across 20 apps. Each component gets the `ai` field plus a patch version bump; each app's `package.json` is bumped (`check_version` gate). Batches cover disjoint apps and can merge independently in any order.

Apps: _302_ai,asana codex,databricks dataforseo,docusign eppo,linkupapi luma,microsoft_outlook mindbody,pipedream_utils pipedrive,renderio returnista,rydoo servicem8,strava tiktok_ads_manager,zendesk