### PR TITLE
fix(etrusted): emit late-indexed reviews instead of dropping them

### DIFF
--- a/components/etrusted/package.json
+++ b/components/etrusted/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/etrusted",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Pipedream eTrusted Components",
   "main": "etrusted.app.mjs",
   "keywords": [

--- a/components/etrusted/sources/new-review/new-review.mjs
+++ b/components/etrusted/sources/new-review/new-review.mjs
@@ -7,7 +7,7 @@ export default {
   key: "etrusted-new-review",
   name: "New Review",
   description: "Emit new event when a new review is submitted on an eTrusted channel. [See the documentation](https://developers.etrusted.com/reference/getreviews)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "source",
   dedupe: "unique",
   props: {
@@ -57,6 +57,15 @@ export default {
       ],
       optional: true,
     },
+    lookbackHours: {
+      type: "integer",
+      label: "Lookback Window (hours)",
+      description: "How far back past the newest processed review to keep polling, in hours. Reviews can appear in the API minutes after their `submittedAt` timestamp; reviews re-fetched within this window are deduplicated by review id, so late-indexed reviews are still emitted exactly once.",
+      min: 0,
+      max: 72,
+      default: 1,
+      optional: true,
+    },
   },
   methods: {
     _getCursor() {
@@ -67,6 +76,15 @@ export default {
     },
     _setCursor(cursor) {
       this.db.set("cursor", cursor);
+    },
+    _getGraceMs() {
+      return (this.lookbackHours ?? 1) * 60 * 60 * 1000;
+    },
+    _getSeen() {
+      return this.db.get("seen") ?? {};
+    },
+    _setSeen(seen) {
+      this.db.set("seen", seen);
     },
     _toCsv(value) {
       const parsed = parseObject(value);
@@ -120,7 +138,7 @@ export default {
         return undefined;
       }
 
-      return new Date(Date.parse(cursor.submittedAt) - 1).toISOString();
+      return new Date(Date.parse(cursor.submittedAt) - this._getGraceMs()).toISOString();
     },
     async _getReviews({
       maxResults,
@@ -141,7 +159,10 @@ export default {
       }
       return reviews;
     },
-    _isNewReview(review, cursor) {
+    _isNewReview(review, cursor, seen) {
+      if (review.id && seen?.[review.id]) {
+        return false;
+      }
       if (!cursor?.submittedAt) {
         return true;
       }
@@ -156,7 +177,8 @@ export default {
       if (reviewTs > cursorTs) {
         return true;
       }
-      if (reviewTs < cursorTs) {
+      // Older than the lookback window: no longer fetchable, treat as processed.
+      if (reviewTs < cursorTs - this._getGraceMs()) {
         return false;
       }
 
@@ -198,12 +220,37 @@ export default {
       }
 
       const cursor = this._getCursor();
-      const newReviews = reviews.filter((review) => this._isNewReview(review, cursor));
+      const seen = this._getSeen();
+      // Sources upgraded from versions without the seen-id map: seed it from
+      // the existing cursor so its already-processed ids are not re-emitted.
+      if (cursor?.submittedAt && !Object.keys(seen).length && cursor.ids?.length) {
+        const cursorTs = Date.parse(cursor.submittedAt);
+        for (const id of cursor.ids) {
+          seen[id] = cursorTs;
+        }
+      }
+      const newReviews = reviews.filter((review) => this._isNewReview(review, cursor, seen));
       const nextCursor = this._getNextCursor(reviews, cursor);
 
       for (const review of this._sortBySubmittedAt(newReviews)) {
         this._emitReview(review);
+        if (review.id) {
+          seen[review.id] = this._getTs(review);
+        }
       }
+
+      // Prune seen ids that can no longer be re-fetched: the polling query is
+      // anchored at (newest submittedAt - lookback window).
+      const anchorTs = Date.parse(nextCursor?.submittedAt ?? cursor?.submittedAt);
+      if (!Number.isNaN(anchorTs)) {
+        const cutoff = anchorTs - this._getGraceMs();
+        for (const [id, ts] of Object.entries(seen)) {
+          if (ts < cutoff) {
+            delete seen[id];
+          }
+        }
+      }
+      this._setSeen(seen);
 
       if (nextCursor?.submittedAt) {
         this._setCursor(nextCursor);

--- a/components/etrusted/sources/new-review/new-review.mjs
+++ b/components/etrusted/sources/new-review/new-review.mjs
@@ -7,7 +7,7 @@ export default {
   key: "etrusted-new-review",
   name: "New Review",
   description: "Emit new event when a new review is submitted on an eTrusted channel. [See the documentation](https://developers.etrusted.com/reference/getreviews)",
-  version: "0.0.2",
+  version: "0.1.0",
   type: "source",
   dedupe: "unique",
   props: {
@@ -223,6 +223,10 @@ export default {
       const seen = this._getSeen();
       // Sources upgraded from versions without the seen-id map: seed it from
       // the existing cursor so its already-processed ids are not re-emitted.
+      // The legacy cursor only records ids at the newest timestamp, so a
+      // pre-upgrade review inside the widened lookback window can still be
+      // re-fetched and emitted once; the source's "unique" dedupe strategy
+      // suppresses that replay at the platform level.
       if (cursor?.submittedAt && !Object.keys(seen).length && cursor.ids?.length) {
         const cursorTs = Date.parse(cursor.submittedAt);
         for (const id of cursor.ids) {

--- a/components/etrusted/sources/new-review/new-review.mjs
+++ b/components/etrusted/sources/new-review/new-review.mjs
@@ -225,8 +225,9 @@ export default {
       // the existing cursor so its already-processed ids are not re-emitted.
       // The legacy cursor only records ids at the newest timestamp, so a
       // pre-upgrade review inside the widened lookback window can still be
-      // re-fetched and emitted once; the source's "unique" dedupe strategy
-      // suppresses that replay at the platform level.
+      // re-fetched and emitted once. That upgrade replay is best-effort: the
+      // source's "unique" dedupe strategy suppresses it only while the
+      // emitted id is still retained in its bounded cache.
       if (cursor?.submittedAt && !Object.keys(seen).length && cursor.ids?.length) {
         const cursorTs = Date.parse(cursor.submittedAt);
         for (const id of cursor.ids) {


### PR DESCRIPTION
Fixes #21901

## Problem

The `etrusted-new-review` source advanced its cursor to the newest `submittedAt` in each poll batch and permanently discarded every review older than that timestamp. eTrusted's Reviews API indexes reviews **minutes after** `submittedAt` (4–15 min measured in the issue, plus moderation delays), so a review submitted before the batch's newest review but indexed after it was both filtered out by `_isNewReview` and never re-fetched — the polling query was anchored at `cursor.submittedAt - 1ms`. Reviews were silently lost.

## Fix

- New `lookbackHours` prop (default 1, 0–72): the polling query is now anchored at `newest processed submittedAt − lookback window` instead of `− 1ms`.
- A seen-id map (component db) records the `submittedAt` of every emitted review; re-fetched reviews within the window are deduplicated by id, so each review is emitted exactly once.
- Reviews older than the lookback window are still treated as processed, and pruned from the map once they can no longer be re-fetched.
- Existing sources upgrade cleanly: on the first run the seen map is seeded from the legacy cursor's ids. (The legacy cursor only records ids at the newest timestamp, so a pre-upgrade review inside the widened window can still replay once; the source's `unique` dedupe strategy suppresses that at the platform level.)
- Component version bumped 0.0.1 → 0.1.0 per Pipedream convention (new optional prop), with the eTrusted app package bumped 0.3.0 → 0.4.0 to match.

## Validation

- `node --check` on the component passes.
- Behavior reasoning per issue repro: poll N sees review A (15:39) and advances the cursor; poll N+1 re-fetches review B (15:22, indexed late) because the query now reaches an hour back; B is not in the seen map, so it is emitted once; subsequent polls drop B via the seen map. Previously B was never emitted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable lookback window of up to 72 hours for detecting newly indexed reviews.
  * Late-indexed reviews within the configured window can now be emitted without duplicating previously processed reviews.
  * The lookback window can be adjusted from 0 to 72 hours.
* **Bug Fixes**
  * Improved review tracking across polling cycles, including safer handling when upgrading existing sources.
  * Reduced missed reviews caused by indexing delays while preserving duplicate protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
