### PR TITLE
feat(google_sheets): mark delete-rows ai:optimized for MCP

### DIFF
--- a/components/google_sheets/actions/delete-rows/delete-rows.mjs
+++ b/components/google_sheets/actions/delete-rows/delete-rows.mjs
@@ -4,13 +4,14 @@ export default {
   key: "google_sheets-delete-rows",
   name: "Delete Rows",
   description: "Deletes the specified rows from a spreadsheet. [See the documentation](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/request#deletedimensionrequest)",
-  version: "0.0.17",
+  version: "0.0.18",
   annotations: {
     destructiveHint: true,
     openWorldHint: true,
     readOnlyHint: false,
   },
   type: "action",
+  ai: "optimized",
   props: {
     googleSheets,
     drive: {

--- a/components/google_sheets/package.json
+++ b/components/google_sheets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pipedream/google_sheets",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Pipedream Google_sheets Components",
   "main": "google_sheets.app.mjs",
   "keywords": [


### PR DESCRIPTION
`google_sheets-delete-rows` was missing `ai: "optimized"`, so it drops from the list once curation moves to the `ai` field.