### PR TITLE
fix(slack_v2): restore user authorship in post-message with an `as_user` prop

### DIFF
--- a/components/slack_v2/actions/post-message/post-message.mjs
+++ b/components/slack_v2/actions/post-message/post-message.mjs
@@ -11,7 +11,7 @@ export default {
     + " To reply to a thread, provide `threadTs` (Slack calls this `thread_ts`) from **Get Channel History**."
     + " Supports plain text with Slack mrkdwn formatting and Block Kit blocks."
     + " [See the documentation](https://api.slack.com/methods/chat.postMessage)",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "action",
   ai: "optimized",
   annotations: {
@@ -30,6 +30,13 @@ export default {
       type: "string",
       label: "Text",
       description: "The message text. Supports Slack mrkdwn formatting (e.g. `*bold*`, `_italic_`, `<https://example.com|link>`). To mention a user, use `<@U123>` with their user ID. Do NOT append a display name after a pipe: Slack renders `<@U123|Name>` as literal text, not a mention.",
+    },
+    asUser: {
+      type: "boolean",
+      label: "Send as User",
+      description: "Post as the authenticated user (the default). Set to `false` to post as the app's bot identity instead: the message then carries the app's name and icon, and Slack prefixes notification and sidebar previews with that name.",
+      default: true,
+      optional: true,
     },
     blocks: {
       type: "string",
@@ -75,9 +82,13 @@ export default {
   async run({ $ }) {
     // chat.postMessage accepts channel names directly — no ID resolution needed
     const channel = this.slack.normalizeChannel(this.channel);
+    // Slack decides authorship from `as_user` for classic apps, and it defaults to
+    // `false` there — a user-token post with the flag omitted is attributed to the app's
+    // bot, not to the caller. Send it explicitly so the author is the connected user.
     const args = {
       channel,
       text: this.text,
+      as_user: this.asUser,
       mrkdwn: this.mrkdwn,
       unfurl_links: this.unfurlLinks,
       unfurl_media: this.unfurlMedia,

--- a/components/slack_v2/package.json
+++ b/components/slack_v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/slack_v2",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Pipedream Slack_v2 Components",
   "main": "slack_v2.app.mjs",
   "keywords": [


### PR DESCRIPTION
## Problem

Messages sent by **Post Message** are authored by the Pipedream bot, not by the connected user. Slack renders notification and sidebar previews as `Pipedream: <text>` while the message body itself is unchanged — which is why the prefix looks like it is being injected into the text. It is not; it is Slack's preview format, `<author>: <text>`, with the app as the author.

## Why #21842 did not fix it

#21842 removed the explicit `as_user: false` that #21786 had added, on the premise that omitting the flag restores the pre-v0.0.4 behavior of posting as the authenticated user.

Omitting it changes nothing. Slack documents `as_user` as defaulting to `false`, so "flag omitted" and "flag explicitly false" are the same request.

Verified against the live API on current `master` (v0.0.8), using a **user** token — note `message.user` is the human's ID and `acceptedScopes` is the user-token scope set:

```json
"message": {
  "user": "U0A4…",
  "bot_id": "B0AM…",
  "app_id": "A09M…",
  "bot_profile": { "name": "Pipedream" }
},
"response_metadata": { "acceptedScopes": ["chat:write"] }
```

`bot_profile.name: "Pipedream"` is the author Slack puts in the preview line.

## Change

- Add an `asUser` prop, **defaulting to `true`**, and send it explicitly as `as_user`.
- `as_user: true` takes the pass-through branch of `makeRequest` and keeps the user token.
- `as_user: false` routes to `bot_token` where the account has one, matching the existing `send-message*` behavior, so bot authorship stays available to anyone who wants it.

This is a behavior change for callers who have been getting bot authorship since v0.0.4 (2026-08-27). That behavior was itself unintended — #21786's stated scope was MCP v3 prop compatibility — and #21842 already established the intent to restore user authorship. This PR carries that intent out.

## Testing

Published to a personal workspace and confirmed the prop reaches the registry schema (`asUser`, boolean, default `true`). **End-to-end confirmation that `as_user: true` strips `bot_id`/`bot_profile` from the response is still pending** — if the Pipedream Slack app turns out to be a granular-scope app rather than a classic one, Slack ignores `as_user` and the real cause is the token itself rather than the flag. Reviewers with app-config access can settle this quickly: OAuth & Permissions shows a single flat *Scopes* table for classic apps and split *Bot*/*User Token Scopes* tables for granular ones.

## Follow-up (not in this PR)

`edit-message` also omits `as_user`, so `chat.update` runs under bot identity. Once Post Message authors as the user, editing one of those messages may fail with `cant_update_message` — the two actions need matching identities. `delete-message` already handles this with an explicit dual-identity fallback (see its comments). Worth a companion change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to choose whether Slack messages are posted as the authenticated user or the app bot.
  * The setting defaults to posting as the authenticated user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->