### PR TITLE
fix(todoist): follow next_cursor when reading REST collections

### DIFF
--- a/components/todoist/actions/create-project-comment/create-project-comment.mjs
+++ b/components/todoist/actions/create-project-comment/create-project-comment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-create-project-comment",
   name: "Create Project Comment",
   description: "Adds a comment to a project. [See the documentation](https://developer.todoist.com/api/v1#tag/Comments/operation/create_comment_api_v1_comments_post)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/todoist/actions/create-project/create-project.mjs
+++ b/components/todoist/actions/create-project/create-project.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-create-project",
   name: "Create Project",
   description: "Creates a project. [See the documentation](https://developer.todoist.com/api/v1#tag/Projects/operation/create_project_api_v1_projects_post)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/todoist/actions/create-section/create-section.mjs
+++ b/components/todoist/actions/create-section/create-section.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-create-section",
   name: "Create Section",
   description: "Creates a section. [See the documentation](https://developer.todoist.com/api/v1#tag/Sections/operation/create_section_api_v1_sections_post)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/todoist/actions/create-task-comment/create-task-comment.mjs
+++ b/components/todoist/actions/create-task-comment/create-task-comment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-create-task-comment",
   name: "Create Task Comment",
   description: "Adds a comment to a task. [See the documentation](https://developer.todoist.com/api/v1#tag/Comments/operation/create_comment_api_v1_comments_post)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/todoist/actions/create-task/create-task.mjs
+++ b/components/todoist/actions/create-task/create-task.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-create-task",
   name: "Create Task",
   description: "Creates a task. [See the documentation](https://developer.todoist.com/api/v1#tag/Tasks/operation/create_task_api_v1_tasks_post)",
-  version: "0.0.12",
+  version: "0.0.13",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/todoist/actions/delete-comment/delete-comment.mjs
+++ b/components/todoist/actions/delete-comment/delete-comment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-delete-comment",
   name: "Delete Comment",
   description: "Deletes a comment. [See the documentation](https://developer.todoist.com/api/v1#tag/Comments/operation/delete_comment_api_v1_comments__comment_id__delete)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/todoist/actions/delete-label/delete-label.mjs
+++ b/components/todoist/actions/delete-label/delete-label.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-delete-label",
   name: "Delete Label",
   description: "Deletes a label. [See the documentation](https://developer.todoist.com/api/v1#tag/Labels/operation/delete_label_api_v1_labels__label_id__delete)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/todoist/actions/delete-project/delete-project.mjs
+++ b/components/todoist/actions/delete-project/delete-project.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-delete-project",
   name: "Delete Project",
   description: "Deletes a project. [See the documentation](https://developer.todoist.com/api/v1#tag/Projects/operation/delete_project_api_v1_projects__project_id__delete)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/todoist/actions/delete-section/delete-section.mjs
+++ b/components/todoist/actions/delete-section/delete-section.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-delete-section",
   name: "Delete Section",
   description: "Deletes a section. [See the documentation](https://developer.todoist.com/api/v1#tag/Sections/operation/delete_section_api_v1_sections__section_id__delete)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/todoist/actions/delete-task/delete-task.mjs
+++ b/components/todoist/actions/delete-task/delete-task.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-delete-task",
   name: "Delete Task",
   description: "Deletes a task. [See the documentation](https://developer.todoist.com/api/v1#tag/Tasks/operation/delete_task_api_v1_tasks__task_id__delete)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/todoist/actions/export-tasks/export-tasks.mjs
