### PR TITLE
feat(ai): mark AI-optimized components with `ai` field (batch 7/7)

### DIFF
--- a/components/_2markdown/package.json
+++ b/components/_2markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/_2markdown",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Pipedream 2markdown Components",
   "main": "_2markdown.app.mjs",
   "keywords": [

--- a/components/deel/package.json
+++ b/components/deel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/deel",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream Deel Components",
   "main": "deel.app.mjs",
   "keywords": [

--- a/components/enrich_layer/package.json
+++ b/components/enrich_layer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/enrich_layer",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream Enrich Layer Components",
   "main": "enrich_layer.app.mjs",
   "keywords": [

--- a/components/hedy/actions/create-topic/create-topic.mjs
+++ b/components/hedy/actions/create-topic/create-topic.mjs
@@ -7,7 +7,7 @@ export default {
     + " Topics can include a custom AI analysis context (`topicContext`) — up to 20,000 characters of instructions that guide Hedy's AI when analyzing meetings in this topic."
     + " Use **Update Topic** to modify an existing topic, or **Delete Topic** to remove one."
     + " [See the documentation](https://app.swaggerhub.com/apis-docs/HedyAI/hedy-api/1.5.2#/Topics/post_topics)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   ai: "optimized",
   annotations: {

--- a/components/hedy/actions/delete-topic/delete-topic.mjs
+++ b/components/hedy/actions/delete-topic/delete-topic.mjs
@@ -6,7 +6,7 @@ export default {
   description: "Deletes a Hedy topic. Sessions that were linked to the topic are NOT deleted — they are unlinked and remain in your account."
     + " This action is irreversible. Use **Get Many Topics** to find the topic ID before deleting."
     + " [See the documentation](https://app.swaggerhub.com/apis-docs/HedyAI/hedy-api/1.5.2#/Topics/delete_topics__topicId_)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   ai: "optimized",
   annotations: {

--- a/components/hedy/package.json
+++ b/components/hedy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/hedy",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream Hedy Components",
   "main": "hedy.app.mjs",
   "keywords": [

--- a/components/hubspot/actions/get-meeting-link-booking-info/get-meeting-link-booking-info.mjs
+++ b/components/hubspot/actions/get-meeting-link-booking-info/get-meeting-link-booking-info.mjs
@@ -4,7 +4,7 @@ export default {
   key: "hubspot-get-meeting-link-booking-info",
   name: "Get Meeting Link Booking Info",
   description: "Retrieve the booking configuration and availability for a meeting scheduling page. Returns link metadata, availability windows by duration, busy times, branding, and organizer details. [See the documentation](https://developers.hubspot.com/docs/api-reference/legacy/scheduler/guide#list-booking-information)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/hubspot/package.json
+++ b/components/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/hubspot",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Pipedream Hubspot Components",
   "main": "hubspot.app.mjs",
   "keywords": [

--- a/components/ipgeolocation/actions/parse-user-agent/parse-user-agent.mjs
+++ b/components/ipgeolocation/actions/parse-user-agent/parse-user-agent.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Parse User Agent",
   description:
     "Extract browser, device, operating system, and engine details from a user agent string. Only available on paid plans. [See the documentation](https://ipgeolocation.io/documentation/user-agent-api.html)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   ai: "optimized",
   annotations: {

--- a/components/ipgeolocation/package.json
+++ b/components/ipgeolocation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/ipgeolocation",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream IPGeolocation Components",
   "main": "ipgeolocation.app.mjs",
   "keywords": [

--- a/components/lever/actions/list-archive-reasons/list-archive-reasons.mjs
+++ b/components/lever/actions/list-archive-reasons/list-archive-reasons.mjs
@@ -11,7 +11,7 @@ export default {
     + " Returns one page (up to `limit`); if the response's `hasNext` is true, pass its `next` value to `offset` to fetch the following page."
     + " Example: call with type=\"non-hired\" → returns rejection reasons each with id, text, and type; pass an id as the reason for **Archive Opportunity**."
     + " [See the documentation](https://hire.lever.co/developer/documentation#list-all-archive-reasons)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   ai: "optimized",
   annotations: {

--- a/components/lever/package.json
+++ b/components/lever/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/lever",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream Lever Components",
   "main": "lever.app.mjs",
   "keywords": [

--- a/components/servicenow/actions/get-catalog-item-variables/get-catalog-item-variables.mjs
+++ b/components/servicenow/actions/get-catalog-item-variables/get-catalog-item-variables.mjs
@@ -4,7 +4,7 @@ export default {
   key: "servicenow-get-catalog-item-variables",
   name: "Get Catalog Item Variables",
   description: "Retrieve the ordered variables (form fields) for a ServiceNow catalog item. Run **Search Catalog Items** first to obtain the item `sys_id`, then use the returned variable names to build the `variables` payload for **Add Item to Cart**, **Order Catalog Item**, or **Submit Record Producer**. [See the documentation](https://www.servicenow.com/docs/r/zurich/api-reference/rest-apis/c_ServiceCatalogAPI.html)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   ai: "optimized",
   annotations: {

--- a/components/servicenow/actions/list-knowledge-bases/list-knowledge-bases.mjs
+++ b/components/servicenow/actions/list-knowledge-bases/list-knowledge-bases.mjs
@@ -4,7 +4,7 @@ export default {
   key: "servicenow-list-knowledge-bases",
   name: "List Knowledge Bases",
   description: "List the knowledge bases in the instance, to find the `sys_id`s that scope a search on **Search Knowledge Base**. [See the documentation](https://www.servicenow.com/docs/r/zurich/api-reference/rest-apis/c_TableAPI.html)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   ai: "optimized",
   annotations: {

--- a/components/servicenow/actions/submit-record-producer/submit-record-producer.mjs
+++ b/components/servicenow/actions/submit-record-producer/submit-record-producer.mjs
@@ -5,7 +5,7 @@ export default {
   key: "servicenow-submit-record-producer",
   name: "Submit Record Producer",
   description: "Submit a ServiceNow record producer to create the target record (e.g. an incident or RITM) from catalog variables. Run **Search Catalog Items** to find the record producer `sys_id` and **Get Catalog Item Variables** to learn which variable names to supply. [See the documentation](https://www.servicenow.com/docs/r/zurich/api-reference/rest-apis/c_ServiceCatalogAPI.html)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   ai: "optimized",
   annotations: {

--- a/components/servicenow/package.json
+++ b/components/servicenow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/servicenow",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Pipedream ServiceNow Components",
   "main": "servicenow.app.mjs",
   "keywords": [

--- a/components/shopify/actions/create-gift-card/create-gift-card.mjs
+++ b/components/shopify/actions/create-gift-card/create-gift-card.mjs
@@ -4,7 +4,7 @@ export default {
   key: "shopify-create-gift-card",
   name: "Create Gift Card",
   description: "Creates a new gift card. To supply an optional customer, run **Get Customers** first to retrieve the customer GID. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/giftCardCreate).",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
   ai: "optimized",
   annotations: {

--- a/components/shopify/package.json
+++ b/components/shopify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/shopify",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Pipedream Shopify Components",
   "main": "shopify.app.mjs",
   "keywords": [

--- a/components/smartsheet/actions/get-current-user/get-current-user.mjs
+++ b/components/smartsheet/actions/get-current-user/get-current-user.mjs
@@ -7,7 +7,7 @@ export default {
     "Get the authenticated user's identity — returns user ID, email, first/last name, and account details."
     + " Use this when the user says 'my sheets' or 'my account' to identify the owner."
     + " [See the documentation](https://developers.smartsheet.com/api/smartsheet/openapi/users/get-current-user)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   ai: "optimized",
   annotations: {

--- a/components/smartsheet/actions/list-workspace-templates/list-workspace-templates.mjs
+++ b/components/smartsheet/actions/list-workspace-templates/list-workspace-templates.mjs
@@ -7,7 +7,7 @@ export default {
     "Lists templates available in your workspaces."
     + " Use this to find template IDs for **New Sheet From Template**."
     + " [See the documentation](https://developers.smartsheet.com/api/smartsheet/openapi/workspaces/get-workspace-children)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   ai: "optimized",
   annotations: {

--- a/components/smartsheet/package.json
+++ b/components/smartsheet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/smartsheet",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Pipedream Smartsheet Components",
   "main": "smartsheet.app.mjs",
   "keywords": [

--- a/components/universal_api/actions/delete-consumer/delete-consumer.mjs
+++ b/components/universal_api/actions/delete-consumer/delete-consumer.mjs
@@ -5,7 +5,7 @@ export default {
   name: "Delete Consumer",
   description:
     "Permanently delete a consumer via the Platform API on Universal API. This is irreversible. Run **List Consumers** first to find the consumer ID. [See the documentation](https://docs.universalapi.io/reference/delete-consumer).",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   ai: "optimized",
   annotations: {

--- a/components/universal_api/actions/list-distributor-orders/list-distributor-orders.mjs
+++ b/components/universal_api/actions/list-distributor-orders/list-distributor-orders.mjs
@@ -5,7 +5,7 @@ export default {
   name: "List Distributor Orders",
   description:
     "List orders from the Distributors API on Universal API. Returns an array; use the returned IDs with **Get Distributor Order**. This hits a different endpoint than **List Asset Management Orders**. [See the documentation](https://docs.universalapi.io/reference/list-orders-1).",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   ai: "optimized",
   annotations: {

--- a/components/universal_api/actions/update-connection/update-connection.mjs
+++ b/components/universal_api/actions/update-connection/update-connection.mjs
@@ -6,7 +6,7 @@ export default {
   name: "Update Connection",
   description:
     "Update a connection identified by `universalApi` and `serviceId` via the Platform API on Universal API (PATCH; only supplied fields are changed). Run **List Connections** first to find the correct `serviceId`. [See the documentation](https://docs.universalapi.io/reference/update-connection).",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   ai: "optimized",
   annotations: {

--- a/components/universal_api/package.json
+++ b/components/universal_api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/universal_api",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream Universal API Components",
   "main": "universal_api.app.mjs",
   "keywords": [

--- a/components/whop/actions/terminate-membership/terminate-membership.mjs
+++ b/components/whop/actions/terminate-membership/terminate-membership.mjs
@@ -4,13 +4,14 @@ export default {
   key: "whop-terminate-membership",
   name: "Terminate Membership",
   description: "Permanently invalidates a specified membership using its unique ID, effectively unfulfilling the user's product experiences. Termination is irreversible. [See the documentation](https://dev.whop.com/api-reference/v2/memberships/terminate-a-membership)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     whop,
     membershipId: {

--- a/components/whop/package.json
+++ b/components/whop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/whop",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Pipedream Whop Components",
   "main": "whop.app.mjs",
   "keywords": [

--- a/components/wildapricot/actions/add-update-event-registration/add-update-event-registration.mjs
+++ b/components/wildapricot/actions/add-update-event-registration/add-update-event-registration.mjs
@@ -4,13 +4,14 @@ export default {
   key: "wildapricot-add-update-event-registration",
   name: "Add or Update Event Registration",
   description: "Searches event registrations using a contact email. If a match is found, the registration details are updated. If not, a new registration is added to the event. [See the documentation](https://app.swaggerhub.com/apis-docs/WildApricot/wild-apricot_public_api/7.24.0#/Events.EventRegistrations/CreateEventRegistration)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     wildapricot,
     accountId: {

--- a/components/wildapricot/package.json
+++ b/components/wildapricot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/wildapricot",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream WildApricot Components",
   "main": "wildapricot.app.mjs",
   "keywords": [

--- a/components/wordpress_com/actions/create-post/create-post.mjs
+++ b/components/wordpress_com/actions/create-post/create-post.mjs
@@ -4,13 +4,14 @@ export default {
   key: "wordpress_com-create-post",
   name: "Create New Post",
   description: "Creates a new post on a WordPress.com site. [See the documentation](https://developer.wordpress.com/docs/api/1.1/post/sites/%24site/posts/new/)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     wordpress,
     site: {

--- a/components/wordpress_com/package.json
+++ b/components/wordpress_com/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/wordpress_com",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Pipedream wordpress_com Components",
   "main": "wordpress_com.app.mjs",
   "keywords": [

--- a/components/wordpress_org/actions/upload-media/upload-media.mjs
+++ b/components/wordpress_org/actions/upload-media/upload-media.mjs
@@ -6,13 +6,14 @@ export default {
   key: "wordpress_org-upload-media",
   name: "Upload Media",
   description: "Upload a media item to your WordPress media library. Returns a media ID to be used in creating or updating posts.[See the documentation](https://www.npmjs.com/package/wpapi#uploading-media)",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     wordpress,
     filePath: {

--- a/components/wordpress_org/package.json
+++ b/components/wordpress_org/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/wordpress_org",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Pipedream Wordpress.org Components",
   "main": "wordpress_org.app.mjs",
   "keywords": [

--- a/components/world_news_api/actions/extract-news/extract-news.mjs
+++ b/components/world_news_api/actions/extract-news/extract-news.mjs
@@ -4,13 +4,14 @@ export default {
   name: "Extract News",
   description: "Extract a news article from a website to a well structure JSON object. [See the docs here](https://worldnewsapi.com/docs/#Extract-News). **Calling this endpoint requires 1 point, plus 2 points if analyze is true.**",
   key: "world_news_api-extract-news",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     url: {

--- a/components/world_news_api/package.json
+++ b/components/world_news_api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/world_news_api",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Pipedream World News API Components",
   "main": "world_news_api.app.mjs",
   "keywords": [

--- a/components/you_need_a_budget/actions/update-transaction/update-transaction.mjs
+++ b/components/you_need_a_budget/actions/update-transaction/update-transaction.mjs
@@ -5,13 +5,14 @@ export default {
   key: "you_need_a_budget-update-transaction",
   name: "Update Transaction",
   description: "Update an existing transaction. [See the docs](https://api.youneedabudget.com/v1#/Transactions/updateTransaction)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     budgetId: {

--- a/components/you_need_a_budget/package.json
+++ b/components/you_need_a_budget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/you_need_a_budget",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Pipedream You Need A Budget Components",
   "main": "you_need_a_budget.app.mjs",
   "keywords": [

--- a/components/zenfulfillment/actions/create-or-retrieve-return-label/create-or-retrieve-return-label.mjs
+++ b/components/zenfulfillment/actions/create-or-retrieve-return-label/create-or-retrieve-return-label.mjs
@@ -4,8 +4,9 @@ export default {
   key: "zenfulfillment-create-or-retrieve-return-label",
   name: "Create or Retrieve Return Label",
   description: "Create or retrieve a Return Label for a specific Order. [See the documentation](https://partner.alaiko.com/docs#tag/ReturnLabel/operation/api_partnerreturn-label_post)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zenfulfillment/package.json
+++ b/components/zenfulfillment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/zenfulfillment",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Pipedream Zenfulfillment Components",
   "main": "zenfulfillment.app.mjs",
   "keywords": [

--- a/components/zenrows/actions/scrape-url-css-selectors/scrape-url-css-selectors.mjs
+++ b/components/zenrows/actions/scrape-url-css-selectors/scrape-url-css-selectors.mjs
@@ -2,7 +2,7 @@ import app from "../../zenrows.app.mjs";
 
 export default {
   name: "Scrape URL CSS Selectors",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -11,6 +11,7 @@ export default {
   key: "zenrows-scrape-url-css-selectors",
   description: "Scrape HTML of the URL with CSS Selectors. [See the documentation](https://www.zenrows.com/docs#css-selectors-curl)",
   type: "action",
+  ai: "optimized",
   props: {
     app,
     url: {

--- a/components/zenrows/package.json
+++ b/components/zenrows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/zenrows",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream ZenRows Components",
   "main": "zenrows.app.mjs",
   "keywords": [

--- a/components/zep/actions/add-memory/add-memory.mjs
+++ b/components/zep/actions/add-memory/add-memory.mjs
@@ -5,13 +5,14 @@ export default {
   key: "zep-add-memory",
   name: "Add Memory to Session",
   description: "Adds memory to an existing session in Zep. [See the documentation](https://help.getzep.com/api-reference/memory/add)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     zep,
     sessionId: {

--- a/components/zep/package.json
+++ b/components/zep/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/zep",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Pipedream Zep Components",
   "main": "zep.app.mjs",
   "keywords": [

--- a/components/zerobounce/actions/get-validation-results-file/get-validation-results-file.mjs
+++ b/components/zerobounce/actions/get-validation-results-file/get-validation-results-file.mjs
@@ -6,13 +6,14 @@ export default {
   key: "zerobounce-get-validation-results-file",
   name: "Get Validation Results File",
   description: "Downloads the validation results for a file submitted using sendfile API. [See the documentation](https://www.zerobounce.net/docs/email-validation-api-quickstart/#get_file__v2__)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     zerobounce,
     fileId: {

--- a/components/zerobounce/package.json
+++ b/components/zerobounce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/zerobounce",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Pipedream ZeroBounce Components",
   "main": "zerobounce.app.mjs",
   "keywords": [

--- a/components/zoho_bookings/actions/reschedule-appointment/reschedule-appointment.mjs
+++ b/components/zoho_bookings/actions/reschedule-appointment/reschedule-appointment.mjs
@@ -6,13 +6,14 @@ export default {
   key: "zoho_bookings-reschedule-appointment",
   name: "Reschedule Appointment",
   description: "Reschedule an appointment to a different time or to a different staff. [See the documentation](https://www.zoho.com/bookings/help/api/v1/reschedule-appointment.html)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     bookingId: {

--- a/components/zoho_bookings/package.json
+++ b/components/zoho_bookings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/zoho_bookings",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Zoho Bookings Components",
   "main": "zoho_bookings.app.mjs",
   "keywords": [


### PR DESCRIPTION
Continuation of the DJ-4272 AI-optimized backfill, sourced from the product team's AI-optimized actions list (Aug 11 2026). Also carries two retries for batch 1 (#21887), which merged but hit partial publish failures.

## 1. New AI-optimized components (batch 7 of 7)
11 components across 11 apps get the top-level `ai: "optimized"` field + a patch version bump; each app's `package.json` is bumped (`check_version` gate).

Component apps: whop,wildapricot wordpress_com,wordpress_org world_news_api,you_need_a_budget zenfulfillment,zenrows zep,zerobounce zoho_bookings

## 2. Retry — npm publish-packages 403 (batch 1)
After batch 1 merged, `publish-packages` hit npm `403 — cannot publish over previously published version` on 11 app packages whose `package.json` on master was one patch behind their npm-published `latest`. This bumps those 11 apps' `package.json` to npm-latest+1 (no component change) so the next publish clears the collision: `deel`, `hubspot`, `shopify`, `smartsheet`, `servicenow`, `lever`, `hedy`, `enrich_layer`, `ipgeolocation`, `universal_api`, `_2markdown`.

## 3. Retry — registry promotion gap (batch 1)
Prod DB verification showed 185/200 batch-1 components correctly serve `ai_status='optimized'`. 14 components published their optimized version under the platform org but never got promoted to the public (owner-nil) registry pointer — the two overlapping publish-components runs left them in a gap (published by run 1, whose promotion failed; skipped by run 2 as "already published"). These 14 get a patch version bump to force a clean re-publish + promotion:
`smartsheet-get-current-user`, `smartsheet-list-workspace-templates`, `hubspot-get-meeting-link-booking-info`, `shopify-create-gift-card`, `universal_api-delete-consumer`, `universal_api-list-distributor-orders`, `universal_api-update-connection`, `hedy-create-topic`, `hedy-delete-topic`, `servicenow-get-catalog-item-variables`, `servicenow-list-knowledge-bases`, `servicenow-submit-record-producer`, `lever-list-archive-reasons`, `ipgeolocation-parse-user-agent`.

> Not included: `shopify-create-order` — its prod registry pointer is on a divergent legacy `0.1.3` (no `ai`) while the repo source has always been `0.0.x`; needs separate investigation, out of scope for this metadata backfill.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Refreshed selected actions across Whop, WildApricot, WordPress, World News API, You Need a Budget, ZenFulfillment, ZenRows, Zep, ZeroBounce, and Zoho Bookings.
  - Updated action metadata now identifies applicable actions as AI-optimized.
  - Updated integration versions for 2Markdown, Deel, Enrich Layer, Hedy, HubSpot, IP Geolocation, Lever, ServiceNow, Shopify, Smartsheet, and Universal API.
  - Refreshed versions for additional actions across Hedy, HubSpot, IP Geolocation, Lever, ServiceNow, Shopify, Smartsheet, and Universal API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->