### PR TITLE
build: make the root jest run actually work

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,10 +3,16 @@ module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
   // See https://kulshekhar.github.io/ts-jest/docs/guides/esm-support
+  // ".js" is rejected here — jest always infers it from the nearest package.json
   extensionsToTreatAsEsm: [
-    ".js",
     ".ts",
     ".mts",
+  ],
+  // the default testMatch covers .js/.ts only, and components are written in .mjs
+  testMatch: [
+    "**/__tests__/**/*.[jt]s?(x)",
+    "**/?(*.)+(spec|test).[jt]s?(x)",
+    "**/?(*.)+(spec|test).mjs",
   ],
   moduleNameMapper: {
     "^(.+)\\.js$": "$1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "prepare": "husky install",
     "build": "node scripts/build-components.mjs",
-    "test": "jest --passWithNoTests components",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --passWithNoTests components",
     "test-all": "npm test && npm run platform-test && npm run types-test",
     "platform-dist": "cd platform && git add dist && (git diff-index --quiet HEAD || git commit -m 'update platform/dist')",
     "platform-test": "cd platform && npm test",


### PR DESCRIPTION
## Summary

`npm test` fails on `master` before running a single suite:

```
$ npm test
> jest --passWithNoTests components

● Validation Error:

  Option: extensionsToTreatAsEsm: ['.js', '.ts', '.mts'] includes '.js' which is
  always inferred based on type in its nearest package.json.
```

jest 29 rejects `.js` in `extensionsToTreatAsEsm`, since it infers that one from the nearest `package.json`. It has gone unnoticed because there are no tests under `components/` and no workflow calls the script — `pull-request-checks.yaml` runs eslint, `pnpm build` and the key checks, and only the SDK workflow runs jest.

Two more things stood between the config and a runnable component test:

- the default `testMatch` covers `.js`/`.ts` only, while components are written in `.mjs`, so a `.mjs` test is never discovered
- loading `.mjs` needs `--experimental-vm-modules`, which the script did not pass, so a discovered test dies on `Cannot use import statement outside a module`

### Change

Three small edits, no behaviour change for anything that runs today:

- drop `.js` from `extensionsToTreatAsEsm`
- add `**/?(*.)+(spec|test).mjs` to `testMatch`, keeping the two defaults
- run jest through `node --experimental-vm-modules` in the `test` script, rather than expecting the caller to set `NODE_OPTIONS`

### Verification

On `master`, `npm test` exits 1 on the validation error above. With this change it exits 0:

```
> node --experimental-vm-modules node_modules/jest/bin/jest.js --passWithNoTests components
No tests found, exiting with code 0
```

Running an actual `.mjs` suite through it is exercised in #21903, which adds the first tests under `components/` and is where I hit this.

## Checklist
Please check the following items before your PR can be reviewed:

### Versioning
- [x] All components updated in this PR had their version updated (`0.0.1` for new ones)
- [x] The app updated in this PR had its `package.json`'s version updated

### New app
If this is a new app, please submit [an app integration request](https://github.com/PipedreamHQ/pipedream/issues/new?template=app---service-integration.md) - the PR will only be reviewed after the app is integrated.
- [x] The app updated in this PR is already integrated

### CodeRabbit review
After the PR is opened, and if new changes are pushed, CodeRabbit will automatically review it. Do not 'mark as resolved' CodeRabbit's comments, but reply to them instead, whether you agree (and update the PR accordingly) or disagree.
- [ ] I have addressed or acknowledged all of CodeRabbit's review comments

No components or apps are touched here, so the versioning and app items are not applicable rather than done.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test execution compatibility for ECMAScript modules.
  * Expanded test file matching for JavaScript, TypeScript, and component tests.
  * Tests continue to pass when no matching test files are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->