+++ b/components/todoist/actions/export-tasks/export-tasks.mjs
@@ -7,7 +7,7 @@ export default {
   key: "todoist-export-tasks",
   name: "Export Tasks",
   description: "Export project task names as comma separated file. Returns path to new file. [See the documentation](https://developer.todoist.com/api/v1#tag/Tasks/operation/get_tasks_api_v1_tasks_get)",
-  version: "0.1.8",
+  version: "0.1.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/todoist/actions/find-project/find-project.mjs
+++ b/components/todoist/actions/find-project/find-project.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-find-project",
   name: "Find Project",
   description: "Finds a project (by name/title). [See the documentation](https://developer.todoist.com/api/v1#tag/Projects/operation/get_projects_api_v1_projects_get) Optionally, create one if none are found. [See the documentation](https://developer.todoist.com/api/v1#tag/Projects/operation/create_project_api_v1_projects_post)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/todoist/actions/find-task/find-task.mjs
+++ b/components/todoist/actions/find-task/find-task.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-find-task",
   name: "Find Task",
   description: "Finds a task by name. [See the documentation](https://developer.todoist.com/api/v1#tag/Tasks/operation/get_tasks_api_v1_tasks_get) Optionally, create one if none are found. [See the documentation](https://developer.todoist.com/api/v1#tag/Tasks/operation/create_task_api_v1_tasks_post)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/todoist/actions/get-label/get-label.mjs
+++ b/components/todoist/actions/get-label/get-label.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-get-label",
   name: "Get Label",
   description: "Returns info about a label. [See the documentation](https://developer.todoist.com/api/v1#tag/Labels/operation/get_label_api_v1_labels__label_id__get)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/todoist/actions/get-project-comment/get-project-comment.mjs
+++ b/components/todoist/actions/get-project-comment/get-project-comment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-get-project-comment",
   name: "Get Project Comment",
   description: "Returns info about a project comment. [See the documentation](https://developer.todoist.com/api/v1#tag/Comments/operation/get_comment_api_v1_comments__comment_id__get)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/todoist/actions/get-project/get-project.mjs
+++ b/components/todoist/actions/get-project/get-project.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-get-project",
   name: "Get Project",
   description: "Returns info about a project. [See the documentation](https://developer.todoist.com/api/v1#tag/Projects/operation/get_project_api_v1_projects__project_id__get)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/todoist/actions/get-section/get-section.mjs
+++ b/components/todoist/actions/get-section/get-section.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-get-section",
   name: "Get Section",
   description: "Returns info about a section. [See the documentation](https://developer.todoist.com/api/v1#tag/Sections/operation/get_section_api_v1_sections__section_id__get)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/todoist/actions/get-task-comment/get-task-comment.mjs
+++ b/components/todoist/actions/get-task-comment/get-task-comment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-get-task-comment",
   name: "Get Task Comment",
   description: "Returns info about a task comment. [See the documentation](https://developer.todoist.com/api/v1#tag/Comments/operation/get_comment_api_v1_comments__comment_id__get)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/todoist/actions/get-task/get-task.mjs
+++ b/components/todoist/actions/get-task/get-task.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-get-task",
   name: "Get Task",
   description: "Returns info about a task. [See the documentation](https://developer.todoist.com/api/v1#tag/Tasks/operation/get_task_api_v1_tasks__task_id__get)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/todoist/actions/import-tasks/import-tasks.mjs
+++ b/components/todoist/actions/import-tasks/import-tasks.mjs
@@ -6,7 +6,7 @@ export default {
   key: "todoist-import-tasks",
   name: "Import Tasks",
   description: "Import tasks into a selected project. [See the documentation](https://developer.todoist.com/api/v1#tag/Tasks/operation/create_task_api_v1_tasks_post)",
-  version: "0.1.8",
+  version: "0.1.9",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/todoist/actions/invite-user-to-project/invite-user-to-project.mjs
+++ b/components/todoist/actions/invite-user-to-project/invite-user-to-project.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-invite-user-to-project",
   name: "Invite User To Project",
   description: "Sends email to a person, inviting them to use one of your projects. [See the documentation](https://developer.todoist.com/api/v1#tag/Sync/Sharing/Share-a-project)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/todoist/actions/list-labels/list-labels.mjs
+++ b/components/todoist/actions/list-labels/list-labels.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-list-labels",
   name: "List Labels",
   description: "Returns a list of all labels. [See the documentation](https://developer.todoist.com/api/v1#tag/Labels/operation/get_labels_api_v1_labels_get)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/todoist/actions/list-project-comments/list-project-comments.mjs
+++ b/components/todoist/actions/list-project-comments/list-project-comments.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-list-project-comments",
   name: "List Project Comments",
   description: "Returns a list of comments for a project. [See the documentation](https://developer.todoist.com/api/v1#tag/Comments/operation/get_comments_api_v1_comments_get)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/todoist/actions/list-projects/list-projects.mjs
+++ b/components/todoist/actions/list-projects/list-projects.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-list-projects",
   name: "List Projects",
   description: "Returns a list of all projects. [See the documentation](https://developer.todoist.com/api/v1#tag/Projects/operation/get_projects_api_v1_projects_get)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/todoist/actions/list-sections/list-sections.mjs
+++ b/components/todoist/actions/list-sections/list-sections.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-list-sections",
   name: "List Sections",
   description: "Returns a list of all sections. [See the documentation](https://developer.todoist.com/api/v1#tag/Sections/operation/get_sections_api_v1_sections_get)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/todoist/actions/list-task-comments/list-task-comments.mjs
+++ b/components/todoist/actions/list-task-comments/list-task-comments.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-list-task-comments",
   name: "List Task Comments",
   description: "Returns a list of comments for a task. [See the documentation](https://developer.todoist.com/api/v1#tag/Comments/operation/get_comments_api_v1_comments_get)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/todoist/actions/list-uncompleted-tasks/list-uncompleted-tasks.mjs
+++ b/components/todoist/actions/list-uncompleted-tasks/list-uncompleted-tasks.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-list-uncompleted-tasks",
   name: "List Uncompleted Tasks",
   description: "Returns a list of uncompleted tasks by project, section, and/or label. [See the documentation](https://developer.todoist.com/api/v1#tag/Tasks/operation/get_tasks_api_v1_tasks_get)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/todoist/actions/mark-task-completed/mark-task-completed.mjs
+++ b/components/todoist/actions/mark-task-completed/mark-task-completed.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-mark-task-completed",
   name: "Mark Task as Completed",
   description: "Marks a task as being completed. [See the documentation](https://developer.todoist.com/api/v1#tag/Tasks/operation/close_task_api_v1_tasks__task_id__close_post)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/todoist/actions/move-task-to-section/move-task-to-section.mjs
+++ b/components/todoist/actions/move-task-to-section/move-task-to-section.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-move-task-to-section",
   name: "Move Task To Section",
   description: "Move a Task to a different section within the same project. [See the documentation](https://developer.todoist.com/api/v1#tag/Tasks/operation/move_task_api_v1_tasks__task_id__move_post)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/todoist/actions/search-tasks/search-tasks.mjs
+++ b/components/todoist/actions/search-tasks/search-tasks.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-search-tasks",
   name: "Search Tasks",
   description: "Search tasks by name, label, project and/or section. [See the documentation](https://developer.todoist.com/api/v1#tag/Tasks/operation/get_tasks_api_v1_tasks_get)",
-  version: "0.0.9",
+  version: "0.0.10",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/todoist/actions/uncomplete-task/uncomplete-task.mjs
+++ b/components/todoist/actions/uncomplete-task/uncomplete-task.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-uncomplete-task",
   name: "Uncomplete Task",
   description: "Uncompletes a task. [See the documentation](https://developer.todoist.com/api/v1#tag/Tasks/operation/reopen_task_api_v1_tasks__task_id__reopen_post)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/todoist/actions/update-comment/update-comment.mjs
+++ b/components/todoist/actions/update-comment/update-comment.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-update-comment",
   name: "Update Comment",
   description: "Updates a comment. [See the documentation](https://developer.todoist.com/api/v1#tag/Comments/operation/update_comment_api_v1_comments__comment_id__post)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/todoist/actions/update-label/update-label.mjs
+++ b/components/todoist/actions/update-label/update-label.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-update-label",
   name: "Update Label",
   description: "Updates a label. [See the documentation](https://developer.todoist.com/api/v1#tag/Labels/operation/update_label_api_v1_labels__label_id__post)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/todoist/actions/update-project/update-project.mjs
+++ b/components/todoist/actions/update-project/update-project.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-update-project",
   name: "Update Project",
   description: "Updates a project. [See the documentation](https://developer.todoist.com/api/v1#tag/Projects/operation/update_project_api_v1_projects__project_id__post)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/todoist/actions/update-section/update-section.mjs
+++ b/components/todoist/actions/update-section/update-section.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-update-section",
   name: "Update Section",
   description: "Updates a section. [See the documentation](https://developer.todoist.com/api/v1#tag/Sections/operation/update_section_api_v1_sections__section_id__post)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/todoist/actions/update-task/update-task.mjs
+++ b/components/todoist/actions/update-task/update-task.mjs
@@ -4,7 +4,7 @@ export default {
   key: "todoist-update-task",
   name: "Update Task",
   description: "Updates a task. [See the documentation](https://developer.todoist.com/api/v1#tag/Tasks/operation/update_task_api_v1_tasks__task_id__post)",
-  version: "0.0.10",
+  version: "0.0.11",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/todoist/common/constants.mjs
+++ b/components/todoist/common/constants.mjs
@@ -33,3 +33,8 @@ export const POLL_SAFETY_BUFFER_MS = 60 * 1000;
 // completions beyond the first 20 in the lookback window, since the
 // watermark would already have advanced past them.
 export const MAX_RESULTS_PER_POLL = 20;
+
+// REST collection page size. Todoist's v1 collection endpoints are cursor-
+// paginated and default to 50 records per page; 200 is the documented maximum,
+// so it minimizes round trips when reading a collection in full.
+export const REST_PAGE_LIMIT = 200;

--- a/components/todoist/package.json
+++ b/components/todoist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/todoist",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Pipedream Todoist Components",
   "main": "todoist.app.mjs",
   "keywords": [

--- a/components/todoist/sources/completed-task/completed-task.mjs
+++ b/components/todoist/sources/completed-task/completed-task.mjs
@@ -30,7 +30,7 @@ export default {
   key: "todoist-completed-task",
   name: "New Completed Task",
   description: "Emit new event for each completed Todoist task, including recurring task completions. Non-recurring completions are polled via `GET /tasks/completed/by_completion_date`. Recurring completions don't appear there - Todoist reschedules a recurring task instead of marking it completed there - so they're additionally polled via the v1 Activity Log (`GET /api/v1/activities`), detected as an `item:completed` event with `extra_data.is_recurring` set to `true`. **Accessing recurring task completions older than 7 days requires a Todoist premium/business plan**.  Respects the Projects filter. [See the documentation](https://developer.todoist.com/api/v1/#tag/Activity/operation/get_activity_logs_api_v1_activities_get).",
-  version: "2.0.0",
+  version: "2.0.1",
   type: "source",
   dedupe: "unique",
   methods: {

--- a/components/todoist/sources/incomplete-task/incomplete-task.mjs
+++ b/components/todoist/sources/incomplete-task/incomplete-task.mjs
@@ -5,7 +5,7 @@ export default {
   key: "todoist-incomplete-task",
   name: "New Incomplete Task",
   description: "Emit new event for each new incomplete task. [See the documentation](https://developer.todoist.com/api/v1#tag/Sync/Overview/Read-resources)",
-  version: "0.1.6",
+  version: "0.1.7",
   type: "source",
   dedupe: "unique",
   props: {

--- a/components/todoist/sources/new-or-modified-task/new-or-modified-task.mjs
+++ b/components/todoist/sources/new-or-modified-task/new-or-modified-task.mjs
@@ -5,6 +5,6 @@ export default {
   key: "todoist-new-or-modified-task",
   name: "New or Modified Task",
   description: "Emit new event for each new or modified task. [See the documentation](https://developer.todoist.com/api/v1#tag/Sync/Overview/Read-resources)",
-  version: "0.0.12",
+  version: "0.0.13",
   type: "source",
 };

--- a/components/todoist/sources/new-task/new-task.mjs
+++ b/components/todoist/sources/new-task/new-task.mjs
@@ -5,7 +5,7 @@ export default {
   key: "todoist-new-task",
   name: "New Task",
   description: "Emit new event for each new task. [See the documentation](https://developer.todoist.com/api/v1#tag/Sync/Overview/Read-resources)",
-  version: "0.0.12",
+  version: "0.0.13",
   type: "source",
   dedupe: "greatest",
 };

--- a/components/todoist/todoist.app.mjs
+++ b/components/todoist/todoist.app.mjs
@@ -2,6 +2,7 @@ import { axios } from "@pipedream/platform";
 import querystring from "query-string";
 import { v4 as uuid } from "uuid";
 import colors, { numericToString } from "./common/colors.mjs";
+import { REST_PAGE_LIMIT } from "./common/constants.mjs";
 import resourceTypes from "./common/resource-types.mjs";
 
 export default {
@@ -328,6 +329,39 @@ export default {
       return axios($ ?? this, opts);
     },
     /**
+     * Make a request to a paginated Todoist REST collection endpoint, following
+     * `next_cursor` until the collection is exhausted.
+     *
+     * Todoist's v1 collection endpoints return `{ results, next_cursor }` and
+     * default to 50 records per page, so a single request silently returns the
+     * first page of a larger collection.
+     * @params {Object} opts - The options accepted by `_makeRestRequest`
+     * @returns {Object} An object with a `results` array holding every record
+     */
+    async _makePaginatedRestRequest(opts) {
+      const results = [];
+      let cursor;
+
+      do {
+        const response = await this._makeRestRequest({
+          ...opts,
+          params: {
+            ...opts.params,
+            limit: REST_PAGE_LIMIT,
+            ...(cursor && {
+              cursor,
+            }),
+          },
+        });
+        results.push(...(response?.results ?? []));
+        cursor = response?.next_cursor;
+      } while (cursor);
+
+      return {
+        results,
+      };
+    },
+    /**
      * Get syncToken from a db
      * @params {Object} db - a database instance
      * @returns {*} "syncToken" in the db specified
@@ -418,11 +452,16 @@ export default {
         $,
         id = "",
       } = opts;
-      return this._makeRestRequest({
+      if (id) {
+        return this._makeRestRequest({
+          $,
+          path: `/projects/${id}`,
+          method: "GET",
+        });
+      }
+      return this._makePaginatedRestRequest({
         $,
-        path: id
-          ? `/projects/${id}`
-          : "/projects",
+        path: "/projects",
         method: "GET",
       });
     },
@@ -528,7 +567,7 @@ export default {
           results: [],
         };
       }
-      return this._makeRestRequest({
+      return this._makePaginatedRestRequest({
         path: `/projects/${projectId}/collaborators`,
         method: "GET",
       });
@@ -547,11 +586,17 @@ export default {
       } = opts;
       const { section_id: id = "" } = params;
       delete params.section_id;
-      return this._makeRestRequest({
+      if (id) {
+        return this._makeRestRequest({
+          $,
+          path: `/sections/${id}`,
+          method: "GET",
+          params,
+        });
+      }
+      return this._makePaginatedRestRequest({
         $,
-        path: id
-          ? `/sections/${id}`
-          : "/sections",
+        path: "/sections",
         method: "GET",
         params,
       });
@@ -625,11 +670,16 @@ export default {
         $,
         id = "",
       } = opts;
-      return this._makeRestRequest({
+      if (id) {
+        return this._makeRestRequest({
+          $,
+          path: `/labels/${id}`,
+          method: "GET",
+        });
+      }
+      return this._makePaginatedRestRequest({
         $,
-        path: id
-          ? `/labels/${id}`
-          : "/labels",
+        path: "/labels",
         method: "GET",
       });
     },
@@ -717,11 +767,17 @@ export default {
         delete params.project_id;
       }
       delete params.comment_id;
-      return this._makeRestRequest({
+      if (id) {
+        return this._makeRestRequest({
+          $,
+          path: `/comments/${id}`,
+          method: "GET",
+          params,
+        });
+      }
+      return this._makePaginatedRestRequest({
         $,
-        path: id
-          ? `/comments/${id}`
-          : "/comments",
+        path: "/comments",
         method: "GET",
         params,
       });
@@ -798,11 +854,17 @@ export default {
       } = opts;
       const { task_id: id = "" } = params;
       delete params.task_id;
-      return this._makeRestRequest({
+      if (id) {
+        return this._makeRestRequest({
+          $,
+          path: `/tasks/${id}`,
+          method: "GET",
+          params,
+        });
+      }
+      return this._makePaginatedRestRequest({
         $,
-        path: id
-          ? `/tasks/${id}`
-          : "/tasks",
+        path: "/tasks",
         method: "GET",
         params,
       });


### PR DESCRIPTION
## Problem

Todoist's v1 collection endpoints are cursor-paginated: each response is `{ results, next_cursor }` and `limit` defaults to 50 (max 200). The shared getters in `todoist.app.mjs` issue a single request, so every collection read silently returns the first 50 records as though it were the whole set.

Two consequences:

1. **List and export actions under-report.** `list-uncompleted-tasks`, `list-projects`, `list-sections`, `list-labels`, `list-task-comments`, `list-project-comments` and `export-tasks` stop at 50.
2. **Search and find actions report false negatives.** `search-tasks`, `find-task` and `find-project` filter that first page locally, so a record past item 50 is reported as not found. For the two `find-*` actions with `createIfNotFound` enabled, that means creating a duplicate of a record that already exists.

The option loaders for `project`, `section`, `label`, `labelString`, `task`, `assignee` and `commentId` have the same ceiling, so a workspace with more than 50 projects cannot select the ones past that point in any component.

Because the actions return `resp.results`, `next_cursor` never reaches the caller, so this cannot be worked around downstream.

Observed on a real account: a project with more than one page of tasks returned exactly 50 tasks from `list-uncompleted-tasks`, and exact-title `search-tasks` calls for three tasks that exist in that project returned `[]`.

## Change

Adds `_makePaginatedRestRequest`, which follows `next_cursor` at `limit=200` until the collection is exhausted, and routes the collection branch of `getProjects`, `getActiveTasks`, `getSections`, `getLabels`, `getComments` and `getProjectCollaborators` through it.

Two things are deliberately left alone:

- **The single-record branch of each getter.** `/tasks/{id}`, `/projects/{id}` and friends return a bare record with no `results` envelope, so `get-task`, `get-project`, `get-section`, `get-label` and the two `get-*-comment` actions keep the existing unpaginated path and their output shape is unchanged.
- **`getCompletedTasks` and `getActivityLogs`.** The `completed-task` source (2.0.0) and the `completedTask` option loader already follow those cursors themselves; paginating inside the getter would break both.

Version bumps cover the 36 actions and 4 sources whose behaviour changes, either by calling a changed getter or by using an option loader that now returns the full collection.

## Testing

`npx eslint components/todoist` passes. Verified by inspection that every caller of the six changed getters reads `.results` and none passes a cursor of its own; the only cursor-aware callers in the component are the `completed-task` source and the `completedTask` option loader, both of which use the two untouched getters.

## Separate issue, not fixed here

`list-uncompleted-tasks` passes `label_id` to `GET /tasks`, but that endpoint filters by label *name* and has no `label_id` parameter, so Todoist ignores it and the action returns unfiltered results whenever a label is selected. Its `label` prop is the id-valued `label` propDefinition, where `search-tasks` correctly uses the name-valued `labelString`. Happy to fix that in a follow-up PR if you'd like it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Todoist collection lookups now retrieve all available results across multiple pages, improving completeness for projects, collaborators, sections, labels, comments, and active tasks.
  - Collection requests support larger page sizes to reduce the number of requests needed when loading extensive Todoist data.

- **Chores**
  - Updated the Todoist integration package, actions, and event sources to newer component versions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->