### PR TITLE
Add AnyAPI components

### DIFF
--- a/components/anyapi/actions/get-api/get-api.mjs
+++ b/components/anyapi/actions/get-api/get-api.mjs
@@ -1,0 +1,32 @@
+import anyapi from "../../anyapi.app.mjs";
+
+export default {
+  key: "anyapi-get-api",
+  name: "Get API",
+  description: "Get one API from the AnyAPI catalog, including its normalized input and output JSON Schema and its USD pricing. [See the documentation](https://getanyapi.com/docs/api-reference/get-one-api)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  type: "action",
+  props: {
+    anyapi,
+    sku: {
+      propDefinition: [
+        anyapi,
+        "sku",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const response = await this.anyapi.getApi({
+      $,
+      sku: this.sku,
+    });
+
+    $.export("$summary", `Retrieved the definition of \`${this.sku}\``);
+    return response;
+  },
+};

--- a/components/anyapi/actions/get-api/get-api.mjs
+++ b/components/anyapi/actions/get-api/get-api.mjs
@@ -3,7 +3,7 @@ import anyapi from "../../anyapi.app.mjs";
 export default {
   key: "anyapi-get-api",
   name: "Get API",
-  description: "Get one API from the AnyAPI catalog, including its normalized input and output JSON Schema and its USD pricing. [See the documentation](https://getanyapi.com/docs/api-reference/get-one-api)",
+  description: "Get one API from the AnyAPI catalog, including its normalized input and output JSON Schema and its USD pricing. Run **Search APIs** first to find the API you want; the slug it returns is what the API prop takes, and that slug is the only thing selecting which API you get back. Read `inputSchema` in the response and build the Input of **Run API** from it, because AnyAPI checks the input against that schema and refuses a request that does not match. [See the documentation](https://getanyapi.com/docs/api-reference/get-one-api)",
   version: "0.0.1",
   annotations: {
     destructiveHint: false,

--- a/components/anyapi/actions/get-balance/get-balance.mjs
+++ b/components/anyapi/actions/get-balance/get-balance.mjs
@@ -1,0 +1,25 @@
+import anyapi from "../../anyapi.app.mjs";
+
+export default {
+  key: "anyapi-get-balance",
+  name: "Get Balance",
+  description: "Get the remaining USD balance of your AnyAPI wallet. [See the documentation](https://getanyapi.com/docs/api-reference/get-your-wallet-balance)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  type: "action",
+  props: {
+    anyapi,
+  },
+  async run({ $ }) {
+    const response = await this.anyapi.getBalance({
+      $,
+    });
+
+    $.export("$summary", `Your AnyAPI balance is $${response.usd}`);
+    return response;
+  },
+};

--- a/components/anyapi/actions/run-api/run-api.mjs
+++ b/components/anyapi/actions/run-api/run-api.mjs
@@ -1,0 +1,40 @@
+import anyapi from "../../anyapi.app.mjs";
+import { parseObjectEntries } from "../../common/utils.mjs";
+
+export default {
+  key: "anyapi-run-api",
+  name: "Run API",
+  description: "Run one API from the AnyAPI catalog and get its normalized output, the number of result rows, and the USD charged. Use **Get API** first to read the API's input schema. [See the documentation](https://getanyapi.com/docs/quickstart)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: false,
+  },
+  type: "action",
+  props: {
+    anyapi,
+    sku: {
+      propDefinition: [
+        anyapi,
+        "sku",
+      ],
+    },
+    input: {
+      type: "object",
+      label: "Input",
+      description: "The API's input, matching the `inputSchema` returned by the **Get API** action. For example, `reddit.search` takes `{ \"query\": \"pipedream\" }`.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const response = await this.anyapi.runApi({
+      $,
+      sku: this.sku,
+      data: parseObjectEntries(this.input) ?? {},
+    });
+
+    $.export("$summary", `Ran \`${this.sku}\` for $${response.costUsd}`);
+    return response;
+  },
+};

--- a/components/anyapi/actions/run-api/run-api.mjs
+++ b/components/anyapi/actions/run-api/run-api.mjs
@@ -1,10 +1,10 @@
 import anyapi from "../../anyapi.app.mjs";
-import { parseObjectEntries } from "../../common/utils.mjs";
+import { parseInput } from "../../common/utils.mjs";
 
 export default {
   key: "anyapi-run-api",
   name: "Run API",
-  description: "Run one API from the AnyAPI catalog and get its normalized output, the number of result rows, and the USD charged. Use **Get API** first to read the API's input schema. [See the documentation](https://getanyapi.com/docs/quickstart)",
+  description: "Run one API from the AnyAPI catalog and get its normalized output, the number of result rows, and the USD charged. Find the API with **Search APIs**, read its input schema with **Get API**, then run it here. [See the documentation](https://getanyapi.com/docs/quickstart)",
   version: "0.0.1",
   annotations: {
     destructiveHint: false,
@@ -23,15 +23,20 @@ export default {
     input: {
       type: "object",
       label: "Input",
-      description: "The API's input, matching the `inputSchema` returned by the **Get API** action. For example, `reddit.search` takes `{ \"query\": \"pipedream\" }`.",
+      description: "The API's input, matching the `inputSchema` returned by the **Get API** action. For example, `reddit.search` takes `{ \"query\": \"pipedream\" }`. Each value is matched to the type that schema declares before the request is sent, so a numeric id stays text where the schema asks for text.",
       optional: true,
     },
   },
   async run({ $ }) {
+    const { inputSchema } = await this.anyapi.getApi({
+      $,
+      sku: this.sku,
+    });
+
     const response = await this.anyapi.runApi({
       $,
       sku: this.sku,
-      data: parseObjectEntries(this.input) ?? {},
+      data: parseInput(this.input, inputSchema) ?? {},
     });
 
     $.export("$summary", `Ran \`${this.sku}\` for $${response.costUsd}`);

--- a/components/anyapi/actions/search-apis/search-apis.mjs
+++ b/components/anyapi/actions/search-apis/search-apis.mjs
@@ -1,9 +1,10 @@
+import { ConfigurationError } from "@pipedream/platform";
 import anyapi from "../../anyapi.app.mjs";
 
 export default {
   key: "anyapi-search-apis",
   name: "Search APIs",
-  description: "Search the AnyAPI catalog and get the matching APIs, each with its slug, description and USD price. No credential is required for this endpoint. [See the documentation](https://getanyapi.com/docs/api-reference/search-the-api-catalog)",
+  description: "Search the AnyAPI catalog and get the matching APIs, each with its slug, description and USD price. Search whenever you do not already know the slug of the API you need: describe the data in plain words, or scope the catalog with a category or a platform. Pass at least one of Query, Category or Platform. Then take a slug from the results to **Get API**, which returns that API's input schema, and run it with **Run API**. Searching the catalog is free, is never charged to your wallet, and needs no credential. [See the documentation](https://getanyapi.com/docs/api-reference/search-the-api-catalog)",
   version: "0.0.1",
   annotations: {
     destructiveHint: false,
@@ -16,28 +17,34 @@ export default {
     query: {
       type: "string",
       label: "Query",
-      description: "What you need, in your own words (for example `instagram profile` or `google maps reviews`).",
+      description: "What you need, in your own words (for example `instagram profile` or `google maps reviews`). Optional if you set Category or Platform instead.",
+      optional: true,
     },
     category: {
       type: "string",
       label: "Category",
-      description: "Restrict the results to one category, using the `category` of an earlier result.",
+      description: "Restrict the results to one category, given as the API's `category` string from an earlier result (for example `social`). Optional; omit it to search every category.",
       optional: true,
     },
     platform: {
       type: "string",
       label: "Platform",
-      description: "Restrict the results to one platform, using the `platformId` of an earlier result (for example `instagram`).",
+      description: "Restrict the results to one platform, given as the `platformId` of an earlier result (for example `instagram`). Optional; omit it to search every platform.",
       optional: true,
     },
     limit: {
       type: "integer",
       label: "Limit",
-      description: "Maximum number of results to return. Omit it for the ranked default.",
+      description: "Maximum number of results to return, as an integer of 1 or more. Omit it for the ranked default.",
       optional: true,
+      min: 1,
     },
   },
   async run({ $ }) {
+    if (!this.query && !this.category && !this.platform) {
+      throw new ConfigurationError("Set at least one of Query, Category or Platform. AnyAPI's catalog search needs a query, a category or a platform, and any one of the three on its own is enough.");
+    }
+
     const response = await this.anyapi.searchCatalog({
       $,
       params: {
@@ -48,7 +55,12 @@ export default {
       },
     });
 
-    $.export("$summary", `Found ${response.results?.length ?? 0} API(s) matching "${this.query}"`);
+    const scope = [
+      this.query && `matching "${this.query}"`,
+      this.category && `in category \`${this.category}\``,
+      this.platform && `on platform \`${this.platform}\``,
+    ].filter(Boolean).join(", ");
+    $.export("$summary", `Found ${response.results?.length ?? 0} API(s) ${scope}`);
     return response;
   },
 };

--- a/components/anyapi/actions/search-apis/search-apis.mjs
+++ b/components/anyapi/actions/search-apis/search-apis.mjs
@@ -1,0 +1,54 @@
+import anyapi from "../../anyapi.app.mjs";
+
+export default {
+  key: "anyapi-search-apis",
+  name: "Search APIs",
+  description: "Search the AnyAPI catalog and get the matching APIs, each with its slug, description and USD price. No credential is required for this endpoint. [See the documentation](https://getanyapi.com/docs/api-reference/search-the-api-catalog)",
+  version: "0.0.1",
+  annotations: {
+    destructiveHint: false,
+    openWorldHint: true,
+    readOnlyHint: true,
+  },
+  type: "action",
+  props: {
+    anyapi,
+    query: {
+      type: "string",
+      label: "Query",
+      description: "What you need, in your own words (for example `instagram profile` or `google maps reviews`).",
+    },
+    category: {
+      type: "string",
+      label: "Category",
+      description: "Restrict the results to one category, using the `category` of an earlier result.",
+      optional: true,
+    },
+    platform: {
+      type: "string",
+      label: "Platform",
+      description: "Restrict the results to one platform, using the `platformId` of an earlier result (for example `instagram`).",
+      optional: true,
+    },
+    limit: {
+      type: "integer",
+      label: "Limit",
+      description: "Maximum number of results to return. Omit it for the ranked default.",
+      optional: true,
+    },
+  },
+  async run({ $ }) {
+    const response = await this.anyapi.searchCatalog({
+      $,
+      params: {
+        q: this.query,
+        category: this.category,
+        platform: this.platform,
+        limit: this.limit,
+      },
+    });
+
+    $.export("$summary", `Found ${response.results?.length ?? 0} API(s) matching "${this.query}"`);
+    return response;
+  },
+};

--- a/components/anyapi/anyapi.app.mjs
+++ b/components/anyapi/anyapi.app.mjs
@@ -26,14 +26,30 @@ export default {
     },
   },
   methods: {
+    /**
+     * @returns {string} the AnyAPI gateway base URL
+     */
     _baseUrl() {
       return "https://api.getanyapi.com";
     },
+    /**
+     * Builds the request headers. The catalog search endpoint answers without a
+     * credential, so the key is sent only when an AnyAPI account is connected.
+     *
+     * @returns {object} the headers for a gateway request
+     */
     _headers() {
-      return {
-        "X-API-Key": this.$auth.api_key,
-      };
+      const apiKey = this.$auth?.api_key;
+      return apiKey
+        ? {
+          "X-API-Key": apiKey,
+        }
+        : {};
     },
+    /**
+     * @param {object} opts - axios options, plus the gateway `path` to call
+     * @returns {Promise<object>} the parsed gateway response
+     */
     _makeRequest({
       $ = this, path, ...opts
     }) {
@@ -43,18 +59,32 @@ export default {
         ...opts,
       });
     },
+    /**
+     * Searches the catalog. Accepts any one of `q`, `category` or `platform`.
+     *
+     * @param {object} [opts] - axios options, including `params`
+     * @returns {Promise<object>} the ranked matches and their USD pricing
+     */
     searchCatalog(opts = {}) {
       return this._makeRequest({
         path: "/catalog/search",
         ...opts,
       });
     },
+    /**
+     * @param {object} [opts] - axios options
+     * @returns {Promise<object>} every API in the catalog
+     */
     listApis(opts = {}) {
       return this._makeRequest({
         path: "/v1/apis",
         ...opts,
       });
     },
+    /**
+     * @param {object} opts - axios options, plus the API `sku` slug
+     * @returns {Promise<object>} the API definition, with its `inputSchema`
+     */
     getApi({
       sku, ...opts
     }) {
@@ -63,6 +93,10 @@ export default {
         ...opts,
       });
     },
+    /**
+     * @param {object} opts - axios options, plus the API `sku` slug and `data`
+     * @returns {Promise<object>} the normalized output and the USD charged
+     */
     runApi({
       sku, ...opts
     }) {
@@ -72,6 +106,10 @@ export default {
         ...opts,
       });
     },
+    /**
+     * @param {object} [opts] - axios options
+     * @returns {Promise<object>} the wallet's remaining USD balance
+     */
     getBalance(opts = {}) {
       return this._makeRequest({
         path: "/v1/balance",

--- a/components/anyapi/anyapi.app.mjs
+++ b/components/anyapi/anyapi.app.mjs
@@ -7,7 +7,7 @@ export default {
     sku: {
       type: "string",
       label: "API",
-      description: "The API to call, identified by its slug (for example `reddit.search`). Type to search the catalog, or enter a slug directly.",
+      description: "The API to call, identified by its slug (for example `reddit.search`). Type to search the catalog, or run the **Search APIs** action first and paste a slug from its results.",
       async options({ query }) {
         const apis = query
           ? (await this.searchCatalog({

--- a/components/anyapi/anyapi.app.mjs
+++ b/components/anyapi/anyapi.app.mjs
@@ -1,0 +1,82 @@
+import { axios } from "@pipedream/platform";
+
+export default {
+  type: "app",
+  app: "anyapi",
+  propDefinitions: {
+    sku: {
+      type: "string",
+      label: "API",
+      description: "The API to call, identified by its slug (for example `reddit.search`). Type to search the catalog, or enter a slug directly.",
+      async options({ query }) {
+        const apis = query
+          ? (await this.searchCatalog({
+            params: {
+              q: query,
+            },
+          })).results
+          : (await this.listApis()).apis;
+        return (apis ?? []).map(({
+          slug, name,
+        }) => ({
+          label: `${name} (${slug})`,
+          value: slug,
+        }));
+      },
+    },
+  },
+  methods: {
+    _baseUrl() {
+      return "https://api.getanyapi.com";
+    },
+    _headers() {
+      return {
+        "X-API-Key": this.$auth.api_key,
+      };
+    },
+    _makeRequest({
+      $ = this, path, ...opts
+    }) {
+      return axios($, {
+        url: `${this._baseUrl()}${path}`,
+        headers: this._headers(),
+        ...opts,
+      });
+    },
+    searchCatalog(opts = {}) {
+      return this._makeRequest({
+        path: "/catalog/search",
+        ...opts,
+      });
+    },
+    listApis(opts = {}) {
+      return this._makeRequest({
+        path: "/v1/apis",
+        ...opts,
+      });
+    },
+    getApi({
+      sku, ...opts
+    }) {
+      return this._makeRequest({
+        path: `/v1/apis/${encodeURIComponent(sku)}`,
+        ...opts,
+      });
+    },
+    runApi({
+      sku, ...opts
+    }) {
+      return this._makeRequest({
+        method: "POST",
+        path: `/v1/run/${encodeURIComponent(sku)}`,
+        ...opts,
+      });
+    },
+    getBalance(opts = {}) {
+      return this._makeRequest({
+        path: "/v1/balance",
+        ...opts,
+      });
+    },
+  },
+};

--- a/components/anyapi/common/utils.mjs
+++ b/components/anyapi/common/utils.mjs
@@ -6,25 +6,83 @@ function optionalParseAsJSON(value) {
   }
 }
 
+function schemaType(schema) {
+  const type = schema?.type;
+  return Array.isArray(type)
+    ? type[0]
+    : type;
+}
+
+function coerceStringToSchema(value, schema) {
+  switch (schemaType(schema)) {
+  case "string":
+    return value;
+  case "integer":
+  case "number": {
+    const parsed = Number(value);
+    return value.trim() && Number.isFinite(parsed)
+      ? parsed
+      : value;
+  }
+  case "boolean":
+    if (value === "true") return true;
+    if (value === "false") return false;
+    return value;
+  case "object":
+  case "array":
+    return coerceToSchema(optionalParseAsJSON(value), schema);
+  default:
+    return optionalParseAsJSON(value);
+  }
+}
+
 /**
- * Pipedream object props deliver every value as a string. AnyAPI validates each
- * input against the API's JSON Schema, so numbers, booleans, arrays and nested
- * objects have to be restored before the request is sent.
+ * Restores the JSON types an AnyAPI input schema declares, at every depth.
+ * A field the schema types as `string` is left alone, so a numeric id such as
+ * `"314216"` stays a string instead of becoming the number AnyAPI rejects.
+ * A field with no schema keeps the previous best-effort JSON parse.
+ *
+ * @param {*} value - the value to normalize
+ * @param {object} [schema] - the JSON Schema fragment describing `value`
+ * @returns {*} the value with schema-declared types restored
  */
-export function parseObjectEntries(value) {
+export function coerceToSchema(value, schema) {
+  if (typeof value === "string") {
+    return coerceStringToSchema(value, schema);
+  }
+  if (Array.isArray(value)) {
+    return schema?.items
+      ? value.map((entry) => coerceToSchema(entry, schema.items))
+      : value;
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([
+        key,
+        entry,
+      ]) => [
+        key,
+        coerceToSchema(entry, schema?.properties?.[key]),
+      ]),
+    );
+  }
+  return value;
+}
+
+/**
+ * Pipedream object props deliver every value the user typed as a string, while
+ * AnyAPI validates the request against the API's JSON Schema and charges
+ * nothing for a rejection. This restores the declared types before the request
+ * is sent.
+ *
+ * @param {object|string} [value] - the raw object prop value
+ * @param {object} [inputSchema] - the API's `inputSchema`, from **Get API**
+ * @returns {object|undefined} the request body, or undefined when empty
+ */
+export function parseInput(value, inputSchema) {
   if (!value) return undefined;
   const obj = typeof value === "string"
     ? JSON.parse(value)
     : value;
-  return Object.fromEntries(
-    Object.entries(obj).map(([
-      key,
-      entry,
-    ]) => [
-      key,
-      typeof entry === "string"
-        ? optionalParseAsJSON(entry)
-        : entry,
-    ]),
-  );
+  return coerceToSchema(obj, inputSchema);
 }

--- a/components/anyapi/common/utils.mjs
+++ b/components/anyapi/common/utils.mjs
@@ -1,0 +1,30 @@
+function optionalParseAsJSON(value) {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * Pipedream object props deliver every value as a string. AnyAPI validates each
+ * input against the API's JSON Schema, so numbers, booleans, arrays and nested
+ * objects have to be restored before the request is sent.
+ */
+export function parseObjectEntries(value) {
+  if (!value) return undefined;
+  const obj = typeof value === "string"
+    ? JSON.parse(value)
+    : value;
+  return Object.fromEntries(
+    Object.entries(obj).map(([
+      key,
+      entry,
+    ]) => [
+      key,
+      typeof entry === "string"
+        ? optionalParseAsJSON(entry)
+        : entry,
+    ]),
+  );
+}

--- a/components/anyapi/package.json
+++ b/components/anyapi/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@pipedream/anyapi",
+  "version": "0.1.0",
+  "description": "Pipedream AnyAPI Components",
+  "main": "anyapi.app.mjs",
+  "keywords": [
+    "pipedream",
+    "anyapi"
+  ],
+  "homepage": "https://pipedream.com/apps/anyapi",
+  "author": "Pipedream <support@pipedream.com> (https://pipedream.com/)",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@pipedream/platform": "^3.1.1"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1017,6 +1017,12 @@ importers:
         specifier: ^1.6.8
         version: 1.6.8
 
+  components/anyapi:
+    dependencies:
+      '@pipedream/platform':
+        specifier: ^3.1.1
+        version: 3.4.0
+
   components/anydb: {}
 
   components/anyflow: {}


### PR DESCRIPTION
## Summary

A new component app, `components/anyapi/`, for [AnyAPI](https://getanyapi.com). AnyAPI is a
gateway that puts several hundred scraping and data APIs behind one key, one normalized request
and response shape, and USD pay-per-request pricing with no subscription.

Files:

- `components/anyapi/anyapi.app.mjs`
- `components/anyapi/common/utils.mjs`
- `components/anyapi/actions/search-apis/search-apis.mjs`
- `components/anyapi/actions/get-api/get-api.mjs`
- `components/anyapi/actions/run-api/run-api.mjs`
- `components/anyapi/actions/get-balance/get-balance.mjs`
- `components/anyapi/package.json`
- `pnpm-lock.yaml` (the new workspace package)

## Checklist

### Versioning
- [x] All components updated in this PR had their version updated (`0.0.1` for new ones)
- [x] The app updated in this PR had its `package.json`'s version updated

All four actions are new and carry `version: "0.0.1"`. `components/anyapi/package.json` is a new
package at `0.1.0`.

### New app
- [x] The app updated in this PR is already integrated

### CodeRabbit review
- [x] I have addressed or acknowledged all of CodeRabbit's review comments

Each of the six inline comments has a reply on the thread saying what changed or why it was not
changed. Nothing is marked resolved.

## The four actions, and why not one per platform

AnyAPI is a catalog, not a single endpoint. It currently publishes 363 APIs across Instagram,
TikTok, YouTube, X, Reddit, LinkedIn, Google Search, Google Maps, Amazon, generic web scraping
and more. One Pipedream action per API would mean hundreds of near-identical components that go
stale whenever the catalog changes.

So this ships the discovery loop that the API itself is designed around:

| Action | Request | Purpose |
| --- | --- | --- |
| Search APIs | `GET /catalog/search` | Find an API by describing what you need, or by scoping to a category or a platform. Returns each match with its slug, description and USD price. |
| Get API | `GET /v1/apis/{sku}` | Read one API's normalized input and output JSON Schema plus its pricing, so you know what to send. |
| Run API | `POST /v1/run/{sku}` | Execute it. Returns the normalized output, the number of result rows, and `costUsd`. |
| Get Balance | `GET /v1/balance` | Remaining USD in the wallet. |

The **API** field on Get API and Run API is a dynamic dropdown. It calls `GET /catalog/search`
with whatever the user types and falls back to `GET /v1/apis` for the unfiltered list. A slug can
also be pasted directly, and the prop description points at the standalone **Search APIs** action.

`common/utils.mjs` restores the JSON types an API's `inputSchema` declares before **Run API**
sends the request. Pipedream object props deliver every value the user typed as a string, and
AnyAPI checks the request against that schema, so an integer field entered as text has to become
a number while a string field holding a numeric id has to stay text.

## Auth

Static API key, sent as the `X-API-Key` request header. `GET /catalog/search` answers without a
credential, so the app sends the header only when an account is connected. No OAuth step.

- Base URL: `https://api.getanyapi.com`
- Docs: https://getanyapi.com/docs
- OpenAPI document: `https://api.getanyapi.com/openapi.json`

## Verifying the API without a credential

`GET /catalog/search` is public, so you can confirm the service is real with no signup:

```
curl -s 'https://api.getanyapi.com/catalog/search?q=instagram%20profile'
curl -s 'https://api.getanyapi.com/catalog/search?category=social'
curl -s 'https://api.getanyapi.com/catalog/search?platform=twitter'
```

For the three authenticated endpoints, a key is self-serve and creates no account:

```
curl -s -X POST 'https://api.getanyapi.com/agent/signup' -H 'Content-Type: application/json' -d '{}'
```

That returns a free trial key with a small starting balance, good for seven days.

## Checks run

Run on this branch with Node 20.13.1 and pnpm 10.28.2, matching `.tool-versions` and
`.github/workflows/pull-request-checks.yaml`. Every step exits 0.

```
pnpm install --frozen-lockfile --filter=pipedream    Lockfile is up to date, Done in 6.6s
pnpm exec eslint <the 6 changed files>               exit=0
node scripts/findBadKeys.js <files> ""               exit=0
node --experimental-loader ./scripts/version-strip-loader.mjs \
  scripts/checkComponentAppProp.js <files> ""        exit=0
node scripts/findDuplicateKeys.js                    exit=0
pnpm build                                           exit=0
```

`pnpm-lock.yaml` is unchanged by the review fixes; its only diff in this PR is the six lines that
add the new `components/anyapi` importer.

No Markdown or MDX file is added, so the spellcheck job has nothing to read.

## Live verification

Every request path here was exercised against the production gateway through the component code
itself, with a real key. Field names are confirmed, not inferred. Re-run after the review fixes:

```
PASS search category-only        Found 3 API(s) in category `social`
PASS search platform-only        Found 3 API(s) on platform `twitter`
PASS search query-only           Found 3 API(s) matching "instagram profile"
PASS search with no scope        ConfigurationError naming Query, Category and Platform,
                                 raised before any request is sent
PASS search with no account      keyless GET /catalog/search returns 200
PASS get-api                     inputSchema present, userId type "string"
PASS run-api {"userId":"314216"} Ran `instagram.basic_profile` for $0.0015
```

The last line is the one that used to fail. Before the fix, `"314216"` was parsed into the number
`314216` and the gateway answered
`400 invalid_input: at "/userId": got number, want string`.

Also verified earlier and unchanged: the dropdown returns 25 options for a typed query and all 363
with no query; Get Balance returns `{"usd":...}`.

## Disclosure

I work on AnyAPI. Happy to change anything here to match your conventions, and happy to add
sources or more actions if you would prefer a different shape.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AnyAPI integration for accessing the AnyAPI catalog.
  * Search APIs by query, category, platform, and result limit.
  * Retrieve details for a selected API.
  * Run APIs with optional JSON input.
  * View the current account balance.
  * Select APIs directly from dynamically populated catalog options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
