### PR TITLE
fix(ai): re-publish batch-5 tail components dropped by 300-file cap

### DIFF
--- a/components/vincario/actions/check-stolen/check-stolen.mjs
+++ b/components/vincario/actions/check-stolen/check-stolen.mjs
@@ -4,7 +4,7 @@ export default {
   key: "vincario-check-stolen",
   name: "Check Stolen",
   description: "Performs a real-time VIN check in national police databases of stolen vehicles of Czech Republic, Hungary, Romania, Slovenia, Slovakia and Vincario's own database of stolen vehicles. [See the documentation](https://vincario.com/api-docs/3.2/#api-endpoints)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   ai: "optimized",
   annotations: {

--- a/components/vincario/actions/get-vin-decoder-info/get-vin-decoder-info.mjs
+++ b/components/vincario/actions/get-vin-decoder-info/get-vin-decoder-info.mjs
@@ -4,7 +4,7 @@ export default {
   key: "vincario-get-vin-decoder-info",
   name: "Get VIN Decoder Info",
   description: "Get a list of vehicle attributes. Each represents label that is available for given VIN when you do a 'VIN Decode' request. [See the documentation](https://vincario.com/api-docs/3.2/#api-endpoints)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   ai: "optimized",
   annotations: {

--- a/components/vincario/package.json
+++ b/components/vincario/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/vincario",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream Vincario Components",
   "main": "vincario.app.mjs",
   "keywords": [

--- a/components/youtube_data_api/actions/create-comment-thread/create-comment-thread.mjs
+++ b/components/youtube_data_api/actions/create-comment-thread/create-comment-thread.mjs
@@ -6,7 +6,7 @@ export default {
   key: "youtube_data_api-create-comment-thread",
   name: "Create Comment Thread",
   description: "Creates a new top-level comment in a video. [See the documentation](https://developers.google.com/youtube/v3/docs/commentThreads/insert) for more information",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/youtube_data_api/actions/upload-thumbnail/upload-thumbnail.mjs
+++ b/components/youtube_data_api/actions/upload-thumbnail/upload-thumbnail.mjs
@@ -6,7 +6,7 @@ export default {
   key: "youtube_data_api-upload-thumbnail",
   name: "Upload Thumbnail",
   description: "Uploads a custom video thumbnail to YouTube and sets it for a video. Note: Account must be [verified](https://www.youtube.com/verify). [See the documentation](https://developers.google.com/youtube/v3/docs/thumbnails/set) for more information",
-  version: "1.0.3",
+  version: "1.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/youtube_data_api/package.json
+++ b/components/youtube_data_api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/youtube_data_api",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Pipedream Youtube Components",
   "main": "youtube_data_api.app.mjs",
   "keywords": [

--- a/components/zenventory/actions/create-item/create-item.mjs
+++ b/components/zenventory/actions/create-item/create-item.mjs
@@ -4,7 +4,7 @@ export default {
   key: "zenventory-create-item",
   name: "Create Item",
   description: "Generates a new item. [See the documentation](https://docs.zenventory.com/#tag/items/paths/~1items/post)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zenventory/actions/create-purchase-order/create-purchase-order.mjs
+++ b/components/zenventory/actions/create-purchase-order/create-purchase-order.mjs
@@ -6,7 +6,7 @@ export default {
   key: "zenventory-create-purchase-order",
   name: "Create Purchase Order",
   description: "Generates a new purchase order. [See the documentation](https://docs.zenventory.com/)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zenventory/package.json
+++ b/components/zenventory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/zenventory",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream Zenventory Components",
   "main": "zenventory.app.mjs",
   "keywords": [

--- a/components/zoho_crm/actions/list-attachments/list-attachments.mjs
+++ b/components/zoho_crm/actions/list-attachments/list-attachments.mjs
@@ -4,7 +4,7 @@ export default {
   key: "zoho_crm-list-attachments",
   name: "List Attachments",
   description: "Gets the list of attachments for a record in Zoho CRM. Use **List Modules** to find the `module` API name and **List Objects** to find the `recordId`. Results are paginated 200 per page (`page` is 0-indexed). [See the documentation](https://www.zoho.com/crm/developer/docs/api/v8/get-attachments.html)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   ai: "optimized",
   annotations: {

--- a/components/zoho_crm/actions/upsert-records/upsert-records.mjs
+++ b/components/zoho_crm/actions/upsert-records/upsert-records.mjs
@@ -5,7 +5,7 @@ export default {
   key: "zoho_crm-upsert-records",
   name: "Upsert Records",
   description: "Inserts new records or updates existing ones based on duplicate check field values. [See the documentation](https://www.zoho.com/crm/developer/docs/api/v8/upsert-records.html)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   ai: "optimized",
   annotations: {

--- a/components/zoho_crm/package.json
+++ b/components/zoho_crm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/zoho_crm",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Pipedream Zoho CRM Components",
   "main": "zoho_crm.app.mjs",
   "keywords": [

--- a/components/zoho_desk/actions/list-departments/list-departments.mjs
+++ b/components/zoho_desk/actions/list-departments/list-departments.mjs
@@ -6,7 +6,7 @@ export default {
   description: "Lists the departments configured in the organization, with optional filtering by enabled/disabled state. Use this to drive workflows by department name lookups instead of hardcoded department IDs. [See the documentation](https://desk.zoho.com/DeskAPIDocument#Departments#Departments_Listdepartments)",
   type: "action",
   ai: "optimized",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zoho_desk/actions/list-ticket-fields/list-ticket-fields.mjs
+++ b/components/zoho_desk/actions/list-ticket-fields/list-ticket-fields.mjs
@@ -6,7 +6,7 @@ export default {
   description: "Lists every field configured on a Zoho Desk module (defaults to Tickets), including each field's `apiName`, `displayLabel`, `type`, and for picklist fields - the `allowedValues` array. Useful for discovering valid picklist values (e.g. for `status`, `priority`, `channel`, `category`, `subCategory`, `classification`) before creating or routing tickets. [See the documentation](https://desk.zoho.com/DeskAPIDocument#OrganizationFields_Getorganizationfieldsinamodule)",
   type: "action",
   ai: "optimized",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/zoho_desk/package.json
+++ b/components/zoho_desk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/zoho_desk",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Pipedream Zoho_desk Components",
   "main": "zoho_desk.app.mjs",
   "keywords": [


### PR DESCRIPTION
Batch 5 (#21891) changed **316 files** (200 components + 116 package.json). The `publish-components` changed-files detection caps at ~300 files, so the alphabetical tail was silently dropped and never published to the registry — 10 AI-optimized components ended up with `ai_status` NULL in prod:

`vincario-check-stolen`, `vincario-get-vin-decoder-info`, `youtube_data_api-create-comment-thread`, `youtube_data_api-upload-thumbnail`, `zenventory-create-item`, `zenventory-create-purchase-order`, `zoho_crm-list-attachments`, `zoho_crm-upsert-records`, `zoho_desk-list-departments`, `zoho_desk-list-ticket-fields`.

These already have the `ai` field on master; this patch-bumps their versions (15 files total, well under the cap) to re-trigger publish + registry promotion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated action and package versions for Vincario, YouTube Data API, Zenventory, Zoho CRM, and Zoho Desk integrations.
  - Published patch-level updates across supported actions, including VIN decoding, YouTube comments and thumbnails, inventory management, CRM records and attachments, and help desk data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->