### PR TITLE
feat(ai): mark AI-optimized components with `ai` field (batch 6b/6, split of #21892)

### DIFF
--- a/components/mem/actions/create-mem/create-mem.mjs
+++ b/components/mem/actions/create-mem/create-mem.mjs
@@ -3,7 +3,7 @@ import mem from "../../mem.app.mjs";
 export default {
   key: "mem-create-mem",
   name: "Create Mem",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -11,6 +11,7 @@ export default {
   },
   description: "Create a new mem. [See the documentation](https://docs.mem.ai/docs/api/mems/create)",
   type: "action",
+  ai: "optimized",
   props: {
     mem,
     content: {

--- a/components/mem/package.json
+++ b/components/mem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/mem",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream Mem Components",
   "main": "mem.app.mjs",
   "keywords": [

--- a/components/memberstack/actions/create-member/create-member.mjs
+++ b/components/memberstack/actions/create-member/create-member.mjs
@@ -5,13 +5,14 @@ export default {
   key: "memberstack-create-member",
   name: "Create Member",
   description: "Creates a member connected to a free plan. [See the docs](https://memberstack.notion.site/Admin-API-5b9233507d734091bd6ed604fb893bb8)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     memberstack,
     email: {

--- a/components/memberstack/package.json
+++ b/components/memberstack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/memberstack",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Memberstack Components",
   "main": "memberstack.app.mjs",
   "keywords": [

--- a/components/metaphor/actions/get-documents-content/get-documents-content.mjs
+++ b/components/metaphor/actions/get-documents-content/get-documents-content.mjs
@@ -3,7 +3,7 @@ import metaphor from "../../metaphor.app.mjs";
 export default {
   key: "metaphor-get-documents-content",
   name: "Get Contents of Documents",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -11,6 +11,7 @@ export default {
   },
   description: "Retrieve contents of documents based on a list of document IDs. [See the documentation](https://docs.metaphor.systems/reference/contents). It is used to `instantly` get content for documents, given the IDs of the documents. We currently support extracts - the first 1000 tokens (~750 words) of parsed HTML for a site. **Note that each piece of content retrieved costs 1 request.** Also note that `instant` is a little bit of a lie if you are using keyword search, in which case contents might take a few seconds to retrieve.",
   type: "action",
+  ai: "optimized",
   props: {
     metaphor,
     ids: {

--- a/components/metaphor/package.json
+++ b/components/metaphor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/metaphor",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream Metaphor Components",
   "main": "metaphor.app.mjs",
   "keywords": [

--- a/components/microsoft_clarity/actions/get-live-insights/get-live-insights.mjs
+++ b/components/microsoft_clarity/actions/get-live-insights/get-live-insights.mjs
@@ -11,8 +11,9 @@ export default {
     + " **Rate limit: 10 requests per project per day — combine all desired dimensions into a single call rather than issuing multiple requests.**"
     + " Results are limited to 1,000 rows with no pagination."
     + " [See the documentation](https://learn.microsoft.com/en-us/clarity/setup-and-installation/clarity-data-export-api)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/microsoft_clarity/package.json
+++ b/components/microsoft_clarity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/microsoft_clarity",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Microsoft Clarity Components",
   "main": "microsoft_clarity.app.mjs",
   "keywords": [

--- a/components/microsoft_entra_id/actions/get-organization-users/get-organization-users.mjs
+++ b/components/microsoft_entra_id/actions/get-organization-users/get-organization-users.mjs
@@ -4,8 +4,9 @@ export default {
   key: "microsoft_entra_id-get-organization-users",
   name: "Get Organization Users",
   description: "List all users in the organization. By default returns only enabled accounts. [See the documentation](https://learn.microsoft.com/en-us/graph/api/user-list?view=graph-rest-1.0&tabs=http)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/microsoft_entra_id/package.json
+++ b/components/microsoft_entra_id/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/microsoft_entra_id",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Pipedream Microsoft Entra ID Components",
   "main": "microsoft_entra_id.app.mjs",
   "keywords": [

--- a/components/microsoft_teams/actions/get-current-user/get-current-user.mjs
+++ b/components/microsoft_teams/actions/get-current-user/get-current-user.mjs
@@ -4,8 +4,9 @@ export default {
   key: "microsoft_teams-get-current-user",
   name: "Get Current User",
   description: "Returns the authenticated Microsoft Teams user's ID, display name, email, and principal name via Microsoft Graph. Call this first when the user says 'my channels', 'my chats', or needs identity context. Use the returned `id` to identify the sender in **Send Channel Message** or **Send Chat Message** results. [See the documentation](https://learn.microsoft.com/en-us/graph/api/user-get).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/microsoft_teams/package.json
+++ b/components/microsoft_teams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/microsoft_teams",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Pipedream Microsoft Teams Components",
   "main": "microsoft_teams.app.mjs",
   "keywords": [

--- a/components/moosend/actions/add-subscriber/add-subscriber.mjs
+++ b/components/moosend/actions/add-subscriber/add-subscriber.mjs
@@ -5,13 +5,14 @@ export default {
   key: "moosend-add-subscriber",
   name: "Add subscriber",
   description: "Adds a new subscriber to the specified mailing list. If there is already a subscriber with the specified email address in the list, an update will be performed instead. The rate limit for this request is 10 requests per 10 seconds (*per API key). See the [docs](https://moosendapp.docs.apiary.io/#reference/subscribers/add-or-update-subscribers/adding-subscribers) for more info.",
-  version: "0.2.1",
+  version: "0.2.2",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     email: {

--- a/components/moosend/package.json
+++ b/components/moosend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/moosend",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Moosend Components",
   "main": "moosend.app.mjs",
   "keywords": [

--- a/components/motion/actions/move-workspace/move-workspace.mjs
+++ b/components/motion/actions/move-workspace/move-workspace.mjs
@@ -3,7 +3,7 @@ import motion from "../../motion.app.mjs";
 export default {
   key: "motion-move-workspace",
   name: "Move Workspace",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
@@ -11,6 +11,7 @@ export default {
   },
   description: "Move a specific task to another workspace. When moving tasks from one workspace to another, the tasks project, status, and label(s) and assignee will all be reset. [See the documentation](https://docs.usemotion.com/docs/motion-rest-api/0440c0ba81f10-move-workspace)",
   type: "action",
+  ai: "optimized",
   props: {
     motion,
     taskId: {

--- a/components/motion/package.json
+++ b/components/motion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/motion",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Pipedream Motion Components",
   "main": "motion.app.mjs",
   "keywords": [

--- a/components/muapi/actions/get-prediction/get-prediction.mjs
+++ b/components/muapi/actions/get-prediction/get-prediction.mjs
@@ -2,10 +2,11 @@ import muapi from "../../muapi.app.mjs";
 
 export default {
   name: "Get Prediction Result",
-  version: "0.0.1",
+  version: "0.0.2",
   key: "muapi-get-prediction",
   description: "Check the status and retrieve the output of a prediction by its request ID. [See the documentation](https://docs.muapi.ai)",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/muapi/package.json
+++ b/components/muapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/muapi",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream MuAPI Components",
   "main": "muapi.app.mjs",
   "keywords": [

--- a/components/nationbuilder/actions/push-person/push-person.mjs
+++ b/components/nationbuilder/actions/push-person/push-person.mjs
@@ -4,7 +4,7 @@ import nationbuilder from "../../nationbuilder.app.mjs";
 export default {
   key: "nationbuilder-push-person",
   name: "Push Person",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -12,6 +12,7 @@ export default {
   },
   description: "This endpoint attempts to match the input person resource to a person already in the nation. If a match is found, the matched person is updated and a 200 status code is returned. If a match is not found, a new person is created and a 201 status code is returned. Matches are found by including one of the following IDs in the request: `civicrm_id`,  `county_file_id`,  `dw_id`,  `external_id`,  `email`,  `facebook_username`,  `ngp_id`,  `salesforce_id`,  `twitter_login`, `van_id`. [See the documentation](https://nationbuilder.com/people_api)",
   type: "action",
+  ai: "optimized",
   props: {
     nationbuilder,
     civicrmId: {

--- a/components/nationbuilder/package.json
+++ b/components/nationbuilder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/nationbuilder",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream NationBuilder Components",
   "main": "nationbuilder.app.mjs",
   "keywords": [

--- a/components/navan/actions/list-users/list-users.mjs
+++ b/components/navan/actions/list-users/list-users.mjs
@@ -4,8 +4,9 @@ export default {
   key: "navan-list-users",
   name: "List Users",
   description: "Retrieves a paginated list of all users in the company. [See the documentation](https://u.pcloud.link/publink/show?code=XZ7Bww5ZoKb93VNf7ISOdR5UzVo6JzBLs7AX)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: true,
     destructiveHint: false,

--- a/components/navan/package.json
+++ b/components/navan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/navan",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Navan Components",
   "main": "navan.app.mjs",
   "keywords": [

--- a/components/news_api/actions/search-top-headlines/search-top-headlines.mjs
+++ b/components/news_api/actions/search-top-headlines/search-top-headlines.mjs
@@ -6,13 +6,14 @@ export default {
   key: "news_api-search-top-headlines",
   name: "Search Top Headlines",
   description: "Retrieve live top and breaking headlines for a category, single source, multiple sources, or keywords. [See the documentation](https://newsapi.org/docs/endpoints/top-headlines)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     newsapi,
     q: {

--- a/components/news_api/package.json
+++ b/components/news_api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/news_api",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream News API Components",
   "main": "news_api.app.mjs",
   "keywords": [

--- a/components/noticeable/actions/create-publication/create-publication.mjs
+++ b/components/noticeable/actions/create-publication/create-publication.mjs
@@ -2,8 +2,9 @@ import app from "../../noticeable.app.mjs";
 
 export default {
   type: "action",
+  ai: "optimized",
   key: "noticeable-create-publication",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/noticeable/package.json
+++ b/components/noticeable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/noticeable",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pipedream Noticeable Components",
   "main": "noticeable.app.mjs",
   "keywords": [

--- a/components/numverify/actions/validate-phone/validate-phone.mjs
+++ b/components/numverify/actions/validate-phone/validate-phone.mjs
@@ -4,13 +4,14 @@ export default {
   key: "numverify-validate-phone",
   name: "Validate Phone",
   description: "Validates a phone number. [See the documentation](https://numverify.com/documentation)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     numverify,
     number: {

--- a/components/numverify/package.json
+++ b/components/numverify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/numverify",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream numverify Components",
   "main": "numverify.app.mjs",
   "keywords": [

--- a/components/octopush_sms/actions/send-new-sms/send-new-sms.mjs
+++ b/components/octopush_sms/actions/send-new-sms/send-new-sms.mjs
@@ -4,13 +4,14 @@ export default {
   key: "octopush_sms-send-new-sms",
   name: "Send New SMS",
   description: "Sends a new SMS using Octopush SMS. [See the documentation](https://dev.octopush.com/en/sms-gateway-api-documentation/send-sms/)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     octopush,
     text: {

--- a/components/octopush_sms/package.json
+++ b/components/octopush_sms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/octopush_sms",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Octopush SMS Components",
   "main": "octopush_sms.app.mjs",
   "keywords": [

--- a/components/omnisend/actions/unsubscribe-contact-by-email/unsubscribe-contact-by-email.mjs
+++ b/components/omnisend/actions/unsubscribe-contact-by-email/unsubscribe-contact-by-email.mjs
@@ -5,13 +5,14 @@ export default {
   key: "omnisend-unsubscribe-contact-by-email",
   name: "Unsubscribe Contact by Email",
   description: "Unsubscribe an existing Omnisend contact from the email channel by their full email address. This action does not create new contacts. [See the documentation](https://api-docs.omnisend.com/v3/docs/how-to-sync-contacts)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     omnisend,
     email: {

--- a/components/omnisend/package.json
+++ b/components/omnisend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/omnisend",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Pipedream Omnisend Components",
   "main": "omnisend.app.mjs",
   "keywords": [

--- a/components/openweather_api/actions/get-weather-forecast-by-location/get-weather-forecast-by-location.mjs
+++ b/components/openweather_api/actions/get-weather-forecast-by-location/get-weather-forecast-by-location.mjs
@@ -6,13 +6,14 @@ export default {
   name: "Get Current Weather Forecast by Location",
   description: `Retrieves 1-16 days weather forecast for a specified location. 
   [See the docs here](https://openweathermap.org/forecast16#geo16). For more accurate reading, you are advised to fill in the country and/or state code`,
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     openweatherApi,
     city: {

--- a/components/openweather_api/package.json
+++ b/components/openweather_api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/openweather_api",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Pipedream Openweather Components",
   "main": "openweather_api.app.mjs",
   "keywords": [

--- a/components/orbit/actions/get-member-by-identity/get-member-by-identity.mjs
+++ b/components/orbit/actions/get-member-by-identity/get-member-by-identity.mjs
@@ -4,13 +4,14 @@ export default {
   name: "Get Member by Identity",
   description: "Provide a source and one of username/uid/email params to return a member with that identity, if one exists. Common values for source include github, twitter, and email. [See the docs here](https://api.orbit.love/reference/get_workspace-slug-members-find)",
   key: "orbit-get-member-by-identity",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     workspaceSlug: {

--- a/components/orbit/package.json
+++ b/components/orbit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/orbit",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Orbit Components",
   "main": "orbit.app.mjs",
   "keywords": [

--- a/components/orca_scan/actions/find-row/find-row.mjs
+++ b/components/orca_scan/actions/find-row/find-row.mjs
@@ -4,13 +4,14 @@ export default {
   key: "orca_scan-find-row",
   name: "Find Row",
   description: "Locates a row record based on a given barcode. If no barcode is provided, return all rows. [See the documentation](https://orcascan.com/guides/add-barcode-tracking-to-your-system-using-a-rest-api-f09a21c3#rows-1)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     orca_scan,
     sheetId: {

--- a/components/orca_scan/package.json
+++ b/components/orca_scan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/orca_scan",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Orca Scan Components",
   "main": "orca_scan.app.mjs",
   "keywords": [

--- a/components/outscraper/actions/search-places/search-places.mjs
+++ b/components/outscraper/actions/search-places/search-places.mjs
@@ -6,13 +6,14 @@ export default {
   key: "outscraper-search-places",
   name: "Search Places on Google Maps",
   description: "Searches for places on Google Maps using queries. [See the documentation](https://app.outscraper.com/api-docs#tag/Businesses-and-POI/paths/~1maps~1search-v3/get)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     outscraper,
     query: {

--- a/components/outscraper/package.json
+++ b/components/outscraper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/outscraper",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Outscraper Components",
   "main": "outscraper.app.mjs",
   "keywords": [

--- a/components/overledger/actions/execute-signed-transaction/execute-signed-transaction.mjs
+++ b/components/overledger/actions/execute-signed-transaction/execute-signed-transaction.mjs
@@ -4,13 +4,14 @@ export default {
   key: "overledger-execute-signed-transaction",
   name: "Execute Signed Transaction",
   description: "Executes a signed transaction by sending it to a blockchain node via Overledger. [See the documentation](https://developers.quant.network/reference/executesignedrequest)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     overledger,
     environment: {

--- a/components/overledger/package.json
+++ b/components/overledger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/overledger",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Pipedream Overledger Components",
   "main": "overledger.app.mjs",
   "keywords": [

--- a/components/papertrail/actions/search-events/search-events.mjs
+++ b/components/papertrail/actions/search-events/search-events.mjs
@@ -5,8 +5,9 @@ export default {
   name: "Search Log Events",
   description:
     "Search Papertrail log events programmatically. Supports query syntax, system/group scope, time or ID bounds, limit, and tail mode. [See the documentation](https://www.papertrail.com/help/search-api/)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/papertrail/package.json
+++ b/components/papertrail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/papertrail",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Papertrail Components",
   "main": "papertrail.app.mjs",
   "keywords": [

--- a/components/paytrace/actions/batch-summary/batch-summary.mjs
+++ b/components/paytrace/actions/batch-summary/batch-summary.mjs
@@ -4,13 +4,14 @@ export default {
   name: "Batch Summary",
   description: "This method can be used to export a summary of specific batch details or currently pending settlement details by card and transaction type. If no optional parameter is provided, the latest batch details will be returned. [See docs here](https://developers.paytrace.com/support/home#14000045456)",
   key: "paytrace-batch-summary",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     paytrace,
     batchNumber: {

--- a/components/paytrace/package.json
+++ b/components/paytrace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/paytrace",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Pipedream Paytrace Components",
   "main": "paytrace.app.mjs",
   "keywords": [

--- a/components/peaka/actions/run-query/run-query.mjs
+++ b/components/peaka/actions/run-query/run-query.mjs
@@ -5,13 +5,14 @@ export default {
   key: "peaka-run-query",
   name: "Run Query",
   description: "Runs a specific query in Peaka and returns the result as line items. [See the documentation](https://docs.peaka.com/api-reference/data-%3E-query/execute-a-query).",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     projectId: {

--- a/components/peaka/package.json
+++ b/components/peaka/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/peaka",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Peaka Components",
   "main": "peaka.app.mjs",
   "keywords": [

--- a/components/perplexity/actions/chat-completions-advanced/chat-completions-advanced.mjs
+++ b/components/perplexity/actions/chat-completions-advanced/chat-completions-advanced.mjs
@@ -4,13 +4,14 @@ export default {
   key: "perplexity-chat-completions-advanced",
   name: "Chat Completions (Advanced)",
   description: "Generates a model's response for the given chat conversation with multi-message support and Perplexity search controls. Docs: https://docs.perplexity.ai/api-reference/chat-completions-post",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     model: {

--- a/components/perplexity/package.json
+++ b/components/perplexity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/perplexity",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Pipedream Perplexity Components",
   "main": "perplexity.app.mjs",
   "keywords": [

--- a/components/phantombuster/actions/launch-phantom/launch-phantom.mjs
+++ b/components/phantombuster/actions/launch-phantom/launch-phantom.mjs
@@ -2,8 +2,9 @@ import app from "../../phantombuster.app.mjs";
 
 export default {
   type: "action",
+  ai: "optimized",
   key: "phantombuster-launch-phantom",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/phantombuster/package.json
+++ b/components/phantombuster/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/phantombuster",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Phantombuster Components",
   "main": "phantombuster.app.mjs",
   "keywords": [

--- a/components/pinecone/actions/query-ids/query-ids.mjs
+++ b/components/pinecone/actions/query-ids/query-ids.mjs
@@ -6,7 +6,8 @@ export default {
   name: "Query IDs",
   description: "Searches a namespace, using a query vector. It retrieves the ids of the most similar items in a namespace, along with their similarity scores. [See the documentation](https://docs.pinecone.io/reference/api/data-plane/query).",
   type: "action",
-  version: "0.0.3",
+  ai: "optimized",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/pinecone/package.json
+++ b/components/pinecone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/pinecone",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Pinecone Components",
   "main": "pinecone.app.mjs",
   "keywords": [

--- a/components/pipedream/actions/generate-component-code/generate-component-code.mjs
+++ b/components/pipedream/actions/generate-component-code/generate-component-code.mjs
@@ -5,13 +5,14 @@ export default {
   key: "pipedream-generate-component-code",
   name: "Generate Component Code",
   description: "Generate component code using AI.",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     pipedream,
     prompt: {

--- a/components/pipedream/package.json
+++ b/components/pipedream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/pipedream",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Pipedream Pipedream Components",
   "main": "pipedream.app.mjs",
   "keywords": [

--- a/components/plaid/actions/get-transactions/get-transactions.mjs
+++ b/components/plaid/actions/get-transactions/get-transactions.mjs
@@ -4,13 +4,14 @@ export default {
   key: "plaid-get-transactions",
   name: "Get Transactions",
   description: "Retrieves user-authorized transaction data for a specified date range. [See the documentation](https://plaid.com/docs/api/products/transactions/#transactionsget)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     accessToken: {

--- a/components/plaid/package.json
+++ b/components/plaid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/plaid",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Pipedream plaid Components",
   "main": "plaid.app.mjs",
   "keywords": [

--- a/components/polar/actions/create-checkout/create-checkout.mjs
+++ b/components/polar/actions/create-checkout/create-checkout.mjs
@@ -4,8 +4,9 @@ export default {
   key: "polar-create-checkout",
   name: "Create Checkout",
   description: "Create a checkout session for one or more products. [See the documentation](https://polar.sh/docs/api-reference/checkouts/create-session)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/polar/package.json
+++ b/components/polar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/polar",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Polar Components",
   "main": "polar.app.mjs",
   "keywords": [

--- a/components/polygon/actions/get-historical-prices/get-historical-prices.mjs
+++ b/components/polygon/actions/get-historical-prices/get-historical-prices.mjs
@@ -8,13 +8,14 @@ export default {
   key: "polygon-get-historical-prices",
   name: "Get Historical Prices",
   description: "Fetches historical price data for a specified stock ticker within a date range. [See the documentation](https://polygon.io/docs/stocks/get_v2_aggs_ticker__stocksticker__range__multiplier___timespan___from___to)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     polygon,
     stockTicker: {

--- a/components/polygon/package.json
+++ b/components/polygon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/polygon",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Pipedream polygon Components",
   "main": "polygon.app.mjs",
   "keywords": [

--- a/components/postgrid/actions/create-postcard/create-postcard.mjs
+++ b/components/postgrid/actions/create-postcard/create-postcard.mjs
@@ -5,13 +5,14 @@ export default {
   key: "postgrid-create-postcard",
   name: "Create Postcard",
   description: "Creates a new postcard in PostGrid. [See the documentation](https://docs.postgrid.com/#fe8c4cd6-7617-4023-9437-669fa847ccc1)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     postgrid,
     to: {

--- a/components/postgrid/package.json
+++ b/components/postgrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/postgrid",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream PostGrid Print & Mail Components",
   "main": "postgrid.app.mjs",
   "keywords": [

--- a/components/postgrid_verify/actions/verify-address/verify-address.mjs
+++ b/components/postgrid_verify/actions/verify-address/verify-address.mjs
@@ -4,13 +4,14 @@ export default {
   name: "Verify Address",
   description: "Verify, standardize, and correct an address written on a single line. Ensure that you add the ISO 2-letter country code to the end of the line for best results. [See the documentation](https://avdocs.postgrid.com/#1061f2ea-00ee-4977-99da-a54872de28c2).",
   key: "postgrid_verify-verify-address",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     address: {

--- a/components/postgrid_verify/package.json
+++ b/components/postgrid_verify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/postgrid_verify",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream PostGrid Verify Components",
   "main": "postgrid_verify.app.mjs",
   "keywords": [

--- a/components/practitest/actions/create-run/create-run.ts
+++ b/components/practitest/actions/create-run/create-run.ts
@@ -10,13 +10,14 @@ export default defineAction({
   name: "Create Run",
   description: `Create a run [See docs here](${DOCS.createRun})`,
   key: "practitest-create-run",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     practitest,
     projectId: {

--- a/components/practitest/package.json
+++ b/components/practitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/practitest",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Pipedream PractiTest Components",
   "main": "dist/app/practitest.app.mjs",
   "keywords": [

--- a/components/precisefp/actions/create-account/create-account.mjs
+++ b/components/precisefp/actions/create-account/create-account.mjs
@@ -5,7 +5,8 @@ export default {
   name: "Create Account",
   description: "Create a new account. [See the documentation](https://documenter.getpostman.com/view/6125750/UyrDEFnd#b6db56e1-2767-499e-9928-38c82f3bd3e6)",
   type: "action",
-  version: "0.0.2",
+  ai: "optimized",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/precisefp/package.json
+++ b/components/precisefp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/precisefp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream PreciseFP Components",
   "main": "precisefp.app.mjs",
   "keywords": [

--- a/components/printautopilot/actions/add-pdf-to-queue/add-pdf-to-queue.mjs
+++ b/components/printautopilot/actions/add-pdf-to-queue/add-pdf-to-queue.mjs
@@ -5,13 +5,14 @@ export default {
   key: "printautopilot-add-pdf-to-queue",
   name: "Add PDF to Print Autopilot Queue",
   description: "Uploads a PDF document to the print-autopilot queue. [See the documentation](https://documenter.getpostman.com/view/1334461/TW6wJonb#53f82327-4f23-416d-b2f0-ce17b8037933)",
-  version: "0.1.3",
+  version: "0.1.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     printAutopilot,
     filePath: {

--- a/components/printautopilot/package.json
+++ b/components/printautopilot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/printautopilot",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Pipedream PrintAutopilot Components",
   "main": "printautopilot.app.mjs",
   "keywords": [

--- a/components/printnode/actions/send-print-job/send-print-job.mjs
+++ b/components/printnode/actions/send-print-job/send-print-job.mjs
@@ -5,13 +5,14 @@ export default {
   key: "printnode-send-print-job",
   name: "Send Print Job",
   description: "Sends a print job to a specified printer. [See the documentation](https://www.printnode.com/en/docs/api/curl#creating-print-jobs)",
-  version: "1.0.3",
+  version: "1.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     printnode,
     printerId: {

--- a/components/printnode/package.json
+++ b/components/printnode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/printnode",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Pipedream PrintNode Components",
   "main": "printnode.app.mjs",
   "keywords": [

--- a/components/proabono/actions/create-customer/create-customer.mjs
+++ b/components/proabono/actions/create-customer/create-customer.mjs
@@ -5,13 +5,14 @@ export default {
   key: "proabono-create-customer",
   name: "Create or Update a Customer",
   description: "Creates a new customer or updates an existing one in the ProAbono system. [See the documentation](https://docs.proabono.com/api/#create-a-customer)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     proabono,
     customerId: {

--- a/components/proabono/package.json
+++ b/components/proabono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/proabono",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream ProAbono Components",
   "main": "proabono.app.mjs",
   "keywords": [

--- a/components/productboard/actions/create-note/create-note.mjs
+++ b/components/productboard/actions/create-note/create-note.mjs
@@ -5,7 +5,8 @@ export default {
   name: "Create Note",
   description: "Create a new note. [See the docs here](https://developer.productboard.com/#operation/create_note)",
   type: "action",
-  version: "0.0.2",
+  ai: "optimized",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/productboard/package.json
+++ b/components/productboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/productboard",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Pipedream Productboard Components",
   "main": "productboard.app.mjs",
   "keywords": [

--- a/components/profitwell/actions/create-subscription/create-subscription.ts
+++ b/components/profitwell/actions/create-subscription/create-subscription.ts
@@ -9,13 +9,14 @@ export default defineAction({
   description:
     "Create a subscription [See docs here](https://profitwellapiv2.docs.apiary.io/#/reference/manually-added-customers/creating-subscriptions/create-a-subscription)",
   key: "profitwell-create-subscription",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     profitwell,
     userId: {

--- a/components/profitwell/package.json
+++ b/components/profitwell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/profitwell",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Pipedream ProfitWell Components",
   "main": "dist/app/profitwell.app.mjs",
   "keywords": [

--- a/components/pushover/actions/emergency-push-notification/emergency-push-notification.mjs
+++ b/components/pushover/actions/emergency-push-notification/emergency-push-notification.mjs
@@ -7,13 +7,14 @@ export default {
   description: `Sends an Emergency Push Notification to devices with Pushover.
     Notifications are repeated until they are acknowledged by the user.
     More information at [Pushing Messages](https://pushover.net/api#messages) and [Message Priority](https://pushover.net/api#priority)`,
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     pushover,
     message: {

--- a/components/pushover/package.json
+++ b/components/pushover/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/pushover",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pushover Components",
   "main": "pushover.app.mjs",
   "keywords": [

--- a/components/qstash/actions/verify-webhook/verify-webhook.mjs
+++ b/components/qstash/actions/verify-webhook/verify-webhook.mjs
@@ -3,7 +3,7 @@ import { methods } from "../../common.mjs";
 
 export default {
   name: "Verify Webhook",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -20,6 +20,7 @@ export default {
     },
   },
   type: "action",
+  ai: "optimized",
   methods: {
     ...methods,
   },

--- a/components/qstash/package.json
+++ b/components/qstash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/qstash",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Pipedream qstash Components",
   "main": "qstash.app.mjs",
   "keywords": [

--- a/components/qualetics/actions/send-data/send-data.mjs
+++ b/components/qualetics/actions/send-data/send-data.mjs
@@ -4,13 +4,14 @@ export default {
   key: "qualetics-send-data",
   name: "Send Data",
   description: "Send an event with data to the system. [See the documentation](https://docs.qualetics.com/rest-api-integration-to-send-data)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     qualetics,
     actor: {

--- a/components/qualetics/package.json
+++ b/components/qualetics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/qualetics",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Qualetics Components",
   "main": "qualetics.app.mjs",
   "keywords": [

--- a/components/quriiri/actions/send-message/send-message.mjs
+++ b/components/quriiri/actions/send-message/send-message.mjs
@@ -9,13 +9,14 @@ export default {
   key: "quriiri-send-message",
   name: "Send Message",
   description: "Sends an SMS message using the Quriiri API. [See the documentation](https://docs.quriiri.fi/docs/quriiri/send-sms/operations/create-a)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     quriiri,
     sender: {

--- a/components/quriiri/package.json
+++ b/components/quriiri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/quriiri",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Quriiri Components",
   "main": "quriiri.app.mjs",
   "keywords": [

--- a/components/raindrop/actions/parse-bookmark-file/parse-bookmark-file.mjs
+++ b/components/raindrop/actions/parse-bookmark-file/parse-bookmark-file.mjs
@@ -6,13 +6,14 @@ export default {
   key: "raindrop-parse-bookmark-file",
   name: "Parse HTML Bookmark File",
   description: "Convert an HTML bookmark file to JSON. Supports Nestcape, Pocket and Instapaper file formats. [See the documentation](https://developer.raindrop.io/v1/import#parse-html-import-file)",
-  version: "1.0.4",
+  version: "1.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     raindrop,
     filePath: {

--- a/components/raindrop/package.json
+++ b/components/raindrop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/raindrop",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Pipedream Raindrop.io Components",
   "main": "raindrop.app.mjs",
   "keywords": [

--- a/components/readwise/actions/list-highlights/list-highlights.mjs
+++ b/components/readwise/actions/list-highlights/list-highlights.mjs
@@ -4,13 +4,14 @@ export default {
   key: "readwise-list-highlights",
   name: "List Highlights",
   description: "A list of highlights with a pagination metadata. The rate limit of this endpoint is restricted to 20 requests per minute. Each request returns 1000 items. [See the docs here](https://readwise.io/api_deets)",
-  version: "0.0.4",
+  version: "0.0.5",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     readwise,
     bookId: {

--- a/components/readwise/package.json
+++ b/components/readwise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/readwise",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Pipedream Readwise Components",
   "main": "readwise.app.mjs",
   "keywords": [

--- a/components/recreation_gov/actions/search-campsites/search-campsites.mjs
+++ b/components/recreation_gov/actions/search-campsites/search-campsites.mjs
@@ -3,13 +3,14 @@ import utils from "../../common/utils.mjs";
 
 export default {
   key: "recreation_gov-search-campsites",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   name: "Search Campsites",
   description: "Searchs campsites with the given query. If no query given, returns campsites from the beginning. Returning campsite number is limited to `1000`. [See the documentation](https://ridb.recreation.gov/docs#/Campsites/getCampsites)",
   props: {

--- a/components/recreation_gov/package.json
+++ b/components/recreation_gov/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/recreation_gov",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Recreation.gov Components",
   "main": "recreation_gov.app.mjs",
   "keywords": [

--- a/components/referralhero/actions/track-referral-conversion-event/track-referral-conversion-event.mjs
+++ b/components/referralhero/actions/track-referral-conversion-event/track-referral-conversion-event.mjs
@@ -4,13 +4,14 @@ export default {
   key: "referralhero-track-referral-conversion-event",
   name: "Track Referral Conversion Event",
   description: "Track a referral conversion event. Use when your Campaign Goal is set to track two or three conversion events. [See the documentation](https://support.referralhero.com/integrate/rest-api/endpoints-reference#track-referral-conversion-event)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     referralhero,
     listId: {

--- a/components/referralhero/package.json
+++ b/components/referralhero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/referralhero",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream ReferralHero Components",
   "main": "referralhero.app.mjs",
   "keywords": [

--- a/components/remove_bg/actions/remove-background/remove-background.mjs
+++ b/components/remove_bg/actions/remove-background/remove-background.mjs
@@ -5,13 +5,14 @@ export default {
   key: "remove_bg-remove-background",
   name: "Remove background",
   description: "Remove the background of an image",
-  version: "0.1.2",
+  version: "0.1.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     remove_bg: {
       type: "app",

--- a/components/remove_bg/package.json
+++ b/components/remove_bg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/remove_bg",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Pipedream remove_bg Components",
   "main": "remove_bg.app.mjs",
   "keywords": [

--- a/components/rentcast/actions/find-rental-listings/find-rental-listings.mjs
+++ b/components/rentcast/actions/find-rental-listings/find-rental-listings.mjs
@@ -4,13 +4,14 @@ export default {
   key: "rentcast-find-rental-listings",
   name: "Find Rental Listings",
   description: "Search for rental listings in a geographical area, or by a specific address. [See the documentation](https://developers.rentcast.io/reference/rental-listings-long-term)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     rentcast,
     infoAlert: {

--- a/components/rentcast/package.json
+++ b/components/rentcast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/rentcast",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream RentCast Components",
   "main": "rentcast.app.mjs",
   "keywords": [

--- a/components/rev_ai/actions/submit-transcription-job/submit-transcription-job.mjs
+++ b/components/rev_ai/actions/submit-transcription-job/submit-transcription-job.mjs
@@ -5,13 +5,14 @@ export default {
   key: "rev_ai-submit-transcription-job",
   name: "Submit Transcription Job",
   description: "Starts an asynchronous job to transcribe speech-to-text for a media file. Add an optional callback URL to invoke when processing is complete.",
-  version: "0.1.2",
+  version: "0.1.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     rev_ai: {
       type: "app",

--- a/components/rev_ai/package.json
+++ b/components/rev_ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/rev_ai",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Pipedream rev_ai Components",
   "main": "rev_ai.app.mjs",
   "keywords": [

--- a/components/rockset/actions/create-integration/create-integration.mjs
+++ b/components/rockset/actions/create-integration/create-integration.mjs
@@ -5,13 +5,14 @@ export default {
   key: "rockset-create-integration",
   name: "Create Integration",
   description: "Create a new integration with Rockset. Learn more at https://docs.rockset.com/rest/#createintegration",
-  version: "0.1.2",
+  version: "0.1.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     rockset: {
       type: "app",

--- a/components/rockset/package.json
+++ b/components/rockset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/rockset",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Pipedream rockset Components",
   "main": "rockset.app.mjs",
   "keywords": [

--- a/components/samsara/actions/create-route/create-route.mjs
+++ b/components/samsara/actions/create-route/create-route.mjs
@@ -6,13 +6,14 @@ export default {
   key: "samsara-create-route",
   name: "Create Route",
   description: "Generates a new route to an existing address. As a prerequisite, the user must create an address using the 'create-address' action if the location is not already available in the address book. The user must provide the necessary props such as destination address.",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     samsara,
     driverId: {

--- a/components/samsara/package.json
+++ b/components/samsara/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/samsara",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Samsara Components",
   "main": "samsara.app.mjs",
   "keywords": [

--- a/components/selzy/actions/create-email-message/create-email-message.mjs
+++ b/components/selzy/actions/create-email-message/create-email-message.mjs
@@ -9,13 +9,14 @@ export default {
   key: "selzy-create-email-message",
   name: "Create Email Message",
   description: "Adds a new email message. [See the documentation](https://selzy.com/en/support/category/api/messages/)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     selzy,
     senderName: {

--- a/components/selzy/package.json
+++ b/components/selzy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/selzy",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Pipedream Selzy Components",
   "main": "selzy.app.mjs",
   "keywords": [

--- a/components/sendoso/actions/send-physical-gift-with-address-confirmation/send-physical-gift-with-address-confirmation.mjs
+++ b/components/sendoso/actions/send-physical-gift-with-address-confirmation/send-physical-gift-with-address-confirmation.mjs
@@ -3,7 +3,7 @@ import sendoso from "../../sendoso.app.mjs";
 export default {
   key: "sendoso-send-physical-gift-with-address-confirmation",
   name: "Send A Physical Gift With Address Confirmation",
-  version: "0.1.0",
+  version: "0.1.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -11,6 +11,7 @@ export default {
   },
   description: "Send a physical gift. [See the docs here](https://developer.sendoso.com/rest-api/reference/sends/physical/physicalAC)",
   type: "action",
+  ai: "optimized",
   props: {
     sendoso,
     touchId: {

--- a/components/sendoso/package.json
+++ b/components/sendoso/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/sendoso",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Sendoso Components",
   "main": "sendoso.app.mjs",
   "keywords": [

--- a/components/shift4/actions/create-plan/create-plan.mjs
+++ b/components/shift4/actions/create-plan/create-plan.mjs
@@ -5,13 +5,14 @@ export default {
   key: "shift4-create-plan",
   name: "Create Plan",
   description: "Creates a new plan object. [See the documentation](https://dev.shift4.com/docs/api#plan-create)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     shift4,
     amount: {

--- a/components/shift4/package.json
+++ b/components/shift4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/shift4",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Shift4 Components",
   "main": "shift4.app.mjs",
   "keywords": [

--- a/components/shipstation/actions/list-orders/list-orders.mjs
+++ b/components/shipstation/actions/list-orders/list-orders.mjs
@@ -14,13 +14,14 @@ export default {
   key: "shipstation-list-orders",
   name: "List Orders",
   description: "List orders optionally filtered by various criteria. [See the documentation](https://docs.shipstation.com/apis/shipstation-v1/openapi/orders/list_orders)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     shipstation,
     customerName: {

--- a/components/shipstation/package.json
+++ b/components/shipstation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/shipstation",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Pipedream ShipStation Components",
   "main": "shipstation.app.mjs",
   "keywords": [

--- a/components/shopify_developer_app/actions/create-order/create-order.mjs
+++ b/components/shopify_developer_app/actions/create-order/create-order.mjs
@@ -5,13 +5,14 @@ export default {
   key: "shopify_developer_app-create-order",
   name: "Create Order",
   description: "Creates a new order. For full order object details [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/ordercreate)",
-  version: "0.0.18",
+  version: "0.0.19",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     shopify,
     lineItems: {

--- a/components/shopify_developer_app/package.json
+++ b/components/shopify_developer_app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/shopify_developer_app",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Pipedream Shopify (Developer App) Components",
   "main": "shopify_developer_app.app.mjs",
   "keywords": [

--- a/components/shorten_rest/actions/short-link/short-link.mjs
+++ b/components/shorten_rest/actions/short-link/short-link.mjs
@@ -5,13 +5,14 @@ export default {
   key: "shorten_rest-short-link",
   name: "Shorten Link",
   description: "Shortens a given long URL into an alias. If the alias name is not provided, the system generates one. If the domain input is not provided, it defaults to short.fyi. [See the documentation](https://docs.shorten.rest/#tag/Alias/operation/CreateAlias)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     domainName: {

--- a/components/shorten_rest/package.json
+++ b/components/shorten_rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/shorten_rest",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Shorten.REST Components",
   "main": "shorten_rest.app.mjs",
   "keywords": [

--- a/components/skyvern/actions/create-run-task/create-run-task.mjs
+++ b/components/skyvern/actions/create-run-task/create-run-task.mjs
@@ -5,13 +5,14 @@ export default {
   key: "skyvern-create-run-task",
   name: "Create and Run Task",
   description: "Create a new task and run it instantly in Skyvern. Useful for one-off automations. [See the documentation](https://docs.skyvern.com/)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     skyvern,
     url: {

--- a/components/skyvern/package.json
+++ b/components/skyvern/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/skyvern",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Skyvern Components",
   "main": "skyvern.app.mjs",
   "keywords": [

--- a/components/sms/actions/send-sms/send-sms.mjs
+++ b/components/sms/actions/send-sms/send-sms.mjs
@@ -4,13 +4,14 @@ export default {
   key: "sms-send-sms",
   name: "Send SMS",
   description: "Send an SMS to the [verified phone number for your account](https://pipedream.com/settings). While this feature is in alpha, you may send up to 10 messages per day.",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     sms,
     message: {

--- a/components/sms/package.json
+++ b/components/sms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/sms",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Pipedream SMS Components",
   "main": "sms.app.mjs",
   "keywords": [

--- a/components/snipe_it/actions/get-license/get-license.mjs
+++ b/components/snipe_it/actions/get-license/get-license.mjs
@@ -4,13 +4,14 @@ export default {
   key: "snipe_it-get-license",
   name: "Get License",
   description: "Retrieves license details including seat count, expiration, and current usage metrics. Note: The response returns 'product_key' but uses 'serial' field for POST/PUT/PATCH requests. [See the documentation](https://snipe-it.readme.io/reference/licensesid)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     licenseId: {

--- a/components/snipe_it/package.json
+++ b/components/snipe_it/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/snipe_it",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Snipe-IT Components",
   "main": "snipe_it.app.mjs",
   "keywords": [

--- a/components/softr/actions/search-records/search-records.mjs
+++ b/components/softr/actions/search-records/search-records.mjs
@@ -4,13 +4,14 @@ export default {
   key: "softr-search-records",
   name: "Search Records",
   description: "Searches for records in a Softr database by field value. [See the documentation](https://docs.softr.io/softr-api/softr-database-api/records/search-records)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     softr,
     databaseId: {

--- a/components/softr/package.json
+++ b/components/softr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/softr",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Softr Components",
   "main": "softr.app.mjs",
   "keywords": [

--- a/components/sonix/actions/upload-media/upload-media.mjs
+++ b/components/sonix/actions/upload-media/upload-media.mjs
@@ -7,13 +7,14 @@ export default {
   key: "sonix-upload-media",
   name: "Upload Media",
   description: "Submits new media for processing. [See the documentation](https://sonix.ai/docs/api#new_media)",
-  version: "1.0.3",
+  version: "1.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     sonix,
     file: {

--- a/components/sonix/package.json
+++ b/components/sonix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/sonix",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Pipedream Sonix Components",
   "main": "sonix.app.mjs",
   "keywords": [

--- a/components/sperse/actions/add-or-update-contact/add-or-update-contact.mjs
+++ b/components/sperse/actions/add-or-update-contact/add-or-update-contact.mjs
@@ -5,8 +5,9 @@ export default {
   key: "sperse-add-or-update-contact",
   name: "Add or Update Contact",
   description: "Creates or updates a contact. [See the documentation](https://app.sperse.com/app/api/swagger)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/sperse/package.json
+++ b/components/sperse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/sperse",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Pipedream Sperse Components",
   "main": "sperse.app.mjs",
   "keywords": [

--- a/components/spider/actions/scrape-new-page/scrape-new-page.mjs
+++ b/components/spider/actions/scrape-new-page/scrape-new-page.mjs
@@ -4,13 +4,14 @@ export default {
   key: "spider-scrape-new-page",
   name: "Scrape New Page",
   description: "Initiates a new page scrape (crawl). [See the documentation](https://spider.cloud/docs/api#crawl-website)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     spider,
     infoBox: {

--- a/components/spider/package.json
+++ b/components/spider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/spider",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Spider Components",
   "main": "spider.app.mjs",
   "keywords": [

--- a/components/spiritme/actions/generate-video/generate-video.mjs
+++ b/components/spiritme/actions/generate-video/generate-video.mjs
@@ -5,13 +5,14 @@ export default {
   key: "spiritme-generate-video",
   name: "Generate Video",
   description: "Generates a new video using specific voice and avatar props. [See the documentation](https://api.spiritme.tech/api/swagger/#/videos/videos_create)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     spiritme,
     name: {

--- a/components/spiritme/package.json
+++ b/components/spiritme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/spiritme",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream SpiritMe Components",
   "main": "spiritme.app.mjs",
   "keywords": [

--- a/components/spondyr/actions/create-spondyr/create-spondyr.mjs
+++ b/components/spondyr/actions/create-spondyr/create-spondyr.mjs
@@ -3,7 +3,7 @@ import spondyr from "../../spondyr.app.mjs";
 export default {
   key: "spondyr-create-spondyr",
   name: "Create Spondyr",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -11,6 +11,7 @@ export default {
   },
   description: "Generate and optionally deliver correspondence. [See the docs here](https://client.spondyr.io/#/Public/Public/Documentation?Section=send-api)",
   type: "action",
+  ai: "optimized",
   props: {
     spondyr,
     transactionType: {

--- a/components/spondyr/package.json
+++ b/components/spondyr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/spondyr",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Spondyr Components",
   "main": "spondyr.app.mjs",
   "keywords": [

--- a/components/spreadsheet_com/actions/create-rows/create-rows.mjs
+++ b/components/spreadsheet_com/actions/create-rows/create-rows.mjs
@@ -4,7 +4,7 @@ import spreadsheetCom from "../../spreadsheet_com.app.mjs";
 export default {
   key: "spreadsheet_com-create-rows",
   name: "Create Rows",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -12,6 +12,7 @@ export default {
   },
   description: "Adds new row(s) after last row that has data. Empty data sets are ignored. Provide data for at least 1 column. [See the documentation](https://developer.spreadsheet.com/#tag/Rows/operation/createRows)",
   type: "action",
+  ai: "optimized",
   props: {
     spreadsheetCom,
     workbookId: {

--- a/components/spreadsheet_com/package.json
+++ b/components/spreadsheet_com/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/spreadsheet_com",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Spreadsheet.com Components",
   "main": "spreadsheet_com.app.mjs",
   "keywords": [

--- a/components/statuspage/actions/fetch-active-incidents/fetch-active-incidents.mjs
+++ b/components/statuspage/actions/fetch-active-incidents/fetch-active-incidents.mjs
@@ -4,8 +4,9 @@ export default {
   key: "statuspage-fetch-active-incidents",
   name: "Fetch Active Incidents",
   description: "Fetch unresolved (active) incidents for a Statuspage page — i.e. incidents not yet in the `resolved` or `postmortem` state. Returns an array (possibly empty) of incident objects. [See the documentation](https://developer.statuspage.io/#operation/getPagesPageIdIncidentsUnresolved)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/statuspage/package.json
+++ b/components/statuspage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/statuspage",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Pipedream Statuspage Components",
   "main": "statuspage.app.mjs",
   "keywords": [

--- a/components/strale/actions/search-and-execute/search-and-execute.mjs
+++ b/components/strale/actions/search-and-execute/search-and-execute.mjs
@@ -2,10 +2,11 @@ import strale from "../../strale.app.mjs";
 
 export default {
   name: "Search and Execute",
-  version: "0.0.1",
+  version: "0.0.2",
   key: "strale-search-and-execute",
   description: "Describe what you need in plain language \u2014 Strale picks the best capability and executes it in one step. Use this when you don't know the exact capability slug. If you already know the slug, use **Execute Capability** instead; if you only want to discover matches without running anything, use **Search Capabilities**. [See the documentation](https://strale.dev/docs)",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/strale/package.json
+++ b/components/strale/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/strale",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Strale Components",
   "main": "strale.app.mjs",
   "keywords": [

--- a/components/streak/actions/update-box/update-box.mjs
+++ b/components/streak/actions/update-box/update-box.mjs
@@ -6,13 +6,14 @@ export default {
   key: "streak-update-box",
   name: "Update Box",
   description: `Update the properties for a box. To update field values use **Update Box Field Value**. [See the docs](${docLink})`,
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     streak,
     pipelineId: {

--- a/components/streak/package.json
+++ b/components/streak/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/streak",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Streak Components",
   "main": "streak.app.mjs",
   "keywords": [

--- a/components/tableau/actions/list-workbooks/list-workbooks.mjs
+++ b/components/tableau/actions/list-workbooks/list-workbooks.mjs
@@ -5,8 +5,9 @@ export default {
   key: "tableau-list-workbooks",
   name: "List Workbooks",
   description: "Returns a list of the workbooks on the specified site. [See the documentation](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref_workbooks_and_views.htm#query_workbooks_for_site)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/tableau/package.json
+++ b/components/tableau/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/tableau",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Pipedream Tableau Components",
   "main": "tableau.app.mjs",
   "keywords": [

--- a/components/taleez/actions/create-candidate/create-candidate.mjs
+++ b/components/taleez/actions/create-candidate/create-candidate.mjs
@@ -4,13 +4,14 @@ export default {
   key: "taleez-create-candidate",
   name: "Create Candidate",
   description: "Creates a new candidate in Taleez. [See the documentation](https://api.taleez.com/swagger-ui/index.html#/candidates/create_1)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     taleez,
     firstName: {

--- a/components/taleez/package.json
+++ b/components/taleez/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/taleez",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Taleez Components",
   "main": "taleez.app.mjs",
   "keywords": [

--- a/components/talkspirit/actions/create-post-comment/create-post-comment.mjs
+++ b/components/talkspirit/actions/create-post-comment/create-post-comment.mjs
@@ -4,13 +4,14 @@ export default {
   key: "talkspirit-create-post-comment",
   name: "Create Post Comment",
   description: "Creates a new post or adds a comment to an existing thread in Talkspirit using Incoming Webhooks. [See the documentation](https://talkspirit.github.io/docs/incoming-webhooks/)",
-  version: "0.0.1",
+  version: "0.0.2",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     talkspirit,
     title: {

--- a/components/talkspirit/package.json
+++ b/components/talkspirit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/talkspirit",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream talkSpirit Components",
   "main": "talkspirit.app.mjs",
   "keywords": [

--- a/components/taxjar/actions/validate-address/validate-address.mjs
+++ b/components/taxjar/actions/validate-address/validate-address.mjs
@@ -4,13 +4,14 @@ export default {
   key: "taxjar-validate-address",
   name: "Validate Address",
   description: "Validates a customer address and returns back a collection of address matches. [See the documentation](https://developers.taxjar.com/api/reference/#post-validate-an-address)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     country: {

--- a/components/taxjar/package.json
+++ b/components/taxjar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/taxjar",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream TaxJar Components",
   "main": "taxjar.app.mjs",
   "keywords": [

--- a/components/telegram_bot_api/actions/download-voice-message/download-voice-message.mjs
+++ b/components/telegram_bot_api/actions/download-voice-message/download-voice-message.mjs
@@ -7,13 +7,14 @@ export default {
   key: "telegram_bot_api-download-voice-message",
   name: "Download Voice Message",
   description: "Downloads a Telegram voice message to the `/tmp` directory using its `file_id`. Use this after receiving a voice message update to persist the audio locally. [See the documentation](https://core.telegram.org/bots/api#getfile)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     telegramBotApi,
     syncDir: {

--- a/components/telegram_bot_api/package.json
+++ b/components/telegram_bot_api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/telegram_bot_api",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Pipedream Telegram_bot_api Components",
   "main": "telegram_bot_api.app.mjs",
   "keywords": [

--- a/components/testmo/actions/create-automation-run/create-automation-run.mjs
+++ b/components/testmo/actions/create-automation-run/create-automation-run.mjs
@@ -4,7 +4,7 @@ import testmo from "../../testmo.app.mjs";
 export default {
   key: "testmo-create-automation-run",
   name: "Create Automation Run",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -12,6 +12,7 @@ export default {
   },
   description: "Creates a new automation run in a target project in preparation for adding threads and test results. [See the documentation](https://docs.testmo.com/api/reference/automation-runs#post-projects-project_id-automation-runs)",
   type: "action",
+  ai: "optimized",
   props: {
     testmo,
     projectId: {

--- a/components/testmo/package.json
+++ b/components/testmo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/testmo",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Pipedream Testmo Components",
   "main": "testmo.app.mjs",
   "keywords": [

--- a/components/textcortex/actions/summarize-text/summarize-text.mjs
+++ b/components/textcortex/actions/summarize-text/summarize-text.mjs
@@ -6,7 +6,8 @@ export default {
   name: "Summarize Text",
   description: "Summarize given text. The text can be provided as a string or as a file ID. [See the documentation](https://docs.textcortex.com/api/paths/texts-summarizations/post)",
   type: "action",
-  version: "0.0.2",
+  ai: "optimized",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/textcortex/package.json
+++ b/components/textcortex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/textcortex",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream TextCortex Components",
   "main": "textcortex.app.mjs",
   "keywords": [

--- a/components/textlocal/actions/send-sms/send-sms.mjs
+++ b/components/textlocal/actions/send-sms/send-sms.mjs
@@ -6,13 +6,14 @@ export default {
   description:
     `This Action can be used to send text messages to either individual numbers or entire contact groups. [See the docs here](https://api.txtlocal.com/docs/sendsms)
     Note: While both numbers and group_id are optional parameters, one or the other must be included in the request for the message to be sent.`,
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     textlocal,
     sender: {

--- a/components/textlocal/package.json
+++ b/components/textlocal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/textlocal",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Textlocal Components",
   "main": "textlocal.app.mjs",
   "keywords": [

--- a/components/the_colony/actions/send-message/send-message.mjs
+++ b/components/the_colony/actions/send-message/send-message.mjs
@@ -4,8 +4,9 @@ export default {
   key: "the_colony-send-message",
   name: "Send Direct Message",
   description: "Send a direct message to another agent. Requires the sending agent to have at least 5 karma. [See the documentation](https://thecolony.cc/api/v1/instructions).",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     readOnlyHint: false,
     destructiveHint: false,

--- a/components/the_colony/package.json
+++ b/components/the_colony/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/the_colony",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream The Colony Components",
   "main": "the_colony.app.mjs",
   "keywords": [

--- a/components/threads/actions/post-chat-message/post-chat-message.mjs
+++ b/components/threads/actions/post-chat-message/post-chat-message.mjs
@@ -4,13 +4,14 @@ export default {
   key: "threads-post-chat-message",
   name: "Post a Chat Message",
   description: "Post a message to a chat. First, make sure you add your Bot user to the chat. [See the Documentation](https://github.com/ThreadsHQ/api-documentation#post-chat-message)",
-  version: "0.0.6",
+  version: "0.0.7",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     threads,
     chatID: {

--- a/components/threads/package.json
+++ b/components/threads/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/threads",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Pipedream Threads Components",
   "main": "threads.app.mjs",
   "keywords": [

--- a/components/toggl/actions/get-time-entries/get-time-entries.mjs
+++ b/components/toggl/actions/get-time-entries/get-time-entries.mjs
@@ -2,7 +2,7 @@ import toggl from "../../toggl.app.mjs";
 
 export default {
   name: "Get Time Entries",
-  version: "0.0.8",
+  version: "0.0.9",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -11,6 +11,7 @@ export default {
   key: "toggl-get-time-entries",
   description: "Get the last thousand time entries. [See docs here](https://developers.track.toggl.com/docs/api/time_entries#get-timeentries)",
   type: "action",
+  ai: "optimized",
   props: {
     toggl,
     startDate: {

--- a/components/toggl/package.json
+++ b/components/toggl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/toggl",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream Toggl Components",
   "main": "toggl.app.mjs",
   "keywords": [

--- a/components/tomba/actions/search-companies/search-companies.mjs
+++ b/components/tomba/actions/search-companies/search-companies.mjs
@@ -5,8 +5,9 @@ export default {
   name: "Search Companies",
   description:
     "Search for companies using natural language queries or structured filters. The AI assistant will automatically generate appropriate filters from your query. [See the documentation](https://docs.tomba.io/api/reveal#search-companies)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/tomba/package.json
+++ b/components/tomba/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/tomba",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Tomba Components - Email finder, verifier, enrichment, company search, and account management tools",
   "main": "tomba.app.mjs",
   "keywords": [

--- a/components/trackingtime/actions/start-tracking-time/start-tracking-time.mjs
+++ b/components/trackingtime/actions/start-tracking-time/start-tracking-time.mjs
@@ -2,7 +2,7 @@ import app from "../../trackingtime.app.mjs";
 
 export default {
   name: "Start Tracking Time",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
@@ -11,6 +11,7 @@ export default {
   key: "trackingtime-start-tracking-time",
   description: "Start tracking time of a task. [See the documentation](https://api.trackingtime.co/doc/time_tracking.html#sync:~:text=Sync%20tracking%20event-,Start%20Tracking%20Time,-Starts%20a%20timer)",
   type: "action",
+  ai: "optimized",
   props: {
     app,
     taskId: {

--- a/components/trackingtime/package.json
+++ b/components/trackingtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/trackingtime",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream TrackingTime Components",
   "main": "trackingtime.app.mjs",
   "keywords": [

--- a/components/trint/actions/upload-file/upload-file.mjs
+++ b/components/trint/actions/upload-file/upload-file.mjs
@@ -6,8 +6,9 @@ export default {
   key: "trint-upload-file",
   name: "Upload File",
   description: "Upload media files directly to Trint for immediate transcription. [See the documentation](https://dev.trint.com/reference/upload)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/trint/package.json
+++ b/components/trint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/trint",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Pipedream Trint Components",
   "main": "trint.app.mjs",
   "keywords": [

--- a/components/twilio/actions/make-phone-call/make-phone-call.mjs
+++ b/components/twilio/actions/make-phone-call/make-phone-call.mjs
@@ -6,13 +6,14 @@ export default {
   key: "twilio-make-phone-call",
   name: "Make a Phone Call",
   description: "Make a phone call passing text, a URL, or an application that Twilio will use to handle the call. [See the documentation](https://www.twilio.com/docs/voice/api/call-resource#create-a-call-resource)",
-  version: "1.0.0",
+  version: "1.0.1",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     twilio,
     from: {

--- a/components/twilio/package.json
+++ b/components/twilio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/twilio",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Pipedream Twilio Components",
   "main": "twilio.app.mjs",
   "keywords": [

--- a/components/twitter/actions/create-tweet/create-tweet.ts
+++ b/components/twitter/actions/create-tweet/create-tweet.ts
@@ -10,13 +10,14 @@ export default defineAction({
   key: "twitter-create-tweet",
   name: "Create Tweet",
   description: `Create a new tweet. [See the documentation](${DOCS_LINK})`,
-  version: "2.1.7",
+  version: "2.1.8",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     text: {

--- a/components/twitter/package.json
+++ b/components/twitter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/twitter",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "Pipedream Twitter Components",
   "main": "dist/app/twitter.app.mjs",
   "keywords": [

--- a/components/unirateapi/actions/get-exchange-rates/get-exchange-rates.mjs
+++ b/components/unirateapi/actions/get-exchange-rates/get-exchange-rates.mjs
@@ -3,7 +3,7 @@ import app from "../../unirateapi.app.mjs";
 export default {
   key: "unirateapi-get-exchange-rates",
   name: "Get Exchange Rates",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
@@ -11,6 +11,7 @@ export default {
   },
   description: "Get the latest exchange rate(s) for a base currency. Returns a single rate when a target is provided, or all rates keyed by currency code when omitted. [See the documentation](https://unirateapi.com/apidocs).",
   type: "action",
+  ai: "optimized",
   props: {
     app,
     from: {

--- a/components/unirateapi/package.json
+++ b/components/unirateapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/unirateapi",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Pipedream UniRateAPI Components",
   "main": "unirateapi.app.mjs",
   "keywords": [

--- a/components/unsplash/actions/search-photos/search-photos.mjs
+++ b/components/unsplash/actions/search-photos/search-photos.mjs
@@ -5,13 +5,14 @@ export default {
   key: "unsplash-search-photos",
   name: "Search Photos",
   description: "Get a single page of photo results for a query. [See the documentation](https://unsplash.com/documentation#search-photos)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     app,
     query: {

--- a/components/unsplash/package.json
+++ b/components/unsplash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/unsplash",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Unsplash Components",
   "main": "unsplash.app.mjs",
   "keywords": [

--- a/components/upkeep/actions/find-vendor/find-vendor.mjs
+++ b/components/upkeep/actions/find-vendor/find-vendor.mjs
@@ -3,8 +3,9 @@ import utils from "../../common/utils.mjs";
 
 export default {
   type: "action",
+  ai: "optimized",
   key: "upkeep-find-vendor",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/upkeep/package.json
+++ b/components/upkeep/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/upkeep",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Upkeep Components",
   "main": "upkeep.app.mjs",
   "keywords": [

--- a/components/vero/actions/track-event-for-user/track-event-for-user.mjs
+++ b/components/vero/actions/track-event-for-user/track-event-for-user.mjs
@@ -3,9 +3,10 @@ import app from "../../vero.app.mjs";
 
 export default {
   type: "action",
+  ai: "optimized",
   key: "vero-track-event-for-user",
   name: "Track Event for User",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/vero/package.json
+++ b/components/vero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/vero",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Pipedream Vero Components",
   "main": "vero.app.mjs",
   "keywords": [

--- a/components/vestaboard/actions/create-message/create-message.mjs
+++ b/components/vestaboard/actions/create-message/create-message.mjs
@@ -5,13 +5,14 @@ export default {
   key: "vestaboard-create-message",
   name: "Create Message",
   description: "Creates a new message for a subscription. [See the docs](https://swagger.vestaboard.com/docs/vestaboard/b3A6MTYwMTA4OTc-post-v2-0-subscriptions-with-id-message)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     vestaboard,
     subscriptionId: {

--- a/components/vestaboard/package.json
+++ b/components/vestaboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/vestaboard",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pipedream Vestaboard Components",
   "main": "vestaboard.app.mjs",
   "keywords": [

--- a/components/viewdns_info/actions/dns-record-lookup/dns-record-lookup.mjs
+++ b/components/viewdns_info/actions/dns-record-lookup/dns-record-lookup.mjs
@@ -4,13 +4,14 @@ export default {
   key: "viewdns_info-dns-record-lookup",
   name: "DNS Record Lookup",
   description: "Performs a DNS record lookup to retrieve various DNS record types for a domain. [See the documentation](https://viewdns.info/api/dns-record-lookup/)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     viewdnsInfo,
     domain: {

--- a/components/viewdns_info/package.json
+++ b/components/viewdns_info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/viewdns_info",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream ViewDNS.info Components",
   "main": "viewdns_info.app.mjs",
   "keywords": [

--- a/components/voilanorbert/actions/find-contact/find-contact.mjs
+++ b/components/voilanorbert/actions/find-contact/find-contact.mjs
@@ -5,13 +5,14 @@ export default {
   key: "voilanorbert-find-contact",
   name: "Find Contact",
   description: "This action returns a specific contact. The object email is either null when the email is not found, or contains an object with at least email (the email string) and the score. [See the docs here](https://api.voilanorbert.com/2018-01-08/#contacts-get-1)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     ...common.props,
     contactId: {

--- a/components/voilanorbert/package.json
+++ b/components/voilanorbert/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/voilanorbert",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream VoilaNorbert Components",
   "main": "voilanorbert.app.mjs",
   "keywords": [

--- a/components/walletap/actions/update-pass/update-pass.mjs
+++ b/components/walletap/actions/update-pass/update-pass.mjs
@@ -5,8 +5,9 @@ export default {
   key: "walletap-update-pass",
   name: "Update Pass",
   description: "Updates an existing Walletap pass and pushes the updated pass to the user. [See the documentation](https://walletap.io/docs/api#tag/Pass/operation/updatePass)",
-  version: "0.0.1",
+  version: "0.0.2",
   type: "action",
+  ai: "optimized",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,

--- a/components/walletap/package.json
+++ b/components/walletap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/walletap",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream WalleTap Components",
   "main": "walletap.app.mjs",
   "keywords": [

--- a/components/wappalyzer/actions/get-technologies/get-technologies.mjs
+++ b/components/wappalyzer/actions/get-technologies/get-technologies.mjs
@@ -4,13 +4,14 @@ export default {
   key: "wappalyzer-get-technologies",
   name: "Get Technologies",
   description: "Returns the details of technologies used on a specific URL. [See the documentation](https://www.wappalyzer.com/docs/api/v2/lookup/)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     wappalyzer,
     urls: {

--- a/components/wappalyzer/package.json
+++ b/components/wappalyzer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/wappalyzer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Wappalyzer Components",
   "main": "wappalyzer.app.mjs",
   "keywords": [

--- a/components/webscrape_ai/actions/scrape-website/scrape-website.mjs
+++ b/components/webscrape_ai/actions/scrape-website/scrape-website.mjs
@@ -4,13 +4,14 @@ export default {
   key: "webscrape_ai-scrape-website",
   name: "Scrape Website",
   description: "Scrape the provided URL and store the results in the system. [See the documentation](https://webscrapeai.com/docs)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     webscrapeAi,
     alert: {

--- a/components/webscrape_ai/package.json
+++ b/components/webscrape_ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/webscrape_ai",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pipedream Webscrape AI Components",
   "main": "webscrape_ai.app.mjs",
   "keywords": [

--- a/components/white_swan/actions/submit-complete-plan-request/submit-complete-plan-request.mjs
+++ b/components/white_swan/actions/submit-complete-plan-request/submit-complete-plan-request.mjs
@@ -6,13 +6,14 @@ export default {
   key: "white_swan-submit-complete-plan-request",
   name: "Submit Complete Plan Request",
   description: "Creates a new comprehensive quote request based on the information provided and generates the final quotation without further data requirements. [See the documentation](https://docs.whiteswan.io/partner-knowledge-base/api-documentation/action-calls/submit-complete-plan-request)",
-  version: "0.0.2",
+  version: "0.0.3",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     whiteSwan,
     name: {

--- a/components/white_swan/package.json
+++ b/components/white_swan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/white_swan",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pipedream White Swan Components",
   "main": "white_swan.app.mjs",
   "keywords": [

--- a/components/whoisfreaks/actions/reverse-lookup/reverse-lookup.mjs
+++ b/components/whoisfreaks/actions/reverse-lookup/reverse-lookup.mjs
@@ -6,13 +6,14 @@ export default {
   name: "Reverse Lookup",
   description:
     "Retrieve details about a domain by keyword, email, registrant name or company. Must enter one and only one of keyword, email, owner, or company. [See the documentation](https://whoisfreaks.com/documentation/whois-api#reverse-lookup)",
-  version: "0.0.3",
+  version: "0.0.4",
   annotations: {
     destructiveHint: false,
     openWorldHint: true,
     readOnlyHint: true,
   },
   type: "action",
+  ai: "optimized",
   props: {
     whoisfreaks,
     keyword: {

--- a/components/whoisfreaks/package.json
+++ b/components/whoisfreaks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/whoisfreaks",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Pipedream WhoisFreaks Components",
   "main": "whoisfreaks.app.mjs",
   "keywords": [


### PR DESCRIPTION
Split of the oversized batch 6 (#21892), which changed 400 files (200 components + 200 app package.json) — over the ~300-file cap of the `publish-components` changed-files detection, which would silently drop ~100 components. This half is **100 components / 100 apps = 200 changed files**, safely under the cap.

Continuation of the DJ-4272 AI-optimized backfill (product CSV, Aug 11 2026). Adds top-level `ai: "optimized"` + patch version bump per component; each app's `package.json` bumped (`check_version`). Disjoint apps; regenerated fresh off current master.

Apps (mem…whoisfreaks): mem,memberstack metaphor,microsoft_clarity microsoft_entra_id,microsoft_teams moosend,motion muapi,nationbuilder navan,news_api noticeable,numverify octopush_sms,omnisend openweather_api,orbit orca_scan,outscraper overledger,papertrail paytrace,peaka perplexity,phantombuster pinecone,pipedream plaid,polar polygon,postgrid postgrid_verify,practitest precisefp,printautopilot printnode,proabono productboard,profitwell pushover,qstash qualetics,quriiri raindrop,readwise recreation_gov,referralhero remove_bg,rentcast rev_ai,rockset samsara,selzy sendoso,shift4 shipstation,shopify_developer_app shorten_rest,skyvern sms,snipe_it softr,sonix sperse,spider spiritme,spondyr spreadsheet_com,statuspage strale,streak tableau,taleez talkspirit,taxjar telegram_bot_api,testmo textcortex,textlocal the_colony,threads toggl,tomba trackingtime,trint twilio,twitter unirateapi,unsplash upkeep,vero vestaboard,viewdns_info voilanorbert,walletap wappalyzer,webscrape_ai white_swan,whoisfreaks