### PR TITLE
riddle_quiz_maker: update app overview to cover all content types

### DIFF
--- a/components/riddle_quiz_maker/README.md
+++ b/components/riddle_quiz_maker/README.md
@@ -1,11 +1,13 @@
 # Overview
 
-Riddle Quiz Maker API lets you tap into a rich seam of interactive content, from quizzes to polls and surveys. By leveraging this API on Pipedream, you can automate interactions with your quizzes, extract responses in real-time, synchronize data across platforms, and trigger actions based on user engagement. Exploiting Pipedream's serverless platform allows you to create workflows that respond swiftly, integrate with numerous apps, and streamline content management—turning audience insights into actionable intelligence.
+Riddle is an interactive content platform for quizzes, personality tests, polls and surveys, forms, predictors, leaderboards, minigames and stories. Build, publish and embed interactive content, then collect and route the results — no code required.
+
+By leveraging the Riddle Quiz Maker API on Pipedream, you can automate interactions with your interactive content, extract responses in real-time, synchronize data across platforms, and trigger actions based on user engagement. Exploiting Pipedream's serverless platform allows you to create workflows that respond swiftly, integrate with numerous apps, and streamline content management—turning audience insights into actionable intelligence.
 
 # Example Use Cases
 
-- **Content Engagement Trigger for Email Campaigns**: When a user completes a quiz, you could trigger a workflow that adds or updates their information in a Mailchimp audience list, including their quiz results. This allows for personalized follow-up emails, tailored content delivery, or segmenting users based on their preferences.
+- **Content Engagement Trigger for Email Campaigns**: When a user completes a quiz or personality test, you could trigger a workflow that adds or updates their information in a Mailchimp audience list, including their results. This allows for personalized follow-up emails, tailored content delivery, or segmenting users based on their preferences.
 
-- **Real-time Analytics Dashboard Update**: After a new set of quiz responses is collected, you could automate the transfer of this data to a Google Sheets spreadsheet. From there, it’s possible to visualize this data using tools like Google Data Studio, providing up-to-date analytics to inform marketing strategies or content creation.
+- **Real-time Analytics Dashboard Update**: After a new set of responses is collected, you could automate the transfer of this data to a Google Sheets spreadsheet. From there, it’s possible to visualize this data using tools like Google Data Studio, providing up-to-date analytics to inform marketing strategies or content creation.
 
-- **Lead Scoring and CRM Integration**: Use quiz results to score leads and automatically push this information into a CRM like Salesforce. Scoring can be based on the user's answers, indicating their interest level or fit for a product or service, allowing for more efficient lead prioritization and follow-up by the sales team.
+- **Lead Scoring and CRM Integration**: Use quiz and form results to score leads and automatically push this information into a CRM like Salesforce. Scoring can be based on the user's answers, indicating their interest level or fit for a product or service, allowing for more efficient lead prioritization and follow-up by the sales team.


### PR DESCRIPTION
## Summary

The `riddle_quiz_maker` overview described Riddle as quizzes, polls and surveys only. Riddle is an interactive content platform that also covers personality tests, forms, predictors, leaderboards, minigames and stories, so the listing understated what the app does.

The replacement wording is the copy supplied by the Riddle team in #21717. The three example use cases are kept as-is, with the quiz-only phrasing broadened to match.

Partially addresses #21717 — that issue asks for three changes, and only the description lives in this repo (`scripts/updateMarketplaceReadme.mts` publishes `components/<app>/README.md` to the marketplace listing). The other two need a change on the Pipedream side rather than a PR:

- **Logo** — the listing uses an older version; current brand assets are linked in the issue.
- **MCP URL** — the issue asks it to point at Riddle's documentation and MCP server endpoint.

Flagging those so a maintainer can pick them up; happy to help if any part of them is repo-side after all.

## Checklist

### Versioning

No component or app code changed — this is a README-only update, so there are no component or `package.json` versions to bump.

### New app

- [x] The app updated in this PR is already integrated

### CodeRabbit review

- [ ] I have addressed or acknowledged all of CodeRabbit's review comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the product overview to reflect support for interactive content including quizzes, personality tests, polls, surveys, forms, predictors, leaderboards, minigames, and stories.
  - Clarified that content can be built, published, and embedded without coding.
  - Broadened example use cases beyond quizzes to include personality tests, forms, and customizable responses or results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->