### PR TITLE
fix(shopify): bump major version

### DIFF
--- a/components/shopify/actions/create-order/create-order.mjs
+++ b/components/shopify/actions/create-order/create-order.mjs
@@ -6,7 +6,7 @@ export default {
   key: "shopify-create-order",
   name: "Create Order",
   description: "Creates a new order. [See the documentation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/orderCreate).",
-  version: "0.0.13",
+  version: "1.0.0",
   type: "action",
   ai: "optimized",
   annotations: {

--- a/components/shopify/package.json
+++ b/components/shopify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/shopify",
-  "version": "0.15.2",
+  "version": "1.0.0",
   "description": "Pipedream Shopify Components",
   "main": "shopify.app.mjs",
   "keywords": [


### PR DESCRIPTION
## Summary

<!-- Add your PR description here -->
Bump major version since the version in pd public registry is `0.1.3` and any version below `0.1.3` does not reflect to the users.


## Checklist
Please check the following items before your PR can be reviewed:

### Versioning
- [x] All components updated in this PR had their version updated (`0.0.1` for new ones)
- [x] The app updated in this PR had its `package.json`'s version updated

### New app
If this is a new app, please submit [an app integration request](https://github.com/PipedreamHQ/pipedream/issues/new?template=app---service-integration.md) - the PR will only be reviewed after the app is integrated.
- [x] The app updated in this PR is already integrated

### CodeRabbit review
After the PR is opened, and if new changes are pushed, CodeRabbit will automatically review it. Do not 'mark as resolved' CodeRabbit's comments, but reply to them instead, whether you agree (and update the PR accordingly) or disagree.
- [ ] I have addressed or acknowledged all of CodeRabbit's review comments



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Shopify package and create-order action to version 1.0.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->