### PR TITLE
feat(ai): mark AI-optimized components with `ai` field (batch 6a/6, split of #21892)

### DIFF
--- a/components/bippybox/actions/activate-box/activate-box.mjs
+++ b/components/bippybox/actions/activate-box/activate-box.mjs
@@ -4,13 +4,14 @@ export default {
   key: "bippybox-activate-box",
   name: "Activate Box",
   description: "Triggers the BippyBox to play an audio file. [See the documentation](https://bippybox.io/docs/).",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     device: {

--- a/components/bippybox/package.json
+++ b/components/bippybox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/bippybox",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream BippyBox Components",
   "main": "bippybox.app.mjs",
   "keywords": [

--- a/components/blink/actions/post-feed/post-feed.mjs
+++ b/components/blink/actions/post-feed/post-feed.mjs
@@ -2,7 +2,7 @@ import app from "../../blink.app.mjs";
 
 export default {
   name: "Post feed",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -11,6 +11,7 @@ export default {
   key: "blink-post-feed",
   description: "Send feed events to users. [See the documentation](https://developer.joinblink.com/reference/send-feed-event)",
   type: "action",
+  ai: "optimized",
   props: {
     app,
     allowComments: {

--- a/components/blink/package.json
+++ b/components/blink/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/blink",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Pipedream Blink Components",
   "main": "blink.app.mjs",
   "keywords": [

--- a/components/blogger/actions/create-post/create-post.mjs
+++ b/components/blogger/actions/create-post/create-post.mjs
@@ -4,13 +4,14 @@ export default {
   name: "Create a Post",
   description: "Creates and publishes a new post or creates a new post as a draft. [See the docs here](https://developers.google.com/blogger/docs/3.0/reference/posts/insert).",
   key: "blogger-create-post",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     bloggerApp,
     blog: {

--- a/components/blogger/package.json
+++ b/components/blogger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/blogger",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Blogger Components",
   "main": "blogger.app.mjs",
   "keywords": [

--- a/components/blotato/actions/upload-media/upload-media.mjs
+++ b/components/blotato/actions/upload-media/upload-media.mjs
@@ -4,13 +4,14 @@ export default {
   key: "blotato-upload-media",
   name: "Upload Media",
   description: "Uploads a media file by providing a URL. The uploaded media will be processed and stored, returning a new media URL that can be used to publish a post. [See documentation](https://help.blotato.com/api/api-reference/upload-media-v2-media)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     blotato,
     alert: {

--- a/components/blotato/package.json
+++ b/components/blotato/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/blotato",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Blotato Components",
   "main": "blotato.app.mjs",
   "keywords": [

--- a/components/bol_com/actions/list-orders/list-orders.mjs
+++ b/components/bol_com/actions/list-orders/list-orders.mjs
@@ -5,8 +5,9 @@ export default {
   key: "bol_com-list-orders",
   name: "List Orders",
   description: "List orders. [See the documentation](https://api.bol.com/retailer/public/redoc/v10/retailer.html#tag/Orders/operation/get-orders)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/bol_com/package.json
+++ b/components/bol_com/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/bol_com",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Bol.com Components",
   "main": "bol_com.app.mjs",
   "keywords": [

--- a/components/botpenguin/actions/send-whatsapp-message/send-whatsapp-message.mjs
+++ b/components/botpenguin/actions/send-whatsapp-message/send-whatsapp-message.mjs
@@ -4,13 +4,14 @@ export default {
   key: "botpenguin-send-whatsapp-message",
   name: "Send WhatsApp Message",
   description: "Sends a WhatsApp message. [See the documentation](https://help.botpenguin.com/api-references/whatsapp-cloud-api/post-send-message-api)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     botpenguin,
     apiKey: {

--- a/components/botpenguin/package.json
+++ b/components/botpenguin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/botpenguin",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream BotPenguin Components",
   "main": "botpenguin.app.mjs",
   "keywords": [

--- a/components/bubble/actions/search-things/search-things.mjs
+++ b/components/bubble/actions/search-things/search-things.mjs
@@ -5,8 +5,9 @@ export default {
   key: "bubble-search-things",
   name: "Search Things",
   description: "Searches for things (records) in your Bubble app's database with optional filtering, sorting, and pagination. [See the documentation](https://manual.bubble.io/core-resources/api/the-bubble-api/the-data-api/data-api-requests#get-a-list-of-things)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/bubble/package.json
+++ b/components/bubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/bubble",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Pipedream bubble Components",
   "main": "bubble.app.mjs",
   "keywords": [

--- a/components/buildkite/actions/retry-job/retry-job.mjs
+++ b/components/buildkite/actions/retry-job/retry-job.mjs
@@ -4,8 +4,9 @@ export default {
   key: "buildkite-retry-job",
   name: "Retry Job",
   description: "Retries a failed or timed out job. Each job can only be retried once. [See the documentation](https://buildkite.com/docs/apis/rest-api/jobs#retry-a-job)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/buildkite/package.json
+++ b/components/buildkite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/buildkite",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Pipedream buildkite Components",
   "main": "buildkite.app.mjs",
   "keywords": [

--- a/components/campaign_cleaner/actions/send-campaign/send-campaign.mjs
+++ b/components/campaign_cleaner/actions/send-campaign/send-campaign.mjs
@@ -4,7 +4,7 @@ import { clearObj } from "../../common/utils.mjs";
 export default {
   key: "campaign_cleaner-send-campaign",
   name: "Send Campaign",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -12,6 +12,7 @@ export default {
   },
   description: "Send in a campaign to be processed and analyzed. [See the documentation](https://api-docs.campaigncleaner.com/#540a9e44-bd17-4bb4-ac8f-150ecbc8066a)",
   type: "action",
+  ai: "optimized",
   props: {
     campaignCleaner,
     campaignHtml: {

--- a/components/campaign_cleaner/package.json
+++ b/components/campaign_cleaner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/campaign_cleaner",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Campaign Cleaner Components",
   "main": "campaign_cleaner.app.mjs",
   "keywords": [

--- a/components/castmagic/actions/submit-transcription-request/submit-transcription-request.mjs
+++ b/components/castmagic/actions/submit-transcription-request/submit-transcription-request.mjs
@@ -5,13 +5,14 @@ export default {
   key: "castmagic-submit-transcription-request",
   name: "Submit Transcription Request",
   description: "Submits a request to transcribe from a URL. [See the documentation](https://docs.castmagic.io/endpoints/transcripts)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     castmagic,
     url: {

--- a/components/castmagic/package.json
+++ b/components/castmagic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/castmagic",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Castmagic Components",
   "main": "castmagic.app.mjs",
   "keywords": [

--- a/components/change_photos/actions/transform-image/transform-image.mjs
+++ b/components/change_photos/actions/transform-image/transform-image.mjs
@@ -5,13 +5,14 @@ export default {
   key: "change_photos-transform-image",
   name: "Transform Image",
   description: "Transforms an image with various effects and optimizations. [See the documentation](https://www.change.photos/api-docs)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     changePhotos,
     imageUrl: {

--- a/components/change_photos/package.json
+++ b/components/change_photos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/change_photos",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream change.photos Components",
   "main": "change_photos.app.mjs",
   "keywords": [

--- a/components/checkvist/actions/create-multiple-list-items/create-multiple-list-items.mjs
+++ b/components/checkvist/actions/create-multiple-list-items/create-multiple-list-items.mjs
@@ -7,13 +7,14 @@ export default {
   key: "checkvist-create-multiple-list-items",
   name: "Create Multiple List Items",
   description: "Enables creation of several list items at once from a block of text. Indentations in the text indicate nested list items. [See the documentation](https://checkvist.com/auth/api)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     checkvist,
     listId: {

--- a/components/checkvist/package.json
+++ b/components/checkvist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/checkvist",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Checkvist Components",
   "main": "checkvist.app.mjs",
   "keywords": [

--- a/components/circleci/actions/trigger-pipeline/trigger-pipeline.mjs
+++ b/components/circleci/actions/trigger-pipeline/trigger-pipeline.mjs
@@ -4,13 +4,14 @@ export default {
   key: "circleci-trigger-pipeline",
   name: "Trigger a Pipeline",
   description: "Trigger a pipeline given a pipeline definition ID. Supports all integrations except GitLab. [See the documentation](https://circleci.com/docs/api/v2/index.html#tag/Pipeline/operation/triggerPipelineRun)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     circleci,
     alert: {

--- a/components/circleci/package.json
+++ b/components/circleci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/circleci",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream CircleCI Components",
   "main": "circleci.app.mjs",
   "keywords": [

--- a/components/cisco_webex/actions/create-message/create-message.mjs
+++ b/components/cisco_webex/actions/create-message/create-message.mjs
@@ -5,7 +5,8 @@ export default {
   name: "Create Message",
   description: "Post a plain text or [rich text](https://developer.webex.com/docs/basics#formatting-messages) message, and optionally, a [file attachment](https://developer.webex.com/docs/basics#message-attachments), to a room. [See the docs here](https://developer.webex.com/docs/api/v1/messages/create-a-message)",
   type: "action",
-  version: "0.1.1",
+  ai: "optimized",
+  version: "0.1.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/cisco_webex/package.json
+++ b/components/cisco_webex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/cisco_webex",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Pipedream Cisco_webex Components",
   "main": "cisco_webex.app.mjs",
   "keywords": [

--- a/components/claap/actions/create-recording/create-recording.mjs
+++ b/components/claap/actions/create-recording/create-recording.mjs
@@ -5,13 +5,14 @@ export default {
   key: "claap-create-recording",
   name: "Create Recording",
   description: "Create a new recording in Claap. [See the documentation](https://docs.claap.io/api-reference/endpoint/post_recording).",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     claap,
     authorEmail: {

--- a/components/claap/package.json
+++ b/components/claap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/claap",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Pipedream Claap Components",
   "main": "claap.app.mjs",
   "keywords": [

--- a/components/clickfunnels/actions/remove-tag-contact/remove-tag-contact.mjs
+++ b/components/clickfunnels/actions/remove-tag-contact/remove-tag-contact.mjs
@@ -4,13 +4,14 @@ export default {
   key: "clickfunnels-remove-tag-contact",
   name: "Remove Tag from Contact",
   description: "Removes a specified tag from a contact. This action will take no effect if the specified tag doesn't exist on the contact. [See the documentation](https://developers.myclickfunnels.com/reference/removecontactsappliedtags)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     clickfunnels,
     teamId: {

--- a/components/clickfunnels/package.json
+++ b/components/clickfunnels/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/clickfunnels",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream ClickFunnels Components",
   "main": "clickfunnels.app.mjs",
   "keywords": [

--- a/components/clientify/actions/create-task/create-task.mjs
+++ b/components/clientify/actions/create-task/create-task.mjs
@@ -3,7 +3,7 @@ import clientify from "../../clientify.app.mjs";
 export default {
   key: "clientify-create-task",
   name: "Create Task",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -11,6 +11,7 @@ export default {
   },
   description: "Add a new task. [See the documentation](https://developer.clientify.com/#1ee10d02-b3d8-4373-afa4-08d7b678bb26)",
   type: "action",
+  ai: "optimized",
   props: {
     clientify,
     owner: {

--- a/components/clientify/package.json
+++ b/components/clientify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/clientify",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Clientify Components",
   "main": "clientify.app.mjs",
   "keywords": [

--- a/components/cloudflare_browser_rendering/actions/scrape/scrape.mjs
+++ b/components/cloudflare_browser_rendering/actions/scrape/scrape.mjs
@@ -7,13 +7,14 @@ export default {
   key: "cloudflare_browser_rendering-scrape",
   name: "Scrape",
   description: "Get meta attributes like height, width, text and others of selected elements. [See the documentation](https://developers.cloudflare.com/api/resources/browser_rendering/subresources/scrape/methods/create/)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     ...common.props,
     elements: {

--- a/components/cloudflare_browser_rendering/package.json
+++ b/components/cloudflare_browser_rendering/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/cloudflare_browser_rendering",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream Cloudflare Browser Rendering Components",
   "main": "cloudflare_browser_rendering.app.mjs",
   "keywords": [

--- a/components/coassemble/actions/create-new-user/create-new-user.ts
+++ b/components/coassemble/actions/create-new-user/create-new-user.ts
@@ -3,7 +3,7 @@ import coassemble from "../../app/coassemble.app";
 export default {
   key: "coassemble-create-new-user",
   name: "Create New User",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -11,6 +11,7 @@ export default {
   },
   description: "Create a user as a member of your campus or add an existing user to it. [See the docs here](https://developers.coassemble.com/api/users#add-users)",
   type: "action",
+  ai: "optimized",
   props: {
     coassemble,
     email: {

--- a/components/coassemble/package.json
+++ b/components/coassemble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/coassemble",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Pipedream Coassemble Components",
   "main": "dist/app/coassemble.app.mjs",
   "keywords": [

--- a/components/codereadr/actions/generate-qr-code/generate-qr-code.mjs
+++ b/components/codereadr/actions/generate-qr-code/generate-qr-code.mjs
@@ -5,13 +5,14 @@ export default {
   key: "codereadr-generate-qr-code",
   name: "Generate QR Code",
   description: "Generates a unique QR code. [See the documentation](https://secure.codereadr.com/apidocs/BarcodeGenerator.md#generate)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     value: {

--- a/components/codereadr/package.json
+++ b/components/codereadr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/codereadr",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream CodeREADr Components",
   "main": "codereadr.app.mjs",
   "keywords": [

--- a/components/coingecko/actions/get-coin-value/get-coin-value.mjs
+++ b/components/coingecko/actions/get-coin-value/get-coin-value.mjs
@@ -5,8 +5,9 @@ export default {
   key: "coingecko-get-coin-value",
   name: "Get Coin Value",
   description: "Get the current price of one or more cryptocurrencies in any supported currencies. [See the documentation](https://docs.coingecko.com/v3.0.1/reference/simple-price)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/coingecko/package.json
+++ b/components/coingecko/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/coingecko",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream CoinGecko Components",
   "main": "coingecko.app.mjs",
   "keywords": [

--- a/components/commpeak/actions/request-bulk-number-lookup/request-bulk-number-lookup.mjs
+++ b/components/commpeak/actions/request-bulk-number-lookup/request-bulk-number-lookup.mjs
@@ -4,13 +4,14 @@ export default {
   key: "commpeak-request-bulk-number-lookup",
   name: "Request Bulk Number Lookup",
   description: "Perform a bulk number lookup, to later fetch the results when the operation is finished. [See the documentation](https://lookup.api-docs.commpeak.com/?_gl=1*50xs02*_gcl_au*MTMxMzgzMzA3Ny4xNjk3NTY0NDE3#cda1e4c3-963e-4d9e-b9a7-16b6616bdda5)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     commpeak,
     keys: {

--- a/components/commpeak/package.json
+++ b/components/commpeak/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/commpeak",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream CommPeak Components",
   "main": "commpeak.app.mjs",
   "keywords": [

--- a/components/confection/actions/get-related-uuids/get-related-uuids.mjs
+++ b/components/confection/actions/get-related-uuids/get-related-uuids.mjs
@@ -4,7 +4,8 @@ export default {
   key: "confection-get-related-uuids",
   name: "Get Related UUIDs",
   type: "action",
-  version: "0.1.1",
+  ai: "optimized",
+  version: "0.1.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/confection/package.json
+++ b/components/confection/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/confection",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Confection Components",
   "main": "confection.app.mjs",
   "keywords": [

--- a/components/contactout/actions/get-contact-info/get-contact-info.mjs
+++ b/components/contactout/actions/get-contact-info/get-contact-info.mjs
@@ -4,13 +4,14 @@ export default {
   key: "contactout-get-contact-info",
   name: "Get Contact Info from LinkedIn Profile",
   description: "Get contact information (email and phone) for a LinkedIn profile using a LinkedIn URL. [See the documentation](https://api.contactout.com/#from-linkedin-profile).",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     profile: {

--- a/components/contactout/package.json
+++ b/components/contactout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/contactout",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream ContactOut Components",
   "main": "contactout.app.mjs",
   "keywords": [

--- a/components/craftmypdf/actions/create-editor-session/create-editor-session.mjs
+++ b/components/craftmypdf/actions/create-editor-session/create-editor-session.mjs
@@ -3,7 +3,7 @@ import craftmypdf from "../../craftmypdf.app.mjs";
 export default {
   key: "craftmypdf-create-editor-session",
   name: "Create Editor Session",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
@@ -11,6 +11,7 @@ export default {
   },
   description: "Create a new PDF editor session. The PDF editor url can be embedded into an IFrame. [See the documentation](https://craftmypdf.com/docs/index.html#tag/Template-Management-API/operation/delete-template)",
   type: "action",
+  ai: "optimized",
   props: {
     craftmypdf,
     templateId: {

--- a/components/craftmypdf/package.json
+++ b/components/craftmypdf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/craftmypdf",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream CraftMyPDF Components",
   "main": "craftmypdf.app.mjs",
   "keywords": [

--- a/components/customer_io/actions/add-customers-to-segment/add-customers-to-segment.mjs
+++ b/components/customer_io/actions/add-customers-to-segment/add-customers-to-segment.mjs
@@ -5,13 +5,14 @@ export default {
   key: "customer_io-add-customers-to-segment",
   name: "Add Customers to Segment",
   description: "Add people to a manual segment by ID. You are limited to 1000 customer IDs per request. [See the docs here](https://www.customer.io/docs/api/#operation/add_to_segment)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     customerIds: {

--- a/components/customer_io/package.json
+++ b/components/customer_io/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/customer_io",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Pipedream Customer.io Components",
   "main": "customer_io.app.mjs",
   "keywords": [

--- a/components/customgpt/actions/create-project/create-project.mjs
+++ b/components/customgpt/actions/create-project/create-project.mjs
@@ -6,13 +6,14 @@ export default {
   key: "customgpt-create-project",
   name: "Create Project (Agent)",
   description: "Create a new agent by importing data either from a sitemap or an uploaded file. The system will process the provided data and generate a new agent based on the imported or uploaded information. [See the documentation](https://docs.customgpt.ai/reference/post_api-v1-projects)",
-  version: "0.1.0",
+  version: "0.1.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     customgpt,
     name: {

--- a/components/customgpt/package.json
+++ b/components/customgpt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/customgpt",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream CustomGPT Components",
   "main": "customgpt.app.mjs",
   "keywords": [

--- a/components/cutt_ly/actions/update-source-url/update-source-url.mjs
+++ b/components/cutt_ly/actions/update-source-url/update-source-url.mjs
@@ -4,13 +4,14 @@ export default {
   key: "cutt_ly-update-source-url",
   name: "Update Source URL",
   description: "Changes the source URL of a previously shortened URL. Requires a Paid Subscription. [See the documentation](https://cutt.ly/cuttly-api)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     cuttLy,
     shortenedUrl: {

--- a/components/cutt_ly/package.json
+++ b/components/cutt_ly/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/cutt_ly",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Cutt.ly Components",
   "main": "cutt_ly.app.mjs",
   "keywords": [

--- a/components/deftship/actions/get-insurance-rate/get-insurance-rate.mjs
+++ b/components/deftship/actions/get-insurance-rate/get-insurance-rate.mjs
@@ -5,13 +5,14 @@ export default {
   key: "deftship-get-insurance-rate",
   name: "Get Insurance Rate",
   description: "Checks pricing for Insurance based on the supplied information. Also automatically creates an insurance and returns the pricing. [See the documentation](https://developer.deftship.com/insurance/get-rates)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     deftship,
     carrier: {

--- a/components/deftship/package.json
+++ b/components/deftship/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/deftship",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Deftship Components",
   "main": "deftship.app.mjs",
   "keywords": [

--- a/components/dex/actions/create-update-contact/create-update-contact.mjs
+++ b/components/dex/actions/create-update-contact/create-update-contact.mjs
@@ -5,13 +5,14 @@ export default {
   key: "dex-create-update-contact",
   name: "Create or Update Contact",
   description: "Adds a new contact or updates an existing one if the email address already exists in the Dex system. [See the documentation](https://guide.getdex.com/dex-user-api/post-contact)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     dex,
     email: {

--- a/components/dex/package.json
+++ b/components/dex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/dex",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Dex Components",
   "main": "dex.app.mjs",
   "keywords": [

--- a/components/dhl/actions/get-tracking/get-tracking.mjs
+++ b/components/dhl/actions/get-tracking/get-tracking.mjs
@@ -5,13 +5,14 @@ export default {
   key: "dhl-get-tracking",
   name: "Get Tracking Information",
   description: "Get tracking information for shipments. [See the documentation](https://developer.dhl.com/api-reference/shipment-tracking#operations-default-getTrackingShipment)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     dhl,
     trackingNumber: {

--- a/components/dhl/package.json
+++ b/components/dhl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/dhl",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream DHL Components",
   "main": "dhl.app.mjs",
   "keywords": [

--- a/components/dhl_parcel/actions/track-and-trace-parcel/track-and-trace-parcel.mjs
+++ b/components/dhl_parcel/actions/track-and-trace-parcel/track-and-trace-parcel.mjs
@@ -4,8 +4,9 @@ export default {
   key: "dhl_parcel-track-and-trace-parcel",
   name: "Track and Trace Parcel",
   description: "Get track and trace information for a parcel. [See the documentation](https://api-gw.dhlparcel.nl/docs/guide/chapters/05-track-and-trace.html)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/dhl_parcel/package.json
+++ b/components/dhl_parcel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/dhl_parcel",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream DHL Parcel Components",
   "main": "dhl_parcel.app.mjs",
   "keywords": [

--- a/components/dispatch/actions/create-estimate/create-estimate.mjs
+++ b/components/dispatch/actions/create-estimate/create-estimate.mjs
@@ -4,8 +4,9 @@ export default {
   key: "dispatch-create-estimate",
   name: "Create Estimate",
   description: "Create a delivery estimate to get pricing and timing options before placing an order. [See the documentation](https://api.dispatchit.com/docs/v1)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/dispatch/package.json
+++ b/components/dispatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/dispatch",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Dispatch Components",
   "main": "dispatch.app.mjs",
   "keywords": [

--- a/components/dixa/actions/claim-conversation/claim-conversation.mjs
+++ b/components/dixa/actions/claim-conversation/claim-conversation.mjs
@@ -4,13 +4,14 @@ export default {
   key: "dixa-claim-conversation",
   name: "Claim Conversation",
   description: "Claims a conversation for a given agent. To avoid taking over assigned conversations, set the force parameter to false. [See the documentation](https://docs.dixa.io/openapi/dixa-api/v1/tag/Conversations/#tag/Conversations/operation/putConversationsConversationidClaim)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     dixa,
     endUserId: {

--- a/components/dixa/package.json
+++ b/components/dixa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/dixa",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Pipedream Dixa Components",
   "main": "dixa.app.mjs",
   "keywords": [

--- a/components/dock_certs/actions/issue-credential/issue-credential.mjs
+++ b/components/dock_certs/actions/issue-credential/issue-credential.mjs
@@ -5,13 +5,14 @@ export default {
   key: "dock_certs-issue-credential",
   name: "Issue Credential",
   description: "Issue a new credential. [See the documentation](https://docs.api.dock.io/#credentials)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     dockCerts,
     issuerProfile: {

--- a/components/dock_certs/package.json
+++ b/components/dock_certs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/dock_certs",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Pipedream Dock Certs Components",
   "main": "dock_certs.app.mjs",
   "keywords": [

--- a/components/docugenerate/actions/create-template/create-template.mjs
+++ b/components/docugenerate/actions/create-template/create-template.mjs
@@ -7,8 +7,9 @@ export default {
   key: "docugenerate-create-template",
   name: "New Template",
   description: "Creates a new document template from a file. [See the documentation](https://api.docugenerate.com/#/Template/createTemplate)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/docugenerate/package.json
+++ b/components/docugenerate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/docugenerate",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream DocuGenerate Components",
   "main": "docugenerate.app.mjs",
   "keywords": [

--- a/components/document360/actions/drive-search-files-and-folders/drive-search-files-and-folders.mjs
+++ b/components/document360/actions/drive-search-files-and-folders/drive-search-files-and-folders.mjs
@@ -4,13 +4,14 @@ export default {
   key: "document360-drive-search-files-and-folders",
   name: "Drive Search - Files and Folders",
   description: "Search for files and folders in Document360 Drive. [See the documentation](https://apidocs.document360.com/apidocs/drive-search-files-and-folders)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     searchKeyword: {

--- a/components/document360/package.json
+++ b/components/document360/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/document360",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Pipedream Document360 Components",
   "main": "document360.app.mjs",
   "keywords": [

--- a/components/dpd_shipping/actions/get-tracking-data/get-tracking-data.mjs
+++ b/components/dpd_shipping/actions/get-tracking-data/get-tracking-data.mjs
@@ -5,8 +5,9 @@ export default {
   key: "dpd_shipping-get-tracking-data",
   name: "Get Tracking Data",
   description: "Track the current status and history of individual parcels during transit and after delivery. Provide the 14-character parcel label number to look up. [See the documentation](https://integrations.dpd.nl/dpd-shipper/dpd-shipper-webservices-rest-api/parcellifecycle-service-rest-api/)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/dpd_shipping/package.json
+++ b/components/dpd_shipping/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/dpd_shipping",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream DPD Shipping Components",
   "main": "dpd_shipping.app.mjs",
   "keywords": [

--- a/components/dropboard/actions/create-client/create-client.mjs
+++ b/components/dropboard/actions/create-client/create-client.mjs
@@ -4,13 +4,14 @@ export default {
   key: "dropboard-create-client",
   name: "Create Client",
   description: "Creates a new client within Dropboard. Note this is available only for recruiter plan users and may incur additional charges based on your organization's plan. [See the documentation](https://dropboard.readme.io/reference/clients-post)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     dropboard,
     clientName: {

--- a/components/dropboard/package.json
+++ b/components/dropboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/dropboard",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Dropboard Components",
   "main": "dropboard.app.mjs",
   "keywords": [

--- a/components/dropbox/actions/download-and-export/download-and-export.mjs
+++ b/components/dropbox/actions/download-and-export/download-and-export.mjs
@@ -10,8 +10,9 @@ export default {
   name: "Download and Export",
   description: "Export a file from a user's Dropbox. If file is not exportable, it will be downloaded in original format. [See the documentation](https://www.dropbox.com/developers/documentation/http/documentation#files-export)",
   key: "dropbox-download-and-export",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/dropbox/package.json
+++ b/components/dropbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/dropbox",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Pipedream Dropbox Components",
   "main": "dropbox.app.mjs",
   "keywords": [

--- a/components/dropinblog/actions/create-post/create-post.mjs
+++ b/components/dropinblog/actions/create-post/create-post.mjs
@@ -5,13 +5,14 @@ export default {
   key: "dropinblog-create-post",
   name: "Create Post",
   description: "Allows you to create a new blog post in your DropInBlog account. Requires a private API key. [See the documentation](https://dropinblog.readme.io/reference/posts-create).",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     title: {

--- a/components/dropinblog/package.json
+++ b/components/dropinblog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/dropinblog",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream DropInBlog Components",
   "main": "dropinblog.app.mjs",
   "keywords": [

--- a/components/dynalist/actions/insert-document-content/insert-document-content.mjs
+++ b/components/dynalist/actions/insert-document-content/insert-document-content.mjs
@@ -5,13 +5,14 @@ export default {
   key: "dynalist-insert-document-content",
   name: "Insert Document Content",
   description: "Inserts content to a specific document. If the document has existing content, the new content will be appended. [See the documentation](https://apidocs.dynalist.io/)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     dynalist,
     documentId: {

--- a/components/dynalist/package.json
+++ b/components/dynalist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/dynalist",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Dynalist Components",
   "main": "dynalist.app.mjs",
   "keywords": [

--- a/components/egnyte/actions/download-file/download-file.mjs
+++ b/components/egnyte/actions/download-file/download-file.mjs
@@ -6,8 +6,9 @@ export default {
   key: "egnyte-download-file",
   name: "Download File",
   description: "Download a file from Egnyte and save it under `/tmp`. For common text-based types (for example `text/*`, JSON, XML, CSV, Markdown), the response can include a `content` string with the file body. [See the documentation](https://developers.egnyte.com/api-docs/read/file-system-management-api-documentation)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/egnyte/package.json
+++ b/components/egnyte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/egnyte",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Pipedream Egnyte Components",
   "main": "egnyte.app.mjs",
   "keywords": [

--- a/components/elastic_email/actions/add-contact/add-contact.mjs
+++ b/components/elastic_email/actions/add-contact/add-contact.mjs
@@ -10,13 +10,14 @@ export default {
   key: "elastic_email-add-contact",
   name: "Add Contact to Mailing List",
   description: "Adds a new contact to a mailing list. [See the documentation](https://elasticemail.com/developers/api-documentation/rest-api#operation/contactsPost)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     email: {

--- a/components/elastic_email/package.json
+++ b/components/elastic_email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/elastic_email",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Pipedream Elastic Email Components",
   "main": "elastic_email.app.mjs",
   "keywords": [

--- a/components/email/actions/send-email-to-self/send-email-to-self.mjs
+++ b/components/email/actions/send-email-to-self/send-email-to-self.mjs
@@ -5,13 +5,14 @@ export default {
   key: "email-send-email-to-self",
   name: "Send Yourself an Email",
   description: "Customize and send an email to the email address you registered with Pipedream. The email will be sent by notifications@pipedream.com.",
-  version: "0.4.5",
+  version: "0.4.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     email,
     subject: {

--- a/components/email/package.json
+++ b/components/email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/email",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Pipedream email Components",
   "main": "email.app.mjs",
   "keywords": [

--- a/components/emailoctopus/actions/add-subscribers-to-list/add-subscribers-to-list.mjs
+++ b/components/emailoctopus/actions/add-subscribers-to-list/add-subscribers-to-list.mjs
@@ -2,13 +2,14 @@ import app from "../../emailoctopus.app.mjs";
 
 export default {
   key: "emailoctopus-add-subscribers-to-list",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   name: "Add Subscribers To List",
   description: "Add subscribers to a list, [See the docs here](https://emailoctopus.com/api-documentation/lists/create-contact)",
   props: {

--- a/components/emailoctopus/package.json
+++ b/components/emailoctopus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/emailoctopus",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Emailoctopus Components",
   "main": "emailoctopus.app.mjs",
   "keywords": [

--- a/components/eodhd_apis/actions/search-stock-symbol/search-stock-symbol.mjs
+++ b/components/eodhd_apis/actions/search-stock-symbol/search-stock-symbol.mjs
@@ -4,7 +4,7 @@ import eodhdApis from "../../eodhd_apis.app.mjs";
 export default {
   key: "eodhd_apis-search-stock-symbol",
   name: "Search Stock Symbol",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -12,6 +12,7 @@ export default {
   },
   description: "Find stock symbols using company names or partial symbols. [See the docs here](https://eodhistoricaldata.com/financial-apis/search-api-for-stocks-etfs-mutual-funds-and-indices/)",
   type: "action",
+  ai: "optimized",
   props: {
     eodhdApis,
     query: {

--- a/components/eodhd_apis/package.json
+++ b/components/eodhd_apis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/eodhd_apis",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream EODHD APIs Components",
   "main": "eodhd_apis.app.mjs",
   "keywords": [

--- a/components/esignatures_io/actions/create-contract/create-contract.mjs
+++ b/components/esignatures_io/actions/create-contract/create-contract.mjs
@@ -1,7 +1,7 @@
 import esignatures_io from "../../esignatures_io.app.mjs";
 
 export default {
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -11,6 +11,7 @@ export default {
   name: "Create Contract",
   description: "Creates a contract and sends the links (via email or SMS) to the signers to collect their signatures. [See docs here](https://esignatures.io/docs/api#contracts)",
   type: "action",
+  ai: "optimized",
   props: {
     esignatures_io,
     templateId: {

--- a/components/esignatures_io/package.json
+++ b/components/esignatures_io/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/esignatures_io",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Esignatures IO Components",
   "main": "esignatures_io.app.mjs",
   "keywords": [

--- a/components/esputnik/actions/subscribe-contact/subscribe-contact.mjs
+++ b/components/esputnik/actions/subscribe-contact/subscribe-contact.mjs
@@ -4,13 +4,14 @@ export default {
   key: "esputnik-subscribe-contact",
   name: "Subscribe Contact",
   description: "Create a new unverified contact in eSputnik. For use with double opt-in implementation. User will need to verify the email to confirm their subscription. [See the docs here](https://esputnik.com/api/methods.html#/v1/contact/subscribe-POST)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     esputnik,
     firstName: {

--- a/components/esputnik/package.json
+++ b/components/esputnik/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/esputnik",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Pipedream eSputnik Components",
   "main": "esputnik.app.mjs",
   "keywords": [

--- a/components/evernote/actions/list-notes/list-notes.mjs
+++ b/components/evernote/actions/list-notes/list-notes.mjs
@@ -4,8 +4,9 @@ export default {
   key: "evernote-list-notes",
   name: "List Notes",
   description: "List all notes in Evernote. [See the documentation](https://dev.evernote.com/doc/reference/NoteStore.html#Fn_NoteStore_findNotesMetadata).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/evernote/package.json
+++ b/components/evernote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/evernote",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Pipedream Evernote Components",
   "main": "evernote.app.mjs",
   "keywords": [

--- a/components/fitbit/actions/get-heart-rate/get-heart-rate.mjs
+++ b/components/fitbit/actions/get-heart-rate/get-heart-rate.mjs
@@ -4,13 +4,14 @@ export default {
   key: "fitbit-get-heart-rate",
   name: "Get Heart Rate",
   description: "Gets the heart rate intraday time series data on a specific date range for a 24 hour period. [See the documentation](https://dev.fitbit.com/build/reference/web-api/intraday/get-heartrate-intraday-by-interval/)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     fitbit,
     startDate: {

--- a/components/fitbit/package.json
+++ b/components/fitbit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/fitbit",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Pipedream fitbit Components",
   "main": "fitbit.app.mjs",
   "keywords": [

--- a/components/float/actions/create-project/create-project.mjs
+++ b/components/float/actions/create-project/create-project.mjs
@@ -13,8 +13,9 @@ export default {
   key: "float-create-project",
   name: "Create Project",
   description: "Create a new project. [See the documentation](https://developer.float.com/tutorial_managing_your_projects.html)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/float/package.json
+++ b/components/float/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/float",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Float Components",
   "main": "float.app.mjs",
   "keywords": [

--- a/components/fogbugz/actions/update-person/update-person.mjs
+++ b/components/fogbugz/actions/update-person/update-person.mjs
@@ -4,13 +4,14 @@ export default {
   key: "fogbugz-update-person",
   name: "Update Person",
   description: "Edits an existing person in FogBugz. [See the documentation](https://support.fogbugz.com/hc/en-us/articles/360011330733-FogBugz-XML-API-Editing-a-Person)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     fogbugz,
     ixPersonId: {

--- a/components/fogbugz/package.json
+++ b/components/fogbugz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/fogbugz",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream FogBugz Components",
   "main": "fogbugz.app.mjs",
   "keywords": [

--- a/components/forcemanager/actions/create-opportunity/create-opportunity.mjs
+++ b/components/forcemanager/actions/create-opportunity/create-opportunity.mjs
@@ -4,13 +4,14 @@ export default {
   key: "forcemanager-create-opportunity",
   name: "Create Opportunity",
   description: "Creates a new business opportunity in ForceManager. [See the documentation](https://developer.forcemanager.com/#836754be-f32d-47d2-a8ab-73a147c62ca9)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     forcemanager,
     name: {

--- a/components/forcemanager/package.json
+++ b/components/forcemanager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/forcemanager",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Pipedream ForceManager Components",
   "main": "forcemanager.app.mjs",
   "keywords": [

--- a/components/freedcamp/actions/create-task/create-task.mjs
+++ b/components/freedcamp/actions/create-task/create-task.mjs
@@ -5,8 +5,9 @@ export default {
   key: "freedcamp-create-task",
   name: "Create Task",
   description: "Creates a new task in a Freedcamp project. [See the documentation](https://freedcamp.com/help_/tutorials/wiki/wiki_public/view/DFaab#post_fcu_8)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/freedcamp/package.json
+++ b/components/freedcamp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/freedcamp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Pipedream Freedcamp Components",
   "main": "freedcamp.app.mjs",
   "keywords": [

--- a/components/freshchat/actions/update-conversation-status/update-conversation-status.mjs
+++ b/components/freshchat/actions/update-conversation-status/update-conversation-status.mjs
@@ -6,13 +6,14 @@ export default {
   key: "freshchat-update-conversation-status",
   name: "Update Conversation",
   description: "Updates a conversation's status, assignment, or properties. [See the documentation](https://developers.freshchat.com/api/#update_a_conversation)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     freshchat,
     userId: {

--- a/components/freshchat/package.json
+++ b/components/freshchat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/freshchat",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Pipedream Freshchat Components",
   "main": "freshchat.app.mjs",
   "keywords": [

--- a/components/fullenrich/actions/enrich-contact/enrich-contact.mjs
+++ b/components/fullenrich/actions/enrich-contact/enrich-contact.mjs
@@ -5,13 +5,14 @@ export default {
   key: "fullenrich-enrich-contact",
   name: "Enrich Contact",
   description: "Starts the enrichment process for a specified contact. [See the documentation](https://docs.fullenrich.com/startbulk)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     name: {

--- a/components/fullenrich/package.json
+++ b/components/fullenrich/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/fullenrich",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream FullEnrich Components",
   "main": "fullenrich.app.mjs",
   "keywords": [

--- a/components/genderize/actions/get-gender-from-names/get-gender-from-names.mjs
+++ b/components/genderize/actions/get-gender-from-names/get-gender-from-names.mjs
@@ -5,13 +5,14 @@ export default {
   key: "genderize-get-gender-from-names",
   name: "Get Gender From Names (Batch)",
   description: "Check the statistical probability of up to 10 names being male or female in a single batch request. [See the documentation](https://genderize.io/documentation#batch-usage)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     names: {

--- a/components/genderize/package.json
+++ b/components/genderize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/genderize",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Genderize Components",
   "main": "genderize.app.mjs",
   "keywords": [

--- a/components/geodb_cities/actions/find-cities/find-cities.mjs
+++ b/components/geodb_cities/actions/find-cities/find-cities.mjs
@@ -7,7 +7,8 @@ export default {
   name: "Find Cities",
   description: "Find cities, filtering by optional criteria. If no criteria are set, you will get back all known cities with a population of at least 1000. [See the docs](https://rapidapi.com/wirefreethought/api/geodb-cities).",
   type: "action",
-  version: "0.0.2",
+  ai: "optimized",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/geodb_cities/package.json
+++ b/components/geodb_cities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/geodb_cities",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Pipedream Geodb_cities Components",
   "main": "geodb_cities.app.mjs",
   "keywords": [

--- a/components/giantcampaign/actions/add-tags-to-subscriber/add-tags-to-subscriber.mjs
+++ b/components/giantcampaign/actions/add-tags-to-subscriber/add-tags-to-subscriber.mjs
@@ -4,13 +4,14 @@ export default {
   name: "Add Tags to Subscriber",
   description: "Add tags to a new subscriber [See the documentation](https://giantcampaign.com/developers/#add-tags-to-subscriber).",
   key: "giantcampaign-add-tags-to-subscriber",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     listUid: {

--- a/components/giantcampaign/package.json
+++ b/components/giantcampaign/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/giantcampaign",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream GiantCampaign Components",
   "main": "giantcampaign.app.mjs",
   "keywords": [

--- a/components/gist/actions/add-tag-to-contacts/add-tag-to-contacts.mjs
+++ b/components/gist/actions/add-tag-to-contacts/add-tag-to-contacts.mjs
@@ -5,7 +5,8 @@ export default {
   name: "Add Tag To Existing Contacts",
   description: "This Action lets you assign a tag to multiple contacts at once. If the tag does not already exist it will be created for you. [See docs](https://developers.getgist.com/api/#add-a-tag-to-contacts)",
   type: "action",
-  version: "0.0.2",
+  ai: "optimized",
+  version: "0.0.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,

--- a/components/gist/package.json
+++ b/components/gist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/gist",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Gist Components",
   "main": "gist.app.mjs",
   "keywords": [

--- a/components/gitlab/actions/list-projects/list-projects.mjs
+++ b/components/gitlab/actions/list-projects/list-projects.mjs
@@ -5,13 +5,14 @@ export default {
   key: "gitlab-list-projects",
   name: "List Projects",
   description: "List or search GitLab projects, optionally filtering by search term, membership, or ownership. Use this to discover projects (and their IDs) before acting on them with other GitLab actions. Supports ordering by `name`, `path`, creation/update time, star count, last activity, or search `similarity`, plus pagination. The `similarity` order requires a `Search` term. [See the documentation](https://docs.gitlab.com/api/projects/#list-all-projects)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     gitlab,
     search: {

--- a/components/gitlab/package.json
+++ b/components/gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/gitlab",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Pipedream Gitlab Components",
   "main": "gitlab.app.mjs",
   "keywords": [

--- a/components/google_chat/actions/list-spaces/list-spaces.mjs
+++ b/components/google_chat/actions/list-spaces/list-spaces.mjs
@@ -5,13 +5,14 @@ export default {
   key: "google_chat-list-spaces",
   name: "List Spaces",
   description: "Lists spaces the caller is a member of. Group chats and DMs aren't listed until the first message is sent. [See the documentation](https://developers.google.com/chat/api/reference/rest/v1/spaces/list)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     pageSize: {

--- a/components/google_chat/package.json
+++ b/components/google_chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_chat",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Pipedream Google Chat Components",
   "main": "google_chat.app.mjs",
   "keywords": [

--- a/components/google_search_console/actions/retrieve-site-performance-data/retrieve-site-performance-data.mjs
+++ b/components/google_search_console/actions/retrieve-site-performance-data/retrieve-site-performance-data.mjs
@@ -5,13 +5,14 @@ export default {
   name: "Retrieve Site Performance Data",
   description: "Fetches search analytics (clicks, impressions, CTR, position) from Google Search Console for a verified site. Use it to pull traffic metrics, optionally broken down by dimensions like page or query. Filter to a subset of pages with Subdomain Filter (a simple contains-style path/subdomain match), or with Advanced Dimension Filters (a JSON array of filter groups per the Search Console API, used only when Subdomain Filter is empty). Max Rows caps how many rows come back per call; use Start Row to page through more. [See the documentation](https://developers.google.com/webmaster-tools/v1/searchanalytics/query)",
   key: "google_search_console-retrieve-site-performance-data",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     googleSearchConsole,
     siteUrl: {

--- a/components/google_search_console/package.json
+++ b/components/google_search_console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_search_console",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Pipedream google_search_console Components",
   "main": "google_search_console.app.mjs",
   "keywords": [

--- a/components/google_slides/actions/get-presentation/get-presentation.mjs
+++ b/components/google_slides/actions/get-presentation/get-presentation.mjs
@@ -4,13 +4,14 @@ export default {
   key: "google_slides-get-presentation",
   name: "Get Presentation",
   description: "Get a Google Slides presentation by its ID. Returns the presentation's metadata and structure (title, slides, masters, layouts, page size, etc.) according to requested `fields`. Use **Find a Presentation** first to resolve a presentation's name to its ID. [See the documentation](https://developers.google.com/slides/api/reference/rest/v1/presentations/get)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     presentationId: {

--- a/components/google_slides/package.json
+++ b/components/google_slides/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_slides",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Pipedream Google Slides Components",
   "main": "google_slides.app.mjs",
   "keywords": [

--- a/components/granola/actions/get-note/get-note.mjs
+++ b/components/granola/actions/get-note/get-note.mjs
@@ -5,13 +5,14 @@ export default {
   key: "granola-get-note",
   name: "Get Note",
   description: "Retrieve a single meeting note by ID. Use **List Notes** to find note IDs. [See the documentation](https://docs.granola.ai/api-reference/get-note)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     granola,
     noteId: {

--- a/components/granola/package.json
+++ b/components/granola/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/granola",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Granola Components",
   "main": "granola.app.mjs",
   "keywords": [

--- a/components/help_scout/actions/send-reply/send-reply.mjs
+++ b/components/help_scout/actions/send-reply/send-reply.mjs
@@ -4,13 +4,14 @@ export default {
   key: "help_scout-send-reply",
   name: "Send Reply",
   description: "Sends a reply to a conversation. Be careful as this sends an actual email to the customer. [See the documentation](https://developer.helpscout.com/mailbox-api/endpoints/conversations/threads/reply/)",
-  version: "0.0.5",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     helpScout,
     conversationId: {

--- a/components/help_scout/package.json
+++ b/components/help_scout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/help_scout",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Pipedream Help Scout Components",
   "main": "help_scout.app.mjs",
   "keywords": [

--- a/components/hex/actions/run-project/run-project.mjs
+++ b/components/hex/actions/run-project/run-project.mjs
@@ -5,13 +5,14 @@ export default {
   key: "hex-run-project",
   name: "Run Project",
   description: "Trigger a run of the latest published version of a project. [See the documentation](https://learn.hex.tech/docs/api/api-reference#operation/RunProject)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     hex,
     projectId: {

--- a/components/hex/package.json
+++ b/components/hex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/hex",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Hex Components",
   "main": "hex.app.mjs",
   "keywords": [

--- a/components/holded/actions/send-email/send-email.mjs
+++ b/components/holded/actions/send-email/send-email.mjs
@@ -6,7 +6,8 @@ export default {
   name: "Send Email",
   description: "Deliver an email with a document to a contact through Holded. [See the docs](https://developers.holded.com/reference/send-document-1).",
   type: "action",
-  version: "0.0.2",
+  ai: "optimized",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/holded/package.json
+++ b/components/holded/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/holded",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Holded Components",
   "main": "holded.app.mjs",
   "keywords": [

--- a/components/homerun/actions/create-job-application/create-job-application.mjs
+++ b/components/homerun/actions/create-job-application/create-job-application.mjs
@@ -4,13 +4,14 @@ export default {
   key: "homerun-create-job-application",
   name: "Create Job Application",
   description: "Creates a new job application. [See the documentation](https://developers.homerun.co/#tag/Job-Applications/operation/job-applications.post).",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     firstName: {

--- a/components/homerun/package.json
+++ b/components/homerun/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/homerun",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Homerun Components",
   "main": "homerun.app.mjs",
   "keywords": [

--- a/components/hookdeck/actions/create-connection/create-connection.mjs
+++ b/components/hookdeck/actions/create-connection/create-connection.mjs
@@ -5,13 +5,14 @@ export default {
   name: "Create Connection",
   description: "This endpoint creates a connection. [See the documentation](https://hookdeck.com/api-ref#create-a-connection).",
   key: "hookdeck-create-connection",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     name: {

--- a/components/hookdeck/package.json
+++ b/components/hookdeck/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/hookdeck",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Pipedream Hookdeck Components",
   "main": "hookdeck.app.mjs",
   "keywords": [

--- a/components/hootsuite/actions/schedule-message/schedule-message.mjs
+++ b/components/hootsuite/actions/schedule-message/schedule-message.mjs
@@ -13,13 +13,14 @@ export default {
   key: "hootsuite-schedule-message",
   name: "Schedule Message",
   description: "Schedules a message on your Hootsuite account. [See the documentation](https://apidocs.hootsuite.com/docs/api/index.html#operation/scheduleMessage)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     hootsuite,
     text: {

--- a/components/hootsuite/package.json
+++ b/components/hootsuite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/hootsuite",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Pipedream Hootsuite Components",
   "main": "hootsuite.app.mjs",
   "keywords": [

--- a/components/http/actions/return-http-response/return-http-response.mjs
+++ b/components/http/actions/return-http-response/return-http-response.mjs
@@ -6,7 +6,8 @@ export default {
   description:
     "Use with an HTTP trigger that uses \"Return a custom response from your workflow\" as its `HTTP Response`",
   type: "action",
-  version: "0.0.5",
+  ai: "optimized",
+  version: "0.0.6",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/http/package.json
+++ b/components/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/http",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Pipedream Http Components",
   "main": "http.app.mjs",
   "keywords": [

--- a/components/hunter/actions/list-leads/list-leads.mjs
+++ b/components/hunter/actions/list-leads/list-leads.mjs
@@ -4,13 +4,14 @@ export default {
   key: "hunter-list-leads",
   name: "List Leads",
   description: "List all your leads with comprehensive filtering options. The leads are returned in sorted order, with the most recent leads appearing first. [See the documentation](https://hunter.io/api-documentation/v2#leads).",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     leadsListId: {

--- a/components/hunter/package.json
+++ b/components/hunter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/hunter",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Pipedream hunter Components",
   "main": "hunter.app.mjs",
   "keywords": [

--- a/components/iauditor_by_safetyculture/actions/generate-pdf-report/generate-pdf-report.mjs
+++ b/components/iauditor_by_safetyculture/actions/generate-pdf-report/generate-pdf-report.mjs
@@ -4,13 +4,14 @@ export default {
   key: "iauditor_by_safetyculture-generate-pdf-report",
   name: "Generate PDF Report",
   description: "Retrieve the web report link for the specified inspection. This will return the existing link if one has been generated before, or generate a new one if one does not exist already. [See the documentation](https://developer.safetyculture.com/reference/thepubservice_getinspectionwebreportlink)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     safetyculture,
     inspectionId: {

--- a/components/iauditor_by_safetyculture/package.json
+++ b/components/iauditor_by_safetyculture/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/iauditor_by_safetyculture",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Pipedream iAuditor by SafetyCulture Components",
   "main": "iauditor_by_safetyculture.app.mjs",
   "keywords": [

--- a/components/icontact/actions/create-contact/create-contact.mjs
+++ b/components/icontact/actions/create-contact/create-contact.mjs
@@ -6,13 +6,14 @@ export default {
   key: "icontact-create-contact",
   name: "Create Contact",
   description: "Creates a new contact within the iContact account. [See the documentation](https://help.icontact.com/customers/s/article/Contacts-iContact-API?r=153&ui-knowledge-components-aura-actions.KnowledgeArticleVersionCreateDraftFromOnlineAction.createDraftFromOnlineArticle=1)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     icontact,
     email: {

--- a/components/icontact/package.json
+++ b/components/icontact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/icontact",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Pipedream iContact Components",
   "main": "icontact.app.mjs",
   "keywords": [

--- a/components/inmobile/actions/send-sms-messages/send-sms-messages.mjs
+++ b/components/inmobile/actions/send-sms-messages/send-sms-messages.mjs
@@ -5,8 +5,9 @@ export default {
   key: "inmobile-send-sms-messages",
   name: "Send SMS Messages",
   description: "Send one or more SMS messages using the InMobile API. [See the documentation](https://www.inmobile.com/docs/rest-api)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: true,

--- a/components/inmobile/package.json
+++ b/components/inmobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/inmobile",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream InMobile Components",
   "main": "inmobile.app.mjs",
   "keywords": [

--- a/components/instantly/actions/add-lead-campaign/add-lead-campaign.mjs
+++ b/components/instantly/actions/add-lead-campaign/add-lead-campaign.mjs
@@ -5,13 +5,14 @@ export default {
   key: "instantly-add-lead-campaign",
   name: "Add Leads to Campaign",
   description: "Adds a lead or leads to a campaign for tracking or further actions. [See the documentation](https://developer.instantly.ai/api/v2/lead/moveleads)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     instantly,
     leadIds: {

--- a/components/instantly/package.json
+++ b/components/instantly/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/instantly",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream Instantly Components",
   "main": "instantly.app.mjs",
   "keywords": [

--- a/components/interzoid/actions/generate-match-report/generate-match-report.mjs
+++ b/components/interzoid/actions/generate-match-report/generate-match-report.mjs
@@ -5,13 +5,14 @@ export default {
   key: "interzoid-generate-match-report",
   name: "Generate Match Report",
   description: "Generate a Match Report using a dataset table or file (CSV/TSV/Excel). [See the documentation](https://connect.interzoid.com/data-matching-workflow)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     interzoid,
     category: {

--- a/components/interzoid/package.json
+++ b/components/interzoid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/interzoid",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Interzoid Components",
   "main": "interzoid.app.mjs",
   "keywords": [

--- a/components/intuiface/actions/send-message/send-message.mjs
+++ b/components/intuiface/actions/send-message/send-message.mjs
@@ -4,13 +4,14 @@ export default {
   key: "intuiface-send-message",
   name: "Send Message",
   description: "Send messages to any connected Intuiface Player running an experience that embeds the [Web Triggers Interface Asset](https://support.intuiface.com/hc/en-us/articles/360007431151-Web-Triggers-Overview). [See the docs](https://my.intuiface.com/api-doc/#/default/sendMessage).",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     message: {

--- a/components/intuiface/package.json
+++ b/components/intuiface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/intuiface",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Intuiface Components",
   "main": "intuiface.app.mjs",
   "keywords": [

--- a/components/ip2geo/actions/lookup-ip/lookup-ip.mjs
+++ b/components/ip2geo/actions/lookup-ip/lookup-ip.mjs
@@ -2,7 +2,7 @@ import ip2geo from "../../ip2geo.app.mjs";
 
 export default {
   name: "Lookup IP",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -11,6 +11,7 @@ export default {
   key: "ip2geo-lookup-ip",
   description: "Convert an IP address into geolocation data including city, country, timezone, ASN, and currency. [See the documentation](https://docs.ip2geo.dev/api/convert-ip)",
   type: "action",
+  ai: "optimized",
   props: {
     ip2geo,
     ip: {

--- a/components/ip2geo/package.json
+++ b/components/ip2geo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/ip2geo",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Ip2Geo Components",
   "main": "ip2geo.app.mjs",
   "keywords": [

--- a/components/jibble/actions/create-timesheets-daily-summary/create-timesheets-daily-summary.mjs
+++ b/components/jibble/actions/create-timesheets-daily-summary/create-timesheets-daily-summary.mjs
@@ -4,13 +4,14 @@ export default {
   name: "Create Timesheets Daily Summary",
   description: "Gets daily timsheets summary for given date range and given persons. May omit personIds parameters in query so it will return data for all member of the organization.  [See the documentation](https://docs.api.jibble.io/#5510bcd1-3c58-4ffb-9048-a962edf9133a).",
   key: "jibble-create-timesheets-daily-summary",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     startDate: {

--- a/components/jibble/package.json
+++ b/components/jibble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/jibble",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Jibble Components",
   "main": "jibble.app.mjs",
   "keywords": [

--- a/components/knack/actions/get-record/get-record.mjs
+++ b/components/knack/actions/get-record/get-record.mjs
@@ -7,13 +7,14 @@ export default {
   name: "Get Record(s)",
   description:
     "Get one or more Records for a Knack object [(See docs here)](https://docs.knack.com/docs/retrieving-records)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     ...base.props,
     recordId,

--- a/components/knack/package.json
+++ b/components/knack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/knack",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Pipedream Knack Components",
   "main": "knack.app.mjs",
   "keywords": [

--- a/components/komos/actions/list-tasks/list-tasks.mjs
+++ b/components/komos/actions/list-tasks/list-tasks.mjs
@@ -4,8 +4,9 @@ export default {
   key: "komos-list-tasks",
   name: "List Tasks",
   description: "Return a paginated list of Komos tasks, with optional filtering by name or status. [See the documentation](https://docs.komos.ai/api-reference/tasks/list)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/komos/package.json
+++ b/components/komos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/komos",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Komos Components",
   "main": "komos.app.mjs",
   "keywords": [

--- a/components/labsmobile/actions/send-sms/send-sms.mjs
+++ b/components/labsmobile/actions/send-sms/send-sms.mjs
@@ -6,13 +6,14 @@ export default {
   key: "labsmobile-send-sms",
   name: "Send SMS",
   description: "Sends a new SMS message. [See the documentation](https://apidocs.labsmobile.com/)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     labsmobile,
     msisdn: {

--- a/components/labsmobile/package.json
+++ b/components/labsmobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/labsmobile",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream LabsMobile Components",
   "main": "labsmobile.app.mjs",
   "keywords": [

--- a/components/lamini/actions/upload-dataset/upload-dataset.mjs
+++ b/components/lamini/actions/upload-dataset/upload-dataset.mjs
@@ -8,13 +8,14 @@ export default {
   key: "lamini-upload-dataset",
   name: "Upload Dataset",
   description: "Upload a dataset to Lamini for training.",
-  version: "1.0.1",
+  version: "1.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     file: {

--- a/components/lamini/package.json
+++ b/components/lamini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/lamini",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Pipedream Lamini Components",
   "main": "lamini.app.mjs",
   "keywords": [

--- a/components/launch27/actions/get-booking-spots/get-booking-spots.mjs
+++ b/components/launch27/actions/get-booking-spots/get-booking-spots.mjs
@@ -4,8 +4,9 @@ export default {
   key: "launch27-get-booking-spots",
   name: "Get Booking Spots",
   description: "Retrieves all booking spots for a given event type. [See the documentation](https://bitbucket.org/awoo23/api-2.0/wiki/Spots_for_booking)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/launch27/package.json
+++ b/components/launch27/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/launch27",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Pipedream launch27 Components",
   "main": "launch27.app.mjs",
   "keywords": [

--- a/components/leadboxer/actions/list-leads/list-leads.mjs
+++ b/components/leadboxer/actions/list-leads/list-leads.mjs
@@ -4,8 +4,9 @@ export default {
   key: "leadboxer-list-leads",
   name: "List Leads",
   description: "Retrieve a list of leads. [See the documentation](https://developers.leadboxer.com/reference/users)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/leadboxer/package.json
+++ b/components/leadboxer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/leadboxer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream LeadBoxer Components",
   "main": "leadboxer.app.mjs",
   "keywords": [

--- a/components/leexi/actions/create-call/create-call.mjs
+++ b/components/leexi/actions/create-call/create-call.mjs
@@ -4,13 +4,14 @@ export default {
   key: "leexi-create-call",
   name: "Create Call",
   description: "Create a new call in Leexi. [See the documentation](https://developer.leexi.ai/)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     recordingS3Key: {

--- a/components/leexi/package.json
+++ b/components/leexi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/leexi",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Leexi Components",
   "main": "leexi.app.mjs",
   "keywords": [

--- a/components/leonardo_ai/actions/generate-image/generate-image.mjs
+++ b/components/leonardo_ai/actions/generate-image/generate-image.mjs
@@ -4,13 +4,14 @@ export default {
   key: "leonardo_ai-generate-image",
   name: "Generate Image",
   description: "Generates new images using Leonardo AI's image generation API.  [See the documentation](https://docs.leonardo.ai/reference/creategeneration)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     prompt: {

--- a/components/leonardo_ai/package.json
+++ b/components/leonardo_ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/leonardo_ai",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream Leonardo AI Components",
   "main": "leonardo_ai.app.mjs",
   "keywords": [

--- a/components/linear/actions/get-current-user/get-current-user.mjs
+++ b/components/linear/actions/get-current-user/get-current-user.mjs
@@ -6,8 +6,9 @@ export default {
   key: "linear-get-current-user",
   name: "Get Current User",
   description: "Retrieve rich context about the authenticated Linear user, including core profile fields, recent timestamps, direct team memberships, and high-level organization settings. Returns the user object, a paginated team list (with names, keys, cycle configs, etc.), associated team memberships, and organization metadata such as auth defaults and SCIM/SAML flags. Use this when your workflow or agent needs to understand who is currently authenticated, which teams they belong to, or what workspace policies might influence subsequent Linear actions. See Linear's GraphQL viewer docs [here](https://linear.app/developers/graphql).",
-  version: "0.0.5",
+  version: "0.0.6",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/linear/package.json
+++ b/components/linear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/linear",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Pipedream Linear Components",
   "main": "linear.app.mjs",
   "keywords": [

--- a/components/linkedin_ads/actions/send-conversion-event/send-conversion-event.mjs
+++ b/components/linkedin_ads/actions/send-conversion-event/send-conversion-event.mjs
@@ -5,13 +5,14 @@ export default {
   key: "linkedin_ads-send-conversion-event",
   name: "Send Conversion Event",
   description: "Sends a conversion event to LinkedIn Ads. [See the documentation](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/conversions-api?view=li-lms-2024-01&tabs=http#streaming-conversion-events)",
-  version: "0.0.7",
+  version: "0.0.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     adAccountId: {

--- a/components/linkedin_ads/package.json
+++ b/components/linkedin_ads/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/linkedin_ads",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Pipedream LinkedIn Ads Components",
   "main": "linkedin_ads.app.mjs",
   "keywords": [

--- a/components/linkly/actions/update-link/update-link.mjs
+++ b/components/linkly/actions/update-link/update-link.mjs
@@ -4,13 +4,14 @@ export default {
   key: "linkly-update-link",
   name: "Update Link",
   description: "Update an existing short link via `POST /api/v1/link` (with `id`) — change its destination URL, slug, name, or custom domain without breaking the existing short URL. [See the documentation](https://app.linklyhq.com/swaggerui#/Links/createOrUpdateLink).",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     linkly,
     linkId: {

--- a/components/linkly/package.json
+++ b/components/linkly/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/linkly",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Linkly Components",
   "main": "linkly.app.mjs",
   "keywords": [

--- a/components/llmwhisperer/actions/extract-text/extract-text.mjs
+++ b/components/llmwhisperer/actions/extract-text/extract-text.mjs
@@ -5,13 +5,14 @@ export default {
   key: "llmwhisperer-extract-text",
   name: "Extract Text",
   description: "Convert your PDF/scanned documents to text format which can be used by LLMs. [See the documentation](https://docs.unstract.com/llm_whisperer/apis/llm_whisperer_text_extraction_api)",
-  version: "0.1.3",
+  version: "0.1.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     processingMode: {

--- a/components/llmwhisperer/package.json
+++ b/components/llmwhisperer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/llmwhisperer",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Pipedream LLMWhisperer Components",
   "main": "llmwhisperer.app.mjs",
   "keywords": [

--- a/components/lumin_pdf/actions/send-signature-request/send-signature-request.mjs
+++ b/components/lumin_pdf/actions/send-signature-request/send-signature-request.mjs
@@ -10,13 +10,14 @@ export default {
   key: "lumin_pdf-send-signature-request",
   name: "Send Signature Request",
   description: "Send a signature request to signers. [See the documentation](https://developers.luminpdf.com/api/send-signature-request/)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     luminPdf,
     fileUrl: {

--- a/components/lumin_pdf/package.json
+++ b/components/lumin_pdf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/lumin_pdf",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream Lumin PDF Components",
   "main": "lumin_pdf.app.mjs",
   "keywords": [

--- a/components/mailgun/actions/create-route/create-route.mjs
+++ b/components/mailgun/actions/create-route/create-route.mjs
@@ -5,13 +5,14 @@ export default {
   key: "mailgun-create-route",
   name: "Create Route",
   description: "Create a new route. [See the docs here](https://documentation.mailgun.com/en/latest/api-routes.html#actions)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     mailgun,
     priority: {

--- a/components/mailgun/package.json
+++ b/components/mailgun/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/mailgun",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Mailgun Components",
   "main": "mailgun.app.mjs",
   "keywords": [

--- a/components/mailjet/actions/send-message/send-message.mjs
+++ b/components/mailjet/actions/send-message/send-message.mjs
@@ -5,7 +5,8 @@ export default {
   name: "Send Message",
   description: "Send a message via Send API v3. Send API v3 is built mainly for speed, allowing you to send up to 100 messages in a single API call. [See the docs here](https://dev.mailjet.com/email/reference/send-emails/#v3_1_post_send)",
   type: "action",
-  version: "0.0.4",
+  ai: "optimized",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/mailjet/package.json
+++ b/components/mailjet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/mailjet",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Pipedream Mailjet Components",
   "main": "mailjet.app.mjs",
   "keywords": [

--- a/components/mattermost/actions/post-message/post-message.ts
+++ b/components/mattermost/actions/post-message/post-message.ts
@@ -9,13 +9,14 @@ export default defineAction({
   description:
     "Create a new post in a channel [See docs here](https://api.mattermost.com/#tag/posts/operation/CreatePost)",
   key: "mattermost-post-message",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     mattermost,
     channelId: {

--- a/components/mattermost/package.json
+++ b/components/mattermost/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/mattermost",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Pipedream Mattermost Components",
   "main": "dist/app/mattermost.app.mjs",
   "keywords": [

--- a/components/medium/actions/create-post/create-post.mjs
+++ b/components/medium/actions/create-post/create-post.mjs
@@ -5,7 +5,7 @@ import { axios } from "@pipedream/platform";
 export default {
   key: "medium-create-post",
   name: "Create a post",
-  version: "0.1.4",
+  version: "0.1.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -13,6 +13,7 @@ export default {
   },
   description: "Create a new Medium post.",
   type: "action",
+  ai: "optimized",
   props: {
     medium: {
       type: "app",

--- a/components/medium/package.json
+++ b/components/medium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/medium",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Pipedream medium Components",
   "main": "medium.app.mjs",
   "keywords": [

--- a/components/meetstream_ai/actions/create-bot/create-bot.mjs
+++ b/components/meetstream_ai/actions/create-bot/create-bot.mjs
@@ -4,13 +4,14 @@ export default {
   key: "meetstream_ai-create-bot",
   name: "Create Bot",
   description: "Creates a new bot instance to join a meeting. [See the documentation](https://vento.so/view/35d0142d-f91f-47f6-8175-d42e1953d6f1?utm_medium=share)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     meetstreamAi,
     meetingLink: {

--- a/components/meetstream_ai/package.json
+++ b/components/meetstream_ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/meetstream_ai",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Meetstream AI Components",
   "main": "meetstream_ai.app.mjs",
   "keywords": [


### PR DESCRIPTION
Split of the oversized batch 6 (#21892), which changed 400 files (200 components + 200 app package.json) — over the ~300-file cap of the `publish-components` changed-files detection, which would silently drop ~100 components. This half is **100 components / 100 apps = 200 changed files**, safely under the cap.

Continuation of the DJ-4272 AI-optimized backfill (product CSV, Aug 11 2026). Adds top-level `ai: "optimized"` + patch version bump per component; each app's `package.json` bumped (`check_version`). Disjoint apps; regenerated fresh off current master.

Apps (bippybox…meetstream_ai): bippybox,blink blogger,blotato bol_com,botpenguin bubble,buildkite campaign_cleaner,castmagic change_photos,checkvist circleci,cisco_webex claap,clickfunnels clientify,cloudflare_browser_rendering coassemble,codereadr coingecko,commpeak confection,contactout craftmypdf,customer_io customgpt,cutt_ly deftship,dex dhl,dhl_parcel dispatch,dixa dock_certs,docugenerate document360,dpd_shipping dropboard,dropbox dropinblog,dynalist egnyte,elastic_email email,emailoctopus eodhd_apis,esignatures_io esputnik,evernote fitbit,float fogbugz,forcemanager freedcamp,freshchat fullenrich,genderize geodb_cities,giantcampaign gist,gitlab google_chat,google_search_console google_slides,granola help_scout,hex holded,homerun hookdeck,hootsuite http,hunter iauditor_by_safetyculture,icontact inmobile,instantly interzoid,intuiface ip2geo,jibble knack,komos labsmobile,lamini launch27,leadboxer leexi,leonardo_ai linear,linkedin_ads linkly,llmwhisperer lumin_pdf,mailgun mailjet,mattermost medium,meetstream_ai